### PR TITLE
fix(ui): stop ApiSourceFooter paths overflowing off-screen on mobile (#5309)

### DIFF
--- a/apps/ui/src/components/metagraphed/api-source-footer.tsx
+++ b/apps/ui/src/components/metagraphed/api-source-footer.tsx
@@ -15,8 +15,11 @@ export function ApiSourceFooter({ paths, artifacts }: { paths: string[]; artifac
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
         <span className="font-mono uppercase tracking-widest text-[10px]">data sources</span>
         {paths.map((p) => (
-          <div key={p} className="flex items-center gap-1.5">
-            <ExternalLink href={`${API_BASE}${p}`} className="hover:text-ink-strong">
+          <div key={p} className="flex min-w-0 max-w-full items-center gap-1.5">
+            <ExternalLink
+              href={`${API_BASE}${p}`}
+              className="min-w-0 truncate hover:text-ink-strong"
+            >
               {p}
             </ExternalLink>
             <CopyableCode value={`${API_BASE}${p}`} label="copy" className="px-1.5 py-0.5" />
@@ -27,7 +30,11 @@ export function ApiSourceFooter({ paths, artifacts }: { paths: string[]; artifac
         <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2">
           <span className="font-mono uppercase tracking-widest text-[10px]">artifacts</span>
           {artifacts.map((p) => (
-            <ExternalLink key={p} href={`${API_BASE}${p}`} className="hover:text-ink-strong">
+            <ExternalLink
+              key={p}
+              href={`${API_BASE}${p}`}
+              className="min-w-0 max-w-full truncate hover:text-ink-strong"
+            >
               {p}
             </ExternalLink>
           ))}


### PR DESCRIPTION
## Summary

Closes #5309

Each `ApiSourceFooter` data-source row rendered its API path in a `flex items-center` box with no width constraint or truncation. On account/validator pages — where the path embeds a 48-char ss58 and repeats across up to 8 rows — every row ran past the viewport edge and pushed its copy button off-canvas and untappable at 375px.

Constrain each row to the container width (`min-w-0 max-w-full`) and truncate the path link (`min-w-0 truncate`) so the row stays within the viewport and the copy button remains on-screen; artifact links get the same truncation. The full URL is still reachable via the copy button and the link's title/href.

## Gates
typecheck ✓ · unit tests ✓ · prettier ✓ · build ✓ · responsive-overflow e2e ✓ (24/24 — incl. the 4 routes this footer appears on)

## Screenshots

Captured with the repo's Playwright harness on a validator page (its footer embeds the 48-char hotkey). The mobile pair is the meaningful change (paths overflow off-canvas → truncate with a reachable copy button); tablet/desktop already fit.

| Viewport · Theme | Before (paths overflow) | After (truncated, copy on-screen) |
| --- | --- | --- |
| Mobile · Light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5309-apisourcefooter/before-mobile-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5309-apisourcefooter/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5309-apisourcefooter/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5309-apisourcefooter/after-mobile-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5309-apisourcefooter/before-tablet-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5309-apisourcefooter/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5309-apisourcefooter/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5309-apisourcefooter/after-tablet-dark.png) |
| Desktop · Light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5309-apisourcefooter/before-desktop-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5309-apisourcefooter/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5309-apisourcefooter/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5309-apisourcefooter/after-desktop-dark.png) |
