### PR TITLE
fix(ui): align validators table headers with their column data

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-columns.test.ts
+++ b/apps/ui/src/components/metagraphed/validator-columns.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { VALIDATOR_COLUMNS } from "./validator-columns";
+import type { GlobalValidator } from "@/lib/metagraphed/types";
+
+// A fully-populated row so every column's cell renderer resolves a real value
+// rather than its null fallback.
+const SAMPLE: GlobalValidator = {
+  hotkey: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+  featured: true,
+  coldkey: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+  coldkey_identity: {
+    has_identity: true,
+    name: "Foundry",
+    url: null,
+    github: null,
+    image: null,
+    discord: null,
+    description: null,
+    additional: null,
+    captured_at: null,
+  },
+  coldkey_count: 1,
+  subnet_count: 12,
+  uid_count: 34,
+  take: 0.18,
+  total_stake_tao: 56_260_000,
+  root_stake_tao: 40_000_000,
+  alpha_stake_tao: 16_260_000,
+  total_emission_tao: 1234.5,
+  nominator_count: 512,
+  apy_estimate: 0.1423,
+  apy_estimate_eligible_subnet_count: 10,
+  avg_validator_trust: 0.9,
+  max_validator_trust: 1,
+  stake_dominance: 0.0812,
+  latest_captured_at: null,
+  latest_block_number: null,
+  subnets: [],
+};
+
+describe("VALIDATOR_COLUMNS", () => {
+  // #5307: the table shipped with 12 headers over 9 cells (columns showing
+  // another column's data, a duplicated "Est. APY" header). Both <thead> and
+  // every <tbody> row now map over this single array, so these invariants keep
+  // header count === per-row cell count and forbid the duplicate-header class of
+  // regression at the source.
+  it("has at least one column", () => {
+    expect(VALIDATOR_COLUMNS.length).toBeGreaterThan(0);
+  });
+
+  it("has no duplicate headers (guards the duplicate 'Est. APY')", () => {
+    const headers = VALIDATOR_COLUMNS.map((c) => c.header);
+    expect(new Set(headers).size).toBe(headers.length);
+  });
+
+  it("gives every header exactly one cell renderer (header count === cell count)", () => {
+    for (const col of VALIDATOR_COLUMNS) {
+      expect(col.header.trim()).not.toBe("");
+      expect(typeof col.cell).toBe("function");
+      // Each header maps 1:1 to a defined cell for a populated row.
+      expect(col.cell(SAMPLE)).toBeDefined();
+    }
+  });
+
+  it("exposes the completed column set the incomplete merge was missing", () => {
+    const headers = VALIDATOR_COLUMNS.map((c) => c.header);
+    for (const h of [
+      "Operator",
+      "Hotkey",
+      "Coldkey",
+      "Take",
+      "Est. APY",
+      "Total stake",
+      "Total emission",
+    ]) {
+      expect(headers).toContain(h);
+    }
+  });
+});

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -1,0 +1,112 @@
+import type { ReactNode } from "react";
+import { Link } from "@tanstack/react-router";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { formatNumber } from "@/lib/metagraphed/format";
+import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
+import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
+import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
+import type { GlobalValidator } from "@/lib/metagraphed/types";
+
+const TH_BASE = "px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted";
+const TD_BASE = "px-3 py-2 font-mono text-[11px]";
+const TD_NUM = `${TD_BASE} text-right tabular-nums`;
+
+/**
+ * One column of the global-validators table. Both the `<thead>` and every
+ * `<tbody>` row map over the SAME array, so the header count and per-row cell
+ * count are equal by construction — the header/cell misalignment that #5307
+ * fixed (12 headers over 9 cells, columns showing another column's data) is
+ * structurally impossible here. `header` values are unique (asserted in tests).
+ */
+export interface ValidatorColumn {
+  header: string;
+  thClassName: string;
+  tdClassName: string;
+  cell: (v: GlobalValidator) => ReactNode;
+}
+
+const numeric = (
+  header: string,
+): Pick<ValidatorColumn, "header" | "thClassName" | "tdClassName"> => ({
+  header,
+  thClassName: `${TH_BASE} text-right`,
+  tdClassName: `${TD_NUM} text-ink`,
+});
+
+export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
+  {
+    header: "Operator",
+    thClassName: TH_BASE,
+    tdClassName: TD_BASE,
+    cell: (v) => (
+      <div className="flex items-center gap-1.5">
+        {v.featured ? <FeaturedBadge /> : null}
+        <ValidatorIdentityChip hotkey={v.hotkey} identity={v.coldkey_identity} size={20} />
+      </div>
+    ),
+  },
+  {
+    header: "Hotkey",
+    thClassName: TH_BASE,
+    tdClassName: `${TD_BASE} text-ink-muted`,
+    cell: (v) => (
+      <Link
+        to="/validators/$hotkey"
+        params={{ hotkey: v.hotkey }}
+        className="text-ink-strong hover:text-accent hover:underline"
+        title={v.hotkey}
+      >
+        {shortHash(v.hotkey) ?? v.hotkey}
+      </Link>
+    ),
+  },
+  {
+    header: "Coldkey",
+    thClassName: TH_BASE,
+    tdClassName: `${TD_BASE} text-ink-muted`,
+    cell: (v) =>
+      v.coldkey ? (
+        <Link
+          to="/accounts/$ss58"
+          params={{ ss58: v.coldkey }}
+          className="hover:text-accent hover:underline"
+          title={v.coldkey}
+        >
+          {shortHash(v.coldkey) ?? v.coldkey}
+        </Link>
+      ) : (
+        "—"
+      ),
+  },
+  {
+    ...numeric("Take"),
+    tdClassName: `${TD_NUM} text-ink-muted`,
+    cell: (v) => formatTakePct(v.take),
+  },
+  {
+    ...numeric("Est. APY"),
+    // apy_estimate (#2551) is a 0..1 fraction; formatApyPct takes a percentage.
+    cell: (v) => formatApyPct(v.apy_estimate != null ? v.apy_estimate * 100 : null),
+  },
+  { ...numeric("Active subnets"), cell: (v) => formatNumber(v.subnet_count) },
+  {
+    ...numeric("UIDs"),
+    tdClassName: `${TD_NUM} text-ink-muted`,
+    cell: (v) => formatNumber(v.uid_count),
+  },
+  {
+    ...numeric("Nominators"),
+    tdClassName: `${TD_NUM} text-ink-muted`,
+    cell: (v) => (v.nominator_count != null ? formatNumber(v.nominator_count) : "—"),
+  },
+  {
+    ...numeric("Dominance"),
+    cell: (v) => (v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"),
+  },
+  { ...numeric("Total stake"), cell: (v) => taoCompact(v.total_stake_tao) },
+  {
+    ...numeric("Total emission"),
+    tdClassName: `${TD_NUM} text-ink-muted`,
+    cell: (v) => taoCompact(v.total_emission_tao),
+  },
+];

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -14,12 +14,7 @@ import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
-import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
-import {
-  annualizedDelegatorApyPct,
-  formatApyPct,
-  formatTakePct,
-} from "@/lib/metagraphed/validator-apy";
+import { VALIDATOR_COLUMNS } from "@/components/metagraphed/validator-columns";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 // The full GlobalValidatorSort set the /api/v1/validators endpoint accepts.
@@ -109,8 +104,6 @@ function ValidatorsPage() {
   );
 }
 
