### PR TITLE
feat(ui): surface take and coldkey identity on validators directory

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -14,6 +14,14 @@ import { classNames } from "@/lib/metagraphed/format";
  */
 const METRICS: Array<{ term: string; def: string }> = [
   {
+    term: "Identity",
+    def: "The coldkey's self-declared on-chain name and logo (SubtensorModule::set_identity), joined server-side. It is not hotkey-specific — one coldkey can run many hotkeys, so the same identity may appear on more than one row and says nothing about how any one hotkey brands itself.",
+  },
+  {
+    term: "Take",
+    def: "The validator's commission: the fraction (shown as a percent) of delegator rewards the operator keeps. Global per hotkey. A dash means no Delegates entry was captured yet — not a zero take.",
+  },
+  {
     term: "Active subnets",
     def: "How many subnets this hotkey is registered and validating on. A validator may operate broadly across many subnets or concentrate on a few.",
   },

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -194,6 +194,7 @@ import type {
   MetagraphNeuron,
   SubnetMetagraph,
   SubnetValidators,
+  ColdkeyIdentity,
   GlobalValidator,
   GlobalValidators,
   GlobalValidatorSort,
@@ -5342,6 +5343,35 @@ function normalizeGlobalValidatorSubnet(raw: unknown): GlobalValidatorSubnet | n
   };
 }
 
