### PR TITLE
fix(ui): normalize mobile menu touch targets (#5335)

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -135,7 +135,7 @@ export function AppShell({ children }: { children: ReactNode }) {
           >
             <div className="max-w-shell-max mx-auto px-4 md:px-8 flex h-nav items-center gap-3">
               <button
-                className="lg:hidden rounded-md p-2 text-ink hover:bg-surface min-h-10 min-w-10 inline-flex items-center justify-center"
+                className="lg:hidden rounded-md p-2 text-ink hover:bg-surface min-h-11 min-w-11 inline-flex items-center justify-center"
                 onClick={() => setMobileOpen(true)}
                 aria-label="Open menu"
               >
@@ -220,7 +220,7 @@ export function AppShell({ children }: { children: ReactNode }) {
                   <button
                     onClick={() => setMobileOpen(false)}
                     aria-label="Close menu"
-                    className="rounded-md p-2 text-ink-muted hover:bg-surface min-h-10 min-w-10 inline-flex items-center justify-center"
+                    className="rounded-md p-2 text-ink-muted hover:bg-surface min-h-11 min-w-11 inline-flex items-center justify-center"
                   >
                     <X className="size-4" />
                   </button>


### PR DESCRIPTION
## Summary

- Normalize the mobile header "Open menu" button to the same `min-h-11 min-w-11` floor used by sibling header controls.
- Normalize the mobile drawer "Close menu" button to the same 44px touch target.

## Template Used

- Frontend/UI bug fix

Closes #5335

## Screenshots

Desktop is omitted because these menu controls are hidden at the desktop viewport; mobile and tablet cover the affected `lg:hidden` header/drawer controls.

| Viewport · Theme · State | Before | After |
| ------------------------ | ------ | ----- |
| Mobile · Light · Closed header | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-mobile-light-closed.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-mobile-light-closed.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-mobile-light-closed.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-mobile-light-closed.png)<br><sub>after</sub> |
| Mobile · Light · Open drawer | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-mobile-light-open.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-mobile-light-open.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-mobile-light-open.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-mobile-light-open.png)<br><sub>after</sub> |
| Mobile · Dark · Closed header | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-mobile-dark-closed.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-mobile-dark-closed.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-mobile-dark-closed.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-mobile-dark-closed.png)<br><sub>after</sub> |
| Mobile · Dark · Open drawer | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-mobile-dark-open.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-mobile-dark-open.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-mobile-dark-open.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-mobile-dark-open.png)<br><sub>after</sub> |
| Tablet · Light · Closed header | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-tablet-light-closed.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-tablet-light-closed.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-tablet-light-closed.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-tablet-light-closed.png)<br><sub>after</sub> |
| Tablet · Light · Open drawer | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-tablet-light-open.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-tablet-light-open.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-tablet-light-open.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-tablet-light-open.png)<br><sub>after</sub> |
| Tablet · Dark · Closed header | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-tablet-dark-closed.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-tablet-dark-closed.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-tablet-dark-closed.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-tablet-dark-closed.png)<br><sub>after</sub> |
| Tablet · Dark · Open drawer | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-tablet-dark-open.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-before-tablet-dark-open.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-tablet-dark-open.png" width="260">](https://raw.githubusercontent.com/kstefanovic/metagraphed/screenshots-menu-5335/menu-after-tablet-dark-open.png)<br><sub>after</sub> |

## Validation

- `git diff --check`
- `npx prettier --check apps/ui/src/components/metagraphed/app-shell.tsx`
- `npx eslint apps/ui/src/components/metagraphed/app-shell.tsx`
- `npm run build --workspace=packages/ui-kit`
- `npm run --workspace=apps/ui typecheck`