### PR TITLE
refactor(api): consolidate 7 near-identical handleAccount* handlers

### DIFF
--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -2466,269 +2466,120 @@ export async function handleAccountStakeFlow(request, env, ss58, url) {
   );
 }
 
+// Factory for the account-events handlers below (#5296): each GET /api/v1/accounts/{ss58}/<kind>
+// endpoint validates ?window=, resolves via the Postgres tier with a schema-stable-zeros fallback,
+// and wraps the result in the standard account envelope — identical control flow across all 7,
+// differing only in the window enum, the shaping builder, and the response artifact's URL suffix.
+function makeAccountEventHandler({ windows, defaultWindow, build, urlSuffix }) {
+  return async function handleAccountEvent(request, env, ss58, url) {
+    const validationError = validateQueryParams(url, ["window"]);
+    if (validationError) return analyticsQueryError(validationError);
+    const windowParam = url.searchParams.get("window") || defaultWindow;
+    if (!Object.hasOwn(windows, windowParam)) {
+      return analyticsQueryError({
+        parameter: "window",
+        message: unsupportedWindowMessage(windowParam, windows),
+      });
+    }
+    const { data, generatedAt } = (await tryPostgresTier(
+      env,
+      request,
+      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+    )) ?? {
+      data: build([], ss58, { window: windowParam }),
+      generatedAt: null,
+    };
+    return accountEnvelopeResponse(
+      request,
+      {
+        data,
+        meta: await accountMeta(
+          env,
+          `/metagraph/accounts/${ss58}/${urlSuffix}.json`,
+          generatedAt,
+        ),
+      },
+      "short",
+    );
+  };
+}
+
 // GET /api/v1/accounts/{ss58}/stake-moves: the account's per-subnet StakeMoved footprint
 // over a 7d/30d/90d window — movement count + first/last timestamps per subnet, an HHI
 // concentration of where its re-delegation churn is focused, and the dominant subnet.
 // account_events-derived (source "chain-events"). Cold/absent store → schema-stable zeros.
-export async function handleAccountStakeMoves(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW;
-  if (!Object.hasOwn(ACCOUNT_STAKE_MOVES_WINDOWS, windowParam)) {
-    return analyticsQueryError({
-      parameter: "window",
-      message: unsupportedWindowMessage(
-        windowParam,
-        ACCOUNT_STAKE_MOVES_WINDOWS,
-      ),
-    });
-  }
-  const { data, generatedAt } = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) ?? {
-    data: buildAccountStakeMoves([], ss58, { window: windowParam }),
-    generatedAt: null,
-  };
-  return accountEnvelopeResponse(
-    request,
-    {
-      data,
-      meta: await accountMeta(
-        env,
-        `/metagraph/accounts/${ss58}/stake-moves.json`,
-        generatedAt,
-      ),
-    },
-    "short",
-  );
-}
+export const handleAccountStakeMoves = makeAccountEventHandler({
+  windows: ACCOUNT_STAKE_MOVES_WINDOWS,
+  defaultWindow: DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW,
+  build: buildAccountStakeMoves,
+  urlSuffix: "stake-moves",
+});
 
 // GET /api/v1/accounts/{ss58}/weight-setters: the account's (validator's) per-subnet WeightsSet
 // footprint over a 7d/30d window — weight-set count + first/last timestamps per subnet, an HHI
 // concentration of where its weight-setting activity is focused, and the dominant subnet.
 // account_events-derived (source "chain-events"). Cold/absent store → schema-stable zeros.
-export async function handleAccountWeightSetters(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW;
-  if (!Object.hasOwn(ACCOUNT_WEIGHT_SETTERS_WINDOWS, windowParam)) {
-    return analyticsQueryError({
-      parameter: "window",
-      message: unsupportedWindowMessage(
-        windowParam,
-        ACCOUNT_WEIGHT_SETTERS_WINDOWS,
-      ),
-    });
-  }
-  const { data, generatedAt } = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) ?? {
-    data: buildAccountWeightSetters([], ss58, { window: windowParam }),
-    generatedAt: null,
-  };
-  return accountEnvelopeResponse(
-    request,
-    {
-      data,
-      meta: await accountMeta(
-        env,
-        `/metagraph/accounts/${ss58}/weight-setters.json`,
-        generatedAt,
-      ),
-    },
-    "short",
-  );
-}
+export const handleAccountWeightSetters = makeAccountEventHandler({
+  windows: ACCOUNT_WEIGHT_SETTERS_WINDOWS,
+  defaultWindow: DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW,
+  build: buildAccountWeightSetters,
+  urlSuffix: "weight-setters",
+});
 
 // GET /api/v1/accounts/{ss58}/registrations: the account's per-subnet NeuronRegistered footprint
 // over a 7d/30d/90d window — registration count + first/last timestamps per subnet, an HHI
 // concentration of where its registration activity is focused, and the dominant subnet.
 // account_events-derived (source "chain-events"). Cold/absent store → schema-stable zeros (never 404).
