### PR TITLE
fix(ui-kit): give CopyButton a 44px minimum touch target

### DIFF
--- a/packages/ui-kit/src/components/metagraphed/copy-button.tsx
+++ b/packages/ui-kit/src/components/metagraphed/copy-button.tsx
@@ -24,7 +24,7 @@ export function CopyButton({
       aria-label={copied ? "Copied" : `Copy ${label ?? "value"}`}
       title={copied ? "Copied!" : `Copy ${label ?? "value"}`}
       className={classNames(
-        "shrink-0 inline-flex items-center justify-center rounded p-1 text-ink-muted hover:text-ink-strong transition-colors",
+        "shrink-0 inline-flex items-center justify-center rounded p-1 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong transition-colors",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
The icon-only \CopyButton\ (packages/ui-kit) rendered at ~20x20px with only \p-1\ padding, below the 44px minimum touch-target guidance (WCAG 2.5.5 / Apple HIG). Added \min-h-11 min-w-11\ so the hit area is at least 44x44px while the 12px glyph stays centered.

## Change
- packages/ui-kit/src/components/metagraphed/copy-button.tsx: added \min-h-11 min-w-11\

## Verification
- eslint clean on the file; prettier-clean.

Closes #5333

> Visual/frontend change — held for manual review per the contributor guide. A before/after screenshot pair should be captured in the devcontainer during review (Chromium is preinstalled there); I could not auto-generate screenshots in this environment.