### PR TITLE
feat(ui): staking risk disclosure & windowed APY methodology copy (#5247)

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
-import { MethodologyCallout } from "@jsonbored/ui-kit";
+import { MethodologyCallout, StakingRiskNote, STAKING_RISK_COPY } from "@jsonbored/ui-kit";
 import { validatorHistoryQuery } from "@/lib/metagraphed/queries";
 import {
   apyFromRewardsPer1000,
@@ -8,7 +8,7 @@ import {
   type ValidatorApyWindow,
 } from "@/lib/metagraphed/validator-apy";
 
-const WINDOWS: ValidatorApyWindow[] = ["7d", "30d", "90d"];
+const WINDOWS: Exclude<ValidatorApyWindow, "snapshot">[] = ["7d", "30d", "90d"];
 
 function latestRewards(points: Array<{ rewards_per_1000_tao?: number | null }>) {
   for (const p of points) {
@@ -18,7 +18,7 @@ function latestRewards(points: Array<{ rewards_per_1000_tao?: number | null }>) 
   return null;
 }
 
-/** Multi-window delegator APY tiles from validator history (#5245 / #2551 methodology). */
+/** Multi-window delegator APY tiles from validator history (#5245 / #2551 / #5247). */
 export function ValidatorApyPanel({
   hotkey,
   take,
@@ -63,8 +63,9 @@ export function ValidatorApyPanel({
               {anyLoading && row.apy == null ? "…" : formatApyPct(row.apy)}
             </div>
             <p className="mt-1 text-[10px] leading-relaxed text-ink-muted">
-              Net of take · daily neuron_daily rollup
+              Trailing {row.window} · net of take · not a forecast
             </p>
+            <StakingRiskNote className="mt-1.5" />
           </div>
         ))}
       </div>
@@ -74,11 +75,13 @@ export function ValidatorApyPanel({
           exist for this validator.
         </p>
       ) : null}
-      <MethodologyCallout generatedAt={generatedAt ?? undefined} windowLabel="history windows" />
+      <MethodologyCallout
+        variant="staking"
+        generatedAt={generatedAt ?? undefined}
+        windowLabel="7d / 30d / 90d"
+      />
       <p className="text-[11px] leading-relaxed text-ink-muted">
-        Delegator APY annualizes the latest daily rewards-per-1k-τ rate from neuron_daily, net of
-        validator take. Snapshot-tier emission can lag; server-side modelling (#2551) will replace
-        this client estimate.
+        {STAKING_RISK_COPY.methodology.long}
       </p>
     </div>
   );

--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -30,8 +30,8 @@ const METRICS: Array<{ term: string; def: string }> = [
     def: "The validator's commission (#2548): the fraction of delegator rewards the validator keeps (0–100%). Lower take means nominators keep more of the emission flow.",
   },
   {
-    term: "Est. APY",
-    def: "Annualized delegator yield estimated from emission÷stake, net of take. On the directory this uses the latest metagraph snapshot; on a validator detail page, 7d/30d/90d windows use daily neuron_daily history. Server-side modelling (#2551) will supersede these client estimates.",
+    term: "Est. APY · snapshot",
+    def: "Trailing-snapshot annualized yield (#2551 / #5247): emission÷stake over the latest captured epoch, net of take, labeled with its window. Not a forecast. Root stake is TAO-denominated with no principal price risk; alpha stake is price-exposed and can net-lose TAO despite a positive nominal APY. History tiles on a validator detail page use explicit 7d / 30d / 90d trailing windows instead.",
   },
   {
     term: "Nominators",
@@ -43,15 +43,11 @@ const METRICS: Array<{ term: string; def: string }> = [
   },
   {
     term: "Total stake",
-    def: "The TAO backing the validator: its own stake plus TAO delegated to it by nominators. Stake sets how much weight the validator's votes carry.",
+    def: "The TAO backing the validator: its own stake plus TAO delegated to it by nominators. Stake sets how much weight the validator's votes carry. Root (netuid 0) is TAO-denominated with no AMM; alpha legs are price-exposed.",
   },
   {
     term: "Total emission",
     def: "The TAO the validator earned over the window. Emission is split between the validator and its nominators via commission — it reflects reward flow, not profit.",
-  },
-  {
-    term: "Est. APY",
-    def: "An estimated annualized yield (#2551): projects the validator's most recently captured epoch payout across a full year, using each subnet's own epoch length. It's a snapshot-based estimate, not a forecast or a guarantee — it can swing between refreshes, especially for validators concentrated on short-epoch subnets. A dash means none of the validator's subnets have a captured epoch length yet.",
   },
   {
     term: "Validator trust (Sort)",

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -299,9 +299,16 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         />
         <StatTile
           icon={Zap}
-          eyebrow="Est. APY"
+          eyebrow="Est. APY · snapshot"
           value={formatApyPct(snapshotApy)}
-          hint="snapshot · net of take"
+          hint={
+            <span className="space-y-1">
+              <span className="block">Trailing snapshot · net of take · not a forecast</span>
+              <span className="block">
+                Root: no principal risk · TAO-denominated. Alpha: price-exposed · can net-lose TAO.
+              </span>
+            </span>
+          }
           truncate={false}
           className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
         />
@@ -310,7 +317,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
       <SectionAnchor
         id="apy"
         title="Delegator yield (APY)"
-        subtitle="7d / 30d / 90d windows from daily history"
+        subtitle="Trailing 7d / 30d / 90d windows — labeled, not projected"
         tone="accent"
       >
         <ValidatorApyPanel hotkey={hotkey} take={detail.take} generatedAt={detail.captured_at} />

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { PageHero, ShareButton } from "@jsonbored/ui-kit";
+import { MethodologyCallout, PageHero, ShareButton } from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
@@ -15,11 +15,7 @@ import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validato
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
-import {
-  annualizedDelegatorApyPct,
-  formatApyPct,
-  formatTakePct,
-} from "@/lib/metagraphed/validator-apy";
+import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 // The full GlobalValidatorSort set the /api/v1/validators endpoint accepts.
@@ -84,6 +80,7 @@ function ValidatorsPage() {
         actions={<ShareButton />}
       />
       <ValidatorGuide />
+      <MethodologyCallout variant="staking" windowLabel="snapshot" />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>
           <ValidatorsTable
@@ -173,14 +170,13 @@ function ValidatorsTable({
                 <th className={TH}>Hotkey</th>
                 <th className={TH}>Coldkey</th>
                 <th className={`${TH} text-right`}>Take</th>
-                <th className={`${TH} text-right`}>Est. APY</th>
+                <th className={`${TH} text-right`}>Est. APY · snapshot</th>
                 <th className={`${TH} text-right`}>Active subnets</th>
                 <th className={`${TH} text-right`}>UIDs</th>
                 <th className={`${TH} text-right`}>Nominators</th>
                 <th className={`${TH} text-right`}>Dominance</th>
                 <th className={`${TH} text-right`}>Total stake</th>
                 <th className={`${TH} text-right`}>Total emission</th>
-                <th className={`${TH} text-right`}>Est. APY</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
@@ -189,15 +185,22 @@ function ValidatorsTable({
                   <td className="px-3 py-2 font-mono text-[11px]">
                     <div className="flex items-center gap-1.5">
                       {v.featured ? <FeaturedBadge /> : null}
-                      <Link
-                        to="/validators/$hotkey"
-                        params={{ hotkey: v.hotkey }}
-                        className="text-ink-strong hover:text-accent hover:underline"
-                        title={v.hotkey}
-                      >
-                        {shortHash(v.hotkey) ?? v.hotkey}
-                      </Link>
+                      <ValidatorIdentityChip
+                        hotkey={v.hotkey}
+                        identity={v.coldkey_identity}
+                        size={22}
+                      />
                     </div>
+                  </td>
+                  <td className="px-3 py-2 font-mono text-[11px]">
+                    <Link
+                      to="/validators/$hotkey"
+                      params={{ hotkey: v.hotkey }}
+                      className="text-ink-strong hover:text-accent hover:underline"
+                      title={v.hotkey}
+                    >
+                      {shortHash(v.hotkey) ?? v.hotkey}
+                    </Link>
                   </td>
                   <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
                     {v.coldkey ? (
@@ -211,6 +214,19 @@ function ValidatorsTable({
                       </Link>
                     ) : (
                       "—"
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                    {formatTakePct(v.take)}
+                  </td>
+                  <td
+                    className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted"
+                    title="Trailing snapshot · not a forecast. Root: no principal risk · Alpha: price-exposed."
+                  >
+                    {formatApyPct(
+                      v.apy_estimate != null && Number.isFinite(v.apy_estimate)
+                        ? v.apy_estimate * 100
+                        : null,
                     )}
                   </td>
                   <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
@@ -230,9 +246,6 @@ function ValidatorsTable({
                   </td>
                   <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
                     {taoCompact(v.total_emission_tao)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {v.apy_estimate != null ? `${(v.apy_estimate * 100).toFixed(1)}%` : "—"}
                   </td>
                 </tr>
               ))}

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2882,17 +2882,99 @@ function ProfileHero({
     ] }, s.label)) }) : null
   ] });
 }
+var STAKING_RISK_COPY = {
+  root: {
+    term: "Root stake",
+    short: "No principal risk \xB7 TAO-denominated",
+    long: "Root (netuid 0) stake is TAO-denominated 1:1 with no AMM. There is no alpha price leg, so principal is not exposed to subnet token price moves."
+  },
+  alpha: {
+    term: "Alpha stake",
+    short: "Price-exposed \xB7 can net-lose TAO",
+    long: "Alpha (non-root) stake is denominated in that subnet's alpha token. Positive nominal APY can still net-lose TAO when alpha price falls \u2014 yield figures never erase that risk."
+  },
+  windows: {
+    term: "Yield windows",
+    short: "Trailing window \xB7 not a forecast",
+    long: "Every yield / APY figure is labeled with its trailing window (for example 7d, 30d, 90d, or latest snapshot). Numbers annualize observed emission\xF7stake over that window \u2014 they are not a projection or a promised return."
+  },
+  methodology: {
+    term: "APY methodology",
+    short: "Emission \xF7 stake, net of take",
+    long: "Directory and detail snapshot APY annualize the latest captured epoch rate across eligible subnet memberships (server-side apy_estimate). History tiles annualize the latest daily rewards-per-1k-\u03C4 rate from neuron_daily, net of validator take. Both can swing between refreshes."
+  }
+};
+function StakingRiskNote({
+  netuid,
+  className
+}) {
+  const copy = netuid == null ? `${STAKING_RISK_COPY.root.short}. ${STAKING_RISK_COPY.alpha.short}.` : netuid === 0 ? STAKING_RISK_COPY.root.short : STAKING_RISK_COPY.alpha.short;
+  return /* @__PURE__ */ jsxRuntime.jsx(
+    "p",
+    {
+      className: classNames(
+        "text-[10px] leading-relaxed text-ink-muted",
+        className
+      ),
+      children: copy
+    }
+  );
+}
+function SubnetSections() {
+  return /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
+    /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
+      /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Sparklines" }),
+      /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1", children: "Uptime & latency sparklines plot the active health window (7d default, switchable to 30d). Each point is the mean across every tracked endpoint in that bucket \u2014 gaps mean no probe landed in the window, not zero." })
+    ] }),
+    /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
+      /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Donuts & mosaics" }),
+      /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1", children: "Pool ratio comes from on-chain AMM reserves; endpoint topology counts tracked public surfaces by kind. The mosaic in Operational status colors one cell per endpoint by its last probe result." })
+    ] }),
+    /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
+      /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Staleness" }),
+      /* @__PURE__ */ jsxRuntime.jsxs("p", { className: "mt-1", children: [
+        "Tiles show a ",
+        /* @__PURE__ */ jsxRuntime.jsx("span", { className: "text-health-warn-text", children: "stale" }),
+        " chip when the snapshot is older than the refresh budget. Visuals still render with the last known values; retry buttons re-fetch just the affected panel. Each tile carries its own",
+        " ",
+        /* @__PURE__ */ jsxRuntime.jsx("span", { className: "text-ink-strong", children: "updated \xB7 window" }),
+        " stamp so you can tell stale from missing at a glance."
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
+      /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Verified vs. candidate" }),
+      /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1", children: "Only curated surfaces feed donuts and the topology breakdown. Unverified leads live in the Candidates tab and never count toward health, completeness, or pool ratios." })
+    ] })
+  ] });
+}
+function StakingSections() {
+  const sections = [
+    STAKING_RISK_COPY.root,
+    STAKING_RISK_COPY.alpha,
+    STAKING_RISK_COPY.windows,
+    STAKING_RISK_COPY.methodology
+  ];
+  return /* @__PURE__ */ jsxRuntime.jsx(jsxRuntime.Fragment, { children: sections.map((s) => /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
+    /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: s.term }),
+    /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1", children: s.long })
+  ] }, s.term)) });
+}
 function MethodologyCallout({
   generatedAt,
-  windowLabel
+  windowLabel,
+  variant = "subnet"
 }) {
   const [open, setOpen] = React3.useState(false);
   const freshLine = formatFreshness(generatedAt, windowLabel);
   const freshAbs = formatFreshnessAbsolute(generatedAt);
+  const isStaking = variant === "staking";
+  const title = isStaking ? "Staking risk & yield methodology" : "Data freshness & methodology";
+  const ariaLabel = isStaking ? "Staking risk and yield methodology" : "Data freshness and methodology";
+  const body = isStaking ? /* @__PURE__ */ jsxRuntime.jsx(StakingSections, {}) : /* @__PURE__ */ jsxRuntime.jsx(SubnetSections, {});
   return /* @__PURE__ */ jsxRuntime.jsxs(
     "aside",
     {
-      "aria-label": "Data freshness and methodology",
+      "aria-label": ariaLabel,
       className: "mb-6 rounded-lg border border-border bg-card/60",
       children: [
         /* @__PURE__ */ jsxRuntime.jsxs(
@@ -2905,7 +2987,7 @@ function MethodologyCallout({
             children: [
               /* @__PURE__ */ jsxRuntime.jsx(lucideReact.Info, { className: "mt-0.5 size-3.5 shrink-0 text-accent" }),
               /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "min-w-0 flex-1", children: [
-                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "block font-mono text-[10px] uppercase tracking-widest text-ink-muted", children: "Data freshness & methodology" }),
+                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "block font-mono text-[10px] uppercase tracking-widest text-ink-muted", children: title }),
                 freshLine ? /* @__PURE__ */ jsxRuntime.jsx(
                   "span",
                   {
@@ -2913,7 +2995,7 @@ function MethodologyCallout({
                     title: freshAbs ?? void 0,
                     children: freshLine
                   }
-                ) : null
+                ) : isStaking ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mt-0.5 block font-mono text-[10px] text-ink-muted/80", children: "Root: no principal risk \xB7 Alpha: price-exposed \xB7 windows labeled, not projected" }) : null
               ] }),
               /* @__PURE__ */ jsxRuntime.jsx(
                 lucideReact.ChevronDown,
@@ -2927,32 +3009,7 @@ function MethodologyCallout({
             ]
           }
         ),
-        open ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "grid gap-3 border-t border-border px-3 py-3 text-[11.5px] leading-relaxed text-ink-muted md:grid-cols-2", children: [
-          /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Sparklines" }),
-            /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1", children: "Uptime & latency sparklines plot the active health window (7d default, switchable to 30d). Each point is the mean across every tracked endpoint in that bucket \u2014 gaps mean no probe landed in the window, not zero." })
-          ] }),
-          /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Donuts & mosaics" }),
-            /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1", children: "Pool ratio comes from on-chain AMM reserves; endpoint topology counts tracked public surfaces by kind. The mosaic in Operational status colors one cell per endpoint by its last probe result." })
-          ] }),
-          /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Staleness" }),
-            /* @__PURE__ */ jsxRuntime.jsxs("p", { className: "mt-1", children: [
-              "Tiles show a ",
-              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "text-health-warn-text", children: "stale" }),
-              " ",
-              "chip when the snapshot is older than the refresh budget. Visuals still render with the last known values; retry buttons re-fetch just the affected panel. Each tile carries its own",
-              " ",
-              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "text-ink-strong", children: "updated \xB7 window" }),
-              " stamp so you can tell stale from missing at a glance."
-            ] })
-          ] }),
-          /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Verified vs. candidate" }),
-            /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1", children: "Only curated surfaces feed donuts and the topology breakdown. Unverified leads live in the Candidates tab and never count toward health, completeness, or pool ratios." })
-          ] })
-        ] }) : null
+        open ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "grid gap-3 border-t border-border px-3 py-3 text-[11.5px] leading-relaxed text-ink-muted md:grid-cols-2", children: body }) : null
       ]
     }
   );
