### PR TITLE
feat(ui): wire interactive window/sort controls into the movers band

### DIFF
--- a/apps/ui/src/components/metagraphed/movers-band.tsx
+++ b/apps/ui/src/components/metagraphed/movers-band.tsx
@@ -1,7 +1,26 @@
+import { useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { subnetMoversQuery } from "@/lib/metagraphed/queries";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { SelectFilter } from "@/components/metagraphed/table-controls";
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { SubnetMover } from "@/lib/metagraphed/types";
+
+const WINDOWS = [
+  { value: "7d", label: "7d" },
+  { value: "30d", label: "30d" },
+  { value: "90d", label: "90d" },
+] as const;
+type MoversWindow = (typeof WINDOWS)[number]["value"];
+
+const SORTS = [
+  { value: "stake", label: "Stake" },
+  { value: "emission", label: "Emission" },
+  { value: "validators", label: "Validators" },
+  { value: "neurons", label: "Neurons" },
+] as const;
+type MoversSort = (typeof SORTS)[number]["value"];
 
 // Signed TAO delta: taoCompact already carries a leading minus for negatives and
 // renders an em-dash for null/non-finite, so we only prepend "+" for gains.
@@ -9,32 +28,80 @@ function signedTao(delta: number): string {
   return `${delta >= 0 ? "+" : ""}${taoCompact(delta)} τ`;
 }
 
+function signedCount(delta: number): string {
+  return `${delta >= 0 ? "+" : ""}${formatNumber(delta)}`;
+}
+
+// The active sort dimension's own delta (and, for stake only, a pct-change
+// figure — the only dimension the API's normalizer carries one for).
+function moverDelta(m: SubnetMover, sort: MoversSort) {
+  switch (sort) {
+    case "stake":
+      return {
+        delta: m.stake_delta_tao,
+        pct: m.stake_pct_change,
+        formatted: signedTao(m.stake_delta_tao),
+      };
+    case "emission":
+      return { delta: m.emission_delta_tao, pct: null, formatted: signedTao(m.emission_delta_tao) };
+    case "validators":
+      return { delta: m.validators_delta, pct: null, formatted: signedCount(m.validators_delta) };
+    case "neurons":
+      return { delta: m.neurons_delta, pct: null, formatted: signedCount(m.neurons_delta) };
+  }
+}
+
 /**
  * #3344: cross-subnet biggest-movers band for the Home page — the top subnets by
- * stake change over the endpoint's default 30d window, each linking to its detail
- * page. Ships with the endpoint defaults (window=30d, sort=stake); interactive
- * window/sort controls are a deliberate follow-up. Renders nothing when the
- * board is empty (cold store / single snapshot).
+ * the selected sort dimension's change over the selected window, each linking to
+ * its detail page. Window (7d/30d/90d) and sort (stake/emission/validators/
+ * neurons) default to the endpoint's own defaults (30d/stake) and are
+ * user-adjustable, wired straight into the same /api/v1/subnets/movers params
+ * the sibling subnets-index page uses. Renders nothing when the board is empty
+ * (cold store / single snapshot).
  */
 export function MoversBand() {
-  const res = useSuspenseQuery(subnetMoversQuery()).data;
+  const [window, setWindow] = useState<MoversWindow>("30d");
+  const [sort, setSort] = useState<MoversSort>("stake");
+  const res = useSuspenseQuery(subnetMoversQuery({ window, sort })).data;
   const movers = res.data.movers.slice(0, 10);
   const network = res.data.network;
 
   if (movers.length === 0) return null;
 
+  const sortLabel = SORTS.find((s) => s.value === sort)?.label ?? "Stake";
+
   return (
     <section className="mt-section-gap">
-      <div className="mb-4">
-        <h2 className="font-display text-lg font-semibold text-ink-strong">Biggest movers</h2>
-        <p className="font-mono text-[11px] text-ink-muted">
-          Subnets by stake change · {res.data.window} window
-          {network ? ` · ${network.gainers} up · ${network.losers} down` : ""}
-        </p>
+      <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="font-display text-lg font-semibold text-ink-strong">Biggest movers</h2>
+          <p className="font-mono text-[11px] text-ink-muted">
+            Subnets by {sortLabel.toLowerCase()} change · {res.data.window} window
+            {network ? ` · ${network.gainers} up · ${network.losers} down` : ""}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <SelectFilter
+            label="Sort"
+            value={sort}
+            onChange={(v) => setSort(v as MoversSort)}
+            options={[...SORTS]}
+            allowEmpty={false}
+          />
+          <SelectFilter
+            label="Window"
+            value={window}
+            onChange={(v) => setWindow(v as MoversWindow)}
+            options={[...WINDOWS]}
+            allowEmpty={false}
+          />
+        </div>
       </div>
       <ul className="grid gap-1.5 sm:grid-cols-2">
         {movers.map((m, i) => {
-          const up = m.stake_delta_tao >= 0;
+          const { delta, pct, formatted } = moverDelta(m, sort);
+          const up = delta >= 0;
           return (
             <li key={m.netuid}>
               <Link
@@ -51,8 +118,8 @@ export function MoversBand() {
                       : "font-mono text-[11px] tabular-nums text-health-down"
                   }
                 >
-                  {signedTao(m.stake_delta_tao)}
-                  {m.stake_pct_change != null ? ` (${m.stake_pct_change.toFixed(1)}%)` : ""}
+                  {formatted}
+                  {pct != null ? ` (${pct.toFixed(1)}%)` : ""}
                 </span>
               </Link>
             </li>


### PR DESCRIPTION
## Summary
- Wires the follow-up `movers-band.tsx`'s own comment promised: interactive **window** (7d/30d/90d) and **sort** (stake/emission/validators/neurons) controls for the Home page's "Biggest movers" band.
- Backend was already complete — `GET /api/v1/subnets/movers` has supported both `?window=` and `?sort=` params since #4832, and every mover row already carries all four dimensions' deltas. Only the frontend never wired the controls in.
- Reuses the existing `SelectFilter` control from `table-controls.tsx` — the same pattern already used for this exact window/sort combo in `validator-nominators-table.tsx` — rather than inventing a new control.
- Each row's delta display now reflects the active sort dimension (stake/emission in TAO, validators/neurons as a signed count) instead of always showing stake.
- Verified functionally (not just visually): switching Sort→Emission and Window→7d live re-queries the endpoint and updates both the subtitle ("Subnets by emission change · 7d window · ...") and the row ordering/values correctly.

## Screenshots

| Viewport · Theme | Before | After |
| ---- | ---- | ---- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/movers-after-mobile-dark.png)<br><sub>after</sub> |

## Validation run
- `npx eslint` / `npx prettier --check` on the touched file
- `npx tsc --noEmit` (no new errors; 3 pre-existing unrelated errors on `main` confirmed via a clean baseline branch)
- `npm run build` (apps/ui production build succeeds)
- Manual functional verification via Playwright: switching Sort/Window live re-queries and updates the UI correctly

Closes #5278