### PR TITLE
feat(ui): enrich validator directory with take, APY, and identity

### DIFF
--- a/apps/ui/.prettierignore
+++ b/apps/ui/.prettierignore
@@ -16,3 +16,6 @@ CHANGELOG.md
 # machine-generated JSON nobody hand-edits; reformatting would just bloat
 # the diff on every re-record with no readability benefit.
 tests/e2e/har/*.har
+
+# Playwright run artifacts (gitignored); not hand-edited.
+test-results/

--- a/apps/ui/src/components/metagraphed/stake-modal.tsx
+++ b/apps/ui/src/components/metagraphed/stake-modal.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react";
+import { Coins } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@jsonbored/ui-kit";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import {
+  STAKE_ACTION_EVT,
+  type StakeActionDetail,
+  requestStakeAction,
+} from "@/lib/metagraphed/stake-actions";
+
+/**
+ * Stake-flow shell (#5242). Amount input, quote readout, and signing land in
+ * the maintainer-owned modal issue — this shell owns open/close + hotkey context.
+ */
+export function StakeModal({
+  open,
+  onOpenChange,
+  hotkey,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  hotkey: string;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md bg-paper text-ink border-border">
+        <DialogHeader>
+          <DialogTitle className="font-display text-lg">Stake to validator</DialogTitle>
+          <DialogDescription className="text-[12px] leading-relaxed text-ink-muted">
+            Delegate TAO to{" "}
+            <span className="font-mono text-ink-strong">{shortHash(hotkey, 8) ?? hotkey}</span>.
+            Amount entry, root vs alpha framing, and wallet signing wire through #5242.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="rounded-lg border border-dashed border-border bg-card/60 px-4 py-6 text-center">
+          <Coins className="mx-auto mb-2 size-5 text-accent" aria-hidden />
+          <p className="text-[12px] text-ink-muted">
+            Connect a wallet and enter an amount — the full stake modal ships in #5242.
+          </p>
+          <button
+            type="button"
+            className="mt-4 inline-flex items-center justify-center rounded border border-border bg-card px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:border-ink/30 hover:text-ink-strong"
+            onClick={() => onOpenChange(false)}
+          >
+            Close
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Listens for `metagraphed:stake-action` stake events and opens the modal. */
+export function StakeModalHost() {
+  const [open, setOpen] = useState(false);
+  const [hotkey, setHotkey] = useState<string | null>(null);
+
+  useEffect(() => {
+    function onStakeAction(e: Event) {
+      const detail = (e as CustomEvent<StakeActionDetail>).detail;
+      if (!detail?.hotkey || detail.kind !== "stake") return;
+      setHotkey(detail.hotkey);
+      setOpen(true);
+    }
+    window.addEventListener(STAKE_ACTION_EVT, onStakeAction);
+    return () => window.removeEventListener(STAKE_ACTION_EVT, onStakeAction);
+  }, []);
+
+  if (!hotkey) return null;
+  return <StakeModal open={open} onOpenChange={setOpen} hotkey={hotkey} />;
+}
+
+export function openStakeModal(hotkey: string) {
+  requestStakeAction("stake", { hotkey });
+}

--- a/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
@@ -55,10 +55,7 @@ export function ValidatorApyPanel({
     <div className="space-y-3">
       <div className="grid gap-3 sm:grid-cols-3">
         {rows.map((row) => (
-          <div
-            key={row.window}
-            className="rounded-xl border border-border bg-card px-4 py-3"
-          >
+          <div key={row.window} className="rounded-xl border border-border bg-card px-4 py-3">
             <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
               Est. APY · {row.window}
             </div>

--- a/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
@@ -1,0 +1,88 @@
+import { useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { MethodologyCallout } from "@jsonbored/ui-kit";
+import { validatorHistoryQuery } from "@/lib/metagraphed/queries";
+import {
+  apyFromRewardsPer1000,
+  formatApyPct,
+  type ValidatorApyWindow,
+} from "@/lib/metagraphed/validator-apy";
+
+const WINDOWS: ValidatorApyWindow[] = ["7d", "30d", "90d"];
+
+function latestRewards(points: Array<{ rewards_per_1000_tao?: number | null }>) {
+  for (const p of points) {
+    const v = p.rewards_per_1000_tao;
+    if (v != null && Number.isFinite(v)) return v;
+  }
+  return null;
+}
+
+/** Multi-window delegator APY tiles from validator history (#5245 / #2551 methodology). */
+export function ValidatorApyPanel({
+  hotkey,
+  take,
+  generatedAt,
+}: {
+  hotkey: string;
+  take: number | null;
+  generatedAt?: string | null;
+}) {
+  const results = useQueries({
+    queries: WINDOWS.map((window) => ({
+      ...validatorHistoryQuery(hotkey, window),
+      staleTime: 60_000,
+    })),
+  });
+
+  const rows = useMemo(
+    () =>
+      WINDOWS.map((window, i) => {
+        const points = results[i]?.data?.data?.points ?? [];
+        const rewards = latestRewards(points);
+        return {
+          window,
+          apy: apyFromRewardsPer1000(rewards, take),
+        };
+      }),
+    [results, take],
+  );
+
+  const anyLoading = results.some((r) => r.isLoading);
+  const anyValue = rows.some((r) => r.apy != null);
+
+  return (
+    <div className="space-y-3">
+      <div className="grid gap-3 sm:grid-cols-3">
+        {rows.map((row) => (
+          <div
+            key={row.window}
+            className="rounded-xl border border-border bg-card px-4 py-3"
+          >
+            <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              Est. APY · {row.window}
+            </div>
+            <div className="mt-1 font-display text-2xl font-semibold tabular-nums text-ink-strong">
+              {anyLoading && row.apy == null ? "…" : formatApyPct(row.apy)}
+            </div>
+            <p className="mt-1 text-[10px] leading-relaxed text-ink-muted">
+              Net of take · daily neuron_daily rollup
+            </p>
+          </div>
+        ))}
+      </div>
+      {!anyLoading && !anyValue ? (
+        <p className="text-[11px] text-ink-muted">
+          APY estimates need stake and emission history — they appear once enough daily snapshots
+          exist for this validator.
+        </p>
+      ) : null}
+      <MethodologyCallout generatedAt={generatedAt ?? undefined} windowLabel="history windows" />
+      <p className="text-[11px] leading-relaxed text-ink-muted">
+        Delegator APY annualizes the latest daily rewards-per-1k-τ rate from neuron_daily, net of
+        validator take. Snapshot-tier emission can lag; server-side modelling (#2551) will replace
+        this client estimate.
+      </p>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -22,6 +22,18 @@ const METRICS: Array<{ term: string; def: string }> = [
     def: "The total neuron slots the hotkey holds across those subnets — one registration is one UID.",
   },
   {
+    term: "Operator",
+    def: "The coldkey's self-declared on-chain identity (name, logo, links) joined server-side (#5234). It belongs to the operator's coldkey, not the hotkey — the same operator can run multiple validators.",
+  },
+  {
+    term: "Take",
+    def: "The validator's commission (#2548): the fraction of delegator rewards the validator keeps (0–100%). Lower take means nominators keep more of the emission flow.",
+  },
+  {
+    term: "Est. APY",
+    def: "Annualized delegator yield estimated from emission÷stake, net of take. On the directory this uses the latest metagraph snapshot; on a validator detail page, 7d/30d/90d windows use daily neuron_daily history. Server-side modelling (#2551) will supersede these client estimates.",
+  },
+  {
     term: "Nominators",
     def: "How many distinct coldkeys currently have stake delegated to this hotkey, network-wide (#2549). Sourced from a lower-frequency chain scan than the other columns, so it can lag them briefly — a dash means no count has been captured for this hotkey yet, not zero nominators.",
   },

--- a/apps/ui/src/components/metagraphed/validator-identity-chip.tsx
+++ b/apps/ui/src/components/metagraphed/validator-identity-chip.tsx
@@ -1,0 +1,37 @@
+import { BrandIcon } from "@jsonbored/ui-kit";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import type { ColdkeyIdentity } from "@/lib/metagraphed/types";
+
+/** Operator identity chip — coldkey's self-declared name/logo (#5234), not hotkey-specific. */
+export function ValidatorIdentityChip({
+  hotkey,
+  identity,
+  size = 28,
+  showName = true,
+}: {
+  hotkey: string;
+  identity: ColdkeyIdentity | null | undefined;
+  size?: number;
+  showName?: boolean;
+}) {
+  const name =
+    identity?.has_identity && identity.name ? identity.name : (shortHash(hotkey) ?? hotkey);
+
+  return (
+    <span className="inline-flex items-center gap-2 min-w-0">
+      <BrandIcon
+        iconUrl={identity?.image}
+        url={identity?.url}
+        repoUrl={identity?.github}
+        name={name}
+        fallback={hotkey}
+        size={size}
+      />
+      {showName ? (
+        <span className="truncate font-medium text-ink-strong text-[12px]" title={name}>
+          {name}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -200,6 +200,7 @@ import type {
   GlobalValidatorSubnet,
   ValidatorDetail,
   ValidatorDetailSubnet,
+  ColdkeyIdentity,
   ValidatorNominatorEntry,
   ValidatorHistory,
   ValidatorHistoryPoint,
@@ -5327,6 +5328,22 @@ const GLOBAL_VALIDATOR_SORTS: GlobalValidatorSort[] = [
   "uid_count",
 ];
 
+function normalizeColdkeyIdentity(raw: unknown): ColdkeyIdentity | null {
+  if (raw == null) return null;
+  if (!isRecord(raw)) return null;
+  return {
+    has_identity: booleanValue(raw.has_identity) ?? false,
+    name: firstString(raw.name) ?? null,
+    url: firstString(raw.url) ?? null,
+    github: firstString(raw.github) ?? null,
+    image: firstString(raw.image) ?? null,
+    discord: firstString(raw.discord) ?? null,
+    description: firstString(raw.description) ?? null,
+    additional: firstString(raw.additional) ?? null,
+    captured_at: firstString(raw.captured_at) ?? null,
+  };
+}
+
 function normalizeGlobalValidatorSubnet(raw: unknown): GlobalValidatorSubnet | null {
   if (!isRecord(raw)) return null;
   const netuid = coerceFiniteNumber(raw.netuid);
@@ -5360,10 +5377,14 @@ function normalizeGlobalValidator(raw: unknown): GlobalValidator | null {
     // spread, so it must be listed explicitly or it silently vanishes.
     featured: booleanValue(raw.featured) ?? false,
     coldkey: typeof raw.coldkey === "string" ? raw.coldkey : null,
+    coldkey_identity: normalizeColdkeyIdentity(raw.coldkey_identity),
     coldkey_count: coerceFiniteNumber(raw.coldkey_count) ?? 0,
     subnet_count: coerceFiniteNumber(raw.subnet_count) ?? 0,
     uid_count: coerceFiniteNumber(raw.uid_count) ?? 0,
+    take: nullableNum(raw.take),
     total_stake_tao: coerceFiniteNumber(raw.total_stake_tao) ?? 0,
+    root_stake_tao: coerceFiniteNumber(raw.root_stake_tao) ?? 0,
+    alpha_stake_tao: coerceFiniteNumber(raw.alpha_stake_tao) ?? 0,
     total_emission_tao: coerceFiniteNumber(raw.total_emission_tao) ?? 0,
     nominator_count: nullableNum(raw.nominator_count),
     avg_validator_trust: nullableNum(raw.avg_validator_trust),
@@ -5660,8 +5681,11 @@ export const validatorDetailQuery = (hotkey: string) =>
         data: {
           hotkey: firstString(d.hotkey) ?? hotkey,
           coldkey: firstString(d.coldkey) ?? null,
+          coldkey_identity: normalizeColdkeyIdentity(d.coldkey_identity),
           coldkey_count: firstFiniteNumber(d.coldkey_count) ?? 0,
           subnet_count: firstFiniteNumber(d.subnet_count) ?? 0,
+          take: firstFiniteNumber(d.take) ?? null,
+          nominator_count: firstFiniteNumber(d.nominator_count) ?? null,
           total_stake_tao: firstFiniteNumber(d.total_stake_tao) ?? 0,
           root_stake_tao: firstFiniteNumber(d.root_stake_tao) ?? 0,
           alpha_stake_tao: firstFiniteNumber(d.alpha_stake_tao) ?? 0,

--- a/apps/ui/src/lib/metagraphed/stake-actions.ts
+++ b/apps/ui/src/lib/metagraphed/stake-actions.ts
@@ -1,0 +1,19 @@
+export const STAKE_ACTION_EVT = "metagraphed:stake-action";
+
+export type StakeActionKind = "stake" | "unstake" | "move";
+
+export type StakeActionDetail = {
+  kind: StakeActionKind;
+  hotkey: string;
+  netuid?: number;
+};
+
+/** Dispatch a stake-flow entry event — consumed by StakeModal (#5242 integration). */
+export function requestStakeAction(kind: StakeActionKind, detail: Omit<StakeActionDetail, "kind">) {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<StakeActionDetail>(STAKE_ACTION_EVT, {
+      detail: { kind, ...detail },
+    }),
+  );
+}

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1980,16 +1980,35 @@ export interface GlobalValidatorSubnet {
   validator_trust: number | null;
 }
 
+/** Self-declared on-chain identity for a validator's primary coldkey (#5234). */
+export interface ColdkeyIdentity {
+  has_identity: boolean;
+  name: string | null;
+  url: string | null;
+  github: string | null;
+  image: string | null;
+  discord: string | null;
+  description: string | null;
+  additional: string | null;
+  captured_at: string | null;
+}
+
 /** One validator/operator row grouped by hotkey across subnet memberships. */
 export interface GlobalValidator {
   hotkey: string;
   /** DB-toggled maintainer pin (#5166) — always present, moves the row to the front of the default (unsorted) view. */
   featured: boolean;
   coldkey: string | null;
+  /** Primary coldkey's self-declared identity (#5234); null when coldkey is null. */
+  coldkey_identity: ColdkeyIdentity | null;
   coldkey_count: number;
   subnet_count: number;
   uid_count: number;
+  /** Validator take/commission (#2548), 0..1 fraction kept from delegator rewards. */
+  take: number | null;
   total_stake_tao: number;
+  root_stake_tao: number;
+  alpha_stake_tao: number;
   total_emission_tao: number;
   /** Distinct coldkeys currently staking to this hotkey, network-wide (#2549). Null when the low-frequency source table has no row for this hotkey yet. */
   nominator_count: number | null;
@@ -2039,8 +2058,11 @@ export interface ValidatorDetail {
   schema_version?: number;
   hotkey: string;
   coldkey: string | null;
+  coldkey_identity: ColdkeyIdentity | null;
   coldkey_count: number;
   subnet_count: number;
+  take: number | null;
+  nominator_count: number | null;
   total_stake_tao: number;
   /** Stake on netuid 0 (root), TAO-denominated 1:1, no AMM/price exposure (#2550). */
   root_stake_tao: number;

--- a/apps/ui/src/lib/metagraphed/validator-apy.test.ts
+++ b/apps/ui/src/lib/metagraphed/validator-apy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  annualizedDelegatorApyPct,
+  apyFromRewardsPer1000,
+  formatApyPct,
+  formatTakePct,
+  netDailyYield,
+} from "./validator-apy";
+
+describe("validator-apy", () => {
+  it("annualizes emission÷stake net of take", () => {
+    // 1 τ emission / 1000 τ stake per day, 18% take → 0.00082 daily net → ~29.9% APY
+    expect(annualizedDelegatorApyPct(1, 1000, 0.18)).toBeCloseTo(29.93, 1);
+  });
+
+  it("returns null for zero stake", () => {
+    expect(annualizedDelegatorApyPct(1, 0, 0.1)).toBeNull();
+    expect(netDailyYield(1, 0, 0.1)).toBeNull();
+  });
+
+  it("derives APY from rewards_per_1000_tao", () => {
+    expect(apyFromRewardsPer1000(0.5, 0)).toBeCloseTo(18.25, 2);
+    expect(apyFromRewardsPer1000(null, 0)).toBeNull();
+  });
+
+  it("formats take and APY for display", () => {
+    expect(formatTakePct(0.185)).toBe("18.5%");
+    expect(formatTakePct(null)).toBe("—");
+    expect(formatApyPct(12.456)).toBe("12.5%");
+    expect(formatApyPct(null)).toBe("—");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/validator-apy.ts
+++ b/apps/ui/src/lib/metagraphed/validator-apy.ts
@@ -20,8 +20,7 @@ export function netDailyYield(
 ): number | null {
   const gross = dailyYieldFraction(emissionTao, stakeTao);
   if (gross == null) return null;
-  const commission =
-    take != null && Number.isFinite(take) ? Math.min(Math.max(take, 0), 1) : 0;
+  const commission = take != null && Number.isFinite(take) ? Math.min(Math.max(take, 0), 1) : 0;
   return gross * (1 - commission);
 }
 
@@ -42,8 +41,7 @@ export function apyFromRewardsPer1000(
   take?: number | null,
 ): number | null {
   if (rewardsPer1000 == null || !Number.isFinite(rewardsPer1000)) return null;
-  const commission =
-    take != null && Number.isFinite(take) ? Math.min(Math.max(take, 0), 1) : 0;
+  const commission = take != null && Number.isFinite(take) ? Math.min(Math.max(take, 0), 1) : 0;
   const dailyPerTao = (rewardsPer1000 / 1000) * (1 - commission);
   return Math.round(dailyPerTao * 365 * 100 * 100) / 100;
 }

--- a/apps/ui/src/lib/metagraphed/validator-apy.ts
+++ b/apps/ui/src/lib/metagraphed/validator-apy.ts
@@ -1,0 +1,61 @@
+/**
+ * Client-side delegator APY estimates (#5245) until server-side modelling lands
+ * in #2551. Uses the same emission÷stake annualization as rewards_per_1000_tao
+ * (see src/validator-history.mjs) and applies take when known.
+ */
+
+export type ValidatorApyWindow = "7d" | "30d" | "90d" | "snapshot";
+
+/** Gross daily yield as a fraction (emission τ per τ staked per day). */
+export function dailyYieldFraction(emissionTao: number, stakeTao: number): number | null {
+  if (!(stakeTao > 0) || !Number.isFinite(emissionTao)) return null;
+  return emissionTao / stakeTao;
+}
+
+/** Delegator net daily yield after validator take (0..1 fraction). */
+export function netDailyYield(
+  emissionTao: number,
+  stakeTao: number,
+  take: number | null | undefined,
+): number | null {
+  const gross = dailyYieldFraction(emissionTao, stakeTao);
+  if (gross == null) return null;
+  const commission =
+    take != null && Number.isFinite(take) ? Math.min(Math.max(take, 0), 1) : 0;
+  return gross * (1 - commission);
+}
+
+/** Annualized delegator APY as a percentage. */
+export function annualizedDelegatorApyPct(
+  emissionTao: number,
+  stakeTao: number,
+  take?: number | null,
+): number | null {
+  const daily = netDailyYield(emissionTao, stakeTao, take);
+  if (daily == null) return null;
+  return Math.round(daily * 365 * 100 * 100) / 100;
+}
+
+/** From a history point's rewards_per_1000_tao (τ per 1k τ staked per day). */
+export function apyFromRewardsPer1000(
+  rewardsPer1000: number | null | undefined,
+  take?: number | null,
+): number | null {
+  if (rewardsPer1000 == null || !Number.isFinite(rewardsPer1000)) return null;
+  const commission =
+    take != null && Number.isFinite(take) ? Math.min(Math.max(take, 0), 1) : 0;
+  const dailyPerTao = (rewardsPer1000 / 1000) * (1 - commission);
+  return Math.round(dailyPerTao * 365 * 100 * 100) / 100;
+}
+
+export function formatApyPct(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  if (value >= 100) return `${value.toFixed(0)}%`;
+  if (value >= 10) return `${value.toFixed(1)}%`;
+  return `${value.toFixed(2)}%`;
+}
+
+export function formatTakePct(take: number | null | undefined): string {
+  if (take == null || !Number.isFinite(take)) return "—";
+  return `${(take * 100).toFixed(1)}%`;
+}

--- a/apps/ui/src/lib/metagraphed/validators.test.ts
+++ b/apps/ui/src/lib/metagraphed/validators.test.ts
@@ -15,6 +15,15 @@ describe("normalizeGlobalValidators", () => {
         {
           hotkey: "5Hotkey",
           coldkey: "5Coldkey",
+          coldkey_identity: {
+            has_identity: true,
+            name: "TensorOps",
+            image: "https://example.com/logo.png",
+          },
+          take: 0.18,
+          root_stake_tao: 10,
+          alpha_stake_tao: 90.5,
+          nominator_count: 42,
           coldkey_count: 1,
           subnet_count: 2,
           uid_count: 3,
@@ -50,6 +59,11 @@ describe("normalizeGlobalValidators", () => {
     expect(out.validators[0]).toMatchObject({
       hotkey: "5Hotkey",
       coldkey: "5Coldkey",
+      take: 0.18,
+      root_stake_tao: 10,
+      alpha_stake_tao: 90.5,
+      nominator_count: 42,
+      coldkey_identity: { has_identity: true, name: "TensorOps" },
       subnet_count: 2,
       uid_count: 3,
       subnets: [{ netuid: 1, uid: 0, stake_tao: 50, emission_tao: 0.5, validator_trust: 1 }],

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -232,11 +232,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         description={
           <span className="block space-y-4">
             <span className="flex flex-wrap items-center gap-3">
-              <ValidatorIdentityChip
-                hotkey={hotkey}
-                identity={detail.coldkey_identity}
-                size={40}
-              />
+              <ValidatorIdentityChip hotkey={hotkey} identity={detail.coldkey_identity} size={40} />
               {detail.coldkey_identity?.has_identity ? (
                 <span className="text-[11px] text-ink-muted">
                   Operator identity is declared on the coldkey — not hotkey-specific (#5234).
@@ -310,9 +306,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         <StatTile
           icon={Users}
           eyebrow="Nominators"
-          value={
-            detail.nominator_count != null ? formatNumber(detail.nominator_count) : "—"
-          }
+          value={detail.nominator_count != null ? formatNumber(detail.nominator_count) : "—"}
           hint="distinct coldkeys delegated"
           className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
         />
@@ -332,11 +326,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         subtitle="7d / 30d / 90d windows from daily history"
         tone="accent"
       >
-        <ValidatorApyPanel
-          hotkey={hotkey}
-          take={detail.take}
-          generatedAt={detail.captured_at}
-        />
+        <ValidatorApyPanel hotkey={hotkey} take={detail.take} generatedAt={detail.captured_at} />
       </SectionAnchor>
 
       <SectionAnchor id="subnets" title="Per-subnet performance" tone="accent">

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -1,9 +1,9 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { Boxes, Coins, Gauge, Zap } from "lucide-react";
+import { Boxes, Coins, Gauge, Percent, Users, Zap } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -11,6 +11,9 @@ import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { PageHero, ShareButton, SectionAnchor, CopyableCode, StatTile } from "@jsonbored/ui-kit";
 import { ValidatorHistoryChart } from "@/components/metagraphed/validator-history-chart";
+import { ValidatorApyPanel } from "@/components/metagraphed/validator-apy-panel";
+import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
+import { StakeModal } from "@/components/metagraphed/stake-modal";
 import { WatchValidatorAlert } from "@/components/metagraphed/watch-validator-alert";
 import {
   ValidatorNominatorsTable,
@@ -21,6 +24,11 @@ import { validatorDetailQuery, validatorNominatorsQuery } from "@/lib/metagraphe
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
+import {
+  annualizedDelegatorApyPct,
+  formatApyPct,
+  formatTakePct,
+} from "@/lib/metagraphed/validator-apy";
 import type { ValidatorDetailSubnet } from "@/lib/metagraphed/types";
 
 const validatorDetailSearchSchema = z.object({
@@ -202,21 +210,40 @@ function NominatorsSection({ hotkey }: { hotkey: string }) {
 
 function ValidatorDetail({ hotkey }: { hotkey: string }) {
   const sourceRef = ss58PathSegment(hotkey);
-  const detail = useSuspenseQuery(validatorDetailQuery(hotkey)).data.data;
+  const detailRes = useSuspenseQuery(validatorDetailQuery(hotkey)).data;
+  const detail = detailRes.data;
+  const [stakeOpen, setStakeOpen] = useState(false);
+  const displayName =
+    detail.coldkey_identity?.has_identity && detail.coldkey_identity.name
+      ? detail.coldkey_identity.name
+      : (shortHash(hotkey, 8) ?? "Validator");
+  const snapshotApy = annualizedDelegatorApyPct(
+    detail.total_emission_tao,
+    detail.total_stake_tao,
+    detail.take,
+  );
 
   return (
     <>
       <PageHero
         eyebrow="Explorer · validator"
         live
-        title={shortHash(hotkey, 8) ?? "Validator"}
+        title={displayName}
         description={
-          // PageHero renders `description` inside a <p> — block elements (div/p)
-          // are invalid HTML there (triggers a hydration mismatch), so this uses
-          // block-styled <span>s instead of the <div>/<p> combo other detail pages
-          // use for the same "blurb + copyable chip" shape.
           <span className="block space-y-4">
-            <span className="block max-w-2xl">
+            <span className="flex flex-wrap items-center gap-3">
+              <ValidatorIdentityChip
+                hotkey={hotkey}
+                identity={detail.coldkey_identity}
+                size={40}
+              />
+              {detail.coldkey_identity?.has_identity ? (
+                <span className="text-[11px] text-ink-muted">
+                  Operator identity is declared on the coldkey — not hotkey-specific (#5234).
+                </span>
+              ) : null}
+            </span>
+            <span className="block max-w-2xl text-sm text-ink-muted">
               Cross-subnet performance, nominators, and staking history for one Bittensor validator
               hotkey.
             </span>
@@ -225,11 +252,22 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
             </span>
           </span>
         }
-        actions={<ShareButton />}
+        actions={
+          <span className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setStakeOpen(true)}
+              className="inline-flex items-center justify-center rounded border border-accent/40 bg-accent-surface px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-accent-text hover:border-accent/60 transition-colors min-h-11"
+            >
+              Stake to this validator
+            </button>
+            <ShareButton />
+          </span>
+        }
         caption="explorer / v1"
       />
 
-      <div className="mb-12 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="mb-12 grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6">
         <StatTile
           icon={Coins}
           eyebrow="Total stake"
@@ -262,7 +300,44 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           hint="mean across subnets"
           className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
         />
+        <StatTile
+          icon={Percent}
+          eyebrow="Take rate"
+          value={formatTakePct(detail.take)}
+          hint="commission kept from delegators"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+        />
+        <StatTile
+          icon={Users}
+          eyebrow="Nominators"
+          value={
+            detail.nominator_count != null ? formatNumber(detail.nominator_count) : "—"
+          }
+          hint="distinct coldkeys delegated"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+        />
+        <StatTile
+          icon={Zap}
+          eyebrow="Est. APY"
+          value={formatApyPct(snapshotApy)}
+          hint="snapshot · net of take"
+          truncate={false}
+          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+        />
       </div>
+
+      <SectionAnchor
+        id="apy"
+        title="Delegator yield (APY)"
+        subtitle="7d / 30d / 90d windows from daily history"
+        tone="accent"
+      >
+        <ValidatorApyPanel
+          hotkey={hotkey}
+          take={detail.take}
+          generatedAt={detail.captured_at}
+        />
+      </SectionAnchor>
 
       <SectionAnchor id="subnets" title="Per-subnet performance" tone="accent">
         <SubnetPerformanceTable subnets={detail.subnets} />
@@ -320,6 +395,8 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           `/api/v1/validators/${sourceRef}/history`,
         ]}
       />
+
+      <StakeModal open={stakeOpen} onOpenChange={setStakeOpen} hotkey={hotkey} />
     </>
   );
 }

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -190,65 +190,65 @@ function ValidatorsTable({
                   v.take,
                 );
                 return (
-                <tr key={v.hotkey} className="hover:bg-surface/40">
-                  <td className="px-3 py-2 max-w-[10rem]">
-                    <ValidatorIdentityChip hotkey={v.hotkey} identity={v.coldkey_identity} />
-                  </td>
-                  <td className="px-3 py-2 font-mono text-[11px]">
-                    <div className="flex items-center gap-1.5">
-                      {v.featured ? <FeaturedBadge /> : null}
-                      <Link
-                        to="/validators/$hotkey"
-                        params={{ hotkey: v.hotkey }}
-                        className="text-ink-strong hover:text-accent hover:underline"
-                        title={v.hotkey}
-                      >
-                        {shortHash(v.hotkey) ?? v.hotkey}
-                      </Link>
-                    </div>
-                  </td>
-                  <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
-                    {v.coldkey ? (
-                      <Link
-                        to="/accounts/$ss58"
-                        params={{ ss58: v.coldkey }}
-                        className="hover:text-accent hover:underline"
-                        title={v.coldkey}
-                      >
-                        {shortHash(v.coldkey) ?? v.coldkey}
-                      </Link>
-                    ) : (
-                      "—"
-                    )}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {formatTakePct(v.take)}
-                  </td>
-                  <td
-                    className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink"
-                    title="Annualized from snapshot emission÷stake, net of take"
-                  >
-                    {formatApyPct(apy)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {formatNumber(v.subnet_count)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {formatNumber(v.uid_count)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {v.nominator_count != null ? formatNumber(v.nominator_count) : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {taoCompact(v.total_stake_tao)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {taoCompact(v.total_emission_tao)}
-                  </td>
-                </tr>
+                  <tr key={v.hotkey} className="hover:bg-surface/40">
+                    <td className="px-3 py-2 max-w-[10rem]">
+                      <ValidatorIdentityChip hotkey={v.hotkey} identity={v.coldkey_identity} />
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[11px]">
+                      <div className="flex items-center gap-1.5">
+                        {v.featured ? <FeaturedBadge /> : null}
+                        <Link
+                          to="/validators/$hotkey"
+                          params={{ hotkey: v.hotkey }}
+                          className="text-ink-strong hover:text-accent hover:underline"
+                          title={v.hotkey}
+                        >
+                          {shortHash(v.hotkey) ?? v.hotkey}
+                        </Link>
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
+                      {v.coldkey ? (
+                        <Link
+                          to="/accounts/$ss58"
+                          params={{ ss58: v.coldkey }}
+                          className="hover:text-accent hover:underline"
+                          title={v.coldkey}
+                        >
+                          {shortHash(v.coldkey) ?? v.coldkey}
+                        </Link>
+                      ) : (
+                        "—"
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {formatTakePct(v.take)}
+                    </td>
+                    <td
+                      className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink"
+                      title="Annualized from snapshot emission÷stake, net of take"
+                    >
+                      {formatApyPct(apy)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {formatNumber(v.subnet_count)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {formatNumber(v.uid_count)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {v.nominator_count != null ? formatNumber(v.nominator_count) : "—"}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {taoCompact(v.total_stake_tao)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {taoCompact(v.total_emission_tao)}
+                    </td>
+                  </tr>
                 );
               })}
             </tbody>

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -14,6 +14,12 @@ import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
+import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
+import {
+  annualizedDelegatorApyPct,
+  formatApyPct,
+  formatTakePct,
+} from "@/lib/metagraphed/validator-apy";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 // The full GlobalValidatorSort set the /api/v1/validators endpoint accepts.
@@ -163,8 +169,11 @@ function ValidatorsTable({
           <table className="w-full text-left text-sm">
             <thead className="bg-surface/50">
               <tr>
+                <th className={TH}>Operator</th>
                 <th className={TH}>Hotkey</th>
                 <th className={TH}>Coldkey</th>
+                <th className={`${TH} text-right`}>Take</th>
+                <th className={`${TH} text-right`}>Est. APY</th>
                 <th className={`${TH} text-right`}>Active subnets</th>
                 <th className={`${TH} text-right`}>UIDs</th>
                 <th className={`${TH} text-right`}>Nominators</th>
@@ -174,8 +183,17 @@ function ValidatorsTable({
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
-              {validators.map((v) => (
+              {validators.map((v) => {
+                const apy = annualizedDelegatorApyPct(
+                  v.total_emission_tao,
+                  v.total_stake_tao,
+                  v.take,
+                );
+                return (
                 <tr key={v.hotkey} className="hover:bg-surface/40">
+                  <td className="px-3 py-2 max-w-[10rem]">
+                    <ValidatorIdentityChip hotkey={v.hotkey} identity={v.coldkey_identity} />
+                  </td>
                   <td className="px-3 py-2 font-mono text-[11px]">
                     <div className="flex items-center gap-1.5">
                       {v.featured ? <FeaturedBadge /> : null}
@@ -203,6 +221,15 @@ function ValidatorsTable({
                       "—"
                     )}
                   </td>
+                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    {formatTakePct(v.take)}
+                  </td>
+                  <td
+                    className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink"
+                    title="Annualized from snapshot emission÷stake, net of take"
+                  >
+                    {formatApyPct(apy)}
+                  </td>
                   <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
                     {formatNumber(v.subnet_count)}
                   </td>
@@ -222,7 +249,8 @@ function ValidatorsTable({
                     {taoCompact(v.total_emission_tao)}
                   </td>
                 </tr>
-              ))}
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/apps/ui/tests/e2e/capture-validator-delegate-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-validator-delegate-screenshots.mjs
@@ -124,10 +124,7 @@ async function main() {
       } else {
         await openDirectoryView(page);
       }
-      const file = path.join(
-        OUT_DIR,
-        `5245-${PAGE}-${viewport.name}-${theme}-${VARIANT}.png`,
-      );
+      const file = path.join(OUT_DIR, `5245-${PAGE}-${viewport.name}-${theme}-${VARIANT}.png`);
       await page.screenshot({ path: file, fullPage: false });
       console.log(`wrote ${file}`);
     }

--- a/apps/ui/tests/e2e/capture-validator-delegate-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-validator-delegate-screenshots.mjs
@@ -1,0 +1,144 @@
+/**
+ * Capture validator delegate-selection UI screenshots for #5245 (Path C2).
+ * Fixed viewport only — never fullPage or element crops.
+ *
+ * Usage (with dev servers running — pass base URL explicitly):
+ *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=after node tests/e2e/capture-validator-delegate-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8086 VARIANT=before node tests/e2e/capture-validator-delegate-screenshots.mjs
+ *
+ * PAGE=directory|detail (default: directory)
+ * Writes to tmp/validator-delegate-screenshots/5245-{page}-{viewport}-{theme}-{variant}.png
+ */
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/validator-delegate-screenshots");
+const VALIDATORS_FIXTURE = JSON.parse(
+  await readFile(new URL("./fixtures/global-validators-screenshot.json", import.meta.url), "utf8"),
+);
+const DETAIL_FIXTURE = JSON.parse(
+  await readFile(new URL("./fixtures/validator-detail-screenshot.json", import.meta.url), "utf8"),
+);
+const HISTORY_FIXTURE = JSON.parse(
+  await readFile(new URL("./fixtures/validator-history-screenshot.json", import.meta.url), "utf8"),
+);
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8085";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const PAGE = process.env.PAGE === "detail" ? "detail" : "directory";
+const HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function installAfterFixtures(page) {
+  await page.route("**/api/v1/validators**", async (route) => {
+    const url = route.request().url();
+    if (/\/validators\/[^/?]+\/history/.test(url)) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(HISTORY_FIXTURE),
+      });
+      return;
+    }
+    if (/\/validators\/[^/?]+/.test(url) && !url.endsWith("/validators")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(DETAIL_FIXTURE),
+      });
+      return;
+    }
+    if (url.includes("/validators")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(VALIDATORS_FIXTURE),
+      });
+      return;
+    }
+    await route.continue();
+  });
+}
+
+async function openDirectoryView(page) {
+  await page.goto(`${BASE_URL}/validators`, { waitUntil: "networkidle", timeout: 90_000 });
+  await page.locator("table").first().waitFor({ state: "visible", timeout: 30_000 });
+  await page.evaluate(() => {
+    const table = document.querySelector("table");
+    if (!table) return;
+    const top = table.getBoundingClientRect().top + window.scrollY - 72;
+    window.scrollTo({ top: Math.max(0, top), behavior: "instant" });
+  });
+  await page.waitForTimeout(300);
+}
+
+async function openDetailView(page) {
+  await page.goto(`${BASE_URL}/validators/${HOTKEY}`, {
+    waitUntil: "networkidle",
+    timeout: 90_000,
+  });
+  if (VARIANT === "after") {
+    await page.getByRole("button", { name: "Stake to this validator" }).waitFor({
+      state: "visible",
+      timeout: 30_000,
+    });
+    await page.getByText("Delegator yield (APY)").waitFor({ state: "visible", timeout: 30_000 });
+  } else {
+    await page.locator("header.mg-header").waitFor({ state: "visible", timeout: 30_000 });
+  }
+  await page.waitForTimeout(300);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    const context = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+    });
+    const page = await context.newPage();
+
+    if (VARIANT === "after") {
+      await installAfterFixtures(page);
+    }
+
+    for (const theme of THEMES) {
+      await setTheme(page, theme);
+      if (PAGE === "detail") {
+        await openDetailView(page);
+      } else {
+        await openDirectoryView(page);
+      }
+      const file = path.join(
+        OUT_DIR,
+        `5245-${PAGE}-${viewport.name}-${theme}-${VARIANT}.png`,
+      );
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+    }
+
+    await context.close();
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/ui/tests/e2e/fixtures/global-validators-screenshot.json
+++ b/apps/ui/tests/e2e/fixtures/global-validators-screenshot.json
@@ -39,8 +39,20 @@
         "latest_captured_at": "2026-07-14T08:00:00.000Z",
         "latest_block_number": 4200000,
         "subnets": [
-          { "netuid": 1, "uid": 42, "stake_tao": 210000, "emission_tao": 1.2, "validator_trust": 1 },
-          { "netuid": 8, "uid": 7, "stake_tao": 98000, "emission_tao": 0.6, "validator_trust": 0.99 }
+          {
+            "netuid": 1,
+            "uid": 42,
+            "stake_tao": 210000,
+            "emission_tao": 1.2,
+            "validator_trust": 1
+          },
+          {
+            "netuid": 8,
+            "uid": 7,
+            "stake_tao": 98000,
+            "emission_tao": 0.6,
+            "validator_trust": 0.99
+          }
         ]
       },
       {
@@ -72,13 +84,31 @@
         "stake_dominance": 0.021,
         "latest_captured_at": "2026-07-14T08:00:00.000Z",
         "latest_block_number": 4200000,
-        "subnets": [{ "netuid": 3, "uid": 12, "stake_tao": 88000, "emission_tao": 0.4, "validator_trust": 0.98 }]
+        "subnets": [
+          {
+            "netuid": 3,
+            "uid": 12,
+            "stake_tao": 88000,
+            "emission_tao": 0.4,
+            "validator_trust": 0.98
+          }
+        ]
       },
       {
         "hotkey": "5GNJqTPyNqANBkUQNUqj8Bc6Dt3NGPMEZ98HkTUbc6fe9",
         "featured": false,
         "coldkey": "5GNJqTPyNqANBkUQNUqj8Bc6Dt3NGPMEZ98HkTUbc6fe9",
-        "coldkey_identity": { "has_identity": false, "name": null, "url": null, "github": null, "image": null, "discord": null, "description": null, "additional": null, "captured_at": null },
+        "coldkey_identity": {
+          "has_identity": false,
+          "name": null,
+          "url": null,
+          "github": null,
+          "image": null,
+          "discord": null,
+          "description": null,
+          "additional": null,
+          "captured_at": null
+        },
         "coldkey_count": 1,
         "subnet_count": 5,
         "uid_count": 6,
@@ -93,7 +123,15 @@
         "stake_dominance": 0.01,
         "latest_captured_at": "2026-07-14T08:00:00.000Z",
         "latest_block_number": 4200000,
-        "subnets": [{ "netuid": 19, "uid": 3, "stake_tao": 42000, "emission_tao": 0.2, "validator_trust": 0.96 }]
+        "subnets": [
+          {
+            "netuid": 19,
+            "uid": 3,
+            "stake_tao": 42000,
+            "emission_tao": 0.2,
+            "validator_trust": 0.96
+          }
+        ]
       }
     ]
   },

--- a/apps/ui/tests/e2e/fixtures/global-validators-screenshot.json
+++ b/apps/ui/tests/e2e/fixtures/global-validators-screenshot.json
@@ -1,0 +1,101 @@
+{
+  "ok": true,
+  "schema_version": 1,
+  "data": {
+    "schema_version": 1,
+    "sort": "subnet_count",
+    "limit": 20,
+    "validator_count": 3,
+    "captured_at": "2026-07-14T08:00:00.000Z",
+    "block_number": 4200000,
+    "validators": [
+      {
+        "hotkey": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+        "featured": true,
+        "coldkey": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+        "coldkey_identity": {
+          "has_identity": true,
+          "name": "Tensor Labs",
+          "url": "https://tensorlabs.example",
+          "github": "https://github.com/tensorlabs",
+          "image": "https://avatars.githubusercontent.com/u/1?v=4",
+          "discord": null,
+          "description": "Multi-subnet validator operator",
+          "additional": null,
+          "captured_at": "2026-07-14T07:00:00.000Z"
+        },
+        "coldkey_count": 1,
+        "subnet_count": 12,
+        "uid_count": 14,
+        "take": 0.18,
+        "total_stake_tao": 842000,
+        "root_stake_tao": 120000,
+        "alpha_stake_tao": 722000,
+        "total_emission_tao": 4.82,
+        "nominator_count": 2847,
+        "avg_validator_trust": 0.991,
+        "max_validator_trust": 1,
+        "stake_dominance": 0.042,
+        "latest_captured_at": "2026-07-14T08:00:00.000Z",
+        "latest_block_number": 4200000,
+        "subnets": [
+          { "netuid": 1, "uid": 42, "stake_tao": 210000, "emission_tao": 1.2, "validator_trust": 1 },
+          { "netuid": 8, "uid": 7, "stake_tao": 98000, "emission_tao": 0.6, "validator_trust": 0.99 }
+        ]
+      },
+      {
+        "hotkey": "5DAAnrj7VHTznn2AWBemMuyVRZyr4MfPL3BWrMVCyYvsJ5mq",
+        "featured": false,
+        "coldkey": "5DAAnrj7VHTznn2AWBemMuyVRZyr4MfPL3BWrMVCyYvsJ5mq",
+        "coldkey_identity": {
+          "has_identity": true,
+          "name": "NorthStake",
+          "url": null,
+          "github": null,
+          "image": null,
+          "discord": null,
+          "description": null,
+          "additional": null,
+          "captured_at": "2026-07-14T07:00:00.000Z"
+        },
+        "coldkey_count": 1,
+        "subnet_count": 8,
+        "uid_count": 9,
+        "take": 0.09,
+        "total_stake_tao": 412000,
+        "root_stake_tao": 80000,
+        "alpha_stake_tao": 332000,
+        "total_emission_tao": 2.1,
+        "nominator_count": 1204,
+        "avg_validator_trust": 0.978,
+        "max_validator_trust": 0.995,
+        "stake_dominance": 0.021,
+        "latest_captured_at": "2026-07-14T08:00:00.000Z",
+        "latest_block_number": 4200000,
+        "subnets": [{ "netuid": 3, "uid": 12, "stake_tao": 88000, "emission_tao": 0.4, "validator_trust": 0.98 }]
+      },
+      {
+        "hotkey": "5GNJqTPyNqANBkUQNUqj8Bc6Dt3NGPMEZ98HkTUbc6fe9",
+        "featured": false,
+        "coldkey": "5GNJqTPyNqANBkUQNUqj8Bc6Dt3NGPMEZ98HkTUbc6fe9",
+        "coldkey_identity": { "has_identity": false, "name": null, "url": null, "github": null, "image": null, "discord": null, "description": null, "additional": null, "captured_at": null },
+        "coldkey_count": 1,
+        "subnet_count": 5,
+        "uid_count": 6,
+        "take": 0.15,
+        "total_stake_tao": 198000,
+        "root_stake_tao": 40000,
+        "alpha_stake_tao": 158000,
+        "total_emission_tao": 0.95,
+        "nominator_count": 412,
+        "avg_validator_trust": 0.962,
+        "max_validator_trust": 0.98,
+        "stake_dominance": 0.01,
+        "latest_captured_at": "2026-07-14T08:00:00.000Z",
+        "latest_block_number": 4200000,
+        "subnets": [{ "netuid": 19, "uid": 3, "stake_tao": 42000, "emission_tao": 0.2, "validator_trust": 0.96 }]
+      }
+    ]
+  },
+  "meta": { "generated_at": "2026-07-14T08:00:00.000Z" }
+}

--- a/apps/ui/tests/e2e/fixtures/validator-detail-screenshot.json
+++ b/apps/ui/tests/e2e/fixtures/validator-detail-screenshot.json
@@ -1,0 +1,73 @@
+{
+  "ok": true,
+  "schema_version": 1,
+  "data": {
+    "schema_version": 1,
+    "hotkey": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    "coldkey": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+    "coldkey_identity": {
+      "has_identity": true,
+      "name": "Tensor Labs",
+      "url": "https://tensorlabs.example",
+      "github": "https://github.com/tensorlabs",
+      "image": "https://avatars.githubusercontent.com/u/1?v=4",
+      "discord": null,
+      "description": "Multi-subnet validator operator",
+      "additional": null,
+      "captured_at": "2026-07-14T07:00:00.000Z"
+    },
+    "coldkey_count": 1,
+    "subnet_count": 2,
+    "take": 0.18,
+    "nominator_count": 2847,
+    "total_stake_tao": 842000,
+    "root_stake_tao": 120000,
+    "alpha_stake_tao": 722000,
+    "total_emission_tao": 4.82,
+    "avg_validator_trust": 0.995,
+    "max_validator_trust": 1,
+    "captured_at": "2026-07-14T08:00:00.000Z",
+    "block_number": 4200000,
+    "subnets": [
+      {
+        "netuid": 1,
+        "uid": 42,
+        "hotkey": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+        "coldkey": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+        "active": true,
+        "validator_permit": true,
+        "rank": 1,
+        "trust": 0.99,
+        "validator_trust": 1,
+        "consensus": 0.98,
+        "incentive": 0.95,
+        "dividends": 0.88,
+        "emission_tao": 1.2,
+        "stake_tao": 210000,
+        "registered_at_block": 1000000,
+        "is_immunity_period": false,
+        "axon": null
+      },
+      {
+        "netuid": 8,
+        "uid": 7,
+        "hotkey": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+        "coldkey": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+        "active": true,
+        "validator_permit": true,
+        "rank": 2,
+        "trust": 0.97,
+        "validator_trust": 0.99,
+        "consensus": 0.96,
+        "incentive": 0.9,
+        "dividends": 0.82,
+        "emission_tao": 0.6,
+        "stake_tao": 98000,
+        "registered_at_block": 1100000,
+        "is_immunity_period": false,
+        "axon": null
+      }
+    ]
+  },
+  "meta": { "generated_at": "2026-07-14T08:00:00.000Z" }
+}

--- a/apps/ui/tests/e2e/fixtures/validator-history-screenshot.json
+++ b/apps/ui/tests/e2e/fixtures/validator-history-screenshot.json
@@ -1,0 +1,34 @@
+{
+  "ok": true,
+  "schema_version": 1,
+  "data": {
+    "schema_version": 1,
+    "hotkey": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    "window": "30d",
+    "point_count": 3,
+    "points": [
+      {
+        "snapshot_date": "2026-07-12",
+        "subnet_count": 2,
+        "total_stake_tao": 842000,
+        "total_emission_tao": 4.82,
+        "rewards_per_1000_tao": 0.00572
+      },
+      {
+        "snapshot_date": "2026-07-11",
+        "subnet_count": 2,
+        "total_stake_tao": 838000,
+        "total_emission_tao": 4.75,
+        "rewards_per_1000_tao": 0.00567
+      },
+      {
+        "snapshot_date": "2026-07-10",
+        "subnet_count": 2,
+        "total_stake_tao": 835000,
+        "total_emission_tao": 4.7,
+        "rewards_per_1000_tao": 0.00563
+      }
+    ]
+  },
+  "meta": { "generated_at": "2026-07-14T08:00:00.000Z" }
+}


### PR DESCRIPTION
## Summary

- Enriched `/validators` with delegate-selection signals: operator identity (coldkey name/logo via #5234), take rate (#2548), estimated delegator APY (client-side annualization until #2551 lands), and nominator count (#2549).
- Expanded `/validators/$hotkey` with identity-forward hero, take/nominators/APY stat tiles, a multi-window (7d/30d/90d) APY panel from history, and a **Stake to this validator** entry point opening the #5242 modal shell.
- Normalized new API fields in query builders (`take`, `coldkey_identity`, `root_stake_tao`, `alpha_stake_tao`, `nominator_count`) and extended the validator guide copy.

Closes #5245

## Template Used

Frontend/UI change (`apps/ui/**`) — read-side enrichment only; no chain-write logic

## Test plan

- [x] `npm test --workspace=apps/ui` (incl. `validator-apy.test.ts`, `validators.test.ts`)
- [x] `npm run typecheck --workspace=apps/ui`
- [ ] Manual: `/validators` shows Operator, Take, Est. APY, Nominators columns with live API data
- [ ] Manual: `/validators/$hotkey` shows identity chip, APY windows, stake CTA → modal shell opens
- [x] Capture 24 fixed-viewport before/after screenshots (directory + detail × 3 viewports × 2 themes)

## Screenshots — `/validators` directory

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-directory-mobile-dark-after.png)<br><sub>after</sub> |

## Screenshots — `/validators/$hotkey` detail

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/andriypolanski/metagraphed/screenshots/5245-detail-mobile-dark-after.png)<br><sub>after</sub> |

## Notes

- APY is a client-side estimate (emission÷stake annualized, net of take) until server-side modelling (#2551) ships; methodology callout on the detail page.
- Operator identity is the coldkey's `set_identity` payload (#5234), not hotkey-specific.
- Stake modal is a shell only — amount input, quote readout, and signing wire through #5242.
