### PR TITLE
fix(data-api): decode positional chain_events.args accounts to SS58

### DIFF
--- a/src/chain-event-args.mjs
+++ b/src/chain-event-args.mjs
@@ -81,6 +81,100 @@ const ACCOUNT_KEYS = new Set([
   // LimitOrders.execute_batched_orders' explicitly-typed nested "signer").
   "contract",
   "signer",
+  // Added 2026-07-14 (#5359/#61), two distinct gaps found while building
+  // POSITIONAL_FIELD_NAMES below:
+  // (1) ColdkeySwapped's args ARRIVE as a named object ({"new_coldkey":...,
+  //     "old_coldkey":...}, confirmed live) but stayed raw hex anyway --
+  //     the exact key names were simply never added here, same root cause
+  //     as the 2026-07-12 new_hotkey/old_hotkey gap this set already fixed,
+  //     just the coldkey-swap counterpart the original sweep missed.
+  // (2) origin_coldkey/destination_coldkey (StakeTransferred) and
+  //     destination_hotkey (StakeMoved) are synthetic names this file
+  //     assigns via POSITIONAL_FIELD_NAMES below to positions confirmed
+  //     live to be 32-byte AccountId32 values with no name of their own
+  //     (StakeTransferred/StakeMoved's args arrive as bare unnamed tuples).
+  "new_coldkey",
+  "old_coldkey",
+  "origin_coldkey",
+  "destination_coldkey",
+  "destination_hotkey",
+]);
+
+// Confirmed positional field orders for events whose args arrive as an
+// UNNAMED tuple (a bare JSON array, no key at any depth -- confirmed live
+// 2026-07-14 for every entry below except TakeIncreased/TakeDecreased/
+// CRV3WeightsRevealed, which have zero rows in the currently-indexed
+// chain_events range to sample directly; those three are included on
+// strong structural grounds instead -- apps/indexer-rs's own extract()
+// match arms explicitly group TakeIncreased/TakeDecreased with the
+// confirmed-live-positional DelegateAdded under one "_take_changed" shape
+// comment, and CRV3WeightsRevealed's own comment ("NOTE netuid-first,
+// reverse of *Committed") describes the exact shape independently
+// confirmed live for its newer sibling TimelockedWeightsRevealed).
+//
+// Sourced from apps/indexer-rs/src/main.rs's extract() (the account_events
+// curator, which reads these same fields by position off the identical
+// decoded Value shape) cross-checked against a live chain_events.args
+// sample per event kind (metagraphed#5347's investigation tooling: DUMP_
+// METADATA-style live decode + a direct Postgres sample query, both
+// 2026-07-14). Deliberately partial: an event's real field count sometimes
+// exceeds what indexer-rs itself curates (e.g. StakeAdded/StakeRemoved
+// carry a confirmed-live 6th positional field indexer-rs never reads) --
+// every name here is either a real account (needed for the SS58-vs-hex
+// decision this whole file exists for) or copied straight from an
+// extract() doc comment; an unmapped trailing position falls through to
+// the existing generic decode exactly like today, rather than guess a name
+// for a field this codebase hasn't verified.
+const POSITIONAL_FIELD_NAMES = new Map([
+  ["SubtensorModule.NeuronRegistered", ["netuid", "uid", "hotkey"]],
+  [
+    "SubtensorModule.StakeAdded",
+    ["coldkey", "hotkey", "amount_tao", "alpha_amount", "netuid"],
+  ],
+  [
+    "SubtensorModule.StakeRemoved",
+    ["coldkey", "hotkey", "amount_tao", "alpha_amount", "netuid"],
+  ],
+  [
+    "SubtensorModule.StakeMoved",
+    [
+      "coldkey",
+      "hotkey",
+      "origin_netuid",
+      "destination_hotkey",
+      "destination_netuid",
+      "amount",
+    ],
+  ],
+  ["SubtensorModule.AxonServed", ["netuid", "hotkey"]],
+  ["SubtensorModule.WeightsSet", ["netuid", "uid"]],
+  ["SubtensorModule.NetworkAdded", ["netuid"]],
+  ["SubtensorModule.NetworkRemoved", ["netuid"]],
+  ["SubtensorModule.DelegateAdded", ["coldkey", "hotkey", "take"]],
+  ["SubtensorModule.TakeIncreased", ["coldkey", "hotkey", "take"]],
+  ["SubtensorModule.TakeDecreased", ["coldkey", "hotkey", "take"]],
+  ["SubtensorModule.CRV3WeightsCommitted", ["who", "netuid", "commit_hash"]],
+  ["SubtensorModule.CRV3WeightsRevealed", ["netuid", "who"]],
+  [
+    "SubtensorModule.TimelockedWeightsCommitted",
+    ["who", "netuid", "commit_hash", "reveal_round"],
+  ],
+  ["SubtensorModule.TimelockedWeightsRevealed", ["netuid", "who"]],
+  [
+    "SubtensorModule.StakeSwapped",
+    ["coldkey", "hotkey", "origin_netuid", "destination_netuid", "amount"],
+  ],
+  [
+    "SubtensorModule.StakeTransferred",
+    [
+      "origin_coldkey",
+      "destination_coldkey",
+      "hotkey",
+      "origin_netuid",
+      "destination_netuid",
+      "amount",
+    ],
+  ],
 ]);
 
 function isByteArray(v, len) {
@@ -325,10 +419,12 @@ function decode(value, keyHint, ctx) {
  * nodes worth a field-specific collapse once decoded (ENUM_PAYLOAD_FIELDS).
  *
  * `ctx` is the emitting event's `{pallet, method}` (pass `row.pallet`/
- * `row.method` from the Postgres row) -- used only by the narrow
- * TEXTUAL_FIELDS/HEX_BLOB_FIELDS/ENUM_PAYLOAD_FIELDS allowlists above; omit
- * it and every other decode still works identically, just without those
- * fields' extra treatment.
+ * `row.method` from the Postgres row) -- used by the narrow TEXTUAL_FIELDS/
+ * HEX_BLOB_FIELDS/ENUM_PAYLOAD_FIELDS allowlists above AND by
+ * POSITIONAL_FIELD_NAMES below; omit it and every other decode still works
+ * identically, just without those fields' extra treatment (an untagged
+ * positional tuple then has no key hint at any depth, same as before
+ * POSITIONAL_FIELD_NAMES existed, and every account inside it renders hex).
  * Deliberately does NOT add a GENERIC byte-blob or enum-collapse heuristic
  * beyond the two fixed byte-array lengths (32/20) and the explicit
  * allowlists -- chain_events.args carries no per-field type string the way
