### PR TITLE
feat(ui): unify Validators and Leaderboards with Subnets ranked-list controls (#5344)

### DIFF
--- a/apps/ui/src/components/metagraphed/leaderboards-saved-views.tsx
+++ b/apps/ui/src/components/metagraphed/leaderboards-saved-views.tsx
@@ -102,8 +102,7 @@ export function LeaderboardsSavedViews() {
               title={p.hint}
               onClick={() => {
                 navigate({
-                  search: (prev: Record<string, unknown>) =>
-                    ({ ...prev, ...p.patch }) as never,
+                  search: (prev: Record<string, unknown>) => ({ ...prev, ...p.patch }) as never,
                   replace: true,
                 });
                 // Nudge into the focused board after the URL lands.

--- a/apps/ui/src/components/metagraphed/leaderboards-saved-views.tsx
+++ b/apps/ui/src/components/metagraphed/leaderboards-saved-views.tsx
@@ -2,8 +2,11 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { Scale, UserMinus, type LucideIcon } from "lucide-react";
 import { classNames } from "@/lib/metagraphed/format";
 
+type Focus = "weights" | "deregistrations";
+
 type Patch = {
-  window?: "7d" | "30d";
+  focus: Focus;
+  window: "7d" | "30d";
   weightsSort?: string;
   weightsOrder?: "asc" | "desc";
   deregSort?: string;
@@ -18,12 +21,15 @@ type Preset = {
   hint?: string;
 };
 
+// `focus` makes chips mutually exclusive — without it, the default
+// weightsSort + deregSort both match their ·7d presets at once (#5344 mobile).
 const PRESETS: Preset[] = [
   {
     id: "weights-7d",
-    label: "Weight-sets · 7d",
+    label: "Weights · 7d",
     icon: Scale,
     patch: {
+      focus: "weights",
       window: "7d",
       weightsSort: "weight_sets",
       weightsOrder: "desc",
@@ -32,9 +38,10 @@ const PRESETS: Preset[] = [
   },
   {
     id: "weights-30d",
-    label: "Weight-sets · 30d",
+    label: "Weights · 30d",
     icon: Scale,
     patch: {
+      focus: "weights",
       window: "30d",
       weightsSort: "weight_sets",
       weightsOrder: "desc",
@@ -43,9 +50,10 @@ const PRESETS: Preset[] = [
   },
   {
     id: "dereg-7d",
-    label: "Deregistrations · 7d",
+    label: "Dereg · 7d",
     icon: UserMinus,
     patch: {
+      focus: "deregistrations",
       window: "7d",
       deregSort: "deregistrations",
       deregOrder: "desc",
@@ -54,9 +62,10 @@ const PRESETS: Preset[] = [
   },
   {
     id: "dereg-30d",
-    label: "Deregistrations · 30d",
+    label: "Dereg · 30d",
     icon: UserMinus,
     patch: {
+      focus: "deregistrations",
       window: "30d",
       deregSort: "deregistrations",
       deregOrder: "desc",
@@ -75,14 +84,14 @@ export function LeaderboardsSavedViews() {
   const navigate = useNavigate({ from: "/leaderboards" });
 
   return (
-    <div className="-mt-2 mb-6">
+    <div className="mb-4 md:mb-6">
       <div className="flex items-center gap-2 mb-2">
-        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted shrink-0">
           Saved views
         </span>
-        <span aria-hidden className="h-px flex-1 bg-border/60" />
+        <span aria-hidden className="h-px flex-1 min-w-0 bg-border/60" />
       </div>
-      <div className="flex flex-wrap gap-1.5">
+      <div className="flex flex-wrap justify-start gap-1.5">
         {PRESETS.map((p) => {
           const active = matches(search, p.patch);
           const Icon = p.icon;
@@ -91,15 +100,23 @@ export function LeaderboardsSavedViews() {
               key={p.id}
               type="button"
               title={p.hint}
-              onClick={() =>
+              onClick={() => {
                 navigate({
                   search: (prev: Record<string, unknown>) =>
                     ({ ...prev, ...p.patch }) as never,
                   replace: true,
-                })
-              }
+                });
+                // Nudge into the focused board after the URL lands.
+                window.setTimeout(() => {
+                  document
+                    .getElementById(
+                      p.patch.focus === "weights" ? "weights-board" : "deregistrations-board",
+                    )
+                    ?.scrollIntoView({ behavior: "smooth", block: "start" });
+                }, 40);
+              }}
               className={classNames(
-                "inline-flex h-7 items-center gap-1.5 rounded-full border px-2.5 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                "inline-flex h-7 shrink-0 items-center gap-1.5 rounded-full border px-2.5 font-mono text-[10px] uppercase tracking-widest transition-colors",
                 active
                   ? "border-accent bg-primary-soft text-ink-strong"
                   : "border-border bg-card text-ink-muted hover:border-accent/50 hover:text-ink-strong",

--- a/apps/ui/src/components/metagraphed/leaderboards-saved-views.tsx
+++ b/apps/ui/src/components/metagraphed/leaderboards-saved-views.tsx
@@ -1,0 +1,117 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { Scale, UserMinus, type LucideIcon } from "lucide-react";
+import { classNames } from "@/lib/metagraphed/format";
+
+type Patch = {
+  window?: "7d" | "30d";
+  weightsSort?: string;
+  weightsOrder?: "asc" | "desc";
+  deregSort?: string;
+  deregOrder?: "asc" | "desc";
+};
+
+type Preset = {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  patch: Patch;
+  hint?: string;
+};
+
+const PRESETS: Preset[] = [
+  {
+    id: "weights-7d",
+    label: "Weight-sets · 7d",
+    icon: Scale,
+    patch: {
+      window: "7d",
+      weightsSort: "weight_sets",
+      weightsOrder: "desc",
+    },
+    hint: "highest weight-setting activity this week",
+  },
+  {
+    id: "weights-30d",
+    label: "Weight-sets · 30d",
+    icon: Scale,
+    patch: {
+      window: "30d",
+      weightsSort: "weight_sets",
+      weightsOrder: "desc",
+    },
+    hint: "highest weight-setting activity this month",
+  },
+  {
+    id: "dereg-7d",
+    label: "Deregistrations · 7d",
+    icon: UserMinus,
+    patch: {
+      window: "7d",
+      deregSort: "deregistrations",
+      deregOrder: "desc",
+    },
+    hint: "most evictions this week",
+  },
+  {
+    id: "dereg-30d",
+    label: "Deregistrations · 30d",
+    icon: UserMinus,
+    patch: {
+      window: "30d",
+      deregSort: "deregistrations",
+      deregOrder: "desc",
+    },
+    hint: "most evictions this month",
+  },
+];
+
+function matches(search: Record<string, unknown>, patch: Patch) {
+  return Object.entries(patch).every(([k, v]) => String(search[k] ?? "") === String(v));
+}
+
+/** Preset window/sort chips for /leaderboards — mirrors SubnetsSavedViews (#5344). */
+export function LeaderboardsSavedViews() {
+  const search = useSearch({ from: "/leaderboards" }) as Record<string, unknown>;
+  const navigate = useNavigate({ from: "/leaderboards" });
+
+  return (
+    <div className="-mt-2 mb-6">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          Saved views
+        </span>
+        <span aria-hidden className="h-px flex-1 bg-border/60" />
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {PRESETS.map((p) => {
+          const active = matches(search, p.patch);
+          const Icon = p.icon;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              title={p.hint}
+              onClick={() =>
+                navigate({
+                  search: (prev: Record<string, unknown>) =>
+                    ({ ...prev, ...p.patch }) as never,
+                  replace: true,
+                })
+              }
+              className={classNames(
+                "inline-flex h-7 items-center gap-1.5 rounded-full border px-2.5 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                active
+                  ? "border-accent bg-primary-soft text-ink-strong"
+                  : "border-border bg-card text-ink-muted hover:border-accent/50 hover:text-ink-strong",
+              )}
+              aria-pressed={active}
+            >
+              <Icon className="size-3" aria-hidden />
+              {p.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/validators-saved-views.tsx
+++ b/apps/ui/src/components/metagraphed/validators-saved-views.tsx
@@ -1,0 +1,113 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { Layers, Coins, Flame, Scale, Shield, TrendingUp, type LucideIcon } from "lucide-react";
+import { classNames } from "@/lib/metagraphed/format";
+import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
+
+type Patch = {
+  sort?: GlobalValidatorSort;
+  order?: "asc" | "desc";
+};
+
+type Preset = {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  patch: Patch;
+  hint?: string;
+};
+
+const PRESETS: Preset[] = [
+  {
+    id: "subnets",
+    label: "Most subnets",
+    icon: Layers,
+    patch: { sort: "subnet_count", order: "desc" },
+    hint: "broadest footprint first",
+  },
+  {
+    id: "stake",
+    label: "Top stake",
+    icon: Coins,
+    patch: { sort: "total_stake", order: "desc" },
+    hint: "highest total stake",
+  },
+  {
+    id: "emission",
+    label: "Top emission",
+    icon: Flame,
+    patch: { sort: "total_emission", order: "desc" },
+    hint: "highest total emission",
+  },
+  {
+    id: "dominance",
+    label: "Highest dominance",
+    icon: TrendingUp,
+    patch: { sort: "stake_dominance", order: "desc" },
+    hint: "share of network stake",
+  },
+  {
+    id: "trust",
+    label: "Highest trust",
+    icon: Shield,
+    patch: { sort: "avg_validator_trust", order: "desc" },
+    hint: "average validator trust",
+  },
+  {
+    id: "uids",
+    label: "Most UIDs",
+    icon: Scale,
+    patch: { sort: "uid_count", order: "desc" },
+    hint: "most validator UIDs",
+  },
+];
+
+function matches(search: Record<string, unknown>, patch: Patch) {
+  return Object.entries(patch).every(([k, v]) => String(search[k] ?? "") === String(v));
+}
+
+/** Preset sort chips for /validators — mirrors SubnetsSavedViews (#5344). */
+export function ValidatorsSavedViews() {
+  const search = useSearch({ from: "/validators/" }) as Record<string, unknown>;
+  const navigate = useNavigate({ from: "/validators/" });
+
+  return (
+    <div className="-mt-2 mb-6">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          Saved views
+        </span>
+        <span aria-hidden className="h-px flex-1 bg-border/60" />
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {PRESETS.map((p) => {
+          const active = matches(search, p.patch);
+          const Icon = p.icon;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              title={p.hint}
+              onClick={() =>
+                navigate({
+                  search: (prev: Record<string, unknown>) =>
+                    ({ ...prev, ...p.patch }) as never,
+                  replace: true,
+                })
+              }
+              className={classNames(
+                "inline-flex h-7 items-center gap-1.5 rounded-full border px-2.5 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                active
+                  ? "border-accent bg-primary-soft text-ink-strong"
+                  : "border-border bg-card text-ink-muted hover:border-accent/50 hover:text-ink-strong",
+              )}
+              aria-pressed={active}
+            >
+              <Icon className="size-3" aria-hidden />
+              {p.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/validators-saved-views.tsx
+++ b/apps/ui/src/components/metagraphed/validators-saved-views.tsx
@@ -1,4 +1,5 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
+
 import { Layers, Coins, Flame, Scale, Shield, TrendingUp, type LucideIcon } from "lucide-react";
 import { classNames } from "@/lib/metagraphed/format";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";

--- a/apps/ui/src/components/metagraphed/validators-saved-views.tsx
+++ b/apps/ui/src/components/metagraphed/validators-saved-views.tsx
@@ -89,8 +89,7 @@ export function ValidatorsSavedViews() {
               title={p.hint}
               onClick={() =>
                 navigate({
-                  search: (prev: Record<string, unknown>) =>
-                    ({ ...prev, ...p.patch }) as never,
+                  search: (prev: Record<string, unknown>) => ({ ...prev, ...p.patch }) as never,
                   replace: true,
                 })
               }

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -193,11 +193,7 @@ function useSubnetById(): Map<number, Subnet> {
   }, [snRes]);
 }
 
-function matchesSubnetFilter(
-  netuid: number,
-  subnet: Subnet | undefined,
-  q: string,
-): boolean {
+function matchesSubnetFilter(netuid: number, subnet: Subnet | undefined, q: string): boolean {
   const needle = q.trim().toLowerCase();
   if (!needle) return true;
   if (String(netuid).includes(needle)) return true;
@@ -242,8 +238,7 @@ function WeightSettingLeaderboard({
         ({
           ...prev,
           weightsSort: field,
-          weightsOrder:
-            prev.weightsSort === field && prev.weightsOrder === "desc" ? "asc" : "desc",
+          weightsOrder: prev.weightsSort === field && prev.weightsOrder === "desc" ? "asc" : "desc",
         }) as never,
       replace: true,
     });
@@ -318,7 +313,10 @@ function WeightSettingLeaderboard({
           lastChecked={board.observed_at ?? undefined}
         />
       ) : rows.length === 0 ? (
-        <EmptyState title="No subnets match this filter" description={`No weight-setting rows for “${q.trim()}”.`} />
+        <EmptyState
+          title="No subnets match this filter"
+          description={`No weight-setting rows for “${q.trim()}”.`}
+        />
       ) : (
         <section className="rounded-lg border border-border bg-card">
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -40,6 +40,9 @@ const leaderboardsSearchSchema = z.object({
   window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
   q: fallback(z.string(), "").default(""),
   density: fallback(z.enum(["comfortable", "compact"]), "comfortable").default("comfortable"),
+  // Exclusive saved-view focus so Weights·7d and Dereg·7d don't both light up
+  // when both boards sit on their default sorts (#5344).
+  focus: fallback(z.enum(["", "weights", "deregistrations"]), "").default(""),
   weightsSort: fallback(z.enum(WEIGHTS_SORT), "weight_sets").default("weight_sets"),
   weightsOrder: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
   deregSort: fallback(z.enum(DEREG_SORT), "deregistrations").default("deregistrations"),
@@ -104,19 +107,20 @@ function LeaderboardsPage() {
   return (
     <AppShell>
       <PageHero
+        className="mb-6 md:mb-10"
         eyebrow="Explorer"
         live
         title="Leaderboards"
         description="Network-wide chain activity boards — ranked by subnet from live chain-direct analytics."
         actions={
-          <>
+          <div className="flex flex-wrap items-center gap-2">
             <DensityToggle value={effectiveDensity} onChange={setDensity} />
             <ShareButton />
-          </>
+          </div>
         }
       />
       <LeaderboardsSavedViews />
-      <div className="mb-6 flex flex-wrap items-center gap-2">
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
         <SearchInput
           value={q}
           onChange={(v) =>
@@ -127,9 +131,9 @@ function LeaderboardsPage() {
             })
           }
           placeholder="Filter by subnet name or netuid…"
-          className="max-w-xs"
+          className="w-full min-w-0 sm:max-w-xs sm:flex-1"
         />
-        <div className="ml-auto flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
           <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
             Window
           </span>
@@ -266,7 +270,7 @@ function WeightSettingLeaderboard({
   }, [board.subnets, subnetById, q, sort, order]);
 
   return (
-    <div className="space-y-8">
+    <div id="weights-board" className="space-y-8 scroll-mt-20">
       <div>
         <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
           Weight-setting activity
@@ -512,7 +516,7 @@ function DeregistrationsLeaderboard({
   }, [board.subnets, subnetById, q, sort, order]);
 
   return (
-    <div className="space-y-8">
+    <div id="deregistrations-board" className="space-y-8 scroll-mt-20">
       <div>
         <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
           Deregistrations

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -8,20 +8,47 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { PageHero, BrandIcon, TimeAgo, StatTile } from "@jsonbored/ui-kit";
+import {
+  PageHero,
+  BrandIcon,
+  TimeAgo,
+  StatTile,
+  DensityToggle,
+  ShareButton,
+  type Density,
+} from "@jsonbored/ui-kit";
+import { ariaSort, SearchInput, SortHeader } from "@/components/metagraphed/table-controls";
+import { LeaderboardsSavedViews } from "@/components/metagraphed/leaderboards-saved-views";
 import {
   chainDeregistrationsQuery,
   chainWeightsQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { useIsMobile } from "@/hooks/use-mobile";
 import type { Subnet } from "@/lib/metagraphed/types";
+
+const WEIGHTS_SORT = ["netuid", "weight_sets", "distinct_setters", "sets_per_setter"] as const;
+const DEREG_SORT = [
+  "netuid",
+  "deregistrations",
+  "distinct_deregistered_hotkeys",
+  "deregistrations_per_hotkey",
+] as const;
 
 const leaderboardsSearchSchema = z.object({
   window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+  q: fallback(z.string(), "").default(""),
+  density: fallback(z.enum(["comfortable", "compact"]), "comfortable").default("comfortable"),
+  weightsSort: fallback(z.enum(WEIGHTS_SORT), "weight_sets").default("weight_sets"),
+  weightsOrder: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
+  deregSort: fallback(z.enum(DEREG_SORT), "deregistrations").default("deregistrations"),
+  deregOrder: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
 });
 
 type LeaderboardWindow = z.infer<typeof leaderboardsSearchSchema>["window"];
+type WeightsSort = (typeof WEIGHTS_SORT)[number];
+type DeregSort = (typeof DEREG_SORT)[number];
 
 export const Route = createFileRoute("/leaderboards")({
   validateSearch: zodValidator(leaderboardsSearchSchema),
@@ -44,7 +71,6 @@ export const Route = createFileRoute("/leaderboards")({
   component: LeaderboardsPage,
 });
 
-const TH = "px-4 py-2.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
 const WINDOW_BTN_ACTIVE =
   "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent";
 const WINDOW_BTN =
@@ -55,7 +81,25 @@ const WINDOW_BTN =
 function LeaderboardsPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
-  const win = search.window;
+  const isMobile = useIsMobile();
+  const win = search.window as LeaderboardWindow;
+  const q = typeof search.q === "string" ? search.q : "";
+  const weightsSort = (search.weightsSort as WeightsSort) ?? "weight_sets";
+  const weightsOrder = search.weightsOrder === "asc" ? "asc" : "desc";
+  const deregSort = (search.deregSort as DeregSort) ?? "deregistrations";
+  const deregOrder = search.deregOrder === "asc" ? "asc" : "desc";
+  const effectiveDensity: Density =
+    search.density === "compact" || search.density === "comfortable"
+      ? search.density
+      : isMobile
+        ? "compact"
+        : "comfortable";
+
+  const setDensity = (d: Density) =>
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, density: d }) as never,
+      replace: true,
+    });
 
   return (
     <AppShell>
@@ -64,31 +108,68 @@ function LeaderboardsPage() {
         live
         title="Leaderboards"
         description="Network-wide chain activity boards — ranked by subnet from live chain-direct analytics."
+        actions={
+          <>
+            <DensityToggle value={effectiveDensity} onChange={setDensity} />
+            <ShareButton />
+          </>
+        }
       />
-      <div className="flex flex-wrap items-center justify-end gap-2">
-        <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Window
-        </span>
-        {(["7d", "30d"] as const).map((w) => (
-          <button
-            key={w}
-            type="button"
-            onClick={() => navigate({ search: { window: w } })}
-            className={w === win ? WINDOW_BTN_ACTIVE : WINDOW_BTN}
-          >
-            {w}
-          </button>
-        ))}
+      <LeaderboardsSavedViews />
+      <div className="mb-6 flex flex-wrap items-center gap-2">
+        <SearchInput
+          value={q}
+          onChange={(v) =>
+            navigate({
+              search: (prev: Record<string, unknown>) => ({ ...prev, q: v }) as never,
+              replace: true,
+              resetScroll: false,
+            })
+          }
+          placeholder="Filter by subnet name or netuid…"
+          className="max-w-xs"
+        />
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Window
+          </span>
+          {(["7d", "30d"] as const).map((w) => (
+            <button
+              key={w}
+              type="button"
+              onClick={() =>
+                navigate({
+                  search: (prev: Record<string, unknown>) => ({ ...prev, window: w }) as never,
+                })
+              }
+              className={w === win ? WINDOW_BTN_ACTIVE : WINDOW_BTN}
+            >
+              {w}
+            </button>
+          ))}
+        </div>
       </div>
       <div className="space-y-12">
         <QueryErrorBoundary>
           <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
-            <WeightSettingLeaderboard win={win} />
+            <WeightSettingLeaderboard
+              win={win}
+              q={q}
+              density={effectiveDensity}
+              sort={weightsSort}
+              order={weightsOrder}
+            />
           </Suspense>
         </QueryErrorBoundary>
         <QueryErrorBoundary>
           <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
-            <DeregistrationsLeaderboard win={win} />
+            <DeregistrationsLeaderboard
+              win={win}
+              q={q}
+              density={effectiveDensity}
+              sort={deregSort}
+              order={deregOrder}
+            />
           </Suspense>
         </QueryErrorBoundary>
       </div>
@@ -108,12 +189,81 @@ function useSubnetById(): Map<number, Subnet> {
   }, [snRes]);
 }
 
-function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
+function matchesSubnetFilter(
+  netuid: number,
+  subnet: Subnet | undefined,
+  q: string,
+): boolean {
+  const needle = q.trim().toLowerCase();
+  if (!needle) return true;
+  if (String(netuid).includes(needle)) return true;
+  const name = (subnet?.name ?? "").toLowerCase();
+  const slug = (typeof subnet?.slug === "string" ? subnet.slug : "").toLowerCase();
+  return name.includes(needle) || slug.includes(needle);
+}
+
+function cmpNum(a: number | null | undefined, b: number | null | undefined, order: "asc" | "desc") {
+  const av = a ?? Number.NEGATIVE_INFINITY;
+  const bv = b ?? Number.NEGATIVE_INFINITY;
+  return order === "asc" ? av - bv : bv - av;
+}
+
+function WeightSettingLeaderboard({
+  win,
+  q,
+  density,
+  sort,
+  order,
+}: {
+  win: LeaderboardWindow;
+  q: string;
+  density: Density;
+  sort: WeightsSort;
+  order: "asc" | "desc";
+}) {
+  const navigate = useNavigate({ from: Route.fullPath });
   const { data: boardRes } = useSuspenseQuery(chainWeightsQuery(win));
   const subnetById = useSubnetById();
   const board = boardRes.data;
   const network = board.network;
   const dist = board.intensity_distribution;
+  const compact = density === "compact";
+  const cellPad = compact ? "px-3 py-1.5" : "px-4 py-2.5";
+  const monoSize = compact ? "text-[10px]" : "text-[11px]";
+
+  const onSort = (field: string) => {
+    if (!(WEIGHTS_SORT as readonly string[]).includes(field)) return;
+    navigate({
+      search: (prev: { weightsSort?: string; weightsOrder?: "asc" | "desc" }) =>
+        ({
+          ...prev,
+          weightsSort: field,
+          weightsOrder:
+            prev.weightsSort === field && prev.weightsOrder === "desc" ? "asc" : "desc",
+        }) as never,
+      replace: true,
+    });
+  };
+
+  const rows = useMemo(() => {
+    const filtered = board.subnets.filter((row) =>
+      matchesSubnetFilter(row.netuid, subnetById.get(row.netuid), q),
+    );
+    const sorted = [...filtered].sort((a, b) => {
+      switch (sort) {
+        case "netuid":
+          return cmpNum(a.netuid, b.netuid, order);
+        case "distinct_setters":
+          return cmpNum(a.distinct_setters, b.distinct_setters, order);
+        case "sets_per_setter":
+          return cmpNum(a.sets_per_setter, b.sets_per_setter, order);
+        case "weight_sets":
+        default:
+          return cmpNum(a.weight_sets, b.weight_sets, order);
+      }
+    });
+    return sorted;
+  }, [board.subnets, subnetById, q, sort, order]);
 
   return (
     <div className="space-y-8">
@@ -163,6 +313,8 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
           description="The chain poller has not indexed any WeightsSet events for this window yet, or no validators set weights."
           lastChecked={board.observed_at ?? undefined}
         />
+      ) : rows.length === 0 ? (
+        <EmptyState title="No subnets match this filter" description={`No weight-setting rows for “${q.trim()}”.`} />
       ) : (
         <section className="rounded-lg border border-border bg-card">
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
@@ -170,7 +322,8 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
               Per-subnet rankings
             </span>
             <span className="font-mono text-[11px] text-ink-muted">
-              {formatNumber(board.subnet_count)} subnets
+              {formatNumber(rows.length)}
+              {q.trim() ? ` of ${formatNumber(board.subnet_count)}` : ""} subnets
               {board.observed_at ? (
                 <>
                   {" "}
@@ -181,32 +334,82 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
           </div>
           <div className="overflow-x-auto">
             <table className="w-full text-left text-sm">
-              <thead>
+              <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
                 <tr>
-                  <th className={TH}>Rank</th>
-                  <th className={TH}>Subnet</th>
-                  <th className={`${TH} text-right`}>Weight-sets</th>
-                  <th className={`${TH} text-right`}>Distinct setters</th>
-                  <th className={`${TH} text-right`}>Per setter</th>
+                  <th className={cellPad}>Rank</th>
+                  <th className={cellPad} aria-sort={ariaSort(sort === "netuid", order)}>
+                    <SortHeader
+                      label="Subnet"
+                      field="netuid"
+                      active={sort === "netuid"}
+                      order={order}
+                      onSort={onSort}
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(sort === "weight_sets", order)}
+                  >
+                    <SortHeader
+                      label="Weight-sets"
+                      field="weight_sets"
+                      active={sort === "weight_sets"}
+                      order={order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(sort === "distinct_setters", order)}
+                  >
+                    <SortHeader
+                      label="Distinct setters"
+                      field="distinct_setters"
+                      active={sort === "distinct_setters"}
+                      order={order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(sort === "sets_per_setter", order)}
+                  >
+                    <SortHeader
+                      label="Per setter"
+                      field="sets_per_setter"
+                      active={sort === "sets_per_setter"}
+                      order={order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
-                {board.subnets.map((row, i) => {
+                {rows.map((row, i) => {
                   const subnet = subnetById.get(row.netuid);
                   const name = subnet?.name ?? `Subnet ${row.netuid}`;
                   return (
-                    <tr key={row.netuid} className="hover:bg-surface/40">
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    <tr key={row.netuid} className="mg-row-accent hover:bg-surface/40">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-muted",
+                          monoSize,
+                        )}
+                      >
                         {i + 1}
                       </td>
-                      <td className="px-4 py-2.5">
+                      <td className={cellPad}>
                         <Link
                           to="/subnets/$netuid"
                           params={{ netuid: row.netuid }}
                           className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
                         >
                           <BrandIcon
-                            size={18}
+                            size={compact ? 16 : 18}
                             name={name}
                             fallback={row.netuid}
                             netuid={row.netuid}
@@ -215,13 +418,31 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
                           <span className="truncate text-sm text-ink-strong">{name}</span>
                         </Link>
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-strong",
+                          monoSize,
+                        )}
+                      >
                         {formatNumber(row.weight_sets)}
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-muted",
+                          monoSize,
+                        )}
+                      >
                         {formatNumber(row.distinct_setters)}
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-muted",
+                          monoSize,
+                        )}
+                      >
                         {row.sets_per_setter != null ? row.sets_per_setter.toFixed(2) : "—"}
                       </td>
                     </tr>
@@ -236,11 +457,59 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
   );
 }
 
-function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
+function DeregistrationsLeaderboard({
+  win,
+  q,
+  density,
+  sort,
+  order,
+}: {
+  win: LeaderboardWindow;
+  q: string;
+  density: Density;
+  sort: DeregSort;
+  order: "asc" | "desc";
+}) {
+  const navigate = useNavigate({ from: Route.fullPath });
   const { data: boardRes } = useSuspenseQuery(chainDeregistrationsQuery(win));
   const subnetById = useSubnetById();
   const board = boardRes.data;
   const network = board.network;
+  const compact = density === "compact";
+  const cellPad = compact ? "px-3 py-1.5" : "px-4 py-2.5";
+  const monoSize = compact ? "text-[10px]" : "text-[11px]";
+
+  const onSort = (field: string) => {
+    if (!(DEREG_SORT as readonly string[]).includes(field)) return;
+    navigate({
+      search: (prev: { deregSort?: string; deregOrder?: "asc" | "desc" }) =>
+        ({
+          ...prev,
+          deregSort: field,
+          deregOrder: prev.deregSort === field && prev.deregOrder === "desc" ? "asc" : "desc",
+        }) as never,
+      replace: true,
+    });
+  };
+
+  const rows = useMemo(() => {
+    const filtered = board.subnets.filter((row) =>
+      matchesSubnetFilter(row.netuid, subnetById.get(row.netuid), q),
+    );
+    return [...filtered].sort((a, b) => {
+      switch (sort) {
+        case "netuid":
+          return cmpNum(a.netuid, b.netuid, order);
+        case "distinct_deregistered_hotkeys":
+          return cmpNum(a.distinct_deregistered_hotkeys, b.distinct_deregistered_hotkeys, order);
+        case "deregistrations_per_hotkey":
+          return cmpNum(a.deregistrations_per_hotkey, b.deregistrations_per_hotkey, order);
+        case "deregistrations":
+        default:
+          return cmpNum(a.deregistrations, b.deregistrations, order);
+      }
+    });
+  }, [board.subnets, subnetById, q, sort, order]);
 
   return (
     <div className="space-y-8">
@@ -286,6 +555,11 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
           description="The chain poller has not indexed any NeuronDeregistered events for this window yet, or eviction activity was zero."
           lastChecked={board.observed_at ?? undefined}
         />
+      ) : rows.length === 0 ? (
+        <EmptyState
+          title="No subnets match this filter"
+          description={`No deregistration rows for “${q.trim()}”.`}
+        />
       ) : (
         <section className="rounded-lg border border-border bg-card">
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
@@ -293,7 +567,8 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
               Per-subnet rankings
             </span>
             <span className="font-mono text-[11px] text-ink-muted">
-              {formatNumber(board.subnet_count)} subnets
+              {formatNumber(rows.length)}
+              {q.trim() ? ` of ${formatNumber(board.subnet_count)}` : ""} subnets
               {board.observed_at ? (
                 <>
                   {" "}
@@ -304,32 +579,82 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
           </div>
           <div className="overflow-x-auto">
             <table className="w-full text-left text-sm">
-              <thead>
+              <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
                 <tr>
-                  <th className={TH}>Rank</th>
-                  <th className={TH}>Subnet</th>
-                  <th className={`${TH} text-right`}>Deregistrations</th>
-                  <th className={`${TH} text-right`}>Distinct hotkeys</th>
-                  <th className={`${TH} text-right`}>Per hotkey</th>
+                  <th className={cellPad}>Rank</th>
+                  <th className={cellPad} aria-sort={ariaSort(sort === "netuid", order)}>
+                    <SortHeader
+                      label="Subnet"
+                      field="netuid"
+                      active={sort === "netuid"}
+                      order={order}
+                      onSort={onSort}
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(sort === "deregistrations", order)}
+                  >
+                    <SortHeader
+                      label="Deregistrations"
+                      field="deregistrations"
+                      active={sort === "deregistrations"}
+                      order={order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(sort === "distinct_deregistered_hotkeys", order)}
+                  >
+                    <SortHeader
+                      label="Distinct hotkeys"
+                      field="distinct_deregistered_hotkeys"
+                      active={sort === "distinct_deregistered_hotkeys"}
+                      order={order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(sort === "deregistrations_per_hotkey", order)}
+                  >
+                    <SortHeader
+                      label="Per hotkey"
+                      field="deregistrations_per_hotkey"
+                      active={sort === "deregistrations_per_hotkey"}
+                      order={order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
-                {board.subnets.map((row, i) => {
+                {rows.map((row, i) => {
                   const subnet = subnetById.get(row.netuid);
                   const name = subnet?.name ?? `Subnet ${row.netuid}`;
                   return (
-                    <tr key={row.netuid} className="hover:bg-surface/40">
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    <tr key={row.netuid} className="mg-row-accent hover:bg-surface/40">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-muted",
+                          monoSize,
+                        )}
+                      >
                         {i + 1}
                       </td>
-                      <td className="px-4 py-2.5">
+                      <td className={cellPad}>
                         <Link
                           to="/subnets/$netuid"
                           params={{ netuid: row.netuid }}
                           className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
                         >
                           <BrandIcon
-                            size={18}
+                            size={compact ? 16 : 18}
                             name={name}
                             fallback={row.netuid}
                             netuid={row.netuid}
@@ -338,13 +663,31 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
                           <span className="truncate text-sm text-ink-strong">{name}</span>
                         </Link>
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-strong",
+                          monoSize,
+                        )}
+                      >
                         {formatNumber(row.deregistrations)}
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-muted",
+                          monoSize,
+                        )}
+                      >
                         {formatNumber(row.distinct_deregistered_hotkeys)}
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-muted",
+                          monoSize,
+                        )}
+                      >
                         {row.deregistrations_per_hotkey != null
                           ? row.deregistrations_per_hotkey.toFixed(2)
                           : "—"}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -1,31 +1,27 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
+import { Suspense, useMemo } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { PageHero, ShareButton } from "@jsonbored/ui-kit";
+import { DensityToggle, PageHero, ShareButton, type Density } from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { ariaSort, SortHeader } from "@/components/metagraphed/table-controls";
+import { ValidatorsSavedViews } from "@/components/metagraphed/validators-saved-views";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
-import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
-import {
-  annualizedDelegatorApyPct,
-  formatApyPct,
-  formatTakePct,
-} from "@/lib/metagraphed/validator-apy";
-import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
+import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
+import { useIsMobile } from "@/hooks/use-mobile";
+import type { GlobalValidator, GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 // The full GlobalValidatorSort set the /api/v1/validators endpoint accepts.
-// Stake / emission / dominance / trust get their own columns in #3359; this
-// baseline page only renders hotkey identity + subnet/UID counts (#3360 adds the
-// dedicated active-subnet column), but every sort key stays selectable.
 const validatorSortKeys = [
   "subnet_count",
   "uid_count",
@@ -48,6 +44,10 @@ const SORT_LABELS: Record<GlobalValidatorSort, string> = {
 
 const validatorsSearchSchema = z.object({
   sort: fallback(z.enum(validatorSortKeys), "subnet_count").default("subnet_count"),
+  // API ranks desc for every sort key; URL-backed order flips client-side so
+  // SortHeader matches the Subnets asc/desc toggle model (#5344).
+  order: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
+  density: fallback(z.enum(["comfortable", "compact"]), "comfortable").default("comfortable"),
 });
 
 export const Route = createFileRoute("/validators/")({
@@ -73,7 +73,35 @@ export const Route = createFileRoute("/validators/")({
 function ValidatorsPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
-  const sort = search.sort ?? "subnet_count";
+  const isMobile = useIsMobile();
+  const sort = (search.sort as GlobalValidatorSort) ?? "subnet_count";
+  const order = search.order === "asc" ? "asc" : "desc";
+  const effectiveDensity: Density =
+    search.density === "compact" || search.density === "comfortable"
+      ? search.density
+      : isMobile
+        ? "compact"
+        : "comfortable";
+
+  const setDensity = (d: Density) =>
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, density: d }) as never,
+      replace: true,
+    });
+
+  const onSort = (field: string) => {
+    if (!(validatorSortKeys as readonly string[]).includes(field)) return;
+    navigate({
+      search: (prev: { sort?: string; order?: "asc" | "desc" }) =>
+        ({
+          ...prev,
+          sort: field,
+          order: prev.sort === field && prev.order === "desc" ? "asc" : "desc",
+        }) as never,
+      replace: true,
+    });
+  };
+
   return (
     <AppShell>
       <PageHero
@@ -81,20 +109,18 @@ function ValidatorsPage() {
         live
         title="Validators"
         description="Network-wide validator directory — hotkeys ranked across all Bittensor subnets, computed live from the chain-direct metagraph."
-        actions={<ShareButton />}
+        actions={
+          <>
+            <DensityToggle value={effectiveDensity} onChange={setDensity} />
+            <ShareButton />
+          </>
+        }
       />
       <ValidatorGuide />
+      <ValidatorsSavedViews />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>
-          <ValidatorsTable
-            sort={sort}
-            onSortChange={(v) =>
-              navigate({
-                search: (prev: Record<string, unknown>) => ({ ...prev, sort: v }) as never,
-                replace: true,
-              })
-            }
-          />
+          <ValidatorsTable sort={sort} order={order} density={effectiveDensity} onSort={onSort} />
         </Suspense>
       </QueryErrorBoundary>
       <div className="mt-6" id="validator-subnet-heatmap">
@@ -109,44 +135,28 @@ function ValidatorsPage() {
   );
 }
 
-const TH = "px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted";
-
-function SortSelect({
-  value,
-  onChange,
-}: {
-  value: GlobalValidatorSort;
-  onChange: (v: GlobalValidatorSort) => void;
-}) {
-  return (
-    <label className="inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs">
-      <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">Sort</span>
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value as GlobalValidatorSort)}
-        className="bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        aria-label="Sort validators"
-      >
-        {validatorSortKeys.map((k) => (
-          <option key={k} value={k}>
-            {SORT_LABELS[k]}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
 function ValidatorsTable({
   sort,
-  onSortChange,
+  order,
+  density,
+  onSort,
 }: {
   sort: GlobalValidatorSort;
-  onSortChange: (v: GlobalValidatorSort) => void;
+  order: "asc" | "desc";
+  density: Density;
+  onSort: (field: string) => void;
 }) {
   const res = useSuspenseQuery(validatorsQuery({ sort })).data;
-  const validators = res.data.validators;
   const generatedAt = res.meta?.generated_at ?? null;
+  // API always returns the active sort descending; reverse when the URL asks for asc.
+  const validators = useMemo(() => {
+    const rows = res.data.validators;
+    return order === "asc" ? [...rows].reverse() : rows;
+  }, [res.data.validators, order]);
+
+  const compact = density === "compact";
+  const cellPad = compact ? "px-2 py-1.5" : "px-3 py-2";
+  const monoSize = compact ? "text-[10px]" : "text-[11px]";
 
   return (
     <div className="space-y-3">
@@ -159,82 +169,118 @@ function ValidatorsTable({
 
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span className="font-mono text-[11px] text-ink-muted">
-          {formatNumber(validators.length)} validators · ranked by {SORT_LABELS[sort]}
+          {formatNumber(validators.length)} validators · ranked by {SORT_LABELS[sort]} (
+          {order})
         </span>
-        <SortSelect value={sort} onChange={onSortChange} />
       </div>
 
       {validators.length > 0 ? (
         <div className="overflow-x-auto rounded-lg border border-border">
           <table className="w-full text-left text-sm">
-            <thead className="bg-surface/50">
+            <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
               <tr>
-                <th className={TH}>Operator</th>
-                <th className={TH}>Hotkey</th>
-                <th className={TH}>Coldkey</th>
-                <th className={`${TH} text-right`}>Take</th>
-                <th className={`${TH} text-right`}>Est. APY</th>
-                <th className={`${TH} text-right`}>Active subnets</th>
-                <th className={`${TH} text-right`}>UIDs</th>
-                <th className={`${TH} text-right`}>Nominators</th>
-                <th className={`${TH} text-right`}>Dominance</th>
-                <th className={`${TH} text-right`}>Total stake</th>
-                <th className={`${TH} text-right`}>Total emission</th>
-                <th className={`${TH} text-right`}>Est. APY</th>
+                <th className={cellPad}>Operator</th>
+                <th className={cellPad}>Hotkey</th>
+                <th className={cellPad}>Coldkey</th>
+                <th className={classNames(cellPad, "text-right")}>Take</th>
+                <th className={classNames(cellPad, "text-right")}>Est. APY</th>
+                <th
+                  className={classNames(cellPad, "text-right")}
+                  aria-sort={ariaSort(sort === "subnet_count", order)}
+                >
+                  <SortHeader
+                    label="Active subnets"
+                    field="subnet_count"
+                    active={sort === "subnet_count"}
+                    order={order}
+                    onSort={onSort}
+                    align="right"
+                  />
+                </th>
+                <th
+                  className={classNames(cellPad, "text-right")}
+                  aria-sort={ariaSort(sort === "uid_count", order)}
+                >
+                  <SortHeader
+                    label="UIDs"
+                    field="uid_count"
+                    active={sort === "uid_count"}
+                    order={order}
+                    onSort={onSort}
+                    align="right"
+                  />
+                </th>
+                <th className={classNames(cellPad, "text-right")}>Nominators</th>
+                <th
+                  className={classNames(cellPad, "text-right")}
+                  aria-sort={ariaSort(sort === "stake_dominance", order)}
+                >
+                  <SortHeader
+                    label="Dominance"
+                    field="stake_dominance"
+                    active={sort === "stake_dominance"}
+                    order={order}
+                    onSort={onSort}
+                    align="right"
+                  />
+                </th>
+                <th
+                  className={classNames(cellPad, "text-right")}
+                  aria-sort={ariaSort(sort === "total_stake", order)}
+                >
+                  <SortHeader
+                    label="Total stake"
+                    field="total_stake"
+                    active={sort === "total_stake"}
+                    order={order}
+                    onSort={onSort}
+                    align="right"
+                  />
+                </th>
+                <th
+                  className={classNames(cellPad, "text-right")}
+                  aria-sort={ariaSort(sort === "total_emission", order)}
+                >
+                  <SortHeader
+                    label="Total emission"
+                    field="total_emission"
+                    active={sort === "total_emission"}
+                    order={order}
+                    onSort={onSort}
+                    align="right"
+                  />
+                </th>
+                <th
+                  className={classNames(cellPad, "text-right")}
+                  aria-sort={ariaSort(sort === "avg_validator_trust", order)}
+                >
+                  <SortHeader
+                    label="Avg trust"
+                    field="avg_validator_trust"
+                    active={sort === "avg_validator_trust"}
+                    order={order}
+                    onSort={onSort}
+                    align="right"
+                  />
+                </th>
+                <th
+                  className={classNames(cellPad, "text-right")}
+                  aria-sort={ariaSort(sort === "max_validator_trust", order)}
+                >
+                  <SortHeader
+                    label="Max trust"
+                    field="max_validator_trust"
+                    active={sort === "max_validator_trust"}
+                    order={order}
+                    onSort={onSort}
+                    align="right"
+                  />
+                </th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
               {validators.map((v) => (
-                <tr key={v.hotkey} className="hover:bg-surface/40">
-                  <td className="px-3 py-2 font-mono text-[11px]">
-                    <div className="flex items-center gap-1.5">
-                      {v.featured ? <FeaturedBadge /> : null}
-                      <Link
-                        to="/validators/$hotkey"
-                        params={{ hotkey: v.hotkey }}
-                        className="text-ink-strong hover:text-accent hover:underline"
-                        title={v.hotkey}
-                      >
-                        {shortHash(v.hotkey) ?? v.hotkey}
-                      </Link>
-                    </div>
-                  </td>
-                  <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
-                    {v.coldkey ? (
-                      <Link
-                        to="/accounts/$ss58"
-                        params={{ ss58: v.coldkey }}
-                        className="hover:text-accent hover:underline"
-                        title={v.coldkey}
-                      >
-                        {shortHash(v.coldkey) ?? v.coldkey}
-                      </Link>
-                    ) : (
-                      "—"
-                    )}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {formatNumber(v.subnet_count)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {formatNumber(v.uid_count)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {v.nominator_count != null ? formatNumber(v.nominator_count) : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                    {taoCompact(v.total_stake_tao)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {taoCompact(v.total_emission_tao)}
-                  </td>
-                  <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                    {v.apy_estimate != null ? `${(v.apy_estimate * 100).toFixed(1)}%` : "—"}
-                  </td>
-                </tr>
+                <ValidatorRow key={v.hotkey} v={v} cellPad={cellPad} monoSize={monoSize} />
               ))}
             </tbody>
           </table>
@@ -246,5 +292,147 @@ function ValidatorsTable({
         />
       )}
     </div>
+  );
+}
+
+function ValidatorRow({
+  v,
+  cellPad,
+  monoSize,
+}: {
+  v: GlobalValidator;
+  cellPad: string;
+  monoSize: string;
+}) {
+  const apyPct = v.apy_estimate != null ? v.apy_estimate * 100 : null;
+  return (
+    <tr className="mg-row-accent hover:bg-surface/40">
+      <td className={cellPad}>
+        <div className="flex items-center gap-1.5 min-w-0">
+          {v.featured ? <FeaturedBadge /> : null}
+          <Link
+            to="/validators/$hotkey"
+            params={{ hotkey: v.hotkey }}
+            className="min-w-0 hover:text-accent"
+          >
+            <ValidatorIdentityChip hotkey={v.hotkey} identity={v.coldkey_identity} size={22} />
+          </Link>
+        </div>
+      </td>
+      <td className={classNames(cellPad, "font-mono text-ink-muted", monoSize)}>
+        <Link
+          to="/validators/$hotkey"
+          params={{ hotkey: v.hotkey }}
+          className="text-ink-strong hover:text-accent hover:underline"
+          title={v.hotkey}
+        >
+          {shortHash(v.hotkey) ?? v.hotkey}
+        </Link>
+      </td>
+      <td className={classNames(cellPad, "font-mono text-ink-muted", monoSize)}>
+        {v.coldkey ? (
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: v.coldkey }}
+            className="hover:text-accent hover:underline"
+            title={v.coldkey}
+          >
+            {shortHash(v.coldkey) ?? v.coldkey}
+          </Link>
+        ) : (
+          "—"
+        )}
+      </td>
+      <td
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink",
+          monoSize,
+        )}
+      >
+        {formatTakePct(v.take)}
+      </td>
+      <td
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink",
+          monoSize,
+        )}
+      >
+        {formatApyPct(apyPct)}
+      </td>
+      <td
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink",
+          monoSize,
+        )}
+      >
+        {formatNumber(v.subnet_count)}
+      </td>
+      <td
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink-muted",
+          monoSize,
+        )}
+      >
+        {formatNumber(v.uid_count)}
+      </td>
+      <td
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink-muted",
+          monoSize,
+        )}
+      >
+        {v.nominator_count != null ? formatNumber(v.nominator_count) : "—"}
+      </td>
+      <td
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink",
+          monoSize,
+        )}
+      >
+        {v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"}
+      </td>
+      <td
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink",
+          monoSize,
+        )}
+      >
+        {taoCompact(v.total_stake_tao)}
+      </td>
+      <td
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink-muted",
+          monoSize,
+        )}
+      >
+        {taoCompact(v.total_emission_tao)}
+      </td>
+      <td
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink-muted",
+          monoSize,
+        )}
+      >
+        {v.avg_validator_trust != null ? v.avg_validator_trust.toFixed(3) : "—"}
+      </td>
+      <td
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink-muted",
+          monoSize,
+        )}
+      >
+        {v.max_validator_trust != null ? v.max_validator_trust.toFixed(3) : "—"}
+      </td>
+    </tr>
   );
 }

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -360,12 +360,20 @@ function ValidatorRow({
         {formatNumber(v.subnet_count)}
       </td>
       <td
-        className={classNames(cellPad, "text-right font-mono tabular-nums text-ink-muted", monoSize)}
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink-muted",
+          monoSize,
+        )}
       >
         {formatNumber(v.uid_count)}
       </td>
       <td
-        className={classNames(cellPad, "text-right font-mono tabular-nums text-ink-muted", monoSize)}
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink-muted",
+          monoSize,
+        )}
       >
         {v.nominator_count != null ? formatNumber(v.nominator_count) : "—"}
       </td>
@@ -376,17 +384,29 @@ function ValidatorRow({
         {taoCompact(v.total_stake_tao)}
       </td>
       <td
-        className={classNames(cellPad, "text-right font-mono tabular-nums text-ink-muted", monoSize)}
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink-muted",
+          monoSize,
+        )}
       >
         {taoCompact(v.total_emission_tao)}
       </td>
       <td
-        className={classNames(cellPad, "text-right font-mono tabular-nums text-ink-muted", monoSize)}
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink-muted",
+          monoSize,
+        )}
       >
         {v.avg_validator_trust != null ? v.avg_validator_trust.toFixed(3) : "—"}
       </td>
       <td
-        className={classNames(cellPad, "text-right font-mono tabular-nums text-ink-muted", monoSize)}
+        className={classNames(
+          cellPad,
+          "text-right font-mono tabular-nums text-ink-muted",
+          monoSize,
+        )}
       >
         {v.max_validator_trust != null ? v.max_validator_trust.toFixed(3) : "—"}
       </td>

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -170,8 +170,7 @@ function ValidatorsTable({
 
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span className="font-mono text-[11px] text-ink-muted">
-          {formatNumber(validators.length)} validators · ranked by {SORT_LABELS[sort]} (
-          {order})
+          {formatNumber(validators.length)} validators · ranked by {SORT_LABELS[sort]} ({order})
         </span>
       </div>
 
@@ -351,93 +350,43 @@ function ValidatorRow({
           "—"
         )}
       </td>
-      <td
-        className={classNames(
-          cellPad,
-          "text-right font-mono tabular-nums text-ink",
-          monoSize,
-        )}
-      >
+      <td className={classNames(cellPad, "text-right font-mono tabular-nums text-ink", monoSize)}>
         {formatTakePct(v.take)}
       </td>
-      <td
-        className={classNames(
-          cellPad,
-          "text-right font-mono tabular-nums text-ink",
-          monoSize,
-        )}
-      >
+      <td className={classNames(cellPad, "text-right font-mono tabular-nums text-ink", monoSize)}>
         {formatApyPct(apyPct)}
       </td>
-      <td
-        className={classNames(
-          cellPad,
-          "text-right font-mono tabular-nums text-ink",
-          monoSize,
-        )}
-      >
+      <td className={classNames(cellPad, "text-right font-mono tabular-nums text-ink", monoSize)}>
         {formatNumber(v.subnet_count)}
       </td>
       <td
-        className={classNames(
-          cellPad,
-          "text-right font-mono tabular-nums text-ink-muted",
-          monoSize,
-        )}
+        className={classNames(cellPad, "text-right font-mono tabular-nums text-ink-muted", monoSize)}
       >
         {formatNumber(v.uid_count)}
       </td>
       <td
-        className={classNames(
-          cellPad,
-          "text-right font-mono tabular-nums text-ink-muted",
-          monoSize,
-        )}
+        className={classNames(cellPad, "text-right font-mono tabular-nums text-ink-muted", monoSize)}
       >
         {v.nominator_count != null ? formatNumber(v.nominator_count) : "—"}
       </td>
-      <td
-        className={classNames(
-          cellPad,
-          "text-right font-mono tabular-nums text-ink",
-          monoSize,
-        )}
-      >
+      <td className={classNames(cellPad, "text-right font-mono tabular-nums text-ink", monoSize)}>
         {v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"}
       </td>
-      <td
-        className={classNames(
-          cellPad,
-          "text-right font-mono tabular-nums text-ink",
-          monoSize,
-        )}
-      >
+      <td className={classNames(cellPad, "text-right font-mono tabular-nums text-ink", monoSize)}>
         {taoCompact(v.total_stake_tao)}
       </td>
       <td
-        className={classNames(
-          cellPad,
-          "text-right font-mono tabular-nums text-ink-muted",
-          monoSize,
-        )}
+        className={classNames(cellPad, "text-right font-mono tabular-nums text-ink-muted", monoSize)}
       >
         {taoCompact(v.total_emission_tao)}
       </td>
       <td
-        className={classNames(
-          cellPad,
-          "text-right font-mono tabular-nums text-ink-muted",
-          monoSize,
-        )}
+        className={classNames(cellPad, "text-right font-mono tabular-nums text-ink-muted", monoSize)}
       >
         {v.avg_validator_trust != null ? v.avg_validator_trust.toFixed(3) : "—"}
       </td>
       <td
-        className={classNames(
-          cellPad,
-          "text-right font-mono tabular-nums text-ink-muted",
-          monoSize,
-        )}
+        className={classNames(cellPad, "text-right font-mono tabular-nums text-ink-muted", monoSize)}
       >
         {v.max_validator_trust != null ? v.max_validator_trust.toFixed(3) : "—"}
       </td>


### PR DESCRIPTION
## Summary

- Canonical ranked-list model is Subnets': clickable `SortHeader` column headers + density toggle + saved-view presets.
- **Validators:** replaces the standalone `<select>` sort with URL-backed column header sorts (`sort`/`order`), a density toggle, and saved-view chips; also aligns Operator / Take / Est. APY / trust columns with the row cells.
- **Leaderboards:** adds the same controls — per-board sortable headers, density, subnet name/netuid filter, and saved-view presets for weight-set / deregistration rankings across 7d/30d.

Closes #5344

## Test plan

- [ ] `/validators` — click Active subnets / Stake / Trust headers; order toggles asc↔desc; density changes row padding
- [ ] `/validators` — saved-view chips update URL sort/order and highlight when active
- [ ] `/leaderboards` — sort Weight-sets / Deregistrations headers; density + filter by subnet name/netuid
- [ ] `/leaderboards` — saved views switch window + board sort presets
- [ ] `/subnets` unchanged (canonical reference)
- [x] eslint on changed files — 0 errors
- [x] prettier on changed files
- [x] `npm run typecheck --workspace=apps/ui`

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light · `/validators` | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/3edae010-5acc-4af5-804c-777db432eb5b" /> | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/e92e8793-fe3d-4313-9c75-f9fce4ab47dc" /> |
| Desktop · Dark · `/validators` | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/4a5ddf46-3afe-4988-8380-08927a76f711" /> | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/66241ae7-75da-402f-9df5-5ea1e891cac9" /> |
| Desktop · Light · `/leaderboards` | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/ee5106bb-c2ae-4faf-bf2a-674966d5e474" /> | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/e2a3184e-ba31-4981-87e4-1f3adcfb71a7" /> |
| Desktop · Dark · `/leaderboards` | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/63b1171d-cb80-4751-bfe4-421bbc3e4406" /> | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/a50ed4aa-d024-4a62-ab99-a48be039c653" /> |
| Tablet · Light · `/validators` | <img width="1001" height="805" alt="image" src="https://github.com/user-attachments/assets/331fb56e-4720-43b7-b393-c399c84edc4a" /> | <img width="1001" height="805" alt="image" src="https://github.com/user-attachments/assets/6d7f3996-f3c4-4901-94d9-e47ca032c0b0" /> |
| Tablet · Dark · `/validators` | <img width="1001" height="805" alt="image" src="https://github.com/user-attachments/assets/32c75b2c-0ce0-45f9-b37e-7d7783eaa11b" /> | <img width="1001" height="805" alt="image" src="https://github.com/user-attachments/assets/0e1551ae-de42-4f3d-8f0e-221e4d444447" /> |
| Tablet · Light · `/leaderboards` | <img width="1001" height="805" alt="image" src="https://github.com/user-attachments/assets/fe85f52e-51d3-42cf-92c2-210574dc39e3" /> | <img width="1001" height="805" alt="image" src="https://github.com/user-attachments/assets/cfabb81c-ce46-436b-b5fd-ea1dedc65038" /> |
| Tablet · Dark · `/leaderboards` | <img width="1001" height="805" alt="image" src="https://github.com/user-attachments/assets/5338355b-bd56-4abd-8549-1d496f73648e" /> | <img width="1001" height="805" alt="image" src="https://github.com/user-attachments/assets/5a65d6e3-6c00-4b8f-9bbb-53c7c31565ac" /> |
| Mobile · Light · `/validators` | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/a8a32d74-ebb1-4127-974f-195893a3c1bc" /> | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/9c613b24-c281-41ef-a1ba-e6c33f3e5bc7" /> |
| Mobile · Dark · `/validators` | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/07f81291-7bd2-44eb-acc5-a2e3288b867d" /> | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/beab236f-d6a4-4729-a993-65a00fdddd6b" /> |
| Mobile · Light · `/leaderboards` | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/ef9f6260-3fcf-46fe-b686-058be9f84eee" /> | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/9c613b24-c281-41ef-a1ba-e6c33f3e5bc7" /> |
| Mobile · Dark · `/leaderboards` | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/2fca819b-5fc4-490e-a19f-c39ee74717b0" /> | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/359d9a1d-6680-454d-b2fb-6159533ac214" /> |