### PR TITLE
fix(ui): truncate block hash to match parent hash, fixing mobile overflow (#5343)

### DIFF
--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -226,7 +226,15 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
           </FieldRow>
           <FieldRow label="Block hash">
             {block.block_hash ? (
-              <CopyableCode value={block.block_hash} truncate={false} />
+              // Truncate to match "Parent hash" below (#5343) — the raw untruncated
+              // CopyableCode overflowed the details row on mobile. It's the current
+              // block, so no self-link; the full hash stays available on hover.
+              <span
+                className="font-mono text-[12px] text-ink-strong break-all"
+                title={block.block_hash}
+              >
+                {shortHash(block.block_hash, 10)}
+              </span>
             ) : (
               <span className="text-ink-muted">—</span>
             )}


### PR DESCRIPTION
## Summary

Closes #5343

In the block-detail `<dl>`, "Block hash" rendered the raw untruncated hash via `CopyableCode value={...} truncate={false}`, whose inline-flex button grows to the full hash width and **overflows the details row on mobile**. Two rows down,
"Parent hash" — a conceptually identical field — already truncates with `shortHash(parent_hash, 10)` and renders cleanly (#5343).

This standardizes "Block hash" on the same `shortHash(hash, 10)` truncation.
Since it's the *current* block, there's no self-link — it renders as a `shortHash` span with the full hash preserved on `title` (hover), matching Parent hash's truncation strategy exactly.

## Changes
- `routes/blocks.$ref.tsx` — "Block hash" now uses `shortHash(block.block_hash, 10)`   (full hash on hover) instead of the overflowing raw `CopyableCode`.

## Scope
Narrowly the Block-hash↔Parent-hash inconsistency this issue names. The separate `CopyableCode` overflow (e.g. the Author field, tracked as #5308 in the same audit batch) is intentionally left out.

## Screenshots

Block details on `/blocks/{ref}` — **before** ("Block hash" raw, overflowing the row) vs **after** ("Block hash" truncated, identical to "Parent hash").

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5343-block-hash/before-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5343-block-hash/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5343-block-hash/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5343-block-hash/after-mobile-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5343-block-hash/before-tablet-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5343-block-hash/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5343-block-hash/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5343-block-hash/after-tablet-dark.png) |
| Desktop · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5343-block-hash/before-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5343-block-hash/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5343-block-hash/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5343-block-hash/after-desktop-dark.png) |

## Validation
- `tsc --noEmit` ✓ · `eslint` (0 errors) ✓ · `prettier --check` (3.9.4, LF) ✓ · `vitest` (690) ✓ · `build` ✓
- 1 file; rebased to **0-behind `main`** (main moved 10 commits mid-build — caught and rebased)