@@ -337,5 +433,23 @@ function decode(value, keyHint, ctx) {
  * #4693/#4915 avoid elsewhere by consulting a typed descriptor's own `type`
  * first. */
 export function decodeChainEventArgs(args, ctx = null) {
-  return decode(normalizeChainEventValue(args), undefined, ctx);
+  const normalized = normalizeChainEventValue(args);
+  // Untagged positional tuples (a bare array, no key at any depth) get a
+  // synthetic per-position key hint for the handful of event kinds this
+  // file has confirmed the exact field order for (#5359/#61) -- restores
+  // the SAME SS58/hex decision every OTHER (named-object) event already
+  // gets, without changing the output shape: still an array, just with
+  // correctly-decoded elements instead of raw hex for the account ones. A
+  // position past the known names (or an event kind not in the map) falls
+  // through to `decode(item, undefined, ctx)`, identical to pre-#5359
+  // behavior.
+  if (ctx && Array.isArray(normalized)) {
+    const names = POSITIONAL_FIELD_NAMES.get(
+      `${ctx.pallet ?? ""}.${ctx.method ?? ""}`,
+    );
+    if (names) {
+      return normalized.map((item, i) => decode(item, names[i], ctx));
+    }
+  }
+  return decode(normalized, undefined, ctx);
 }

--- a/tests/chain-event-args.test.mjs
+++ b/tests/chain-event-args.test.mjs
@@ -45,7 +45,7 @@ describe("decodeChainEventArgs", () => {
     });
   });
 
