### PR TITLE
fix(ui-kit): add 44px minimum touch height to error-state actions

### DIFF
--- a/packages/ui-kit/src/components/metagraphed/table-state.tsx
+++ b/packages/ui-kit/src/components/metagraphed/table-state.tsx
@@ -123,7 +123,7 @@ export function TableState({
             <button
               type="button"
               onClick={onRetry}
-              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-paper px-3.5 py-1.5 text-[12px] font-medium text-ink hover:border-accent/50 hover:text-accent transition-colors"
+              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-paper px-3.5 py-1.5 min-h-11 text-[12px] font-medium text-ink hover:border-accent/50 hover:text-accent transition-colors"
             >
               <RefreshCw className="size-3" /> Retry
             </button>
@@ -134,7 +134,7 @@ export function TableState({
               {...(cta.external
                 ? { target: "_blank", rel: "noopener noreferrer" }
                 : {})}
-              className="inline-flex items-center gap-1.5 rounded-full bg-ink-strong px-3.5 py-1.5 text-[12px] font-medium text-paper hover:opacity-90 transition-opacity"
+              className="inline-flex items-center gap-1.5 rounded-full bg-ink-strong px-3.5 py-1.5 min-h-11 text-[12px] font-medium text-paper hover:opacity-90 transition-opacity"
             >
               {cta.label}
               {cta.external ? <ExternalLinkIcon className="size-3" /> : null}
@@ -145,7 +145,7 @@ export function TableState({
               href={url}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-[11px] font-mono text-ink-muted hover:text-ink-strong"
+              className="inline-flex items-center gap-1.5 text-[11px] font-mono min-h-11 text-ink-muted hover:text-ink-strong"
             >
               View API URL <ExternalLinkIcon className="size-3" />
             </a>


### PR DESCRIPTION
## Summary
In \TableState\ (packages/ui-kit), the error-state actions had no minimum touch height: the \Retry\ pill, the primary CTA, and the \View API URL\ link were all sub-44px. Added \min-h-11\ to each so they meet the 44px touch-target minimum.

## Change
- packages/ui-kit/src/components/metagraphed/table-state.tsx: added \min-h-11\ to the Retry button, the CTA anchor, and the View API URL anchor.

## Verification
- eslint clean on the file; prettier-clean.

Closes #5338

> Visual/frontend change — held for manual review per the contributor guide. A before/after screenshot pair should be captured in the devcontainer during review (Chromium is preinstalled there); I could not auto-generate screenshots in this environment.