### PR TITLE
fix(ui): add a mobile card fallback to the validators table (#5320)

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -1,0 +1,79 @@
+import { Link } from "@tanstack/react-router";
+
+import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
+import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
+import type { GlobalValidator } from "@/lib/metagraphed/types";
+
+export interface ValidatorCardListProps {
+  validators: GlobalValidator[];
+  /** Layout classes for the wrapper — e.g. a responsive grid, or `md:hidden`
+   *  when the list is only a mobile fallback for the desktop table. */
+  className?: string;
+}
+
+/**
+ * Renders the global validator directory as cards — the mobile fallback for the
+ * 12-column desktop table, whose columns are unreadable on a narrow viewport
+ * (see #5320). Each metric is labelled by its data field, so the cards read
+ * correctly on their own.
+ */
+export function ValidatorCardList({ validators, className }: ValidatorCardListProps) {
+  return (
+    <div className={className}>
+      {validators.map((v) => {
+        const f = resolveValidatorCard(v);
+        return (
+          <div
+            key={v.hotkey}
+            className="min-w-0 space-y-2 rounded-lg border border-border bg-card p-3"
+          >
+            <div className="flex min-w-0 items-center gap-1.5">
+              {v.featured ? <FeaturedBadge /> : null}
+              <Link
+                to="/validators/$hotkey"
+                params={{ hotkey: v.hotkey }}
+                title={v.hotkey}
+                className="truncate font-mono text-[12px] text-ink-strong hover:text-accent hover:underline"
+              >
+                {f.hotkeyShort}
+              </Link>
+            </div>
+            <div className="font-mono text-[11px] text-ink-muted">
+              <span className="uppercase tracking-widest text-[10px]">coldkey </span>
+              {v.coldkey ? (
+                <Link
+                  to="/accounts/$ss58"
+                  params={{ ss58: v.coldkey }}
+                  title={v.coldkey}
+                  className="hover:text-accent hover:underline"
+                >
+                  {f.coldkeyShort}
+                </Link>
+              ) : (
+                "—"
+              )}
+            </div>
+            <dl className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-[11px]">
+              <Stat label="Active subnets" value={f.subnetsLabel} />
+              <Stat label="UIDs" value={f.uidsLabel} />
+              <Stat label="Nominators" value={f.nominatorsLabel} />
+              <Stat label="Dominance" value={f.dominanceLabel} />
+              <Stat label="Total stake" value={taoCompact(v.total_stake_tao)} />
+              <Stat label="Total emission" value={taoCompact(v.total_emission_tao)} />
+              <Stat label="Est. APY" value={f.apyLabel} />
+            </dl>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <dt className="text-ink-muted">{label}</dt>
+      <dd className="font-mono tabular-nums text-ink">{value}</dd>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/validator-card-fields.test.ts
+++ b/apps/ui/src/lib/metagraphed/validator-card-fields.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveValidatorCard } from "./validator-card-fields";
+import type { GlobalValidator } from "./types";
+
+function validator(overrides: Partial<GlobalValidator> = {}): GlobalValidator {
+  return {
+    hotkey: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+    featured: false,
+    coldkey: "5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY",
+    coldkey_identity: null,
+    coldkey_count: 1,
+    subnet_count: 12,
+    uid_count: 12,
+    take: 0.18,
+    total_stake_tao: 1234567,
+    root_stake_tao: 0,
+    alpha_stake_tao: 0,
+    total_emission_tao: 42,
+    nominator_count: 340,
+    apy_estimate: 0.1834,
+    apy_estimate_eligible_subnet_count: 10,
+    avg_validator_trust: null,
+    max_validator_trust: null,
+    stake_dominance: 0.05263,
+    latest_captured_at: null,
+    latest_block_number: null,
+    subnets: [],
+    ...overrides,
+  };
+}
+
+describe("resolveValidatorCard", () => {
+  it("shortens hotkey and coldkey", () => {
+    const f = resolveValidatorCard(validator());
+    expect(f.hotkeyShort.length).toBeLessThan(48);
+    expect(f.coldkeyShort).not.toBeNull();
+    expect(f.coldkeyShort!.length).toBeLessThan(48);
+  });
+
+  it("returns a null coldkey label when the row has no coldkey", () => {
+    expect(resolveValidatorCard(validator({ coldkey: null })).coldkeyShort).toBeNull();
+  });
+
+  it("formats dominance as a 2-dp percentage, em dash when null", () => {
+    expect(resolveValidatorCard(validator({ stake_dominance: 0.05263 })).dominanceLabel).toBe(
+      "5.26%",
+    );
+    expect(resolveValidatorCard(validator({ stake_dominance: null })).dominanceLabel).toBe("—");
+  });
+
+  it("formats APY as a 1-dp percentage, em dash when null", () => {
+    expect(resolveValidatorCard(validator({ apy_estimate: 0.1834 })).apyLabel).toBe("18.3%");
+    expect(resolveValidatorCard(validator({ apy_estimate: null })).apyLabel).toBe("—");
+  });
+
+  it("shows an em dash for a missing nominator count", () => {
+    expect(resolveValidatorCard(validator({ nominator_count: null })).nominatorsLabel).toBe("—");
+    expect(resolveValidatorCard(validator({ nominator_count: 340 })).nominatorsLabel).toBe("340");
+  });
+
+  it("formats the subnet and UID counts", () => {
+    const f = resolveValidatorCard(validator({ subnet_count: 12, uid_count: 34 }));
+    expect(f.subnetsLabel).toBe("12");
+    expect(f.uidsLabel).toBe("34");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/validator-card-fields.ts
+++ b/apps/ui/src/lib/metagraphed/validator-card-fields.ts
@@ -1,0 +1,41 @@
+import { formatNumber } from "@/lib/metagraphed/format";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import type { GlobalValidator } from "@/lib/metagraphed/types";
+
+/**
+ * Display strings a validator card derives from a `GlobalValidator` row. Kept
+ * pure (no JSX, no component imports) so the null-handling branches are
+ * unit-tested apart from the DOM. Stake/emission stay in the component since
+ * they format via `taoCompact`.
+ */
+export interface ValidatorCardFields {
+  /** Shortened hotkey, falling back to the full key when too short to shorten. */
+  hotkeyShort: string;
+  /** Shortened coldkey, or null when the row has no coldkey. */
+  coldkeyShort: string | null;
+  subnetsLabel: string;
+  uidsLabel: string;
+  /** Nominator count, or an em dash when the low-frequency source has no row. */
+  nominatorsLabel: string;
+  /** Stake dominance as a 2-dp percentage, or an em dash when null. */
+  dominanceLabel: string;
+  /** Estimated APY as a 1-dp percentage, or an em dash when null. */
+  apyLabel: string;
+}
+
+/**
+ * Resolve the labelled fields a validator card renders. Labels track the
+ * underlying data field (not table column position), so the cards read
+ * correctly regardless of the table's header layout.
+ */
+export function resolveValidatorCard(v: GlobalValidator): ValidatorCardFields {
+  return {
+    hotkeyShort: shortHash(v.hotkey) ?? v.hotkey,
+    coldkeyShort: v.coldkey ? (shortHash(v.coldkey) ?? v.coldkey) : null,
+    subnetsLabel: formatNumber(v.subnet_count),
+    uidsLabel: formatNumber(v.uid_count),
+    nominatorsLabel: v.nominator_count != null ? formatNumber(v.nominator_count) : "—",
+    dominanceLabel: v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—",
+    apyLabel: v.apy_estimate != null ? `${(v.apy_estimate * 100).toFixed(1)}%` : "—",
+  };
+}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -13,6 +13,7 @@ import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
+import { ValidatorCardList } from "@/components/metagraphed/validator-card-list";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
 import {
@@ -165,7 +166,7 @@ function ValidatorsTable({
       </div>
 
       {validators.length > 0 ? (
-        <div className="overflow-x-auto rounded-lg border border-border">
+        <div className="hidden md:block overflow-x-auto rounded-lg border border-border">
           <table className="w-full text-left text-sm">
             <thead className="bg-surface/50">
               <tr>
@@ -245,6 +246,13 @@ function ValidatorsTable({
           description="The global validator directory is empty for this window."
         />
       )}
+
+      {validators.length > 0 ? (
+        <ValidatorCardList
+          validators={validators}
+          className="grid gap-3 sm:grid-cols-2 md:hidden"
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #5320

The global validator directory renders a 12-column table with no mobile alternative — on a 375px viewport only ~5 columns fit and the rest sit off-screen behind a horizontal scroll.
This adds a reusable `ValidatorCardList` (backed by a pure, unit-tested `resolveValidatorCard` normalizer) rendered as a `md:hidden` fallback beneath the table, so phones get one readable card per validator. The desktop table is unchanged — just hidden below `md`. Each card metric is labelled by its data field, so the cards read correctly on their own.

## Changes
- `lib/metagraphed/validator-card-fields.ts` (+ test) — pure `resolveValidatorCard` normalizer (6 unit tests).
- `components/metagraphed/validator-card-list.tsx` — the card-list component.
- `routes/validators.index.tsx` — `hidden md:block` on the table + the `md:hidden` card fallback.

## Gates
typecheck ✓ · unit tests ✓ (696, 6 new) · prettier ✓ · build ✓ · responsive-overflow e2e ✓

## Screenshots

Captured with the repo's Playwright harness. The mobile pair is the meaningful change
(cramped table → cards); tablet/desktop show the unchanged table, confirming no regression
(the fallback only applies below `md`).

| Viewport · Theme | Before (cramped table) | After (card fallback) |
| --- | --- | --- |
| Mobile · Light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5320-validators/before-mobile-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5320-validators/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5320-validators/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5320-validators/after-mobile-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5320-validators/before-tablet-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5320-validators/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5320-validators/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5320-validators/after-tablet-dark.png) |
| Desktop · Light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5320-validators/before-desktop-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5320-validators/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5320-validators/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5320-validators/after-desktop-dark.png) |
