### PR TITLE
feat(registry): add SN39 Basilica docs llms-full.txt data-artifact (#4041)

### DIFF
--- a/registry/subnets/basilica.json
+++ b/registry/subnets/basilica.json
@@ -147,6 +147,25 @@
         "https://github.com/one-covenant/basilica/blob/1a75c1cb7c62caabe929b280931f0e074e2757f2/crates/basilica-validator/tests/fixtures/lshw/a100_sxm5_30vcpu.json"
       ],
       "url": "https://raw.githubusercontent.com/one-covenant/basilica/1a75c1cb7c62caabe929b280931f0e074e2757f2/crates/basilica-validator/tests/fixtures/lshw/a100_sxm5_30vcpu.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-39-basilica-docs-llms-full-txt",
+      "kind": "data-artifact",
+      "name": "Basilica docs llms-full.txt index",
+      "notes": "Public no-auth machine-readable llms-full.txt full-text index of the official SN39 Basilica documentation, served at docs.basilica.ai (the same domain as the registered website basilica.ai, api.basilica.ai subnet-api, and docs.basilica.ai/miners docs surfaces). The document itself states 'netuid = 39' / 'subnet 39', self-identifying it as SN39's docs. An agent-consumable full-text Markdown map of the Basilica docs (GPU rental / verifiable compute), distinct from the docs.basilica.ai/miners HTML docs page already registered.",
+      "provider": "one-covenant",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://github.com/one-covenant/basilica",
+        "https://www.basilica.ai/"
+      ],
+      "url": "https://docs.basilica.ai/llms-full.txt"
     }
   ],
   "website_url": "https://www.basilica.ai/"


### PR DESCRIPTION
## Summary

Registers **SN39 Basilica**'s public **`llms-full.txt` documentation index** as a `data-artifact` surface — an agent-consumable, no-auth, machine-readable full-text map of the official Basilica docs (GPU rental / verifiable compute).

## Surface

- **kind:** `data-artifact`
- **url:** `https://docs.basilica.ai/llms-full.txt`
- **provider:** `one-covenant` (existing)
- `auth_required: false`, `public_safe: true`, `authority: community`, `review.state: community-submitted`

## Proof of ownership (airtight)

- The document itself states **`netuid = 39`** and **"subnet 39"**, self-identifying as SN39's documentation.
- Served from `docs.basilica.ai` — the same domain as SN39's registered `website` (basilica.ai), `subnet-api` (api.basilica.ai/health), and `docs` (docs.basilica.ai/miners) surfaces.
- `source_url`s: the registered `source_repo` (`one-covenant/basilica`) and `website_url` (basilica.ai).

## Verified live + public + safe

- `GET https://docs.basilica.ai/llms-full.txt` → **HTTP 200**, `text/plain; charset=utf-8`, ~114 KB, **no auth**.
- Public-safe: scanned the full body for SS58/base58 wallet or hotkey strings → **zero matches**; documentation text only.

## Non-duplication

Distinct from Basilica's existing surfaces — `source-repo`, `website`, `example`, the `docs` page `docs.basilica.ai/miners`, the `subnet-api` health endpoint, and the lshw data-artifact. This is a different URL: the full-docs machine-readable index. No open PR targets SN39.

## Scope note (relative to #4041)

#4041 asks for SN39 Basilica's OpenAPI/Swagger spec. Basilica publishes no standalone machine-readable OpenAPI JSON; this `llms-full.txt` is the agent-consumable machine-readable documentation surface it does publish — the concrete artifact behind the issue's intent.

## Validation (local)

- `npm run validate:surface -- registry/subnets/basilica.json` → passes (7 surfaces)
- `npm run validate:schemas` → passes
- `npx prettier --check registry/subnets/basilica.json` → clean
- `git diff --stat` → single file, 19-line pure append (no top-level metadata or other surfaces touched)

## Template Used

- Subnet surface

Closes #4041
