### PR TITLE
chore: remove dead indexer_cursor table definition

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -584,18 +584,6 @@ CREATE INDEX IF NOT EXISTS idx_rpc_proxy_events_observed_endpoint
   ON rpc_proxy_events (observed_at, endpoint_id);
 
 -- ---------------------------------------------------------------------------
--- Indexer coordination
--- ---------------------------------------------------------------------------
-
--- Durable cursor (also mirrored in Redis for hot access). Single row id=1.
-CREATE TABLE IF NOT EXISTS indexer_cursor (
-  id               SMALLINT PRIMARY KEY DEFAULT 1,
-  last_block       BIGINT NOT NULL,
-  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
-  CONSTRAINT indexer_cursor_singleton CHECK (id = 1)
-);
-
--- ---------------------------------------------------------------------------
 -- Realtime firehose outbox (ADR 0015, #4980)
 -- ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #5361 (task #63/#63 from the production-readiness audit).

`apps/indexer-rs`'s `run_live()` derives its live-follow cursor via `db_max_block()` (`SELECT coalesce(max(block_number), 0) FROM blocks`) — a self-deriving design that never reads or writes `indexer_cursor`. Confirmed zero references anywhere in the repo (all extensions — `.rs`/`.mjs`/`.sql`/`.md`/`.sh`/`.yml`) besides the `CREATE TABLE` itself, independently re-verified before removing.

`economics_history` needed no edit here — its `CREATE TABLE` was already removed in a prior commit (`git log` confirms); the two remaining prose comments (this file + `docs/block-explorer-data-model.md`) already document that removal accurately and are left as-is.

## Not in scope

The live `DROP TABLE` on production Postgres is a separate ops action (single-row/near-empty tables, no CPU-limit concern like a large-table drop) — this PR only removes the dead source definition so a fresh box-init wouldn't recreate it. Tracked separately for the actual `DROP TABLE`.

## Test plan

- [x] `npx vitest run tests/chain-firehose-outbox-schema.test.mjs` — the one existing test that parses `schema.sql` content (unrelated trigger function) — 2/2 pass, unaffected by this deletion
- [x] Not covered by `npm run lint`/codecov (`.sql`, not `src/**`/`workers/**`)