### PR TITLE
feat(ui): add settings summary strip to match utility-page weight (#5346)

### DIFF
--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
@@ -1,8 +1,9 @@
 import { useState, type FormEvent, type ReactNode } from "react";
 import { useMutation } from "@tanstack/react-query";
+import { BellPlus, KeyRound, Search, Trash2 } from "lucide-react";
 import { apiFetch, ApiError } from "@/lib/metagraphed/client";
 import { classNames } from "@/lib/metagraphed/format";
-import { CopyableCode, SectionHeading } from "@jsonbored/ui-kit";
+import { CopyableCode, SectionHeading, StatTile } from "@jsonbored/ui-kit";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import type {
   WebhookDeliveryStatus,
@@ -52,9 +53,68 @@ function describeApiError(error: unknown): string {
 export function WebhookSubscriptionManager() {
   return (
     <div className="space-y-8">
+      <SubscriptionActionsStrip />
       <CreateSubscriptionSection />
       <LookupSubscriptionSection />
       <DeleteSubscriptionSection />
+    </div>
+  );
+}
+
+/**
+ * Light summary strip above the forms (#5346) — mirrors the StatTile weight
+ * on sibling utility pages (`/endpoints`, …). Jump links only; forms below
+ * keep the same create/look-up/delete behavior.
+ */
+function SubscriptionActionsStrip() {
+  return (
+    <div
+      aria-label="Webhook subscription actions"
+      className="grid grid-cols-2 gap-3 md:grid-cols-4"
+    >
+      <a
+        href="#create-subscription-heading"
+        className="rounded-lg outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <StatTile
+          icon={BellPlus}
+          eyebrow="Create"
+          value="Register"
+          hint="webhook URL"
+          tone="accent"
+          className="h-full transition-colors hover:border-accent/60"
+        />
+      </a>
+      <a
+        href="#lookup-subscription-heading"
+        className="rounded-lg outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <StatTile
+          icon={Search}
+          eyebrow="Look up"
+          value="Status"
+          hint="delivery health"
+          className="h-full transition-colors hover:border-ink/30"
+        />
+      </a>
+      <a
+        href="#delete-subscription-heading"
+        className="rounded-lg outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <StatTile
+          icon={Trash2}
+          eyebrow="Delete"
+          value="Revoke"
+          hint="secret required"
+          className="h-full transition-colors hover:border-ink/30"
+        />
+      </a>
+      <StatTile
+        icon={KeyRound}
+        eyebrow="Auth model"
+        value="Token"
+        hint="operator-issued · no account"
+      />
     </div>
   );
 }

--- a/apps/ui/src/routes/settings.tsx
+++ b/apps/ui/src/routes/settings.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { PageHero } from "@jsonbored/ui-kit";
+import { PageHero, ShareButton } from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { WebhookSubscriptionManager } from "@/components/metagraphed/webhook-subscription-manager";
 
@@ -22,13 +22,26 @@ export const Route = createFileRoute("/settings")({
   component: SettingsPage,
 });
 
+/**
+ * Utility-page family treatment (#5346): sibling routes (`/schemas`, `/health`,
+ * `/endpoints`, …) open with PageHero + a KPI strip. Settings previously
+ * jumped straight from title into the three forms.
+ */
 function SettingsPage() {
   return (
     <AppShell>
       <PageHero
-        eyebrow="Developer"
+        eyebrow="Operations"
         title="Developer settings"
         description="Self-service webhook subscription management against the public subscription API. Nothing here is stored server-side beyond the subscription record itself — there is no account model."
+        caption="settings / v1"
+        actions={<ShareButton />}
+        kpis={[
+          { label: "Create", value: "POST", hint: "token-gated" },
+          { label: "Look up", value: "GET", hint: "by id" },
+          { label: "Delete", value: "DELETE", hint: "secret" },
+          { label: "Accounts", value: "None", hint: "no login" },
+        ]}
       />
       <WebhookSubscriptionManager />
       <ApiSourceFooter paths={["/api/v1/webhooks/subscriptions"]} />


### PR DESCRIPTION
## Summary

- Aligns `/settings` with sibling utility pages (`/schemas`, `/health`, `/endpoints`) by giving `PageHero` a KPI strip (Create/Look up/Delete/Accounts), Share, and `settings / v1` caption instead of jumping straight into forms.
- Adds a light StatTile actions strip above the webhook forms (Create / Look up / Delete jump links + auth-model tile). Create/look-up/delete form behavior is unchanged.

Closes #5346

## Template Used

Frontend/UI change (`apps/ui/**`)

## Test plan

- [x] `npx eslint` on touched files (0 errors)
- [x] Prettier check on touched files
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui -- src/components/metagraphed/webhook-subscription-manager.test.ts` (5 passed)
- [x] Manual: before `8101/settings` vs after `8100/settings` — hero KPIs + action strip visible; forms unchanged
- [ ] Capture 12 fixed-viewport before/after screenshots (3 viewports × 2 themes × before/after)

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/2532a1fe-d4be-400d-9bdf-a59aff1a0b3b" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/3fa86ab2-4170-4547-8447-07ed0e4d950f" /> |
| Desktop · Dark | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/dafee0d6-88ee-466d-8d4e-646f0c0475b0" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/eba35e92-bb8e-44af-9f9e-e6e0f304e21c" /> |
| Tablet · Light | <img width="787" height="760" alt="image" src="https://github.com/user-attachments/assets/4bce36ac-319e-4a0a-b5d2-a41889ee56c0" /> | <img width="787" height="760" alt="image" src="https://github.com/user-attachments/assets/19133fd4-dc0d-4095-81c7-6e7dead1ebe1" /> |
| Tablet · Dark | <img width="787" height="760" alt="image" src="https://github.com/user-attachments/assets/b8a9f84f-4360-4742-8348-e182384dfdcc" /> | <img width="787" height="760" alt="image" src="https://github.com/user-attachments/assets/a9962643-64a7-46a7-804c-aecaf2640c35" /> |
| Mobile · Light | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/043538a8-57e2-4582-b22d-0c4f383a9499" /> | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/308a5a67-0b5b-4ca8-98d2-9f5c2e6290bd" /> |
| Mobile · Dark | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/18f8ba82-9e47-4f7f-859c-125474ff4825" /> | <img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/0c81f6d7-371f-4804-9a27-b220e7d4a3c4" /> |