-export async function handleAccountRegistrations(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_REGISTRATION_WINDOW;
-  if (!Object.hasOwn(REGISTRATION_WINDOWS, windowParam)) {
-    return analyticsQueryError({
-      parameter: "window",
-      message: unsupportedWindowMessage(windowParam, REGISTRATION_WINDOWS),
-    });
-  }
-  const { data, generatedAt } = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) ?? {
-    data: buildAccountRegistrations([], ss58, { window: windowParam }),
-    generatedAt: null,
-  };
-  return accountEnvelopeResponse(
-    request,
-    {
-      data,
-      meta: await accountMeta(
-        env,
-        `/metagraph/accounts/${ss58}/registrations.json`,
-        generatedAt,
-      ),
-    },
-    "short",
-  );
-}
+export const handleAccountRegistrations = makeAccountEventHandler({
+  windows: REGISTRATION_WINDOWS,
+  defaultWindow: DEFAULT_REGISTRATION_WINDOW,
+  build: buildAccountRegistrations,
+  urlSuffix: "registrations",
+});
 
 // GET /api/v1/accounts/{ss58}/serving: the account's per-subnet AxonServed footprint over a
 // 7d/30d/90d window — announcement count + first/last timestamps per subnet, an HHI concentration
 // of where its serving activity is focused, and the dominant subnet. account_events-derived (source
 // "chain-events"). Cold/absent store → schema-stable zeros (never 404).
-export async function handleAccountServing(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
-  const windowParam = url.searchParams.get("window") || DEFAULT_SERVING_WINDOW;
-  if (!Object.hasOwn(SERVING_WINDOWS, windowParam)) {
-    return analyticsQueryError({
-      parameter: "window",
-      message: unsupportedWindowMessage(windowParam, SERVING_WINDOWS),
-    });
-  }
-  const { data, generatedAt } = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) ?? {
-    data: buildAccountServing([], ss58, { window: windowParam }),
-    generatedAt: null,
-  };
-  return accountEnvelopeResponse(
-    request,
-    {
-      data,
-      meta: await accountMeta(
-        env,
-        `/metagraph/accounts/${ss58}/serving.json`,
-        generatedAt,
-      ),
-    },
-    "short",
-  );
-}
+export const handleAccountServing = makeAccountEventHandler({
+  windows: SERVING_WINDOWS,
+  defaultWindow: DEFAULT_SERVING_WINDOW,
+  build: buildAccountServing,
+  urlSuffix: "serving",
+});
 
 // GET /api/v1/accounts/{ss58}/axon-removals: the account's per-subnet AxonInfoRemoved footprint over
 // a 7d/30d/90d window — removal count + first/last timestamps per subnet, an HHI concentration of
 // where its teardown activity is focused, and the dominant subnet. account_events-derived (source
 // "chain-events"). Cold/absent store → schema-stable zeros (never 404).
-export async function handleAccountAxonRemovals(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_AXON_REMOVAL_WINDOW;
-  if (!Object.hasOwn(AXON_REMOVAL_WINDOWS, windowParam)) {
-    return analyticsQueryError({
-      parameter: "window",
-      message: unsupportedWindowMessage(windowParam, AXON_REMOVAL_WINDOWS),
-    });
-  }
-  const { data, generatedAt } = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) ?? {
-    data: buildAccountAxonRemovals([], ss58, { window: windowParam }),
-    generatedAt: null,
-  };
-  return accountEnvelopeResponse(
-    request,
-    {
-      data,
-      meta: await accountMeta(
-        env,
-        `/metagraph/accounts/${ss58}/axon-removals.json`,
-        generatedAt,
-      ),
-    },
-    "short",
-  );
-}
+export const handleAccountAxonRemovals = makeAccountEventHandler({
+  windows: AXON_REMOVAL_WINDOWS,
+  defaultWindow: DEFAULT_AXON_REMOVAL_WINDOW,
+  build: buildAccountAxonRemovals,
+  urlSuffix: "axon-removals",
+});
 
 // GET /api/v1/accounts/{ss58}/prometheus: the account's per-subnet PrometheusServed footprint over a
 // 7d/30d/90d window — announcement count + first/last timestamps per subnet, an HHI concentration of
 // where its telemetry activity is focused, and the dominant subnet. account_events-derived (source
 // "chain-events"). Cold/absent store → schema-stable zeros (never 404).
