### PR TITLE
fix(ui): add a mobile card fallback to the leaderboards tables (#5321)

### DIFF
--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -179,7 +179,49 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
               ) : null}
             </span>
           </div>
-          <div className="overflow-x-auto">
+          {/* < md: the 5-column table clips its trailing columns behind an
+              undiscoverable horizontal scroll, so narrow viewports get a
+              stacked card per subnet instead — mirrors the cards/desktop-only
+              split the explorer leaderboards use for the same static boards. */}
+          <div className="md:hidden space-y-2 p-3">
+            {board.subnets.map((row, i) => {
+              const subnet = subnetById.get(row.netuid);
+              const name = subnet?.name ?? `Subnet ${row.netuid}`;
+              return (
+                <div key={row.netuid} className="rounded border border-border bg-card p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: row.netuid }}
+                      className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
+                    >
+                      <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
+                        {i + 1}
+                      </span>
+                      <BrandIcon
+                        size={18}
+                        name={name}
+                        fallback={row.netuid}
+                        netuid={row.netuid}
+                        subnetSlug={typeof subnet?.slug === "string" ? subnet.slug : undefined}
+                      />
+                      <span className="truncate text-sm text-ink-strong">{name}</span>
+                    </Link>
+                    <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
+                      {row.sets_per_setter != null
+                        ? `${row.sets_per_setter.toFixed(2)} / setter`
+                        : "—"}
+                    </span>
+                  </div>
+                  <div className="mt-2 flex items-center justify-between font-mono text-[11px] tabular-nums text-ink-muted">
+                    <span>{formatNumber(row.weight_sets)} weight-sets</span>
+                    <span>{formatNumber(row.distinct_setters)} setters</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div className="hidden md:block overflow-x-auto">
             <table className="w-full text-left text-sm">
               <thead>
                 <tr>
@@ -302,7 +344,46 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
               ) : null}
             </span>
           </div>
-          <div className="overflow-x-auto">
+          {/* < md: card fallback per subnet (see the weight-setting board). */}
+          <div className="md:hidden space-y-2 p-3">
+            {board.subnets.map((row, i) => {
+              const subnet = subnetById.get(row.netuid);
+              const name = subnet?.name ?? `Subnet ${row.netuid}`;
+              return (
+                <div key={row.netuid} className="rounded border border-border bg-card p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: row.netuid }}
+                      className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
+                    >
+                      <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
+                        {i + 1}
+                      </span>
+                      <BrandIcon
+                        size={18}
+                        name={name}
+                        fallback={row.netuid}
+                        netuid={row.netuid}
+                        subnetSlug={typeof subnet?.slug === "string" ? subnet.slug : undefined}
+                      />
+                      <span className="truncate text-sm text-ink-strong">{name}</span>
+                    </Link>
+                    <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
+                      {row.deregistrations_per_hotkey != null
+                        ? `${row.deregistrations_per_hotkey.toFixed(2)} / hotkey`
+                        : "—"}
+                    </span>
+                  </div>
+                  <div className="mt-2 flex items-center justify-between font-mono text-[11px] tabular-nums text-ink-muted">
+                    <span>{formatNumber(row.deregistrations)} deregistrations</span>
+                    <span>{formatNumber(row.distinct_deregistered_hotkeys)} hotkeys</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div className="hidden md:block overflow-x-auto">
             <table className="w-full text-left text-sm">
               <thead>
                 <tr>


### PR DESCRIPTION
## Summary

Closes #5321

Both boards on `/leaderboards` (weight-setting and deregistrations) wrapped a 5-column table in a plain `overflow-x-auto` div — at 375px only Rank/Subnet/first-metric fit and the trailing columns clip behind an undiscoverable horizontal scroll. This gives each board a `md:hidden` stacked card per subnet and hides the table below `md`.

**On ListShell:** the issue suggested routing through `ListShell`, but that component's sticky filter bar + sort/pagination machinery don't fit a filter-less, multi-board page (you'd get two stacked sticky bars). This mirrors the exact cards/desktop-only split the **explorer** page already uses for these same static boards (`explorer.tsx`, via `ExplorerLeaderboardTableShell`) —
which exists precisely to avoid ListShell here. Same shared visual pattern, no new machinery.

## Gates
typecheck ✓ · unit tests ✓ (690) · prettier ✓ · build ✓ · responsive-overflow e2e ✓ (24/24)

## Screenshots

Captured with the repo's Playwright harness. The mobile pair is the meaningful change (cramped table → cards); tablet/desktop show the unchanged table (the fallback only applies below `md`).

| Viewport · Theme | Before (cramped table) | After (card fallback) |
| --- | --- | --- |
| Mobile · Light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5321-leaderboards/before-mobile-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5321-leaderboards/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5321-leaderboards/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5321-leaderboards/after-mobile-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5321-leaderboards/before-tablet-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5321-leaderboards/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5321-leaderboards/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5321-leaderboards/after-tablet-dark.png) |
| Desktop · Light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5321-leaderboards/before-desktop-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5321-leaderboards/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5321-leaderboards/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5321-leaderboards/after-desktop-dark.png) |
