### PR TITLE
fix(ui): split the Endpoints page into concern tabs (#5329)

### DIFF
--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -147,6 +147,22 @@ function EndpointsPage() {
         description="A load-balanced reverse proxy for Bittensor RPC, plus the registry of callable Subtensor and subnet endpoints behind it."
       />
       <div className="space-y-section">
+        {/* Endpoint KPIs stay visible above the tabs so the tab bar has context
+            and doesn't float alone under the hero. */}
+        <QueryErrorBoundary>
+          <Suspense
+            fallback={
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                <Skeleton className="h-20" />
+                <Skeleton className="h-20" />
+                <Skeleton className="h-20" />
+                <Skeleton className="h-20" />
+              </div>
+            }
+          >
+            <EndpointsStatStrip />
+          </Suspense>
+        </QueryErrorBoundary>
         <div
           className="flex flex-wrap gap-2 border-b border-border pb-3"
           role="tablist"
@@ -184,20 +200,6 @@ function EndpointsPage() {
                 </Suspense>
               </QueryErrorBoundary>
             </section>
-            <QueryErrorBoundary>
-              <Suspense
-                fallback={
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                    <Skeleton className="h-20" />
-                    <Skeleton className="h-20" />
-                    <Skeleton className="h-20" />
-                    <Skeleton className="h-20" />
-                  </div>
-                }
-              >
-                <EndpointsStatStrip />
-              </Suspense>
-            </QueryErrorBoundary>
           </>
         )}
 

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense, useEffect, useMemo } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -112,6 +112,14 @@ export const Route = createFileRoute("/endpoints")({
   component: EndpointsPage,
 });
 
