### PR TITLE
fix(ui): restore role=tablist/tab ARIA on validator + account-position history window pickers

### DIFF
--- a/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
@@ -51,11 +51,17 @@ export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; ne
   const hasData = series.stake.length + series.emission.length + series.yield.length > 0;
 
   const windowSelector = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="History window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",

--- a/apps/ui/src/components/metagraphed/validator-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/validator-history-chart.tsx
@@ -49,11 +49,17 @@ export function ValidatorHistoryChart({ hotkey }: { hotkey: string }) {
   const hasData = series.stake.length + series.rewards.length > 0;
 
   const windowSelector = (
-    <div className="inline-flex rounded-md border border-border bg-surface/40 p-0.5">
+    <div
+      role="tablist"
+      aria-label="History window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
       {WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
+          role="tab"
+          aria-selected={w === win}
           onClick={() => setWin(w)}
           className={classNames(
             "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",


### PR DESCRIPTION
## Summary

The window-picker (`7d`/`30d`/`90d`/`1y`/`all`) in `validator-history-chart.tsx` and `account-position-history-chart.tsx` was rendered as a bare `<div>` of `<button>`s with **no ARIA roles** — a regression against the identical widget in `subnet-history-chart.tsx`, which correctly uses `role="tablist"` / `role="tab"` / `aria-selected`. Both broken components' own header comments claim to mirror that pattern. This restores it so the pickers are announced as a tab list to assistive tech.

## Change

Add `role="tablist"` + `aria-label="History window"` to the container and `role="tab"` + `aria-selected={w === win}` to each button in both components — byte-for-byte the same markup `subnet-history-chart.tsx` already ships. Two files, +14/-2, no behavior/visual change.

## Verification

- `tsc --noEmit`, `eslint`, `prettier --check` — all pass.
- This is a **semantic-only (ARIA) change with no visual effect** — the pickers render pixel-identically before and after (as the matrix below confirms). Screenshots are the validator page's "Stake & rewards over time" window picker (`ValidatorHistoryChart`); `AccountPositionHistoryChart` got the identical fix.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5291-mobile-dark-after.png)<br><sub>after</sub> |

Closes #5291
