### PR TITLE
fix(mcp): unwrap .data when get_validator_nominators hits Postgres

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -4397,7 +4397,7 @@ export const MCP_TOOLS = [
       required: ["hotkey"],
       additionalProperties: false,
     },
-    async handler(args, _ctx) {
+    async handler(args, ctx) {
       const hotkey = requireHotkey(args);
       const window =
         optionalEnum(args, "window", Object.keys(NOMINATOR_WINDOWS)) ??
@@ -4417,12 +4417,25 @@ export const MCP_TOOLS = [
           "Argument `coldkey` must be a valid SS58 account address (base58, 47-48 chars).",
         );
       }
-      return buildValidatorNominators([], hotkey, {
-        window,
-        sort,
-        limit,
-        offset,
-      });
+      // The DATA_API route (workers/data-api.mjs) wraps its response as
+      // { data, generatedAt } -- unlike the flat-shaped neurons-tier routes
+      // mcpNeuronsTierRequest's other callers hit, this one needs its own
+      // .data unwrap or a live-Postgres response would violate this tool's
+      // own outputSchema (hotkey/nominator_count/nominators at the top
+      // level) the moment METAGRAPH_ACCOUNT_EVENTS_SOURCE flips to postgres.
+      return (
+        (
+          await tryPostgresTier(
+            ctx.env,
+            mcpNeuronsTierRequest(
+              `/api/v1/validators/${encodeURIComponent(hotkey)}/nominators`,
+              { window, sort, limit, offset, coldkey },
+            ),
+            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+          )
+        )?.data ??
+        buildValidatorNominators([], hotkey, { window, sort, limit, offset })
+      );
     },
   },
   {
@@ -5128,6 +5141,19 @@ export const MCP_TOOLS = [
       return buildAccountPositionHistory([], ss58, netuid, { window: label });
     },
   },
+  // get_account_stake_flow, get_account_stake_moves, get_account_axon_removals,
+  // get_account_prometheus, get_account_registrations, get_account_weight_setters,
+  // get_account_serving, and get_account_deregistrations (this cluster) are not
+  // yet wired to Postgres -- each still calls its builder unconditionally with an
+  // empty D1 result (account_events' D1 write path is retired, #4772), taking an
+  // unused _ctx. When one of these gets wired: its DATA_API route in
+  // workers/data-api.mjs returns json({ data: builder(...), generatedAt }), the
+  // SAME wrapped shape get_validator_nominators's own DATA_API route uses (see
+  // that tool's handler, above) -- not the flat shape the neurons-tier routes
+  // mcpNeuronsTierRequest's other callers hit. Wiring one of these with a bare
+  // `tryPostgresTier(...) ?? builder(...)` (no `.data` unwrap) would violate its
+  // own outputSchema the moment the Postgres flag flips on, exactly as
+  // get_validator_nominators's own wiring had to guard against.
   {
     name: "get_account_stake_flow",
     title: "Get an account's staking flow scorecard",

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14038,6 +14038,54 @@ describe("MCP validator detail/nominators/history tools (#5225 parity)", () => {
     assert.match(badColdkey.body.result.content[0].text, /coldkey/);
   });
 
+  test("get_validator_nominators: flag=postgres unwraps the DATA_API {data, generatedAt} envelope onto the top level", async () => {
+    // workers/data-api.mjs's own nominators route wraps its response as
+    // { data: buildValidatorNominators(...), generatedAt } -- unlike the
+    // flat-shaped neurons-tier routes. Assert hotkey/nominator_count/
+    // nominators land at the TOP of structuredContent (matching this tool's
+    // own outputSchema), not nested under .data, so a future regression to a
+    // bare `tryPostgresTier(...) ?? builder(...)` (no unwrap) fails loudly
+    // here instead of only violating the schema silently in production.
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            data: {
+              schema_version: 1,
+              hotkey: HOTKEY,
+              window: "30d",
+              sort: "net_staked",
+              limit: 20,
+              offset: 0,
+              nominator_count: 1,
+              nominators: [
+                {
+                  coldkey: "5Cold",
+                  net_staked_tao: 10,
+                  gross_staked_tao: 10,
+                  unstaked_tao: 0,
+                  event_count: 1,
+                  last_observed_at: "2026-07-01T00:00:00.000Z",
+                },
+              ],
+            },
+            generatedAt: "2026-07-01T00:00:00.000Z",
+          }),
+      },
+    };
+    const res = await callTool(
+      "get_validator_nominators",
+      { hotkey: HOTKEY },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.data, undefined);
+    assert.equal(out.hotkey, HOTKEY);
+    assert.equal(out.nominator_count, 1);
+    assert.equal(out.nominators[0].coldkey, "5Cold");
+  });
+
   test("get_validator_history returns a schema-stable empty point series", async () => {
     const res = await callTool("get_validator_history", { hotkey: HOTKEY });
     const out = res.body.result.structuredContent;


### PR DESCRIPTION
## Summary

- `workers/data-api.mjs`'s `/api/v1/validators/{hotkey}/nominators` route wraps its response as `json({ data: buildValidatorNominators(...), generatedAt })` — a `{data, generatedAt}` envelope, not the flat nominators object `get_validator_nominators`'s own documented `outputSchema` requires at the top level (`hotkey`/`nominator_count`/`nominators`).
- Wires the tool's Postgres tier with the correct unwrap:
  ```js
  return (
    (await tryPostgresTier(ctx.env, mcpNeuronsTierRequest(...), "METAGRAPH_ACCOUNT_EVENTS_SOURCE"))?.data ??
    buildValidatorNominators([], hotkey, { window, sort, limit, offset })
  );
  ```
  so a live-Postgres response matches the D1-fallback branch's own shape instead of violating the tool's contract the moment `METAGRAPH_ACCOUNT_EVENTS_SOURCE` flips to `"postgres"`.
- Left an in-code comment on the sibling not-yet-wired `get_account_stake_flow`/`get_account_stake_moves`/`get_account_axon_removals`/`get_account_prometheus`/`get_account_registrations`/`get_account_weight_setters`/`get_account_serving`/`get_account_deregistrations` cluster flagging that their own eventual Postgres wiring hits the identical `{data, generatedAt}`-wrapped shape (their `account_events` D1 write path is retired, so they currently always return an empty result) — not the flat shape the neurons-tier routes `mcpNeuronsTierRequest`'s other callers hit.

## Tests

New regression test mocks `DATA_API` returning the real wrapped `{data, generatedAt}` shape and asserts `hotkey`/`nominator_count`/`nominators` land at the top of `structuredContent`, not nested under `.data`. Verified this test genuinely catches the bug: temporarily reverted the `.data` unwrap and confirmed the test fails (`out.hotkey` is `undefined`, `out.data` is the whole wrapped object), then restored the fix and confirmed it passes.

## Validation run

- `node --check src/mcp-server.mjs`
- `npm run lint` / `npm run format:check`
- `npm run validate` / `validate:api` / `validate:openapi`
- `npx vitest run tests/mcp-server.test.mjs` (773 tests, all passing) + targeted coverage check confirming 100% patch coverage on every changed line

Closes #5285