### PR TITLE
chore(claude): add contributor-pipeline-gardening skill

### DIFF
--- a/.claude/skills/contributor-pipeline-gardening/SKILL.md
+++ b/.claude/skills/contributor-pipeline-gardening/SKILL.md
@@ -32,13 +32,14 @@ grep confirming the described code/route/page exists); leave partial work open, 
 scope-clarifying comment.
 
 **metagraphed-specific things to check while doing this:**
+
 - Milestone **#9 "Wave 3 — Frontend (post-consolidation)"** is marked `open` but currently shows 0
   open / 480 closed issues — check whether this is simply drained (in which case close the milestone
   itself) or whether it's silently missing new work that should be filed under it.
 - **74 of 142 open issues (as of 2026-07-14) have no milestone at all** — a much bigger gap than
   gittensory's equivalent. Before generating new issues, spend part of a sweep folding orphaned
   issues into the milestone they actually belong to (`Foundations & Infra`, `Wave 4 — Docs & Dev
-  Surface`, `Partner Flywheel Hardening`, or a new one if none fit) — this repo's issue hygiene needs
+Surface`, `Partner Flywheel Hardening`, or a new one if none fit) — this repo's issue hygiene needs
   more of this than gittensory's does.
 - The **native-staking feature work** (`gittensor:feature`/`maintainer-only` issues in the low-5200s
   numbering, "take/commission management," "move/re-delegate stake flow," "risk disclosure copy") is

--- a/.claude/skills/contributor-pipeline-gardening/SKILL.md
+++ b/.claude/skills/contributor-pipeline-gardening/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: contributor-pipeline-gardening
+description: >-
+  Daily maintenance of the contributor issue pipeline for JSONbored/metagraphed — closing issues
+  that are already done but not marked so, and topping up the contributor-available backlog with
+  well-scoped new issues. Invoke for "run the daily issue gardening", "audit open issues for
+  stale/complete ones", "generate new contributor issues", or any recurring/scheduled run of this
+  process. `reference.md` (next to this file) has the exhaustive label/milestone/template detail —
+  read it before doing real work, not just this file. This is the metagraphed-specific instance;
+  JSONbored/gittensory (loopover) has its own separate copy with different conventions — do not
+  cross-apply either repo's specifics to the other without being asked.
+---
+
+# Contributor pipeline gardening — metagraphed
+
+metagraphed is a Bittensor subnet registry / block-explorer product. Unlike gittensory/loopover,
+**a linked issue is optional here** — the gate judges a PR on its own merit when nothing is linked,
+it only auto-closes for a missing link if a linked issue was claimed and doesn't hold up (see
+`.claude/skills/metagraphed/SKILL.md`). So the existential pressure to keep a full pipeline is lower
+than in gittensory, but it's still the main way to (a) direct contributor effort at what actually
+matters instead of ad-hoc surface PRs, and (b) hand out `gittensor:*` points fairly. Do both passes
+below; treat the top-up target as "keep good, well-directed work available," not "prevent PRs from
+being rejected."
+
+## Pass 1 — stale-issue sweep (do this first, every run)
+
+Same method as gittensory's copy of this skill (see that repo's `reference.md` if you need the full
+GraphQL walkthrough) — for every open issue, query `timelineItems(itemTypes: [CROSS_REFERENCED_EVENT])`
+for merged PRs that referenced it, then read the actual PR body for any hit where `willCloseTarget`
+was false. Close what's genuinely done (with a comment naming the shipping PR and, ideally, a direct
+grep confirming the described code/route/page exists); leave partial work open, optionally with a
+scope-clarifying comment.
+
+**metagraphed-specific things to check while doing this:**
+- Milestone **#9 "Wave 3 — Frontend (post-consolidation)"** is marked `open` but currently shows 0
+  open / 480 closed issues — check whether this is simply drained (in which case close the milestone
+  itself) or whether it's silently missing new work that should be filed under it.
+- **74 of 142 open issues (as of 2026-07-14) have no milestone at all** — a much bigger gap than
+  gittensory's equivalent. Before generating new issues, spend part of a sweep folding orphaned
+  issues into the milestone they actually belong to (`Foundations & Infra`, `Wave 4 — Docs & Dev
+  Surface`, `Partner Flywheel Hardening`, or a new one if none fit) — this repo's issue hygiene needs
+  more of this than gittensory's does.
+- The **native-staking feature work** (`gittensor:feature`/`maintainer-only` issues in the low-5200s
+  numbering, "take/commission management," "move/re-delegate stake flow," "risk disclosure copy") is
+  active and security-sensitive — treat anything touching real stake movement, phishing surface, or
+  the pre-launch security review as `maintainer-only` by default; don't second-guess that boundary.
+
+## Pass 2 — backlog top-up
+
+1. Compute the **combined** contributor-available count across both gittensory/loopover and
+   metagraphed before deciding how much to generate here — the 30-50/day target is a combined total,
+   not per-repo (confirmed with the maintainer 2026-07-14).
+2. This repo's contributor-availability query needs `gittensor:priority` counted alongside
+   `gittensor:feature`/`gittensor:bug` — unlike gittensory, metagraphed frequently uses
+   `gittensor:priority` as a **standalone** points label (54 of 59 `gittensor:priority` issues here
+   carry no `gittensor:feature`/`gittensor:bug` pairing, as of 2026-07-14). Don't "fix" this to match
+   gittensory's scarcer convention unless asked — it's this repo's own established norm.
+3. Real, concrete gaps worth scoping from first: the **"Docs page: <endpoint>" family** in
+   `Wave 4 — Docs & Dev Surface` (docs for existing shipped API surfaces — `/rpc/*`, `/api/v1/search`,
+   `/api/v1/webhooks/*`, etc.) are currently `maintainer-only` but look like exactly the kind of
+   low-risk, precedent-following, no-business-judgment work this framework says is safe to unlock —
+   worth a first-pass review to confirm and relabel rather than only generating net-new issues.
+4. Every new issue: correct milestone, a `gittensor:bug`/`gittensor:feature`/`gittensor:priority`
+   label (this repo's own convention — priority isn't scarce here the way it is in gittensory, but
+   still means "the maintainer actually wants this soon," don't apply it reflexively to everything),
+   `help wanted` (paired convention here too), and `good first issue` when genuinely scoped/documented
+   enough for a newcomer (a label gittensory doesn't use — apply it honestly, not as a default).
+5. Full body template — Context, Requirements, Deliverables, Expected Outcome, Links & Resources (see
+   `reference.md`). Registry/surface-data contributions have their own distinct shape (one file per
+   subnet, `registry/subnets/<slug>.json`) — don't template a data-contribution issue the same as a
+   code/schema issue; see the `metagraphed` skill's own reference.md for the surface model if
+   generating that kind of issue.
+6. Link relationships with GitHub's native `addSubIssue`/`addBlockedBy` mutations (same as gittensory
+   — confirmed available on this repo too via the same GraphQL check) rather than a markdown checklist.
+7. Quality over the number, same as gittensory's copy of this rule.
+
+## Daily digest
+
+Same shape as gittensory's: issues closed + why, milestones/checklists fixed, new issues filed with
+milestone/label, before/after contributor-available count, anything left alone on purpose.

--- a/.claude/skills/contributor-pipeline-gardening/reference.md
+++ b/.claude/skills/contributor-pipeline-gardening/reference.md
@@ -10,13 +10,13 @@ skill only covers issue-pipeline hygiene, not PR review mechanics.
 
 ## Milestone taxonomy (as of 2026-07-14 — re-check, this repo's hygiene drifts faster than gittensory's)
 
-| Milestone | Open | Nature |
-|---|---|---|
-| `Foundations & Infra` (#11) | ~39-41 | General backend/infra work, mixed maintainer/contributor |
-| `Wave 4 — Docs & Dev Surface` (#10) | ~25 | Docs pages for shipped API surfaces — mostly currently `maintainer-only` but low-risk to unlock, see SKILL.md |
-| `Partner Flywheel Hardening` (#13) | ~4 | Small, check individually |
-| `Wave 3 — Frontend (post-consolidation)` (#9) | 0 open / 480 closed, still marked `open` | Likely fully drained — verify and close the milestone if so, or find out why it's still open |
-| Unmilestoned | ~74 (over half of all open issues) | Real hygiene gap — fold into the closest fit rather than leaving orphaned |
+| Milestone                                     | Open                                     | Nature                                                                                                        |
+| --------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `Foundations & Infra` (#11)                   | ~39-41                                   | General backend/infra work, mixed maintainer/contributor                                                      |
+| `Wave 4 — Docs & Dev Surface` (#10)           | ~25                                      | Docs pages for shipped API surfaces — mostly currently `maintainer-only` but low-risk to unlock, see SKILL.md |
+| `Partner Flywheel Hardening` (#13)            | ~4                                       | Small, check individually                                                                                     |
+| `Wave 3 — Frontend (post-consolidation)` (#9) | 0 open / 480 closed, still marked `open` | Likely fully drained — verify and close the milestone if so, or find out why it's still open                  |
+| Unmilestoned                                  | ~74 (over half of all open issues)       | Real hygiene gap — fold into the closest fit rather than leaving orphaned                                     |
 
 ## Labels — this repo's own convention, don't force gittensory's onto it
 
@@ -54,19 +54,24 @@ doesn't require access a contributor can't have). metagraphed-specific instances
 
 ```md
 ## Context
+
 <what exists today, cite real file/schema/route paths, why this matters>
 
 ## Requirements
+
 <concrete, testable requirements>
 
 ## Deliverables
+
 - [ ] <concrete artifact 1>
 - [ ] <concrete artifact 2>
 
 ## Expected Outcome
+
 <what's true after this ships that wasn't true before>
 
 ## Links & Resources
+
 <related issues, files to anchor on>
 ```
 
@@ -77,8 +82,24 @@ code-issue template above for that kind of ask.
 ## Native relationship linking (GraphQL — confirmed available on this repo, 2026-07-14)
 
 ```graphql
-mutation { addSubIssue(input: { issueId: "<parent node id>", subIssueId: "<child node id>" }) { issue { number } } }
-mutation { addBlockedBy(input: { issueId: "<blocked node id>", blockedById: "<blocker node id>" }) { issue { number } } }
+mutation {
+  addSubIssue(
+    input: { issueId: "<parent node id>", subIssueId: "<child node id>" }
+  ) {
+    issue {
+      number
+    }
+  }
+}
+mutation {
+  addBlockedBy(
+    input: { issueId: "<blocked node id>", blockedById: "<blocker node id>" }
+  ) {
+    issue {
+      number
+    }
+  }
+}
 ```
 
 Get a node ID: `gh api graphql -f query='query { repository(owner:"JSONbored", name:"metagraphed") { issue(number: N) { id } } }'`.

--- a/.claude/skills/contributor-pipeline-gardening/reference.md
+++ b/.claude/skills/contributor-pipeline-gardening/reference.md
@@ -1,0 +1,95 @@
+# Contributor pipeline gardening — reference (metagraphed)
+
+## Product shape
+
+metagraphed is a Bittensor subnet registry + block-explorer product: `registry/subnets/<slug>.json`
+(one file per subnet, community-contributed surfaces), a Worker API (`workers/`, OpenAPI-schema-driven,
+`schemas/` is the contract), and `apps/ui` (the explorer frontend). See `.claude/skills/metagraphed/`
+for the full contribution model — that skill is authoritative for how a PR gets merged here; this
+skill only covers issue-pipeline hygiene, not PR review mechanics.
+
+## Milestone taxonomy (as of 2026-07-14 — re-check, this repo's hygiene drifts faster than gittensory's)
+
+| Milestone | Open | Nature |
+|---|---|---|
+| `Foundations & Infra` (#11) | ~39-41 | General backend/infra work, mixed maintainer/contributor |
+| `Wave 4 — Docs & Dev Surface` (#10) | ~25 | Docs pages for shipped API surfaces — mostly currently `maintainer-only` but low-risk to unlock, see SKILL.md |
+| `Partner Flywheel Hardening` (#13) | ~4 | Small, check individually |
+| `Wave 3 — Frontend (post-consolidation)` (#9) | 0 open / 480 closed, still marked `open` | Likely fully drained — verify and close the milestone if so, or find out why it's still open |
+| Unmilestoned | ~74 (over half of all open issues) | Real hygiene gap — fold into the closest fit rather than leaving orphaned |
+
+## Labels — this repo's own convention, don't force gittensory's onto it
+
+- `gittensor:bug` (0.05x), `gittensor:feature` (0.25x), `gittensor:priority` (1.5x) — same point
+  values as gittensory, **but `gittensor:priority` is used far more liberally here** (roughly a third
+  of all open issues, often standalone with no `gittensor:feature`/`gittensor:bug` pairing). Follow
+  this repo's existing density, don't artificially scarce it down to match gittensory.
+- `good first issue` — used on ~40% of open issues here (gittensory has no equivalent label). Apply
+  honestly: genuinely scoped, well-documented, low-context-needed work only.
+- `help wanted` — paired with points labels, same as gittensory.
+- `backend` / `frontend` — apply when the work is clearly one or the other; skip when it's genuinely
+  both or neither (e.g. a pure docs/data issue).
+- `maintainer-only` — used on ~57% of open issues (81/142). Only ~14 of those also carry `roadmap`,
+  so **don't assume the `roadmap`+`maintainer-only` pairing convention from gittensory applies here**
+  — in this repo `maintainer-only` alone is a complete, sufficient signal.
+- Never add anything beyond the above to a gardening-generated issue.
+
+## What's safe to unleash
+
+Same underlying test as gittensory's copy of this skill (clear precedent to follow, no business/product
+decision required, doesn't touch security-sensitive surfaces without a maintainer design pass first,
+doesn't require access a contributor can't have). metagraphed-specific instances of the boundary:
+
+- **Docs pages for already-shipped API endpoints** (the Wave 4 "Docs page: X" family) — writing
+  accurate docs for an existing, stable endpoint is mechanical and low-risk. Good unlock candidates.
+- **Native-staking feature work** (real stake movement, commission/take management, re-delegation,
+  the pre-launch security review, phishing-resistance/subdomain work) — stays `maintainer-only`.
+  This is live financial functionality; don't unlock any of it without an explicit ask.
+- **Registry/surface data contributions** are a distinct category from code issues — they're the
+  community's main contribution path (one file per subnet) and don't need the same
+  maintainer-vs-contributor gating a code change does, since the gate's own AI-reviewer +
+  ownership-proof verification is the real safety net there, not issue labeling.
+
+## Issue body template
+
+```md
+## Context
+<what exists today, cite real file/schema/route paths, why this matters>
+
+## Requirements
+<concrete, testable requirements>
+
+## Deliverables
+- [ ] <concrete artifact 1>
+- [ ] <concrete artifact 2>
+
+## Expected Outcome
+<what's true after this ships that wasn't true before>
+
+## Links & Resources
+<related issues, files to anchor on>
+```
+
+For a registry/surface-data issue (asking a contributor to add a subnet's surfaces), follow the
+surface-contribution shape in `.claude/skills/metagraphed/reference.md` instead — do not use the
+code-issue template above for that kind of ask.
+
+## Native relationship linking (GraphQL — confirmed available on this repo, 2026-07-14)
+
+```graphql
+mutation { addSubIssue(input: { issueId: "<parent node id>", subIssueId: "<child node id>" }) { issue { number } } }
+mutation { addBlockedBy(input: { issueId: "<blocked node id>", blockedById: "<blocker node id>" }) { issue { number } } }
+```
+
+Get a node ID: `gh api graphql -f query='query { repository(owner:"JSONbored", name:"metagraphed") { issue(number: N) { id } } }'`.
+
+## gh CLI gotchas
+
+- `gh api graphql -f query=@file.txt` does **not** read the file — `-f` treats `@file` as a literal
+  string and the request fails with a GraphQL parse error on the `@`. Use **`-F query=@file.txt`**
+  (capital F) whenever the query is large enough to be worth writing to a file first.
+- `gh issue close` has no `--comment-file` flag — write the comment to a file, then pass
+  `-c "$(cat file.md)"` (double-quoted around the whole substitution) so any backticks in the comment
+  text are treated as literal characters, not re-parsed by bash as command substitution.
+- Never embed a body/comment string containing backticks directly inside a `python3 -c "..."`
+  double-quoted bash argument for the same reason — write it to a file first.


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/contributor-pipeline-gardening/` (SKILL.md + reference.md): the daily process for auditing open issues for stale/already-shipped ones (GraphQL cross-reference of merged PRs against open issues, verified against actual PR bodies before closing) and topping up the contributor-available backlog with well-scoped, correctly-labeled, correctly-milestoned new issues.
- This is the durable, repo-committed context a scheduled automation reads each run, since a fresh scheduled run has no memory of any prior session.
- Reflects this repo's own conventions specifically (linked-issue-optional gate, `gittensor:priority` used more liberally than gittensory's, `good first issue` label, current milestone gaps) rather than copying gittensory's copy of the same skill verbatim.

## Test plan
- [x] Docs-only change under `.claude/`; no `src/`/`workers/`/`schemas/` changes, no CI/coverage impact.