### PR TITLE
feat(registry): add SN96 Verathos dashboard API surface (#427)

### DIFF
--- a/registry/subnets/verathos.json
+++ b/registry/subnets/verathos.json
@@ -309,6 +309,25 @@
         "https://verathos.ai/docs"
       ],
       "url": "https://api.verathos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-subnet-api-verathos-ai",
+      "kind": "subnet-api",
+      "name": "Verathos dashboard API",
+      "notes": "Public no-auth GET /api/dashboard returning SN96 Verathos network dashboard JSON: proxy connectivity, epoch, miner/model status, scores, hardware metadata, and usage counters. Documented in the official Verathos OpenAPI under the dashboard tag; distinct from the existing model-list, health, circulating-supply, chain-info, and model-preset surfaces.",
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "kstefanovic"
+      },
+      "source_urls": [
+        "https://verathos.ai/openapi.json",
+        "https://verathos.ai/docs"
+      ],
+      "url": "https://verathos.ai/api/dashboard"
     }
   ],
   "website_url": "https://verathos.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

This PR appends one community surface to `registry/subnets/verathos.json` for SN96 Verathos.

## Surface

- Netuid: 96
- Kind: `subnet-api`
- Public URL: `https://verathos.ai/api/dashboard`
- Source URL: `https://verathos.ai/openapi.json`, `https://verathos.ai/docs`
- Provider slug: `verathos`

## Summary

- Registers the public no-auth Verathos dashboard JSON endpoint as a standalone `subnet-api` surface.
- The endpoint returns SN96 dashboard data including proxy connectivity, epoch, miner/model status, scores, hardware metadata, and usage counters.
- The route is documented in the official Verathos OpenAPI under the `dashboard` tag and is distinct from the existing model-list, health, circulating-supply, chain-info, and model-preset surfaces.

## Checklist

- [x] Changes exactly one `registry/subnets/<slug>.json` file.
- [x] Generated with `npm run surface:add`.
- [x] The `url` is public and safe for read-only probes.
- [x] The `source_url` independently proves the subnet publishes it.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked open issue: Refs #427.

## Validation

- [x] `npm run validate:surface -- registry/subnets/verathos.json`
- [x] `git diff --check`
- [ ] `npm run scan:public-safety` — blocked locally on Windows by pre-existing scanner/test-fixture findings outside `registry/subnets/verathos.json`; the changed subnet file has no public-safety hits.

Refs #427