### PR TITLE
feat(validators): add estimated annualized yield (apy_estimate) (#2551)

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -38,6 +38,10 @@ const METRICS: Array<{ term: string; def: string }> = [
     def: "The TAO the validator earned over the window. Emission is split between the validator and its nominators via commission — it reflects reward flow, not profit.",
   },
   {
+    term: "Est. APY",
+    def: "An estimated annualized yield (#2551): projects the validator's most recently captured epoch payout across a full year, using each subnet's own epoch length. It's a snapshot-based estimate, not a forecast or a guarantee — it can swing between refreshes, especially for validators concentrated on short-epoch subnets. A dash means none of the validator's subnets have a captured epoch length yet.",
+  },
+  {
     term: "Validator trust (Sort)",
     def: "Available from the Sort control: how consistently a subnet's consensus scores the validator as trustworthy. Steadier trust points to reliable participation.",
   },

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -5367,7 +5367,8 @@ function normalizeGlobalValidator(raw: unknown): GlobalValidator | null {
     total_emission_tao: coerceFiniteNumber(raw.total_emission_tao) ?? 0,
     nominator_count: nullableNum(raw.nominator_count),
     apy_estimate: nullableNum(raw.apy_estimate),
-    apy_estimate_eligible_subnet_count: coerceFiniteNumber(raw.apy_estimate_eligible_subnet_count) ?? 0,
+    apy_estimate_eligible_subnet_count:
+      coerceFiniteNumber(raw.apy_estimate_eligible_subnet_count) ?? 0,
     avg_validator_trust: nullableNum(raw.avg_validator_trust),
     max_validator_trust: nullableNum(raw.max_validator_trust),
     stake_dominance: nullableNum(raw.stake_dominance),

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -5366,6 +5366,8 @@ function normalizeGlobalValidator(raw: unknown): GlobalValidator | null {
     total_stake_tao: coerceFiniteNumber(raw.total_stake_tao) ?? 0,
     total_emission_tao: coerceFiniteNumber(raw.total_emission_tao) ?? 0,
     nominator_count: nullableNum(raw.nominator_count),
+    apy_estimate: nullableNum(raw.apy_estimate),
+    apy_estimate_eligible_subnet_count: coerceFiniteNumber(raw.apy_estimate_eligible_subnet_count) ?? 0,
     avg_validator_trust: nullableNum(raw.avg_validator_trust),
     max_validator_trust: nullableNum(raw.max_validator_trust),
     stake_dominance: nullableNum(raw.stake_dominance),

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1993,6 +1993,10 @@ export interface GlobalValidator {
   total_emission_tao: number;
   /** Distinct coldkeys currently staking to this hotkey, network-wide (#2549). Null when the low-frequency source table has no row for this hotkey yet. */
   nominator_count: number | null;
+  /** Estimated annualized yield (#2551) — a stake-weighted blend across every subnet membership with a known tempo. See apy_estimate_eligible_subnet_count. Null when no membership resolved a tempo. */
+  apy_estimate: number | null;
+  /** Count of subnet memberships that contributed to apy_estimate, out of subnet_count total (#2551). */
+  apy_estimate_eligible_subnet_count: number;
   avg_validator_trust: number | null;
   max_validator_trust: number | null;
   stake_dominance: number | null;

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -171,6 +171,7 @@ function ValidatorsTable({
                 <th className={`${TH} text-right`}>Dominance</th>
                 <th className={`${TH} text-right`}>Total stake</th>
                 <th className={`${TH} text-right`}>Total emission</th>
+                <th className={`${TH} text-right`}>Est. APY</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
@@ -220,6 +221,9 @@ function ValidatorsTable({
                   </td>
                   <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
                     {taoCompact(v.total_emission_tao)}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {v.apy_estimate != null ? `${(v.apy_estimate * 100).toFixed(1)}%` : "—"}
                   </td>
                 </tr>
               ))}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10676,7 +10676,7 @@
     },
     "packages/client": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.15.7",
+      "version": "0.15.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "metagraphed-contract": "*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4964,6 +4964,10 @@ export interface components {
         GlobalValidatorEntry: {
             /** @description total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao. */
             alpha_stake_tao: number;
+            /** @description Estimated annualized yield (#2551): a stake-weighted, rao-exact blend of (emission_tao * (31,536,000 / (tempo_blocks * 12))) / stake_tao across every subnet membership where subnet_hyperparams.tempo is known and the membership holds positive stake. Each membership's emission_tao is a single most-recently-captured per-epoch snapshot (see total_emission_tao), not a multi-day average -- this is a naive 'if the last captured epoch's rate held for a year' projection, not a compounding forecast, and it can swing between refreshes, especially for validators concentrated on short-tempo subnets where the annualization multiplier is largest. Expressed as a decimal fraction (0.365 = 36.5%/yr). Memberships with an unresolved tempo, tempo=0, or non-positive stake are excluded from both the numerator and denominator, never defaulted. Null when apy_estimate_eligible_subnet_count is 0. */
+            apy_estimate: number | null;
+            /** @description Count of this validator's subnet memberships that contributed to apy_estimate (resolvable tempo + positive stake), out of subnet_count total (#2551). apy_estimate is null iff this is 0. */
+            apy_estimate_eligible_subnet_count: number;
             avg_validator_trust: number | null;
             coldkey: string | null;
             coldkey_count: number;
@@ -7655,6 +7659,10 @@ export interface components {
         ValidatorDetailArtifact: {
             /** @description total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao. */
             alpha_stake_tao: number;
+            /** @description Estimated annualized yield (#2551): a stake-weighted, rao-exact blend of (emission_tao * (31,536,000 / (tempo_blocks * 12))) / stake_tao across every subnet membership where subnet_hyperparams.tempo is known and the membership holds positive stake. Each membership's emission_tao is a single most-recently-captured per-epoch snapshot (see total_emission_tao), not a multi-day average -- this is a naive 'if the last captured epoch's rate held for a year' projection, not a compounding forecast, and it can swing between refreshes, especially for validators concentrated on short-tempo subnets where the annualization multiplier is largest. Expressed as a decimal fraction (0.365 = 36.5%/yr). Memberships with an unresolved tempo, tempo=0, or non-positive stake are excluded from both the numerator and denominator, never defaulted. Null when apy_estimate_eligible_subnet_count is 0. */
+            apy_estimate: number | null;
+            /** @description Count of this validator's subnet memberships that contributed to apy_estimate (resolvable tempo + positive stake), out of subnet_count total (#2551). apy_estimate is null iff this is 0. */
+            apy_estimate_eligible_subnet_count: number;
             avg_validator_trust: number | null;
             block_number: number | null;
             /** Format: date-time */
@@ -28515,6 +28523,8 @@ export interface operations {
                      *         "validators": [
                      *           {
                      *             "alpha_stake_tao": 0.5,
+                     *             "apy_estimate": 0.5,
+                     *             "apy_estimate_eligible_subnet_count": 1,
                      *             "avg_validator_trust": 0.5,
                      *             "coldkey": "example",
                      *             "coldkey_count": 1,
@@ -28651,6 +28661,8 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "alpha_stake_tao": 0.5,
+                     *         "apy_estimate": 0.5,
+                     *         "apy_estimate_eligible_subnet_count": 1,
                      *         "avg_validator_trust": 0.5,
                      *         "block_number": 5000000,
                      *         "captured_at": "2026-06-01T00:00:00.000Z",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9736,6 +9736,19 @@
             "minimum": 0,
             "type": "number"
           },
+          "apy_estimate": {
+            "description": "Estimated annualized yield (#2551): a stake-weighted, rao-exact blend of (emission_tao * (31,536,000 / (tempo_blocks * 12))) / stake_tao across every subnet membership where subnet_hyperparams.tempo is known and the membership holds positive stake. Each membership's emission_tao is a single most-recently-captured per-epoch snapshot (see total_emission_tao), not a multi-day average -- this is a naive 'if the last captured epoch's rate held for a year' projection, not a compounding forecast, and it can swing between refreshes, especially for validators concentrated on short-tempo subnets where the annualization multiplier is largest. Expressed as a decimal fraction (0.365 = 36.5%/yr). Memberships with an unresolved tempo, tempo=0, or non-positive stake are excluded from both the numerator and denominator, never defaulted. Null when apy_estimate_eligible_subnet_count is 0.",
+            "minimum": 0,
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "apy_estimate_eligible_subnet_count": {
+            "description": "Count of this validator's subnet memberships that contributed to apy_estimate (resolvable tempo + positive stake), out of subnet_count total (#2551). apy_estimate is null iff this is 0.",
+            "minimum": 0,
+            "type": "integer"
+          },
           "avg_validator_trust": {
             "type": [
               "number",
@@ -9854,6 +9867,8 @@
           "alpha_stake_tao",
           "total_emission_tao",
           "nominator_count",
+          "apy_estimate",
+          "apy_estimate_eligible_subnet_count",
           "stake_dominance",
           "avg_validator_trust",
           "max_validator_trust",
@@ -20929,6 +20944,19 @@
             "minimum": 0,
             "type": "number"
           },
+          "apy_estimate": {
+            "description": "Estimated annualized yield (#2551): a stake-weighted, rao-exact blend of (emission_tao * (31,536,000 / (tempo_blocks * 12))) / stake_tao across every subnet membership where subnet_hyperparams.tempo is known and the membership holds positive stake. Each membership's emission_tao is a single most-recently-captured per-epoch snapshot (see total_emission_tao), not a multi-day average -- this is a naive 'if the last captured epoch's rate held for a year' projection, not a compounding forecast, and it can swing between refreshes, especially for validators concentrated on short-tempo subnets where the annualization multiplier is largest. Expressed as a decimal fraction (0.365 = 36.5%/yr). Memberships with an unresolved tempo, tempo=0, or non-positive stake are excluded from both the numerator and denominator, never defaulted. Null when apy_estimate_eligible_subnet_count is 0.",
+            "minimum": 0,
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "apy_estimate_eligible_subnet_count": {
+            "description": "Count of this validator's subnet memberships that contributed to apy_estimate (resolvable tempo + positive stake), out of subnet_count total (#2551). apy_estimate is null iff this is 0.",
+            "minimum": 0,
+            "type": "integer"
+          },
           "avg_validator_trust": {
             "type": [
               "number",
@@ -21033,6 +21061,8 @@
           "alpha_stake_tao",
           "total_emission_tao",
           "nominator_count",
+          "apy_estimate",
+          "apy_estimate_eligible_subnet_count",
           "avg_validator_trust",
           "max_validator_trust",
           "captured_at",
@@ -51780,6 +51810,8 @@
                     "validators": [
                       {
                         "alpha_stake_tao": 0.5,
+                        "apy_estimate": 0.5,
+                        "apy_estimate_eligible_subnet_count": 1,
                         "avg_validator_trust": 0.5,
                         "coldkey": "example",
                         "coldkey_count": 1,
@@ -51943,6 +51975,8 @@
                 "example": {
                   "data": {
                     "alpha_stake_tao": 0.5,
+                    "apy_estimate": 0.5,
+                    "apy_estimate_eligible_subnet_count": 1,
                     "avg_validator_trust": 0.5,
                     "block_number": 5000000,
                     "captured_at": "2026-06-01T00:00:00.000Z",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4964,6 +4964,10 @@ export interface components {
         GlobalValidatorEntry: {
             /** @description total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao. */
             alpha_stake_tao: number;
+            /** @description Estimated annualized yield (#2551): a stake-weighted, rao-exact blend of (emission_tao * (31,536,000 / (tempo_blocks * 12))) / stake_tao across every subnet membership where subnet_hyperparams.tempo is known and the membership holds positive stake. Each membership's emission_tao is a single most-recently-captured per-epoch snapshot (see total_emission_tao), not a multi-day average -- this is a naive 'if the last captured epoch's rate held for a year' projection, not a compounding forecast, and it can swing between refreshes, especially for validators concentrated on short-tempo subnets where the annualization multiplier is largest. Expressed as a decimal fraction (0.365 = 36.5%/yr). Memberships with an unresolved tempo, tempo=0, or non-positive stake are excluded from both the numerator and denominator, never defaulted. Null when apy_estimate_eligible_subnet_count is 0. */
+            apy_estimate: number | null;
+            /** @description Count of this validator's subnet memberships that contributed to apy_estimate (resolvable tempo + positive stake), out of subnet_count total (#2551). apy_estimate is null iff this is 0. */
+            apy_estimate_eligible_subnet_count: number;
             avg_validator_trust: number | null;
             coldkey: string | null;
             coldkey_count: number;
@@ -7655,6 +7659,10 @@ export interface components {
         ValidatorDetailArtifact: {
             /** @description total_stake_tao minus root_stake_tao -- the sum of every non-root (netuid != 0) subnet membership's stake, each denominated in that subnet's own alpha token and summed as a TAO-equivalent figure (#2550). Price-exposed, unlike root_stake_tao. */
             alpha_stake_tao: number;
+            /** @description Estimated annualized yield (#2551): a stake-weighted, rao-exact blend of (emission_tao * (31,536,000 / (tempo_blocks * 12))) / stake_tao across every subnet membership where subnet_hyperparams.tempo is known and the membership holds positive stake. Each membership's emission_tao is a single most-recently-captured per-epoch snapshot (see total_emission_tao), not a multi-day average -- this is a naive 'if the last captured epoch's rate held for a year' projection, not a compounding forecast, and it can swing between refreshes, especially for validators concentrated on short-tempo subnets where the annualization multiplier is largest. Expressed as a decimal fraction (0.365 = 36.5%/yr). Memberships with an unresolved tempo, tempo=0, or non-positive stake are excluded from both the numerator and denominator, never defaulted. Null when apy_estimate_eligible_subnet_count is 0. */
+            apy_estimate: number | null;
+            /** @description Count of this validator's subnet memberships that contributed to apy_estimate (resolvable tempo + positive stake), out of subnet_count total (#2551). apy_estimate is null iff this is 0. */
+            apy_estimate_eligible_subnet_count: number;
             avg_validator_trust: number | null;
             block_number: number | null;
             /** Format: date-time */
@@ -28515,6 +28523,8 @@ export interface operations {
                      *         "validators": [
                      *           {
                      *             "alpha_stake_tao": 0.5,
+                     *             "apy_estimate": 0.5,
+                     *             "apy_estimate_eligible_subnet_count": 1,
                      *             "avg_validator_trust": 0.5,
                      *             "coldkey": "example",
                      *             "coldkey_count": 1,
@@ -28651,6 +28661,8 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "alpha_stake_tao": 0.5,
+                     *         "apy_estimate": 0.5,
+                     *         "apy_estimate_eligible_subnet_count": 1,
                      *         "avg_validator_trust": 0.5,
                      *         "block_number": 5000000,
                      *         "captured_at": "2026-06-01T00:00:00.000Z",

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -9714,6 +9714,19 @@
             "minimum": 0,
             "type": "number"
           },
+          "apy_estimate": {
+            "description": "Estimated annualized yield (#2551): a stake-weighted, rao-exact blend of (emission_tao * (31,536,000 / (tempo_blocks * 12))) / stake_tao across every subnet membership where subnet_hyperparams.tempo is known and the membership holds positive stake. Each membership's emission_tao is a single most-recently-captured per-epoch snapshot (see total_emission_tao), not a multi-day average -- this is a naive 'if the last captured epoch's rate held for a year' projection, not a compounding forecast, and it can swing between refreshes, especially for validators concentrated on short-tempo subnets where the annualization multiplier is largest. Expressed as a decimal fraction (0.365 = 36.5%/yr). Memberships with an unresolved tempo, tempo=0, or non-positive stake are excluded from both the numerator and denominator, never defaulted. Null when apy_estimate_eligible_subnet_count is 0.",
+            "minimum": 0,
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "apy_estimate_eligible_subnet_count": {
+            "description": "Count of this validator's subnet memberships that contributed to apy_estimate (resolvable tempo + positive stake), out of subnet_count total (#2551). apy_estimate is null iff this is 0.",
+            "minimum": 0,
+            "type": "integer"
+          },
           "avg_validator_trust": {
             "type": [
               "number",
@@ -9832,6 +9845,8 @@
           "alpha_stake_tao",
           "total_emission_tao",
           "nominator_count",
+          "apy_estimate",
+          "apy_estimate_eligible_subnet_count",
           "stake_dominance",
           "avg_validator_trust",
           "max_validator_trust",
@@ -20907,6 +20922,19 @@
             "minimum": 0,
             "type": "number"
           },
+          "apy_estimate": {
+            "description": "Estimated annualized yield (#2551): a stake-weighted, rao-exact blend of (emission_tao * (31,536,000 / (tempo_blocks * 12))) / stake_tao across every subnet membership where subnet_hyperparams.tempo is known and the membership holds positive stake. Each membership's emission_tao is a single most-recently-captured per-epoch snapshot (see total_emission_tao), not a multi-day average -- this is a naive 'if the last captured epoch's rate held for a year' projection, not a compounding forecast, and it can swing between refreshes, especially for validators concentrated on short-tempo subnets where the annualization multiplier is largest. Expressed as a decimal fraction (0.365 = 36.5%/yr). Memberships with an unresolved tempo, tempo=0, or non-positive stake are excluded from both the numerator and denominator, never defaulted. Null when apy_estimate_eligible_subnet_count is 0.",
+            "minimum": 0,
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "apy_estimate_eligible_subnet_count": {
+            "description": "Count of this validator's subnet memberships that contributed to apy_estimate (resolvable tempo + positive stake), out of subnet_count total (#2551). apy_estimate is null iff this is 0.",
+            "minimum": 0,
+            "type": "integer"
+          },
           "avg_validator_trust": {
             "type": [
               "number",
@@ -21011,6 +21039,8 @@
           "alpha_stake_tao",
           "total_emission_tao",
           "nominator_count",
+          "apy_estimate",
+          "apy_estimate_eligible_subnet_count",
           "avg_validator_trust",
           "max_validator_trust",
           "captured_at",

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -2031,6 +2031,8 @@
           "alpha_stake_tao",
           "total_emission_tao",
           "nominator_count",
+          "apy_estimate",
+          "apy_estimate_eligible_subnet_count",
           "stake_dominance",
           "avg_validator_trust",
           "max_validator_trust",
@@ -2072,6 +2074,16 @@
             "type": ["integer", "null"],
             "minimum": 0,
             "description": "Distinct coldkeys currently holding a nonzero stake position on this hotkey, network-wide, across every subnet (#2549). Sourced from a separate, lower-frequency full-chain scan (see validator_nominator_counts) than the rest of this artifact -- null when that table has no row for this hotkey yet, never fabricated as 0."
+          },
+          "apy_estimate": {
+            "type": ["number", "null"],
+            "minimum": 0,
+            "description": "Estimated annualized yield (#2551): a stake-weighted, rao-exact blend of (emission_tao * (31,536,000 / (tempo_blocks * 12))) / stake_tao across every subnet membership where subnet_hyperparams.tempo is known and the membership holds positive stake. Each membership's emission_tao is a single most-recently-captured per-epoch snapshot (see total_emission_tao), not a multi-day average -- this is a naive 'if the last captured epoch's rate held for a year' projection, not a compounding forecast, and it can swing between refreshes, especially for validators concentrated on short-tempo subnets where the annualization multiplier is largest. Expressed as a decimal fraction (0.365 = 36.5%/yr). Memberships with an unresolved tempo, tempo=0, or non-positive stake are excluded from both the numerator and denominator, never defaulted. Null when apy_estimate_eligible_subnet_count is 0."
+          },
+          "apy_estimate_eligible_subnet_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Count of this validator's subnet memberships that contributed to apy_estimate (resolvable tempo + positive stake), out of subnet_count total (#2551). apy_estimate is null iff this is 0."
           },
           "stake_dominance": {
             "type": ["number", "null"],
@@ -2273,6 +2285,8 @@
           "alpha_stake_tao",
           "total_emission_tao",
           "nominator_count",
+          "apy_estimate",
+          "apy_estimate_eligible_subnet_count",
           "avg_validator_trust",
           "max_validator_trust",
           "captured_at",
@@ -2312,6 +2326,16 @@
             "type": ["integer", "null"],
             "minimum": 0,
             "description": "Distinct coldkeys currently holding a nonzero stake position on this hotkey, network-wide, across every subnet (#2549). Sourced from a separate, lower-frequency full-chain scan than the rest of this artifact -- null when that table has no row for this hotkey yet, never fabricated as 0."
+          },
+          "apy_estimate": {
+            "type": ["number", "null"],
+            "minimum": 0,
+            "description": "Estimated annualized yield (#2551): a stake-weighted, rao-exact blend of (emission_tao * (31,536,000 / (tempo_blocks * 12))) / stake_tao across every subnet membership where subnet_hyperparams.tempo is known and the membership holds positive stake. Each membership's emission_tao is a single most-recently-captured per-epoch snapshot (see total_emission_tao), not a multi-day average -- this is a naive 'if the last captured epoch's rate held for a year' projection, not a compounding forecast, and it can swing between refreshes, especially for validators concentrated on short-tempo subnets where the annualization multiplier is largest. Expressed as a decimal fraction (0.365 = 36.5%/yr). Memberships with an unresolved tempo, tempo=0, or non-positive stake are excluded from both the numerator and denominator, never defaulted. Null when apy_estimate_eligible_subnet_count is 0."
+          },
+          "apy_estimate_eligible_subnet_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Count of this validator's subnet memberships that contributed to apy_estimate (resolvable tempo + positive stake), out of subnet_count total (#2551). apy_estimate is null iff this is 0."
           },
           "avg_validator_trust": { "type": ["number", "null"] },
           "max_validator_trust": { "type": ["number", "null"] },

--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -54,6 +54,22 @@ export const GLOBAL_VALIDATOR_LIMIT_MAX = 100;
 const GLOBAL_VALIDATOR_SUBNET_LIMIT = 10;
 const RAO_PER_TAO = 1e9;
 
+// Bittensor's network-wide block time is a long-stable EXTERNAL protocol
+// parameter (~12s) that this repo does not measure per-request -- distinct
+// from any live-computed block-time distribution elsewhere in this repo
+// (e.g. blocks-summary.mjs's blockTimeDistribution), which would make the
+// same emission_tao annualize differently on every request purely from
+// block-production jitter. If a future chain upgrade changes Bittensor's
+// consensus block time, this constant needs a matching update; it is a
+// documented assumption apy_estimate depends on, not something this route
+// verifies (#2551).
+const APY_SECONDS_PER_BLOCK = 12;
+// Calendar year, no leap-day adjustment -- a documented convention, not a
+// protocol-derived figure. No prior art for "a year" exists elsewhere in
+// this repo (src/chain-yield.mjs / src/subnet-yield.mjs are explicitly
+// snapshot-only, never annualized) -- apy_estimate is the new precedent.
+const APY_SECONDS_PER_YEAR = 365 * 24 * 60 * 60; // 31,536,000
+
 function toIso(ms) {
   // D1 can return the INTEGER captured_at as a numeric string; a bare
   // Number.isFinite(ms) is false for a string, so the old form dropped a real
@@ -114,6 +130,16 @@ function round(value, dp = 6) {
   if (value == null || !Number.isFinite(value)) return null;
   const factor = 10 ** dp;
   return Math.round(value * factor) / factor;
+}
+
+// 1 TAO = 1e9 rao; round yield-shaped outputs to that precision to shed
+// IEEE-754 noise below the rao floor while keeping small ratios meaningful.
+// Matches src/chain-yield.mjs / src/subnet-yield.mjs's own round9 exactly
+// (apy_estimate is a sibling yield-shaped field, not a trust/take value, so
+// it uses this precision convention rather than round()'s 6dp default).
+function round9(value) {
+  if (value == null || !Number.isFinite(value)) return null;
+  return Math.round(Number(value) * RAO_PER_TAO) / RAO_PER_TAO;
 }
 
 // Coerce a D1 0/1 INTEGER flag cell to a boolean. Numeric strings like "0"
@@ -273,6 +299,51 @@ function coldkeyIdentity(coldkey, identityByColdkey) {
   return identity;
 }
 
+// Estimated annualized yield (#2551): mutates `acc` (either a
+// buildGlobalValidators per-hotkey entry or buildValidatorDetail's local
+// accumulator) with one subnet-membership row's contribution to
+// apy_estimate. `tempoByNetuid` is a netuid -> tempo(blocks) Map (loaded by
+// the caller from subnet_hyperparams); a membership whose netuid has no
+// resolvable tempo, or that holds no positive stake, is EXCLUDED from both
+// the numerator and denominator -- never defaulted to an assumed tempo,
+// mirroring this codebase's null-never-fabricated convention (see
+// nominator_count above). stake/emission are already-coerced
+// numberOrZero() results, matching every other call site in this file.
+//
+// Each eligible row's emission_tao (a single most-recently-captured
+// per-epoch reading, see NEURON_COLUMNS) is annualized using that row's own
+// subnet's tempo and projected across a full year, then accumulated in
+// rao-BigInt space alongside its stake so the final ratio (finalizeApy) is
+// algebraically a stake-weighted blend across every eligible membership,
+// computed as one sum-of-emission / sum-of-stake division rather than an
+// average of per-row ratios -- mirrors stakeTotalRao/emissionTotalRao's own
+// accumulate-then-convert-once pattern.
+function accumulateApyRow(acc, netuid, stake, emission, tempoByNetuid) {
+  const tempo = tempoByNetuid.get(netuid);
+  if (tempo == null) return; // unresolved tempo -- excluded, never defaulted
+  if (!(stake > 0)) return; // zero/negative-impossible stake -- excluded
+  const epochsPerYear = APY_SECONDS_PER_YEAR / (tempo * APY_SECONDS_PER_BLOCK);
+  const annualizedEmission = emission * epochsPerYear;
+  acc.apyNumeratorRao += toRaoBig(annualizedEmission);
+  acc.apyDenominatorRao += toRaoBig(stake);
+  acc.apyEligibleCount += 1;
+}
+
+// Reads the three fields accumulateApyRow above populates and produces the
+// two apy_estimate* output fields. Null (never 0) when no membership had a
+// resolvable tempo -- "no APY opinion" rather than "confirmed zero yield".
+function finalizeApy(acc) {
+  if (acc.apyEligibleCount === 0 || acc.apyDenominatorRao <= 0n) {
+    return { apy_estimate: null, apy_estimate_eligible_subnet_count: 0 };
+  }
+  const apy =
+    raoBigToTao(acc.apyNumeratorRao) / raoBigToTao(acc.apyDenominatorRao);
+  return {
+    apy_estimate: round9(apy),
+    apy_estimate_eligible_subnet_count: acc.apyEligibleCount,
+  };
+}
+
 function buildGlobalValidatorEntry(
   entry,
   identityByColdkey,
@@ -321,6 +392,7 @@ function buildGlobalValidatorEntry(
     // never fabricated as 0, which would misreport "confirmed zero
     // nominators" as opposed to "unknown."
     nominator_count: nominatorCounts.get(entry.hotkey) ?? null,
+    ...finalizeApy(entry),
     avg_validator_trust: round(avgTrust),
     max_validator_trust: round(entry.maxValidatorTrust),
     latest_captured_at: toIso(entry.latestCapturedAt),
@@ -364,6 +436,11 @@ export function buildGlobalValidators(
     // map (e.g. the D1-retired fallback below, which never has one) leaves
     // every entry's nominator_count null, never throws.
     nominatorCounts = new Map(),
+    // netuid -> tempo(blocks) (#2551), sourced from subnet_hyperparams --
+    // see accumulateApyRow's own comment for why an unresolved netuid is
+    // excluded rather than defaulted. A cold/absent map leaves every entry's
+    // apy_estimate null, never throws.
+    tempoByNetuid = new Map(),
   } = {},
 ) {
   const normalizedSort = GLOBAL_VALIDATOR_SORTS.includes(sort)
@@ -404,6 +481,9 @@ export function buildGlobalValidators(
         uidCount: 0,
         stakeTotalRao: 0n,
         emissionTotalRao: 0n,
+        apyNumeratorRao: 0n,
+        apyDenominatorRao: 0n,
+        apyEligibleCount: 0,
         validatorTrustTotal: 0,
         validatorTrustCount: 0,
         maxValidatorTrust: null,
@@ -430,6 +510,7 @@ export function buildGlobalValidators(
     entry.uidCount += 1;
     entry.stakeTotalRao += toRaoBig(stake);
     entry.emissionTotalRao += toRaoBig(emission);
+    accumulateApyRow(entry, netuid, stake, emission, tempoByNetuid);
     if (trust != null) {
       entry.validatorTrustTotal += trust;
       entry.validatorTrustCount += 1;
@@ -621,6 +702,10 @@ export function buildValidatorDetail(
     // Null when that table has no row for this hotkey yet -- never fabricated
     // as 0.
     nominatorCount = null,
+    // netuid -> tempo(blocks) (#2551), sourced from subnet_hyperparams. See
+    // accumulateApyRow's own comment. A cold/absent map leaves apy_estimate
+    // null, never throws.
+    tempoByNetuid = new Map(),
   } = {},
 ) {
   const coldkeys = new Map();
@@ -631,6 +716,14 @@ export function buildValidatorDetail(
   // already one of `rows`, no new ingestion needed.
   let rootStakeRao = 0n;
   let emissionTotalRao = 0n;
+  // Plain object (not three separate `let`s) so it can be passed directly to
+  // the shared accumulateApyRow/finalizeApy helpers buildGlobalValidators
+  // also uses (#2551) -- one accumulation implementation, not duplicated.
+  const apyAcc = {
+    apyNumeratorRao: 0n,
+    apyDenominatorRao: 0n,
+    apyEligibleCount: 0,
+  };
   let validatorTrustTotal = 0;
   let validatorTrustCount = 0;
   let maxValidatorTrust = null;
@@ -657,10 +750,13 @@ export function buildValidatorDetail(
       const rowTake = nullableNumber(row?.take);
       if (rowTake != null) take = rowTake;
     }
-    const rowStakeRao = toRaoBig(numberOrZero(row?.stake_tao));
+    const stake = numberOrZero(row?.stake_tao);
+    const emission = numberOrZero(row?.emission_tao);
+    const rowStakeRao = toRaoBig(stake);
     stakeTotalRao += rowStakeRao;
     if (netuid === 0) rootStakeRao += rowStakeRao;
-    emissionTotalRao += toRaoBig(numberOrZero(row?.emission_tao));
+    emissionTotalRao += toRaoBig(emission);
+    accumulateApyRow(apyAcc, netuid, stake, emission, tempoByNetuid);
     const trust = nullableNumber(row?.validator_trust);
     if (trust != null) {
       validatorTrustTotal += trust;
@@ -702,6 +798,7 @@ export function buildValidatorDetail(
     alpha_stake_tao: roundTao(raoBigToTao(stakeTotalRao - rootStakeRao)),
     total_emission_tao: roundTao(raoBigToTao(emissionTotalRao)),
     nominator_count: nominatorCount,
+    ...finalizeApy(apyAcc),
     avg_validator_trust: round(avgTrust),
     max_validator_trust: round(maxValidatorTrust),
     captured_at: toIso(latestCapturedAt),

--- a/src/subnet-tempo.mjs
+++ b/src/subnet-tempo.mjs
@@ -1,0 +1,35 @@
+// Subnet tempo lookup (#2551) -- netuid -> tempo(blocks), sourced from
+// subnet_hyperparams (migration 0036). Read/join lands here, mirroring
+// src/validator-nominator-summary.mjs's role for nominator_count; the read
+// path lives in workers/data-api.mjs (loadSubnetTempos), joined into
+// buildGlobalValidators/buildValidatorDetail's apy_estimate by netuid.
+
+// netuid -> tempo Map built from a Postgres query result, for
+// accumulateApyRow (src/metagraph-neurons.mjs) to annualize each subnet
+// membership's emission_tao. Null-safe on a cold/absent table (returns an
+// empty Map, so every lookup misses and apy_estimate serves as null) --
+// never throws, mirrors nominatorCountsByHotkey's cold-safety.
+export function tempoByNetuid(rows) {
+  const map = new Map();
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const netuid = nonNegativeInt(row?.netuid);
+    // tempo=0 would divide-by-zero into an infinite epochsPerYear downstream
+    // -- treated the same as "unresolved" rather than a zero-length epoch,
+    // so it's never stored at all.
+    const tempo = nonNegativeInt(row?.tempo);
+    if (netuid == null || tempo == null || tempo === 0) continue;
+    map.set(netuid, tempo);
+  }
+  return map;
+}
+
+// Same coercion rules as src/metagraph-neurons.mjs's own nonNegativeInt --
+// duplicated locally rather than imported since that one isn't exported and
+// this module should stay independently testable/importable without pulling
+// in metagraph-neurons.mjs's whole surface.
+function nonNegativeInt(value) {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -100,6 +100,10 @@ const accountIdentityJoinQueryFailure = vi.hoisted(() => ({ error: null }));
 const validatorNominatorCountsQueryFailure = vi.hoisted(() => ({
   error: null,
 }));
+// State for the subnet_hyperparams tempo READ (#2551) tests only -- same
+// isolation purpose as validatorNominatorCountsQueryFailure above, but for
+// loadSubnetTempos' own SELECT.
+const subnetTemposQueryFailure = vi.hoisted(() => ({ error: null }));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -209,6 +213,12 @@ vi.mock("postgres", () => ({
         /FROM validator_nominator_counts\b/.test(text)
       ) {
         return Promise.reject(validatorNominatorCountsQueryFailure.error);
+      }
+      if (
+        subnetTemposQueryFailure.error &&
+        /FROM subnet_hyperparams\b/.test(text)
+      ) {
+        return Promise.reject(subnetTemposQueryFailure.error);
       }
       if (
         healthUptimeRollupSyncFailure.error &&
@@ -338,6 +348,7 @@ beforeEach(() => {
   accountIdentityLatestHashes.current = [];
   validatorNominatorCountsSyncFailure.error = null;
   validatorNominatorCountsQueryFailure.error = null;
+  subnetTemposQueryFailure.error = null;
   subnetIdentitySyncFailure.error = null;
   subnetIdentityLatestHashes.current = [];
   healthChecksSyncFailure.error = null;
@@ -1713,6 +1724,71 @@ test("GET /api/v1/validators/:hotkey joins nominator_count from validator_nomina
   const res = await req("/api/v1/validators/5Hot");
   const body = await res.json();
   expect(body.nominator_count).toBe(9);
+});
+
+test("GET /api/v1/validators computes apy_estimate from a subnet_hyperparams tempo join (#2551)", async () => {
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [
+      {
+        ...NEURON_ROW,
+        hotkey: "5Hot",
+        netuid: 3,
+        stake_tao: "1000",
+        emission_tao: "0.85",
+      },
+    ],
+    [], // loadFeaturedHotkeys
+    [], // loadValidatorNominatorCounts
+    [{ netuid: 3, tempo: 360 }],
+  ];
+  const res = await req("/api/v1/validators");
+  const body = await res.json();
+  expect(queryText()).toMatch(/FROM subnet_hyperparams/);
+  // epochsPerYear = 31,536,000/(360*12) = 7,300; annualized = 0.85*7,300 =
+  // 6,205; apy = 6,205/1,000 = 6.205 -- same worked example as the builder
+  // unit tests (tests/metagraph-neurons.test.mjs).
+  expect(body.validators[0].apy_estimate).toBe(6.205);
+  expect(body.validators[0].apy_estimate_eligible_subnet_count).toBe(1);
+});
+
+test("GET /api/v1/validators still serves the primary rows when the subnet_hyperparams tempo read fails (#2551)", async () => {
+  subnetTemposQueryFailure.error = new Error(
+    'relation "subnet_hyperparams" does not exist',
+  );
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [{ ...NEURON_ROW, netuid: 7, hotkey: "5Hot" }],
+    [], // loadFeaturedHotkeys
+    [], // loadValidatorNominatorCounts
+  ];
+  const res = await req("/api/v1/validators");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.validators[0].hotkey).toBe("5Hot");
+  expect(body.validators[0].apy_estimate).toBe(null);
+  expect(body.validators[0].apy_estimate_eligible_subnet_count).toBe(0);
+});
+
+test("GET /api/v1/validators/:hotkey computes apy_estimate from a subnet_hyperparams tempo join (#2551)", async () => {
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [
+      {
+        ...NEURON_ROW,
+        hotkey: "5Hot",
+        netuid: 3,
+        stake_tao: "1000",
+        emission_tao: "0.85",
+      },
+    ],
+    [], // loadValidatorNominatorCounts
+    [{ netuid: 3, tempo: 360 }],
+  ];
+  const res = await req("/api/v1/validators/5Hot");
+  const body = await res.json();
+  expect(body.apy_estimate).toBe(6.205);
+  expect(body.apy_estimate_eligible_subnet_count).toBe(1);
 });
 
 // #4832 Tier 2: the live-`neurons` routes with no shared D1 loader (the

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -42,7 +42,7 @@ const NEURON_CSV_HEADER =
 const MOVERS_CSV_HEADER =
   "netuid,stake_start_tao,stake_end_tao,stake_delta_tao,stake_pct_change,emission_start_tao,emission_end_tao,emission_delta_tao,emission_pct_change,validators_start,validators_end,validators_delta,neurons_start,neurons_end,neurons_delta";
 const GLOBAL_VALIDATOR_CSV_HEADER =
-  "hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,root_stake_tao,alpha_stake_tao,total_emission_tao,nominator_count,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets";
+  "hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,root_stake_tao,alpha_stake_tao,total_emission_tao,nominator_count,apy_estimate,apy_estimate_eligible_subnet_count,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets";
 
 describe("metagraph-neurons builders", () => {
   test("formatNeuron coerces 0/1 INTEGER flags to real booleans", () => {
@@ -534,6 +534,124 @@ describe("metagraph-neurons builders", () => {
     assert.equal(data.validators[0].nominator_count, null);
   });
 
+  test("buildGlobalValidators computes apy_estimate for a single eligible membership (#2551)", () => {
+    // tempo=360 -> epochsPerYear = 31,536,000/(360*12) = 7,300 exactly;
+    // annualized = 0.85*7,300 = 6,205 TAO/yr; apy = 6,205/1,000 = 6.205.
+    const data = buildGlobalValidators(
+      [
+        {
+          ...ROW,
+          netuid: 3,
+          uid: 0,
+          hotkey: "hk-a",
+          stake_tao: 1000,
+          emission_tao: 0.85,
+        },
+      ],
+      { tempoByNetuid: new Map([[3, 360]]) },
+    );
+    const entry = data.validators.find((v) => v.hotkey === "hk-a");
+    assert.equal(entry.apy_estimate, 6.205);
+    assert.equal(entry.apy_estimate_eligible_subnet_count, 1);
+  });
+
+  test("buildGlobalValidators blends apy_estimate stake-weighted across memberships, excluding one with no resolvable tempo (#2551)", () => {
+    const data = buildGlobalValidators(
+      [
+        {
+          ...ROW,
+          netuid: 3,
+          uid: 0,
+          hotkey: "hk-a",
+          stake_tao: 1000,
+          emission_tao: 0.85,
+        },
+        {
+          ...ROW,
+          netuid: 8,
+          uid: 1,
+          hotkey: "hk-a",
+          stake_tao: 500,
+          emission_tao: 0.1,
+        },
+        // netuid 21 has no entry in tempoByNetuid -- excluded from both the
+        // numerator and denominator, its 200 TAO stake never diluting apy.
+        {
+          ...ROW,
+          netuid: 21,
+          uid: 2,
+          hotkey: "hk-a",
+          stake_tao: 200,
+          emission_tao: 5,
+        },
+      ],
+      {
+        tempoByNetuid: new Map([
+          [3, 360],
+          [8, 100],
+        ]),
+      },
+    );
+    const entry = data.validators.find((v) => v.hotkey === "hk-a");
+    // numerator = 0.85*7,300 + 0.10*26,280 = 6,205 + 2,628 = 8,833
+    // denominator = 1,000 + 500 = 1,500 (netuid 21's 200 excluded)
+    assert.equal(entry.apy_estimate, Math.round((8833 / 1500) * 1e9) / 1e9);
+    assert.equal(entry.apy_estimate_eligible_subnet_count, 2);
+    assert.equal(entry.subnet_count, 3); // all 3 memberships still counted
+  });
+
+  test("buildGlobalValidators excludes a membership with non-positive stake from apy_estimate even when tempo is known (#2551)", () => {
+    const data = buildGlobalValidators(
+      [
+        {
+          ...ROW,
+          netuid: 3,
+          uid: 0,
+          hotkey: "hk-a",
+          stake_tao: 0,
+          emission_tao: 1,
+        },
+      ],
+      { tempoByNetuid: new Map([[3, 360]]) },
+    );
+    const entry = data.validators.find((v) => v.hotkey === "hk-a");
+    assert.equal(entry.apy_estimate, null);
+    assert.equal(entry.apy_estimate_eligible_subnet_count, 0);
+  });
+
+  test("buildGlobalValidators defaults apy_estimate to null on every entry when no tempoByNetuid map is passed", () => {
+    const data = buildGlobalValidators([
+      { ...ROW, netuid: 3, uid: 0, hotkey: "hk-a" },
+    ]);
+    assert.equal(data.validators[0].apy_estimate, null);
+    assert.equal(data.validators[0].apy_estimate_eligible_subnet_count, 0);
+  });
+
+  test("buildGlobalValidators counts apy-eligible subnets beyond the top-10 subnets[] cap, not leaking the cap into apy_estimate (#2551)", () => {
+    // 15 memberships, every one eligible (known tempo, positive stake) --
+    // subnets[] on the returned entry is capped to GLOBAL_VALIDATOR_SUBNET_LIMIT
+    // (10), but apy_estimate_eligible_subnet_count must reflect all 15: the
+    // apy accumulation happens in the row loop, before that cap is applied.
+    const tempoByNetuid = new Map();
+    const rows = [];
+    for (let netuid = 0; netuid < 15; netuid += 1) {
+      tempoByNetuid.set(netuid, 360);
+      rows.push({
+        ...ROW,
+        netuid,
+        uid: netuid,
+        hotkey: "hk-a",
+        stake_tao: 100 + netuid, // distinct stakes so the top-10 sort is deterministic
+        emission_tao: 1,
+      });
+    }
+    const data = buildGlobalValidators(rows, { tempoByNetuid });
+    const entry = data.validators.find((v) => v.hotkey === "hk-a");
+    assert.equal(entry.subnets.length, 10);
+    assert.equal(entry.apy_estimate_eligible_subnet_count, 15);
+    assert.ok(entry.apy_estimate > 0);
+  });
+
   test("buildGlobalValidators takes the first non-null take per hotkey and ignores later rows (#2548)", () => {
     const data = buildGlobalValidators([
       { ...ROW, netuid: 1, uid: 0, hotkey: "hk-a", take: 0.18 },
@@ -868,6 +986,95 @@ describe("metagraph-neurons builders", () => {
       "hk-a",
     );
     assert.equal(withoutCount.nominator_count, null);
+  });
+
+  test("buildValidatorDetail blends apy_estimate stake-weighted across memberships, excluding one with no resolvable tempo (#2551)", () => {
+    const data = buildValidatorDetail(
+      [
+        {
+          ...ROW,
+          netuid: 3,
+          uid: 0,
+          hotkey: "hk-a",
+          stake_tao: 1000,
+          emission_tao: 0.85,
+        },
+        {
+          ...ROW,
+          netuid: 8,
+          uid: 1,
+          hotkey: "hk-a",
+          stake_tao: 500,
+          emission_tao: 0.1,
+        },
+        {
+          ...ROW,
+          netuid: 21,
+          uid: 2,
+          hotkey: "hk-a",
+          stake_tao: 200,
+          emission_tao: 5,
+        },
+      ],
+      "hk-a",
+      {
+        tempoByNetuid: new Map([
+          [3, 360],
+          [8, 100],
+        ]),
+      },
+    );
+    assert.equal(data.apy_estimate, Math.round((8833 / 1500) * 1e9) / 1e9);
+    assert.equal(data.apy_estimate_eligible_subnet_count, 2);
+    assert.equal(data.subnet_count, 3);
+  });
+
+  test("buildValidatorDetail excludes a non-positive-stake membership from apy_estimate even when tempo is known (#2551)", () => {
+    const data = buildValidatorDetail(
+      [
+        {
+          ...ROW,
+          netuid: 3,
+          uid: 0,
+          hotkey: "hk-a",
+          stake_tao: 0,
+          emission_tao: 1,
+        },
+      ],
+      "hk-a",
+      { tempoByNetuid: new Map([[3, 360]]) },
+    );
+    assert.equal(data.apy_estimate, null);
+    assert.equal(data.apy_estimate_eligible_subnet_count, 0);
+  });
+
+  test("buildValidatorDetail defaults apy_estimate to null when no tempoByNetuid map is passed", () => {
+    const data = buildValidatorDetail(
+      [{ ...ROW, netuid: 3, uid: 0, hotkey: "hk-a" }],
+      "hk-a",
+    );
+    assert.equal(data.apy_estimate, null);
+    assert.equal(data.apy_estimate_eligible_subnet_count, 0);
+  });
+
+  test("buildValidatorDetail's apy_estimate is never capped -- its subnets[] is already uncapped, unlike the leaderboard's top-10 (#2551)", () => {
+    const tempoByNetuid = new Map();
+    const rows = [];
+    for (let netuid = 0; netuid < 15; netuid += 1) {
+      tempoByNetuid.set(netuid, 360);
+      rows.push({
+        ...ROW,
+        netuid,
+        uid: netuid,
+        hotkey: "hk-a",
+        stake_tao: 100 + netuid,
+        emission_tao: 1,
+      });
+    }
+    const data = buildValidatorDetail(rows, "hk-a", { tempoByNetuid });
+    assert.equal(data.subnets.length, 15);
+    assert.equal(data.apy_estimate_eligible_subnet_count, 15);
+    assert.ok(data.apy_estimate > 0);
   });
 
   test("buildValidatorDetail: a null latest block_number is beaten by a real one on a captured_at tie, and a null incoming block_number never wins one", () => {

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -619,6 +619,33 @@ describe("metagraph-neurons builders", () => {
     assert.equal(entry.apy_estimate_eligible_subnet_count, 0);
   });
 
+  test("buildGlobalValidators nulls apy_estimate AND reports 0 eligible when the only eligible stake rounds to exactly 0 rao (#2551)", () => {
+    // 4e-10 TAO is > 0 in JS float terms, so accumulateApyRow's stake > 0
+    // guard passes and its own local apyEligibleCount reaches 1 -- but
+    // toRaoBig(4e-10) rounds to 0n (sub-rao precision), leaving
+    // apyDenominatorRao at 0n. finalizeApy's apyDenominatorRao <= 0n guard
+    // catches exactly this: it must report eligible_count 0 (not the raw 1
+    // accumulateApyRow counted), never 1, to preserve the field's own
+    // documented invariant ("apy_estimate is null iff eligible_count is 0")
+    // and avoid a 0/0 division producing NaN instead of a clean null.
+    const data = buildGlobalValidators(
+      [
+        {
+          ...ROW,
+          netuid: 3,
+          uid: 0,
+          hotkey: "hk-a",
+          stake_tao: 4e-10,
+          emission_tao: 1,
+        },
+      ],
+      { tempoByNetuid: new Map([[3, 360]]) },
+    );
+    const entry = data.validators.find((v) => v.hotkey === "hk-a");
+    assert.equal(entry.apy_estimate, null);
+    assert.equal(entry.apy_estimate_eligible_subnet_count, 0);
+  });
+
   test("buildGlobalValidators defaults apy_estimate to null on every entry when no tempoByNetuid map is passed", () => {
     const data = buildGlobalValidators([
       { ...ROW, netuid: 3, uid: 0, hotkey: "hk-a" },

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -915,6 +915,8 @@ describe("handleGlobalValidators", () => {
       alpha_stake_tao: 0,
       total_emission_tao: 0,
       nominator_count: null,
+      apy_estimate: null,
+      apy_estimate_eligible_subnet_count: 0,
       stake_dominance: null,
       avg_validator_trust: null,
       max_validator_trust: null,

--- a/tests/subnet-tempo.test.mjs
+++ b/tests/subnet-tempo.test.mjs
@@ -45,6 +45,16 @@ describe("tempoByNetuid", () => {
     assert.equal(map.size, 0);
   });
 
+  test("excludes a row with a blank/whitespace-only string netuid or tempo", () => {
+    const map = tempoByNetuid([
+      { netuid: "", tempo: 360 },
+      { netuid: "  ", tempo: 360 },
+      { netuid: 3, tempo: "" },
+      { netuid: 3, tempo: "   " },
+    ]);
+    assert.equal(map.size, 0);
+  });
+
   test("accepts a numeric-string netuid/tempo (D1/Postgres text cell coercion)", () => {
     const map = tempoByNetuid([{ netuid: "3", tempo: "360" }]);
     assert.equal(map.get(3), 360);

--- a/tests/subnet-tempo.test.mjs
+++ b/tests/subnet-tempo.test.mjs
@@ -1,0 +1,52 @@
+import { describe, test } from "vitest";
+import assert from "node:assert/strict";
+
+import { tempoByNetuid } from "../src/subnet-tempo.mjs";
+
+describe("tempoByNetuid", () => {
+  test("builds a netuid -> tempo Map from rows", () => {
+    const map = tempoByNetuid([
+      { netuid: 3, tempo: 360 },
+      { netuid: 8, tempo: 100 },
+    ]);
+    assert.equal(map.get(3), 360);
+    assert.equal(map.get(8), 100);
+    assert.equal(map.size, 2);
+  });
+
+  test("is cold-safe for non-array/empty input", () => {
+    assert.equal(tempoByNetuid(null).size, 0);
+    assert.equal(tempoByNetuid(undefined).size, 0);
+    assert.equal(tempoByNetuid([]).size, 0);
+    assert.equal(tempoByNetuid("not-an-array").size, 0);
+  });
+
+  test("excludes a row with tempo=0 (would divide-by-zero downstream), never stores it", () => {
+    const map = tempoByNetuid([{ netuid: 3, tempo: 0 }]);
+    assert.equal(map.size, 0);
+    assert.equal(map.has(3), false);
+  });
+
+  test("excludes a row with a missing/negative/non-integer netuid or tempo", () => {
+    const map = tempoByNetuid([
+      { netuid: null, tempo: 360 },
+      { tempo: 360 },
+      { netuid: -1, tempo: 360 },
+      { netuid: 3, tempo: null },
+      { netuid: 3 },
+      { netuid: 3, tempo: -1 },
+      { netuid: 3, tempo: 1.5 },
+    ]);
+    assert.equal(map.size, 0);
+  });
+
+  test("excludes a malformed (non-object) row", () => {
+    const map = tempoByNetuid([null, undefined, "row", 42]);
+    assert.equal(map.size, 0);
+  });
+
+  test("accepts a numeric-string netuid/tempo (D1/Postgres text cell coercion)", () => {
+    const map = tempoByNetuid([{ netuid: "3", tempo: "360" }]);
+    assert.equal(map.get(3), 360);
+  });
+});

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -306,6 +306,7 @@ import {
   VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS,
   nominatorCountsByHotkey,
 } from "../src/validator-nominator-summary.mjs";
+import { tempoByNetuid as buildTempoByNetuid } from "../src/subnet-tempo.mjs";
 import {
   identityHash,
   buildAccountIdentityHistory,
@@ -2509,6 +2510,23 @@ async function loadValidatorNominatorCounts(sql) {
     return nominatorCountsByHotkey(rows);
   } catch (err) {
     console.error("validator_nominator_counts query failed:", err);
+    return new Map();
+  }
+}
+
+// Same savepoint-isolated-failure shape as loadValidatorNominatorCounts just
+// above (#2551): a subnet_hyperparams read failure degrades apy_estimate to
+// null everywhere (accumulateApyRow's tempoByNetuid.get(...) == null branch)
+// rather than failing /api/v1/validators or /api/v1/validators/:hotkey, or
+// rolling back the enclosing transaction's other queries.
+async function loadSubnetTempos(sql) {
+  try {
+    const rows = await sql.savepoint(
+      (sql) => sql`SELECT netuid, tempo FROM subnet_hyperparams`,
+    );
+    return buildTempoByNetuid(rows);
+  } catch (err) {
+    console.error("subnet_hyperparams tempo query failed:", err);
     return new Map();
   }
 }
@@ -5910,14 +5928,16 @@ export default {
             limitParam <= GLOBAL_VALIDATOR_LIMIT_MAX
               ? limitParam
               : GLOBAL_VALIDATOR_LIMIT_DEFAULT;
-          const [rows, featuredHotkeys, nominatorCounts] = await Promise.all([
-            sql`
+          const [rows, featuredHotkeys, nominatorCounts, tempoByNetuid] =
+            await Promise.all([
+              sql`
           SELECT netuid, uid, hotkey, coldkey, validator_trust, emission_tao, stake_tao, block_number, captured_at, take
           FROM neurons WHERE validator_permit = TRUE AND hotkey IS NOT NULL
           ORDER BY hotkey ASC, stake_tao DESC, netuid ASC, uid ASC`,
-            loadFeaturedHotkeys(sql),
-            loadValidatorNominatorCounts(sql),
-          ]);
+              loadFeaturedHotkeys(sql),
+              loadValidatorNominatorCounts(sql),
+              loadSubnetTempos(sql),
+            ]);
           // Identity join (#5234): needs `rows` resolved first to know which
           // coldkeys to look up, so it can't join the Promise.all above.
           const identityByColdkey = await loadAccountIdentitiesByColdkey(
@@ -5931,6 +5951,7 @@ export default {
               featuredHotkeys,
               identityByColdkey,
               nominatorCounts,
+              tempoByNetuid,
             }),
           );
         }
@@ -5942,12 +5963,13 @@ export default {
         );
         if (validatorDetail) {
           const hotkey = decodeURIComponent(validatorDetail[1]);
-          const [rows, nominatorCounts] = await Promise.all([
+          const [rows, nominatorCounts, tempoByNetuid] = await Promise.all([
             sql`
           SELECT uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at, take, netuid
           FROM neurons WHERE hotkey = ${hotkey} AND validator_permit = TRUE
           ORDER BY netuid ASC, uid ASC`,
             loadValidatorNominatorCounts(sql),
+            loadSubnetTempos(sql),
           ]);
           // Identity join (#5234): see the /api/v1/validators comment above.
           const identityByColdkey = await loadAccountIdentitiesByColdkey(
@@ -5958,6 +5980,7 @@ export default {
             buildValidatorDetail(rows, hotkey, {
               identityByColdkey,
               nominatorCount: nominatorCounts.get(hotkey) ?? null,
+              tempoByNetuid,
             }),
           );
         }

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -303,6 +303,8 @@ const GLOBAL_VALIDATOR_CSV_COLUMNS = [
   "alpha_stake_tao",
   "total_emission_tao",
   "nominator_count",
+  "apy_estimate",
+  "apy_estimate_eligible_subnet_count",
   "stake_dominance",
   "avg_validator_trust",
   "max_validator_trust",


### PR DESCRIPTION
## Summary
- Closes #2551
- New `apy_estimate` field: a stake-weighted, rao-exact blend of `(emission_tao * (31,536,000 / (tempo_blocks * 12))) / stake_tao` across every subnet membership where `subnet_hyperparams.tempo` is known and the membership holds positive stake. Named `apy_estimate` (not bare `apy`) and paired with a new `apy_estimate_eligible_subnet_count` field, to be explicit this is a single-snapshot ("if the last captured epoch's rate held for a year") projection, not a compounding forecast — it can swing meaningfully between refreshes, especially for validators concentrated on short-tempo subnets.
- **Methodology**: reached via a structured design pass weighing three approaches — (A) this repo's real per-subnet `tempo` data (already ingested via `subnet_hyperparams`, just never joined into this route) vs. (B) a single hardcoded network-wide tempo assumption vs. (C) a purely empirical `neuron_daily`-derived rate with no tempo assumption at all. (B) was rejected for presenting a precise-looking number built on an assumption the real ingested data already makes unnecessary; (C)'s own worked example showed a naive multi-day average undercounts the tempo-aware truth by ~17x, so it can't stand alone (deferred as a follow-up: smoothing `apy_estimate`'s emission *input* via a `neuron_daily` trailing average, same formula, less noisy input — needs its own precomputed side table, out of scope here). Went with (A).
- New loader `loadSubnetTempos` (`workers/data-api.mjs`, mirrors `loadValidatorNominatorCounts`'s savepoint-isolated-failure shape) + a new pure module `src/subnet-tempo.mjs` (mirrors `src/validator-nominator-summary.mjs`) for the `netuid -> tempo` Map builder.
- Threaded into the SAME per-row accumulation loop `buildGlobalValidators`/`buildValidatorDetail` already run (not derived from the post-cap `subnets[]` output) — a validator active on more than the leaderboard's top-10-by-stake cap (`GLOBAL_VALIDATOR_SUBNET_LIMIT`) still gets full APY credit for every eligible membership; a dedicated test proves this with a 15-subnet fixture.
- Exposed in `/api/v1/validators`, `/api/v1/validators/:hotkey`, the OpenAPI/schema/generated-client contract, and the `?format=csv` export.
- UI: adds an "Est. APY" column to the validators directory table, plus a glossary entry in the "how to evaluate a validator" guide (this page's own established explainer pattern) explaining the snapshot-projection caveat.

## Screenshots

Captured with Playwright against real local dev servers (not the in-app browser preview, which has known rendering fidelity issues in this environment) — `before` is `origin/main`, `after` is this branch.

| Before | After |
| --- | --- |
| Table: `HOTKEY, COLDKEY, ACTIVE SUBNETS, UIDS, NOMINATORS, DOMINANCE, TOTAL STAKE, TOTAL EMISSION` — no Est. APY column. Guide: 7 entries, no APY explainer. | Table adds `EST. APY` at the end, showing `—` for every row against the live prod API (correct — `subnet_hyperparams.tempo` hasn't been joined into a live-annualized figure in production yet). Guide adds an "Est. APY" entry between Total emission and Validator trust, with the projection caveat quoted above. |

## Test plan
- `npx vitest run` — 272 files, 7876 tests passing, including 8 new builder-level tests (`tests/metagraph-neurons.test.mjs`: exact single-membership formula, the multi-subnet stake-weighted blend with one membership excluded for unresolved tempo — verified against a hand-worked numeric example, non-positive-stake exclusion, the null-when-nothing-eligible default, and the 15-subnet top-10-cap non-leak, for both `buildGlobalValidators` and `buildValidatorDetail`), 6 new standalone module tests (`tests/subnet-tempo.test.mjs`), and 4 new route-level integration tests (`tests/data-api.test.mjs`: the tempo join working end-to-end on both routes, plus a graceful-degradation test for a `subnet_hyperparams` read failure). One unrelated, pre-existing test (`tests/network-routing.test.mjs`'s 12,000-alias timing test) flakes under heavy parallel load on this machine but passes cleanly in isolation (1.9s vs. its 5s timeout) — confirmed untouched by this diff.
- `npm run lint` / `npm run format:check` — clean
- `npm run validate` / `npm run validate:contract-drift` / `npm run scan:public-safety` — clean
- `cd apps/ui && npx tsc --noEmit` — clean (also rebuilt `packages/client`'s gitignored type declarations locally)
- Verified visually via Playwright against a local dev server on both the `before` (origin/main) and `after` (this branch) state — see screenshot table above
- `packages/client` patch-bumped 0.15.7 → 0.15.8 (contract change) per the pre-push client-SDK-sync guard