### PR TITLE
fix(ui): restore tablist ARIA on history-chart window pickers

### DIFF
--- a/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
@@ -51,11 +51,17 @@ export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; ne
   const hasData = series.stake.length + series.emission.length + series.yield.length > 0;
 
   const windowSelector = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="History window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",

--- a/apps/ui/src/components/metagraphed/validator-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/validator-history-chart.tsx
@@ -49,11 +49,17 @@ export function ValidatorHistoryChart({ hotkey }: { hotkey: string }) {
   const hasData = series.stake.length + series.rewards.length > 0;
 
   const windowSelector = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="History window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",


### PR DESCRIPTION
## Summary
- `validator-history-chart.tsx` and `account-position-history-chart.tsx` render their `7d/30d/90d/1y/all` window picker as a bare `<div>` of `<button>`s with no ARIA roles.
- `subnet-history-chart.tsx` renders the identical widget correctly with `role="tablist"` + `aria-label` on the wrapper and `role="tab"` + `aria-selected` on each button.
- Both broken components' own header comments claim to mirror that pattern but never carried the ARIA attributes over — screen readers announce the control as an unlabeled button group instead of a tab list with the active window exposed.
- Fix: add the same `role="tablist"`/`aria-label`/`role="tab"`/`aria-selected` attributes used by `subnet-history-chart.tsx`, to both files.

## Screenshot table
Not applicable — this diff only adds ARIA (`role`, `aria-label`, `aria-selected`) attributes, which are not rendered/visible to a sighted user. No className, layout, or DOM-visible content changed, so before/after screenshots would be pixel-identical.

## Validation
- `npm run lint` (apps/ui): 0 errors (pre-existing warnings only, unrelated to this diff)

Closes #5291