### PR TITLE
feat(scripts): add a tracked Postgres migration runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "validate:private-boundary": "node scripts/validate-private-boundary.mjs",
     "validate:workflows": "node scripts/validate-workflows.mjs",
     "validate:migrations": "node scripts/validate-migrations.mjs",
+    "migrate": "node scripts/apply-migrations.mjs",
+    "migrate:dry-run": "node scripts/apply-migrations.mjs --dry-run",
     "openapi:generate": "node scripts/generate-openapi.mjs --write",
     "openapi:generate:dry-run": "node scripts/generate-openapi.mjs",
     "types:generate": "node scripts/generate-types.mjs",

--- a/scripts/apply-migrations.mjs
+++ b/scripts/apply-migrations.mjs
@@ -1,0 +1,173 @@
+// Applies migrations/*.sql to a live Postgres in filename order, tracking
+// what's already been applied in a schema_migrations table (created on
+// first run) -- fixes the schema-apply gap behind three separate live
+// incidents (#5348/#5353): deploy/postgres/schema.sql only runs on a
+// Postgres container's FIRST init against an empty data directory (the
+// official Postgres image's own docker-entrypoint-initdb.d behavior), so
+// any CREATE TABLE added to migrations/ after the box's first boot never
+// reaches production without a manual, easy-to-forget `psql -f`. Missing
+// `chain_alert_triggers`/`featured_validators` broke #4984's alerter epic
+// outright (every alert-create call 502'd); missing `nominator_positions`
+// (migration 0044) broke the nominator-positions-sync box-cron job the
+// same way, 2026-07-14.
+//
+// NOT idempotent-by-construction: several existing migrations use bare
+// `ALTER TABLE ... ADD COLUMN` (no `IF NOT EXISTS`) or a genuinely one-time
+// temp-table rename dance (0006_surface_key_rekey.sql) -- re-running an
+// already-applied migration's SQL directly would fail or, worse, silently
+// re-run something meant to execute exactly once. schema_migrations is
+// therefore load-bearing, not just a nice-to-have audit trail: correctness
+// depends on never re-executing a recorded version's SQL.
+//
+// Usage:
+//   node scripts/apply-migrations.mjs [--dry-run] [--database-url URL]
+//   node scripts/apply-migrations.mjs --bootstrap-through 0044 [--database-url URL]
+//
+//   --dry-run              list what would be applied; touches nothing
+//   --database-url URL     Postgres connection string (default: $DATABASE_URL)
+//   --bootstrap-through NNNN
+//       Records every migration up to and including NNNN as already
+//       applied WITHOUT running its SQL -- for adopting this script against
+//       a box whose schema already reflects those migrations by some other
+//       means (the original docker-entrypoint-initdb.d schema.sql bootstrap,
+//       or an earlier ad-hoc manual `psql -f`). This is a one-time,
+//       explicit, human-verified operation, not an auto-detected guess --
+//       confirm the target tables/columns genuinely exist before using it.
+//       Refuses to run if schema_migrations already has any rows (use the
+//       normal apply path from then on).
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { repoRoot } from "./lib.mjs";
+
+function parseArgs(argv) {
+  const opts = { dryRun: false, databaseUrl: process.env.DATABASE_URL };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--dry-run") opts.dryRun = true;
+    else if (arg === "--database-url") opts.databaseUrl = argv[++i];
+    else if (arg === "--bootstrap-through") opts.bootstrapThrough = argv[++i];
+    else throw new Error(`unrecognized argument: ${arg}`);
+  }
+  return opts;
+}
+
+async function loadMigrationFiles() {
+  const migrationsRoot = path.join(repoRoot, "migrations");
+  const names = (await fs.readdir(migrationsRoot))
+    .filter((name) => name.endsWith(".sql"))
+    .sort();
+  return Promise.all(
+    names.map(async (name) => ({
+      version: name.slice(0, 4),
+      name,
+      sql: await fs.readFile(path.join(migrationsRoot, name), "utf8"),
+    })),
+  );
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (!opts.databaseUrl) {
+    throw new Error(
+      "DATABASE_URL required (or pass --database-url) -- refusing to guess a connection target",
+    );
+  }
+
+  const migrations = await loadMigrationFiles();
+
+  const { default: postgres } = await import("postgres");
+  const sql = postgres(opts.databaseUrl, {
+    max: 1,
+    prepare: false,
+    fetch_types: false,
+    // Routine "already exists, skipping" NOTICEs from the IF NOT EXISTS
+    // guards below are expected noise on every run after the first, not
+    // something an operator running this script needs to see.
+    onnotice: () => {},
+  });
+
+  try {
+    await sql`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        version     TEXT   PRIMARY KEY,
+        name        TEXT   NOT NULL,
+        applied_at  BIGINT NOT NULL
+      )`;
+
+    if (opts.bootstrapThrough) {
+      const existing =
+        await sql`SELECT count(*)::int AS n FROM schema_migrations`;
+      if (existing[0].n > 0) {
+        throw new Error(
+          "--bootstrap-through refuses to run: schema_migrations already has rows " +
+            "(this box has already been adopted onto the tracked apply path -- " +
+            "use the normal, no-flag apply instead)",
+        );
+      }
+      const toBootstrap = migrations.filter(
+        (m) => m.version <= opts.bootstrapThrough,
+      );
+      if (opts.dryRun) {
+        console.log(
+          `[dry-run] would mark ${toBootstrap.length} migration(s) applied without running their SQL: ` +
+            toBootstrap.map((m) => m.name).join(", "),
+        );
+        return;
+      }
+      const now = Date.now();
+      await sql`
+        INSERT INTO schema_migrations ${sql(
+          toBootstrap.map((m) => ({
+            version: m.version,
+            name: m.name,
+            applied_at: now,
+          })),
+          "version",
+          "name",
+          "applied_at",
+        )}`;
+      console.log(
+        `Bootstrapped schema_migrations with ${toBootstrap.length} migration(s) through ${opts.bootstrapThrough} (recorded only, not executed).`,
+      );
+      return;
+    }
+
+    const appliedRows = await sql`SELECT version FROM schema_migrations`;
+    const applied = new Set(appliedRows.map((r) => r.version));
+    const pending = migrations.filter((m) => !applied.has(m.version));
+
+    if (pending.length === 0) {
+      console.log(
+        `Nothing to apply -- all ${migrations.length} migration(s) already recorded in schema_migrations.`,
+      );
+      return;
+    }
+
+    if (opts.dryRun) {
+      console.log(
+        `[dry-run] would apply ${pending.length} migration(s): ` +
+          pending.map((m) => m.name).join(", "),
+      );
+      return;
+    }
+
+    for (const migration of pending) {
+      console.log(`Applying ${migration.name}...`);
+      await sql.begin(async (sql) => {
+        await sql.unsafe(migration.sql);
+        await sql`
+          INSERT INTO schema_migrations (version, name, applied_at)
+          VALUES (${migration.version}, ${migration.name}, ${Date.now()})`;
+      });
+      console.log(`  done.`);
+    }
+    console.log(`Applied ${pending.length} migration(s).`);
+  } finally {
+    await sql.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Closes #5353 (task #55 from the production-readiness audit) — though scoped to the primitive itself; see "Not in scope" below.

`deploy/postgres/schema.sql` only runs on a Postgres container's FIRST init against an empty data directory (the official Postgres image's own `docker-entrypoint-initdb.d` behavior). The production indexer box's container has been running for 10+ days, so any `CREATE TABLE` added to `migrations/*.sql` after that point never reaches production without a manual `psql -f` — an easy step to forget, and nothing catches the omission until something breaks.

This is confirmed as the root cause behind **three separate live incidents**:
- `chain_alert_triggers` / `featured_validators` missing — broke the entire #4984 alerter epic (every alert-create call 502'd)
- `nominator_positions` (migration 0044) missing — broke the nominator-positions-sync box-cron job today, live-reproduced and root-caused while verifying #5352

## Fix

`scripts/apply-migrations.mjs` tracks applied migrations in a `schema_migrations` table and applies only new ones, in filename order, each inside its own transaction. Tracking is **load-bearing**, not just an audit trail — several existing migrations use bare `ALTER TABLE ... ADD COLUMN` (no `IF NOT EXISTS`) or a one-time temp-table rename dance (`0006_surface_key_rekey.sql`), so re-running an already-applied migration's SQL directly would fail outright or silently re-execute something meant to run exactly once.

`--bootstrap-through NNNN` adopts this onto a box whose schema already reflects some migrations by other means (this box's original `schema.sql` init, or an earlier ad-hoc manual apply) — records them as applied without re-running their SQL. This is explicit and human-verified, not auto-detected: I spot-checked that the columns 10 of the non-idempotent migrations add actually exist on the box before bootstrapping.

## Not in scope

Not wired into automatic deploy triggers — that needs box-reachable CI (the box is Tailscale-only), which is a larger, separate piece of infra work. This PR lands the tracked-apply primitive; a human runs `npm run migrate` after merging a migration for now. Also not fixed here: `deploy/postgres/schema.sql` has itself drifted from `migrations/*.sql` (missing several tables entirely, including `validator_nominator_counts`/`nominator_positions`) — a separate disaster-recovery risk (only matters if the box's Postgres volume is ever rebuilt from scratch) worth a follow-up, not blocking this fix.

## Test plan

- [x] `npm run lint && npm run format:check` clean
- [x] Live-verified against the real indexer box end-to-end:
  - `--dry-run` correctly listed all 44 migrations as pending against an unseeded box
  - Spot-checked 16 columns across 10 non-idempotent `ALTER TABLE ADD COLUMN` migrations (0005/0008/0012/0015/0016/0017/0018/0019/0020/0042) all genuinely exist before bootstrapping
  - `--bootstrap-through 0044` correctly recorded all 44 without executing any SQL; re-running `--dry-run` afterward correctly reported "nothing to apply"
  - Round-tripped the real apply path with a throwaway migration (applied, confirmed recorded, re-ran to confirm no-op, then fully reverted — dropped the test table, deleted its `schema_migrations` row, removed the file — before committing anything)
  - Actually fixed the live `nominator_positions` gap with this exact mechanism (applied migration 0044 for real, `validator-nominator-counts-sync` + `nominator-positions-sync` both now succeed against production)
- [x] This script is intentionally excluded from `vitest.config.mjs`'s `coverage.include` (matches the established convention for direct-Postgres ops scripts like `scripts/backfill-account-events-daily-postgres.mjs`, which also has no dedicated test file) — verification is the live end-to-end run above, not unit tests against a mock