### PR TITLE
feat(mcp): add get_subnet_stake_quote parity tool for the stake-quote endpoint

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "1.78.4",
+  "version": "1.79.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -461,6 +461,7 @@ import {
   DEFAULT_STAKE_FLOW_DIRECTION,
 } from "./stake-flow.mjs";
 import { buildAccountStakeFlow } from "./account-stake-flow.mjs";
+import { computeStakeQuote, STAKE_QUOTE_DIRECTIONS } from "./stake-quote.mjs";
 import {
   buildAccountStakeMoves,
   ACCOUNT_STAKE_MOVES_WINDOWS,
@@ -575,7 +576,7 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - change or remove a tool's I/O       → MAJOR
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
-export const MCP_SERVER_VERSION = "1.78.4";
+export const MCP_SERVER_VERSION = "1.79.0";
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -703,6 +704,8 @@ export const MCP_INSTRUCTIONS =
   "(base URL, auth, schema, health) for one subnet. For on-chain economics and " +
   "participation, get_subnet_economics returns a subnet's registration cost, " +
   "open slots, and alpha price, " +
+  "get_subnet_stake_quote a read-only constant-product slippage/price-impact " +
+  "estimate for staking or unstaking a given amount against its AMM pool, " +
   GET_ECONOMICS_INSTRUCTIONS +
   "get_economics_trends the network-wide " +
   "per-day economics series (stake, alpha price, validator/miner counts), " +
@@ -4753,6 +4756,73 @@ export const MCP_TOOLS = [
           ? netEconomics.economics.alpha_market_cap_tao
           : null;
       return buildAlphaVolume([], netuid, { marketCapTao });
+    },
+  },
+  {
+    name: "get_subnet_stake_quote",
+    title: "Get a subnet stake/unstake slippage quote",
+    description:
+      "Fetch a read-only constant-product slippage/price-impact quote for " +
+      "staking or unstaking a given amount against one subnet's AMM pool: the " +
+      "expected alpha/TAO out, spot vs effective price (TAO per alpha), and " +
+      "price-impact percent for a swap of ?amount in ?direction=stake|unstake " +
+      "(default stake). Pure math against the live economics-tier pool reserves " +
+      "(tao_in_pool_tao, alpha_in_pool) — no chain write, no custody — mirroring " +
+      "the chain's own constant-product swap and its InsufficientLiquidity " +
+      "guard (an amount over 1000x the relevant reserve is rejected). The root " +
+      "subnet (netuid 0) has no AMM and returns a 1:1, zero-impact quote. " +
+      "Mirrors GET /api/v1/subnets/{netuid}/stake-quote.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        amount: {
+          type: "number",
+          exclusiveMinimum: 0,
+          description:
+            "Swap size: TAO to stake (direction=stake) or alpha to unstake " +
+            "(direction=unstake).",
+        },
+        direction: {
+          type: "string",
+          enum: STAKE_QUOTE_DIRECTIONS,
+          description:
+            "Swap side: stake (TAO -> alpha) or unstake (alpha -> TAO). " +
+            "Default stake.",
+        },
+      },
+      required: ["netuid", "amount"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const direction = optionalString(args, "direction") ?? "stake";
+      // Root (netuid 0) has no AMM pool, so skip the economics lookup and let
+      // computeStakeQuote return its 1:1 short-circuit; every other subnet pulls
+      // its live pool reserves off the economics tier the way get_subnet_economics
+      // does. computeStakeQuote is the same pure-math authority the REST route
+      // uses — it validates amount/direction and pool liquidity in one place, so
+      // the tool stays parity with GET /subnets/{netuid}/stake-quote.
+      const economics =
+        netuid === 0
+          ? null
+          : (await loadSubnetEconomics(ctx, netuid)).economics;
+      const result = computeStakeQuote({
+        netuid,
+        taoInPool: economics?.tao_in_pool_tao,
+        alphaInPool: economics?.alpha_in_pool,
+        amount: args?.amount,
+        direction,
+      });
+      if (!result.ok) {
+        // Its 400s are argument problems (invalid_params in MCP terms); its 422
+        // is a valid request the pool can't fill — surface that domain code.
+        throw toolError(
+          result.status === 400 ? "invalid_params" : result.code,
+          result.error,
+        );
+      }
+      return { schema_version: 1, ...result.quote };
     },
   },
   {
@@ -10295,6 +10365,31 @@ const TOOL_OUTPUT_SCHEMAS = {
       sentiment_ratio: { type: ["number", "null"] },
       sentiment: NULLABLE_STRING,
       vol_mcap_ratio: { type: ["number", "null"] },
+    },
+  },
+  get_subnet_stake_quote: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "netuid",
+      "direction",
+      "amount",
+      "expected_out",
+      "expected_out_unit",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      direction: { type: "string" },
+      amount: { type: "number" },
+      expected_out: { type: "number" },
+      expected_out_unit: { type: "string" },
+      spot_price_tao: { type: "number" },
+      effective_price_tao: { type: "number" },
+      price_impact_pct: { type: "number" },
+      tao_in_pool_tao: { type: ["number", "null"] },
+      alpha_in_pool: { type: ["number", "null"] },
+      is_root: { type: "boolean" },
     },
   },
   get_subnet_recycled: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -7416,6 +7416,94 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(res.body.result.structuredContent.source, "r2-fallback");
   });
 