+type EndpointsTab = "proxy" | "endpoints" | "advanced" | "incidents";
+const ENDPOINTS_TABS: { id: EndpointsTab; label: string }[] = [
+  { id: "proxy", label: "Proxy" },
+  { id: "endpoints", label: "Endpoints" },
+  { id: "advanced", label: "Advanced" },
+  { id: "incidents", label: "Incidents" },
+];
+
 function EndpointsPage() {
   const hash = useRouterState({ select: (s) => s.location.hash });
   useEffect(() => {
@@ -126,6 +134,10 @@ function EndpointsPage() {
     return () => window.clearTimeout(t);
   }, [hash]);
 
+  // #5329: the page stacked ~9 full-width panels into one ~95,000px feed on
+  // mobile. Split its distinct concerns into tabs; each section fetches its own
+  // data, so only the active tab's panels mount (and query) at a time.
+  const [tab, setTab] = useState<EndpointsTab>("proxy");
   return (
     <AppShell>
       <PageHero
@@ -135,87 +147,127 @@ function EndpointsPage() {
         description="A load-balanced reverse proxy for Bittensor RPC, plus the registry of callable Subtensor and subnet endpoints behind it."
       />
       <div className="space-y-section">
-        {/* The headline feature: the live reverse proxy + its usage analytics. */}
-        <section>
-          <ProxyHero />
-        </section>
-        <section>
-          <SectionHeading title="Proxy usage" />
-          <QueryErrorBoundary>
-            <Suspense fallback={<Skeleton className="h-40 w-full" />}>
-              <ProxyUsagePanel />
-            </Suspense>
-          </QueryErrorBoundary>
-        </section>
+        <div
+          className="flex flex-wrap gap-2 border-b border-border pb-3"
+          role="tablist"
+          aria-label="Endpoints sections"
+        >
+          {ENDPOINTS_TABS.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              aria-selected={tab === t.id}
+              onClick={() => setTab(t.id)}
+              className={
+                tab === t.id
+                  ? "rounded-full border border-accent/40 bg-accent/10 px-3.5 py-1.5 font-mono text-[11px] uppercase tracking-widest text-accent"
+                  : "rounded-full border border-border bg-card px-3.5 py-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30 hover:text-ink-strong"
+              }
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
 
-        <QueryErrorBoundary>
-          <Suspense
-            fallback={
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                <Skeleton className="h-20" />
-                <Skeleton className="h-20" />
-                <Skeleton className="h-20" />
-                <Skeleton className="h-20" />
-              </div>
-            }
-          >
-            <EndpointsStatStrip />
-          </Suspense>
-        </QueryErrorBoundary>
+        {tab === "proxy" && (
+          <>
+            {/* The headline feature: the live reverse proxy + its usage analytics. */}
+            <section>
+              <ProxyHero />
+            </section>
+            <section>
+              <SectionHeading title="Proxy usage" />
+              <QueryErrorBoundary>
+                <Suspense fallback={<Skeleton className="h-40 w-full" />}>
+                  <ProxyUsagePanel />
+                </Suspense>
+              </QueryErrorBoundary>
+            </section>
+            <QueryErrorBoundary>
+              <Suspense
+                fallback={
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                    <Skeleton className="h-20" />
+                    <Skeleton className="h-20" />
+                    <Skeleton className="h-20" />
+                    <Skeleton className="h-20" />
+                  </div>
+                }
+              >
+                <EndpointsStatStrip />
+              </Suspense>
+            </QueryErrorBoundary>
+          </>
+        )}
 
-        <TimeRangeProvider>
-          <section>
-            <div className="flex flex-wrap items-end justify-between gap-3 mb-2">
-              <SectionHeading title="Latency & severity heatmap" />
-              <TimeRangeScrub />
-            </div>
-            <QueryErrorBoundary>
-              <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-                <LatencyHeatmapSection />
-              </Suspense>
-            </QueryErrorBoundary>
-          </section>
-          <section>
-            <SectionHeading title="RPC pools" />
-            <QueryErrorBoundary>
-              <Suspense fallback={<Skeleton className="h-24 w-full" />}>
-                <PoolsTable />
-              </Suspense>
-            </QueryErrorBoundary>
-          </section>
-          <section>
-            <SectionHeading title="Endpoint pools" />
-            <QueryErrorBoundary>
-              <Suspense fallback={<Skeleton className="h-24 w-full" />}>
-                <EndpointPoolsTable />
-              </Suspense>
-            </QueryErrorBoundary>
-          </section>
-          <section>
-            <SectionHeading title="Root RPC/WSS endpoints" />
-            <QueryErrorBoundary>
-              <Suspense fallback={<Skeleton className="h-24 w-full" />}>
-                <RpcEndpointsTable />
-              </Suspense>
-            </QueryErrorBoundary>
-          </section>
-          <section>
-            <SectionHeading title="Callable endpoints" />
-            <QueryErrorBoundary>
-              <Suspense fallback={<Skeleton className="h-48 w-full" />}>
-                <EndpointsTable />
-              </Suspense>
-            </QueryErrorBoundary>
-          </section>
-          <section>
-            <SectionHeading title="Incidents timeline" />
-            <QueryErrorBoundary>
-              <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-                <IncidentsTimeline />
-              </Suspense>
-            </QueryErrorBoundary>
-          </section>
-        </TimeRangeProvider>
+        {tab === "endpoints" && (
+          <>
+            <TimeRangeProvider>
+              <section>
+                <div className="flex flex-wrap items-end justify-between gap-3 mb-2">
+                  <SectionHeading title="Latency & severity heatmap" />
+                  <TimeRangeScrub />
+                </div>
+                <QueryErrorBoundary>
+                  <Suspense fallback={<Skeleton className="h-48 w-full" />}>
+                    <LatencyHeatmapSection />
+                  </Suspense>
+                </QueryErrorBoundary>
+              </section>
+            </TimeRangeProvider>
+            <section>
+              <SectionHeading title="Callable endpoints" />
+              <QueryErrorBoundary>
+                <Suspense fallback={<Skeleton className="h-48 w-full" />}>
+                  <EndpointsTable />
+                </Suspense>
+              </QueryErrorBoundary>
+            </section>
+          </>
+        )}
+
+        {tab === "advanced" && (
+          <>
+            <section>
+              <SectionHeading title="RPC pools" />
+              <QueryErrorBoundary>
+                <Suspense fallback={<Skeleton className="h-24 w-full" />}>
+                  <PoolsTable />
+                </Suspense>
+              </QueryErrorBoundary>
+            </section>
+            <section>
+              <SectionHeading title="Endpoint pools" />
+              <QueryErrorBoundary>
+                <Suspense fallback={<Skeleton className="h-24 w-full" />}>
+                  <EndpointPoolsTable />
+                </Suspense>
+              </QueryErrorBoundary>
+            </section>
+            <section>
+              <SectionHeading title="Root RPC/WSS endpoints" />
+              <QueryErrorBoundary>
+                <Suspense fallback={<Skeleton className="h-24 w-full" />}>
+                  <RpcEndpointsTable />
+                </Suspense>
+              </QueryErrorBoundary>
+            </section>
+          </>
+        )}
+
+        {tab === "incidents" && (
+          <>
+            <section>
+              <SectionHeading title="Incidents timeline" />
+              <QueryErrorBoundary>
+                <Suspense fallback={<Skeleton className="h-32 w-full" />}>
+                  <IncidentsTimeline />
+                </Suspense>
+              </QueryErrorBoundary>
+            </section>
+          </>
+        )}
       </div>
       <ApiSourceFooter
         paths={[


### PR DESCRIPTION
## Summary
The Endpoints page stacked **~9 full-width panels** into one long mobile feed with no grouping: the reverse-proxy hero + its usage analytics, the endpoint KPI strip, the latency/severity heatmap, the RPC-pool / endpoint-pool / root-RPC-WSS tables, the 1,622-row callable-endpoints table, and the incidents timeline — each its own heading, none collapsible.

## Change (`apps/ui/src/routes/endpoints.tsx`)
Split the panels into **four concern tabs**. The endpoint **KPI strip stays above the tabs** (always visible) so the tab bar has context and doesn't float alone in the whitespace under the hero:

| Tab | Panels |
| --- | --- |
| **Proxy** (default) | reverse-proxy hero, proxy usage analytics |
| **Endpoints** | latency/severity heatmap, callable-endpoints registry (1,622 rows, paginated) |
| **Advanced** | RPC pools, endpoint pools, root RPC/WSS tables |
| **Incidents** | incidents timeline |

Each section already fetches its own data, so **only the active tab's panels mount (and query)** — a lighter initial load as well as a shorter scroll. `TimeRangeProvider` (only the heatmap needs it) is scoped to the Endpoints tab.

## Measurement
Measured at **375×812** against the live dev server with real production data:

| View | Initial scroll height (375px) |
| --- | --- |
| **Before** (one feed) | **11,052px** |
| **After** — Proxy (default) | **3,591px** (~67% shorter) |
| After — Endpoints | 6,676px · Advanced 3,269px · Incidents 2,003px |

_The audit cited ~95,001px; against current production data the page measures ~11,052px — the 1,622-row callable-endpoints table paginates at 25/page, so that heavier figure isn't reproducible now. Either way the panels are now grouped by concern instead of one undifferentiated feed, and the initial view is a fraction of the height._

## Verification
- `typecheck` / `test` (690) / `build` (apps/ui) — pass
- `eslint` on the changed file (LF-normalized) — 0 errors

## Screenshots
Before = the stacked single feed; After = the Proxy/Endpoints/Advanced/Incidents tabs, only the active tab shown.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5329/v2/after-mobile-dark.png)<br><sub>after</sub> |

Closes #5329
