### PR TITLE
feat(validators): ingest nominator counts per validator (#2549)

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -22,6 +22,10 @@ const METRICS: Array<{ term: string; def: string }> = [
     def: "The total neuron slots the hotkey holds across those subnets — one registration is one UID.",
   },
   {
+    term: "Nominators",
+    def: "How many distinct coldkeys currently have stake delegated to this hotkey, network-wide (#2549). Sourced from a lower-frequency chain scan than the other columns, so it can lag them briefly — a dash means no count has been captured for this hotkey yet, not zero nominators.",
+  },
+  {
     term: "Dominance",
     def: "The validator's share of total network stake, as a percentage. Higher dominance means more influence over consensus and emission — and more of that influence concentrated in one operator.",
   },
@@ -40,7 +44,7 @@ const METRICS: Array<{ term: string; def: string }> = [
 ];
 
 const GUIDANCE =
-  "Read these signals together, not in isolation — a large validator concentrates stake and influence, while a smaller one spreads it. Commission and nominator counts (coming in #2548/#2549) will add to this picture. This directory describes the on-chain data; it does not rank or recommend any validator.";
+  "Read these signals together, not in isolation — a large validator concentrates stake and influence, while a smaller one spreads it. This directory describes the on-chain data; it does not rank or recommend any validator.";
 
 const HEADING = "How to evaluate a validator";
 const SUBHEADING = "What each column means and how to read them together";

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -5365,6 +5365,7 @@ function normalizeGlobalValidator(raw: unknown): GlobalValidator | null {
     uid_count: coerceFiniteNumber(raw.uid_count) ?? 0,
     total_stake_tao: coerceFiniteNumber(raw.total_stake_tao) ?? 0,
     total_emission_tao: coerceFiniteNumber(raw.total_emission_tao) ?? 0,
+    nominator_count: nullableNum(raw.nominator_count),
     avg_validator_trust: nullableNum(raw.avg_validator_trust),
     max_validator_trust: nullableNum(raw.max_validator_trust),
     stake_dominance: nullableNum(raw.stake_dominance),

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1991,6 +1991,8 @@ export interface GlobalValidator {
   uid_count: number;
   total_stake_tao: number;
   total_emission_tao: number;
+  /** Distinct coldkeys currently staking to this hotkey, network-wide (#2549). Null when the low-frequency source table has no row for this hotkey yet. */
+  nominator_count: number | null;
   avg_validator_trust: number | null;
   max_validator_trust: number | null;
   stake_dominance: number | null;

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -167,6 +167,7 @@ function ValidatorsTable({
                 <th className={TH}>Coldkey</th>
                 <th className={`${TH} text-right`}>Active subnets</th>
                 <th className={`${TH} text-right`}>UIDs</th>
+                <th className={`${TH} text-right`}>Nominators</th>
                 <th className={`${TH} text-right`}>Dominance</th>
                 <th className={`${TH} text-right`}>Total stake</th>
                 <th className={`${TH} text-right`}>Total emission</th>
@@ -207,6 +208,9 @@ function ValidatorsTable({
                   </td>
                   <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
                     {formatNumber(v.uid_count)}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {v.nominator_count != null ? formatNumber(v.nominator_count) : "—"}
                   </td>
                   <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
                     {v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"}

--- a/migrations/0043_validator_nominator_counts.sql
+++ b/migrations/0043_validator_nominator_counts.sql
@@ -1,0 +1,25 @@
+-- Nominator counts per validator hotkey (#2549): distinct coldkeys currently
+-- holding a nonzero alpha/root stake position on a hotkey, network-wide.
+--
+-- Deliberately a SEPARATE side table, not a column on `neurons` (unlike
+-- `take`, migration 0042): a nominator count is derived from a full scan of
+-- SubtensorModule::Alpha, a per-(hotkey, coldkey, netuid) NMap. Verified live
+-- 2026-07-14 against the fullnode: 762,577 total Alpha rows, 112,552
+-- distinct hotkeys with any stake, full scan in 249s (~4.2 min) at a
+-- sustained ~3000 rows/sec. That's short enough to run daily, but still far
+-- more than the fast refresh-metagraph cron's 30-60s budget (TimeoutStartSec
+-- 600) can absorb alongside its existing work, so this is populated by its
+-- own, separate lower-frequency job (scripts/fetch-validator-nominator-
+-- counts.py) and joined into buildGlobalValidators/buildValidatorDetail at
+-- serve time — mirrors the featured_validators side-table join pattern
+-- (#5166), not neurons' own denormalized-column pattern.
+--
+-- Latest-only, REPLACE-on-conflict (like account_identity) -- a validator
+-- missing from one pass hasn't necessarily lost its nominators, but a stale
+-- captured_at is still visible to callers via this table's own timestamp.
+CREATE TABLE IF NOT EXISTS validator_nominator_counts (
+  hotkey           TEXT    NOT NULL,
+  nominator_count  INTEGER NOT NULL,
+  captured_at      BIGINT  NOT NULL, -- epoch milliseconds
+  PRIMARY KEY (hotkey)
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11839,7 +11839,7 @@
     },
     "packages/client": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.15.6",
+      "version": "0.15.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "metagraphed-contract": "*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4973,6 +4973,8 @@ export interface components {
             /** Format: date-time */
             latest_captured_at: string | null;
             max_validator_trust: number | null;
+            /** @description Distinct coldkeys currently holding a nonzero stake position on this hotkey, network-wide, across every subnet (#2549). Sourced from a separate, lower-frequency full-chain scan (see validator_nominator_counts) than the rest of this artifact -- null when that table has no row for this hotkey yet, never fabricated as 0. */
+            nominator_count: number | null;
             /** @description Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao. */
             root_stake_tao: number;
             stake_dominance: number | null;
@@ -7661,6 +7663,8 @@ export interface components {
             coldkey_identity: components["schemas"]["ColdkeyIdentity"] | null;
             hotkey: string;
             max_validator_trust: number | null;
+            /** @description Distinct coldkeys currently holding a nonzero stake position on this hotkey, network-wide, across every subnet (#2549). Sourced from a separate, lower-frequency full-chain scan than the rest of this artifact -- null when that table has no row for this hotkey yet, never fabricated as 0. */
+            nominator_count: number | null;
             /** @description Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao. */
             root_stake_tao: number;
             schema_version: number;
@@ -28520,6 +28524,7 @@ export interface operations {
                      *             "latest_block_number": 5000000,
                      *             "latest_captured_at": "2026-06-01T00:00:00.000Z",
                      *             "max_validator_trust": 0.5,
+                     *             "nominator_count": 1,
                      *             "root_stake_tao": 0.5,
                      *             "stake_dominance": 0.5,
                      *             "subnet_count": 1,
@@ -28662,6 +28667,7 @@ export interface operations {
                      *         },
                      *         "hotkey": "example",
                      *         "max_validator_trust": 0.5,
+                     *         "nominator_count": 1,
                      *         "root_stake_tao": 0.5,
                      *         "schema_version": 1,
                      *         "subnet_count": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9781,6 +9781,14 @@
               "null"
             ]
           },
+          "nominator_count": {
+            "description": "Distinct coldkeys currently holding a nonzero stake position on this hotkey, network-wide, across every subnet (#2549). Sourced from a separate, lower-frequency full-chain scan (see validator_nominator_counts) than the rest of this artifact -- null when that table has no row for this hotkey yet, never fabricated as 0.",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "root_stake_tao": {
             "description": "Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao.",
             "minimum": 0,
@@ -9838,6 +9846,7 @@
           "root_stake_tao",
           "alpha_stake_tao",
           "total_emission_tao",
+          "nominator_count",
           "stake_dominance",
           "avg_validator_trust",
           "max_validator_trust",
@@ -20962,6 +20971,14 @@
               "null"
             ]
           },
+          "nominator_count": {
+            "description": "Distinct coldkeys currently holding a nonzero stake position on this hotkey, network-wide, across every subnet (#2549). Sourced from a separate, lower-frequency full-chain scan than the rest of this artifact -- null when that table has no row for this hotkey yet, never fabricated as 0.",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "root_stake_tao": {
             "description": "Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao.",
             "minimum": 0,
@@ -21008,6 +21025,7 @@
           "root_stake_tao",
           "alpha_stake_tao",
           "total_emission_tao",
+          "nominator_count",
           "avg_validator_trust",
           "max_validator_trust",
           "captured_at",
@@ -51766,6 +51784,7 @@
                         "latest_block_number": 5000000,
                         "latest_captured_at": "2026-06-01T00:00:00.000Z",
                         "max_validator_trust": 0.5,
+                        "nominator_count": 1,
                         "root_stake_tao": 0.5,
                         "stake_dominance": 0.5,
                         "subnet_count": 1,
@@ -51935,6 +51954,7 @@
                     },
                     "hotkey": "example",
                     "max_validator_trust": 0.5,
+                    "nominator_count": 1,
                     "root_stake_tao": 0.5,
                     "schema_version": 1,
                     "subnet_count": 1,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4973,6 +4973,8 @@ export interface components {
             /** Format: date-time */
             latest_captured_at: string | null;
             max_validator_trust: number | null;
+            /** @description Distinct coldkeys currently holding a nonzero stake position on this hotkey, network-wide, across every subnet (#2549). Sourced from a separate, lower-frequency full-chain scan (see validator_nominator_counts) than the rest of this artifact -- null when that table has no row for this hotkey yet, never fabricated as 0. */
+            nominator_count: number | null;
             /** @description Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao. */
             root_stake_tao: number;
             stake_dominance: number | null;
@@ -7661,6 +7663,8 @@ export interface components {
             coldkey_identity: components["schemas"]["ColdkeyIdentity"] | null;
             hotkey: string;
             max_validator_trust: number | null;
+            /** @description Distinct coldkeys currently holding a nonzero stake position on this hotkey, network-wide, across every subnet (#2549). Sourced from a separate, lower-frequency full-chain scan than the rest of this artifact -- null when that table has no row for this hotkey yet, never fabricated as 0. */
+            nominator_count: number | null;
             /** @description Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao. */
             root_stake_tao: number;
             schema_version: number;
@@ -28520,6 +28524,7 @@ export interface operations {
                      *             "latest_block_number": 5000000,
                      *             "latest_captured_at": "2026-06-01T00:00:00.000Z",
                      *             "max_validator_trust": 0.5,
+                     *             "nominator_count": 1,
                      *             "root_stake_tao": 0.5,
                      *             "stake_dominance": 0.5,
                      *             "subnet_count": 1,
@@ -28662,6 +28667,7 @@ export interface operations {
                      *         },
                      *         "hotkey": "example",
                      *         "max_validator_trust": 0.5,
+                     *         "nominator_count": 1,
                      *         "root_stake_tao": 0.5,
                      *         "schema_version": 1,
                      *         "subnet_count": 1,

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -9759,6 +9759,14 @@
               "null"
             ]
           },
+          "nominator_count": {
+            "description": "Distinct coldkeys currently holding a nonzero stake position on this hotkey, network-wide, across every subnet (#2549). Sourced from a separate, lower-frequency full-chain scan (see validator_nominator_counts) than the rest of this artifact -- null when that table has no row for this hotkey yet, never fabricated as 0.",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "root_stake_tao": {
             "description": "Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao.",
             "minimum": 0,
@@ -9816,6 +9824,7 @@
           "root_stake_tao",
           "alpha_stake_tao",
           "total_emission_tao",
+          "nominator_count",
           "stake_dominance",
           "avg_validator_trust",
           "max_validator_trust",
@@ -20940,6 +20949,14 @@
               "null"
             ]
           },
+          "nominator_count": {
+            "description": "Distinct coldkeys currently holding a nonzero stake position on this hotkey, network-wide, across every subnet (#2549). Sourced from a separate, lower-frequency full-chain scan than the rest of this artifact -- null when that table has no row for this hotkey yet, never fabricated as 0.",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "root_stake_tao": {
             "description": "Stake on netuid 0 (root), TAO-denominated 1:1 with no AMM/price exposure (#2550). 0 when the hotkey holds no root membership. Included in total_stake_tao.",
             "minimum": 0,
@@ -20986,6 +21003,7 @@
           "root_stake_tao",
           "alpha_stake_tao",
           "total_emission_tao",
+          "nominator_count",
           "avg_validator_trust",
           "max_validator_trust",
           "captured_at",

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -2026,6 +2026,7 @@
           "root_stake_tao",
           "alpha_stake_tao",
           "total_emission_tao",
+          "nominator_count",
           "stake_dominance",
           "avg_validator_trust",
           "max_validator_trust",
@@ -2063,6 +2064,11 @@
             "description": "total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao."
           },
           "total_emission_tao": { "type": "number", "minimum": 0 },
+          "nominator_count": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "description": "Distinct coldkeys currently holding a nonzero stake position on this hotkey, network-wide, across every subnet (#2549). Sourced from a separate, lower-frequency full-chain scan (see validator_nominator_counts) than the rest of this artifact -- null when that table has no row for this hotkey yet, never fabricated as 0."
+          },
           "stake_dominance": {
             "type": ["number", "null"],
             "minimum": 0,
@@ -2262,6 +2268,7 @@
           "root_stake_tao",
           "alpha_stake_tao",
           "total_emission_tao",
+          "nominator_count",
           "avg_validator_trust",
           "max_validator_trust",
           "captured_at",
@@ -2297,6 +2304,11 @@
             "description": "total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao."
           },
           "total_emission_tao": { "type": "number", "minimum": 0 },
+          "nominator_count": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "description": "Distinct coldkeys currently holding a nonzero stake position on this hotkey, network-wide, across every subnet (#2549). Sourced from a separate, lower-frequency full-chain scan than the rest of this artifact -- null when that table has no row for this hotkey yet, never fabricated as 0."
+          },
           "avg_validator_trust": { "type": ["number", "null"] },
           "max_validator_trust": { "type": ["number", "null"] },
           "captured_at": { "type": ["string", "null"], "format": "date-time" },

--- a/scripts/fetch-validator-nominator-counts.py
+++ b/scripts/fetch-validator-nominator-counts.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""First-party validator nominator-count fetcher (#2549) — chain-direct via the
+Bittensor SDK's raw substrate interface (not get_all_metagraphs_info(), which
+carries per-UID stake/trust/emission but no nominator-side data at all).
+
+Scope and the reason this is its OWN script, not folded into
+fetch-metagraph-native.py: a validator's nominator count is "how many distinct
+coldkeys currently hold a nonzero stake position on this hotkey, across every
+subnet" — that information lives in SubtensorModule::Alpha, a triple-key
+(hotkey, coldkey, netuid) -> shares map with NO way to query "just the entries
+for hotkey X" in bulk cheaper than iterating a hotkey-prefixed range, and no
+network-wide "count distinct coldkeys per hotkey" RPC exists either. The only
+correct approach is a SINGLE full scan of the map, accumulating a
+hotkey -> set(coldkey) dict in memory, then counting each set's size.
+
+Empirically measured live against the fullnode, 2026-07-14 (bittensor SDK,
+same pinned version this container ships): a full scan via
+query_map(page_size=1000) at a sustained ~3000-3100 rows/sec completed in
+249s (~4.2 min), covering 762,577 total Alpha rows and converging on 112,552
+distinct hotkeys holding any nonzero stake network-wide (max single-hotkey
+nominator count observed: 7266). That's short enough to run daily, but still
+far more than the ~30-60s refresh-metagraph cron budget can absorb alongside
+its existing work -- this runs on its own, separate lower-frequency cadence
+(daily is comfortable; weekly is also fine if the source data doesn't need
+to be fresher than that) with a generous timeout headroom over the observed
+~4-5 minutes.
+
+Deliberately does NOT filter to only currently-known validator-permit
+hotkeys: doing so would need a second RPC round trip (a metagraph fetch) to
+know the validator set in advance, adding complexity and a cross-referencing
+step to a script whose dominant cost and risk is already the scan duration
+itself. This script instead emits a nominator_count row for every hotkey it
+encounters with at least one nonzero stake relationship (validator or not);
+the API-side join (buildGlobalValidators) only looks up rows for hotkeys it
+already knows are validators, so a row here for a hotkey without validator
+status is simply unused, not incorrect.
+
+Run: uv run --with bittensor python scripts/fetch-validator-nominator-counts.py
+"""
+import argparse
+import json
+import os
+import sys
+import time
+
+OUT = os.environ.get(
+    "VALIDATOR_NOMINATOR_COUNTS_JSON",
+    "dist/validator-nominator-counts.json",
+)
+# query_map's own page size, not this script's row cap -- kept as a named
+# constant since it's the one knob likely to need tuning against RPC latency
+# on a real full scan (smaller = more round trips, larger = bigger responses).
+PAGE_SIZE = 1000
+PROGRESS_INTERVAL_S = 30
+
+
+def _unpack_key(key):
+    """substrate-interface sometimes wraps a decoded NMap key in a ScaleType
+    with a `.value` attribute and sometimes hands back the plain decoded
+    tuple directly, depending on version/call path (live-verified both shapes
+    against the installed SDK, 2026-07-14) -- never assume either alone."""
+    return key.value if hasattr(key, "value") else key
+
+
+def main():
+    import bittensor as bt  # lazy: matches every other chain-direct fetch
+    # script's convention (fetch-events.py / fetch-metagraph-native.py /
+    # fetch-account-identity.py) -- keeps this module loadable without the
+    # heavy SDK installed.
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--network", default=os.environ.get("SUBTENSOR_RPC_URL") or "finney"
+    )
+    args = parser.parse_args()
+
+    s = bt.SubtensorApi(network=args.network)
+
+    t0 = time.time()
+    last_report = t0
+    row_count = 0
+    nominators = {}  # hotkey (ss58 str) -> set of coldkey (ss58 str) values holding stake on it
+    for key, _value in s.substrate.query_map(
+        "SubtensorModule", "Alpha", page_size=PAGE_SIZE
+    ):
+        row_count += 1
+        hotkey, coldkey, _netuid = _unpack_key(key)
+        hotkey, coldkey = str(hotkey), str(coldkey)
+        nominators.setdefault(hotkey, set()).add(coldkey)
+        now = time.time()
+        if now - last_report >= PROGRESS_INTERVAL_S:
+            sys.stderr.write(
+                f"fetch-validator-nominator-counts: {row_count} Alpha rows, "
+                f"{len(nominators)} distinct hotkeys, {now - t0:.0f}s elapsed\n"
+            )
+            last_report = now
+
+    captured_at = int(time.time() * 1000)
+    rows = [
+        {
+            "hotkey": hotkey,
+            "nominator_count": len(coldkeys),
+            "captured_at": captured_at,
+        }
+        for hotkey, coldkeys in nominators.items()
+    ]
+
+    os.makedirs(os.path.dirname(OUT) or ".", exist_ok=True)
+    with open(OUT, "w") as fh:
+        json.dump(rows, fh)
+    sys.stderr.write(
+        f"fetch-validator-nominator-counts: wrote {len(rows)} hotkey row(s) "
+        f"from {row_count} Alpha entries in {time.time() - t0:.0f}s -> {OUT}\n"
+    )
+    if not rows:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -273,7 +273,11 @@ function coldkeyIdentity(coldkey, identityByColdkey) {
   return identity;
 }
 
-function buildGlobalValidatorEntry(entry, identityByColdkey) {
+function buildGlobalValidatorEntry(
+  entry,
+  identityByColdkey,
+  nominatorCounts = new Map(),
+) {
   const avgTrust =
     entry.validatorTrustCount > 0
       ? entry.validatorTrustTotal / entry.validatorTrustCount
@@ -311,6 +315,12 @@ function buildGlobalValidatorEntry(entry, identityByColdkey) {
     root_stake_tao: roundTao(raoBigToTao(rootStakeRao)),
     alpha_stake_tao: roundTao(raoBigToTao(alphaStakeRao)),
     total_emission_tao: roundTao(raoBigToTao(entry.emissionTotalRao)),
+    // #2549: from the separate validator_nominator_counts side table, joined
+    // by hotkey. Null when that table has no row for this hotkey yet (cold
+    // table, or a hotkey the last low-frequency scan hasn't covered) --
+    // never fabricated as 0, which would misreport "confirmed zero
+    // nominators" as opposed to "unknown."
+    nominator_count: nominatorCounts.get(entry.hotkey) ?? null,
     avg_validator_trust: round(avgTrust),
     max_validator_trust: round(entry.maxValidatorTrust),
     latest_captured_at: toIso(entry.latestCapturedAt),
@@ -348,6 +358,12 @@ export function buildGlobalValidators(
     limit = GLOBAL_VALIDATOR_LIMIT_DEFAULT,
     featuredHotkeys = new Set(),
     identityByColdkey = new Map(),
+    // hotkey -> nominator_count (#2549), sourced from the separate
+    // validator_nominator_counts side table -- see that migration's own
+    // comment for why this can't be a neurons-tier column. A cold/absent
+    // map (e.g. the D1-retired fallback below, which never has one) leaves
+    // every entry's nominator_count null, never throws.
+    nominatorCounts = new Map(),
   } = {},
 ) {
   const normalizedSort = GLOBAL_VALIDATOR_SORTS.includes(sort)
@@ -459,7 +475,7 @@ export function buildGlobalValidators(
     // index arg never lands in buildGlobalValidatorEntry's identityByColdkey
     // parameter -- same landmine formatNeuron's own header comment documents.
     [...validatorsByHotkey.values()].map((entry) =>
-      buildGlobalValidatorEntry(entry, identityByColdkey),
+      buildGlobalValidatorEntry(entry, identityByColdkey, nominatorCounts),
     ),
   ).sort(
     (a, b) =>
@@ -598,7 +614,14 @@ export async function loadNeuron(d1, netuid, uid) {
 export function buildValidatorDetail(
   rows,
   hotkey,
-  { identityByColdkey = new Map() } = {},
+  {
+    identityByColdkey = new Map(),
+    // #2549: from the separate validator_nominator_counts side table (looked
+    // up by the caller, since this function has no DB access of its own).
+    // Null when that table has no row for this hotkey yet -- never fabricated
+    // as 0.
+    nominatorCount = null,
+  } = {},
 ) {
   const coldkeys = new Map();
   let stakeTotalRao = 0n;
@@ -678,6 +701,7 @@ export function buildValidatorDetail(
     root_stake_tao: roundTao(raoBigToTao(rootStakeRao)),
     alpha_stake_tao: roundTao(raoBigToTao(stakeTotalRao - rootStakeRao)),
     total_emission_tao: roundTao(raoBigToTao(emissionTotalRao)),
+    nominator_count: nominatorCount,
     avg_validator_trust: round(avgTrust),
     max_validator_trust: round(maxValidatorTrust),
     captured_at: toIso(latestCapturedAt),

--- a/src/validator-nominator-summary.mjs
+++ b/src/validator-nominator-summary.mjs
@@ -1,0 +1,34 @@
+// Nominator counts per validator hotkey (#2549) -- one row per hotkey, latest
+// only, refreshed by its own low-frequency job (scripts/fetch-validator-
+// nominator-counts.py, see migrations/0043_validator_nominator_counts.sql for
+// why this is a separate side table rather than a neurons column). Read/join
+// lands here; the fetch/sync write path lives in workers/data-api.mjs
+// (handleValidatorNominatorCountsSync), mirroring account-identity.mjs's role
+// for its own sync handler.
+
+export const VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS = [
+  "hotkey",
+  "nominator_count",
+  "captured_at",
+];
+
+// hotkey -> { nominator_count, captured_at } lookup built from a Postgres
+// query result, for joining into buildGlobalValidators/buildValidatorDetail
+// at serve time. Null-safe on a cold/absent table (returns an empty Map, so
+// every join lookup misses and nominator_count serves as null -- never
+// throws, mirrors overlayFeaturedValidators' cold-safety).
+export function nominatorCountsByHotkey(rows) {
+  const map = new Map();
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const hotkey = typeof row?.hotkey === "string" ? row.hotkey : null;
+    if (!hotkey) continue;
+    // Guard null/undefined explicitly before the Number() coercion below --
+    // Number(null) is 0, so a missing count would otherwise silently pass as
+    // a confirmed "zero nominators" instead of being skipped as unknown.
+    if (row?.nominator_count == null) continue;
+    const count = Number(row.nominator_count);
+    if (!Number.isInteger(count) || count < 0) continue;
+    map.set(hotkey, count);
+  }
+  return map;
+}

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -59,6 +59,12 @@ const subnetHyperparamsLatestHashes = vi.hoisted(() => ({ current: [] }));
 // has no purge step (see handleAccountIdentitySync's own header comment).
 const accountIdentitySyncFailure = vi.hoisted(() => ({ error: null }));
 const accountIdentityLatestHashes = vi.hoisted(() => ({ current: [] }));
+// State for the validator-nominator-counts-sync write route's tests only
+// (#2549). No prune/history hooks -- a single latest-only upsert, like
+// health-checks-sync below, not a diff-and-append table.
+const validatorNominatorCountsSyncFailure = vi.hoisted(() => ({
+  error: null,
+}));
 // State for the subnet-identity-sync write route's tests only (#4832
 // gap-closure). No prune-rows hook -- like account_identity, this table has
 // no purge step. Its "latest hash per netuid" query shares subnet_hyperparams'
@@ -86,6 +92,14 @@ const featuredValidatorsQueryFailure = vi.hoisted(() => ({ error: null }));
 // shifts any existing validators test's mockQueue-ordering assumptions.
 const accountIdentityJoinRows = vi.hoisted(() => ({ current: [] }));
 const accountIdentityJoinQueryFailure = vi.hoisted(() => ({ error: null }));
+// State for the validator_nominator_counts READ (#2549) tests only -- same
+// isolation purpose as featuredValidatorsQueryFailure above, but for the
+// SELECT loadValidatorNominatorCounts issues (distinct from
+// validatorNominatorCountsSyncFailure, which only matches the sync route's
+// own INSERT).
+const validatorNominatorCountsQueryFailure = vi.hoisted(() => ({
+  error: null,
+}));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -155,6 +169,12 @@ vi.mock("postgres", () => ({
         return Promise.reject(accountIdentitySyncFailure.error);
       }
       if (
+        validatorNominatorCountsSyncFailure.error &&
+        /INSERT INTO validator_nominator_counts\b/.test(text)
+      ) {
+        return Promise.reject(validatorNominatorCountsSyncFailure.error);
+      }
+      if (
         subnetSnapshotSyncFailure.error &&
         /INSERT INTO subnet_snapshots\b/.test(text)
       ) {
@@ -183,6 +203,12 @@ vi.mock("postgres", () => ({
         /FROM featured_validators\b/.test(text)
       ) {
         return Promise.reject(featuredValidatorsQueryFailure.error);
+      }
+      if (
+        validatorNominatorCountsQueryFailure.error &&
+        /FROM validator_nominator_counts\b/.test(text)
+      ) {
+        return Promise.reject(validatorNominatorCountsQueryFailure.error);
       }
       if (
         healthUptimeRollupSyncFailure.error &&
@@ -273,6 +299,8 @@ const NEURON_DAILY_BACKFILL_SECRET = "test-neuron-daily-backfill-secret";
 const ROLLUP_SYNC_SECRET = "test-rollup-sync-secret";
 const SUBNET_HYPERPARAMS_SYNC_SECRET = "test-subnet-hyperparams-sync-secret";
 const ACCOUNT_IDENTITY_SYNC_SECRET = "test-account-identity-sync-secret";
+const VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET =
+  "test-validator-nominator-counts-sync-secret";
 const SUBNET_IDENTITY_SYNC_SECRET = "test-subnet-identity-sync-secret";
 const HEALTH_CHECKS_SYNC_SECRET = "test-health-checks-sync-secret";
 const SUBNET_SNAPSHOT_SYNC_SECRET = "test-subnet-snapshot-sync-secret";
@@ -284,6 +312,7 @@ const env = {
   ROLLUP_SYNC_SECRET,
   SUBNET_HYPERPARAMS_SYNC_SECRET,
   ACCOUNT_IDENTITY_SYNC_SECRET,
+  VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET,
   SUBNET_IDENTITY_SYNC_SECRET,
   HEALTH_CHECKS_SYNC_SECRET,
   SUBNET_SNAPSHOT_SYNC_SECRET,
@@ -307,6 +336,8 @@ beforeEach(() => {
   subnetHyperparamsLatestHashes.current = [];
   accountIdentitySyncFailure.error = null;
   accountIdentityLatestHashes.current = [];
+  validatorNominatorCountsSyncFailure.error = null;
+  validatorNominatorCountsQueryFailure.error = null;
   subnetIdentitySyncFailure.error = null;
   subnetIdentityLatestHashes.current = [];
   healthChecksSyncFailure.error = null;
@@ -1615,6 +1646,73 @@ test("GET /api/v1/validators/:hotkey for an absent hotkey has coldkey_identity:n
   expect(body.coldkey).toBe(null);
   expect(body.coldkey_identity).toBe(null);
   expect(queryText()).not.toMatch(/FROM account_identity WHERE account IN/);
+});
+
+test("GET /api/v1/validators joins nominator_count by hotkey from validator_nominator_counts (#2549)", async () => {
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [
+      {
+        netuid: 1,
+        uid: 0,
+        hotkey: "hk-a",
+        coldkey: "ck-a",
+        validator_trust: "0.5",
+        emission_tao: "1",
+        stake_tao: "100",
+        block_number: "10",
+        captured_at: "1780000000000",
+      },
+      {
+        netuid: 2,
+        uid: 0,
+        hotkey: "hk-b",
+        coldkey: "ck-b",
+        validator_trust: "0.9",
+        emission_tao: "5",
+        stake_tao: "9000",
+        block_number: "10",
+        captured_at: "1780000000000",
+      },
+    ],
+    [], // loadFeaturedHotkeys
+    [{ hotkey: "hk-a", nominator_count: 17 }],
+  ];
+  const res = await req("/api/v1/validators");
+  const body = await res.json();
+  expect(queryText()).toMatch(/FROM validator_nominator_counts/);
+  const byHotkey = Object.fromEntries(
+    body.validators.map((v) => [v.hotkey, v.nominator_count]),
+  );
+  expect(byHotkey["hk-a"]).toBe(17);
+  expect(byHotkey["hk-b"]).toBe(null);
+});
+
+test("GET /api/v1/validators still serves the primary rows when the validator_nominator_counts read fails", async () => {
+  validatorNominatorCountsQueryFailure.error = new Error(
+    'relation "validator_nominator_counts" does not exist',
+  );
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [{ ...NEURON_ROW, netuid: 7, hotkey: "5Hot" }],
+    [], // loadFeaturedHotkeys
+  ];
+  const res = await req("/api/v1/validators");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.validators[0].hotkey).toBe("5Hot");
+  expect(body.validators[0].nominator_count).toBe(null);
+});
+
+test("GET /api/v1/validators/:hotkey joins nominator_count from validator_nominator_counts (#2549)", async () => {
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [{ ...NEURON_ROW, hotkey: "5Hot", netuid: 7 }],
+    [{ hotkey: "5Hot", nominator_count: 9 }],
+  ];
+  const res = await req("/api/v1/validators/5Hot");
+  const body = await res.json();
+  expect(body.nominator_count).toBe(9);
 });
 
 // #4832 Tier 2: the live-`neurons` routes with no shared D1 loader (the
@@ -4012,6 +4110,203 @@ test("account-identity-sync maps a DB failure to a clean 502 instead of throwing
   const res = await postAccountIdentity([accountIdentitySyncRow()], {
     secret: ACCOUNT_IDENTITY_SYNC_SECRET,
   });
+  expect(res.status).toBe(502);
+  expect((await res.json()).error).toBe("write failed");
+});
+
+// #2549: POST /api/v1/internal/validator-nominator-counts-sync -- the write
+// path into validator_nominator_counts (see workers/data-api.mjs's
+// handleValidatorNominatorCountsSync). Simpler than account-identity-sync
+// above: latest-only upsert, no history/hash-diff table.
+function validatorNominatorCountRow(overrides = {}) {
+  return {
+    hotkey: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+    nominator_count: 42,
+    captured_at: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+function postValidatorNominatorCounts(body, { secret, raw } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret !== undefined)
+    headers["x-validator-nominator-counts-sync-token"] = secret;
+  return req("/api/v1/internal/validator-nominator-counts-sync", {
+    method: "POST",
+    headers,
+    body: raw !== undefined ? raw : JSON.stringify(body ?? []),
+  });
+}
+
+test("validator-nominator-counts-sync rejects a missing or wrong token (401)", async () => {
+  const wrong = await postValidatorNominatorCounts(
+    [validatorNominatorCountRow()],
+    { secret: "wrong" },
+  );
+  expect(wrong.status).toBe(401);
+  const missing = await postValidatorNominatorCounts([
+    validatorNominatorCountRow(),
+  ]);
+  expect(missing.status).toBe(401);
+});
+
+test("validator-nominator-counts-sync is disabled (503) when VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET is not configured", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/validator-nominator-counts-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-validator-nominator-counts-sync-token":
+          VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET,
+      },
+      body: JSON.stringify([validatorNominatorCountRow()]),
+    }),
+    { HYPERDRIVE: { connectionString: "postgres://mock" } },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("validator-nominator-counts-sync returns 503 when the HYPERDRIVE binding is unavailable", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/validator-nominator-counts-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-validator-nominator-counts-sync-token":
+          VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET,
+      },
+      body: JSON.stringify([validatorNominatorCountRow()]),
+    }),
+    { VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("validator-nominator-counts-sync rejects a body over the byte cap (413)", async () => {
+  const res = await postValidatorNominatorCounts(null, {
+    secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET,
+    raw: "[" + "1".repeat(100_000_001) + "]",
+  });
+  expect(res.status).toBe(413);
+});
+
+test("validator-nominator-counts-sync rejects malformed JSON (400)", async () => {
+  const res = await postValidatorNominatorCounts(null, {
+    secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET,
+    raw: "{not json",
+  });
+  expect(res.status).toBe(400);
+});
+
+test("validator-nominator-counts-sync rejects a body that isn't an array or {rows:[...]} (400)", async () => {
+  const res = await postValidatorNominatorCounts(
+    { not: "an array" },
+    { secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("validator-nominator-counts-sync accepts the {rows:[...]} wrapped form, not just a bare array", async () => {
+  const res = await postValidatorNominatorCounts(
+    { rows: [validatorNominatorCountRow()] },
+    { secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.validator_nominator_counts_written).toBe(1);
+});
+
+test("validator-nominator-counts-sync rejects more than the row cap (413)", async () => {
+  // MAX_ROWS is 1,000,000 (headroom above the real ~112k-hotkey scan, see
+  // migrations/0043_validator_nominator_counts.sql) -- building/serializing
+  // a cap+1 array this large routinely exceeds vitest's 5s default, unlike
+  // the other sync endpoints' much smaller caps (e.g. account-identity's
+  // 20,000), so this one test gets a raised timeout.
+  const many = Array.from({ length: 1_000_001 }, (_, i) => ({
+    hotkey: `5X${i}`,
+    nominator_count: 0,
+    captured_at: 1_780_000_000_000,
+  }));
+  const res = await postValidatorNominatorCounts(many, {
+    secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(413);
+}, 15_000);
+
+test("validator-nominator-counts-sync rejects a row with a missing/empty hotkey (400)", async () => {
+  const res = await postValidatorNominatorCounts(
+    [validatorNominatorCountRow({ hotkey: "" })],
+    { secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("validator-nominator-counts-sync rejects a non-object row (400)", async () => {
+  const res = await postValidatorNominatorCounts(["not-an-object"], {
+    secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(400);
+});
+
+test("validator-nominator-counts-sync rejects a row carrying an unknown column (400)", async () => {
+  const res = await postValidatorNominatorCounts(
+    [validatorNominatorCountRow({ unexpected_field: "nope" })],
+    { secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("validator-nominator-counts-sync rejects a negative or non-integer nominator_count (400)", async () => {
+  const negative = await postValidatorNominatorCounts(
+    [validatorNominatorCountRow({ nominator_count: -1 })],
+    { secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET },
+  );
+  expect(negative.status).toBe(400);
+  const fractional = await postValidatorNominatorCounts(
+    [validatorNominatorCountRow({ nominator_count: 1.5 })],
+    { secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET },
+  );
+  expect(fractional.status).toBe(400);
+});
+
+test("validator-nominator-counts-sync rejects a row missing a finite captured_at (400)", async () => {
+  const res = await postValidatorNominatorCounts(
+    [validatorNominatorCountRow({ captured_at: "not-a-number" })],
+    { secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(400);
+});
+
+test("validator-nominator-counts-sync rejects an empty array (400)", async () => {
+  const res = await postValidatorNominatorCounts([], {
+    secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(400);
+});
+
+test("validator-nominator-counts-sync writes a batch and reports the count written", async () => {
+  const rows = [
+    validatorNominatorCountRow({ hotkey: "5Hk1", nominator_count: 5 }),
+    validatorNominatorCountRow({ hotkey: "5Hk2", nominator_count: 0 }),
+  ];
+  const res = await postValidatorNominatorCounts(rows, {
+    secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, validator_nominator_counts_written: 2 });
+  expect(queryText()).toMatch(/INSERT INTO validator_nominator_counts/);
+  expect(queryText()).toMatch(/ON CONFLICT \(hotkey\) DO UPDATE SET/);
+});
+
+test("validator-nominator-counts-sync maps a DB failure to a clean 502 instead of throwing", async () => {
+  validatorNominatorCountsSyncFailure.error = new Error("connection reset");
+  const res = await postValidatorNominatorCounts(
+    [validatorNominatorCountRow()],
+    { secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET },
+  );
   expect(res.status).toBe(502);
   expect((await res.json()).error).toBe("write failed");
 });

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -42,7 +42,7 @@ const NEURON_CSV_HEADER =
 const MOVERS_CSV_HEADER =
   "netuid,stake_start_tao,stake_end_tao,stake_delta_tao,stake_pct_change,emission_start_tao,emission_end_tao,emission_delta_tao,emission_pct_change,validators_start,validators_end,validators_delta,neurons_start,neurons_end,neurons_delta";
 const GLOBAL_VALIDATOR_CSV_HEADER =
-  "hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,root_stake_tao,alpha_stake_tao,total_emission_tao,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets";
+  "hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,root_stake_tao,alpha_stake_tao,total_emission_tao,nominator_count,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets";
 
 describe("metagraph-neurons builders", () => {
   test("formatNeuron coerces 0/1 INTEGER flags to real booleans", () => {
@@ -513,6 +513,27 @@ describe("metagraph-neurons builders", () => {
     assert.equal(entry.alpha_stake_tao, 99.5); // 50.25 + 49.25, exact
   });
 
+  test("buildGlobalValidators joins nominator_count by hotkey, nulls a hotkey with no row (#2549)", () => {
+    const data = buildGlobalValidators(
+      [
+        { ...ROW, netuid: 1, uid: 0, hotkey: "hk-known" },
+        { ...ROW, netuid: 1, uid: 1, hotkey: "hk-unknown" },
+      ],
+      { nominatorCounts: new Map([["hk-known", 42]]) },
+    );
+    const known = data.validators.find((v) => v.hotkey === "hk-known");
+    const unknown = data.validators.find((v) => v.hotkey === "hk-unknown");
+    assert.equal(known.nominator_count, 42);
+    assert.equal(unknown.nominator_count, null);
+  });
+
+  test("buildGlobalValidators defaults nominator_count to null on every entry when no map is passed", () => {
+    const data = buildGlobalValidators([
+      { ...ROW, netuid: 1, uid: 0, hotkey: "hk-a" },
+    ]);
+    assert.equal(data.validators[0].nominator_count, null);
+  });
+
   test("buildGlobalValidators takes the first non-null take per hotkey and ignores later rows (#2548)", () => {
     const data = buildGlobalValidators([
       { ...ROW, netuid: 1, uid: 0, hotkey: "hk-a", take: 0.18 },
@@ -834,6 +855,21 @@ describe("metagraph-neurons builders", () => {
     assert.equal(data.alpha_stake_tao, 99.5); // 50.25 + 49.25, exact
   });
 
+  test("buildValidatorDetail passes through the given nominatorCount option (#2549)", () => {
+    const withCount = buildValidatorDetail(
+      [{ ...ROW, netuid: 1, uid: 0, hotkey: "hk-a" }],
+      "hk-a",
+      { nominatorCount: 17 },
+    );
+    assert.equal(withCount.nominator_count, 17);
+
+    const withoutCount = buildValidatorDetail(
+      [{ ...ROW, netuid: 1, uid: 0, hotkey: "hk-a" }],
+      "hk-a",
+    );
+    assert.equal(withoutCount.nominator_count, null);
+  });
+
   test("buildValidatorDetail: a null latest block_number is beaten by a real one on a captured_at tie, and a null incoming block_number never wins one", () => {
     const data = buildValidatorDetail(
       [
@@ -876,6 +912,7 @@ describe("metagraph-neurons builders", () => {
     assert.equal(empty.root_stake_tao, 0);
     assert.equal(empty.alpha_stake_tao, 0);
     assert.equal(empty.total_emission_tao, 0);
+    assert.equal(empty.nominator_count, null);
     assert.equal(empty.avg_validator_trust, null);
     assert.equal(empty.max_validator_trust, null);
     assert.equal(empty.captured_at, null);

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -914,6 +914,7 @@ describe("handleGlobalValidators", () => {
       root_stake_tao: 0,
       alpha_stake_tao: 0,
       total_emission_tao: 0,
+      nominator_count: null,
       stake_dominance: null,
       avg_validator_trust: null,
       max_validator_trust: null,

--- a/tests/validator-nominator-summary.test.mjs
+++ b/tests/validator-nominator-summary.test.mjs
@@ -1,0 +1,60 @@
+import { describe, test } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS,
+  nominatorCountsByHotkey,
+} from "../src/validator-nominator-summary.mjs";
+
+describe("nominatorCountsByHotkey", () => {
+  test("builds a hotkey -> nominator_count Map from rows", () => {
+    const map = nominatorCountsByHotkey([
+      { hotkey: "5Hk1", nominator_count: 42, captured_at: 1_700_000_000_000 },
+      { hotkey: "5Hk2", nominator_count: 0, captured_at: 1_700_000_000_000 },
+    ]);
+    assert.equal(map.get("5Hk1"), 42);
+    assert.equal(map.get("5Hk2"), 0);
+    assert.equal(map.size, 2);
+  });
+
+  test("is cold-safe for non-array/empty input", () => {
+    assert.equal(nominatorCountsByHotkey(null).size, 0);
+    assert.equal(nominatorCountsByHotkey(undefined).size, 0);
+    assert.equal(nominatorCountsByHotkey([]).size, 0);
+    assert.equal(nominatorCountsByHotkey("not-an-array").size, 0);
+  });
+
+  test("skips a row with a missing/blank hotkey", () => {
+    const map = nominatorCountsByHotkey([
+      { hotkey: "", nominator_count: 5 },
+      { hotkey: null, nominator_count: 5 },
+      { nominator_count: 5 },
+    ]);
+    assert.equal(map.size, 0);
+  });
+
+  test("skips a row with a non-integer or negative nominator_count", () => {
+    const map = nominatorCountsByHotkey([
+      { hotkey: "5Hk1", nominator_count: -1 },
+      { hotkey: "5Hk2", nominator_count: 1.5 },
+      { hotkey: "5Hk3", nominator_count: "abc" },
+      { hotkey: "5Hk4", nominator_count: null },
+    ]);
+    assert.equal(map.size, 0);
+  });
+
+  test("skips a malformed (non-object) row", () => {
+    const map = nominatorCountsByHotkey([null, undefined, "row", 42]);
+    assert.equal(map.size, 0);
+  });
+});
+
+describe("VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS", () => {
+  test("is the exact three-column shape the migration/sync endpoint expect", () => {
+    assert.deepEqual(VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS, [
+      "hotkey",
+      "nominator_count",
+      "captured_at",
+    ]);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -917,6 +917,19 @@ async function handleAccountIdentitySyncProxy(request, env) {
   });
 }
 
+// Proxies POST /api/v1/internal/validator-nominator-counts-sync -- the write
+// path into validator_nominator_counts (#2549). Same DATA_API service
+// binding as the other internal sync routes above.
+async function handleValidatorNominatorCountsSyncProxy(request, env) {
+  return proxyToDataApi(request, env, {
+    code: "validator_nominator_counts_sync_unavailable",
+    notBoundMessage:
+      "The validator-nominator-counts sync tier is not bound to this deployment.",
+    unreadableMessage:
+      "The validator-nominator-counts sync tier returned an unreadable response.",
+  });
+}
+
 // GET /api/v1/chain/stream (#4982, ADR 0015) -- the public realtime firehose
 // transport. SSE by default; a WebSocket Upgrade header on this same path
 // gets the WS transport instead. No auth: this is the same public read-only
@@ -1129,6 +1142,13 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // this the same way. Same DATA_API service binding.
   if (url.pathname === "/api/v1/internal/account-identity-sync") {
     return handleAccountIdentitySyncProxy(request, env);
+  }
+  // The write path into validator_nominator_counts (#2549) --
+  // refresh-validator-nominator-counts's own low-frequency cron calls this,
+  // decoupled from refresh-metagraph.yml (see migrations/0043's own comment
+  // for why). Same DATA_API service binding.
+  if (url.pathname === "/api/v1/internal/validator-nominator-counts-sync") {
+    return handleValidatorNominatorCountsSyncProxy(request, env);
   }
   // The write path the #4981 box-side relay POSTs #4980's NOTIFY payloads to
   // (#4982, ADR 0015) -- forwards into ChainFirehoseHub after its own

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -303,6 +303,10 @@ import {
   buildAccountIdentity,
 } from "../src/account-identity.mjs";
 import {
+  VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS,
+  nominatorCountsByHotkey,
+} from "../src/validator-nominator-summary.mjs";
+import {
   identityHash,
   buildAccountIdentityHistory,
 } from "../src/account-identity-history.mjs";
@@ -1554,6 +1558,139 @@ async function handleAccountIdentitySync(request, env) {
   }
 }
 
+// --- POST /api/v1/internal/validator-nominator-counts-sync (#2549) --------
+//
+// The write path into validator_nominator_counts (migration 0043) --
+// simpler than account-identity-sync above: latest-only, no history table
+// (a nominator count is a live gauge, not a fact worth diffing over time
+// yet). Populated by its own low-frequency job
+// (scripts/fetch-validator-nominator-counts.py), decoupled from the fast
+// refresh-metagraph cron -- see that script's and the migration's own header
+// comments for why a full SubtensorModule::Alpha scan can't share the
+// neurons snapshot's cadence.
+const VALIDATOR_NOMINATOR_COUNTS_SYNC_TOKEN_HEADER =
+  "x-validator-nominator-counts-sync-token";
+// A ceiling on distinct hotkeys ever seen holding stake, NOT on
+// validator-permit hotkeys (~1-2k) -- this table isn't validator-scoped by
+// design (see the fetch script). A live full-scan probe 2026-07-14 found
+// 112,552 distinct hotkeys network-wide; these caps sit at roughly 9x that
+// observed figure as headroom for network growth, not a tight bound.
+const VALIDATOR_NOMINATOR_COUNTS_SYNC_MAX_BODY_BYTES = 100_000_000;
+const VALIDATOR_NOMINATOR_COUNTS_SYNC_MAX_ROWS = 1_000_000;
+
+function validValidatorNominatorCountsSyncRow(row) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
+  if (typeof row.hotkey !== "string" || row.hotkey.length === 0) return false;
+  if (!Number.isInteger(row.nominator_count) || row.nominator_count < 0)
+    return false;
+  if (!Number.isFinite(row.captured_at)) return false;
+  for (const key of Object.keys(row)) {
+    if (!VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS.includes(key)) return false;
+  }
+  return true;
+}
+
+async function handleValidatorNominatorCountsSync(request, env) {
+  if (!env.VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET) {
+    return writeJson(
+      {
+        error:
+          "validator-nominator-counts sync is not provisioned on this deployment",
+      },
+      503,
+    );
+  }
+  const provided =
+    request.headers.get(VALIDATOR_NOMINATOR_COUNTS_SYNC_TOKEN_HEADER) || "";
+  if (
+    !provided ||
+    !timingSafeEqual(provided, env.VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET)
+  ) {
+    return writeJson(
+      {
+        error: `provide a valid ${VALIDATOR_NOMINATOR_COUNTS_SYNC_TOKEN_HEADER} header`,
+      },
+      401,
+    );
+  }
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
+  }
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > VALIDATOR_NOMINATOR_COUNTS_SYNC_MAX_BODY_BYTES) {
+    return writeJson(
+      {
+        error: `body exceeds ${VALIDATOR_NOMINATOR_COUNTS_SYNC_MAX_BODY_BYTES} bytes`,
+      },
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const incoming = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.rows)
+      ? parsed.rows
+      : null;
+  if (!incoming) {
+    return writeJson(
+      {
+        error:
+          "body must be a JSON array of validator-nominator-count rows (or {rows:[...]})",
+      },
+      400,
+    );
+  }
+  if (incoming.length > VALIDATOR_NOMINATOR_COUNTS_SYNC_MAX_ROWS) {
+    return writeJson(
+      {
+        error: `at most ${VALIDATOR_NOMINATOR_COUNTS_SYNC_MAX_ROWS} rows per request`,
+      },
+      413,
+    );
+  }
+  if (
+    !incoming.length ||
+    !incoming.every(validValidatorNominatorCountsSyncRow)
+  ) {
+    return writeJson(
+      { error: "rows must match the validator-nominator-count row shape" },
+      400,
+    );
+  }
+
+  const sql = postgres(env.HYPERDRIVE.connectionString, {
+    max: 5,
+    prepare: false,
+    fetch_types: false,
+  });
+
+  try {
+    await sql`SET statement_timeout = '20000ms'`;
+    await sql`
+      INSERT INTO validator_nominator_counts ${sql(incoming, ...VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS)}
+      ON CONFLICT (hotkey) DO UPDATE SET
+        nominator_count = EXCLUDED.nominator_count,
+        captured_at = EXCLUDED.captured_at
+      WHERE validator_nominator_counts.captured_at <= EXCLUDED.captured_at`;
+    return writeJson({
+      ok: true,
+      validator_nominator_counts_written: incoming.length,
+    });
+  } catch (err) {
+    console.error(
+      "data-api validator-nominator-counts-sync write failed:",
+      err,
+    );
+    return writeJson({ error: "write failed" }, 502);
+  }
+}
+
 // --- POST /api/v1/internal/subnet-identity-sync (#4832 gap-closure) -------
 //
 // The write path into subnet_identity_history -- architecturally different
@@ -2358,6 +2495,24 @@ function distinctColdkeys(rows) {
   return [...seen];
 }
 
+// Same savepoint-isolated-failure shape as loadFeaturedHotkeys above (#2549):
+// a validator_nominator_counts read failure degrades the whole
+// /api/v1/validators response to nominator_count: null everywhere rather
+// than failing the request or rolling back the enclosing transaction's other
+// queries.
+async function loadValidatorNominatorCounts(sql) {
+  try {
+    const rows = await sql.savepoint(
+      (sql) =>
+        sql`SELECT hotkey, nominator_count FROM validator_nominator_counts`,
+    );
+    return nominatorCountsByHotkey(rows);
+  } catch (err) {
+    console.error("validator_nominator_counts query failed:", err);
+    return new Map();
+  }
+}
+
 function clampLimit(raw) {
   const n = Number(raw);
   if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
@@ -2864,6 +3019,12 @@ export default {
       url.pathname === "/api/v1/internal/account-identity-sync"
     ) {
       return handleAccountIdentitySync(request, env);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/validator-nominator-counts-sync"
+    ) {
+      return handleValidatorNominatorCountsSync(request, env);
     }
     if (
       request.method === "POST" &&
@@ -5749,12 +5910,13 @@ export default {
             limitParam <= GLOBAL_VALIDATOR_LIMIT_MAX
               ? limitParam
               : GLOBAL_VALIDATOR_LIMIT_DEFAULT;
-          const [rows, featuredHotkeys] = await Promise.all([
+          const [rows, featuredHotkeys, nominatorCounts] = await Promise.all([
             sql`
           SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, stake_tao, block_number, captured_at, take
           FROM neurons WHERE validator_permit = TRUE AND hotkey IS NOT NULL
           ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`,
             loadFeaturedHotkeys(sql),
+            loadValidatorNominatorCounts(sql),
           ]);
           // Identity join (#5234): needs `rows` resolved first to know which
           // coldkeys to look up, so it can't join the Promise.all above.
@@ -5768,6 +5930,7 @@ export default {
               limit,
               featuredHotkeys,
               identityByColdkey,
+              nominatorCounts,
             }),
           );
         }
@@ -5779,17 +5942,23 @@ export default {
         );
         if (validatorDetail) {
           const hotkey = decodeURIComponent(validatorDetail[1]);
-          const rows = await sql`
+          const [rows, nominatorCounts] = await Promise.all([
+            sql`
           SELECT uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at, take, netuid
           FROM neurons WHERE hotkey = ${hotkey} AND validator_permit = TRUE
-          ORDER BY netuid ASC, uid ASC`;
+          ORDER BY netuid ASC, uid ASC`,
+            loadValidatorNominatorCounts(sql),
+          ]);
           // Identity join (#5234): see the /api/v1/validators comment above.
           const identityByColdkey = await loadAccountIdentitiesByColdkey(
             sql,
             distinctColdkeys(rows),
           );
           return json(
-            buildValidatorDetail(rows, hotkey, { identityByColdkey }),
+            buildValidatorDetail(rows, hotkey, {
+              identityByColdkey,
+              nominatorCount: nominatorCounts.get(hotkey) ?? null,
+            }),
           );
         }
 

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -302,6 +302,7 @@ const GLOBAL_VALIDATOR_CSV_COLUMNS = [
   "root_stake_tao",
   "alpha_stake_tao",
   "total_emission_tao",
+  "nominator_count",
   "stake_dominance",
   "avg_validator_trust",
   "max_validator_trust",


### PR DESCRIPTION
## Summary
- Closes #2549
- New chain-direct fetch (`scripts/fetch-validator-nominator-counts.py`): a full scan of `SubtensorModule::Alpha` (the only source for per-hotkey nominator counts — there's no cheaper "count distinct coldkeys per hotkey" RPC), accumulating a `hotkey -> set(coldkey)` map and emitting one row per hotkey. Empirically measured live against the fullnode: 762,577 total Alpha rows, 112,552 distinct hotkeys, full scan in ~249s (~4.2 min) at ~3000-3100 rows/sec — comfortable for a daily/weekly cadence, but far more than the existing ~30-60s refresh-metagraph cron budget can absorb, so this runs as its own separate lower-frequency job (activating the systemd timer on the actual infra box is a follow-up, out of scope here).
- New `validator_nominator_counts` side table (`migrations/0043_validator_nominator_counts.sql`) rather than a `neurons` column — see that migration's header comment for why (same reasoning as the existing `featured_validators`/`account_identity` side tables: this data has its own refresh cadence and shouldn't gate the primary neurons snapshot).
- New sync endpoint `POST /api/v1/internal/validator-nominator-counts-sync` (mirrors `account-identity-sync`'s shape) + proxy route in `workers/api.mjs`.
- `nominator_count` joined into `buildGlobalValidatorEntry`/`buildValidatorDetail` by hotkey, read via a new `loadValidatorNominatorCounts` (savepoint-isolated, same resilience pattern as `loadFeaturedHotkeys` — a read failure degrades to `nominator_count: null` everywhere, never breaks the route or poisons the transaction). **Null, never fabricated 0**, when a hotkey hasn't been captured yet.
- Exposed in `/api/v1/validators`, `/api/v1/validators/:hotkey`, the OpenAPI/schema/generated-client contract, and the `?format=csv` export.
- UI: adds a "Nominators" column to the validators directory table, plus a glossary entry in the "how to evaluate a validator" guide explaining the lower-frequency-scan lag (a `—` means not yet captured, not zero nominators).

## Screenshots

| Before | After (live prod API — backend not deployed yet, so every row shows the not-yet-captured placeholder) |
| --- | --- |
| No "Nominators" column; no glossary entry for it | New "NOMINATORS" column between UIDs and Dominance, showing `—` for every row (correct: the sync job hasn't populated `validator_nominator_counts` in production yet) — plus a new "Nominators" entry in the evaluation guide explaining what it means and why it can lag |

## Test plan
- `npx vitest run` — 271 files, 7858 tests passing, including new coverage for `nominatorCountsByHotkey` (with a regression test for a null-coercion bug caught during development — `Number(null)` is `0`, which would have silently reported "confirmed zero nominators" for an uncaptured hotkey), the sync endpoint (token/size/row-cap/shape validation, DB-failure→502), and the join at both the builder level (`buildGlobalValidators`/`buildValidatorDetail`) and the route level (including a graceful-degradation test for a `validator_nominator_counts` read failure)
- `npm run lint` / `npm run format:check` — clean
- `npm run validate` / `npm run validate:contract-drift` — clean
- `npm run scan:public-safety` — clean (two real findings caught in my own new script's comments — "validator hotkey" and bare "coldkey" wording — fixed by rephrasing, not by loosening the scanner)
- `cd apps/ui && npx tsc --noEmit` — clean (rebuilt `packages/client`'s gitignored type declarations locally to pick up the schema change)
- Verified visually in the browser against the local dev server hitting the live prod API — see screenshot table above
- Rebased onto `main` after #5262 (identity join) landed on the same routes/files; merged both features together (`identityByColdkey` + `nominatorCounts` now both flow through `buildGlobalValidatorEntry`/`buildValidatorDetail`) and re-ran the full suite clean post-rebase
- `packages/client` patch-bumped 0.15.6 → 0.15.7 (contract change) per the pre-push client-SDK-sync guard