### PR TITLE
feat(mcp): add call_rpc tool for the state-query RPC proxy

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -26,6 +26,7 @@ import { DAY_PATTERN } from "../workers/request-params.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { d1TimeoutMs, withTimeout } from "../workers/storage.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
+import { handleRpcProxyRequest } from "../workers/request-handlers/rpc-proxy.mjs";
 import {
   MCP_CHAIN_STREAM_RESOURCE_URI,
   isValidMcpSessionId,
@@ -8637,6 +8638,117 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "call_rpc",
+    title: "Call a read-only Bittensor RPC method",
+    description:
+      "Proxy a single read-only, allowlisted Substrate/Subtensor JSON-RPC call " +
+      "(chain_getBlock, chain_getBlockHash, chain_getFinalizedHead, chain_getHeader, " +
+      "rpc_methods, state_getRuntimeVersion, system_chain, system_health, " +
+      "system_name, system_properties, system_version, plus the state-query " +
+      "methods state_getStorage/state_getKeysPaged) against the finney or test " +
+      "network, with the same method allowlist, state-query param validation, " +
+      "rate limiting, and endpoint failover as the public proxy. Use " +
+      "get_best_rpc_endpoint to pick a node for direct WSS access instead. " +
+      "Mirrors POST /rpc/v1/{network}.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        method: {
+          type: "string",
+          description:
+            "The JSON-RPC method name, e.g. 'chain_getBlockHash' or 'state_getStorage'.",
+        },
+        params: {
+          type: "array",
+          description:
+            "JSON-RPC positional params for the method. Omit for none.",
+        },
+        network: {
+          type: "string",
+          enum: ["finney", "test"],
+          description: "Bittensor network to query (default 'finney').",
+        },
+      },
+      required: ["method"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      if (typeof args?.method !== "string" || !args.method) {
+        throw toolError(
+          "invalid_params",
+          "Argument `method` is required and must be a non-empty string.",
+        );
+      }
+      if (args.params !== undefined && !Array.isArray(args.params)) {
+        throw toolError(
+          "invalid_params",
+          "Argument `params`, when present, must be an array.",
+        );
+      }
+      if (args.network !== undefined && typeof args.network !== "string") {
+        throw toolError(
+          "invalid_params",
+          "Argument `network`, when present, must be a string.",
+        );
+      }
+      const network = args.network || "finney";
+      const rpcRequestBody = {
+        jsonrpc: "2.0",
+        id: 1,
+        method: args.method,
+        params: args.params ?? [],
+      };
+      // Forward through the SAME handler REST callers hit (allowlist, state-query
+      // param validation, rate limits, endpoint pool + failover, cache) rather
+      // than reimplementing any of it -- cf-connecting-ip is forged from
+      // ctx.clientIp (itself derived from the real inbound header, see
+      // mcpClientKey) so the proxy's per-client rate-limit buckets key on the
+      // actual caller instead of this synthetic request having none.
+      const proxyRequest = new Request(
+        `https://d/rpc/v1/${encodeURIComponent(network)}`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "cf-connecting-ip": ctx.clientIp,
+          },
+          body: JSON.stringify(rpcRequestBody),
+        },
+      );
+      const response = await handleRpcProxyRequest(
+        proxyRequest,
+        ctx.env,
+        new URL(proxyRequest.url),
+      );
+      let payload;
+      try {
+        payload = await response.json();
+      } catch {
+        throw toolError(
+          "rpc_invalid_response",
+          "The RPC proxy returned a non-JSON response.",
+        );
+      }
+      if (!response.ok) {
+        throw toolError(
+          payload?.error?.code || "rpc_error",
+          payload?.error?.message ||
+            `RPC proxy returned status ${response.status}.`,
+        );
+      }
+      return {
+        network,
+        method: args.method,
+        jsonrpc: payload?.jsonrpc ?? "2.0",
+        result: payload && "result" in payload ? payload.result : null,
+        error: payload?.error ?? null,
+        endpoint_id: response.headers.get("x-metagraph-rpc-endpoint-id"),
+        provider: response.headers.get("x-metagraph-rpc-provider"),
+        cache: response.headers.get("x-metagraph-rpc-cache"),
+      };
+    },
+  },
+  {
     name: "registry_summary",
     title: "Get the registry-wide summary",
     description:
@@ -12436,6 +12548,21 @@ const TOOL_OUTPUT_SCHEMAS = {
         status: NULLABLE_STRING,
         health_source: NULLABLE_STRING,
       }),
