### PR TITLE
fix(api): lossless rao-precision string for network-wide total_stake_tao

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.economics-trends.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.economics-trends.test.ts
@@ -135,6 +135,30 @@ describe("economicsTrendsQuery", () => {
     });
   });
 
+  it("normalizes total_stake_tao when the API sends the new lossless rao-precision string (#2924)", async () => {
+    // The network-wide sum already exceeds a JSON number's exact-double
+    // ceiling (~9,007,199 TAO at rao precision), so the wire contract now
+    // sends a fixed 9-decimal string instead of a number -- confirm the
+    // existing defensive coercion (already tolerant of D1 numeric-string
+    // cells) parses it into a display-ready number with no code change.
+    resolveWith({
+      window: "30d",
+      day_count: 1,
+      days: [
+        {
+          snapshot_date: "2026-07-08",
+          subnet_count: 129,
+          total_stake_tao: "327838334.635978317",
+        },
+      ],
+    });
+    const res = await runQuery("30d");
+    // Number(...) here too, not a source literal -- the same 18-significant-
+    // digit value would trip eslint's no-loss-of-precision if written out,
+    // which is exactly the class of bug #2924 exists to avoid on the wire.
+    expect(res.data.days[0].total_stake_tao).toBe(Number("327838334.635978317"));
+  });
+
   it("caps the rendered rows at 31 days", async () => {
     resolveWith({
       day_count: 60,

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4536,7 +4536,8 @@ export interface components {
                 registration_open_count: number;
                 subnet_count: number;
                 total_miners: number;
-                total_stake_tao: number;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding. */
+                total_stake_tao: string;
                 total_validators: number;
                 with_economics_count: number;
             };
@@ -4558,7 +4559,8 @@ export interface components {
             miner_count?: number | null;
             snapshot_date: string;
             subnet_count: number;
-            total_stake_tao?: number | null;
+            /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide daily total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding. Null only when no subnet reported a value that day. */
+            total_stake_tao?: string | null;
             validator_count?: number | null;
         };
         EndpointIncident: {
@@ -15987,7 +15989,7 @@ export interface operations {
                      *           "registration_open_count": 1,
                      *           "subnet_count": 1,
                      *           "total_miners": 1,
-                     *           "total_stake_tao": 0.5,
+                     *           "total_stake_tao": "327838334.635978200",
                      *           "total_validators": 1,
                      *           "with_economics_count": 1
                      *         }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -7998,8 +7998,9 @@
                     "type": "integer"
                   },
                   "total_stake_tao": {
-                    "minimum": 0,
-                    "type": "number"
+                    "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
                   },
                   "total_validators": {
                     "minimum": 0,
@@ -8099,9 +8100,15 @@
             "type": "integer"
           },
           "total_stake_tao": {
-            "type": [
-              "number",
-              "null"
+            "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide daily total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding. Null only when no subnet reported a value that day.",
+            "oneOf": [
+              {
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "validator_count": {
@@ -32620,7 +32627,7 @@
                       "registration_open_count": 1,
                       "subnet_count": 1,
                       "total_miners": 1,
-                      "total_stake_tao": 0.5,
+                      "total_stake_tao": "327838334.635978200",
                       "total_validators": 1,
                       "with_economics_count": 1
                     }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4536,7 +4536,8 @@ export interface components {
                 registration_open_count: number;
                 subnet_count: number;
                 total_miners: number;
-                total_stake_tao: number;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding. */
+                total_stake_tao: string;
                 total_validators: number;
                 with_economics_count: number;
             };
@@ -4558,7 +4559,8 @@ export interface components {
             miner_count?: number | null;
             snapshot_date: string;
             subnet_count: number;
-            total_stake_tao?: number | null;
+            /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide daily total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding. Null only when no subnet reported a value that day. */
+            total_stake_tao?: string | null;
             validator_count?: number | null;
         };
         EndpointIncident: {
@@ -15987,7 +15989,7 @@ export interface operations {
                      *           "registration_open_count": 1,
                      *           "subnet_count": 1,
                      *           "total_miners": 1,
-                     *           "total_stake_tao": 0.5,
+                     *           "total_stake_tao": "327838334.635978200",
                      *           "total_validators": 1,
                      *           "with_economics_count": 1
                      *         }

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -7984,8 +7984,9 @@
                     "type": "integer"
                   },
                   "total_stake_tao": {
-                    "minimum": 0,
-                    "type": "number"
+                    "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
                   },
                   "total_validators": {
                     "minimum": 0,
@@ -8085,9 +8086,15 @@
             "type": "integer"
           },
           "total_stake_tao": {
-            "type": [
-              "number",
-              "null"
+            "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide daily total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding. Null only when no subnet reported a value that day.",
+            "oneOf": [
+              {
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "validator_count": {

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1377,7 +1377,11 @@
                 "properties": {
                   "subnet_count": { "type": "integer", "minimum": 0 },
                   "with_economics_count": { "type": "integer", "minimum": 0 },
-                  "total_stake_tao": { "type": "number", "minimum": 0 },
+                  "total_stake_tao": {
+                    "type": "string",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding."
+                  },
                   "total_validators": { "type": "integer", "minimum": 0 },
                   "total_miners": { "type": "integer", "minimum": 0 },
                   "registration_open_count": { "type": "integer", "minimum": 0 }
@@ -2447,7 +2451,13 @@
         "properties": {
           "snapshot_date": { "type": "string" },
           "subnet_count": { "type": "integer", "minimum": 0 },
-          "total_stake_tao": { "type": ["number", "null"] },
+          "total_stake_tao": {
+            "oneOf": [
+              { "type": "string", "pattern": "^\\d+\\.\\d{9}$" },
+              { "type": "null" }
+            ],
+            "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide daily total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding. Null only when no subnet reported a value that day."
+          },
           "alpha_price_tao_weighted": { "type": ["number", "null"] },
           "alpha_price_tao_median": { "type": ["number", "null"] },
           "validator_count": { "type": ["integer", "null"] },

--- a/scripts/lib/economics-artifacts.mjs
+++ b/scripts/lib/economics-artifacts.mjs
@@ -59,6 +59,33 @@ export function computeAlphaFdvTao(alphaPriceTao) {
   return alphaPriceTao * ALPHA_MAX_SUPPLY;
 }
 
+const RAO_PER_TAO = 1_000_000_000n;
+
+// Sum a per-subnet TAO field in exact rao-integer BigInt space, not float
+// space (#2924): summing ~130 subnets' already-large total_stake_tao values
+// with plain `+=` compounds float error, and the network-wide total is
+// already well past 2^53-1's exact-double ceiling (~9,007,199 TAO at rao
+// precision) -- confirmed live 2026-07-14 at ~328M TAO, 36x over. Formats as
+// a fixed 9-decimal (rao-precision) string, never a JS number, so neither
+// the summation nor the JSON serialization loses precision. Mirrors the
+// toRaoBig/raoBigToTao pattern used for per-entity sums elsewhere (e.g.
+// src/chain-yield.mjs), extended to a string output since -- unlike those
+// per-entity totals -- this sum's magnitude is the whole reason this exists.
+function sumFieldTaoString(rows, field) {
+  let sumRao = 0n;
+  for (const row of rows) {
+    const value = row[field];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      sumRao += BigInt(Math.round(value * 1e9));
+    }
+  }
+  const negative = sumRao < 0n;
+  const abs = negative ? -sumRao : sumRao;
+  const whole = abs / RAO_PER_TAO;
+  const frac = abs % RAO_PER_TAO;
+  return `${negative ? "-" : ""}${whole}.${frac.toString().padStart(9, "0")}`;
+}
+
 export function buildEconomicsArtifact({
   subnets,
   economicsByNetuid,
@@ -134,7 +161,7 @@ export function buildEconomicsArtifact({
     summary: {
       subnet_count: subnets.length,
       with_economics_count: rows.length,
-      total_stake_tao: round(sumField("total_stake_tao"), 9),
+      total_stake_tao: sumFieldTaoString(rows, "total_stake_tao"),
       total_validators: sumField("validator_count"),
       total_miners: sumField("miner_count"),
       registration_open_count: rows.filter((row) => row.registration_allowed)

--- a/src/neuron-history.mjs
+++ b/src/neuron-history.mjs
@@ -114,7 +114,7 @@ export function buildEconomicsTrends(rows, { window, capped } = {}) {
     if (!acc) {
       acc = {
         subnet_count: 0,
-        stake_sum: 0,
+        stake_sum_rao: 0n,
         stake_seen: false,
         validator_sum: 0,
         validator_seen: false,
@@ -135,7 +135,11 @@ export function buildEconomicsTrends(rows, { window, capped } = {}) {
     const miners = toFiniteOrNull(r.miner_count);
     const emission = toFiniteOrNull(r.emission_share);
     if (stake != null) {
-      acc.stake_sum += stake;
+      // Exact rao-integer BigInt accumulation, not float (#2924): this is a
+      // network-wide sum across every reporting subnet for the day, already
+      // well past 2^53-1's exact-double ceiling (~9,007,199 TAO at rao
+      // precision) -- see raoToTaoString's own header comment below.
+      acc.stake_sum_rao += BigInt(Math.round(stake * 1e9));
       acc.stake_seen = true;
     }
     if (validators != null) {
@@ -168,7 +172,7 @@ export function buildEconomicsTrends(rows, { window, capped } = {}) {
   const days = entries.map(([snapshot_date, acc]) => ({
     snapshot_date,
     subnet_count: acc.subnet_count,
-    total_stake_tao: acc.stake_seen ? roundTao(acc.stake_sum) : null,
+    total_stake_tao: acc.stake_seen ? raoToTaoString(acc.stake_sum_rao) : null,
     alpha_price_tao_weighted:
       acc.weighted_price_den > 0
         ? roundPrice(acc.weighted_price_num / acc.weighted_price_den)
@@ -201,6 +205,24 @@ function toFiniteOrNull(v) {
 
 function roundTao(v) {
   return Math.round(v * 1e6) / 1e6;
+}
+
+const RAO_PER_TAO = 1_000_000_000n;
+
+// Exact rao-precision decimal string, never a JS number (#2924): a network-
+// wide daily total_stake_tao sum is already well past 2^53-1's exact-double
+// ceiling (~9,007,199 TAO at rao precision) -- confirmed live 2026-07-14 at
+// ~328M TAO, 36x over. A double can't hold this many significant digits at
+// full rao precision, so both the BigInt accumulation above and this string
+// formatting (instead of returning a float) are required to avoid silently
+// corrupting the value. Mirrors the identical helper in
+// scripts/lib/economics-artifacts.mjs's buildEconomicsArtifact summary.
+function raoToTaoString(rao) {
+  const negative = rao < 0n;
+  const abs = negative ? -rao : rao;
+  const whole = abs / RAO_PER_TAO;
+  const frac = abs % RAO_PER_TAO;
+  return `${negative ? "-" : ""}${whole}.${frac.toString().padStart(9, "0")}`;
 }
 // Round a TAO sum, preserving null — so an unrounded D1 SUM(stake_tao)/SUM(
 // emission_tao) never leaks accumulated float noise, while a null SUM (cold/

--- a/src/openapi-sample.mjs
+++ b/src/openapi-sample.mjs
@@ -34,6 +34,10 @@ function valueForPattern(pattern, name = "") {
       return "2026-06-01";
     case "^\\d+\\.\\d+$":
       return CURSOR2;
+    case "^\\d+\\.\\d{9}$":
+      // Lossless rao-precision TAO string (#2924) -- network-wide sums that
+      // already exceed a JSON number's exact-double ceiling.
+      return "327838334.635978200";
     case "^\\d+\\.\\d+\\.\\d+$":
       return CURSOR3;
     case "^[a-z0-9][a-z0-9-]*$":

--- a/tests/economics-artifacts.test.mjs
+++ b/tests/economics-artifacts.test.mjs
@@ -194,7 +194,7 @@ describe("buildEconomicsArtifact", () => {
     assert.deepEqual(artifact.summary, {
       subnet_count: 0,
       with_economics_count: 0,
-      total_stake_tao: 0,
+      total_stake_tao: "0.000000000",
       total_validators: 0,
       total_miners: 0,
       registration_open_count: 0,
@@ -232,7 +232,7 @@ describe("buildEconomicsArtifact", () => {
     assert.equal(row.slug, "sn-1");
     assert.equal(artifact.summary.subnet_count, 1);
     assert.equal(artifact.summary.with_economics_count, 1);
-    assert.equal(artifact.summary.total_stake_tao, 1000);
+    assert.equal(artifact.summary.total_stake_tao, "1000.000000000");
     assert.equal(artifact.summary.total_validators, 9);
     assert.equal(artifact.summary.total_miners, 200);
     assert.equal(artifact.summary.registration_open_count, 1);

--- a/tests/economics-trends-loader.test.mjs
+++ b/tests/economics-trends-loader.test.mjs
@@ -56,7 +56,7 @@ describe("loadEconomicsTrends", () => {
     assert.equal(rows.length, 1);
     assert.equal(data.window, "7d");
     assert.equal(data.day_count, 1);
-    assert.equal(data.days[0].total_stake_tao, 1000);
+    assert.equal(data.days[0].total_stake_tao, "1000.000000000");
   });
 
   test("omits the date lower bound for the all window", async () => {

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -91,7 +91,7 @@ describe("buildEconomicsArtifact", () => {
     assert.equal(out.summary.with_economics_count, 2);
     assert.equal(out.summary.total_validators, 8);
     assert.equal(out.summary.total_miners, 30);
-    assert.equal(out.summary.total_stake_tao, 400);
+    assert.equal(out.summary.total_stake_tao, "400.000000000");
     assert.equal(out.summary.registration_open_count, 1);
     assert.equal(out.network, "finney");
   });
@@ -122,7 +122,7 @@ describe("buildEconomicsArtifact", () => {
     assert.equal(out.subnets.length, 0);
     assert.equal(out.summary.with_economics_count, 0);
     assert.equal(out.summary.subnet_count, 1);
-    assert.equal(out.summary.total_stake_tao, 0);
+    assert.equal(out.summary.total_stake_tao, "0.000000000");
   });
 
   test("orders equal emission shares by netuid and ignores non-numeric stake", () => {
@@ -146,7 +146,7 @@ describe("buildEconomicsArtifact", () => {
       [2, 5],
     );
     assert.equal(out.subnets[0].emission_share, 0.5);
-    assert.equal(out.summary.total_stake_tao, 40);
+    assert.equal(out.summary.total_stake_tao, "40.000000000");
   });
 
   test("emission_share is null for every subnet when no positive alpha price exists", () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -8286,7 +8286,7 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.window, "30d");
     assert.equal(out.day_count, 2);
     assert.equal(out.days[0].snapshot_date, "2026-06-01");
-    assert.equal(out.days[1].total_stake_tao, 1000);
+    assert.equal(out.days[1].total_stake_tao, "1000.000000000");
   });
 
   test("get_economics_trends rejects an invalid window", async () => {

--- a/tests/neuron-history.test.mjs
+++ b/tests/neuron-history.test.mjs
@@ -327,7 +327,7 @@ describe("history builders", () => {
     const [recent] = out.days;
     assert.equal(recent.snapshot_date, "2026-06-02");
     assert.equal(recent.subnet_count, 2);
-    assert.equal(recent.total_stake_tao, 400);
+    assert.equal(recent.total_stake_tao, "400.000000000");
     // (0.02·300 + 0.06·100)/400 = 0.03 weighted; median([0.02,0.06]) = 0.04.
     assert.equal(recent.alpha_price_tao_weighted, 0.03);
     assert.equal(recent.alpha_price_tao_median, 0.04);
@@ -395,7 +395,7 @@ describe("history builders", () => {
     assert.equal(day.alpha_price_tao_weighted, 0.1);
     // Both prices count toward the unweighted median → median([0.1,0.5]) = 0.3.
     assert.equal(day.alpha_price_tao_median, 0.3);
-    assert.equal(day.total_stake_tao, 200);
+    assert.equal(day.total_stake_tao, "200.000000000");
     assert.equal(day.window, undefined);
   });
 
@@ -422,7 +422,7 @@ describe("history builders", () => {
     // Blank row contributes nothing: aggregates match the single real row, not
     // a 0-inflated/deflated blend.
     assert.equal(day.subnet_count, 2);
-    assert.equal(day.total_stake_tao, 200);
+    assert.equal(day.total_stake_tao, "200.000000000");
     assert.equal(day.alpha_price_tao_weighted, 0.1);
     assert.equal(day.alpha_price_tao_median, 0.1);
     assert.equal(day.validator_count, 3);

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -397,7 +397,7 @@ describe("handleEconomicsTrends", () => {
     const [recent, older] = body.data.days;
     assert.equal(recent.snapshot_date, "2026-06-02");
     assert.equal(recent.subnet_count, 2);
-    assert.equal(recent.total_stake_tao, 400);
+    assert.equal(recent.total_stake_tao, "400.000000000");
     assert.equal(recent.validator_count, 10);
     assert.equal(recent.miner_count, 60);
     // Stake-weighted mean price: (0.02·300 + 0.06·100) / 400 = 0.03.
@@ -408,7 +408,7 @@ describe("handleEconomicsTrends", () => {
     assert.equal(recent.mean_emission_share, 0.03);
     assert.equal(older.snapshot_date, "2026-06-01");
     assert.equal(older.subnet_count, 1);
-    assert.equal(older.total_stake_tao, 100);
+    assert.equal(older.total_stake_tao, "100.000000000");
   });
 
   test("nulls a metric for a day when no subnet reported it", async () => {
@@ -464,7 +464,7 @@ describe("handleEconomicsTrends", () => {
       lines[0],
       "snapshot_date,subnet_count,total_stake_tao,alpha_price_tao_weighted,alpha_price_tao_median,validator_count,miner_count,mean_emission_share",
     );
-    assert.equal(lines[1], "2026-06-02,1,300,0.02,0.02,8,50,0.04");
+    assert.equal(lines[1], "2026-06-02,1,300.000000000,0.02,0.02,8,50,0.04");
   });
 
   test("returns CSV response when Accept: text/csv header is present", async () => {
@@ -488,7 +488,7 @@ describe("handleEconomicsTrends", () => {
     assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
     const text = await res.text();
     const lines = text.split("\r\n");
-    assert.equal(lines[1], "2026-06-02,1,300,0.02,0.02,8,50,0.04");
+    assert.equal(lines[1], "2026-06-02,1,300.000000000,0.02,0.02,8,50,0.04");
   });
 
   test("returns empty/header-only CSV when rollup is cold", async () => {


### PR DESCRIPTION
## Summary

Implements #2924's own deferred "if/when triggered" recipe — the trigger condition has already been met.

- `EconomicsArtifact.summary.total_stake_tao` and `EconomicsTrendsDay.total_stake_tao` are network-wide sums of every subnet's `total_stake_tao`. As JSON numbers they're exact only up to 2^53-1 (~9,007,199 TAO at rao precision). **Confirmed live**: the current network-wide sum is ~327,838,334 TAO — 36x past that ceiling.
- Per-subnet/per-validator/per-account `total_stake_tao` fields are untouched — they never realistically approach this ceiling, matching the issue's explicit "schema change to the specific affected field(s) only" scope.
- `alpha_fdv_tao` (the other field #2924 flagged as a watch item) checked and confirmed still safe today (max ~1.37M TAO across all subnets, well under the ceiling) — not touched.
- Both aggregates now sum in exact rao-integer `BigInt` space instead of float (avoiding compounding summation error on top of the ceiling issue itself) and serialize as a fixed 9-decimal lossless decimal string, matching this repo's existing `next_cursor` precedent for values that must not go through JSON-number semantics.
- `src/openapi-sample.mjs` gets a matching example-generation case for the new `^\d+\.\d{9}$` pattern so `validate:openapi-examples` still ships a schema-valid worked example.

## Client impact

Turned out to be effectively nil, contrary to the issue's original "coordinate npm/Python SDK + metagraphed-ui" concern:
- apps/ui's `economicsQuery()` never reads `summary` at all — zero exposure.
- The trends-day normalizer's existing `coerceFiniteNumber()` already tolerates string input (the same defensive coercion this codebase already uses everywhere for D1 numeric-string cells) — so the wire-format change requires zero consumer code changes. Verified with a new test (`queries.economics-trends.test.ts`) covering the new string format end-to-end.
- GraphQL doesn't expose either field (`EconomicsList` only has the per-subnet array, no `summary`; there's no `EconomicsTrends` type at all).
- MCP's `get_economics`/`get_economics_trends` tools proxy the same generated JSON Schema contract, so they pick up the change automatically with no separate edit.
- A separately-published Python SDK (if one exists outside this monorepo) is out of reach from here — flagging as a heads-up, not a blocker, since a JSON string value is trivially safe for a dynamically-typed consumer.

## Tests

- Updated every existing assertion touching these two specific fields across `tests/economics-artifacts.test.mjs`, `tests/neuron-history.test.mjs`, `tests/economics-trends-loader.test.mjs`, `tests/request-handlers-analytics-routes.test.mjs` (including a real CSV-row value assertion), `tests/lib-helpers.test.mjs`, and `tests/mcp-server.test.mjs` — confirmed each one is genuinely the network-wide aggregate before touching it (left every per-subnet/per-validator `total_stake_tao` assertion untouched).
- New apps/ui test proving the new string wire format round-trips correctly through the existing normalizer with no code change needed.

## Validation run

- `npm run lint` / `npm run format:check`
- `npm run validate` / `validate:contract-drift` / `validate:schemas` / `validate:openapi` / `validate:openapi-examples`
- Full `npm test` (7706 tests) + targeted coverage check confirming 100% patch coverage on every new line in `scripts/lib/economics-artifacts.mjs`, `src/neuron-history.mjs`, and `src/openapi-sample.mjs`
- apps/ui: `npx tsc --noEmit` (zero new errors — 3 pre-existing unrelated errors confirmed via a clean `main` baseline), full `vitest run` (686 tests), `eslint`

Closes #2924