### PR TITLE
fix(ui): make the block hero hash a copyable, non-overflowing CopyableCode

### DIFF
--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -163,7 +163,13 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         eyebrow="Explorer · block"
         live
         title={`#${formatNumber(block.block_number)}`}
-        description={<span className="font-mono text-sm break-all">{block.block_hash || "—"}</span>}
+        description={
+          block.block_hash ? (
+            <CopyableCode value={block.block_hash} className="max-w-full" />
+          ) : (
+            <span className="text-ink-muted">—</span>
+          )
+        }
         actions={<ShareButton />}
         caption="explorer / v1"
       />


### PR DESCRIPTION
Closes #5318

## What

The block detail hero rendered the full block hash as a plain, non-interactive `<span>` (`blocks.$ref.tsx:166`) — uncopyable (unlike every other entity hero, which uses a `CopyableCode`/chip), and it wrapped to two lines / overflowed at 375px.

- Replace the hero `<span>` with **`CopyableCode`**, capped with **`max-w-full`** so it truncates *within* the hero instead of overflowing off-screen (the #5308 concern the issue flags).
- **Kept** the full labelled hash in the "Block details" `<dl>` — its canonical location. The hero now shows a compact, truncated, copyable identifier rather than a verbatim two-line repeat, so it's no longer a straight duplicate.

Single file, +7/−1.

## Verify

`lint` (0 errors) · `format:check` · `typecheck` · `test` (690 pass) · `build` — all green. No 375px overflow (see screenshots).

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5318-before-mobile-light.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5318-after-mobile-light.png" width="300"> |
| Mobile · Dark | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5318-before-mobile-dark.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5318-after-mobile-dark.png" width="300"> |
| Tablet · Light | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5318-before-tablet-light.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5318-after-tablet-light.png" width="300"> |
| Tablet · Dark | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5318-before-tablet-dark.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5318-after-tablet-dark.png" width="300"> |
| Desktop · Light | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5318-before-desktop-light.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5318-after-desktop-light.png" width="300"> |
| Desktop · Dark | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5318-before-desktop-dark.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5318-after-desktop-dark.png" width="300"> |
