### PR TITLE
feat(registry): add SN121 sundae_bar llms.txt index and products catalog API surfaces (#4170)

### DIFF
--- a/registry/subnets/sundae-bar.json
+++ b/registry/subnets/sundae-bar.json
@@ -101,6 +101,56 @@
         "https://github.com/sundae-bar/sb-validator/blob/main/README.md"
       ],
       "url": "https://raw.githubusercontent.com/sundae-bar/sb-validator/main/python/dataset_sbc9.jsonl"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-121-sundae-bar-llms-txt",
+      "kind": "data-artifact",
+      "name": "Sundae Bar llms.txt agent index",
+      "notes": "Public no-auth machine-readable llms.txt index served at www.sundaebar.ai/llms.txt for the SN121 sundae_bar directory (autonomous agents, agent skills, workflows, and prompts). Provides an agent-consumable Markdown map that points LLM crawlers at the site's JSON API as the source of truth and links featured/explore listings; content begins '# sundae_bar'. Regenerated hourly per the file's own header. Distinct from the sb-validator SBC9 JSONL benchmark dataset already registered.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "sundae-bar",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://www.sundaebar.ai/",
+        "https://github.com/sundae-bar/bittensor-subnet"
+      ],
+      "url": "https://www.sundaebar.ai/llms.txt"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-121-sundae-bar-products-api",
+      "kind": "subnet-api",
+      "name": "Sundae Bar products catalog API",
+      "notes": "Public no-auth GET /api/products on www.sundaebar.ai returning the paginated JSON catalog of SN121 sundae_bar listings ({\"data\":[{type,name,description,...}]}) — the source-of-truth listings feed that the site's own llms.txt directs AI agents to query. Verified 200 application/json, distinct in host and path from the api.sundaebar.ai/api/v2/validators coordinator surface already registered.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "sundae-bar",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://www.sundaebar.ai/llms.txt",
+        "https://www.sundaebar.ai/"
+      ],
+      "url": "https://www.sundaebar.ai/api/products"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Adds two new `community` surfaces to SN121 sundae_bar (`registry/subnets/sundae-bar.json`), both public, no-auth, and verified live:

1. **llms.txt agent index** (`data-artifact`) — `https://www.sundaebar.ai/llms.txt`
2. **products catalog API** (`subnet-api`) — `https://www.sundaebar.ai/api/products`

Together these close the file's gap notes for a machine-readable artifact and a verified safe public API endpoint.

## Surfaces

**`sn-121-sundae-bar-llms-txt`** — `data-artifact`
- url: `https://www.sundaebar.ai/llms.txt` — 200 `text/markdown`, regenerated hourly per its own header
- A machine-readable Markdown map for LLM crawlers that points agents at the site's JSON API as source of truth; content begins `# sundae_bar`. Distinct from the sb-validator SBC9 JSONL benchmark already registered.

**`sn-121-sundae-bar-products-api`** — `subnet-api`
- url: `https://www.sundaebar.ai/api/products` — 200 `application/json`, `{"data":[...]}`
- The paginated source-of-truth listings feed that sundae_bar's own `llms.txt` directs agents to query. Distinct in host and path from the already-registered `api.sundaebar.ai/api/v2/validators` coordinator surface.

## Proof of ownership

`www.sundaebar.ai` is the subnet's registered `website_url`. The `llms.txt` is published at the site root and itself documents `/api/products` as the canonical listings API, so the subnet demonstrably publishes both.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/sundae-bar.json` — passed (6 surfaces)
- Both endpoints verified with no auth header: 200, correct content-type, SS58-clean.

One focused change: two surfaces appended to one subnet file; nothing else touched.

Closes #4170

> Scope note: #4170 frames the enrichment as an OpenAPI/Swagger spec. sundae_bar does not serve a verified public OpenAPI document; these add the genuinely-published machine-readable index and the canonical JSON catalog API it references, advancing the same "enrich SN121" intent. Any OpenAPI-specific framing is advisory.
