### PR TITLE
fix(ui): differentiate /health ops drill-down from /status public uptime (#5345)

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -96,7 +96,7 @@ const ROUTE_INDEX: Array<{
     icon: Network,
     scope: "route",
   },
-  { label: "Health", to: "/health", hint: "Global probe status", icon: Activity, scope: "route" },
+  { label: "Health", to: "/health", hint: "Ops matrix, mosaic & freshness", icon: Activity, scope: "route" },
   {
     label: "Status",
     to: "/status",

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -96,7 +96,13 @@ const ROUTE_INDEX: Array<{
     icon: Network,
     scope: "route",
   },
-  { label: "Health", to: "/health", hint: "Ops matrix, mosaic & freshness", icon: Activity, scope: "route" },
+  {
+    label: "Health",
+    to: "/health",
+    hint: "Ops matrix, mosaic & freshness",
+    icon: Activity,
+    scope: "route",
+  },
   {
     label: "Status",
     to: "/status",

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.test.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.test.ts
@@ -109,6 +109,18 @@ describe("MEGA_PANELS catalogue", () => {
       }
     }
   });
+  it("surfaces both /status and /health under the Health mega-panel", () => {
+    // #5345: /status was footer-only while the mega-menu deep-linked only into
+    // /health?view=… — surface both so users can reach public status and the
+    // ops drill-down from the same panel without guessing which page is which.
+    const health = MEGA_PANELS.find((p) => p.key === "health");
+    expect(health).toBeDefined();
+    const browseTos = new Set(health!.browse.map((l) => l.to));
+    expect(browseTos.has("/status")).toBe(true);
+    expect(browseTos.has("/health")).toBe(true);
+    expect(health!.browse[0]?.to).toBe("/status");
+    expect(health!.browse[0]?.label).toMatch(/public status/i);
+  });
 });
 
 describe("storage helpers (SSR/node-safe)", () => {

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
@@ -138,10 +138,19 @@ export const MEGA_PANELS: MegaPanel[] = [
     to: "/health",
     label: "Health",
     icon: Activity,
-    blurb: "Probe-derived freshness and incident state.",
+    blurb: "Public status for everyone; ops drill-down for maintainers.",
     apiPath: "/api/v1/health",
     browse: [
-      { to: "/health", label: "Overview" },
+      {
+        to: "/status",
+        label: "Public status",
+        hint: "Plain-language uptime & incidents",
+      },
+      {
+        to: "/health",
+        label: "Ops overview",
+        hint: "Matrix, mosaic, freshness",
+      },
       { to: "/health", search: { view: "matrix" }, label: "Subnet matrix" },
       { to: "/health", search: { view: "incidents" }, label: "Incidents" },
       { to: "/health", search: { view: "sources" }, label: "Source health" },

--- a/apps/ui/src/components/metagraphed/quick-actions-row.tsx
+++ b/apps/ui/src/components/metagraphed/quick-actions-row.tsx
@@ -41,9 +41,9 @@ const ACTIONS: QuickAction[] = [
   },
   {
     to: "/health",
-    eyebrow: "Status",
+    eyebrow: "Ops",
     title: "Check health",
-    description: "Global probes, source freshness, and per-subnet uptime trends.",
+    description: "Ops drill-down: matrix, mosaic, freshness, and live incidents.",
     icon: Activity,
   },
   {

--- a/apps/ui/src/routes/health.tsx
+++ b/apps/ui/src/routes/health.tsx
@@ -277,8 +277,8 @@ function HealthHero({
       description={
         <>
           Operational drill-down for maintainers — subnet matrix, endpoint mosaic, source freshness,
-          and live incidents. Probe-derived only; submissions cannot set uptime or incident state. For
-          plain-language uptime, see{" "}
+          and live incidents. Probe-derived only; submissions cannot set uptime or incident state.
+          For plain-language uptime, see{" "}
           <Link to="/status" className="text-accent-text underline-offset-2 hover:underline">
             System status
           </Link>

--- a/apps/ui/src/routes/health.tsx
+++ b/apps/ui/src/routes/health.tsx
@@ -1,11 +1,11 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery, useIsFetching, useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
 import { resolveRefetchInterval, usePageVisible } from "@/hooks/use-refetch-interval";
 import { Suspense, useEffect, useMemo, useState } from "react";
-import { RefreshCw, Pause, Play, ChevronDown, ChevronRight } from "lucide-react";
+import { RefreshCw, Pause, Play, ChevronDown, ChevronRight, ArrowUpRight } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton, StaleBanner } from "@/components/metagraphed/states";
@@ -45,10 +45,11 @@ const INTERVAL_OPTIONS: Array<{ label: string; value: number }> = [
 
 const INCIDENT_INITIAL_VISIBLE = 12;
 
-// Mirrors the six Health mega-menu quick-filter links (nav-mega-menu-data.ts
+// Mirrors the Health mega-menu ops deep-links (nav-mega-menu-data.ts
 // `MEGA_PANELS` "health" panel) so `/health?view=...` and `/health?status=...`
-// deep-link into a specific section/filter instead of always rendering the
-// same fixed page. `status` also backs the page's own incident-filter chips.
+// scroll to a specific section/filter. Public plain-language status lives on
+// `/status` (surfaced from the same panel). `status` also backs the page's own
+// incident-filter chips.
 const HEALTH_VIEWS = ["", "matrix", "incidents", "sources", "freshness"] as const;
 type HealthView = (typeof HEALTH_VIEWS)[number];
 
@@ -79,13 +80,13 @@ export const Route = createFileRoute("/health")({
       {
         name: "description",
         content:
-          "Global health, freshness, source health, and recent incidents across the registry.",
+          "Operational health drill-down for maintainers: subnet matrix, endpoint mosaic, source freshness, and live incidents.",
       },
       { property: "og:title", content: "Health — Metagraphed" },
       {
         property: "og:description",
         content:
-          "Global health, freshness, source health, and recent incidents across the registry.",
+          "Operational health drill-down for maintainers: subnet matrix, endpoint mosaic, source freshness, and live incidents.",
       },
     ],
   }),
@@ -131,13 +132,22 @@ function HealthPage() {
           <HealthHero
             interval={effectiveInterval}
             controls={
-              <AutoRefreshControl
-                enabled={enabled}
-                visible={visible}
-                intervalMs={intervalMs}
-                onToggle={() => setEnabled((v) => !v)}
-                onIntervalChange={setIntervalMs}
-              />
+              <>
+                <Link
+                  to="/status"
+                  className="inline-flex items-center gap-1 rounded-md border border-border bg-card px-2.5 py-1.5 text-[11px] font-medium text-ink-muted hover:border-ink/30 hover:text-ink-strong min-h-9"
+                >
+                  Public status
+                  <ArrowUpRight className="size-3" aria-hidden="true" />
+                </Link>
+                <AutoRefreshControl
+                  enabled={enabled}
+                  visible={visible}
+                  intervalMs={intervalMs}
+                  onToggle={() => setEnabled((v) => !v)}
+                  onIntervalChange={setIntervalMs}
+                />
+              </>
             }
           />
         </Suspense>
@@ -264,7 +274,17 @@ function HealthHero({
       eyebrow="Operations"
       live
       title="Health & freshness"
-      description="Probe-derived health. User submissions cannot set uptime, latency, or incident state."
+      description={
+        <>
+          Operational drill-down for maintainers — subnet matrix, endpoint mosaic, source freshness,
+          and live incidents. Probe-derived only; submissions cannot set uptime or incident state. For
+          plain-language uptime, see{" "}
+          <Link to="/status" className="text-accent-text underline-offset-2 hover:underline">
+            System status
+          </Link>
+          .
+        </>
+      }
       actions={controls}
       caption={<>health · {h?.total ?? "—"} surfaces</>}
       kpis={[

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -1,11 +1,11 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useRegistryEvents } from "@/hooks/use-registry-events";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { Suspense, useMemo, useState } from "react";
-import { AlertTriangle, CheckCircle2, XCircle } from "lucide-react";
+import { AlertTriangle, ArrowUpRight, CheckCircle2, XCircle } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
@@ -79,13 +79,13 @@ export const Route = createFileRoute("/status")({
       {
         name: "description",
         content:
-          "Live system status for the metagraphed registry: overall operational health and recent cross-subnet incidents.",
+          "Public system status for the metagraphed registry: plain-language uptime, recent incidents, and probe history.",
       },
       { property: "og:title", content: "Status — Metagraphed" },
       {
         property: "og:description",
         content:
-          "Live system status for the metagraphed registry: overall operational health and recent cross-subnet incidents.",
+          "Public system status for the metagraphed registry: plain-language uptime, recent incidents, and probe history.",
       },
     ],
   }),
@@ -98,9 +98,18 @@ function StatusPage() {
   return (
     <AppShell>
       <PageHeading
-        eyebrow="Status"
+        eyebrow="Public status"
         title="System status"
-        description="Live operational status across every monitored subnet surface. Probe-derived — user submissions cannot set health or incident state."
+        description="Plain-language uptime for everyone — overall verdict, the global incident ledger, and probe history. Probe-derived only; submissions cannot set health. For the ops drill-down (matrix, mosaic, live probes), use Health."
+        right={
+          <Link
+            to="/health"
+            className="inline-flex items-center gap-1 rounded-md border border-border bg-card px-2.5 py-1.5 text-[11px] font-medium text-ink-muted hover:border-ink/30 hover:text-ink-strong min-h-9"
+          >
+            Ops health dashboard
+            <ArrowUpRight className="size-3" aria-hidden="true" />
+          </Link>
+        }
       />
       <div className="space-y-section">
         <QueryErrorBoundary>


### PR DESCRIPTION
## Summary

- Keeps `/health` and `/status` separate (does not merge Status into a Health `view=` tab). Status already owns public-only surfaces (plain-language verdict, RSS/Atom/JSON feeds, 7d/30d global incident ledger, probe history, decentralization/yield) that don't belong in the ops dashboard.
- Differentiates purpose in copy + meta: **Status** = plain-language public uptime; **Health** = maintainer ops drill-down (matrix, mosaic, freshness, live incidents). Adds explicit cross-links both ways.
- Surfaces `/status` from the Health mega-menu (it was footer/command-palette only), and aligns command-palette + home quick-action hints with the same split.

Closes #5345

## Test plan

- [ ] `/status` hero reads as public status and links to Ops health dashboard
- [ ] `/health` hero reads as ops drill-down and links to Public status / System status
- [ ] Health mega-menu browse lists **Public status** then **Ops overview**, plus existing deep-links
- [ ] Command palette hints: Health = ops matrix/mosaic/freshness; Status = public uptime & incidents
- [x] `eslint` on changed files — 0 errors
- [x] `prettier --check` on changed files
- [x] `typecheck` (`apps/ui`)
- [x] `nav-mega-menu-data.test.ts` (7/7)

## Screenshots

Before = main (`:5174`); After = this branch (`:5173`).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Dark · `/health` | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/7d9f8661-938f-4a72-ba7f-e47d5496c336" /> | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/805c1f76-f556-4b80-935d-ed85fbd4ec1e" /> |
| Desktop · Dark · `/status` | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/dd43f417-e1ea-46fa-afe0-ab58164e6303" /> | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/c28ce82b-855f-4d5a-8250-58c596cbf982" /> |
| Desktop · Light · `/health` | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/7548b77f-c308-427e-9d2b-1119ef98c51d" /> | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/e4b586c1-250c-41fd-a1b4-a5ba97308ba1" /> |
| Desktop · Light · `/status` | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/ebc340a4-4177-42d7-87ef-ecd181a23de0" /> | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/ee47bd34-4b80-4b51-8076-21257b2a8b09" /> |
| Tablet · Light · `/health` | <img width="1177" height="803" alt="image" src="https://github.com/user-attachments/assets/bb6d0bae-4b58-468a-bd4b-3d7b8cde5428" /> | <img width="1177" height="803" alt="image" src="https://github.com/user-attachments/assets/1dbc2b60-9b8f-4cdc-ac09-cd8707b56015" /> |
| Tablet · Light · `/status` | <img width="1177" height="803" alt="image" src="https://github.com/user-attachments/assets/6ddfe7c4-e08e-40a7-b020-96ce47cd4390" /> | <img width="1177" height="803" alt="image" src="https://github.com/user-attachments/assets/b37819b6-9e88-484a-b1fd-ea0bc4966cb4" /> |
| Tablet · Dark · `/health` | <img width="1177" height="803" alt="image" src="https://github.com/user-attachments/assets/3adb16ea-be95-48cb-a8d7-95521d22cab6" />| <img width="1177" height="803" alt="image" src="https://github.com/user-attachments/assets/9998064d-1579-49df-b16f-d5678a38d21b" /> |
| Tablet · Dark · `/status` | <img width="1177" height="803" alt="image" src="https://github.com/user-attachments/assets/7d5e9833-e87f-4ad8-acf2-aeae954e53aa" /> | <img width="1177" height="803" alt="image" src="https://github.com/user-attachments/assets/89dd5b80-d7de-4656-a06a-b66b794cead1" /> |
| Mobile · Light · `/health` | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/09850681-523f-4029-b050-a7aa6f4ca79c" /> | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/4f308360-c592-40e5-be9b-4d9e414f80a2" /> |
| Mobile · Light · `/status` | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/32afa2ed-c637-4558-bfb1-d127b3cb2650" /> | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/f11e670c-1eb5-4175-83e7-39b6180b3669" /> |
| Mobile · Dark · `/health` | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/fce49da7-582f-4b17-a16c-2831d8229492" /> | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/2218abd1-4430-4593-a88b-dbc6da96f152" /> |
| Mobile · Dark · `/status` | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/519c6df8-9b91-4ec3-a7e3-0c98c5eb5d9b" /> | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/dea8c859-f5b4-4ac5-baa5-ebfdc5a9fbe6" /> |

Replace `*_URL` with raw GitHub `screenshots` branch links after upload. Add light/tablet/mobile rows (or note “provably unaffected — copy/CTA only at hero”) per Path C.