### PR TITLE
fix(data-api): batch nominator sync inserts under Postgres' param limit

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -4409,6 +4409,48 @@ test("validator-nominator-counts-sync maps a DB failure to a clean 502 instead o
   expect((await res.json()).error).toBe("write failed");
 });
 
+// #5352 live incident: a real 112,550-row sync (762,577-row Alpha scan
+// output) hit Postgres' hard 65535-bound-parameters-per-statement ceiling
+// (112,550 rows x 3 columns = 337,650 params) inside a single INSERT,
+// failing every real-world sync at production scale even though every
+// smaller test above passed. batchedUpsert (workers/data-api.mjs) splits
+// into VALIDATOR_NOMINATOR_COUNTS_MAX_ROWS_PER_BATCH-sized statements inside
+// one sql.begin() transaction -- this proves more than one INSERT actually
+// gets issued for a payload over that threshold, not just that the response
+// still reports the right total.
+test("validator-nominator-counts-sync splits a payload over the per-statement param cap into multiple INSERT statements (#5352)", async () => {
+  const MAX_ROWS_PER_BATCH = 20_000; // must match workers/data-api.mjs's own constant
+  const rows = Array.from({ length: MAX_ROWS_PER_BATCH + 1 }, (_, i) =>
+    validatorNominatorCountRow({ hotkey: `5Hk${i}`, nominator_count: i }),
+  );
+  const res = await postValidatorNominatorCounts(rows, {
+    secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  expect((await res.json()).validator_nominator_counts_written).toBe(
+    rows.length,
+  );
+  const insertCalls = sqlCalls.filter((call) =>
+    call.text.includes("INSERT INTO validator_nominator_counts"),
+  );
+  expect(insertCalls.length).toBe(2);
+});
+
+test("validator-nominator-counts-sync issues a single INSERT for a payload at or under the per-statement batch size", async () => {
+  const rows = [
+    validatorNominatorCountRow({ hotkey: "5Hk1" }),
+    validatorNominatorCountRow({ hotkey: "5Hk2" }),
+  ];
+  const res = await postValidatorNominatorCounts(rows, {
+    secret: VALIDATOR_NOMINATOR_COUNTS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  const insertCalls = sqlCalls.filter((call) =>
+    call.text.includes("INSERT INTO validator_nominator_counts"),
+  );
+  expect(insertCalls.length).toBe(1);
+});
+
 // #5233: POST /api/v1/internal/nominator-positions-sync -- the write path
 // into nominator_positions (see workers/data-api.mjs's
 // handleNominatorPositionsSync). Same latest-only-upsert shape as
@@ -4538,6 +4580,43 @@ test("nominator-positions-sync maps a DB failure to a clean 502 instead of throw
   });
   expect(res.status).toBe(502);
   expect((await res.json()).error).toBe("write failed");
+});
+
+// #5352 live incident (same root cause as validator-nominator-counts-sync's
+// own batching test above): a real 132,505-row sync hit Postgres' 65535
+// bound-parameters-per-statement ceiling even harder here (5 columns vs 3 --
+// 132,505 x 5 = 662,525 params). batchedUpsert applies identically; this
+// proves nominator-positions-sync actually issues multiple INSERT
+// statements for a payload over its own (smaller, 5-column) batch size.
+test("nominator-positions-sync splits a payload over the per-statement param cap into multiple INSERT statements (#5352)", async () => {
+  const MAX_ROWS_PER_BATCH = 10_000; // must match workers/data-api.mjs's own constant
+  const rows = Array.from({ length: MAX_ROWS_PER_BATCH + 1 }, (_, i) =>
+    nominatorPositionRow({ hotkey: `5Hk${i}`, netuid: i % 128 }),
+  );
+  const res = await postNominatorPositions(rows, {
+    secret: NOMINATOR_POSITIONS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  expect((await res.json()).nominator_positions_written).toBe(rows.length);
+  const insertCalls = sqlCalls.filter((call) =>
+    call.text.includes("INSERT INTO nominator_positions"),
+  );
+  expect(insertCalls.length).toBe(2);
+});
+
+test("nominator-positions-sync issues a single INSERT for a payload at or under the per-statement batch size", async () => {
+  const rows = [
+    nominatorPositionRow({ hotkey: "5Hk1" }),
+    nominatorPositionRow({ hotkey: "5Hk2" }),
+  ];
+  const res = await postNominatorPositions(rows, {
+    secret: NOMINATOR_POSITIONS_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  const insertCalls = sqlCalls.filter((call) =>
+    call.text.includes("INSERT INTO nominator_positions"),
+  );
+  expect(insertCalls.length).toBe(1);
 });
 
 test("GET /api/v1/accounts/:ss58/positions joins share_fraction against live neurons stake_tao (#5233)", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -1565,6 +1565,29 @@ async function handleAccountIdentitySync(request, env) {
   }
 }
 
+// Postgres hard-caps a single statement at 65535 bound parameters -- a bulk
+// `INSERT ... ${sql(rows, ...columns)}` blows past that the moment
+// rows.length * columns.length exceeds it, which the ROW-count ceilings
+// alone (*_SYNC_MAX_ROWS above/below) don't prevent, since those bound the
+// PAYLOAD, not any single statement. Found live 2026-07-14 exercising
+// validator-nominator-counts-sync for the first time at real production
+// scale (#5352): 112,550 hotkey rows x 3 columns = 337,650 params, and the
+// paired nominator-positions-sync payload (132,505 rows x 5 columns =
+// 662,525 params) hits the exact same wall -- both single-batch INSERTs
+// failed the request with a Postgres protocol error, surfaced to the caller
+// as a bare 502 with no detail. batchedUpsert splits `rows` into
+// PARAMS_PER_ROW-sized chunks (each well under the 65535 ceiling) and runs
+// them as sequential statements inside ONE transaction (`sql.begin`), same
+// atomicity as every other sync handler's single-statement writes -- a
+// mid-batch failure still rolls back the whole sync rather than leaving a
+// partial write, and both these tables are latest-only/REPLACE-on-conflict
+// so a subsequent retry is safe either way.
+async function batchedUpsert(sql, rows, insertFn, maxRowsPerBatch) {
+  for (let i = 0; i < rows.length; i += maxRowsPerBatch) {
+    await insertFn(sql, rows.slice(i, i + maxRowsPerBatch));
+  }
+}
+
 // --- POST /api/v1/internal/validator-nominator-counts-sync (#2549) --------
 //
 // The write path into validator_nominator_counts (migration 0043) --
@@ -1577,6 +1600,10 @@ async function handleAccountIdentitySync(request, env) {
 // neurons snapshot's cadence.
 const VALIDATOR_NOMINATOR_COUNTS_SYNC_TOKEN_HEADER =
   "x-validator-nominator-counts-sync-token";
+// floor(65535 / 3 columns) = 21845 -- batchedUpsert's per-statement row cap,
+// rounded down for headroom (see batchedUpsert's own header comment for why
+// this exists at all).
+const VALIDATOR_NOMINATOR_COUNTS_MAX_ROWS_PER_BATCH = 20_000;
 // A ceiling on distinct hotkeys ever seen holding stake, NOT on
 // validator-permit hotkeys (~1-2k) -- this table isn't validator-scoped by
 // design (see the fetch script). A live full-scan probe 2026-07-14 found
@@ -1678,13 +1705,20 @@ async function handleValidatorNominatorCountsSync(request, env) {
   });
 
   try {
-    await sql`SET statement_timeout = '20000ms'`;
-    await sql`
-      INSERT INTO validator_nominator_counts ${sql(incoming, ...VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS)}
-      ON CONFLICT (hotkey) DO UPDATE SET
-        nominator_count = EXCLUDED.nominator_count,
-        captured_at = EXCLUDED.captured_at
-      WHERE validator_nominator_counts.captured_at <= EXCLUDED.captured_at`;
+    await sql.begin(async (sql) => {
+      await sql`SET statement_timeout = '20000ms'`;
+      await batchedUpsert(
+        sql,
+        incoming,
+        (sql, batch) => sql`
+          INSERT INTO validator_nominator_counts ${sql(batch, ...VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS)}
+          ON CONFLICT (hotkey) DO UPDATE SET
+            nominator_count = EXCLUDED.nominator_count,
+            captured_at = EXCLUDED.captured_at
+          WHERE validator_nominator_counts.captured_at <= EXCLUDED.captured_at`,
+        VALIDATOR_NOMINATOR_COUNTS_MAX_ROWS_PER_BATCH,
+      );
+    });
     return writeJson({
       ok: true,
       validator_nominator_counts_written: incoming.length,
@@ -1700,6 +1734,10 @@ async function handleValidatorNominatorCountsSync(request, env) {
 
 const NOMINATOR_POSITIONS_SYNC_TOKEN_HEADER =
   "x-nominator-positions-sync-token";
+// floor(65535 / 5 columns) = 13107 -- batchedUpsert's per-statement row cap,
+// rounded down for headroom (see batchedUpsert's own header comment, above
+// validator-nominator-counts-sync, for the live incident this fixes).
+const NOMINATOR_POSITIONS_MAX_ROWS_PER_BATCH = 10_000;
 // Same headroom rationale as VALIDATOR_NOMINATOR_COUNTS_SYNC_MAX_ROWS above --
 // this is one row per (coldkey, hotkey, netuid) triple, not per hotkey, so
 // it carries generous headroom over the 762,577 total Alpha rows observed
@@ -1799,13 +1837,20 @@ async function handleNominatorPositionsSync(request, env) {
   });
 
   try {
-    await sql`SET statement_timeout = '20000ms'`;
-    await sql`
-      INSERT INTO nominator_positions ${sql(incoming, ...NOMINATOR_POSITION_INSERT_COLUMNS)}
-      ON CONFLICT (coldkey, hotkey, netuid) DO UPDATE SET
-        share_fraction = EXCLUDED.share_fraction,
-        captured_at = EXCLUDED.captured_at
-      WHERE nominator_positions.captured_at <= EXCLUDED.captured_at`;
+    await sql.begin(async (sql) => {
+      await sql`SET statement_timeout = '20000ms'`;
+      await batchedUpsert(
+        sql,
+        incoming,
+        (sql, batch) => sql`
+          INSERT INTO nominator_positions ${sql(batch, ...NOMINATOR_POSITION_INSERT_COLUMNS)}
+          ON CONFLICT (coldkey, hotkey, netuid) DO UPDATE SET
+            share_fraction = EXCLUDED.share_fraction,
+            captured_at = EXCLUDED.captured_at
+          WHERE nominator_positions.captured_at <= EXCLUDED.captured_at`,
+        NOMINATOR_POSITIONS_MAX_ROWS_PER_BATCH,
+      );
+    });
     return writeJson({
       ok: true,
       nominator_positions_written: incoming.length,


### PR DESCRIPTION
## Summary

Live incident found while wiring #5352 (the validator-nominator-counts box-cron timer): the first real production-scale sync run (112,550 validator-nominator-count rows / 132,505 nominator-position rows, from the ~4.2min `SubtensorModule::Alpha` full scan) hit Postgres' hard 65535-bound-parameters-per-statement ceiling inside a single bulk `INSERT ... ${sql(rows, ...columns)}` — 112,550 × 3 columns = 337,650 params, 132,505 × 5 columns = 662,525 params. Both single-batch INSERTs failed with a Postgres protocol error, surfaced to the caller as a bare 502.

Every existing test for these two sync handlers passed because none exercised a payload anywhere near real production scale (the row-count ceilings, `*_SYNC_MAX_ROWS`, bound the request payload, not any single SQL statement).

## Fix

`batchedUpsert` splits `rows` into per-statement chunks safely under the 65535 ceiling (20,000/batch for the 3-column table, 10,000/batch for the 5-column table), run as sequential statements inside one `sql.begin()` transaction — same atomicity as every other sync handler's single-statement write (a mid-batch failure still rolls back the whole sync), and both tables are latest-only/REPLACE-on-conflict so a retry is safe either way.

## Test plan

- [x] New regression tests for both handlers proving >1 INSERT statement is issued when the payload exceeds the per-statement batch size, and exactly 1 when it doesn't
- [x] `npm run lint && npm run format:check` clean
- [x] `npx vitest run tests/data-api.test.mjs` — 442/442 pass
- [x] Live-reproduced against the real 112,550-row payload on the indexer box (systemd job failed with the exact 502 this fixes, before this change)