+/** Always-present ColdkeyIdentity shape (#5234); null only when the wire value is null. */
+export function normalizeColdkeyIdentity(raw: unknown): ColdkeyIdentity | null {
+  if (raw == null) return null;
+  if (!isRecord(raw)) {
+    return {
+      has_identity: false,
+      name: null,
+      image: null,
+      url: null,
+      description: null,
+      discord: null,
+      github: null,
+      additional: null,
+      captured_at: null,
+    };
+  }
+  return {
+    has_identity: booleanValue(raw.has_identity) ?? false,
+    name: typeof raw.name === "string" ? raw.name : null,
+    image: typeof raw.image === "string" ? raw.image : null,
+    url: typeof raw.url === "string" ? raw.url : null,
+    description: typeof raw.description === "string" ? raw.description : null,
+    discord: typeof raw.discord === "string" ? raw.discord : null,
+    github: typeof raw.github === "string" ? raw.github : null,
+    additional: typeof raw.additional === "string" ? raw.additional : null,
+    captured_at: typeof raw.captured_at === "string" ? raw.captured_at : null,
+  };
+}
+
 function normalizeGlobalValidator(raw: unknown): GlobalValidator | null {
   if (!isRecord(raw)) return null;
   const hotkey = coerceString(raw.hotkey);
@@ -5360,12 +5390,15 @@ function normalizeGlobalValidator(raw: unknown): GlobalValidator | null {
     // spread, so it must be listed explicitly or it silently vanishes.
     featured: booleanValue(raw.featured) ?? false,
     coldkey: typeof raw.coldkey === "string" ? raw.coldkey : null,
+    // Joined server-side (#5234); listed explicitly for the same no-spread reason.
+    coldkey_identity: normalizeColdkeyIdentity(raw.coldkey_identity),
     coldkey_count: coerceFiniteNumber(raw.coldkey_count) ?? 0,
     subnet_count: coerceFiniteNumber(raw.subnet_count) ?? 0,
     uid_count: coerceFiniteNumber(raw.uid_count) ?? 0,
     total_stake_tao: coerceFiniteNumber(raw.total_stake_tao) ?? 0,
     total_emission_tao: coerceFiniteNumber(raw.total_emission_tao) ?? 0,
     nominator_count: nullableNum(raw.nominator_count),
+    take: nullableNum(raw.take),
     apy_estimate: nullableNum(raw.apy_estimate),
     apy_estimate_eligible_subnet_count:
       coerceFiniteNumber(raw.apy_estimate_eligible_subnet_count) ?? 0,
@@ -5645,6 +5678,35 @@ function normalizeValidatorDetailSubnet(raw: unknown): ValidatorDetailSubnet | n
 /** Cross-subnet validator detail — a validator's rows joined across every subnet
  * they operate in (#4335/7.1). Schema-stable: a cold/unknown hotkey resolves to
  * a zeroed aggregate rather than an error, so this never throws on a bad hotkey. */
+export function normalizeValidatorDetail(raw: unknown, fallbackHotkey = ""): ValidatorDetail {
+  const d = isRecord(raw) ? raw : {};
+  const subnets = Array.isArray(d.subnets)
+    ? d.subnets.flatMap((row) => {
+        const s = normalizeValidatorDetailSubnet(row);
+        return s ? [s] : [];
+      })
+    : [];
+  return {
+    hotkey: firstString(d.hotkey) ?? fallbackHotkey,
+    coldkey: firstString(d.coldkey) ?? null,
+    coldkey_identity: normalizeColdkeyIdentity(d.coldkey_identity),
+    coldkey_count: firstFiniteNumber(d.coldkey_count) ?? 0,
+    subnet_count: firstFiniteNumber(d.subnet_count) ?? 0,
+    total_stake_tao: firstFiniteNumber(d.total_stake_tao) ?? 0,
+    root_stake_tao: firstFiniteNumber(d.root_stake_tao) ?? 0,
+    alpha_stake_tao: firstFiniteNumber(d.alpha_stake_tao) ?? 0,
+    total_emission_tao: firstFiniteNumber(d.total_emission_tao) ?? 0,
+    nominator_count:
+      d.nominator_count == null ? null : (firstFiniteNumber(d.nominator_count) ?? null),
+    take: d.take == null ? null : (firstFiniteNumber(d.take) ?? null),
+    avg_validator_trust: firstFiniteNumber(d.avg_validator_trust) ?? null,
+    max_validator_trust: firstFiniteNumber(d.max_validator_trust) ?? null,
+    captured_at: firstString(d.captured_at) ?? null,
+    block_number: firstFiniteNumber(d.block_number) ?? null,
+    subnets,
+  };
+}
+
 export const validatorDetailQuery = (hotkey: string) =>
   queryOptions({
     queryKey: k("validator-detail", hotkey),
@@ -5652,29 +5714,8 @@ export const validatorDetailQuery = (hotkey: string) =>
       const res = await apiFetch<unknown>(`/api/v1/validators/${ss58PathSegment(hotkey)}`, {
         signal,
       });
-      const d = isRecord(res.data) ? res.data : {};
-      const subnets = Array.isArray(d.subnets)
-        ? d.subnets.flatMap((row) => {
-            const s = normalizeValidatorDetailSubnet(row);
-            return s ? [s] : [];
-          })
-        : [];
       return {
-        data: {
-          hotkey: firstString(d.hotkey) ?? hotkey,
-          coldkey: firstString(d.coldkey) ?? null,
-          coldkey_count: firstFiniteNumber(d.coldkey_count) ?? 0,
-          subnet_count: firstFiniteNumber(d.subnet_count) ?? 0,
-          total_stake_tao: firstFiniteNumber(d.total_stake_tao) ?? 0,
-          root_stake_tao: firstFiniteNumber(d.root_stake_tao) ?? 0,
-          alpha_stake_tao: firstFiniteNumber(d.alpha_stake_tao) ?? 0,
-          total_emission_tao: firstFiniteNumber(d.total_emission_tao) ?? 0,
-          avg_validator_trust: firstFiniteNumber(d.avg_validator_trust) ?? null,
-          max_validator_trust: firstFiniteNumber(d.max_validator_trust) ?? null,
-          captured_at: firstString(d.captured_at) ?? null,
-          block_number: firstFiniteNumber(d.block_number) ?? null,
-          subnets,
-        } as ValidatorDetail,
+        data: normalizeValidatorDetail(res.data, hotkey),
         meta: res.meta,
         url: res.url,
       } as ApiResult<ValidatorDetail>;

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1980,12 +1980,31 @@ export interface GlobalValidatorSubnet {
   validator_trust: number | null;
 }
 
+/**
+ * Self-declared on-chain identity for a coldkey (SubtensorModule::set_identity),
+ * joined server-side (#5234). Not hotkey-specific — one coldkey can run many
+ * hotkeys, so the same identity may appear on multiple directory rows.
+ */
+export interface ColdkeyIdentity {
+  has_identity: boolean;
+  name?: string | null;
+  image?: string | null;
+  url?: string | null;
+  description?: string | null;
+  discord?: string | null;
+  github?: string | null;
+  additional?: string | null;
+  captured_at?: string | null;
+}
+
 /** One validator/operator row grouped by hotkey across subnet memberships. */
 export interface GlobalValidator {
   hotkey: string;
   /** DB-toggled maintainer pin (#5166) — always present, moves the row to the front of the default (unsorted) view. */
   featured: boolean;
   coldkey: string | null;
+  /** Primary coldkey's on-chain identity; null only when coldkey is null (#5234). */
+  coldkey_identity: ColdkeyIdentity | null;
   coldkey_count: number;
   subnet_count: number;
   uid_count: number;
@@ -1993,6 +2012,8 @@ export interface GlobalValidator {
   total_emission_tao: number;
   /** Distinct coldkeys currently staking to this hotkey, network-wide (#2549). Null when the low-frequency source table has no row for this hotkey yet. */
   nominator_count: number | null;
+  /** Validator take/commission (#2548), 0..1 fraction. Null when no Delegates entry at capture. */
+  take: number | null;
   /** Estimated annualized yield (#2551) — a stake-weighted blend across every subnet membership with a known tempo. See apy_estimate_eligible_subnet_count. Null when no membership resolved a tempo. */
   apy_estimate: number | null;
   /** Count of subnet memberships that contributed to apy_estimate, out of subnet_count total (#2551). */
@@ -2043,6 +2064,8 @@ export interface ValidatorDetail {
   schema_version?: number;
   hotkey: string;
   coldkey: string | null;
+  /** Primary coldkey's on-chain identity; null only when coldkey is null (#5234). */
+  coldkey_identity: ColdkeyIdentity | null;
   coldkey_count: number;
   subnet_count: number;
   total_stake_tao: number;
@@ -2051,6 +2074,10 @@ export interface ValidatorDetail {
   /** total_stake_tao minus root_stake_tao — the alpha-token-denominated legs. */
   alpha_stake_tao: number;
   total_emission_tao: number;
+  /** Distinct coldkeys currently staking to this hotkey, network-wide (#2549). */
+  nominator_count: number | null;
+  /** Validator take/commission (#2548), 0..1 fraction. Null when no Delegates entry at capture. */
+  take: number | null;
   avg_validator_trust: number | null;
   max_validator_trust: number | null;
   captured_at?: string | null;

--- a/apps/ui/src/lib/metagraphed/validators.test.ts
+++ b/apps/ui/src/lib/metagraphed/validators.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeGlobalValidators, validatorsQuery } from "./queries";
+import {
+  normalizeColdkeyIdentity,
+  normalizeGlobalValidators,
+  normalizeValidatorDetail,
+  validatorsQuery,
+} from "./queries";
 
 describe("normalizeGlobalValidators", () => {
   it("normalizes a representative global validators payload", () => {
@@ -15,11 +20,18 @@ describe("normalizeGlobalValidators", () => {
         {
           hotkey: "5Hotkey",
           coldkey: "5Coldkey",
+          coldkey_identity: {
+            has_identity: true,
+            name: "Acme Ops",
+            image: "https://example.com/logo.png",
+          },
           coldkey_count: 1,
           subnet_count: 2,
           uid_count: 3,
           total_stake_tao: 100.5,
           total_emission_tao: 1.25,
+          nominator_count: 12,
+          take: 0.18,
           avg_validator_trust: 0.99,
           max_validator_trust: 1,
           stake_dominance: 0.05,
@@ -50,10 +62,29 @@ describe("normalizeGlobalValidators", () => {
     expect(out.validators[0]).toMatchObject({
       hotkey: "5Hotkey",
       coldkey: "5Coldkey",
+      take: 0.18,
+      nominator_count: 12,
+      coldkey_identity: {
+        has_identity: true,
+        name: "Acme Ops",
+        image: "https://example.com/logo.png",
+      },
       subnet_count: 2,
       uid_count: 3,
       subnets: [{ netuid: 1, uid: 0, stake_tao: 50, emission_tao: 0.5, validator_trust: 1 }],
     });
+  });
+
+  it("defaults take and coldkey_identity when the wire omits them (#5245)", () => {
+    const out = normalizeGlobalValidators({
+      sort: "subnet_count",
+      limit: 5,
+      validators: [{ hotkey: "hk", subnet_count: 1, uid_count: 1, subnets: [] }],
+    });
+
+    expect(out.validators[0].take).toBeNull();
+    expect(out.validators[0].coldkey_identity).toBeNull();
+    expect(out.validators[0].nominator_count).toBeNull();
   });
 
   it("drops validator rows with a missing hotkey", () => {
@@ -106,6 +137,59 @@ describe("normalizeGlobalValidators", () => {
     expect(out.validator_count).toBe(1);
     expect(out.validators[0].subnet_count).toBe(2);
     expect(out.validators[0].subnets[0].netuid).toBe(7);
+  });
+});
+
+describe("normalizeColdkeyIdentity", () => {
+  it("returns null for a null wire value", () => {
+    expect(normalizeColdkeyIdentity(null)).toBeNull();
+  });
+
+  it("preserves has_identity:false for an empty identity object", () => {
+    expect(normalizeColdkeyIdentity({ has_identity: false })).toMatchObject({
+      has_identity: false,
+      name: null,
+    });
+  });
+});
+
+describe("normalizeValidatorDetail", () => {
+  it("carries take, nominator_count, and coldkey_identity (#5245)", () => {
+    const out = normalizeValidatorDetail(
+      {
+        hotkey: "5Hotkey",
+        coldkey: "5Coldkey",
+        coldkey_identity: { has_identity: true, name: "Acme Ops" },
+        coldkey_count: 1,
+        subnet_count: 2,
+        total_stake_tao: 100,
+        root_stake_tao: 40,
+        alpha_stake_tao: 60,
+        total_emission_tao: 1,
+        nominator_count: 7,
+        take: 0.09,
+        avg_validator_trust: 0.5,
+        max_validator_trust: 0.8,
+        subnets: [],
+      },
+      "fallback",
+    );
+
+    expect(out).toMatchObject({
+      hotkey: "5Hotkey",
+      take: 0.09,
+      nominator_count: 7,
+      coldkey_identity: { has_identity: true, name: "Acme Ops" },
+      root_stake_tao: 40,
+      alpha_stake_tao: 60,
+    });
+  });
+
+  it("nulls take and nominator_count when absent", () => {
+    const out = normalizeValidatorDetail({ hotkey: "hk", subnets: [] }, "hk");
+    expect(out.take).toBeNull();
+    expect(out.nominator_count).toBeNull();
+    expect(out.coldkey_identity).toBeNull();
   });
 });
 

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -3,7 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { Boxes, Coins, Gauge, Zap } from "lucide-react";
+import { Boxes, Coins, Gauge, Percent, Users, Zap } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -200,16 +200,26 @@ function NominatorsSection({ hotkey }: { hotkey: string }) {
   );
 }
 
+function formatTake(take: number | null | undefined): string {
+  if (take == null || !Number.isFinite(take)) return "—";
+  return `${(take * 100).toFixed(1)}%`;
+}
+
 function ValidatorDetail({ hotkey }: { hotkey: string }) {
   const sourceRef = ss58PathSegment(hotkey);
   const detail = useSuspenseQuery(validatorDetailQuery(hotkey)).data.data;
+  const identityName =
+    detail.coldkey_identity?.has_identity && detail.coldkey_identity.name?.trim()
+      ? detail.coldkey_identity.name.trim()
+      : null;
+  const title = identityName ?? shortHash(hotkey, 8) ?? "Validator";
 
   return (
     <>
       <PageHero
         eyebrow="Explorer · validator"
         live
-        title={shortHash(hotkey, 8) ?? "Validator"}
+        title={title}
         description={
           // PageHero renders `description` inside a <p> — block elements (div/p)
           // are invalid HTML there (triggers a hydration mismatch), so this uses
@@ -217,9 +227,21 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           // use for the same "blurb + copyable chip" shape.
           <span className="block space-y-4">
             <span className="block max-w-2xl">
-              Cross-subnet performance, nominators, and staking history for one Bittensor validator
-              hotkey.
+              {identityName
+                ? `Cross-subnet performance, nominators, and staking history for ${identityName} (coldkey on-chain identity — not hotkey-specific).`
+                : "Cross-subnet performance, nominators, and staking history for one Bittensor validator hotkey."}
             </span>
+            {detail.coldkey_identity?.has_identity && detail.coldkey_identity.image ? (
+              <span className="inline-flex items-center gap-2">
+                <img
+                  src={detail.coldkey_identity.image}
+                  alt=""
+                  className="size-8 rounded-md object-cover"
+                  loading="lazy"
+                  referrerPolicy="no-referrer"
+                />
+              </span>
+            ) : null}
             <span className="inline-flex max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
               <CopyableCode value={hotkey} truncate={false} />
             </span>
@@ -229,7 +251,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         caption="explorer / v1"
       />
 
-      <div className="mb-12 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="mb-12 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
         <StatTile
           icon={Coins}
           eyebrow="Total stake"
@@ -246,6 +268,20 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           eyebrow="Total emission"
           value={taoCompact(detail.total_emission_tao)}
           hint="across all subnets"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+        />
+        <StatTile
+          icon={Percent}
+          eyebrow="Take"
+          value={formatTake(detail.take)}
+          hint="delegator commission kept"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+        />
+        <StatTile
+          icon={Users}
+          eyebrow="Nominators"
+          value={detail.nominator_count != null ? formatNumber(detail.nominator_count) : "—"}
+          hint="distinct coldkeys staking"
           className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
         />
         <StatTile

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -14,7 +14,7 @@ import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
-import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
+import type { ColdkeyIdentity, GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 // The full GlobalValidatorSort set the /api/v1/validators endpoint accepts.
 // Stake / emission / dominance / trust get their own columns in #3359; this
@@ -39,6 +39,18 @@ const SORT_LABELS: Record<GlobalValidatorSort, string> = {
   avg_validator_trust: "Avg trust",
   max_validator_trust: "Max trust",
 };
+
+/** Format take/commission (0..1) as a percentage; dash when unset (#2548 / #5245). */
+function formatTake(take: number | null | undefined): string {
+  if (take == null || !Number.isFinite(take)) return "—";
+  return `${(take * 100).toFixed(1)}%`;
+}
+
+function identityLabel(identity: ColdkeyIdentity | null | undefined): string | null {
+  if (!identity?.has_identity) return null;
+  const name = identity.name?.trim();
+  return name || null;
+}
 
 const validatorsSearchSchema = z.object({
   sort: fallback(z.enum(validatorSortKeys), "subnet_count").default("subnet_count"),
@@ -165,6 +177,7 @@ function ValidatorsTable({
               <tr>
                 <th className={TH}>Hotkey</th>
                 <th className={TH}>Coldkey</th>
+                <th className={`${TH} text-right`}>Take</th>
                 <th className={`${TH} text-right`}>Active subnets</th>
                 <th className={`${TH} text-right`}>UIDs</th>
                 <th className={`${TH} text-right`}>Nominators</th>
@@ -175,58 +188,80 @@ function ValidatorsTable({
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
-              {validators.map((v) => (
-                <tr key={v.hotkey} className="hover:bg-surface/40">
-                  <td className="px-3 py-2 font-mono text-[11px]">
-                    <div className="flex items-center gap-1.5">
-                      {v.featured ? <FeaturedBadge /> : null}
-                      <Link
-                        to="/validators/$hotkey"
-                        params={{ hotkey: v.hotkey }}
-                        className="text-ink-strong hover:text-accent hover:underline"
-                        title={v.hotkey}
-                      >
-                        {shortHash(v.hotkey) ?? v.hotkey}
-                      </Link>
-                    </div>
-                  </td>
-                  <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
-                    {v.coldkey ? (
-                      <Link
-                        to="/accounts/$ss58"
-                        params={{ ss58: v.coldkey }}
-                        className="hover:text-accent hover:underline"
-                        title={v.coldkey}
-                      >
-                        {shortHash(v.coldkey) ?? v.coldkey}
-                      </Link>
-                    ) : (
-                      "—"
-                    )}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {formatNumber(v.subnet_count)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {formatNumber(v.uid_count)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {v.nominator_count != null ? formatNumber(v.nominator_count) : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {taoCompact(v.total_stake_tao)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {taoCompact(v.total_emission_tao)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {v.apy_estimate != null ? `${(v.apy_estimate * 100).toFixed(1)}%` : "—"}
-                  </td>
-                </tr>
-              ))}
+              {validators.map((v) => {
+                const label = identityLabel(v.coldkey_identity);
+                return (
+                  <tr key={v.hotkey} className="hover:bg-surface/40">
+                    <td className="px-3 py-2 font-mono text-[11px]">
+                      <div className="flex items-center gap-1.5">
+                        {v.featured ? <FeaturedBadge /> : null}
+                        {v.coldkey_identity?.has_identity && v.coldkey_identity.image ? (
+                          <img
+                            src={v.coldkey_identity.image}
+                            alt=""
+                            className="size-4 shrink-0 rounded-sm object-cover"
+                            loading="lazy"
+                            referrerPolicy="no-referrer"
+                          />
+                        ) : null}
+                        <Link
+                          to="/validators/$hotkey"
+                          params={{ hotkey: v.hotkey }}
+                          className="min-w-0 text-ink-strong hover:text-accent hover:underline"
+                          title={v.hotkey}
+                        >
+                          {label ? (
+                            <span className="block truncate font-sans text-[12px] font-medium">
+                              {label}
+                            </span>
+                          ) : null}
+                          <span className={label ? "block text-ink-muted" : undefined}>
+                            {shortHash(v.hotkey) ?? v.hotkey}
+                          </span>
+                        </Link>
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
+                      {v.coldkey ? (
+                        <Link
+                          to="/accounts/$ss58"
+                          params={{ ss58: v.coldkey }}
+                          className="hover:text-accent hover:underline"
+                          title={v.coldkey}
+                        >
+                          {shortHash(v.coldkey) ?? v.coldkey}
+                        </Link>
+                      ) : (
+                        "—"
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {formatTake(v.take)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {formatNumber(v.subnet_count)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {formatNumber(v.uid_count)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {v.nominator_count != null ? formatNumber(v.nominator_count) : "—"}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                      {taoCompact(v.total_stake_tao)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {taoCompact(v.total_emission_tao)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      {v.apy_estimate != null ? `${(v.apy_estimate * 100).toFixed(1)}%` : "—"}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
Closes #5245

## Summary

- Backend already returns `take` (#2548) and `coldkey_identity` (#5234) on `/api/v1/validators` and `/api/v1/validators/{hotkey}`, plus `nominator_count` on detail (#2549) — but the UI normalizers dropped them (no `...raw` spread), so they never reached the page.
- Directory (`/validators`): identity name/logo on the hotkey cell + a **Take** column; Nominators and Est. APY unchanged.
- Detail (`/validators/$hotkey`): identity name as hero title when present; **Take** and **Nominators** StatTiles (6-tile grid).
- Extend the “How to evaluate a validator” glossary with Identity + Take (coldkey-not-hotkey caveat).
- Leaves the “Stake to this validator” entry point for later (#5242). Rebased onto current `main` (includes APY #5284).

## Template Used

Frontend/UI change (`apps/ui/**` only)

## Test plan

- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (690 passed)
- [x] `npm run build --workspace=apps/ui`
- [x] Prettier + ESLint on changed files (0 errors)
- [x] Manual: detail page shows Take 18.0% + Nominators tiles vs 4-tile before
- [ ] `npm run test:e2e --workspace=apps/ui`

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://github.com/user-attachments/assets/bdc526f6-b60a-4344-9ae0-c677b5ef289c" width="260">](https://github.com/user-attachments/assets/bdc526f6-b60a-4344-9ae0-c677b5ef289c)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/48d1f7ac-f73d-4d6e-a242-ba36faaec9ef" width="260">](https://github.com/user-attachments/assets/48d1f7ac-f73d-4d6e-a242-ba36faaec9ef)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://github.com/user-attachments/assets/63c870e9-2a6f-4394-8933-33b4a4960e6a" width="260">](https://github.com/user-attachments/assets/63c870e9-2a6f-4394-8933-33b4a4960e6a)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/f3665e3a-fddc-4eb5-b90f-918c502ceda1" width="260">](https://github.com/user-attachments/assets/f3665e3a-fddc-4eb5-b90f-918c502ceda1)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://github.com/user-attachments/assets/b12c5131-9df1-4e44-a727-6a01667e984f" width="260">](https://github.com/user-attachments/assets/b12c5131-9df1-4e44-a727-6a01667e984f)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/06d85dc7-5757-4481-9f8c-02733e286b00" width="260">](https://github.com/user-attachments/assets/06d85dc7-5757-4481-9f8c-02733e286b00)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://github.com/user-attachments/assets/10b9eb61-dfcd-4510-bf97-0dd620f39dbf" width="260">](https://github.com/user-attachments/assets/10b9eb61-dfcd-4510-bf97-0dd620f39dbf)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/83798a8c-50c5-44d7-ac44-e10f06e81b96" width="260">](https://github.com/user-attachments/assets/83798a8c-50c5-44d7-ac44-e10f06e81b96)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://github.com/user-attachments/assets/4e299899-543c-46a1-9f7e-320f16bf9c11" width="260">](https://github.com/user-attachments/assets/4e299899-543c-46a1-9f7e-320f16bf9c11)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/1930d077-6ac8-4251-90d2-ca69977f09a2" width="260">](https://github.com/user-attachments/assets/1930d077-6ac8-4251-90d2-ca69977f09a2)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://github.com/user-attachments/assets/d2686dda-ac16-41f1-affa-35d811e1104d" width="260">](https://github.com/user-attachments/assets/d2686dda-ac16-41f1-affa-35d811e1104d)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/2eda2f17-4d24-46d4-b5b1-394f467f7a08" width="260">](https://github.com/user-attachments/assets/2eda2f17-4d24-46d4-b5b1-394f467f7a08)<br><sub>after</sub> |