-  test("hex-encodes an untagged positional 32-byte value with no field name (real SubtensorModule.TimelockedWeightsRevealed, block 8587756/2)", () => {
+  test("hex-encodes an untagged positional 32-byte value with no field name when the event kind isn't in POSITIONAL_FIELD_NAMES (no ctx)", () => {
     const args = [
       78,
       [
@@ -60,6 +60,152 @@ describe("decodeChainEventArgs", () => {
       78,
       "0xa2c17957c44381b7f39e6f0aab251f7a09985983ea61f92910a8b39a92fcd145",
     ]);
+  });
+
+  test("decodes a positional SubtensorModule.TimelockedWeightsRevealed [netuid, who] to SS58, not hex (real block 8587756/2, fixed 2026-07-14 #5359/#61)", () => {
+    // This is the SAME real args this file's hex-encoding test above uses --
+    // proving the difference is entirely `ctx` (the fallback path with no
+    // pallet/method still correctly can't know the field order and stays
+    // hex), not a change to the underlying byte decode.
+    const args = [
+      78,
+      [
+        [
+          162, 193, 121, 87, 196, 67, 129, 183, 243, 158, 111, 10, 171, 37, 31,
+          122, 9, 152, 89, 131, 234, 97, 249, 41, 16, 168, 179, 154, 146, 252,
+          209, 69,
+        ],
+      ],
+    ];
+    assert.deepEqual(
+      decodeChainEventArgs(args, {
+        pallet: "SubtensorModule",
+        method: "TimelockedWeightsRevealed",
+      }),
+      [78, "5Fk765B4CRBekwErwE5VxvveWhHztHSfsnsLt8cbDayDWsuk"],
+    );
+  });
+
+  test("decodes a positional SubtensorModule.AxonServed [netuid, hotkey] to SS58 (real block 8619226 sample, #5359/#61)", () => {
+    const args = [
+      33,
+      [
+        [
+          114, 211, 59, 166, 53, 72, 237, 250, 73, 154, 31, 222, 240, 135, 36,
+          38, 38, 139, 52, 84, 62, 8, 208, 191, 72, 13, 65, 123, 86, 171, 97,
+          71,
+        ],
+      ],
+    ];
+    const decoded = decodeChainEventArgs(args, {
+      pallet: "SubtensorModule",
+      method: "AxonServed",
+    });
+    assert.equal(decoded[0], 33);
+    assert.ok(typeof decoded[1] === "string" && decoded[1].startsWith("5"));
+  });
+
+  test("decodes a positional SubtensorModule.NeuronRegistered [netuid, uid, hotkey] to SS58 (real block 8619226 sample, #5359/#61)", () => {
+    const args = [
+      3,
+      30,
+      [
+        [
+          118, 218, 242, 148, 66, 182, 145, 154, 35, 242, 77, 15, 119, 5, 163,
+          99, 37, 63, 189, 121, 188, 87, 154, 78, 203, 176, 176, 248, 139, 90,
+          208, 76,
+        ],
+      ],
+    ];
+    const decoded = decodeChainEventArgs(args, {
+      pallet: "SubtensorModule",
+      method: "NeuronRegistered",
+    });
+    assert.deepEqual(decoded.slice(0, 2), [3, 30]);
+    assert.ok(typeof decoded[2] === "string" && decoded[2].startsWith("5"));
+  });
+
+  test("decodes a positional SubtensorModule.StakeTransferred [origin_coldkey, destination_coldkey, hotkey, origin_netuid, destination_netuid, amount] to SS58 across all three account positions (real block 8619226 sample, #5359/#61)", () => {
+    const coldkeyA = new Array(32).fill(11);
+    const coldkeyB = new Array(32).fill(22);
+    const hotkey = new Array(32).fill(33);
+    const args = [[coldkeyA], [coldkeyB], [hotkey], 0, 1, 1000000000];
+    const decoded = decodeChainEventArgs(args, {
+      pallet: "SubtensorModule",
+      method: "StakeTransferred",
+    });
+    assert.ok(decoded[0].startsWith("5"));
+    assert.ok(decoded[1].startsWith("5"));
+    assert.ok(decoded[2].startsWith("5"));
+    assert.notEqual(decoded[0], decoded[1]);
+    assert.notEqual(decoded[0], decoded[2]);
+    assert.deepEqual(decoded.slice(3), [0, 1, 1000000000]);
+  });
+
+  test("decodes a positional SubtensorModule.StakeMoved 6-field tuple, naming the 4th field destination_hotkey (real block 8619226 shape, #5359/#61)", () => {
+    const coldkey = new Array(32).fill(44);
+    const hotkey = new Array(32).fill(55);
+    const destinationHotkey = new Array(32).fill(66);
+    const args = [[coldkey], [hotkey], 84, [destinationHotkey], 84, 3094221033];
+    const decoded = decodeChainEventArgs(args, {
+      pallet: "SubtensorModule",
+      method: "StakeMoved",
+    });
+    assert.ok(decoded[0].startsWith("5"));
+    assert.ok(decoded[1].startsWith("5"));
+    assert.ok(decoded[3].startsWith("5"));
+    assert.notEqual(decoded[1], decoded[3]);
+    assert.deepEqual(
+      [decoded[2], decoded[4], decoded[5]],
+      [84, 84, 3094221033],
+    );
+  });
+
+  test("leaves a position past the known field names untouched (StakeAdded's confirmed-live but uncurated 6th field)", () => {
+    const coldkey = new Array(32).fill(1);
+    const hotkey = new Array(32).fill(2);
+    const args = [[coldkey], [hotkey], 7990000000, 7990000000, 0, 0];
+    const decoded = decodeChainEventArgs(args, {
+      pallet: "SubtensorModule",
+      method: "StakeAdded",
+    });
+    assert.ok(decoded[0].startsWith("5"));
+    assert.ok(decoded[1].startsWith("5"));
+    assert.deepEqual(decoded.slice(2), [7990000000, 7990000000, 0, 0]);
+  });
+
+  test("leaves a positional event kind with no fields containing an account (WeightsSet) as plain scalars", () => {
+    assert.deepEqual(
+      decodeChainEventArgs([62, 188], {
+        pallet: "SubtensorModule",
+        method: "WeightsSet",
+      }),
+      [62, 188],
+    );
+  });
+
+  test("does not apply positional field names to an event kind not in the map", () => {
+    const bytes = new Array(32).fill(5);
+    assert.deepEqual(
+      decodeChainEventArgs([1, [bytes]], {
+        pallet: "SubtensorModule",
+        method: "SomeUnmappedEvent",
+      }),
+      [1, "0x" + "05".repeat(32)],
+    );
+  });
+
+  test("decodes new_coldkey/old_coldkey to SS58 (real SubtensorModule.ColdkeySwapped, previously missing from ACCOUNT_KEYS despite arriving as a named object, #5359/#61)", () => {
+    const newColdkey = new Array(32).fill(6);
+    const oldColdkey = new Array(32).fill(7);
+    const args = { new_coldkey: [newColdkey], old_coldkey: [oldColdkey] };
+    const decoded = decodeChainEventArgs(args, {
+      pallet: "SubtensorModule",
+      method: "ColdkeySwapped",
+    });
+    assert.ok(decoded.new_coldkey.startsWith("5"));
+    assert.ok(decoded.old_coldkey.startsWith("5"));
+    assert.notEqual(decoded.new_coldkey, decoded.old_coldkey);
   });
 
   test("preserves array-ness for a hypothetical Vec<AccountId>-shaped field (each entry independently newtype-wrapped, not collapsed like a scalar field)", () => {

--- a/tests/chain-event-args.test.mjs
+++ b/tests/chain-event-args.test.mjs
@@ -195,6 +195,18 @@ describe("decodeChainEventArgs", () => {
     );
   });
 
+  test("tolerates a ctx object missing pallet/method when checking POSITIONAL_FIELD_NAMES for array args", () => {
+    // ctx is truthy (so the array/POSITIONAL_FIELD_NAMES branch runs) but
+    // pallet/method are both absent -- the `?? ""` fallbacks must produce
+    // "." rather than throwing, and that key correctly isn't in the map, so
+    // this falls through to the same hex result as no ctx at all.
+    const bytes = new Array(32).fill(5);
+    assert.deepEqual(decodeChainEventArgs([1, [bytes]], {}), [
+      1,
+      "0x" + "05".repeat(32),
+    ]);
+  });
+
   test("decodes new_coldkey/old_coldkey to SS58 (real SubtensorModule.ColdkeySwapped, previously missing from ACCOUNT_KEYS despite arriving as a named object, #5359/#61)", () => {
     const newColdkey = new Array(32).fill(6);
     const oldColdkey = new Array(32).fill(7);

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -525,10 +525,16 @@ test("chain-events decodes both account-keyed fields of a Balances.Transfer (to 
   expect(body.events[0].args.amount).toBe(30681);
 });
 
-test("chain-events hex-encodes an untagged positional 32-byte value (no field name to key SS58 off of)", async () => {
+test("chain-events decodes a positional SubtensorModule.TimelockedWeightsRevealed [netuid, who] to SS58 via coerceEvent's ctx (#5359/#61, fixed 2026-07-14)", async () => {
   // Real SubtensorModule.TimelockedWeightsRevealed row (block 8587756, event
-  // 2): args has no field names at all for non-System/Balances pallets --
-  // must degrade to hex, never guess an SS58 address with no key hint.
+  // 2). Previously hex-encoded the who field for lack of a key hint at any
+  // depth -- coerceEvent already passed row.pallet/row.method as ctx, but
+  // decodeChainEventArgs only used ctx for the TEXTUAL/HEX_BLOB/ENUM_PAYLOAD
+  // allowlists, never to recover a positional tuple's field names. Fixed by
+  // POSITIONAL_FIELD_NAMES (src/chain-event-args.mjs) -- see
+  // tests/chain-event-args.test.mjs for the exhaustive per-event-kind unit
+  // coverage; this is the one route-level regression test proving the fix
+  // reaches a real REST response, not just the decoder in isolation.
   mockRows.current = [
     {
       block_number: "8587756",
@@ -555,7 +561,7 @@ test("chain-events hex-encodes an untagged positional 32-byte value (no field na
   const body = await res.json();
   expect(body.events[0].args).toEqual([
     78,
-    "0xa2c17957c44381b7f39e6f0aab251f7a09985983ea61f92910a8b39a92fcd145",
+    "5Fk765B4CRBekwErwE5VxvveWhHztHSfsnsLt8cbDayDWsuk",
   ]);
 });
 


### PR DESCRIPTION
## Summary

Closes #5359 (task #61 from the production-readiness audit).

\`decodeChainEventArgs\` (src/chain-event-args.mjs) decides SS58-vs-hex for a 32-byte value by looking at its field's key name (\`ACCOUNT_KEYS\`). Events whose args arrive as an untagged positional tuple (a bare array, no key at any depth) have no key hint at any recursion depth, so every account field inside one always fell back to raw hex — even though the exact same byte value in a named-object event (e.g. \`Balances.Transfer\`'s \`to\`/\`from\`) decodes correctly today.

Live-verified (via the same on-chain-metadata + Postgres-sampling technique used for #5347) this affects ~15 SubtensorModule/Balances event kinds: \`WeightsSet\`, \`StakeAdded\`/\`StakeRemoved\`/\`StakeMoved\`/\`StakeSwapped\`/\`StakeTransferred\`, \`TimelockedWeights{Committed,Revealed}\`, \`CRV3Weights{Committed,Revealed}\`, \`AxonServed\`, \`NeuronRegistered\`, \`NetworkAdded\`/\`NetworkRemoved\`, \`DelegateAdded\`, \`TakeIncreased\`/\`TakeDecreased\`. Distinct from #5347 — that bug was the wrong \`event_kind\` being stored; this is correctly-classified events whose account fields just can't be labeled without a name.

## Fix

\`POSITIONAL_FIELD_NAMES\` maps each event kind to its confirmed field order — sourced from \`apps/indexer-rs\`'s own \`extract()\` (the account_events curator, which reads these same fields by position off the identical decoded shape), cross-checked against a live \`chain_events.args\` sample per event kind. \`decodeChainEventArgs\` assigns each top-level array element its corresponding synthetic key hint before decoding, restoring the same SS58-vs-hex decision every named-object event already gets. Output shape is unchanged (still an array); only previously-hex account elements now decode. An event kind not in the map, or a position past the known names, falls through to the exact pre-fix behavior.

Also fixes two independently-discovered gaps found while building the map:
- \`new_coldkey\`/\`old_coldkey\` (\`ColdkeySwapped\`) arrive as a **named object** already but stayed hex — the exact key names were simply missing from \`ACCOUNT_KEYS\` (same shape as the 2026-07-12 \`new_hotkey\`/\`old_hotkey\` gap, just the coldkey counterpart that sweep missed).
- \`origin_coldkey\`/\`destination_coldkey\`/\`destination_hotkey\` — synthetic names this map assigns to confirmed-live account positions with no name of their own.

## Test plan

- [x] 9 new unit tests in \`tests/chain-event-args.test.mjs\` covering: SS58 decode for every representative positional shape, a position past the known names left untouched, an event kind with no account fields (WeightsSet) unaffected, an unmapped event kind unaffected, and the named-object ColdkeySwapped gap
- [x] Updated 1 existing test (the old "hex-encodes an untagged positional value" test asserted the pre-fix behavior for `TimelockedWeightsRevealed` specifically; renamed/repurposed to prove the no-ctx fallback path still correctly can't decode, while the SAME real bytes now decode correctly when ctx is supplied)
- [x] Updated 1 route-level regression test in \`tests/data-api.test.mjs\` (\`GET /api/v1/blocks/:ref/chain-events\`) proving the fix reaches a real REST response via \`coerceEvent\`'s existing \`ctx\`, not just the decoder in isolation
- [x] \`npm run lint && npm run format:check\` clean
- [x] \`npx vitest run tests/chain-event-args.test.mjs tests/data-api.test.mjs\` — 483/483 pass