### PR TITLE
feat(ui): add per-metric tooltips to the status decentralization and emission-yield tiles (#5330)

### DIFF
--- a/apps/ui/src/components/metagraphed/emission-yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/emission-yield-panel.tsx
@@ -60,18 +60,21 @@ export function EmissionYieldPanel() {
           value={fmtPct(y.network_yield)}
           hint="Emission ÷ total stake"
           tone="accent"
+          tooltip="Annualized network-wide return: total emission divided by total stake, before validator take. A baseline for what staked TAO earns across the whole network."
         />
         <StatTile
           icon={Server}
           eyebrow="Validator yield"
           value={fmtPct(y.validator_yield)}
           hint={`${formatNumber(y.validator_count)} validators`}
+          tooltip="Average return earned by validating neurons — emission to validators relative to their stake. Typically differs from miner yield by the incentive split."
         />
         <StatTile
           icon={Users}
           eyebrow="Miner yield"
           value={fmtPct(y.miner_yield)}
           hint={`${formatNumber(y.miner_count)} miners`}
+          tooltip="Average return earned by mining neurons — emission to miners relative to their stake. Reflects reward flow to the mining side of the network."
         />
       </div>
 
@@ -86,18 +89,21 @@ export function EmissionYieldPanel() {
               eyebrow="Median"
               value={fmtPct(dist.median)}
               hint={`${formatNumber(dist.count)} neurons`}
+              tooltip="The median per-neuron return — half of neurons earn more, half less. A typical-neuron benchmark that is robust to a few very high or very low outliers."
             />
             <StatTile
               icon={Coins}
               eyebrow="75th pct"
               value={fmtPct(dist.p75)}
               hint="per-neuron return"
+              tooltip="75th-percentile per-neuron return: a quarter of neurons earn more than this. Shows the upper spread of returns above the typical neuron."
             />
             <StatTile
               icon={Coins}
               eyebrow="90th pct"
               value={fmtPct(dist.p90)}
               hint="per-neuron return"
+              tooltip="90th-percentile per-neuron return: only the top 10% of neurons earn more. Highlights how concentrated the strongest returns are."
             />
           </div>
         </div>

--- a/apps/ui/src/components/metagraphed/network-decentralization-panel.tsx
+++ b/apps/ui/src/components/metagraphed/network-decentralization-panel.tsx
@@ -27,6 +27,29 @@ const TILE_ICONS: Record<string, LucideIcon> = {
   "validator-trust-median": ShieldCheck,
 };
 
+// Per-metric explainers (#5330): what each score means and which direction is
+// healthier, surfaced as an info tooltip on each tile.
+const TILE_TOOLTIPS: Record<string, string> = {
+  "stake-gini":
+    "Gini coefficient of stake distribution (0–1). 0 means stake is spread perfectly evenly; 1 means one holder owns it all. Lower is more decentralized.",
+  "stake-hhi":
+    "Herfindahl–Hirschman Index of stake — the sum of squared stake shares. Higher means stake is concentrated in fewer holders; lower is healthier.",
+  "stake-nakamoto":
+    "Nakamoto coefficient: the fewest entities that together control over 50% of stake. Higher means more parties must collude to capture consensus — more resilient.",
+  "stake-entropy":
+    "Shannon entropy of the stake distribution. Higher entropy means stake is spread across more neurons — more decentralized.",
+  "stake-top1":
+    "Share of total stake held by the top 1% of holders. Lower means less concentration at the very top.",
+  "emission-gini":
+    "Gini coefficient of emission (reward) distribution (0–1). Lower means rewards are shared more evenly; higher means a few neurons capture most emission.",
+  "trust-median":
+    "Median on-chain trust score across neurons (0–1) — the consensus view of how much peers weight each neuron. Higher and steadier is healthier.",
+  "consensus-median":
+    "Median consensus score (0–1): how closely each neuron's weights align with the subnet consensus. Higher means broader agreement.",
+  "validator-trust-median":
+    "Median validator-trust score (0–1) among permitted validators. Higher means validators are consistently trusted by their peers.",
+};
+
 // Suspense fallback that mirrors the panel's own grid (6 concentration tiles +
 // a 3-tile score row) so the skeleton occupies the same responsive height as
 // the loaded content — no layout shift when the data arrives, unlike a single
@@ -59,6 +82,7 @@ function Tile({ tile }: { tile: DecentralizationTile }) {
       value={tile.value}
       hint={tile.hint}
       tone={tile.tone}
+      tooltip={TILE_TOOLTIPS[tile.key]}
     />
   );
 }

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3352,7 +3352,8 @@ function StatTile({
   chart,
   tone = "default",
   className,
-  truncate = true
+  truncate = true,
+  tooltip
 }) {
   return /* @__PURE__ */ jsxRuntime.jsxs(
     "div",
@@ -3378,16 +3379,10 @@ function StatTile({
           }
         ) : null,
         /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "min-w-0 flex-1", children: [
-          /* @__PURE__ */ jsxRuntime.jsx(
-            "div",
-            {
-              className: classNames(
-                "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted",
-                truncate ? "truncate" : "leading-tight"
-              ),
-              children: eyebrow
-            }
-          ),
+          /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted", children: [
+            /* @__PURE__ */ jsxRuntime.jsx("span", { className: truncate ? "truncate" : "leading-tight", children: eyebrow }),
+            tooltip ? /* @__PURE__ */ jsxRuntime.jsx(InfoTooltip, { label: tooltip, className: "shrink-0" }) : null
+          ] }),
           /* @__PURE__ */ jsxRuntime.jsxs(
             "div",
             {

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3323,7 +3323,8 @@ function StatTile({
   chart,
   tone = "default",
   className,
-  truncate = true
+  truncate = true,
+  tooltip
 }) {
   return /* @__PURE__ */ jsxs(
     "div",
@@ -3349,16 +3350,10 @@ function StatTile({
           }
         ) : null,
         /* @__PURE__ */ jsxs("div", { className: "min-w-0 flex-1", children: [
-          /* @__PURE__ */ jsx(
-            "div",
-            {
-              className: classNames(
-                "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted",
-                truncate ? "truncate" : "leading-tight"
-              ),
-              children: eyebrow
-            }
-          ),
+          /* @__PURE__ */ jsxs("div", { className: "flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted", children: [
+            /* @__PURE__ */ jsx("span", { className: truncate ? "truncate" : "leading-tight", children: eyebrow }),
+            tooltip ? /* @__PURE__ */ jsx(InfoTooltip, { label: tooltip, className: "shrink-0" }) : null
+          ] }),
           /* @__PURE__ */ jsxs(
             "div",
             {

--- a/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/stat-tile.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 import { classNames } from "@/lib/format";
+import { InfoTooltip } from "@/components/metagraphed/info-tooltip";
 
 interface Props {
   icon?: LucideIcon;
@@ -17,6 +18,12 @@ interface Props {
    * Defaults to true, unchanged for every other consumer.
    */
   truncate?: boolean;
+  /**
+   * Optional hover/focus explainer shown as an info icon next to the eyebrow —
+   * what the statistic means and what a healthy value looks like. Matches the
+   * HeroStatCell tooltip pattern.
+   */
+  tooltip?: string;
 }
 
 /**
@@ -32,6 +39,7 @@ export function StatTile({
   tone = "default",
   className,
   truncate = true,
+  tooltip,
 }: Props) {
   return (
     <div
@@ -63,13 +71,13 @@ export function StatTile({
         />
       ) : null}
       <div className="min-w-0 flex-1">
-        <div
-          className={classNames(
-            "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted",
-            truncate ? "truncate" : "leading-tight",
-          )}
-        >
-          {eyebrow}
+        <div className="flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          <span className={truncate ? "truncate" : "leading-tight"}>
+            {eyebrow}
+          </span>
+          {tooltip ? (
+            <InfoTooltip label={tooltip} className="shrink-0" />
+          ) : null}
         </div>
         <div
           className={classNames(


### PR DESCRIPTION
## Summary

Closes #5330

The Status page's decentralization and emission-yield panels rendered raw `StatTile`s (Trust median, Consensus, Gini/HHI/Nakamoto, Network/Validator/Miner yield, per-neuron return spread) with no per-metric explainer — unlike the
homepage's `HeroStatCell`, which supports a `tooltip` (#5330).

This adds an optional `tooltip` prop to the shared `StatTile` (ui-kit) that renders an `InfoTooltip` beside the eyebrow — matching the `HeroStatCell` pattern — and wires a factual explainer to **every** tile in both panels: what each score means and which direction is healthier.

## Changes
- `packages/ui-kit/.../charts/stat-tile.tsx` — new optional `tooltip?: string` prop
  → `InfoTooltip` next to the label (backward-compatible; no change when omitted).
  Committed the rebuilt `packages/ui-kit/dist` (drift check).
- `components/metagraphed/emission-yield-panel.tsx` — tooltip on all 6 yield tiles.
- `components/metagraphed/network-decentralization-panel.tsx` — a per-key
  `TILE_TOOLTIPS` map wired into the tile grid (9 metrics).

## Screenshots

Status page panels — **before** (no explainers) vs **after** (info icon on every tile). Captured from a single dev server; the last row shows a tooltip open on hover.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5330-status-tooltips/before-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5330-status-tooltips/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5330-status-tooltips/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5330-status-tooltips/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5330-status-tooltips/before-tablet-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5330-status-tooltips/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5330-status-tooltips/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5330-status-tooltips/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5330-status-tooltips/before-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5330-status-tooltips/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5330-status-tooltips/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5330-status-tooltips/after-mobile-dark.png) |

Tooltip open (hover) — Desktop · Light:

![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5330-status-tooltips/after-hover-desktop-light.png)

## Validation
- ui-kit: `typecheck` ✓ · `lint` (import guardrail) ✓ · **dist drift check** (rebuild == committed) ✓
- apps/ui: `eslint` ✓ · `prettier --check` (3.9.4, LF) ✓ · `typecheck` ✓ · `vitest` (690) ✓ · `build` ✓
- **`test:e2e` responsive-overflow: 24/24, incl. `/status` mobile 375px — no new overflow from the tooltip icons**
- 0-behind `main`, no conflicts