-export async function handleAccountPrometheus(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_PROMETHEUS_WINDOW;
-  if (!Object.hasOwn(PROMETHEUS_WINDOWS, windowParam)) {
-    return analyticsQueryError({
-      parameter: "window",
-      message: unsupportedWindowMessage(windowParam, PROMETHEUS_WINDOWS),
-    });
-  }
-  const { data, generatedAt } = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) ?? {
-    data: buildAccountPrometheus([], ss58, { window: windowParam }),
-    generatedAt: null,
-  };
-  return accountEnvelopeResponse(
-    request,
-    {
-      data,
-      meta: await accountMeta(
-        env,
-        `/metagraph/accounts/${ss58}/prometheus.json`,
-        generatedAt,
-      ),
-    },
-    "short",
-  );
-}
+export const handleAccountPrometheus = makeAccountEventHandler({
+  windows: PROMETHEUS_WINDOWS,
+  defaultWindow: DEFAULT_PROMETHEUS_WINDOW,
+  build: buildAccountPrometheus,
+  urlSuffix: "prometheus",
+});
 
 // GET /api/v1/accounts/{ss58}/deregistrations: the account's per-subnet NeuronDeregistered footprint
 // over a 7d/30d/90d window — eviction count + first/last timestamps per subnet, an HHI concentration
 // of where its deregistration activity is focused, and the dominant subnet. account_events-derived
 // (source "chain-events"). Cold/absent store → schema-stable zeros (never 404).
-export async function handleAccountDeregistrations(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, ["window"]);
-  if (validationError) return analyticsQueryError(validationError);
-  const windowParam =
-    url.searchParams.get("window") || DEFAULT_DEREGISTRATION_WINDOW;
-  if (!Object.hasOwn(DEREGISTRATION_WINDOWS, windowParam)) {
-    return analyticsQueryError({
-      parameter: "window",
-      message: unsupportedWindowMessage(windowParam, DEREGISTRATION_WINDOWS),
-    });
-  }
-  const { data, generatedAt } = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) ?? {
-    data: buildAccountDeregistrations([], ss58, { window: windowParam }),
-    generatedAt: null,
-  };
-  return accountEnvelopeResponse(
-    request,
-    {
-      data,
-      meta: await accountMeta(
-        env,
-        `/metagraph/accounts/${ss58}/deregistrations.json`,
-        generatedAt,
-      ),
-    },
-    "short",
-  );
-}
+export const handleAccountDeregistrations = makeAccountEventHandler({
+  windows: DEREGISTRATION_WINDOWS,
+  defaultWindow: DEFAULT_DEREGISTRATION_WINDOW,
+  build: buildAccountDeregistrations,
+  urlSuffix: "deregistrations",
+});
 
 // GET /api/v1/accounts/{ss58}: cross-subnet summary — event-history aggregates
 // (account_events, matched by hotkey OR coldkey) joined to current registrations


### PR DESCRIPTION
## Summary
- `handleAccountStakeMoves`, `handleAccountWeightSetters`, `handleAccountRegistrations`, `handleAccountServing`, `handleAccountAxonRemovals`, `handleAccountPrometheus`, and `handleAccountDeregistrations` in `workers/request-handlers/entities.mjs` were byte-for-byte identical control flow: validate `?window=`, resolve via the Postgres tier with a schema-stable-zeros fallback, wrap in the account envelope — differing only in the window enum, the shaping builder function, and the response artifact's URL suffix.
- Extracted a `makeAccountEventHandler({ windows, defaultWindow, build, urlSuffix })` factory; each of the 7 exported handlers is now a short config declaration instead of a ~35-line duplicated function body. ~230 lines of duplicated control flow collapse to one ~30-line factory + 7 short declarations.
- Each handler's original JSDoc-style header comment (documenting the specific on-chain event kind it serves) is preserved above its declaration.

## No behavior change
- Every call site (`workers/api.mjs`, 7 call sites checked) invokes each handler with the identical 4-arg signature `(request, env, ss58, url)` — none rely on the function's own name/identity (checked, no `.name` reflection anywhere).
- All 7 window-config constant pairs and builder functions are `import`ed at the top of the file, so referencing them eagerly inside the factory-call object literals (evaluated at module-init time, unlike the old per-call function bodies) is safe — no temporal-dead-zone risk.

## Validation
- `npx vitest run tests/request-handlers-entities.test.mjs` — 339/339 passed, no test changes needed (existing tests for all 7 handlers already exercise validation-error, unsupported-window, Postgres-tier-hit, and cold-D1-fallback paths)
- Verified 100% branch coverage on the new factory/declarations via the raw coverage branch map (zero uncovered branches in the changed line range) — the shared logic inherits full coverage since it's exercised via all 7 callers' existing tests
- `npm run lint` / `npm run format:check` — clean
- `npm run validate` — passed

Closes #5296