### PR TITLE
fix(ui): clamp gaps missing-kind bar widths (#5326)

### DIFF
--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -400,6 +400,7 @@ function MissingKindsAtAGlance() {
       <ul className="rounded-xl border border-border bg-card divide-y divide-border">
         {counts.map(([k, n]) => {
           const isActive = activeMissing.has(k);
+          const pct = Math.max(2, Math.round((n / max) * 100));
           return (
             <li key={k} className={isActive ? "bg-primary-soft/40" : undefined}>
               <button
@@ -439,7 +440,7 @@ function MissingKindsAtAGlance() {
                     "h-2 rounded-full transition-colors",
                     isActive ? "bg-accent" : "bg-health-warn/70",
                   )}
-                  style={{ width: `${(n / max) * 100}%` }}
+                  style={{ width: `${pct}%` }}
                   aria-hidden
                 />
                 <span className="font-mono text-[11px] tabular-nums text-ink-muted">


### PR DESCRIPTION
## Summary

- Clamp the `/gaps` missing-kind bar widths to a 2% minimum so low nonzero counts render as visible bars.
- Match the existing `Math.max(2, ...)` bar-width pattern used by the explorer route.

## Template Used

- Frontend/UI bug fix

Closes #5326

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-gaps-5326/gaps-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `git diff --check`
- `npx prettier --check apps/ui/src/routes/gaps.tsx`
- `npx eslint apps/ui/src/routes/gaps.tsx` (0 errors; existing route warnings only)
- `npm run --workspace=apps/ui typecheck`

Notes: full workspace lint/format checks are noisy on this Windows checkout because current files report pre-existing CRLF/prettier findings outside this change.