### PR TITLE
fix(ui): route mega-menu live previews through EntityHoverCard touch guard

### DIFF
--- a/apps/ui/src/components/metagraphed/entity-hover-card.tsx
+++ b/apps/ui/src/components/metagraphed/entity-hover-card.tsx
@@ -12,10 +12,7 @@ import {
 import { useCoarsePointer } from "@/hooks/use-coarse-pointer";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { subnetQuery, providerQuery, accountQuery } from "@/lib/metagraphed/queries";
-import {
-  resolveEntityHoverPlacement,
-  type EntityHoverPlacement,
-} from "./entity-hover-placement";
+import { resolveEntityHoverPlacement, type EntityHoverPlacement } from "./entity-hover-placement";
 
 interface SubnetHoverProps {
   kind: "subnet";

--- a/apps/ui/src/components/metagraphed/entity-hover-card.tsx
+++ b/apps/ui/src/components/metagraphed/entity-hover-card.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 import {
   HoverCard,
   HoverCardContent,
@@ -9,8 +9,13 @@ import {
   HealthPill,
   TimeAgo,
 } from "@jsonbored/ui-kit";
-import { subnetQuery, providerQuery, accountQuery } from "@/lib/metagraphed/queries";
+import { useCoarsePointer } from "@/hooks/use-coarse-pointer";
 import { formatNumber } from "@/lib/metagraphed/format";
+import { subnetQuery, providerQuery, accountQuery } from "@/lib/metagraphed/queries";
+import {
+  resolveEntityHoverPlacement,
+  type EntityHoverPlacement,
+} from "./entity-hover-placement";
 
 interface SubnetHoverProps {
   kind: "subnet";
@@ -27,37 +32,29 @@ interface AccountHoverProps {
   ss58: string;
   children: ReactNode;
 }
-type Props = SubnetHoverProps | ProviderHoverProps | AccountHoverProps;
 
-/**
- * Detect a touch-primary device. On those we don't render a hover card at
- * all — the trigger renders as-is so the underlying <Link> remains the
- * one-tap target. Avoids the "tap once to hover, tap again to navigate"
- * trap of Radix HoverCard on mobile.
- */
-function useCoarsePointer(): boolean {
-  const [coarse, setCoarse] = useState(false);
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const m = window.matchMedia("(hover: none), (pointer: coarse)");
-    const update = () => setCoarse(m.matches);
-    update();
-    m.addEventListener?.("change", update);
-    return () => m.removeEventListener?.("change", update);
-  }, []);
-  return coarse;
-}
+type EntityKindProps = SubnetHoverProps | ProviderHoverProps | AccountHoverProps;
+
+export type EntityHoverCardProps = EntityKindProps & Partial<EntityHoverPlacement>;
 
 /**
  * Linear-style hover profile card. Wraps any link/trigger and fetches its
  * detail payload on first open (cached via the shared query client).
  *
- * On touch devices this is a no-op passthrough so taps go straight to the
- * wrapped link, which keeps accessibility predictable.
+ * On touch-primary devices this is a no-op passthrough so taps go straight to
+ * the wrapped link — matches `(hover: none), (pointer: coarse)` (#5337).
  */
-export function EntityHoverCard(props: Props) {
+export function EntityHoverCard(props: EntityHoverCardProps) {
   const coarse = useCoarsePointer();
   if (coarse) return <>{props.children}</>;
+
+  const placement = resolveEntityHoverPlacement({
+    side: props.side,
+    align: props.align,
+    openDelayMs: props.openDelayMs,
+    closeDelayMs: props.closeDelayMs,
+    sideOffset: props.sideOffset,
+  });
 
   const ariaLabel =
     props.kind === "subnet"
@@ -67,12 +64,12 @@ export function EntityHoverCard(props: Props) {
         : `Preview account ${props.ss58}`;
 
   return (
-    <HoverCard openDelay={250} closeDelay={120}>
+    <HoverCard openDelay={placement.openDelayMs} closeDelay={placement.closeDelayMs}>
       <HoverCardTrigger asChild>{props.children}</HoverCardTrigger>
       <HoverCardContent
-        side="top"
-        align="start"
-        sideOffset={8}
+        side={placement.side}
+        align={placement.align}
+        sideOffset={placement.sideOffset}
         aria-label={ariaLabel}
         data-testid="entity-hover-card"
         className="w-80 p-3 bg-card border-border shadow-lg z-50"

--- a/apps/ui/src/components/metagraphed/entity-hover-placement.test.ts
+++ b/apps/ui/src/components/metagraphed/entity-hover-placement.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENTITY_HOVER_DEFAULTS,
+  MEGA_MENU_HOVER_DEFAULTS,
+  resolveEntityHoverPlacement,
+} from "./entity-hover-placement";
+
+describe("entity hover placement tokens (#5337)", () => {
+  it("defaults entity cells to top-start with a 250ms open delay", () => {
+    expect(ENTITY_HOVER_DEFAULTS).toEqual({
+      side: "top",
+      align: "start",
+      openDelayMs: 250,
+      closeDelayMs: 120,
+      sideOffset: 8,
+    });
+  });
+
+  it("places mega-menu previews to the right with a faster open delay", () => {
+    expect(MEGA_MENU_HOVER_DEFAULTS.side).toBe("right");
+    expect(MEGA_MENU_HOVER_DEFAULTS.openDelayMs).toBe(150);
+    expect(MEGA_MENU_HOVER_DEFAULTS.closeDelayMs).toBe(80);
+  });
+
+  it("merges partial overrides onto entity defaults", () => {
+    expect(resolveEntityHoverPlacement({ side: "right", openDelayMs: 150 })).toEqual({
+      side: "right",
+      align: "start",
+      openDelayMs: 150,
+      closeDelayMs: 120,
+      sideOffset: 8,
+    });
+  });
+
+  it("can merge onto mega-menu defaults for nested callers", () => {
+    expect(
+      resolveEntityHoverPlacement({ openDelayMs: 90 }, MEGA_MENU_HOVER_DEFAULTS),
+    ).toEqual({
+      ...MEGA_MENU_HOVER_DEFAULTS,
+      openDelayMs: 90,
+    });
+  });
+});

--- a/apps/ui/src/components/metagraphed/entity-hover-placement.test.ts
+++ b/apps/ui/src/components/metagraphed/entity-hover-placement.test.ts
@@ -33,9 +33,7 @@ describe("entity hover placement tokens (#5337)", () => {
   });
 
   it("can merge onto mega-menu defaults for nested callers", () => {
-    expect(
-      resolveEntityHoverPlacement({ openDelayMs: 90 }, MEGA_MENU_HOVER_DEFAULTS),
-    ).toEqual({
+    expect(resolveEntityHoverPlacement({ openDelayMs: 90 }, MEGA_MENU_HOVER_DEFAULTS)).toEqual({
       ...MEGA_MENU_HOVER_DEFAULTS,
       openDelayMs: 90,
     });

--- a/apps/ui/src/components/metagraphed/entity-hover-placement.ts
+++ b/apps/ui/src/components/metagraphed/entity-hover-placement.ts
@@ -1,0 +1,52 @@
+/**
+ * Placement / timing tokens for EntityHoverCard and mega-menu previews (#5337).
+ *
+ * Mega-menu live rows prefer a faster open delay and a right-side popover so
+ * the card doesn't cover the filtered list; entity cells elsewhere keep the
+ * slower top placement.
+ */
+
+export type EntityHoverCardSide = "top" | "right" | "bottom" | "left";
+export type EntityHoverCardAlign = "start" | "center" | "end";
+
+export const ENTITY_HOVER_DEFAULTS = {
+  side: "top" as EntityHoverCardSide,
+  align: "start" as EntityHoverCardAlign,
+  openDelayMs: 250,
+  closeDelayMs: 120,
+  sideOffset: 8,
+} as const;
+
+/** Mega-menu live-row preview placement — opens beside the list, not over it. */
+export const MEGA_MENU_HOVER_DEFAULTS = {
+  side: "right" as EntityHoverCardSide,
+  align: "start" as EntityHoverCardAlign,
+  openDelayMs: 150,
+  closeDelayMs: 80,
+  sideOffset: 8,
+} as const;
+
+export type EntityHoverPlacement = {
+  side: EntityHoverCardSide;
+  align: EntityHoverCardAlign;
+  openDelayMs: number;
+  closeDelayMs: number;
+  sideOffset: number;
+};
+
+/**
+ * Merge caller overrides onto the default entity-hover placement.
+ * Used by EntityHoverCard so mega-menu and table cells share one compositor.
+ */
+export function resolveEntityHoverPlacement(
+  overrides: Partial<EntityHoverPlacement> = {},
+  defaults: EntityHoverPlacement = ENTITY_HOVER_DEFAULTS,
+): EntityHoverPlacement {
+  return {
+    side: overrides.side ?? defaults.side,
+    align: overrides.align ?? defaults.align,
+    openDelayMs: overrides.openDelayMs ?? defaults.openDelayMs,
+    closeDelayMs: overrides.closeDelayMs ?? defaults.closeDelayMs,
+    sideOffset: overrides.sideOffset ?? defaults.sideOffset,
+  };
+}

--- a/apps/ui/src/components/metagraphed/mega-menu-live-preview-link.test.ts
+++ b/apps/ui/src/components/metagraphed/mega-menu-live-preview-link.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { MEGA_MENU_HOVER_DEFAULTS } from "./entity-hover-placement";
+import type { MegaMenuLivePreviewItem } from "./mega-menu-live-preview-link";
+
+/**
+ * Structural contract for mega-menu live rows (#5337). Vitest here is limited
+ * to `.test.ts` (no RTL), so we pin the placement wiring the component relies
+ * on rather than mounting React.
+ */
+describe("MegaMenuLivePreviewLink contract (#5337)", () => {
+  it("accepts subnet and provider live items with a numeric/string preview id", () => {
+    const subnet: MegaMenuLivePreviewItem = {
+      kind: "subnet",
+      to: "/subnets/$netuid",
+      params: { netuid: "1" },
+      label: "Root",
+      sub: "SN1",
+      previewId: 1,
+    };
+    const provider: MegaMenuLivePreviewItem = {
+      kind: "provider",
+      to: "/providers/$slug",
+      params: { slug: "opentensor" },
+      label: "OpenTensor",
+      sub: "opentensor",
+      previewId: "opentensor",
+    };
+    expect(subnet.kind).toBe("subnet");
+    expect(provider.kind).toBe("provider");
+    expect(typeof subnet.previewId).toBe("number");
+    expect(typeof provider.previewId).toBe("string");
+  });
+
+  it("uses mega-menu placement that enables EntityHoverCard's right-side preview", () => {
+    expect(MEGA_MENU_HOVER_DEFAULTS.side).toBe("right");
+    expect(MEGA_MENU_HOVER_DEFAULTS.align).toBe("start");
+  });
+});

--- a/apps/ui/src/components/metagraphed/mega-menu-live-preview-link.tsx
+++ b/apps/ui/src/components/metagraphed/mega-menu-live-preview-link.tsx
@@ -31,12 +31,7 @@ type MegaMenuLivePreviewLinkProps = {
 const LIVE_LINK_CLASS =
   "flex items-center justify-between rounded-md px-2 py-1.5 -mx-2 hover:bg-surface/70 focus:bg-surface/70 focus:outline-none transition-colors";
 
-function LiveRowLink({
-  item,
-  onNavigate,
-  registerItem,
-  itemIndex,
-}: MegaMenuLivePreviewLinkProps) {
+function LiveRowLink({ item, onNavigate, registerItem, itemIndex }: MegaMenuLivePreviewLinkProps) {
   return (
     <Link
       to={item.to}

--- a/apps/ui/src/components/metagraphed/mega-menu-live-preview-link.tsx
+++ b/apps/ui/src/components/metagraphed/mega-menu-live-preview-link.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+import { Link } from "@tanstack/react-router";
+import { ArrowUpRight } from "lucide-react";
+import { EntityHoverCard } from "./entity-hover-card";
+import { MEGA_MENU_HOVER_DEFAULTS } from "./entity-hover-placement";
+
+/**
+ * Live mega-menu row wrapped in EntityHoverCard (#5337).
+ *
+ * Subnet/provider preview cards previously used a raw Radix HoverCard with no
+ * touch guard. Routing through EntityHoverCard applies the shared
+ * `(hover: none), (pointer: coarse)` passthrough so touch-primary tablets get
+ * a single-tap link instead of a stuck hover state.
+ */
+export type MegaMenuLivePreviewItem = {
+  kind: "subnet" | "provider";
+  to: string;
+  params: Record<string, string>;
+  label: string;
+  sub: string;
+  previewId: number | string;
+};
+
+type MegaMenuLivePreviewLinkProps = {
+  item: MegaMenuLivePreviewItem;
+  onNavigate?: () => void;
+  registerItem: (el: HTMLAnchorElement | null, index: number) => void;
+  itemIndex: number;
+};
+
+const LIVE_LINK_CLASS =
+  "flex items-center justify-between rounded-md px-2 py-1.5 -mx-2 hover:bg-surface/70 focus:bg-surface/70 focus:outline-none transition-colors";
+
+function LiveRowLink({
+  item,
+  onNavigate,
+  registerItem,
+  itemIndex,
+}: MegaMenuLivePreviewLinkProps) {
+  return (
+    <Link
+      to={item.to}
+      params={item.params as never}
+      onClick={onNavigate}
+      ref={(el) => registerItem(el, itemIndex)}
+      className={LIVE_LINK_CLASS}
+      preload="intent"
+      data-mega-live-preview={item.kind}
+    >
+      <span className="min-w-0">
+        <span className="block text-sm text-ink-strong truncate">{item.label}</span>
+        <span className="block text-[11px] text-ink-muted truncate">{item.sub}</span>
+      </span>
+      <ArrowUpRight className="size-3 text-ink-muted shrink-0" />
+    </Link>
+  );
+}
+
+export function MegaMenuLivePreviewLink(props: MegaMenuLivePreviewLinkProps): ReactNode {
+  const { item } = props;
+  if (item.kind === "subnet") {
+    return (
+      <EntityHoverCard
+        kind="subnet"
+        netuid={item.previewId as number}
+        {...MEGA_MENU_HOVER_DEFAULTS}
+      >
+        <LiveRowLink {...props} />
+      </EntityHoverCard>
+    );
+  }
+  return (
+    <EntityHoverCard kind="provider" slug={item.previewId as string} {...MEGA_MENU_HOVER_DEFAULTS}>
+      <LiveRowLink {...props} />
+    </EntityHoverCard>
+  );
+}

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-content.tsx
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-content.tsx
@@ -12,9 +12,6 @@ import {
 } from "@/lib/metagraphed/queries";
 import { API_BASE } from "@/lib/metagraphed/config";
 import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
   Accordion,
   AccordionContent,
   AccordionItem,
@@ -31,6 +28,7 @@ import {
   persistOpen,
   type MegaPanel,
 } from "./nav-mega-menu-data";
+import { MegaMenuLivePreviewLink } from "./mega-menu-live-preview-link";
 
 type SnapshotResult = {
   tiles: { label: string; value: number | string }[];
@@ -94,135 +92,6 @@ function useSnapshot(key: string): SnapshotResult {
     };
   }
   return { tiles: [], isPending: false, isError: false };
-}
-
-const HEALTH_TONE: Record<string, string> = {
-  ok: "bg-health-ok",
-  warn: "bg-health-warn",
-  down: "bg-health-down",
-  unknown: "bg-ink-subtle",
-};
-
-function PreviewSkeleton() {
-  return (
-    <div className="w-56 space-y-2 animate-pulse">
-      <div className="h-3 w-20 rounded bg-surface" />
-      <div className="h-4 w-32 rounded bg-surface" />
-      <div className="grid grid-cols-2 gap-2">
-        <div className="h-8 rounded bg-surface" />
-        <div className="h-8 rounded bg-surface" />
-      </div>
-    </div>
-  );
-}
-
-function PreviewMissing({ to }: { to: string }) {
-  return (
-    <div className="w-56 text-[11px] text-ink-muted">
-      Details not cached yet. <span className="text-accent-text">Open page →</span>
-      <span className="sr-only">{to}</span>
-    </div>
-  );
-}
-
-function PreviewError({ onRetry }: { onRetry: () => void }) {
-  return (
-    <div className="w-56 flex items-start gap-2">
-      <div className="text-[11px] text-health-down flex-1">Preview unavailable.</div>
-      <button
-        type="button"
-        onClick={onRetry}
-        className="rounded border border-border bg-card p-1 text-ink-muted hover:text-ink-strong"
-        aria-label="Retry preview"
-      >
-        <RefreshCw className="size-3" />
-      </button>
-    </div>
-  );
-}
-
-function SubnetPreviewCard({ netuid }: { netuid: number }) {
-  const qc = useQueryClient();
-  const { data, isPending, isError } = useQuery({
-    ...subnetsQuery(),
-    retry: 0,
-    placeholderData: (prev) => prev,
-  });
-  if (isPending) return <PreviewSkeleton />;
-  if (isError)
-    return (
-      <PreviewError onRetry={() => qc.invalidateQueries({ queryKey: subnetsQuery().queryKey })} />
-    );
-  const sub = data?.data.find((s) => s.netuid === netuid);
-  if (!sub) return <PreviewMissing to={`/subnets/${netuid}`} />;
-  const health = (sub.health ?? "unknown") as string;
-  return (
-    <div className="space-y-2 w-56">
-      <div className="flex items-center justify-between">
-        <div className="mg-label">netuid {sub.netuid}</div>
-        <span
-          className={classNames(
-            "inline-flex items-center gap-1 text-[10px] font-mono uppercase tracking-widest",
-          )}
-        >
-          <span
-            className={classNames(
-              "size-1.5 rounded-full",
-              HEALTH_TONE[health] ?? HEALTH_TONE.unknown,
-            )}
-          />
-          {health}
-        </span>
-      </div>
-      <div className="font-display text-sm font-semibold text-ink-strong truncate">
-        {sub.name ?? `Subnet ${sub.netuid}`}
-      </div>
-      <div className="grid grid-cols-2 gap-2 text-[11px]">
-        <div>
-          <div className="text-ink-muted">Surfaces</div>
-          <div className="mg-num text-ink-strong">{sub.surfaces_count ?? "—"}</div>
-        </div>
-        <div>
-          <div className="text-ink-muted">Curation</div>
-          <div className="text-ink-strong truncate">{sub.curation_level ?? "native"}</div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ProviderPreviewCard({ slug }: { slug: string }) {
-  const qc = useQueryClient();
-  const { data, isPending, isError } = useQuery({
-    ...providersQuery(),
-    retry: 0,
-    placeholderData: (prev) => prev,
-  });
-  if (isPending) return <PreviewSkeleton />;
-  if (isError)
-    return (
-      <PreviewError onRetry={() => qc.invalidateQueries({ queryKey: providersQuery().queryKey })} />
-    );
-  const p = data?.data.find((x) => x.slug === slug);
-  if (!p) return <PreviewMissing to={`/providers/${slug}`} />;
-  return (
-    <div className="space-y-2 w-56">
-      <div className="mg-label">{p.kind ?? "provider"}</div>
-      <div className="font-display text-sm font-semibold text-ink-strong truncate">
-        {p.name ?? p.slug}
-      </div>
-      <div className="grid grid-cols-2 gap-2 text-[11px]">
-        <div>
-          <div className="text-ink-muted">Endpoints</div>
-          <div className="mg-num text-ink-strong">{p.endpoints_count ?? "—"}</div>
-        </div>
-        <div>
-          <div className="text-ink-muted">Surfaces</div>
-          <div className="mg-num text-ink-strong">{p.surfaces_count ?? "—"}</div>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 type LiveItem = {
@@ -468,35 +337,12 @@ export function MegaPanelBody({
                   const i = nextIdx();
                   return (
                     <li key={`${item.kind}-${String(item.previewId)}`}>
-                      <HoverCard openDelay={150} closeDelay={80}>
-                        <HoverCardTrigger asChild>
-                          <Link
-                            to={item.to}
-                            params={item.params as never}
-                            onClick={onNavigate}
-                            ref={(el) => registerItem(el, i)}
-                            className="flex items-center justify-between rounded-md px-2 py-1.5 -mx-2 hover:bg-surface/70 focus:bg-surface/70 focus:outline-none transition-colors"
-                            preload="intent"
-                          >
-                            <span className="min-w-0">
-                              <span className="block text-sm text-ink-strong truncate">
-                                {item.label}
-                              </span>
-                              <span className="block text-[11px] text-ink-muted truncate">
-                                {item.sub}
-                              </span>
-                            </span>
-                            <ArrowUpRight className="size-3 text-ink-muted shrink-0" />
-                          </Link>
-                        </HoverCardTrigger>
-                        <HoverCardContent side="right" align="start" className="w-auto p-3">
-                          {item.kind === "subnet" ? (
-                            <SubnetPreviewCard netuid={item.previewId as number} />
-                          ) : (
-                            <ProviderPreviewCard slug={item.previewId as string} />
-                          )}
-                        </HoverCardContent>
-                      </HoverCard>
+                      <MegaMenuLivePreviewLink
+                        item={item}
+                        onNavigate={onNavigate}
+                        registerItem={registerItem}
+                        itemIndex={i}
+                      />
                     </li>
                   );
                 })}

--- a/apps/ui/src/hooks/use-coarse-pointer.test.ts
+++ b/apps/ui/src/hooks/use-coarse-pointer.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { COARSE_POINTER_MEDIA_QUERY } from "@/lib/metagraphed/coarse-pointer";
+
+/**
+ * The hook itself needs a React environment; these tests pin the contract the
+ * hook and EntityHoverCard share so the mega-menu can't silently diverge from
+ * the touch-safe media query (#5337).
+ */
+describe("useCoarsePointer contract (#5337)", () => {
+  it("shares the coarse-pointer media query constant", () => {
+    expect(COARSE_POINTER_MEDIA_QUERY).toContain("hover: none");
+    expect(COARSE_POINTER_MEDIA_QUERY).toContain("pointer: coarse");
+  });
+});

--- a/apps/ui/src/hooks/use-coarse-pointer.ts
+++ b/apps/ui/src/hooks/use-coarse-pointer.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import {
+  getCoarsePointerMediaQuery,
+  matchesCoarsePointer,
+} from "@/lib/metagraphed/coarse-pointer";
+
+/**
+ * True when the viewport is touch-primary (`(hover: none), (pointer: coarse)`).
+ *
+ * Consumers that wrap links in Radix HoverCard should bail out and render
+ * children as a passthrough so taps navigate on the first press (#5337).
+ */
+export function useCoarsePointer(): boolean {
+  const [coarse, setCoarse] = useState(false);
+
+  useEffect(() => {
+    const media = getCoarsePointerMediaQuery();
+    if (!media) return;
+
+    const update = () => setCoarse(matchesCoarsePointer(media));
+    update();
+    media.addEventListener?.("change", update);
+    return () => media.removeEventListener?.("change", update);
+  }, []);
+
+  return coarse;
+}

--- a/apps/ui/src/hooks/use-coarse-pointer.ts
+++ b/apps/ui/src/hooks/use-coarse-pointer.ts
@@ -1,8 +1,5 @@
 import { useEffect, useState } from "react";
-import {
-  getCoarsePointerMediaQuery,
-  matchesCoarsePointer,
-} from "@/lib/metagraphed/coarse-pointer";
+import { getCoarsePointerMediaQuery, matchesCoarsePointer } from "@/lib/metagraphed/coarse-pointer";
 
 /**
  * True when the viewport is touch-primary (`(hover: none), (pointer: coarse)`).

--- a/apps/ui/src/lib/metagraphed/coarse-pointer.test.ts
+++ b/apps/ui/src/lib/metagraphed/coarse-pointer.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  COARSE_POINTER_MEDIA_QUERY,
+  getCoarsePointerMediaQuery,
+  matchesCoarsePointer,
+} from "./coarse-pointer";
+
+describe("coarse-pointer media helpers (#5337)", () => {
+  it("exports the touch-primary media query EntityHoverCard relies on", () => {
+    expect(COARSE_POINTER_MEDIA_QUERY).toBe("(hover: none), (pointer: coarse)");
+  });
+
+  it("treats missing media as fine-pointer (hover cards stay enabled)", () => {
+    expect(matchesCoarsePointer(null)).toBe(false);
+    expect(matchesCoarsePointer(undefined)).toBe(false);
+  });
+
+  it("returns true when the media query matches", () => {
+    expect(matchesCoarsePointer({ matches: true })).toBe(true);
+    expect(matchesCoarsePointer({ matches: false })).toBe(false);
+  });
+
+  it("returns null from getCoarsePointerMediaQuery when matchMedia is absent", () => {
+    expect(getCoarsePointerMediaQuery(null)).toBeNull();
+    expect(getCoarsePointerMediaQuery({} as Window)).toBeNull();
+  });
+
+  it("delegates to window.matchMedia when available", () => {
+    const list = { matches: true } as MediaQueryList;
+    const win = {
+      matchMedia: (query: string) => {
+        expect(query).toBe(COARSE_POINTER_MEDIA_QUERY);
+        return list;
+      },
+    };
+    expect(getCoarsePointerMediaQuery(win)).toBe(list);
+  });
+
+  it("swallows matchMedia errors and returns null", () => {
+    const win = {
+      matchMedia: () => {
+        throw new Error("unsupported");
+      },
+    };
+    expect(getCoarsePointerMediaQuery(win)).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/coarse-pointer.ts
+++ b/apps/ui/src/lib/metagraphed/coarse-pointer.ts
@@ -1,0 +1,41 @@
+/**
+ * Touch-primary (coarse-pointer) media query for hover-card gating (#5337).
+ *
+ * Devices that match this query cannot reliably "hover" — Radix HoverCard
+ * would stick open on first tap and require a second tap to navigate. The app
+ * convention is to skip the hover chrome entirely and let the underlying link
+ * remain the single-tap target (see EntityHoverCard).
+ *
+ * @see https://github.com/JSONbored/metagraphed/issues/5337
+ */
+
+/** Media query that detects touch-primary / no-hover pointers. */
+export const COARSE_POINTER_MEDIA_QUERY = "(hover: none), (pointer: coarse)";
+
+/**
+ * Pure matcher for the coarse-pointer media query.
+ * Accepts an optional MediaQueryList-like object so unit tests don't need a
+ * full `window.matchMedia` implementation.
+ */
+export function matchesCoarsePointer(
+  media: Pick<MediaQueryList, "matches"> | null | undefined,
+): boolean {
+  return Boolean(media?.matches);
+}
+
+/**
+ * Resolve the MediaQueryList for the coarse-pointer query, or null when the
+ * environment has no matchMedia (SSR / older runtimes).
+ */
+export function getCoarsePointerMediaQuery(
+  win: Pick<Window, "matchMedia"> | null | undefined = typeof window !== "undefined"
+    ? window
+    : null,
+): MediaQueryList | null {
+  if (!win?.matchMedia) return null;
+  try {
+    return win.matchMedia(COARSE_POINTER_MEDIA_QUERY);
+  } catch {
+    return null;
+  }
+}

--- a/apps/ui/tests/e2e/capture-mega-menu-touch-hover-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-mega-menu-touch-hover-screenshots.mjs
@@ -49,7 +49,10 @@ async function openSubnetsMega(page) {
 
   // Prefer after-hook marker; fall back to subnet match links.
   const liveRow = page.locator("[data-mega-live-preview='subnet']").first();
-  const fallbackRow = page.locator("a[href*='/subnets/']").filter({ hasText: /SN|Root|subnet/i }).first();
+  const fallbackRow = page
+    .locator("a[href*='/subnets/']")
+    .filter({ hasText: /SN|Root|subnet/i })
+    .first();
   return { trigger, liveRow, fallbackRow };
 }
 

--- a/apps/ui/tests/e2e/capture-mega-menu-touch-hover-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-mega-menu-touch-hover-screenshots.mjs
@@ -1,0 +1,141 @@
+/**
+ * Capture mega-menu live-preview screenshots + hover video for #5337.
+ *
+ * NavMegaMenu is `hidden lg:flex` — only Desktop (1280) shows the hover path.
+ * Captures open the Subnets mega panel, hover the first live row, and write
+ * fixed-viewport PNGs plus a short webm of the hover interaction.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8094 VARIANT=before node tests/e2e/capture-mega-menu-touch-hover-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8095 VARIANT=after  node tests/e2e/capture-mega-menu-touch-hover-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/mega-menu-touch-hover-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8095";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const THEMES = ["light", "dark"];
+const VIEWPORT = { name: "desktop", width: 1280, height: 800 };
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function openSubnetsMega(page) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 8000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+
+  const trigger = page.getByRole("link", { name: /^Subnets$/i }).first();
+  await trigger.waitFor({ state: "visible", timeout: 60_000 });
+  await trigger.hover();
+  await page.waitForTimeout(500);
+
+  // Live preview rows only render when the panel filter is non-empty.
+  const filter = page.getByPlaceholder(/filter|search/i).first();
+  await filter.waitFor({ state: "visible", timeout: 30_000 });
+  await filter.fill("root");
+  await page.waitForTimeout(1000);
+
+  // Prefer after-hook marker; fall back to subnet match links.
+  const liveRow = page.locator("[data-mega-live-preview='subnet']").first();
+  const fallbackRow = page.locator("a[href*='/subnets/']").filter({ hasText: /SN|Root|subnet/i }).first();
+  return { trigger, liveRow, fallbackRow };
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const theme of THEMES) {
+    const context = await browser.newContext({
+      viewport: { width: VIEWPORT.width, height: VIEWPORT.height },
+      recordVideo:
+        theme === "light"
+          ? { dir: OUT_DIR, size: { width: VIEWPORT.width, height: VIEWPORT.height } }
+          : undefined,
+    });
+    const page = await context.newPage();
+    await setTheme(page, theme);
+    const { liveRow, fallbackRow } = await openSubnetsMega(page);
+
+    // At-rest with mega panel open.
+    const rest = path.join(OUT_DIR, `${VARIANT}-${VIEWPORT.name}-${theme}.png`);
+    await page.screenshot({ path: rest, fullPage: false });
+    console.log(`wrote ${rest}`);
+
+    // Hover interaction — wait for preview card if fine-pointer.
+    const row = (await liveRow.count()) > 0 ? liveRow : fallbackRow;
+    await row.hover({ force: true }).catch(() => {});
+    await page.waitForTimeout(700);
+    const hover = path.join(OUT_DIR, `${VARIANT}-${VIEWPORT.name}-${theme}-hover.png`);
+    await page.screenshot({ path: hover, fullPage: false });
+    console.log(`wrote ${hover}`);
+
+    // Touch-primary simulation: force matchMedia so hover card should not open (after only).
+    if (VARIANT === "after" && theme === "light") {
+      await page.evaluate(() => {
+        const orig = window.matchMedia.bind(window);
+        window.matchMedia = (query) => {
+          if (query.includes("hover: none") || query.includes("pointer: coarse")) {
+            return {
+              matches: true,
+              media: query,
+              onchange: null,
+              addListener() {},
+              removeListener() {},
+              addEventListener() {},
+              removeEventListener() {},
+              dispatchEvent() {
+                return false;
+              },
+            };
+          }
+          return orig(query);
+        };
+      });
+      await page.reload({ waitUntil: "domcontentloaded" });
+      await page.waitForTimeout(1500);
+      const trigger = page.getByRole("link", { name: /^Subnets$/i }).first();
+      await trigger.hover();
+      await page.waitForTimeout(500);
+      const filter = page.getByPlaceholder(/filter subnets/i).first();
+      await filter.fill("root");
+      await page.waitForTimeout(1000);
+      const coarseRow = page.locator("[data-mega-live-preview='subnet']").first();
+      await coarseRow.hover({ force: true }).catch(() => {});
+      await page.waitForTimeout(600);
+      // Ensure no entity hover card is in the DOM under coarse pointer.
+      const cardCount = await page.locator('[data-testid="entity-hover-card"]').count();
+      console.log(`coarse entity-hover-card count=${cardCount}`);
+      const coarse = path.join(OUT_DIR, `${VARIANT}-desktop-light-coarse.png`);
+      await page.screenshot({ path: coarse, fullPage: false });
+      console.log(`wrote ${coarse}`);
+    }
+
+    const video = page.video();
+    await context.close();
+    if (video) {
+      const videoPath = path.join(OUT_DIR, `${VARIANT}-desktop-${theme}-hover.webm`);
+      await video.saveAs(videoPath);
+      console.log(`wrote ${videoPath}`);
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Replace the raw Radix `<HoverCard>` wrapping mega-menu subnet/provider live rows with `EntityHoverCard`, so `(hover: none), (pointer: coarse)` devices get a single-tap link instead of a stuck hover state (#5337).
- Extract shared `useCoarsePointer` + `coarse-pointer` helpers, and placement tokens (`MEGA_MENU_HOVER_DEFAULTS`) so mega-menu previews keep a right-side, faster-open popover.
- Add `MegaMenuLivePreviewLink` and a Playwright capture script for Path C2 evidence.

Closes #5337

## Screenshots

The hover-card change only mounts inside the desktop mega-menu (`hidden lg:flex`). Mobile/Tablet rows show the header/nav at-rest (no visual delta expected); Desktop rows show the live-match hover preview.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-desktop-light-hover.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-desktop-light-hover.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-desktop-light-hover.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-desktop-light-hover.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-desktop-dark-hover.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-desktop-dark-hover.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-desktop-dark-hover.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-desktop-dark-hover.png)<br><sub>after</sub> |
| Tablet · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-tablet-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-tablet-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-tablet-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-tablet-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-tablet-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-tablet-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-mobile-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-mobile-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-mobile-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-mobile-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-mobile-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-mobile-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-mobile-dark.png)<br><sub>after</sub> |

### Hover interaction (animated)

Static images can't show the pointer-driven preview — here's the actual interaction (desktop mega-menu live row).

| Target | Before | After |
| ------ | ------ | ----- |
| Subnets mega-menu · live match row | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-hover.gif width=380>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-before-hover.gif) | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-hover.gif width=380>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-hover.gif) |

### Touch-primary guard (after)

With `(hover: none), (pointer: coarse)` forced, hovering a live row no longer mounts `data-testid=entity-hover-card` (count=0):

[<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-desktop-light-coarse.png width=380>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5337-after-desktop-light-coarse.png)

## Test plan

- [x] `npm test --workspace=apps/ui` (710 tests, including 13 new layout/hook tests)
- [x] `npm run typecheck --workspace=apps/ui`
- [x] Changed-file eslint + prettier pass locally
- [ ] CI: `lint`, `format:check`, `test`, `test:e2e`, `build`, codecov