### PR TITLE
fix(ui): give the Providers table a mobile/tablet card fallback (#5322)

### DIFF
--- a/apps/ui/src/lib/metagraphed/provider-card-fields.test.ts
+++ b/apps/ui/src/lib/metagraphed/provider-card-fields.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveProviderCard } from "./provider-card-fields";
+import type { Provider } from "./types";
+
+const base: Provider = { slug: "acme" };
+
+describe("resolveProviderCard", () => {
+  it("uses the provider name and kind when present", () => {
+    const f = resolveProviderCard(
+      { ...base, name: "Acme Labs", kind: "infra" },
+      { subnets: 3, surfaces: 12, endpoints: 40 },
+    );
+    expect(f.name).toBe("Acme Labs");
+    expect(f.kindLabel).toBe("infra");
+    expect(f.subnetsLabel).toBe("3");
+    expect(f.surfacesLabel).toBe("12");
+    expect(f.endpointsLabel).toBe("40");
+  });
+
+  it("falls back to the slug for the name and a generic kind label", () => {
+    const f = resolveProviderCard(base, { subnets: 1, surfaces: 1, endpoints: 1 });
+    expect(f.name).toBe("acme");
+    expect(f.kindLabel).toBe("provider");
+  });
+
+  it("defaults every count to 0 when counts are missing", () => {
+    const f = resolveProviderCard({ ...base, name: "Acme", kind: "team" });
+    expect(f.subnetsLabel).toBe("0");
+    expect(f.surfacesLabel).toBe("0");
+    expect(f.endpointsLabel).toBe("0");
+  });
+
+  it("formats large counts with thousands separators", () => {
+    const f = resolveProviderCard(base, { subnets: 0, surfaces: 1234, endpoints: 56789 });
+    expect(f.surfacesLabel).toBe("1,234");
+    expect(f.endpointsLabel).toBe("56,789");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/provider-card-fields.ts
+++ b/apps/ui/src/lib/metagraphed/provider-card-fields.ts
@@ -1,0 +1,30 @@
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { Provider } from "@/lib/metagraphed/types";
+import type { ProviderCounts } from "@/lib/metagraphed/queries";
+
+/**
+ * Display strings a provider card derives from a `Provider` row and its
+ * endpoint `ProviderCounts`. Kept pure (no JSX, no component imports) so the
+ * null/fallback branches are unit-tested apart from the DOM — the mobile
+ * fallback cards on the Providers table render from this.
+ */
+export interface ProviderCardFields {
+  /** Display name, falling back to the slug when the provider has no name. */
+  name: string;
+  /** Provider kind, falling back to a generic "provider" label. */
+  kindLabel: string;
+  subnetsLabel: string;
+  surfacesLabel: string;
+  endpointsLabel: string;
+}
+
+/** Resolve the labelled fields a provider card renders (counts default to 0). */
+export function resolveProviderCard(p: Provider, counts?: ProviderCounts): ProviderCardFields {
+  return {
+    name: p.name ?? p.slug,
+    kindLabel: p.kind ?? "provider",
+    subnetsLabel: formatNumber(counts?.subnets ?? 0),
+    surfacesLabel: formatNumber(counts?.surfaces ?? 0),
+    endpointsLabel: formatNumber(counts?.endpoints ?? 0),
+  };
+}

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -22,6 +22,7 @@ import {
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
 import { matchesQuery } from "@/lib/metagraphed/url-state";
 import { matchesProviderAuthority } from "@/lib/metagraphed/providers-url-state";
+import { resolveProviderCard } from "@/lib/metagraphed/provider-card-fields";
 import { healthStatusSegments } from "@/lib/metagraphed/health-segments";
 import {
   BrandIcon,
@@ -337,83 +338,145 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
           action={{ label: "Browse all endpoints", href: "/endpoints" }}
         />
       ) : view === "table" ? (
-        <div className="rounded border border-border bg-card overflow-x-auto">
-          <table className="w-full text-left text-sm">
-            <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
-              <tr>
-                <th className="px-3 py-2">Provider</th>
-                <th className="px-3 py-2">Kind</th>
-                <th className="px-3 py-2">Authority</th>
-                <th className="px-3 py-2">Host</th>
-                <th className="px-3 py-2 text-right">Subnets</th>
-                <th className="px-3 py-2 text-right">Surfaces</th>
-                <th className="px-3 py-2 text-right">Endpoints</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {sorted.map((p) => {
-                const host = maskHost(p.website ?? p.homepage);
-                const c = counts[p.slug];
-                return (
-                  <tr key={p.slug} className="hover:bg-surface/40">
-                    <td className="px-3 py-2">
-                      <Link
-                        to="/providers/$slug"
-                        params={{ slug: p.slug }}
-                        className="inline-flex items-center gap-2 min-w-0"
-                      >
-                        <BrandIcon
-                          url={p.website ?? p.homepage}
-                          iconUrl={p.icon_url}
-                          repoUrl={p.repo}
-                          providerSlug={p.slug}
-                          name={p.name ?? p.slug}
-                          fallback={p.slug}
-                          size={20}
-                        />
-                        <span className="font-medium text-ink-strong truncate">
-                          {p.name ?? p.slug}
-                        </span>
-                        <span className="font-mono text-[10px] text-ink-muted truncate">
+        <>
+          {/* < lg: the 7-column table pushes the Subnets/Surfaces/Endpoints
+              columns off-screen behind an undiscoverable horizontal scroll on
+              phone/tablet widths (the audit flagged 768px specifically), so
+              narrow viewports get a stacked card per provider instead —
+              mirrors the leaderboards/validators mobile fallback split
+              (#5320/#5321). Wider than those 5-column boards, so the cutover
+              is `lg` (1024px) rather than `md`. */}
+          <div className="space-y-2 lg:hidden">
+            {sorted.map((p) => {
+              const f = resolveProviderCard(p, counts[p.slug]);
+              const host = maskHost(p.website ?? p.homepage);
+              return (
+                <Link
+                  key={p.slug}
+                  to="/providers/$slug"
+                  params={{ slug: p.slug }}
+                  className="block rounded border border-border bg-card p-3 transition-colors hover:border-accent/60"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="inline-flex min-w-0 items-center gap-2">
+                      <BrandIcon
+                        url={p.website ?? p.homepage}
+                        iconUrl={p.icon_url}
+                        repoUrl={p.repo}
+                        providerSlug={p.slug}
+                        name={f.name}
+                        fallback={p.slug}
+                        size={20}
+                      />
+                      <span className="min-w-0">
+                        <span className="block truncate font-medium text-ink-strong">{f.name}</span>
+                        <span className="block truncate font-mono text-[10px] text-ink-muted">
                           {p.slug}
                         </span>
-                      </Link>
-                    </td>
-                    <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
-                      {p.kind ?? "—"}
-                    </td>
-                    <td className="px-3 py-2">
-                      {p.authority ? (
-                        <span
-                          className={classNames(
-                            "font-mono text-[10px] uppercase tracking-wider rounded border px-1.5 py-0.5",
-                            authorityTone(p.authority),
-                          )}
+                      </span>
+                    </span>
+                    {p.authority ? (
+                      <span
+                        className={classNames(
+                          "shrink-0 rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider",
+                          authorityTone(p.authority),
+                        )}
+                      >
+                        {p.authority}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="mt-2 flex items-center justify-between gap-2 font-mono text-[11px] text-ink-muted">
+                    <span>{f.kindLabel}</span>
+                    {host ? <span className="max-w-[20ch] truncate">{host}</span> : null}
+                  </div>
+                  <div className="mt-2 grid grid-cols-3 gap-2 border-t border-border/60 pt-2">
+                    <ProviderCardStat label="Subnets" value={f.subnetsLabel} />
+                    <ProviderCardStat label="Surfaces" value={f.surfacesLabel} />
+                    <ProviderCardStat label="Endpoints" value={f.endpointsLabel} />
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+          <div className="hidden overflow-x-auto rounded border border-border bg-card lg:block">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+                <tr>
+                  <th className="px-3 py-2">Provider</th>
+                  <th className="px-3 py-2">Kind</th>
+                  <th className="px-3 py-2">Authority</th>
+                  <th className="px-3 py-2">Host</th>
+                  <th className="px-3 py-2 text-right">Subnets</th>
+                  <th className="px-3 py-2 text-right">Surfaces</th>
+                  <th className="px-3 py-2 text-right">Endpoints</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {sorted.map((p) => {
+                  const host = maskHost(p.website ?? p.homepage);
+                  const c = counts[p.slug];
+                  return (
+                    <tr key={p.slug} className="hover:bg-surface/40">
+                      <td className="px-3 py-2">
+                        <Link
+                          to="/providers/$slug"
+                          params={{ slug: p.slug }}
+                          className="inline-flex items-center gap-2 min-w-0"
                         >
-                          {p.authority}
-                        </span>
-                      ) : (
-                        <span className="text-ink-muted">—</span>
-                      )}
-                    </td>
-                    <td className="px-3 py-2 font-mono text-[11px] text-ink-muted truncate max-w-[22ch]">
-                      {host ?? "—"}
-                    </td>
-                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums">
-                      {c?.subnets ?? 0}
-                    </td>
-                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums">
-                      {c?.surfaces ?? 0}
-                    </td>
-                    <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums">
-                      {c?.endpoints ?? 0}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                          <BrandIcon
+                            url={p.website ?? p.homepage}
+                            iconUrl={p.icon_url}
+                            repoUrl={p.repo}
+                            providerSlug={p.slug}
+                            name={p.name ?? p.slug}
+                            fallback={p.slug}
+                            size={20}
+                          />
+                          <span className="font-medium text-ink-strong truncate">
+                            {p.name ?? p.slug}
+                          </span>
+                          <span className="font-mono text-[10px] text-ink-muted truncate">
+                            {p.slug}
+                          </span>
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
+                        {p.kind ?? "—"}
+                      </td>
+                      <td className="px-3 py-2">
+                        {p.authority ? (
+                          <span
+                            className={classNames(
+                              "font-mono text-[10px] uppercase tracking-wider rounded border px-1.5 py-0.5",
+                              authorityTone(p.authority),
+                            )}
+                          >
+                            {p.authority}
+                          </span>
+                        ) : (
+                          <span className="text-ink-muted">—</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 font-mono text-[11px] text-ink-muted truncate max-w-[22ch]">
+                        {host ?? "—"}
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums">
+                        {c?.subnets ?? 0}
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums">
+                        {c?.surfaces ?? 0}
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums">
+                        {c?.endpoints ?? 0}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </>
       ) : (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {sorted.map((p) => {
@@ -524,6 +587,15 @@ function ProviderCountsRow({
       <CountTile icon={<Layers className="size-3" />} label="Surfaces" value={s} />
       <CountTile icon={<Radio className="size-3" />} label="Endpoints" value={e} />
       <CountTile icon={<Network className="size-3" />} label="Subnets" value={n} />
+    </div>
+  );
+}
+
+function ProviderCardStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="font-mono text-[9px] uppercase tracking-wider text-ink-muted">{label}</span>
+      <span className="font-mono text-[13px] tabular-nums text-ink-strong">{value}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #5322

The `view=table` Providers list (`providers.index.tsx`) wrapped a **7-column** table in a bare `overflow-x-auto` div. Below the desktop breakpoint the Kind / Authority / Host and the Subnets / Surfaces / Endpoints columns are pushed off-screen behind an undiscoverable horizontal scroll — at **768px only the Provider column is visible** (the width the audit called out).

This renders a stacked **card per provider** below `lg` (name + slug + authority badge, kind + host, and the three counts) and hides the table with `hidden lg:block`, mirroring the leaderboards/validators mobile-fallback split (#5320 / #5321). The cutover is `lg` (1024px) rather than `md` because this board has 7 columns and still clips at 768px, so **both mobile and tablet** get the card fallback; desktop is unchanged.

Card display strings come from a pure `resolveProviderCard` helper (`provider-card-fields.ts`) so the name/kind fallbacks and count formatting are unit-tested apart from the DOM.

## Gates

typecheck OK - unit tests OK (`provider-card-fields.test.ts`, 4 new) - eslint `.` OK (0 errors) - prettier OK

## Screenshots

Captured with Playwright at the three SKILL viewports (375x812 / 768x1024 / 1280x800), each theme forced via `mg-theme`, fixed-viewport (never full-page), against the live dev server with real production data. Mobile **and** tablet are the meaningful change (clipped table -> cards); desktop shows the unchanged table.

| Viewport - Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/after-mobile-dark.png)<br><sub>after</sub> |
