### PR TITLE
feat(analytics): surface pool liquidity + net flow on subnet trajectory

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -261,6 +261,12 @@ CREATE TABLE IF NOT EXISTS subnet_snapshots (
   total_stake_tao    NUMERIC,
   alpha_price_tao    NUMERIC,
   emission_share     NUMERIC,
+  -- Pool liquidity + volume (#2552) — point-in-time AMM reserves/cumulative
+  -- volume, NUMERIC like the other TAO-precision economics columns above.
+  tao_in_pool_tao    NUMERIC,
+  alpha_in_pool      NUMERIC,
+  alpha_out_pool     NUMERIC,
+  subnet_volume_tao  NUMERIC,
   PRIMARY KEY (netuid, snapshot_date)
 );
 CREATE INDEX IF NOT EXISTS idx_subnet_snapshots_date

--- a/migrations/0045_subnet_snapshots_pool_liquidity.sql
+++ b/migrations/0045_subnet_snapshots_pool_liquidity.sql
@@ -1,0 +1,19 @@
+-- Pool liquidity + volume time series on subnet_snapshots (#2552).
+--
+-- tao_in_pool_tao / alpha_in_pool / alpha_out_pool / subnet_volume_tao were
+-- already live, point-in-time, on the /api/v1/economics artifact (the 3h KV
+-- tier, sourced from MetagraphInfo's tao_in/alpha_in/alpha_out/subnet_volume
+-- via scripts/fetch-native-subnets.py's normalize_economics) -- #2552's own
+-- "GraphQL declares alpha_in_pool/alpha_out_pool with no backing indexer"
+-- framing predates that build and is stale. What was actually missing was a
+-- *history* of those same values: subnet_snapshots (#1307/#1302) already
+-- rolls up validator_count/total_stake_tao/alpha_price_tao/emission_share
+-- daily but never captured pool reserves or volume, so there was no way to
+-- derive "net TAO/alpha flow" (a delta over time) even though the reserves
+-- themselves were fresh. These four additive nullable columns close that --
+-- no new chain indexer required, same source data the live economics tier
+-- already ingests every 3h.
+ALTER TABLE subnet_snapshots ADD COLUMN tao_in_pool_tao REAL;
+ALTER TABLE subnet_snapshots ADD COLUMN alpha_in_pool REAL;
+ALTER TABLE subnet_snapshots ADD COLUMN alpha_out_pool REAL;
+ALTER TABLE subnet_snapshots ADD COLUMN subnet_volume_tao REAL;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10676,7 +10676,7 @@
     },
     "packages/client": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.15.9",
+      "version": "0.15.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "metagraphed-contract": "*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.15.9",
+  "version": "0.15.10",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7324,6 +7324,7 @@ export interface components {
         SubnetStatus: "active" | "inactive" | "unknown";
         SubnetSurfacesArtifact: components["schemas"]["SurfacesArtifact"];
         SubnetTrajectoryArtifact: {
+            /** @description Windowed deltas (7d/30d) between the latest point and the point at or before that many days prior. tao_in_pool_tao/alpha_in_pool/alpha_out_pool deltas are the net TAO/alpha flow into or out of the pool over the window (#2552) — positive means net inflow. */
             deltas: {
                 [key: string]: {
                     [key: string]: unknown;
@@ -7332,13 +7333,21 @@ export interface components {
             netuid: number;
             point_count: number;
             points: ({
+                /** @description Alpha reserve in the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative. */
+                alpha_in_pool?: number | null;
+                /** @description Alpha issued/staked out of the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative. */
+                alpha_out_pool?: number | null;
                 alpha_price_tao?: number | null;
                 completeness_score?: number | null;
                 date: string;
                 emission_share?: number | null;
                 endpoint_count?: number | null;
                 miner_count?: number | null;
+                /** @description Cumulative subnet trading volume in TAO as reported by the chain at this snapshot (#2552). */
+                subnet_volume_tao?: number | null;
                 surface_count?: number | null;
+                /** @description TAO reserve in the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative — see deltas for net flow. */
+                tao_in_pool_tao?: number | null;
                 total_stake_tao?: number | null;
                 validator_count?: number | null;
             } & {
@@ -27083,8 +27092,8 @@ export interface operations {
                         data?: components["schemas"]["SubnetTrajectoryArtifact"];
                     };
                     /**
-                     * @example date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share
-                     *     2026-06-01,35,1,1,8,60,90,0.01,0.02
+                     * @example date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share,tao_in_pool_tao,alpha_in_pool,alpha_out_pool,subnet_volume_tao
+                     *     2026-06-01,35,1,1,8,60,90,0.01,0.02,26707.57,2956464.98,2257199.02,798027.45
                      */
                     "text/csv": string;
                 };

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -19541,6 +19541,7 @@
                 "null"
               ]
             },
+            "description": "Windowed deltas (7d/30d) between the latest point and the point at or before that many days prior. tao_in_pool_tao/alpha_in_pool/alpha_out_pool deltas are the net TAO/alpha flow into or out of the pool over the window (#2552) — positive means net inflow.",
             "type": "object"
           },
           "netuid": {
@@ -19555,6 +19556,20 @@
             "items": {
               "additionalProperties": true,
               "properties": {
+                "alpha_in_pool": {
+                  "description": "Alpha reserve in the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "alpha_out_pool": {
+                  "description": "Alpha issued/staked out of the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
                 "alpha_price_tao": {
                   "type": [
                     "number",
@@ -19588,9 +19603,23 @@
                     "null"
                   ]
                 },
+                "subnet_volume_tao": {
+                  "description": "Cumulative subnet trading volume in TAO as reported by the chain at this snapshot (#2552).",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
                 "surface_count": {
                   "type": [
                     "integer",
+                    "null"
+                  ]
+                },
+                "tao_in_pool_tao": {
+                  "description": "TAO reserve in the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative — see deltas for net flow.",
+                  "type": [
+                    "number",
                     "null"
                   ]
                 },
@@ -49755,7 +49784,7 @@
                 }
               },
               "text/csv": {
-                "example": "date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share\r\n2026-06-01,35,1,1,8,60,90,0.01,0.02",
+                "example": "date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share,tao_in_pool_tao,alpha_in_pool,alpha_out_pool,subnet_volume_tao\r\n2026-06-01,35,1,1,8,60,90,0.01,0.02,26707.57,2956464.98,2257199.02,798027.45",
                 "schema": {
                   "type": "string"
                 }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7324,6 +7324,7 @@ export interface components {
         SubnetStatus: "active" | "inactive" | "unknown";
         SubnetSurfacesArtifact: components["schemas"]["SurfacesArtifact"];
         SubnetTrajectoryArtifact: {
+            /** @description Windowed deltas (7d/30d) between the latest point and the point at or before that many days prior. tao_in_pool_tao/alpha_in_pool/alpha_out_pool deltas are the net TAO/alpha flow into or out of the pool over the window (#2552) — positive means net inflow. */
             deltas: {
                 [key: string]: {
                     [key: string]: unknown;
@@ -7332,13 +7333,21 @@ export interface components {
             netuid: number;
             point_count: number;
             points: ({
+                /** @description Alpha reserve in the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative. */
+                alpha_in_pool?: number | null;
+                /** @description Alpha issued/staked out of the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative. */
+                alpha_out_pool?: number | null;
                 alpha_price_tao?: number | null;
                 completeness_score?: number | null;
                 date: string;
                 emission_share?: number | null;
                 endpoint_count?: number | null;
                 miner_count?: number | null;
+                /** @description Cumulative subnet trading volume in TAO as reported by the chain at this snapshot (#2552). */
+                subnet_volume_tao?: number | null;
                 surface_count?: number | null;
+                /** @description TAO reserve in the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative — see deltas for net flow. */
+                tao_in_pool_tao?: number | null;
                 total_stake_tao?: number | null;
                 validator_count?: number | null;
             } & {
@@ -27083,8 +27092,8 @@ export interface operations {
                         data?: components["schemas"]["SubnetTrajectoryArtifact"];
                     };
                     /**
-                     * @example date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share
-                     *     2026-06-01,35,1,1,8,60,90,0.01,0.02
+                     * @example date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share,tao_in_pool_tao,alpha_in_pool,alpha_out_pool,subnet_volume_tao
+                     *     2026-06-01,35,1,1,8,60,90,0.01,0.02,26707.57,2956464.98,2257199.02,798027.45
                      */
                     "text/csv": string;
                 };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -19519,6 +19519,7 @@
                 "null"
               ]
             },
+            "description": "Windowed deltas (7d/30d) between the latest point and the point at or before that many days prior. tao_in_pool_tao/alpha_in_pool/alpha_out_pool deltas are the net TAO/alpha flow into or out of the pool over the window (#2552) — positive means net inflow.",
             "type": "object"
           },
           "netuid": {
@@ -19533,6 +19534,20 @@
             "items": {
               "additionalProperties": true,
               "properties": {
+                "alpha_in_pool": {
+                  "description": "Alpha reserve in the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "alpha_out_pool": {
+                  "description": "Alpha issued/staked out of the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative.",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
                 "alpha_price_tao": {
                   "type": [
                     "number",
@@ -19566,9 +19581,23 @@
                     "null"
                   ]
                 },
+                "subnet_volume_tao": {
+                  "description": "Cumulative subnet trading volume in TAO as reported by the chain at this snapshot (#2552).",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
                 "surface_count": {
                   "type": [
                     "integer",
+                    "null"
+                  ]
+                },
+                "tao_in_pool_tao": {
+                  "description": "TAO reserve in the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative — see deltas for net flow.",
+                  "type": [
+                    "number",
                     "null"
                   ]
                 },

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -680,13 +680,30 @@
                 "miner_count": { "type": ["integer", "null"] },
                 "total_stake_tao": { "type": ["number", "null"] },
                 "alpha_price_tao": { "type": ["number", "null"] },
-                "emission_share": { "type": ["number", "null"] }
+                "emission_share": { "type": ["number", "null"] },
+                "tao_in_pool_tao": {
+                  "type": ["number", "null"],
+                  "description": "TAO reserve in the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative — see deltas for net flow."
+                },
+                "alpha_in_pool": {
+                  "type": ["number", "null"],
+                  "description": "Alpha reserve in the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative."
+                },
+                "alpha_out_pool": {
+                  "type": ["number", "null"],
+                  "description": "Alpha issued/staked out of the subnet's AMM pool at this snapshot (#2552). Point-in-time, not cumulative."
+                },
+                "subnet_volume_tao": {
+                  "type": ["number", "null"],
+                  "description": "Cumulative subnet trading volume in TAO as reported by the chain at this snapshot (#2552)."
+                }
               },
               "additionalProperties": true
             }
           },
           "deltas": {
             "type": "object",
+            "description": "Windowed deltas (7d/30d) between the latest point and the point at or before that many days prior. tao_in_pool_tao/alpha_in_pool/alpha_out_pool deltas are the net TAO/alpha flow into or out of the pool over the window (#2552) — positive means net inflow.",
             "additionalProperties": {
               "type": ["object", "null"],
               "additionalProperties": true

--- a/scripts/backfill-subnet-snapshots-postgres.mjs
+++ b/scripts/backfill-subnet-snapshots-postgres.mjs
@@ -66,6 +66,10 @@ const COLUMNS = [
   "total_stake_tao",
   "alpha_price_tao",
   "emission_share",
+  "tao_in_pool_tao",
+  "alpha_in_pool",
+  "alpha_out_pool",
+  "subnet_volume_tao",
 ];
 const INTEGER_COLUMNS = new Set([
   "netuid",
@@ -82,6 +86,10 @@ const REAL_COLUMNS = new Set([
   "total_stake_tao",
   "alpha_price_tao",
   "emission_share",
+  "tao_in_pool_tao",
+  "alpha_in_pool",
+  "alpha_out_pool",
+  "subnet_volume_tao",
 ]);
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const UPDATE_COLUMNS = COLUMNS.filter(

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -4355,8 +4355,8 @@ function csvExampleForRoute(entry) {
   }
   if (entry.id === "subnet-trajectory") {
     return [
-      "date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share",
-      "2026-06-01,35,1,1,8,60,90,0.01,0.02",
+      "date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share,tao_in_pool_tao,alpha_in_pool,alpha_out_pool,subnet_volume_tao",
+      "2026-06-01,35,1,1,8,60,90,0.01,0.02,26707.57,2956464.98,2257199.02,798027.45",
     ].join("\r\n");
   }
   if (entry.id === "extrinsics-feed") {

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -927,6 +927,10 @@ export async function syncSubnetSnapshotToPostgres(
         total_stake_tao: econ.total_stake_tao ?? null,
         alpha_price_tao: econ.alpha_price_tao ?? null,
         emission_share: econ.emission_share ?? null,
+        tao_in_pool_tao: econ.tao_in_pool_tao ?? null,
+        alpha_in_pool: econ.alpha_in_pool ?? null,
+        alpha_out_pool: econ.alpha_out_pool ?? null,
+        subnet_volume_tao: econ.subnet_volume_tao ?? null,
         captured_at: capturedAt,
       };
     });
@@ -1023,14 +1027,19 @@ export async function writeSubnetSnapshot(env, overrides = {}) {
        (netuid, snapshot_date, completeness_score, surface_count,
         endpoint_count, monitored_count, candidate_count,
         validator_count, miner_count, total_stake_tao, alpha_price_tao,
-        emission_share, captured_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        emission_share, tao_in_pool_tao, alpha_in_pool, alpha_out_pool,
+        subnet_volume_tao, captured_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT (netuid, snapshot_date) DO UPDATE SET
        validator_count = COALESCE(subnet_snapshots.validator_count, excluded.validator_count),
        miner_count = COALESCE(subnet_snapshots.miner_count, excluded.miner_count),
        total_stake_tao = COALESCE(subnet_snapshots.total_stake_tao, excluded.total_stake_tao),
        alpha_price_tao = COALESCE(subnet_snapshots.alpha_price_tao, excluded.alpha_price_tao),
-       emission_share = COALESCE(subnet_snapshots.emission_share, excluded.emission_share)`,
+       emission_share = COALESCE(subnet_snapshots.emission_share, excluded.emission_share),
+       tao_in_pool_tao = COALESCE(subnet_snapshots.tao_in_pool_tao, excluded.tao_in_pool_tao),
+       alpha_in_pool = COALESCE(subnet_snapshots.alpha_in_pool, excluded.alpha_in_pool),
+       alpha_out_pool = COALESCE(subnet_snapshots.alpha_out_pool, excluded.alpha_out_pool),
+       subnet_volume_tao = COALESCE(subnet_snapshots.subnet_volume_tao, excluded.subnet_volume_tao)`,
   );
   const statements = profiles
     .filter((profile) => Number.isInteger(profile.netuid))
@@ -1049,6 +1058,10 @@ export async function writeSubnetSnapshot(env, overrides = {}) {
         econ.total_stake_tao ?? null,
         econ.alpha_price_tao ?? null,
         econ.emission_share ?? null,
+        econ.tao_in_pool_tao ?? null,
+        econ.alpha_in_pool ?? null,
+        econ.alpha_out_pool ?? null,
+        econ.subnet_volume_tao ?? null,
         capturedAt,
       );
     });

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1103,6 +1103,14 @@ export function formatTrajectory({ netuid, rows }) {
       total_stake_tao: toFiniteOrNull(row.total_stake_tao),
       alpha_price_tao: toFiniteOrNull(row.alpha_price_tao),
       emission_share: toFiniteOrNull(row.emission_share),
+      // Pool liquidity + volume (#2552) — reserves are a point-in-time chain
+      // read (not cumulative), so unlike the other economics columns their
+      // useful signal is the *delta* between two points, not the raw level;
+      // see deltaOver below for the derived net TAO/alpha flow.
+      tao_in_pool_tao: toFiniteOrNull(row.tao_in_pool_tao),
+      alpha_in_pool: toFiniteOrNull(row.alpha_in_pool),
+      alpha_out_pool: toFiniteOrNull(row.alpha_out_pool),
+      subnet_volume_tao: toFiniteOrNull(row.subnet_volume_tao),
     }))
     .sort((a, b) => String(a.date).localeCompare(String(b.date)));
 
@@ -1120,6 +1128,13 @@ export function formatTrajectory({ netuid, rows }) {
       ),
       surface_count: diff(latest.surface_count, cutoff.surface_count),
       endpoint_count: diff(latest.endpoint_count, cutoff.endpoint_count),
+      // Net TAO/alpha flow into or out of the pool over the window (#2552) —
+      // reserve level now minus reserve level then, positive means net
+      // inflow. tao_in_pool_tao's delta doubles as the requested "TAO in/out
+      // flow" metric; no separate flow-only ingestion needed.
+      tao_in_pool_tao: diff(latest.tao_in_pool_tao, cutoff.tao_in_pool_tao),
+      alpha_in_pool: diff(latest.alpha_in_pool, cutoff.alpha_in_pool),
+      alpha_out_pool: diff(latest.alpha_out_pool, cutoff.alpha_out_pool),
     };
   };
 
@@ -1140,7 +1155,8 @@ export async function loadSubnetTrajectory(d1, netuid) {
   const rows = await d1(
     `SELECT snapshot_date, completeness_score, surface_count, endpoint_count,
             validator_count, miner_count, total_stake_tao, alpha_price_tao,
-            emission_share
+            emission_share, tao_in_pool_tao, alpha_in_pool, alpha_out_pool,
+            subnet_volume_tao
      FROM subnet_snapshots
      WHERE netuid = ?
      ORDER BY snapshot_date DESC

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -993,6 +993,10 @@ describe("writeSubnetSnapshot", () => {
       "total_stake_tao",
       "alpha_price_tao",
       "emission_share",
+      "tao_in_pool_tao",
+      "alpha_in_pool",
+      "alpha_out_pool",
+      "subnet_volume_tao",
     ]) {
       assert.match(
         captured,
@@ -1097,6 +1101,10 @@ describe("syncSubnetSnapshotToPostgres", () => {
         total_stake_tao: null,
         alpha_price_tao: null,
         emission_share: null,
+        tao_in_pool_tao: null,
+        alpha_in_pool: null,
+        alpha_out_pool: null,
+        subnet_volume_tao: null,
         captured_at: 1,
       },
     ]);
@@ -1155,6 +1163,10 @@ describe("syncSubnetSnapshotToPostgres", () => {
         total_stake_tao: null,
         alpha_price_tao: null,
         emission_share: null,
+        tao_in_pool_tao: null,
+        alpha_in_pool: null,
+        alpha_out_pool: null,
+        subnet_volume_tao: null,
         captured_at: 1,
       },
     ]);
@@ -1240,6 +1252,10 @@ function rowsForSql(sql) {
         total_stake_tao: "1500000",
         alpha_price_tao: "0.03",
         emission_share: "0.008",
+        tao_in_pool_tao: "20000",
+        alpha_in_pool: "2900000",
+        alpha_out_pool: "2200000",
+        subnet_volume_tao: "700000",
       },
       {
         snapshot_date: "2026-06-10",
@@ -1251,6 +1267,10 @@ function rowsForSql(sql) {
         total_stake_tao: "1600000",
         alpha_price_tao: "0.035",
         emission_share: "0.009",
+        tao_in_pool_tao: "26707.57",
+        alpha_in_pool: "2956464.98",
+        alpha_out_pool: "2257199.02",
+        subnet_volume_tao: "798027.45",
       },
     ];
   }
@@ -1656,6 +1676,12 @@ describe("analytics routes (fake D1 with data)", () => {
     assert.equal(typeof latest.alpha_price_tao, "number");
     assert.equal(typeof latest.emission_share, "number");
     assert.equal(latest.emission_share, 0.009);
+    // #2552: pool liquidity + volume ride the same D1 string-coerced path.
+    assert.equal(latest.tao_in_pool_tao, 26707.57);
+    assert.equal(latest.alpha_in_pool, 2956464.98);
+    assert.equal(latest.alpha_out_pool, 2257199.02);
+    assert.equal(latest.subnet_volume_tao, 798027.45);
+    assert.equal(body.data.deltas["7d"].tao_in_pool_tao, 6707.57);
   });
   test("leaderboards combines D1 health with registry growth", async () => {
     const { body } = await getJson(

--- a/tests/backfill-subnet-snapshots-postgres.test.mjs
+++ b/tests/backfill-subnet-snapshots-postgres.test.mjs
@@ -34,6 +34,10 @@ const SAMPLE_ROW = {
   total_stake_tao: 123.456,
   alpha_price_tao: 0.789,
   emission_share: 0.0123,
+  tao_in_pool_tao: 26707.57,
+  alpha_in_pool: 2956464.98,
+  alpha_out_pool: 2257199.02,
+  subnet_volume_tao: 798027.45,
 };
 
 test("parseArgs returns defaults with no arguments", () => {
@@ -140,7 +144,7 @@ test("rowTuple renders every column in declared order", () => {
   const tuple = rowTuple(SAMPLE_ROW);
   assert.equal(
     tuple,
-    "(43, '2025-06-23', 80, 3, 2, 1, 0, 1750643200000, 64, 192, 123.456, 0.789, 0.0123)",
+    "(43, '2025-06-23', 80, 3, 2, 1, 0, 1750643200000, 64, 192, 123.456, 0.789, 0.0123, 26707.57, 2956464.98, 2257199.02, 798027.45)",
   );
 });
 
@@ -153,7 +157,20 @@ test("rowTuple carries NULLs through for missing economics columns", () => {
     alpha_price_tao: null,
     emission_share: null,
   });
-  assert.match(tuple, /NULL, NULL, NULL, NULL, NULL\)$/);
+  assert.match(tuple, /NULL, NULL, NULL, NULL, NULL, 26707\.57/);
+});
+
+// #2552: pool liquidity + volume carry NULL through the same as the other
+// economics columns when D1 has yet to backfill a snapshot row.
+test("rowTuple carries NULLs through for missing pool liquidity + volume columns", () => {
+  const tuple = rowTuple({
+    ...SAMPLE_ROW,
+    tao_in_pool_tao: null,
+    alpha_in_pool: null,
+    alpha_out_pool: null,
+    subnet_volume_tao: null,
+  });
+  assert.match(tuple, /NULL, NULL, NULL, NULL\)$/);
 });
 
 test("chunkRows splits into fixed-size chunks with a final remainder", () => {
@@ -186,6 +203,10 @@ test("insertStatement emits an upsert that overwrites every non-key column", () 
     "total_stake_tao",
     "alpha_price_tao",
     "emission_share",
+    "tao_in_pool_tao",
+    "alpha_in_pool",
+    "alpha_out_pool",
+    "subnet_volume_tao",
   ]) {
     assert.match(
       statement,

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -218,7 +218,7 @@ describe("public contract registry", () => {
       ],
       [
         "/api/v1/subnets/{netuid}/trajectory",
-        "date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share",
+        "date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share,tao_in_pool_tao,alpha_in_pool,alpha_out_pool,subnet_volume_tao",
       ],
       [
         "/api/v1/accounts/{ss58}/extrinsics",

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -6222,6 +6222,10 @@ test("GET /api/v1/subnets/:netuid/trajectory: formats daily snapshot rows", asyn
       total_stake_tao: 90,
       alpha_price_tao: 0.01,
       emission_share: 0.02,
+      tao_in_pool_tao: 26707.57,
+      alpha_in_pool: 2956464.98,
+      alpha_out_pool: 2257199.02,
+      subnet_volume_tao: 798027.45,
     },
   ];
   const res = await req("/api/v1/subnets/7/trajectory");
@@ -6230,6 +6234,11 @@ test("GET /api/v1/subnets/:netuid/trajectory: formats daily snapshot rows", asyn
   expect(body.netuid).toBe(7);
   expect(body.points[0].date).toBe("2026-06-01");
   expect(body.points[0].completeness_score).toBe(90);
+  // #2552: pool liquidity + volume flow through the Postgres trajectory path.
+  expect(body.points[0].tao_in_pool_tao).toBe(26707.57);
+  expect(body.points[0].alpha_in_pool).toBe(2956464.98);
+  expect(body.points[0].alpha_out_pool).toBe(2257199.02);
+  expect(body.points[0].subnet_volume_tao).toBe(798027.45);
 });
 
 test("GET /api/v1/economics/trends: aggregates daily rows network-wide", async () => {
@@ -6273,6 +6282,10 @@ function snapshotRow(overrides = {}) {
     total_stake_tao: 90,
     alpha_price_tao: 0.01,
     emission_share: 0.02,
+    tao_in_pool_tao: 26707.57,
+    alpha_in_pool: 2956464.98,
+    alpha_out_pool: 2257199.02,
+    subnet_volume_tao: 798027.45,
     captured_at: 1780000000000,
     ...overrides,
   };
@@ -6397,6 +6410,21 @@ test("subnet-snapshot-sync upserts subnet_snapshots with the COALESCE-on-economi
   expect(queryText()).toMatch(
     /validator_count = COALESCE\(subnet_snapshots\.validator_count, excluded\.validator_count\)/,
   );
+  // #2552: pool liquidity + volume columns follow the same COALESCE-on-conflict
+  // semantics as the other economics columns (a later NULL never wipes an
+  // earlier fire's good value).
+  for (const column of [
+    "tao_in_pool_tao",
+    "alpha_in_pool",
+    "alpha_out_pool",
+    "subnet_volume_tao",
+  ]) {
+    expect(queryText()).toMatch(
+      new RegExp(
+        `${column} = COALESCE\\(subnet_snapshots\\.${column}, excluded\\.${column}\\)`,
+      ),
+    );
+  }
 });
 
 test("subnet-snapshot-sync defaults every optional field to null when absent", async () => {

--- a/tests/economics-history.test.mjs
+++ b/tests/economics-history.test.mjs
@@ -51,3 +51,91 @@ test("formatTrajectory nulls economics on pre-migration rows", () => {
   assert.equal(out.points[0].total_stake_tao, null);
   assert.equal(out.points[0].alpha_price_tao, null);
 });
+
+// #2552: pool reserves + volume carried in the time series alongside the
+// other economics columns.
+test("formatTrajectory carries pool liquidity + volume fields in the time series (#2552)", () => {
+  const out = formatTrajectory({
+    netuid: 1,
+    rows: [
+      {
+        snapshot_date: "2026-06-21",
+        tao_in_pool_tao: 26707.57,
+        alpha_in_pool: 2956464.98,
+        alpha_out_pool: 2257199.02,
+        subnet_volume_tao: 798027.45,
+      },
+    ],
+  });
+  const point = out.points[0];
+  assert.equal(point.tao_in_pool_tao, 26707.57);
+  assert.equal(point.alpha_in_pool, 2956464.98);
+  assert.equal(point.alpha_out_pool, 2257199.02);
+  assert.equal(point.subnet_volume_tao, 798027.45);
+});
+
+test("formatTrajectory nulls pool liquidity + volume on pre-migration rows (#2552)", () => {
+  const out = formatTrajectory({
+    netuid: 1,
+    rows: [{ snapshot_date: "2026-06-01", completeness_score: 70 }],
+  });
+  assert.equal(out.points[0].tao_in_pool_tao, null);
+  assert.equal(out.points[0].alpha_in_pool, null);
+  assert.equal(out.points[0].alpha_out_pool, null);
+  assert.equal(out.points[0].subnet_volume_tao, null);
+});
+
+// #2552's core deliverable: "net TAO in/out flow" is the windowed delta of
+// the point-in-time pool reserves, not a separately-ingested metric.
+test("formatTrajectory's 7d/30d deltas report net pool flow (#2552)", () => {
+  const out = formatTrajectory({
+    netuid: 1,
+    rows: [
+      {
+        snapshot_date: "2026-05-20",
+        tao_in_pool_tao: 20000,
+        alpha_in_pool: 2900000,
+        alpha_out_pool: 2200000,
+      },
+      {
+        snapshot_date: "2026-06-14",
+        tao_in_pool_tao: 24000,
+        alpha_in_pool: 2940000,
+        alpha_out_pool: 2230000,
+      },
+      {
+        snapshot_date: "2026-06-21",
+        tao_in_pool_tao: 26707.57,
+        alpha_in_pool: 2956464.98,
+        alpha_out_pool: 2257199.02,
+      },
+    ],
+  });
+  const delta7d = out.deltas["7d"];
+  assert.equal(delta7d.from_date, "2026-06-14");
+  assert.equal(delta7d.to_date, "2026-06-21");
+  assert.ok(Math.abs(delta7d.tao_in_pool_tao - 2707.57) < 1e-6);
+  assert.ok(Math.abs(delta7d.alpha_in_pool - 16464.98) < 1e-6);
+  assert.ok(Math.abs(delta7d.alpha_out_pool - 27199.02) < 1e-6);
+
+  const delta30d = out.deltas["30d"];
+  assert.equal(delta30d.from_date, "2026-05-20");
+  assert.equal(delta30d.to_date, "2026-06-21");
+  assert.ok(Math.abs(delta30d.tao_in_pool_tao - 6707.57) < 1e-6);
+});
+
+test("formatTrajectory's deltas are null when a bound is missing a pool reading (#2552)", () => {
+  const out = formatTrajectory({
+    netuid: 1,
+    rows: [
+      { snapshot_date: "2026-05-20", tao_in_pool_tao: null },
+      {
+        snapshot_date: "2026-06-21",
+        tao_in_pool_tao: 26707.57,
+        alpha_in_pool: 2956464.98,
+      },
+    ],
+  });
+  assert.equal(out.deltas["30d"].tao_in_pool_tao, null);
+  assert.equal(out.deltas["30d"].alpha_out_pool, null);
+});

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -177,10 +177,10 @@ describe("handleTrajectory", () => {
     const lines = text.split("\r\n");
     assert.equal(
       lines[0],
-      "date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share",
+      "date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share,tao_in_pool_tao,alpha_in_pool,alpha_out_pool,subnet_volume_tao",
     );
-    assert.equal(lines[1], "2026-06-01,35,1,1,8,60,90,0.01,0.02");
-    assert.equal(lines[2], "2026-06-02,40,2,1,8,64,100,0.01,0.02");
+    assert.equal(lines[1], "2026-06-01,35,1,1,8,60,90,0.01,0.02,,,,");
+    assert.equal(lines[2], "2026-06-02,40,2,1,8,64,100,0.01,0.02,,,,");
   });
 
   test("returns CSV response when Accept: text/csv header is present", async () => {
@@ -207,7 +207,7 @@ describe("handleTrajectory", () => {
     assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
     const text = await res.text();
     const lines = text.split("\r\n");
-    assert.equal(lines[1], "2026-06-01,35,1,1,8,60,90,0.01,0.02");
+    assert.equal(lines[1], "2026-06-01,35,1,1,8,60,90,0.01,0.02,,,,");
   });
 
   test("returns header-only CSV when D1 is cold", async () => {
@@ -222,7 +222,7 @@ describe("handleTrajectory", () => {
     const lines = text.split("\r\n");
     assert.equal(
       lines[0],
-      "date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share",
+      "date,completeness_score,surface_count,endpoint_count,validator_count,miner_count,total_stake_tao,alpha_price_tao,emission_share,tao_in_pool_tao,alpha_in_pool,alpha_out_pool,subnet_volume_tao",
     );
     assert.equal(lines.length, 1);
   });

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2416,6 +2416,18 @@ async function handleSubnetSnapshotSync(request, env) {
     emission_share: Number.isFinite(row.emission_share)
       ? row.emission_share
       : null,
+    tao_in_pool_tao: Number.isFinite(row.tao_in_pool_tao)
+      ? row.tao_in_pool_tao
+      : null,
+    alpha_in_pool: Number.isFinite(row.alpha_in_pool)
+      ? row.alpha_in_pool
+      : null,
+    alpha_out_pool: Number.isFinite(row.alpha_out_pool)
+      ? row.alpha_out_pool
+      : null,
+    subnet_volume_tao: Number.isFinite(row.subnet_volume_tao)
+      ? row.subnet_volume_tao
+      : null,
     captured_at: row.captured_at,
   }));
 
@@ -2437,6 +2449,10 @@ async function handleSubnetSnapshotSync(request, env) {
           "total_stake_tao",
           "alpha_price_tao",
           "emission_share",
+          "tao_in_pool_tao",
+          "alpha_in_pool",
+          "alpha_out_pool",
+          "subnet_volume_tao",
           "captured_at",
         )}
         ON CONFLICT (netuid, snapshot_date) DO UPDATE SET
@@ -2444,7 +2460,11 @@ async function handleSubnetSnapshotSync(request, env) {
           miner_count = COALESCE(subnet_snapshots.miner_count, excluded.miner_count),
           total_stake_tao = COALESCE(subnet_snapshots.total_stake_tao, excluded.total_stake_tao),
           alpha_price_tao = COALESCE(subnet_snapshots.alpha_price_tao, excluded.alpha_price_tao),
-          emission_share = COALESCE(subnet_snapshots.emission_share, excluded.emission_share)`;
+          emission_share = COALESCE(subnet_snapshots.emission_share, excluded.emission_share),
+          tao_in_pool_tao = COALESCE(subnet_snapshots.tao_in_pool_tao, excluded.tao_in_pool_tao),
+          alpha_in_pool = COALESCE(subnet_snapshots.alpha_in_pool, excluded.alpha_in_pool),
+          alpha_out_pool = COALESCE(subnet_snapshots.alpha_out_pool, excluded.alpha_out_pool),
+          subnet_volume_tao = COALESCE(subnet_snapshots.subnet_volume_tao, excluded.subnet_volume_tao)`;
       return writeJson({ ok: true, rows_written: snapshotRows.length });
     });
   } catch (err) {
@@ -5347,7 +5367,8 @@ export default {
           const rows = await sql`
           SELECT snapshot_date::text AS snapshot_date, completeness_score,
                  surface_count, endpoint_count, validator_count, miner_count,
-                 total_stake_tao, alpha_price_tao, emission_share
+                 total_stake_tao, alpha_price_tao, emission_share,
+                 tao_in_pool_tao, alpha_in_pool, alpha_out_pool, subnet_volume_tao
           FROM subnet_snapshots
           WHERE netuid = ${netuid}
           ORDER BY snapshot_date DESC

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -71,6 +71,10 @@ const TRAJECTORY_CSV_COLUMNS = [
   "total_stake_tao",
   "alpha_price_tao",
   "emission_share",
+  "tao_in_pool_tao",
+  "alpha_in_pool",
+  "alpha_out_pool",
+  "subnet_volume_tao",
 ];
 
 function validateFormatParam(url) {
@@ -141,7 +145,8 @@ export async function handleTrajectory(request, env, netuid, url) {
       env,
       `SELECT snapshot_date, completeness_score, surface_count, endpoint_count,
               validator_count, miner_count, total_stake_tao, alpha_price_tao,
-              emission_share
+              emission_share, tao_in_pool_tao, alpha_in_pool, alpha_out_pool,
+              subnet_volume_tao
        FROM subnet_snapshots
        WHERE netuid = ?
        ORDER BY snapshot_date DESC


### PR DESCRIPTION
## Summary

Closes #2552

- `alpha_in_pool`/`alpha_out_pool`/`tao_in_pool_tao`/`subnet_volume_tao` were already live, point-in-time, on `/api/v1/economics` (the 3h KV tier, sourced from `MetagraphInfo` via `scripts/fetch-native-subnets.py`). #2552's own "GraphQL declares alpha_in_pool/alpha_out_pool with no backing indexer" framing predates that build and is stale — verified by tracing the live 3h `refresh-economics.yml` → KV → `resolveLiveEconomics` path used by both REST and GraphQL.
- The real gap was a *history* of those values: `subnet_snapshots` (#1307) rolled up `validator_count`/`total_stake_tao`/`alpha_price_tao`/`emission_share` daily but never captured pool reserves or volume, so "net TAO/alpha flow" had nothing to be derived from even though the reserves themselves were fresh.
- Adds 4 additive nullable columns (D1 migration `0045` + the matching Postgres `ALTER TABLE`, already applied live to the indexer box) threaded through the existing daily snapshot writer (`health-prober.mjs`), its Postgres mirror (`handleSubnetSnapshotSync`), and both D1/Postgres trajectory read paths (`GET /api/v1/subnets/{netuid}/trajectory`, JSON + CSV).
- `formatTrajectory`'s existing 7d/30d delta window now computes net TAO/alpha flow as reserve-level-now minus reserve-level-then for `tao_in_pool_tao`/`alpha_in_pool`/`alpha_out_pool` — no new chain indexer, no separate flow ingestion, same source data the live economics tier already ingests every 3h.
- Also fixes `scripts/backfill-subnet-snapshots-postgres.mjs`'s column list (the D1→Postgres backfill sibling to #4772's chain-data backfill) so it doesn't silently drop the new columns on its next run, and patch-bumps the client SDK for the schema addition.

## Test plan
- [x] `npx vitest run` — 273 files / 8140 tests pass
- [x] `npm run lint` / `npm run format:check` — clean
- [x] `npm run validate` / `validate:contract-drift` / `validate:schemas` / `validate:api` (157 routes) / `validate:openapi` (157 routes) / `validate:docs` / `validate:migrations` / `scan:public-safety` — all clean
- [x] Live-verified: SSH'd to the indexer box and applied the matching `ALTER TABLE subnet_snapshots ADD COLUMN ...` to the running Postgres instance, then confirmed via `\d subnet_snapshots` that it matches `deploy/postgres/schema.sql`