### PR TITLE
fix(ui): show netuid labels on subnet health matrix cells, not hover-only (#5331)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-health-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-health-matrix.tsx
@@ -12,6 +12,16 @@ const TONE: Record<HealthState, string> = {
   unknown: "bg-ink-subtle/30 hover:bg-ink-subtle/60",
 };
 
+// Netuid-label contrast per tone, mirroring the latency-heatmap convention:
+// light text on the saturated health fills, dark text on the amber warn fill
+// and the pale "unknown" fill.
+const TONE_TEXT: Record<HealthState, string> = {
+  ok: "text-paper",
+  warn: "text-ink-strong",
+  down: "text-paper",
+  unknown: "text-ink-strong",
+};
+
 /**
  * Heatmap of every active application subnet colored by health. Clicking a
  * cell deep-links to that subnet. Renders a tooltip with the subnet name +
@@ -46,11 +56,16 @@ export function SubnetHealthMatrix() {
                     to="/subnets/$netuid"
                     params={{ netuid: s.netuid }}
                     className={classNames(
-                      "group aspect-square rounded-sm transition-all duration-150 ring-0 hover:ring-2 hover:ring-accent/40 hover:scale-110",
+                      "group flex aspect-square items-center justify-center rounded-sm transition-all duration-150 ring-0 hover:ring-2 hover:ring-accent/40 hover:scale-110",
                       tone,
+                      TONE_TEXT[s.health ?? "unknown"],
                     )}
                     aria-label={`SN${s.netuid}${s.name ? ` — ${s.name}` : ""} — ${s.health ?? "unknown"}`}
-                  />
+                  >
+                    <span className="font-mono text-[9px] font-semibold leading-none tabular-nums tracking-tight">
+                      {s.netuid}
+                    </span>
+                  </Link>
                 </TooltipTrigger>
                 <TooltipContent side="top" className="text-[11px]">
                   <div className="font-display font-semibold text-ink-strong">


### PR DESCRIPTION
## Summary

Closes #5331

The subnet health matrix rendered each subnet as an unlabeled colored square — the netuid was only reachable via the hover tooltip, so a specific subnet couldn't be identified by sight and the matrix was unusable on touch devices (#5331).

Each cell now shows its **netuid inline**, centered, with tone-appropriate text contrast (light text on the saturated ok/down fills, dark on the amber "warn" and pale "unknown" fills — mirroring the latency-heatmap convention). The labels are legible at the existing 28px cell size (no dimension change needed), and the hover tooltip + `aria-label` are unchanged.

## Changes
- `components/metagraphed/subnet-health-matrix.tsx` — add a `TONE_TEXT` contrast  map and render `{s.netuid}` inside each cell (flex-centered). Tooltip preserved.

## Screenshots

/health subnet health matrix — **before** (colored squares, no labels) vs **after** (every cell shows its netuid). Both themes shown to confirm legibility.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5331-health-matrix/before-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5331-health-matrix/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5331-health-matrix/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5331-health-matrix/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5331-health-matrix/before-tablet-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5331-health-matrix/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5331-health-matrix/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5331-health-matrix/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5331-health-matrix/before-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5331-health-matrix/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5331-health-matrix/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5331-health-matrix/after-mobile-dark.png) |

## Validation
- `tsc --noEmit` ✓ · `eslint` (0 errors) ✓ · `prettier --check` (3.9.4, LF) ✓ · `vitest` (690) ✓ · `build` ✓
- 1 file; 0-behind `main`


