### PR TITLE
fix(ui): stop the provider hero repeating its slug as a subtitle

### DIFF
--- a/apps/ui/src/lib/metagraphed/provider-display.test.ts
+++ b/apps/ui/src/lib/metagraphed/provider-display.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { providerSlugSubtitle } from "./provider-display";
+
+describe("providerSlugSubtitle", () => {
+  it("hides the subtitle when name and slug are the same string case-insensitively", () => {
+    expect(providerSlugSubtitle("404-GEN", "404-gen")).toBeNull();
+    expect(providerSlugSubtitle("chutes", "chutes")).toBeNull();
+  });
+
+  it("shows the slug when the name meaningfully differs", () => {
+    expect(providerSlugSubtitle("Chutes AI", "chutes")).toBe("chutes");
+    expect(providerSlugSubtitle("404 GEN Labs", "404-gen")).toBe("404-gen");
+  });
+
+  it("hides the subtitle when there is no usable name (title falls back to slug)", () => {
+    expect(providerSlugSubtitle(null, "chutes")).toBeNull();
+    expect(providerSlugSubtitle(undefined, "chutes")).toBeNull();
+    expect(providerSlugSubtitle("", "chutes")).toBeNull();
+    expect(providerSlugSubtitle("   ", "chutes")).toBeNull();
+  });
+
+  it("ignores surrounding whitespace when comparing", () => {
+    expect(providerSlugSubtitle("  404-gen  ", "404-gen")).toBeNull();
+    expect(providerSlugSubtitle("Acme", "  acme  ")).toBeNull();
+  });
+
+  it("returns the untrimmed slug for display when it differs", () => {
+    expect(providerSlugSubtitle("Acme", "acme-labs")).toBe("acme-labs");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/provider-display.ts
+++ b/apps/ui/src/lib/metagraphed/provider-display.ts
@@ -1,0 +1,18 @@
+/**
+ * Decide what the provider hero should show as its slug subtitle.
+ *
+ * The hero title falls back to the slug when a provider has no display name
+ * (`name ?? slug`), so echoing the slug in the subtitle is redundant whenever
+ * the displayed title already is the slug — e.g. a provider named "404-GEN"
+ * with slug "404-gen" would otherwise render "404-GEN · 404-gen".
+ *
+ * Returns the slug to render as the subtitle, or `null` when it would only
+ * repeat the displayed title (matched case-insensitively).
+ */
+export function providerSlugSubtitle(
+  name: string | null | undefined,
+  slug: string,
+): string | null {
+  const displayTitle = name?.trim() ? name.trim() : slug;
+  return displayTitle.toLowerCase() === slug.trim().toLowerCase() ? null : slug;
+}

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -24,6 +24,7 @@ import { useHashScroll } from "@/components/metagraphed/use-hash-scroll";
 import { providerQuery, providerEndpointsQuery, subnetsQuery } from "@/lib/metagraphed/queries";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
+import { providerSlugSubtitle } from "@/lib/metagraphed/provider-display";
 import type { Endpoint, Subnet } from "@/lib/metagraphed/types";
 
 type SearchParams = { tab?: string };
@@ -104,6 +105,7 @@ function ProviderShell({ slug }: { slug: string }) {
   const tab = useActiveTab("overview");
   useHashScroll(tab, SECTION_TO_TAB);
   const stale = meta?.stale || isStaleFreshness(meta?.generated_at);
+  const slugSubtitle = providerSlugSubtitle(p?.name, slug);
 
   return (
     <>
@@ -127,7 +129,7 @@ function ProviderShell({ slug }: { slug: string }) {
           </span>
         }
         title={p?.name ?? slug}
-        subtitle={<>· {slug}</>}
+        subtitle={slugSubtitle ? <>· {slugSubtitle}</> : null}
         description={p?.notes}
         links={<PrimaryLinksRail website={p?.website ?? p?.homepage} docs={p?.docs} />}
         stats={[


### PR DESCRIPTION
Closes #5317

## Problem

`providers.$slug.tsx` set the hero `title={p?.name ?? slug}` and then unconditionally rendered `subtitle={<>· {slug}</>}`. When a provider's display name is the same string as its slug (case-insensitively) — e.g. **404-GEN** with slug `404-gen` — the hero rendered "**404-GEN** · 404-gen", repeating the same case-folded string right next to itself. The same redundancy occurs whenever a provider has no name at all, since the title then falls back to the slug too.

## Fix

Extract a pure `providerSlugSubtitle(name, slug)` helper (`apps/ui/src/lib/metagraphed/provider-display.ts`) that returns the slug **only** when it meaningfully differs from the displayed title — matched case-insensitively and whitespace-trimmed — and `null` otherwise. The hero subtitle is gated on it:

```tsx
const slugSubtitle = providerSlugSubtitle(p?.name, slug);
// ...
subtitle={slugSubtitle ? <>· {slugSubtitle}</> : null}
```

`ProfileHero` already renders nothing for a falsy `subtitle`, so no other change is needed.

## Tests

`provider-display.test.ts` covers both required cases plus edges: name === slug (case-insensitive), meaningfully-different name, missing/blank name (falls back to slug → hidden), and surrounding whitespace.

## Scope

- `apps/ui/src/lib/metagraphed/provider-display.ts` (new, pure helper)
- `apps/ui/src/lib/metagraphed/provider-display.test.ts` (new)
- `apps/ui/src/routes/providers.$slug.tsx` (wire the helper into the hero subtitle)

3 files, +51/-1.