### PR TITLE
fix(ui): reword About "what this is not" to a precise non-custodial distinction (#5248)

### DIFF
--- a/apps/ui/src/routes/about.tsx
+++ b/apps/ui/src/routes/about.tsx
@@ -24,7 +24,7 @@ export const Route = createFileRoute("/about")({
       {
         name: "description",
         content:
-          "Methodology, scope boundaries, and contribution model for the Metagraphed Bittensor registry.",
+          "Methodology, scope, and contribution model for Metagraphed — the unofficial Bittensor explorer and integration registry.",
       },
     ],
   }),
@@ -37,7 +37,7 @@ function AboutPage() {
       <PageHero
         eyebrow="About"
         title="Methodology & scope"
-        description="Metagraphed extends the native Bittensor metagraph with public-interface and health metadata. Unofficial — not a block explorer."
+        description="An unofficial, public explorer and integration registry for Bittensor — blocks, subnets, validators, and accounts alongside the public interfaces each subnet exposes, all machine-readable for developers and AI agents."
         actions={
           <a
             href={GITHUB_REPO}
@@ -54,20 +54,25 @@ function AboutPage() {
         <div className="space-y-8 min-w-0">
           <Section title="What this is">
             <p>
-              A builder-facing public registry and explorer for Bittensor subnets: APIs, OpenAPI
-              schemas, docs, repos, dashboards, data artifacts, SSE streams, endpoint health, schema
-              drift, freshness, source evidence, providers, and curation gaps. Adapted for the
-              heterogeneous, app-layer shape of Bittensor subnets.
+              An unofficial, public explorer and integration registry for Bittensor. The explorer
+              reads chain-direct data — blocks, subnets, validators, and accounts — with endpoint
+              health, schema drift, and freshness. The registry maps every public interface a subnet
+              exposes — APIs, OpenAPI schemas, docs, repos, SSE streams, data artifacts, and
+              providers — with source evidence and the curation gaps still to fill. Everything is
+              machine-readable, served over REST, GraphQL, and MCP for developers and AI agents
+              alike.
             </p>
           </Section>
           <Section title="What this is not">
             <ul className="list-disc pl-5 space-y-1.5">
-              <li>Not a block explorer, validator dashboard, or operator console.</li>
+              <li>
+                Not an OpenTensor or Bittensor Foundation product — an independent, unofficial
+                project.
+              </li>
               <li>
                 Not a custodial wallet or exchange — non-custodial by design: your keys and funds
                 never leave your own wallet, and any signing stays local, never on our servers.
               </li>
-              <li>Not an OpenTensor/Bittensor product. Unofficial registry only.</li>
               <li>No private keys, PATs, or token-gated data are ever requested or displayed.</li>
               <li>Endpoint pool eligibility is metadata only — proxy routing is future-scoped.</li>
             </ul>
@@ -112,13 +117,26 @@ function AboutPage() {
           </Section>
           <Section title="API & artifacts">
             <p className="mb-3">
-              JSON Schema is canonical. OpenAPI and TypeScript clients are projections. Every public
-              list and detail view is reachable via the API or as a static artifact.
+              JSON Schema is canonical; OpenAPI and the typed clients are projections of it. Every
+              public list and detail view is reachable over REST, GraphQL, and MCP — or as a static
+              JSON artifact — so a human, a script, or an agent all read the same data.
             </p>
             <div className="space-y-2">
               <CopyableCode
-                label="API"
+                label="REST"
                 value={`${API_BASE}/api/v1`}
+                truncate={false}
+                className="w-full"
+              />
+              <CopyableCode
+                label="GraphQL"
+                value={`${API_BASE}/api/v1/graphql`}
+                truncate={false}
+                className="w-full"
+              />
+              <CopyableCode
+                label="MCP"
+                value={`${API_BASE}/mcp`}
                 truncate={false}
                 className="w-full"
               />

--- a/apps/ui/src/routes/about.tsx
+++ b/apps/ui/src/routes/about.tsx
@@ -62,7 +62,11 @@ function AboutPage() {
           </Section>
           <Section title="What this is not">
             <ul className="list-disc pl-5 space-y-1.5">
-              <li>Not a block explorer, wallet app, validator dashboard, or operator console.</li>
+              <li>Not a block explorer, validator dashboard, or operator console.</li>
+              <li>
+                Not a custodial wallet or exchange — non-custodial by design: your keys and funds
+                never leave your own wallet, and any signing stays local, never on our servers.
+              </li>
               <li>Not an OpenTensor/Bittensor product. Unofficial registry only.</li>
               <li>No private keys, PATs, or token-gated data are ever requested or displayed.</li>
               <li>Endpoint pool eligibility is metadata only — proxy routing is future-scoped.</li>


### PR DESCRIPTION
## Summary
The About page's scope boundaries had gone stale: it claimed metagraphed is **"not a block explorer"** and **"not a validator dashboard"** — both now false (metagraph.sh has Blocks, Validators, Accounts, and more). Per review, this is a full accuracy pass over the page.

## Change (`apps/ui/src/routes/about.tsx`, copy-only)
- **Hero + "What this is"** — reframed from a subnet-only registry to what it is today: an unofficial public **explorer *and* integration registry** (blocks, subnets, validators, accounts) that's **machine-readable over REST, GraphQL, and MCP** for developers and AI agents.
- **"What this is not"** — dropped the now-false *"not a block explorer, wallet app, validator dashboard, or operator console"* bullet; kept the accurate boundaries: unofficial (not an OpenTensor/Foundation product), **non-custodial** (keys/funds never leave your wallet, signing stays local), never asks for secrets, and endpoint-pool routing is future-scoped.
- **"API & artifacts"** — surface the **GraphQL** and **MCP** endpoints, not just REST.
- **Curation / coverage levels** and the contribution model were verified against the code and left unchanged (still accurate).

## Verification
- `typecheck` / `test` (685) / `build` (apps/ui) — pass
- `eslint` on the changed file (LF-normalized) — 0 errors

## Screenshots
Before = the current (stale) page; After = the corrected page.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5248/v2/after-mobile-dark.png)<br><sub>after</sub> |

Closes #5248
