### PR TITLE
feat(registry): add SN62 Ridges data-artifact surface

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,25 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-evaluation-leaderboard",
+      "kind": "data-artifact",
+      "name": "Ridges evaluation-set 23 agent leaderboard",
+      "notes": "Public no-auth JSON dataset of the full SN62 Ridges agent leaderboard for evaluation set 23 (1,341 rows, ~616 KB). Each row carries rank, agent_id, miner_hotkey, agent name and version, status, approved/disqualified flags, final_score, average_cost_usd, average_runtime_seconds, and the attesting validator_count/validator_hotkeys — the subnet's SWE-bench-style scoring results. Pinned to a fixed set_id (23) so the artifact is stable rather than a live query. Served by the official Ridges API, whose route is defined in the operator's repository at api/endpoints/evaluation_sets.py.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/ridgesai/ridges/blob/main/api/endpoints/evaluation_sets.py",
+        "https://agent-upload.ridges.ai/openapi.json"
+      ],
+      "url": "https://agent-upload.ridges.ai/evaluation-sets/23/leaderboard"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Summary

Fills the gap named in #4069: **SN62 Ridges** had no **public data artifact** registered. This adds one.

- **url:** https://agent-upload.ridges.ai/evaluation-sets/23/leaderboard (public, no-auth JSON — HTTP 200, ~616 KB, **1,341 rows**)
- **kind:** data-artifact (the exact gap #4069 asks for; the file previously had only source-repo / subnet-api / openapi)
- **source_urls (proof):** https://github.com/ridgesai/ridges/blob/main/api/endpoints/evaluation_sets.py — the operator's own repo defines this route (`@router.get("/{set_id}/leaderboard")`); also declared in https://agent-upload.ridges.ai/openapi.json

### What the data is
The full agent leaderboard for evaluation set 23 — the subnet's SWE-bench-style scoring results. Each row carries rank, agent id, miner identity, agent name/version, status, approved/disqualified flags, `final_score`, `average_cost_usd`, `average_runtime_seconds`, and the attesting validator count/list.

Pinned to a **fixed `set_id` (23)** so the artifact is stable rather than a rolling live query — appropriate for a standalone data artifact.

## Validation
- `npm run validate:surface -- registry/subnets/ridges.json` → passed (4 surfaces)
- `npm run scan:public-safety` → no findings for this file
- `npx prettier --check` → clean

Closes #4069