### PR TITLE
feat(registry): add SN26 Perturb whitepaper docs surface (#4022)

### DIFF
--- a/registry/subnets/perturb.json
+++ b/registry/subnets/perturb.json
@@ -56,6 +56,22 @@
         "submitted_by": "dalledajay-coder"
       },
       "notes": "Public no-auth GET returning SN26 Perturb's current emission burn rate as JSON ({\"burnRate\":0.5} observed at submission time). The endpoint is declared as BURN_RATE_ENDPOINT in the subnet's validator source (perturbnet/constants.py in the official repo, pinned above) and is served from api.perturbai.io, the same host as the already-registered health surface."
+    },
+    {
+      "id": "sn-26-perturb-whitepaper-docs",
+      "name": "Perturb whitepaper",
+      "kind": "docs",
+      "url": "https://www.perturbai.io/whitepaper",
+      "provider": "perturb",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://www.perturbai.io/"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "notes": "Public no-auth whitepaper for SN26 Perturb (adversarial-perturbation ImageNet subnet), served at www.perturbai.io/whitepaper and linked from the official perturbai.io homepage nav (the registered website_url, same operator as the api.perturbai.io surfaces). Covers the abstract, methodology, miner/validator roles, scoring, and emission model. Distinct in URL, host, and kind from the api.perturbai.io endpoints already registered."
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Adds one new `community` surface to SN26 Perturb (`registry/subnets/perturb.json`): the official **Perturb whitepaper** docs page at `https://www.perturbai.io/whitepaper`.

This closes the file's docs gap — perturb.json currently registers only the two `api.perturbai.io` endpoints (health + burn-rate) and has no docs/whitepaper surface, even though the homepage nav links a full whitepaper.

## Surface

- **id:** `sn-26-perturb-whitepaper-docs`
- **kind:** `docs`
- **url:** `https://www.perturbai.io/whitepaper` — public, no-auth, HTTP 200 `text/html`
- **provider:** `perturb`
- **source_url:** `https://www.perturbai.io/` (registered `website_url`; the homepage nav links the whitepaper, proving the subnet publishes it)

## Proof of ownership

`www.perturbai.io` is the subnet's registered `website_url` and the same operator host as the already-registered `api.perturbai.io` surfaces. The whitepaper is linked directly from the homepage navigation.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/perturb.json` — passed (3 surfaces)
- `npm run validate:schemas` — passed

One focused change: one surface appended to one subnet file; nothing else touched.

Closes #4022

> Scope note: #4022 asks for surface coverage on SN26 Perturb. This adds a distinct `docs` surface (URL, host, and kind all distinct from the existing API endpoints). Any OpenAPI-specific framing is advisory.