+    },
+  },
+  call_rpc: {
+    type: "object",
+    additionalProperties: true,
+    required: ["network", "method", "jsonrpc"],
+    properties: {
+      network: { type: "string" },
+      method: { type: "string" },
+      jsonrpc: { type: "string" },
+      result: ANY,
+      error: { type: ["object", "null"] },
+      endpoint_id: NULLABLE_STRING,
+      provider: NULLABLE_STRING,
+      cache: NULLABLE_STRING,
     },
   },
   registry_summary: {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -8730,11 +8730,10 @@ export const MCP_TOOLS = [
         );
       }
       if (!response.ok) {
-        throw toolError(
-          payload?.error?.code || "rpc_error",
-          payload?.error?.message ||
-            `RPC proxy returned status ${response.status}.`,
-        );
+        // handleRpcProxyRequest's every error path goes through workers/http.mjs's
+        // errorResponse(), which always populates error.code/error.message -- no
+        // "malformed error body" case exists to guess a fallback for.
+        throw toolError(payload.error.code, payload.error.message);
       }
       return {
         network,

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5557,6 +5557,210 @@ describe("MCP get_rpc_usage", () => {
   });
 });
 
+describe("MCP call_rpc", () => {
+  // Mirrors rpcEnv() in tests/request-handlers-rpc-proxy.test.mjs: rpc/pools.json
+  // is R2-only, so both ASSETS and METAGRAPH_ARCHIVE are stubbed the same way
+  // readArtifact's tier resolution expects.
+  const RPC_POOL = {
+    pools: [
+      {
+        id: "finney-rpc",
+        endpoints: [
+          {
+            id: "fx",
+            provider: "fx",
+            pool_eligible: true,
+            status: "ok",
+            score: 100,
+            url: "https://bittensor-finney.api.onfinality.io/public",
+          },
+        ],
+      },
+    ],
+  };
+
+  function callRpcEnv(overrides = {}) {
+    return {
+      METAGRAPH_ENABLE_RPC_PROXY: "true",
+      ASSETS: {
+        async fetch(request) {
+          const target = new URL(request.url);
+          if (target.pathname === "/metagraph/rpc/pools.json") {
+            return Response.json(RPC_POOL);
+          }
+          return new Response("{}", { status: 404 });
+        },
+      },
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return {
+            async json() {
+              return RPC_POOL;
+            },
+          };
+        },
+      },
+      ...overrides,
+    };
+  }
+
+  test("rejects a missing method as invalid_params", async () => {
+    const res = await callTool("call_rpc", {}, { env: callRpcEnv() });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /invalid_params/);
+  });
+
+  test("rejects a non-array params as invalid_params", async () => {
+    const res = await callTool(
+      "call_rpc",
+      { method: "system_health", params: "nope" },
+      { env: callRpcEnv() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /invalid_params/);
+  });
+
+  test("propagates the REST route's rpc_method_blocked error verbatim for a denied method", async () => {
+    const res = await callTool(
+      "call_rpc",
+      { method: "author_submitExtrinsic" },
+      { env: callRpcEnv() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /rpc_method_blocked/);
+  });
+
+  test("propagates rpc_network_unsupported for an unknown network", async () => {
+    const res = await callTool(
+      "call_rpc",
+      { method: "system_health", network: "moonbeam" },
+      { env: callRpcEnv() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /rpc_network_unsupported/);
+  });
+
+  test("forwards the real MCP client IP into the proxy's rate-limit key", async () => {
+    let limiterKey;
+    const env = callRpcEnv({
+      // MCP_RATE_LIMITER absent falls back to RPC_RATE_LIMITER for the transport-
+      // level MCP rate limit too (enforceMcpRateLimit) -- stub it separately so
+      // only the proxy's own internal check below is under test.
+      MCP_RATE_LIMITER: {
+        async limit() {
+          return { success: true };
+        },
+      },
+      RPC_RATE_LIMITER: {
+        async limit({ key }) {
+          limiterKey = key;
+          return { success: false };
+        },
+      },
+    });
+    const res = await callTool(
+      "call_rpc",
+      { method: "system_health" },
+      { env, headers: { "cf-connecting-ip": "198.51.100.7" } },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /rpc_rate_limited/);
+    assert.equal(limiterKey, "rpc:198.51.100.7");
+  });
+
+  test("returns the upstream result plus served-endpoint metadata on success", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { isSyncing: false, peers: 3, shouldHavePeers: true },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    try {
+      const res = await callTool(
+        "call_rpc",
+        { method: "system_health" },
+        { env: callRpcEnv() },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(out.network, "finney");
+      assert.equal(out.method, "system_health");
+      assert.deepEqual(out.result, {
+        isSyncing: false,
+        peers: 3,
+        shouldHavePeers: true,
+      });
+      assert.equal(out.error, null);
+      assert.equal(out.endpoint_id, "fx");
+      assert.equal(out.provider, "fx");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("state_getStorage forwards to the state-query path and validates the key", async () => {
+    const res = await callTool(
+      "call_rpc",
+      { method: "state_getStorage", params: ["not-hex"] },
+      { env: callRpcEnv() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /0x-prefixed hex/);
+  });
+
+  test("rpc_invalid_response when the upstream body is not JSON", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response("not json", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      });
+    try {
+      const res = await callTool(
+        "call_rpc",
+        { method: "system_health" },
+        { env: callRpcEnv() },
+      );
+      assert.equal(res.body.result.isError, true);
+      assert.match(res.body.result.content[0].text, /rpc_invalid_response/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("advertises a call_rpc-shaped outputSchema and the result validates against it", async () => {
+    const ajv = new Ajv2020({ strict: false });
+    const def = listToolDefinitions().find((t) => t.name === "call_rpc");
+    assert.ok(def.outputSchema);
+    const validate = ajv.compile(def.outputSchema);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: "finney" }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    try {
+      const res = await callTool(
+        "call_rpc",
+        { method: "system_chain" },
+        { env: callRpcEnv() },
+      );
+      assert.ok(
+        validate(res.body.result.structuredContent),
+        JSON.stringify(validate.errors),
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
 describe("MCP get_account_counterparties", () => {
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
   const CP = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy";

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5620,6 +5620,16 @@ describe("MCP call_rpc", () => {
     assert.match(res.body.result.content[0].text, /invalid_params/);
   });
 
+  test("rejects a non-string network as invalid_params", async () => {
+    const res = await callTool(
+      "call_rpc",
+      { method: "system_health", network: 123 },
+      { env: callRpcEnv() },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /invalid_params/);
+  });
+
   test("propagates the REST route's rpc_method_blocked error verbatim for a denied method", async () => {
     const res = await callTool(
       "call_rpc",
@@ -5696,6 +5706,30 @@ describe("MCP call_rpc", () => {
       assert.equal(out.error, null);
       assert.equal(out.endpoint_id, "fx");
       assert.equal(out.provider, "fx");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("defaults jsonrpc to 2.0 and result to null when the upstream body omits them", async () => {
+    const originalFetch = globalThis.fetch;
+    // A real JSON-RPC 2.0 upstream always includes both fields; this exercises
+    // the defensive fallback for a hypothetical malformed/truncated upstream
+    // body, not a shape the proxy is known to ever actually produce.
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ id: 1 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    try {
+      const res = await callTool(
+        "call_rpc",
+        { method: "system_health" },
+        { env: callRpcEnv() },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(out.jsonrpc, "2.0");
+      assert.equal(out.result, null);
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary

Closes #5354 (task #56 from the production-readiness audit) — MCP feature-parity gap (#4344/#4346).

The REST API has a state-query RPC proxy (`POST /rpc/v1/{network}`) with no MCP equivalent — an MCP-only client couldn't make arbitrary state queries the way a REST caller can.

## Implementation

`call_rpc` delegates directly to the REST route's own `handleRpcProxyRequest` (`workers/request-handlers/rpc-proxy.mjs`) via a synthetic `Request`, forging `cf-connecting-ip` from the MCP caller's real client IP so the proxy's existing rate limiters key on the real caller rather than a shared MCP-process address. Reuses the REST route's method allowlist, state-query param validation, rate limiting, endpoint failover, and error codes verbatim — no reimplementation.

## Test plan

- [x] 9 new tests in `tests/mcp-server.test.mjs`: missing method → `invalid_params`, non-array params → `invalid_params`, denied method propagates `rpc_method_blocked` verbatim, unknown network propagates `rpc_network_unsupported`, real MCP client IP forwarded into the rate-limit key, successful call returns the upstream result plus served-endpoint metadata, `state_getStorage` forwards correctly and validates its key, non-JSON upstream body → `rpc_invalid_response`, and the tool's `outputSchema` validates against its own result shape
- [x] `npm run lint` clean
- [x] `npx prettier --check src/mcp-server.mjs tests/mcp-server.test.mjs` clean
- [x] `npm run build` clean
- [x] `npx vitest run tests/mcp-server.test.mjs` — 1006/1006 pass