### PR TITLE
fix(mcp): close codecov/patch branch gap on get_subnet_uptime/compare_subnets

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -4281,19 +4281,18 @@ export const MCP_TOOLS = [
       if (args?.window !== undefined && window === null) {
         throw toolError("invalid_params", "window must be one of: 90d, 1y.");
       }
-      const resolvedWindow = window || "90d";
       const minSamples = optionalNonNegativeInt(args, "min_samples");
       return (
         (await tryPostgresTier(
           ctx.env,
           mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/uptime`, {
-            window: resolvedWindow,
+            window,
             min_samples: minSamples,
           }),
           "METAGRAPH_HEALTH_SOURCE",
         )) ??
         (await loadSubnetUptime(mcpD1Runner(ctx), netuid, {
-          window: resolvedWindow,
+          window,
           observedAt: await mcpObservedAt(ctx),
           minSamples,
         }))

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -10431,6 +10431,38 @@ describe("MCP economics + metagraph data tools", () => {
     });
   });
 
+  test("compare_subnets: health+economics dimensions flag=postgres still includes economicsRows", async () => {
+    let captured;
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          const reqUrl = new URL(req.url);
+          captured = reqUrl.pathname + reqUrl.search;
+          return Response.json({
+            rows: [
+              { netuid: 7, surface_count: 9, ok_count: 8, avg_latency_ms: 55 },
+            ],
+          });
+        },
+      },
+    };
+    const res = await callTool(
+      "compare_subnets",
+      { netuids: [7], dimensions: ["health", "economics"] },
+      { deps: liveAnalyticsDeps, env },
+    );
+    assert.equal(res.body.result.isError, false);
+    assert.equal(captured, "/api/v1/internal/compare-health?netuids=7");
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(out.subnets[0].health, {
+      surface_count: 9,
+      ok_count: 8,
+      avg_latency_ms: 55,
+    });
+    assert.ok(out.subnets[0].economics);
+  });
+
   test("compare_subnets: health dimension flag=postgres falls back to D1 on DATA_API failure", async () => {
     const env = {
       ...d1Env,
@@ -16890,6 +16922,11 @@ describe("MCP health-tier analytics tools — Postgres tier wiring", () => {
       tool: "get_subnet_uptime",
       args: { netuid: 7, window: "1y", min_samples: 5 },
       path: "/api/v1/subnets/7/uptime?window=1y&min_samples=5",
+    },
+    {
+      tool: "get_subnet_uptime",
+      args: { netuid: 7 },
+      path: "/api/v1/subnets/7/uptime?window=90d",
     },
   ];
 


### PR DESCRIPTION
## Summary

Follow-up to #5298, which merged with a genuine (if small) `codecov/patch` shortfall — 98.98% vs the 99.00% target, 2 partial branches — that got bypassed via `--admin` during an automated continuation of that PR. This closes that gap properly rather than leaving it unaddressed.

- `get_subnet_uptime`'s `window || "90d"` fallback was unreachable dead code: `parseUptimeWindow(undefined)` already returns `"90d"` directly, and any other invalid non-undefined value throws before that line is reached, so `window` is never falsy there. Removed the redundant `resolvedWindow` variable and inlined `window` directly instead of adding a test to paper over unreachable code.
- `compare_subnets`' `economicsRows` ternary was genuinely undertested — the only existing Postgres-tier test always called it with `dimensions` excluding `"economics"`, so the true branch was never exercised. Added a `health+economics` test case to cover both branches.

## Test plan

- `npm run lint` — clean
- `npx prettier --check src/mcp-server.mjs tests/mcp-server.test.mjs` — clean
- `npm run build` — clean
- `npx vitest run tests/mcp-server.test.mjs` — 997/997 passed
- `npm run test:coverage` (full unsharded suite) — 272/272 test files, 8104/8104 tests passed
- Confirmed via direct lcov branch analysis (cross-referenced against the diff's changed line ranges) that zero partial-branch lines remain in this PR's diff