+  // A pool with a round 1000 TAO / 5000 alpha reserve → spot 0.2 TAO/alpha, so
+  // the stake-quote math below lands on tidy, hand-checkable numbers.
+  const QUOTE_BLOB = {
+    schema_version: 1,
+    captured_at: FRESH_RUN,
+    summary: { with_economics_count: 1, subnet_count: 1 },
+    subnets: [{ netuid: 7, tao_in_pool_tao: 1000, alpha_in_pool: 5000 }],
+  };
+
+  test("get_subnet_stake_quote prices a stake against the pool reserves", async () => {
+    const res = await callTool(
+      "get_subnet_stake_quote",
+      { netuid: 7, amount: 100 },
+      { deps: makeDeps({ "/metagraph/economics.json": QUOTE_BLOB }, {}) },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.netuid, 7);
+    assert.equal(out.direction, "stake"); // defaults to stake
+    assert.equal(out.expected_out_unit, "alpha");
+    assert.equal(out.is_root, false);
+    // alpha_out = 5000·100/(1000+100) = 454.5454…; impact = |0.22-0.2|/0.2 = 10%.
+    assert.ok(Math.abs(out.expected_out - 454.545454) < 1e-4);
+    assert.ok(Math.abs(out.spot_price_tao - 0.2) < 1e-9);
+    assert.ok(Math.abs(out.price_impact_pct - 10) < 1e-6);
+  });
+
+  test("get_subnet_stake_quote prices an unstake in the mirror direction", async () => {
+    const res = await callTool(
+      "get_subnet_stake_quote",
+      { netuid: 7, amount: 100, direction: "unstake" },
+      { deps: makeDeps({ "/metagraph/economics.json": QUOTE_BLOB }, {}) },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.direction, "unstake");
+    assert.equal(out.expected_out_unit, "tao");
+    // tao_out = 1000·100/(5000+100) = 19.6078…
+    assert.ok(Math.abs(out.expected_out - 19.607843) < 1e-4);
+  });
+
+  test("get_subnet_stake_quote treats the root subnet as 1:1 zero-impact", async () => {
+    const res = await callTool(
+      "get_subnet_stake_quote",
+      { netuid: 0, amount: 25 },
+      { deps: makeDeps() },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.is_root, true);
+    assert.equal(out.expected_out, 25);
+    assert.equal(out.price_impact_pct, 0);
+  });
+
+  test("get_subnet_stake_quote rejects an unsupported direction", async () => {
+    const res = await callTool(
+      "get_subnet_stake_quote",
+      { netuid: 7, amount: 100, direction: "sideways" },
+      { deps: makeDeps({ "/metagraph/economics.json": QUOTE_BLOB }, {}) },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /direction` must be one of/);
+  });
+
+  test("get_subnet_stake_quote rejects a non-positive amount", async () => {
+    const res = await callTool(
+      "get_subnet_stake_quote",
+      { netuid: 7, amount: 0 },
+      { deps: makeDeps({ "/metagraph/economics.json": QUOTE_BLOB }, {}) },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /greater than 0/);
+  });
+
+  test("get_subnet_stake_quote surfaces insufficient liquidity for a pool-less subnet", async () => {
+    const res = await callTool(
+      "get_subnet_stake_quote",
+      { netuid: 7, amount: 100 },
+      // Economics row present but carrying no AMM reserves → 422 domain error.
+      {
+        deps: makeDeps(
+          { "/metagraph/economics.json": { subnets: [{ netuid: 7 }] } },
+          {},
+        ),
+      },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /no AMM pool liquidity/);
+  });
+
   test("get_subnet_economics returns economics:null for a subnet with no row", async () => {
     const res = await callTool(
       "get_subnet_economics",


### PR DESCRIPTION
## Summary

Adds a read-only `get_subnet_stake_quote` MCP tool mirroring the REST route
`GET /api/v1/subnets/{netuid}/stake-quote` (#5261), closing the last MCP
feature-parity gap left after #5255. It reuses the endpoint's existing pure-math
authority (`computeStakeQuote` in `src/stake-quote.mjs`) — the tool only resolves
the subnet's live AMM pool reserves off the economics tier (the same way
`get_subnet_economics` does) and forwards them, so it stays byte-parity with the
route's spot/effective price, expected out, and price-impact output.

This is a **read-only** tool — pure constant-product slippage math, no chain
write, no custody, no transaction building — consistent with the MCP-scope policy
being formalized in #5252 (reads stay in; tx-building stays out for v1).

- New tool `get_subnet_stake_quote(netuid, amount, direction=stake|unstake)`:
  expected alpha/TAO out, spot vs effective price (TAO per alpha), and
  price-impact percent. Root subnet (netuid 0) → 1:1 zero-impact quote with no
  economics lookup; a pool that can't fill the swap → the route's 422
  `insufficient_liquidity` domain error; bad amount/direction → `invalid_params`.
- Declares an `outputSchema`, lists the tool in `MCP_INSTRUCTIONS`, and bumps
  `MCP_SERVER_VERSION` + `server.json` to 1.79.0 (additive tool → MINOR).
- Tests: stake pricing, unstake mirror, root 1:1, invalid direction, non-positive
  amount, and insufficient-liquidity, all against the economics-tier fixture.

## Validation

- `npm run validate:mcp` — passes (166 tools, lifecycle + tools/call round trip)
- `npx vitest run tests/mcp-server.test.mjs` — 778/778 pass
- `eslint` + `prettier --check` clean on all touched files

Refs #5252
Refs #5229