-const TH = "px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted";
-
 function SortSelect({
   value,
   onChange,
@@ -169,71 +162,21 @@ function ValidatorsTable({
           <table className="w-full text-left text-sm">
             <thead className="bg-surface/50">
               <tr>
-                <th className={TH}>Operator</th>
-                <th className={TH}>Hotkey</th>
-                <th className={TH}>Coldkey</th>
-                <th className={`${TH} text-right`}>Take</th>
-                <th className={`${TH} text-right`}>Est. APY</th>
-                <th className={`${TH} text-right`}>Active subnets</th>
-                <th className={`${TH} text-right`}>UIDs</th>
-                <th className={`${TH} text-right`}>Nominators</th>
-                <th className={`${TH} text-right`}>Dominance</th>
-                <th className={`${TH} text-right`}>Total stake</th>
-                <th className={`${TH} text-right`}>Total emission</th>
-                <th className={`${TH} text-right`}>Est. APY</th>
+                {VALIDATOR_COLUMNS.map((col) => (
+                  <th key={col.header} className={col.thClassName}>
+                    {col.header}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
               {validators.map((v) => (
                 <tr key={v.hotkey} className="hover:bg-surface/40">
-                  <td className="px-3 py-2 font-mono text-[11px]">
-                    <div className="flex items-center gap-1.5">
-                      {v.featured ? <FeaturedBadge /> : null}
-                      <Link
-                        to="/validators/$hotkey"
-                        params={{ hotkey: v.hotkey }}
-                        className="text-ink-strong hover:text-accent hover:underline"
-                        title={v.hotkey}
-                      >
-                        {shortHash(v.hotkey) ?? v.hotkey}
-                      </Link>
-                    </div>
-                  </td>
-                  <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
-                    {v.coldkey ? (
-                      <Link
-                        to="/accounts/$ss58"
-                        params={{ ss58: v.coldkey }}
-                        className="hover:text-accent hover:underline"
-                        title={v.coldkey}
-                      >
-                        {shortHash(v.coldkey) ?? v.coldkey}
-                      </Link>
-                    ) : (
-                      "—"
-                    )}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {formatNumber(v.subnet_count)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {formatNumber(v.uid_count)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {v.nominator_count != null ? formatNumber(v.nominator_count) : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {taoCompact(v.total_stake_tao)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {taoCompact(v.total_emission_tao)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {v.apy_estimate != null ? `${(v.apy_estimate * 100).toFixed(1)}%` : "—"}
-                  </td>
+                  {VALIDATOR_COLUMNS.map((col) => (
+                    <td key={col.header} className={col.tdClassName}>
+                      {col.cell(v)}
+                    </td>
+                  ))}
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
Closes #5307.

## The bug

`apps/ui/src/routes/validators.index.tsx` declared **12 `<th>` headers** but rendered only **9 `<td>` per row**, so every column showed a different column's data:

- **Operator** showed the hotkey, **Hotkey** showed the coldkey, **Coldkey** showed the subnet count
- **Take** showed the UID count, **Active subnets** showed a dominance %, **UIDs** showed total stake (e.g. `56.26M`), **Nominators** showed total emission, **Dominance** showed the APY
- **Total stake**, **Total emission** and a **duplicated** **Est. APY** header had no data under them at all

The imported `annualizedDelegatorApyPct` / `formatApyPct` / `formatTakePct` helpers and `ValidatorIdentityChip` were never called — the hallmark of an incomplete merge.

## The fix

Both the header row and every body row now map over a single shared `VALIDATOR_COLUMNS` array (new `apps/ui/src/components/metagraphed/validator-columns.tsx`), so **header count equals per-row cell count by construction** — this class of misalignment is now structurally impossible. The intended 11-column layout is completed and every header maps 1:1 to real data:

`Operator` (identity chip) · `Hotkey` · `Coldkey` · `Take` · `Est. APY` · `Active subnets` · `UIDs` · `Nominators` · `Dominance` · `Total stake` · `Total emission`

- `Take` → `formatTakePct(v.take)`; `Est. APY` → `formatApyPct(v.apy_estimate * 100)` (the `#2551` server estimate); `Operator` → `ValidatorIdentityChip` — resolving the unused imports the issue flagged.
- The duplicate `Est. APY` header is removed.
- Adds `validator-columns.test.ts` asserting unique headers (guards the duplicate) and a 1:1 header-to-cell mapping (guards the count mismatch).

No schema, contract, or endpoint change — confined to the presentation layer; the row data (`take`, `apy_estimate`, `coldkey_identity`, `total_stake_tao`, `total_emission_tao`, …) was already present on every `GlobalValidator`.

## Before / After

Note in **Before** how "Operator" shows a hotkey, "UIDs" shows `56.26M` (total stake), and the last three columns are empty; in **After** every header sits over its own data.

| Viewport | Before | After |
|---|---|---|
| **Desktop · Light** | ![before](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-5307-assets/5307/before-desktop-light.png) | ![after](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-5307-assets/5307/after-desktop-light.png) |
| **Desktop · Dark** | ![before](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-5307-assets/5307/before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-5307-assets/5307/after-desktop-dark.png) |
| **Tablet · Light** | ![before](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-5307-assets/5307/before-tablet-light.png) | ![after](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-5307-assets/5307/after-tablet-light.png) |
| **Tablet · Dark** | ![before](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-5307-assets/5307/before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-5307-assets/5307/after-tablet-dark.png) |
| **Mobile · Light** | ![before](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-5307-assets/5307/before-mobile-light.png) | ![after](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-5307-assets/5307/after-mobile-light.png) |
| **Mobile · Dark** | ![before](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-5307-assets/5307/before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/davion-knight/metagraphed/sn-5307-assets/5307/after-mobile-dark.png) |

## Verification

- `tsc --noEmit` clean · `eslint` clean · `prettier --check` clean
- `vitest run` — new `validator-columns.test.ts` (4 assertions) green; existing `validators.test.ts` unaffected
- Screenshots captured against a local build serving live production data at 1280 / 768 / 375
