### PR TITLE
fix(api): lossless rao-precision strings for movers network-summary totals

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6886,12 +6886,18 @@ export interface components {
             network: {
                 gainers: number;
                 losers: number;
-                total_emission_delta_tao: number;
-                total_emission_end_tao: number;
-                total_emission_start_tao: number;
-                total_stake_delta_tao: number;
-                total_stake_end_tao: number;
-                total_stake_start_tao: number;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string: total_emission_end_tao minus total_emission_start_tao, computed in exact rao-integer space. May be negative. */
+                total_emission_delta_tao: string;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's end snapshot. See total_stake_start_tao. */
+                total_emission_end_tao: string;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's start snapshot. See total_stake_start_tao. */
+                total_emission_start_tao: string;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string: total_stake_end_tao minus total_stake_start_tao, computed in exact rao-integer space (not as a difference of two already-lossy floats). May be negative (a leading '-') when network stake net-decreased over the window. */
+                total_stake_delta_tao: string;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's end snapshot. See total_stake_start_tao. */
+                total_stake_end_tao: string;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's start snapshot -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#5290, mirrors #2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding. */
+                total_stake_start_tao: string;
                 total_validators_delta: number;
                 total_validators_end: number;
                 total_validators_start: number;
@@ -28022,12 +28028,12 @@ export interface operations {
                      *         "network": {
                      *           "gainers": 1,
                      *           "losers": 1,
-                     *           "total_emission_delta_tao": 0.5,
-                     *           "total_emission_end_tao": 0.5,
-                     *           "total_emission_start_tao": 0.5,
-                     *           "total_stake_delta_tao": 0.5,
-                     *           "total_stake_end_tao": 0.5,
-                     *           "total_stake_start_tao": 0.5,
+                     *           "total_emission_delta_tao": "-1234567.891234500",
+                     *           "total_emission_end_tao": "327838334.635978200",
+                     *           "total_emission_start_tao": "327838334.635978200",
+                     *           "total_stake_delta_tao": "-1234567.891234500",
+                     *           "total_stake_end_tao": "327838334.635978200",
+                     *           "total_stake_start_tao": "327838334.635978200",
                      *           "total_validators_delta": 1,
                      *           "total_validators_end": 1,
                      *           "total_validators_start": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -17735,22 +17735,34 @@
                 "type": "integer"
               },
               "total_emission_delta_tao": {
-                "type": "number"
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string: total_emission_end_tao minus total_emission_start_tao, computed in exact rao-integer space. May be negative.",
+                "pattern": "^-?\\d+\\.\\d{9}$",
+                "type": "string"
               },
               "total_emission_end_tao": {
-                "type": "number"
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's end snapshot. See total_stake_start_tao.",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
               },
               "total_emission_start_tao": {
-                "type": "number"
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's start snapshot. See total_stake_start_tao.",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
               },
               "total_stake_delta_tao": {
-                "type": "number"
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string: total_stake_end_tao minus total_stake_start_tao, computed in exact rao-integer space (not as a difference of two already-lossy floats). May be negative (a leading '-') when network stake net-decreased over the window.",
+                "pattern": "^-?\\d+\\.\\d{9}$",
+                "type": "string"
               },
               "total_stake_end_tao": {
-                "type": "number"
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's end snapshot. See total_stake_start_tao.",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
               },
               "total_stake_start_tao": {
-                "type": "number"
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's start snapshot -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#5290, mirrors #2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding.",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
               },
               "total_validators_delta": {
                 "type": "integer"
@@ -50983,12 +50995,12 @@
                     "network": {
                       "gainers": 1,
                       "losers": 1,
-                      "total_emission_delta_tao": 0.5,
-                      "total_emission_end_tao": 0.5,
-                      "total_emission_start_tao": 0.5,
-                      "total_stake_delta_tao": 0.5,
-                      "total_stake_end_tao": 0.5,
-                      "total_stake_start_tao": 0.5,
+                      "total_emission_delta_tao": "-1234567.891234500",
+                      "total_emission_end_tao": "327838334.635978200",
+                      "total_emission_start_tao": "327838334.635978200",
+                      "total_stake_delta_tao": "-1234567.891234500",
+                      "total_stake_end_tao": "327838334.635978200",
+                      "total_stake_start_tao": "327838334.635978200",
                       "total_validators_delta": 1,
                       "total_validators_end": 1,
                       "total_validators_start": 1,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6886,12 +6886,18 @@ export interface components {
             network: {
                 gainers: number;
                 losers: number;
-                total_emission_delta_tao: number;
-                total_emission_end_tao: number;
-                total_emission_start_tao: number;
-                total_stake_delta_tao: number;
-                total_stake_end_tao: number;
-                total_stake_start_tao: number;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string: total_emission_end_tao minus total_emission_start_tao, computed in exact rao-integer space. May be negative. */
+                total_emission_delta_tao: string;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's end snapshot. See total_stake_start_tao. */
+                total_emission_end_tao: string;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's start snapshot. See total_stake_start_tao. */
+                total_emission_start_tao: string;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string: total_stake_end_tao minus total_stake_start_tao, computed in exact rao-integer space (not as a difference of two already-lossy floats). May be negative (a leading '-') when network stake net-decreased over the window. */
+                total_stake_delta_tao: string;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's end snapshot. See total_stake_start_tao. */
+                total_stake_end_tao: string;
+                /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's start snapshot -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#5290, mirrors #2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding. */
+                total_stake_start_tao: string;
                 total_validators_delta: number;
                 total_validators_end: number;
                 total_validators_start: number;
@@ -28022,12 +28028,12 @@ export interface operations {
                      *         "network": {
                      *           "gainers": 1,
                      *           "losers": 1,
-                     *           "total_emission_delta_tao": 0.5,
-                     *           "total_emission_end_tao": 0.5,
-                     *           "total_emission_start_tao": 0.5,
-                     *           "total_stake_delta_tao": 0.5,
-                     *           "total_stake_end_tao": 0.5,
-                     *           "total_stake_start_tao": 0.5,
+                     *           "total_emission_delta_tao": "-1234567.891234500",
+                     *           "total_emission_end_tao": "327838334.635978200",
+                     *           "total_emission_start_tao": "327838334.635978200",
+                     *           "total_stake_delta_tao": "-1234567.891234500",
+                     *           "total_stake_end_tao": "327838334.635978200",
+                     *           "total_stake_start_tao": "327838334.635978200",
                      *           "total_validators_delta": 1,
                      *           "total_validators_end": 1,
                      *           "total_validators_start": 1,

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -17713,22 +17713,34 @@
                 "type": "integer"
               },
               "total_emission_delta_tao": {
-                "type": "number"
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string: total_emission_end_tao minus total_emission_start_tao, computed in exact rao-integer space. May be negative.",
+                "pattern": "^-?\\d+\\.\\d{9}$",
+                "type": "string"
               },
               "total_emission_end_tao": {
-                "type": "number"
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's end snapshot. See total_stake_start_tao.",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
               },
               "total_emission_start_tao": {
-                "type": "number"
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's start snapshot. See total_stake_start_tao.",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
               },
               "total_stake_delta_tao": {
-                "type": "number"
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string: total_stake_end_tao minus total_stake_start_tao, computed in exact rao-integer space (not as a difference of two already-lossy floats). May be negative (a leading '-') when network stake net-decreased over the window.",
+                "pattern": "^-?\\d+\\.\\d{9}$",
+                "type": "string"
               },
               "total_stake_end_tao": {
-                "type": "number"
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's end snapshot. See total_stake_start_tao.",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
               },
               "total_stake_start_tao": {
-                "type": "number"
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's start snapshot -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#5290, mirrors #2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding.",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
               },
               "total_validators_delta": {
                 "type": "integer"

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -1488,12 +1488,36 @@
               "unchanged"
             ],
             "properties": {
-              "total_stake_start_tao": { "type": "number" },
-              "total_stake_end_tao": { "type": "number" },
-              "total_stake_delta_tao": { "type": "number" },
-              "total_emission_start_tao": { "type": "number" },
-              "total_emission_end_tao": { "type": "number" },
-              "total_emission_delta_tao": { "type": "number" },
+              "total_stake_start_tao": {
+                "type": "string",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's start snapshot -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#5290, mirrors #2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding."
+              },
+              "total_stake_end_tao": {
+                "type": "string",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's end snapshot. See total_stake_start_tao."
+              },
+              "total_stake_delta_tao": {
+                "type": "string",
+                "pattern": "^-?\\d+\\.\\d{9}$",
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string: total_stake_end_tao minus total_stake_start_tao, computed in exact rao-integer space (not as a difference of two already-lossy floats). May be negative (a leading '-') when network stake net-decreased over the window."
+              },
+              "total_emission_start_tao": {
+                "type": "string",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's start snapshot. See total_stake_start_tao."
+              },
+              "total_emission_end_tao": {
+                "type": "string",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet at the window's end snapshot. See total_stake_start_tao."
+              },
+              "total_emission_delta_tao": {
+                "type": "string",
+                "pattern": "^-?\\d+\\.\\d{9}$",
+                "description": "Lossless fixed 9-decimal (rao-precision) TAO string: total_emission_end_tao minus total_emission_start_tao, computed in exact rao-integer space. May be negative."
+              },
               "total_validators_start": { "type": "integer", "minimum": 0 },
               "total_validators_end": { "type": "integer", "minimum": 0 },
               "total_validators_delta": { "type": "integer" },

--- a/src/movers.mjs
+++ b/src/movers.mjs
@@ -26,6 +26,39 @@ function roundTao(value) {
   return Math.round(toNumber(value) * RAO_PER_TAO) / RAO_PER_TAO;
 }
 
+const RAO_PER_TAO_BIG = 1_000_000_000n;
+
+// Exact rao-integer BigInt for one subnet's TAO value, for summation across every subnet
+// (#5290, mirrors toRaoBig/raoBigToTao in chain-yield.mjs and stake_sum_rao in
+// neuron-history.mjs). Summing ~130 subnets' total_stake_tao with plain float `+=`
+// compounds error past the point a JSON number can represent exactly at network scale.
+function toRaoBig(tao) {
+  return BigInt(Math.round(tao * RAO_PER_TAO));
+}
+
+// A display-rounded Number from an exact rao BigInt. Safe ONLY for a value that's about to
+// be rounded again anyway (pctShare's 2dp percentage denominator below) -- the ~1e-16
+// relative error from Number(bigint) is immaterial there, unlike the lossless string totals
+// raoToTaoString produces, which must stay exact.
+function raoToTaoNumber(rao) {
+  return Number(rao) / RAO_PER_TAO;
+}
+
+// Lossless fixed 9-decimal (rao-precision) TAO string -- a JSON number (double) is only
+// exact up to 2^53-1, ~9,007,199 TAO at rao precision, and the network-wide total_stake_tao
+// sum this feeds already exceeds that ceiling at current network scale (#5290, mirrors
+// #2924/#5287's identical fix in neuron-history.mjs and economics-artifacts.mjs). Unlike
+// those siblings' cumulative totals, a boundary DELTA (end - start) is genuinely signed --
+// network stake/emission can net-decrease over a window -- so this keeps the negative-sign
+// handling those siblings dropped as unreachable dead code; here it's live and reachable.
+function raoToTaoString(rao) {
+  const negative = rao < 0n;
+  const abs = negative ? -rao : rao;
+  const whole = abs / RAO_PER_TAO_BIG;
+  const frac = abs % RAO_PER_TAO_BIG;
+  return `${negative ? "-" : ""}${whole}.${frac.toString().padStart(9, "0")}`;
+}
+
 // Coerce a D1 SUM()/COUNT() cell (number, numeric string, or null) to a finite number,
 // defaulting to 0.
 function toNumber(value) {
@@ -88,17 +121,21 @@ const ZERO = { neurons: 0, validators: 0, stake: 0, emission: 0 };
 
 // Sum a boundary map's stake, emission, and validator counts across every subnet — the
 // single source the dominance-share denominator and the network summary totals derive
-// from, so both stay consistent as more network-level fields are added.
+// from, so both stay consistent as more network-level fields are added. stake/emission
+// accumulate as exact rao-integer BigInts (#5290): this is the same network-wide "sum of
+// total_stake_tao across every subnet" quantity that #2924/#5287 already fixed at two other
+// call sites (neuron-history.mjs, economics-artifacts.mjs) — movers hits the identical
+// precision ceiling at the identical live network magnitude.
 function sumBoundary(map) {
-  let stake = 0;
-  let emission = 0;
+  let stakeRao = 0n;
+  let emissionRao = 0n;
   let validators = 0;
   for (const v of map.values()) {
-    stake += v.stake;
-    emission += v.emission;
+    stakeRao += toRaoBig(v.stake);
+    emissionRao += toRaoBig(v.emission);
     validators += v.validators;
   }
-  return { stake, emission, validators };
+  return { stakeRao, emissionRao, validators };
 }
 
 const SORT_KEY = {
@@ -148,12 +185,15 @@ export function computeMovers(
       stake_delta_tao: roundTao(e.stake - s.stake),
       stake_pct_change: pctChange(s.stake, e.stake),
       // Dominance: this subnet's share of network stake at the end snapshot.
-      stake_share_pct: pctShare(e.stake, endTotals.stake),
+      stake_share_pct: pctShare(e.stake, raoToTaoNumber(endTotals.stakeRao)),
       emission_start_tao: roundTao(s.emission),
       emission_end_tao: roundTao(e.emission),
       emission_delta_tao: roundTao(e.emission - s.emission),
       emission_pct_change: pctChange(s.emission, e.emission),
-      emission_share_pct: pctShare(e.emission, endTotals.emission),
+      emission_share_pct: pctShare(
+        e.emission,
+        raoToTaoNumber(endTotals.emissionRao),
+      ),
       validators_start: s.validators,
       validators_end: e.validators,
       validators_delta: e.validators - s.validators,
@@ -187,12 +227,14 @@ function buildNetworkSummary(ranked, sortDeltaKey, startRows, endRows) {
     else unchanged += 1;
   }
   return {
-    total_stake_start_tao: roundTao(start.stake),
-    total_stake_end_tao: roundTao(end.stake),
-    total_stake_delta_tao: roundTao(end.stake - start.stake),
-    total_emission_start_tao: roundTao(start.emission),
-    total_emission_end_tao: roundTao(end.emission),
-    total_emission_delta_tao: roundTao(end.emission - start.emission),
+    total_stake_start_tao: raoToTaoString(start.stakeRao),
+    total_stake_end_tao: raoToTaoString(end.stakeRao),
+    total_stake_delta_tao: raoToTaoString(end.stakeRao - start.stakeRao),
+    total_emission_start_tao: raoToTaoString(start.emissionRao),
+    total_emission_end_tao: raoToTaoString(end.emissionRao),
+    total_emission_delta_tao: raoToTaoString(
+      end.emissionRao - start.emissionRao,
+    ),
     total_validators_start: start.validators,
     total_validators_end: end.validators,
     total_validators_delta: end.validators - start.validators,

--- a/src/openapi-sample.mjs
+++ b/src/openapi-sample.mjs
@@ -38,6 +38,10 @@ function valueForPattern(pattern, name = "") {
       // Lossless rao-precision TAO string (#2924) -- network-wide sums that
       // already exceed a JSON number's exact-double ceiling.
       return "327838334.635978200";
+    case "^-?\\d+\\.\\d{9}$":
+      // Signed variant (#5290) -- a boundary delta (end - start), which can be
+      // negative when a network-wide total net-decreased over the window.
+      return "-1234567.891234500";
     case "^\\d+\\.\\d+\\.\\d+$":
       return CURSOR3;
     case "^[a-z0-9][a-z0-9-]*$":

--- a/tests/movers.test.mjs
+++ b/tests/movers.test.mjs
@@ -252,7 +252,7 @@ describe("computeMovers", () => {
       );
       assert.equal(
         network.total_stake_start_tao,
-        50,
+        "50.000000000",
         `network stake start for total_stake_tao ${JSON.stringify(blank)}`,
       );
       assert.equal(
@@ -406,15 +406,29 @@ describe("movers network summary", () => {
 
   test("totals stake/emission/validators across all subnets with their deltas", () => {
     const { network } = buildMovers(startRows, endRows, opts);
-    assert.equal(network.total_stake_start_tao, 150);
-    assert.equal(network.total_stake_end_tao, 280);
-    assert.equal(network.total_stake_delta_tao, 130);
-    assert.equal(network.total_emission_start_tao, 9);
-    assert.equal(network.total_emission_end_tao, 13);
-    assert.equal(network.total_emission_delta_tao, 4);
+    assert.equal(network.total_stake_start_tao, "150.000000000");
+    assert.equal(network.total_stake_end_tao, "280.000000000");
+    assert.equal(network.total_stake_delta_tao, "130.000000000");
+    assert.equal(network.total_emission_start_tao, "9.000000000");
+    assert.equal(network.total_emission_end_tao, "13.000000000");
+    assert.equal(network.total_emission_delta_tao, "4.000000000");
     assert.equal(network.total_validators_start, 5);
     assert.equal(network.total_validators_end, 6);
     assert.equal(network.total_validators_delta, 1);
+  });
+
+  test("stake/emission deltas are lossless negative strings when the network net-decreased", () => {
+    // End totals (100 + 20 = 120 stake, 4 + 1 = 5 emission) are BELOW start totals
+    // (150 stake, 9 emission) -- exercises raoToTaoString's negative-sign branch,
+    // which (unlike the always-non-negative cumulative totals) is genuinely
+    // reachable here: a window can net-decrease.
+    const decreasing = [
+      agg(1, "e", { neurons: 12, validators: 4, stake: 100, emission: 4 }),
+      agg(2, "e", { neurons: 8, validators: 2, stake: 20, emission: 1 }),
+    ];
+    const { network } = buildMovers(startRows, decreasing, opts);
+    assert.equal(network.total_stake_delta_tao, "-30.000000000");
+    assert.equal(network.total_emission_delta_tao, "-4.000000000");
   });
 
   test("gainer/loser/unchanged counts follow the active sort metric", () => {
@@ -455,7 +469,7 @@ describe("movers network summary", () => {
       startDate: null,
       endDate: null,
     });
-    assert.equal(network.total_stake_end_tao, 0);
+    assert.equal(network.total_stake_end_tao, "0.000000000");
     assert.equal(network.total_validators_delta, 0);
     assert.equal(network.gainers, 0);
     assert.equal(network.losers, 0);


### PR DESCRIPTION
## Summary
- `sumBoundary` in `src/movers.mjs` sums `total_stake_tao`/`total_emission_tao` across every subnet with plain float `+=` — the same network-wide aggregate class #2924 (closed via #5287) already fixed at two other call sites (`src/neuron-history.mjs`, `scripts/lib/economics-artifacts.mjs`).
- A JSON `number` is only exact up to `2^53 - 1` (~9,007,199 TAO at rao precision); the network-wide total already exceeds that ceiling at current stake levels — the same live magnitude `raoToTaoString`'s own header comment in `neuron-history.mjs` documents (~328M TAO, 36x over).
- `total_stake_start_tao`/`total_stake_end_tao`/`total_stake_delta_tao` and their emission counterparts now accumulate as exact rao-integer BigInts and serialize as lossless fixed 9-decimal strings, following the recipe #2924 itself documents (the `next_cursor` lossless-string precedent).
- Unlike the prior two sites' always-non-negative cumulative totals, a boundary **delta** (end − start) is genuinely signed — network stake/emission can net-decrease over a window — so this keeps the negative-sign handling those sites dropped as unreachable dead code; here it's live and covered by a dedicated test (`stake/emission deltas are lossless negative strings when the network net-decreased`).
- `src/openapi-sample.mjs` gets a sample case for the new signed pattern (`^-?\d+\.\d{9}$`) so the generated OpenAPI example stays schema-valid.

## Breaking contract change
`total_stake_start_tao`, `total_stake_end_tao`, `total_stake_delta_tao`, `total_emission_start_tao`, `total_emission_end_tao`, `total_emission_delta_tao` move from `number` to a lossless `string` in the `movers` network-summary response (`schemas/components/06-health.schema.json`'s `SubnetMoversArtifact.network`). `schemas/api-components.schema.json`, `public/metagraph/openapi.json`, `public/metagraph/types.d.ts`, and `packages/contract/index.d.ts` are regenerated via `npm run build` and committed in this PR. No other call site in the repo reads these six fields.

## Validation
- `npx vitest run tests/movers.test.mjs` — 34/34 passed (updated existing assertions to the new string shape, added a negative-delta case)
- `npm run validate:openapi-examples` — 156/156 routes ship a schema-valid worked example
- `npm run validate:contract-drift` — passed
- `npm run validate` — passed
- `npm run lint` / `npm run format:check` — clean

Closes #5290