@@ -3822,6 +3879,7 @@ exports.ProfileHero = ProfileHero;
 exports.RealtimeFreshness = RealtimeFreshness;
 exports.ReviewChip = ReviewChip;
 exports.SCOPES = SCOPES;
+exports.STAKING_RISK_COPY = STAKING_RISK_COPY;
 exports.ScrollReveal = ScrollReveal;
 exports.SearchScopeChip = SearchScopeChip;
 exports.SectionAnchor = SectionAnchor;
@@ -3840,6 +3898,7 @@ exports.SheetTrigger = SheetTrigger;
 exports.Skeleton = Skeleton;
 exports.SparkLegend = SparkLegend;
 exports.Sparkline = Sparkline;
+exports.StakingRiskNote = StakingRiskNote;
 exports.StatTile = StatTile;
 exports.StatWithSpark = StatWithSpark;
 exports.TableState = TableState;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2853,17 +2853,99 @@ function ProfileHero({
     ] }, s.label)) }) : null
   ] });
 }
+var STAKING_RISK_COPY = {
+  root: {
+    term: "Root stake",
+    short: "No principal risk \xB7 TAO-denominated",
+    long: "Root (netuid 0) stake is TAO-denominated 1:1 with no AMM. There is no alpha price leg, so principal is not exposed to subnet token price moves."
+  },
+  alpha: {
+    term: "Alpha stake",
+    short: "Price-exposed \xB7 can net-lose TAO",
+    long: "Alpha (non-root) stake is denominated in that subnet's alpha token. Positive nominal APY can still net-lose TAO when alpha price falls \u2014 yield figures never erase that risk."
+  },
+  windows: {
+    term: "Yield windows",
+    short: "Trailing window \xB7 not a forecast",
+    long: "Every yield / APY figure is labeled with its trailing window (for example 7d, 30d, 90d, or latest snapshot). Numbers annualize observed emission\xF7stake over that window \u2014 they are not a projection or a promised return."
+  },
+  methodology: {
+    term: "APY methodology",
+    short: "Emission \xF7 stake, net of take",
+    long: "Directory and detail snapshot APY annualize the latest captured epoch rate across eligible subnet memberships (server-side apy_estimate). History tiles annualize the latest daily rewards-per-1k-\u03C4 rate from neuron_daily, net of validator take. Both can swing between refreshes."
+  }
+};
+function StakingRiskNote({
+  netuid,
+  className
+}) {
+  const copy = netuid == null ? `${STAKING_RISK_COPY.root.short}. ${STAKING_RISK_COPY.alpha.short}.` : netuid === 0 ? STAKING_RISK_COPY.root.short : STAKING_RISK_COPY.alpha.short;
+  return /* @__PURE__ */ jsx(
+    "p",
+    {
+      className: classNames(
+        "text-[10px] leading-relaxed text-ink-muted",
+        className
+      ),
+      children: copy
+    }
+  );
+}
+function SubnetSections() {
+  return /* @__PURE__ */ jsxs(Fragment, { children: [
+    /* @__PURE__ */ jsxs("div", { children: [
+      /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Sparklines" }),
+      /* @__PURE__ */ jsx("p", { className: "mt-1", children: "Uptime & latency sparklines plot the active health window (7d default, switchable to 30d). Each point is the mean across every tracked endpoint in that bucket \u2014 gaps mean no probe landed in the window, not zero." })
+    ] }),
+    /* @__PURE__ */ jsxs("div", { children: [
+      /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Donuts & mosaics" }),
+      /* @__PURE__ */ jsx("p", { className: "mt-1", children: "Pool ratio comes from on-chain AMM reserves; endpoint topology counts tracked public surfaces by kind. The mosaic in Operational status colors one cell per endpoint by its last probe result." })
+    ] }),
+    /* @__PURE__ */ jsxs("div", { children: [
+      /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Staleness" }),
+      /* @__PURE__ */ jsxs("p", { className: "mt-1", children: [
+        "Tiles show a ",
+        /* @__PURE__ */ jsx("span", { className: "text-health-warn-text", children: "stale" }),
+        " chip when the snapshot is older than the refresh budget. Visuals still render with the last known values; retry buttons re-fetch just the affected panel. Each tile carries its own",
+        " ",
+        /* @__PURE__ */ jsx("span", { className: "text-ink-strong", children: "updated \xB7 window" }),
+        " stamp so you can tell stale from missing at a glance."
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxs("div", { children: [
+      /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Verified vs. candidate" }),
+      /* @__PURE__ */ jsx("p", { className: "mt-1", children: "Only curated surfaces feed donuts and the topology breakdown. Unverified leads live in the Candidates tab and never count toward health, completeness, or pool ratios." })
+    ] })
+  ] });
+}
+function StakingSections() {
+  const sections = [
+    STAKING_RISK_COPY.root,
+    STAKING_RISK_COPY.alpha,
+    STAKING_RISK_COPY.windows,
+    STAKING_RISK_COPY.methodology
+  ];
+  return /* @__PURE__ */ jsx(Fragment, { children: sections.map((s) => /* @__PURE__ */ jsxs("div", { children: [
+    /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: s.term }),
+    /* @__PURE__ */ jsx("p", { className: "mt-1", children: s.long })
+  ] }, s.term)) });
+}
 function MethodologyCallout({
   generatedAt,
-  windowLabel
+  windowLabel,
+  variant = "subnet"
 }) {
   const [open, setOpen] = useState(false);
   const freshLine = formatFreshness(generatedAt, windowLabel);
   const freshAbs = formatFreshnessAbsolute(generatedAt);
+  const isStaking = variant === "staking";
+  const title = isStaking ? "Staking risk & yield methodology" : "Data freshness & methodology";
+  const ariaLabel = isStaking ? "Staking risk and yield methodology" : "Data freshness and methodology";
+  const body = isStaking ? /* @__PURE__ */ jsx(StakingSections, {}) : /* @__PURE__ */ jsx(SubnetSections, {});
   return /* @__PURE__ */ jsxs(
     "aside",
     {
-      "aria-label": "Data freshness and methodology",
+      "aria-label": ariaLabel,
       className: "mb-6 rounded-lg border border-border bg-card/60",
       children: [
         /* @__PURE__ */ jsxs(
@@ -2876,7 +2958,7 @@ function MethodologyCallout({
             children: [
               /* @__PURE__ */ jsx(Info, { className: "mt-0.5 size-3.5 shrink-0 text-accent" }),
               /* @__PURE__ */ jsxs("span", { className: "min-w-0 flex-1", children: [
-                /* @__PURE__ */ jsx("span", { className: "block font-mono text-[10px] uppercase tracking-widest text-ink-muted", children: "Data freshness & methodology" }),
+                /* @__PURE__ */ jsx("span", { className: "block font-mono text-[10px] uppercase tracking-widest text-ink-muted", children: title }),
                 freshLine ? /* @__PURE__ */ jsx(
                   "span",
                   {
@@ -2884,7 +2966,7 @@ function MethodologyCallout({
                     title: freshAbs ?? void 0,
                     children: freshLine
                   }
-                ) : null
+                ) : isStaking ? /* @__PURE__ */ jsx("span", { className: "mt-0.5 block font-mono text-[10px] text-ink-muted/80", children: "Root: no principal risk \xB7 Alpha: price-exposed \xB7 windows labeled, not projected" }) : null
               ] }),
               /* @__PURE__ */ jsx(
                 ChevronDown,
@@ -2898,32 +2980,7 @@ function MethodologyCallout({
             ]
           }
         ),
-        open ? /* @__PURE__ */ jsxs("div", { className: "grid gap-3 border-t border-border px-3 py-3 text-[11.5px] leading-relaxed text-ink-muted md:grid-cols-2", children: [
-          /* @__PURE__ */ jsxs("div", { children: [
-            /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Sparklines" }),
-            /* @__PURE__ */ jsx("p", { className: "mt-1", children: "Uptime & latency sparklines plot the active health window (7d default, switchable to 30d). Each point is the mean across every tracked endpoint in that bucket \u2014 gaps mean no probe landed in the window, not zero." })
-          ] }),
-          /* @__PURE__ */ jsxs("div", { children: [
-            /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Donuts & mosaics" }),
-            /* @__PURE__ */ jsx("p", { className: "mt-1", children: "Pool ratio comes from on-chain AMM reserves; endpoint topology counts tracked public surfaces by kind. The mosaic in Operational status colors one cell per endpoint by its last probe result." })
-          ] }),
-          /* @__PURE__ */ jsxs("div", { children: [
-            /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Staleness" }),
-            /* @__PURE__ */ jsxs("p", { className: "mt-1", children: [
-              "Tiles show a ",
-              /* @__PURE__ */ jsx("span", { className: "text-health-warn-text", children: "stale" }),
-              " ",
-              "chip when the snapshot is older than the refresh budget. Visuals still render with the last known values; retry buttons re-fetch just the affected panel. Each tile carries its own",
-              " ",
-              /* @__PURE__ */ jsx("span", { className: "text-ink-strong", children: "updated \xB7 window" }),
-              " stamp so you can tell stale from missing at a glance."
-            ] })
-          ] }),
-          /* @__PURE__ */ jsxs("div", { children: [
-            /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Verified vs. candidate" }),
-            /* @__PURE__ */ jsx("p", { className: "mt-1", children: "Only curated surfaces feed donuts and the topology breakdown. Unverified leads live in the Candidates tab and never count toward health, completeness, or pool ratios." })
-          ] })
-        ] }) : null
+        open ? /* @__PURE__ */ jsx("div", { className: "grid gap-3 border-t border-border px-3 py-3 text-[11.5px] leading-relaxed text-ink-muted md:grid-cols-2", children: body }) : null
       ]
     }
   );
@@ -3721,4 +3778,4 @@ function TreemapMini({
   );
 }
 
-export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, ExternalLink, FreshnessBadge, FreshnessIndicator, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, InfoTooltip, Kbd, KeyChip, ListCard, ListShell, LoadMore, McpToolsList, MethodologyCallout, MiniRadial, MiniStack, NoDataSpark, PageHero, PageSection, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProfileHero, RealtimeFreshness, ReviewChip, SCOPES, ScrollReveal, SearchScopeChip, SectionAnchor, SectionHeading, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, cn, fmtYield, freshnessBadgeTimeCopy, freshnessDotClass, freshnessTierLabel, prefetchBrandIcon, safeExternalUrl, tierFreshnessLabel, timeAgoAbsoluteTitle, visibleTools };
+export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, ExternalLink, FreshnessBadge, FreshnessIndicator, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, InfoTooltip, Kbd, KeyChip, ListCard, ListShell, LoadMore, McpToolsList, MethodologyCallout, MiniRadial, MiniStack, NoDataSpark, PageHero, PageSection, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, ProfileHero, RealtimeFreshness, ReviewChip, SCOPES, STAKING_RISK_COPY, ScrollReveal, SearchScopeChip, SectionAnchor, SectionHeading, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StakingRiskNote, StatTile, StatWithSpark, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, cn, fmtYield, freshnessBadgeTimeCopy, freshnessDotClass, freshnessTierLabel, prefetchBrandIcon, safeExternalUrl, tierFreshnessLabel, timeAgoAbsoluteTitle, visibleTools };

--- a/packages/ui-kit/src/components/metagraphed/methodology-callout.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/methodology-callout.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { STAKING_RISK_COPY } from "./methodology-callout";
+
+describe("STAKING_RISK_COPY", () => {
+  it("frames root as no principal risk and TAO-denominated", () => {
+    expect(STAKING_RISK_COPY.root.short.toLowerCase()).toContain(
+      "no principal risk",
+    );
+    expect(STAKING_RISK_COPY.root.short.toLowerCase()).toContain(
+      "tao-denominated",
+    );
+    expect(STAKING_RISK_COPY.root.long.toLowerCase()).toContain("netuid 0");
+  });
+
+  it("frames alpha as price-exposed with possible TAO net-loss", () => {
+    expect(STAKING_RISK_COPY.alpha.short.toLowerCase()).toContain(
+      "price-exposed",
+    );
+    expect(STAKING_RISK_COPY.alpha.long.toLowerCase()).toContain("net-lose");
+    expect(STAKING_RISK_COPY.alpha.long.toLowerCase()).toMatch(/nominal apy/);
+  });
+
+  it("states yield figures are trailing windows, not forecasts", () => {
+    expect(STAKING_RISK_COPY.windows.short.toLowerCase()).toContain(
+      "trailing window",
+    );
+    expect(STAKING_RISK_COPY.windows.short.toLowerCase()).toContain(
+      "not a forecast",
+    );
+    expect(STAKING_RISK_COPY.windows.long.toLowerCase()).not.toContain(
+      "projection of future",
+    );
+  });
+});

--- a/packages/ui-kit/src/components/metagraphed/methodology-callout.tsx
+++ b/packages/ui-kit/src/components/metagraphed/methodology-callout.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { ChevronDown, Info } from "lucide-react";
 import {
   classNames,
@@ -7,25 +7,166 @@ import {
 } from "@/lib/format";
 
 /**
- * Compact, collapsible callout that explains what the visualizations on a
- * subnet profile are measuring and how staleness is handled. Lives near
- * the top of /subnets/:netuid so users can orient themselves before
- * trusting any sparkline.
+ * Compact, collapsible callout that explains what a page's figures are
+ * measuring and how staleness / risk is handled.
+ *
+ * - `variant="subnet"` (default): subnet-profile sparklines / donuts / mosaics.
+ * - `variant="staking"`: root vs alpha principal-risk framing + APY window
+ *   disclosure (#5247). Written once here; drop the same component beside
+ *   every staking surface that shows yield (validator directory APY, detail
+ *   tiles/panel, and the future stake modal).
  */
+
+export type MethodologyVariant = "subnet" | "staking";
+
+/** Shared staking risk copy — keep adjacent one-liners in sync with the callout. */
+export const STAKING_RISK_COPY = {
+  root: {
+    term: "Root stake",
+    short: "No principal risk · TAO-denominated",
+    long: "Root (netuid 0) stake is TAO-denominated 1:1 with no AMM. There is no alpha price leg, so principal is not exposed to subnet token price moves.",
+  },
+  alpha: {
+    term: "Alpha stake",
+    short: "Price-exposed · can net-lose TAO",
+    long: "Alpha (non-root) stake is denominated in that subnet's alpha token. Positive nominal APY can still net-lose TAO when alpha price falls — yield figures never erase that risk.",
+  },
+  windows: {
+    term: "Yield windows",
+    short: "Trailing window · not a forecast",
+    long: "Every yield / APY figure is labeled with its trailing window (for example 7d, 30d, 90d, or latest snapshot). Numbers annualize observed emission÷stake over that window — they are not a projection or a promised return.",
+  },
+  methodology: {
+    term: "APY methodology",
+    short: "Emission ÷ stake, net of take",
+    long: "Directory and detail snapshot APY annualize the latest captured epoch rate across eligible subnet memberships (server-side apy_estimate). History tiles annualize the latest daily rewards-per-1k-τ rate from neuron_daily, net of validator take. Both can swing between refreshes.",
+  },
+} as const;
+
+/** Compact risk note for placing directly beside an APY / yield figure. */
+export function StakingRiskNote({
+  netuid,
+  className,
+}: {
+  /** Pass 0 for root, any other netuid for alpha, omit for blended/unknown. */
+  netuid?: number | null;
+  className?: string;
+}) {
+  const copy =
+    netuid == null
+      ? `${STAKING_RISK_COPY.root.short}. ${STAKING_RISK_COPY.alpha.short}.`
+      : netuid === 0
+        ? STAKING_RISK_COPY.root.short
+        : STAKING_RISK_COPY.alpha.short;
+
+  return (
+    <p
+      className={classNames(
+        "text-[10px] leading-relaxed text-ink-muted",
+        className,
+      )}
+    >
+      {copy}
+    </p>
+  );
+}
+
+function SubnetSections() {
+  return (
+    <>
+      <div>
+        <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
+          Sparklines
+        </div>
+        <p className="mt-1">
+          Uptime &amp; latency sparklines plot the active health window (7d
+          default, switchable to 30d). Each point is the mean across every
+          tracked endpoint in that bucket — gaps mean no probe landed in the
+          window, not zero.
+        </p>
+      </div>
+      <div>
+        <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
+          Donuts &amp; mosaics
+        </div>
+        <p className="mt-1">
+          Pool ratio comes from on-chain AMM reserves; endpoint topology counts
+          tracked public surfaces by kind. The mosaic in Operational status
+          colors one cell per endpoint by its last probe result.
+        </p>
+      </div>
+      <div>
+        <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
+          Staleness
+        </div>
+        <p className="mt-1">
+          Tiles show a <span className="text-health-warn-text">stale</span> chip
+          when the snapshot is older than the refresh budget. Visuals still
+          render with the last known values; retry buttons re-fetch just the
+          affected panel. Each tile carries its own{" "}
+          <span className="text-ink-strong">updated · window</span> stamp so you
+          can tell stale from missing at a glance.
+        </p>
+      </div>
+      <div>
+        <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
+          Verified vs. candidate
+        </div>
+        <p className="mt-1">
+          Only curated surfaces feed donuts and the topology breakdown.
+          Unverified leads live in the Candidates tab and never count toward
+          health, completeness, or pool ratios.
+        </p>
+      </div>
+    </>
+  );
+}
+
+function StakingSections() {
+  const sections = [
+    STAKING_RISK_COPY.root,
+    STAKING_RISK_COPY.alpha,
+    STAKING_RISK_COPY.windows,
+    STAKING_RISK_COPY.methodology,
+  ];
+  return (
+    <>
+      {sections.map((s) => (
+        <div key={s.term}>
+          <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
+            {s.term}
+          </div>
+          <p className="mt-1">{s.long}</p>
+        </div>
+      ))}
+    </>
+  );
+}
+
 export function MethodologyCallout({
   generatedAt,
   windowLabel,
+  variant = "subnet",
 }: {
   generatedAt?: string;
   windowLabel?: string;
+  variant?: MethodologyVariant;
 }) {
   const [open, setOpen] = useState(false);
   const freshLine = formatFreshness(generatedAt, windowLabel);
   const freshAbs = formatFreshnessAbsolute(generatedAt);
+  const isStaking = variant === "staking";
+  const title = isStaking
+    ? "Staking risk & yield methodology"
+    : "Data freshness & methodology";
+  const ariaLabel = isStaking
+    ? "Staking risk and yield methodology"
+    : "Data freshness and methodology";
+  const body: ReactNode = isStaking ? <StakingSections /> : <SubnetSections />;
 
   return (
     <aside
-      aria-label="Data freshness and methodology"
+      aria-label={ariaLabel}
       className="mb-6 rounded-lg border border-border bg-card/60"
     >
       <button
@@ -37,7 +178,7 @@ export function MethodologyCallout({
         <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
         <span className="min-w-0 flex-1">
           <span className="block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-            Data freshness &amp; methodology
+            {title}
           </span>
           {freshLine ? (
             <span
@@ -45,6 +186,11 @@ export function MethodologyCallout({
               title={freshAbs ?? undefined}
             >
               {freshLine}
+            </span>
+          ) : isStaking ? (
+            <span className="mt-0.5 block font-mono text-[10px] text-ink-muted/80">
+              Root: no principal risk · Alpha: price-exposed · windows labeled,
+              not projected
             </span>
           ) : null}
         </span>
@@ -57,50 +203,7 @@ export function MethodologyCallout({
       </button>
       {open ? (
         <div className="grid gap-3 border-t border-border px-3 py-3 text-[11.5px] leading-relaxed text-ink-muted md:grid-cols-2">
-          <div>
-            <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
-              Sparklines
-            </div>
-            <p className="mt-1">
-              Uptime &amp; latency sparklines plot the active health window (7d
-              default, switchable to 30d). Each point is the mean across every
-              tracked endpoint in that bucket — gaps mean no probe landed in the
-              window, not zero.
-            </p>
-          </div>
-          <div>
-            <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
-              Donuts &amp; mosaics
-            </div>
-            <p className="mt-1">
-              Pool ratio comes from on-chain AMM reserves; endpoint topology
-              counts tracked public surfaces by kind. The mosaic in Operational
-              status colors one cell per endpoint by its last probe result.
-            </p>
-          </div>
-          <div>
-            <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
-              Staleness
-            </div>
-            <p className="mt-1">
-              Tiles show a <span className="text-health-warn-text">stale</span>{" "}
-              chip when the snapshot is older than the refresh budget. Visuals
-              still render with the last known values; retry buttons re-fetch
-              just the affected panel. Each tile carries its own{" "}
-              <span className="text-ink-strong">updated · window</span> stamp so
-              you can tell stale from missing at a glance.
-            </p>
-          </div>
-          <div>
-            <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
-              Verified vs. candidate
-            </div>
-            <p className="mt-1">
-              Only curated surfaces feed donuts and the topology breakdown.
-              Unverified leads live in the Candidates tab and never count toward
-              health, completeness, or pool ratios.
-            </p>
-          </div>
+          {body}
         </div>
       ) : null}
     </aside>

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -161,7 +161,12 @@ export {
   type ProfileHeroProps,
   ProfileHero,
 } from "@/components/metagraphed/profile-hero";
-export { MethodologyCallout } from "@/components/metagraphed/methodology-callout";
+export {
+  MethodologyCallout,
+  StakingRiskNote,
+  STAKING_RISK_COPY,
+  type MethodologyVariant,
+} from "@/components/metagraphed/methodology-callout";
 export {
   type BarMiniDatum,
   BarMini,


### PR DESCRIPTION
## Summary

- Extends the existing `MethodologyCallout` with `variant="staking"` plus shared `STAKING_RISK_COPY` / `StakingRiskNote` so root vs alpha risk framing is written once and reused on every yield surface.
- Root: **no principal risk · TAO-denominated**. Alpha: **price-exposed · can net-lose TAO** despite positive nominal APY — shown adjacent to APY figures, not buried in docs.
- Labels every yield figure with its trailing window (`snapshot` / `7d` / `30d` / `90d`) and frames them as trailing annualizations, **not forecasts**.
- Also repairs the `/validators` directory table column alignment (Operator / Take / single windowed APY column) left mismatched after #5300.

Closes #5247

## Template Used

Frontend/UI change (`apps/ui/**` + `packages/ui-kit` methodology-callout reuse)

## Test plan

- [x] `npx eslint` on touched ui-kit + apps/ui files (0 errors)
- [x] Prettier check on touched files
- [x] `npm run typecheck --workspace=packages/ui-kit`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=packages/ui-kit` (60 passed, incl. methodology-callout tests)
- [x] `npm test --workspace=apps/ui -- src/lib/metagraphed/validator-apy.test.ts`
- [x] `npm run build --workspace=packages/ui-kit` (dist updated)
- [x] `npm run build --workspace=apps/ui`
- [ ] Manual: `/validators` shows staking methodology callout + `Est. APY · snapshot`
- [ ] Manual: `/validators/$hotkey` snapshot tile + 7d/30d/90d tiles show window labels + risk notes
- [ ] Capture 12 fixed-viewport before/after screenshots (directory + detail × 3 viewports × 2 themes)

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/c3b36456-737c-4d02-9940-9f0ac62e26db" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/d3d78e8a-3032-436a-b6a2-48e6d4d060ac" /> |
| Desktop · Dark | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/8265348b-5fcc-4a9d-a8cb-c253f9deb8e1" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/09ea8ab3-e7d4-4d27-8ee3-37907f607b83" /> |
| Tablet · Light | <img width="787" height="760" alt="image" src="https://github.com/user-attachments/assets/3abf7b8f-2007-4d51-8322-e99616a23eb1" /> | <img width="787" height="760" alt="image" src="https://github.com/user-attachments/assets/bc7a9a06-6d21-4689-b78a-4104b8049a23" /> |
| Tablet · Dark | <img width="787" height="760" alt="image" src="https://github.com/user-attachments/assets/bbf6d1a1-b8d8-41b6-85a0-0455932263b6" /> |  <img width="787" height="760" alt="image" src="https://github.com/user-attachments/assets/616c955c-6375-4020-b025-08c3830d9b80" /> |
| Mobile · Light | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/7168d623-a074-4a85-a7be-d6a11dd7e893" /> | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/0c05da6b-ec1b-408c-a034-b95455333aef" /> |
| Mobile · Dark | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/38cbd63c-cc40-4576-b435-549339ad7f57" /> | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/2dcef7e1-3845-423b-94cc-0322468cf3eb" /> |

## Notes

- Stake modal (#5242) can reuse the same `MethodologyCallout variant="staking"` / `StakingRiskNote` when it lands.
- Depends on settled APY methodology (#2551 / #5284).