### PR TITLE
feat(mcp): add get_subnet_stake_quote tool, call_hash filter to list_extrinsics

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -539,6 +539,7 @@ import {
 import { buildSubnetHyperparams } from "./subnet-hyperparams.mjs";
 import { buildSubnetHyperparamsHistory } from "./subnet-hyperparams-history.mjs";
 import { buildAlphaVolume } from "./alpha-volume.mjs";
+import { computeStakeQuote, STAKE_QUOTE_DIRECTIONS } from "./stake-quote.mjs";
 import { buildAccountPositionHistory } from "./account-position-history.mjs";
 import { loadAccountIdentity } from "./account-identity.mjs";
 import { loadAccountIdentityHistory } from "./account-identity-history.mjs";
@@ -990,9 +991,7 @@ function mcpD1Runner(ctx) {
 // DATA_API via tryPostgresTier (#4694) -- MCP tool handlers receive
 // structured args, not an inbound Request the way REST's handleExtrinsics
 // does, so this reconstructs the identical query-string shape
-// workers/data-api.mjs's extrinsics routes parse. list_extrinsics'
-// inputSchema has no call_hash param (REST-only, #4322), so that filter is
-// never forwarded here -- nothing else to reconcile. The host in the URL is
+// workers/data-api.mjs's extrinsics routes parse. The host in the URL is
 // never dispatched to (DATA_API.fetch resolves the binding directly, the
 // same convention src/data-api-mcp.mjs's dataApiFetchJson already uses).
 function mcpExtrinsicsListRequest(args) {
@@ -1005,6 +1004,8 @@ function mcpExtrinsicsListRequest(args) {
   if (callModule) params.set("call_module", callModule);
   const callFunction = optionalString(args, "call_function");
   if (callFunction) params.set("call_function", callFunction);
+  const callHash = optionalString(args, "call_hash");
+  if (callHash) params.set("call_hash", callHash);
   const success = optionalSuccessFilter(args);
   if (success !== undefined) params.set("success", String(success));
   const blockStart = optionalNonNegativeInt(args, "block_start");
@@ -2580,6 +2581,57 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
       return loadSubnetEconomics(ctx, netuid);
+    },
+  },
+  {
+    name: "get_subnet_stake_quote",
+    title: "Get a subnet stake/unstake quote",
+    description:
+      "Estimate a stake or unstake against one subnet's AMM pool: expected " +
+      "alpha/TAO out, spot and effective price, and price impact, computed " +
+      "with the chain's own constant-product swap formula against the " +
+      "subnet's live pool reserves (the same economics tier get_subnet_economics " +
+      "reads). direction stake (default) spends amount TAO for alpha; unstake " +
+      "spends amount alpha for TAO. Root (netuid 0) has no AMM pool and always " +
+      "quotes 1:1 with zero price impact. Read-only, pure math -- it builds no " +
+      "transaction, signs nothing, and never touches a key. Mirrors " +
+      "GET /api/v1/subnets/{netuid}/stake-quote.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        amount: {
+          type: "number",
+          description:
+            "Amount to quote, in TAO for direction=stake or alpha for " +
+            "direction=unstake. Must be a finite number greater than 0.",
+          exclusiveMinimum: 0,
+        },
+        direction: {
+          type: "string",
+          enum: STAKE_QUOTE_DIRECTIONS,
+          description: 'Swap direction: stake or unstake (default "stake").',
+        },
+      },
+      required: ["netuid", "amount"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const amount = args?.amount;
+      const direction = optionalString(args, "direction") ?? "stake";
+      const { economics } = await loadSubnetEconomics(ctx, netuid);
+      const result = computeStakeQuote({
+        netuid,
+        taoInPool: economics?.tao_in_pool_tao,
+        alphaInPool: economics?.alpha_in_pool,
+        amount,
+        direction,
+      });
+      if (!result.ok) {
+        throw toolError(result.code, result.error);
+      }
+      return { schema_version: 1, ...result.quote };
     },
   },
   {
@@ -6682,10 +6734,13 @@ export const MCP_TOOLS = [
     description:
       "Fetch the extrinsic feed (newest first) from the chain extrinsic tier, with " +
       "optional filters: block (exact height), signer (SS58 address), call_module " +
-      "(e.g. 'SubtensorModule'), call_function (e.g. 'set_weights'), success " +
-      "(true|false), block_start/block_end (inclusive height range), and from/to " +
-      "(observed_at epoch-ms range). Page with limit (1-100, default 50) / offset, " +
-      "or follow next_cursor for stable keyset pagination. Mirrors GET /api/v1/extrinsics.",
+      "(e.g. 'SubtensorModule'), call_function (e.g. 'set_weights'), call_hash (0x " +
+      "hash matched within call_args, e.g. to link a Multisig approve_as_multi/" +
+      "cancel_as_multi/as_multi approval chain — pair with call_module for a " +
+      "narrow scan), success (true|false), block_start/block_end (inclusive " +
+      "height range), and from/to (observed_at epoch-ms range). Page with limit " +
+      "(1-100, default 50) / offset, or follow next_cursor for stable keyset " +
+      "pagination. Mirrors GET /api/v1/extrinsics.",
     inputSchema: {
       type: "object",
       properties: {
@@ -6710,6 +6765,13 @@ export const MCP_TOOLS = [
           type: "string",
           description:
             "Optional call function filter, e.g. 'set_weights'. Omit for all.",
+        },
+        call_hash: {
+          type: "string",
+          description:
+            "Optional 0x call hash to match inside call_args, e.g. to link a " +
+            "Multisig approve_as_multi/cancel_as_multi/as_multi approval chain. " +
+            "Pair with call_module for a narrow scan. Omit for all.",
         },
         success: {
           type: "boolean",
@@ -6769,6 +6831,7 @@ export const MCP_TOOLS = [
       optionalString(args, "signer");
       optionalString(args, "call_module");
       optionalString(args, "call_function");
+      optionalString(args, "call_hash");
       optionalString(args, "cursor");
       optionalNonNegativeInt(args, "block");
       optionalSuccessFilter(args);
@@ -9584,6 +9647,38 @@ const TOOL_OUTPUT_SCHEMAS = {
       captured_at: NULLABLE_STRING,
       summary: { type: ["object", "null"] },
       economics: { type: ["object", "null"] },
+    },
+  },
+  get_subnet_stake_quote: {
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "schema_version",
+      "netuid",
+      "direction",
+      "amount",
+      "expected_out",
+      "expected_out_unit",
+      "spot_price_tao",
+      "effective_price_tao",
+      "price_impact_pct",
+      "tao_in_pool_tao",
+      "alpha_in_pool",
+      "is_root",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      direction: { type: "string", enum: STAKE_QUOTE_DIRECTIONS },
+      amount: { type: "number" },
+      expected_out: { type: "number" },
+      expected_out_unit: { type: "string", enum: ["alpha", "tao"] },
+      spot_price_tao: { type: "number" },
+      effective_price_tao: { type: "number" },
+      price_impact_pct: { type: "number" },
+      tao_in_pool_tao: { type: ["number", "null"] },
+      alpha_in_pool: { type: ["number", "null"] },
+      is_root: { type: "boolean" },
     },
   },
   get_economics: GET_ECONOMICS_OUTPUT_SCHEMA,

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -7462,6 +7462,117 @@ describe("MCP economics + metagraph data tools", () => {
     assert.match(res.body.result.content[0].text, /not_found/);
   });
 
+  // Realistic reserves (SN64 from the live economics.json artifact), matching
+  // the fixture in tests/subnet-stake-quote-api.test.mjs.
+  const STAKE_QUOTE_POOL_ROW = {
+    netuid: 64,
+    tao_in_pool_tao: 201959.938748425,
+    alpha_in_pool: 2730860.150574127,
+  };
+  const STAKE_QUOTE_BLOB = { subnets: [STAKE_QUOTE_POOL_ROW] };
+
+  test("get_subnet_stake_quote quotes a stake against the live pool reserves", async () => {
+    const res = await callTool(
+      "get_subnet_stake_quote",
+      { netuid: 64, amount: 1000, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.netuid, 64);
+    assert.equal(out.direction, "stake");
+    assert.equal(out.expected_out_unit, "alpha");
+    assert.equal(out.is_root, false);
+    assert.ok(out.expected_out > 0);
+    assert.ok(out.price_impact_pct > 0);
+    assert.equal(out.tao_in_pool_tao, STAKE_QUOTE_POOL_ROW.tao_in_pool_tao);
+  });
+
+  test("get_subnet_stake_quote quotes an unstake against the live pool reserves", async () => {
+    const res = await callTool(
+      "get_subnet_stake_quote",
+      { netuid: 64, amount: 500, direction: "unstake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.direction, "unstake");
+    assert.equal(out.expected_out_unit, "tao");
+    assert.ok(out.expected_out > 0);
+  });
+
+  test("get_subnet_stake_quote defaults direction to stake when omitted", async () => {
+    const res = await callTool(
+      "get_subnet_stake_quote",
+      { netuid: 64, amount: 10 },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    assert.equal(res.body.result.structuredContent.direction, "stake");
+  });
+
+  test("get_subnet_stake_quote returns a 1:1 zero-impact quote for root (netuid 0)", async () => {
+    const res = await callTool(
+      "get_subnet_stake_quote",
+      { netuid: 0, amount: 42, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.is_root, true);
+    assert.equal(out.expected_out, 42);
+    assert.equal(out.price_impact_pct, 0);
+    assert.equal(out.tao_in_pool_tao, null);
+  });
+
+  test("get_subnet_stake_quote rejects a non-positive amount as invalid_amount", async () => {
+    const res = await callTool(
+      "get_subnet_stake_quote",
+      { netuid: 64, amount: -5, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /invalid_amount/);
+  });
+
+  test("get_subnet_stake_quote rejects an unknown direction as invalid_direction", async () => {
+    const res = await callTool(
+      "get_subnet_stake_quote",
+      { netuid: 64, amount: 10, direction: "swap" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /invalid_direction/);
+  });
+
+  test("get_subnet_stake_quote surfaces insufficient_liquidity when the subnet has no pool row", async () => {
+    const res = await callTool(
+      "get_subnet_stake_quote",
+      { netuid: 999, amount: 10, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /insufficient_liquidity/);
+  });
+
   test("get_economics serves the live KV economics tier with REST list-query filters", async () => {
     const blob = {
       ...ECON_BLOB,
@@ -11746,6 +11857,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
       signer: EXTRINSIC_ROW.signer,
       call_module: "SubtensorModule",
       call_function: "set_weights",
+      call_hash: "0x" + "a".repeat(64),
       success: true,
       block_start: 100,
       block_end: 200,
@@ -11882,6 +11994,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
           });
         },
       };
+      const callHash = "0x" + "b".repeat(64);
       await callTool(
         "list_extrinsics",
         {
@@ -11889,6 +12002,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
           signer: SS58,
           call_module: "SubtensorModule",
           call_function: "set_weights",
+          call_hash: callHash,
           success: true,
           limit: 10,
           offset: 20,
@@ -11901,6 +12015,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
       assert.equal(seenUrl.searchParams.get("signer"), SS58);
       assert.equal(seenUrl.searchParams.get("call_module"), "SubtensorModule");
       assert.equal(seenUrl.searchParams.get("call_function"), "set_weights");
+      assert.equal(seenUrl.searchParams.get("call_hash"), callHash);
       assert.equal(seenUrl.searchParams.get("success"), "true");
       assert.equal(seenUrl.searchParams.get("limit"), "10");
     });


### PR DESCRIPTION
## Summary

Closes #5355, closes #5356 — two REST-parity gaps from the production-readiness audit.

**`get_subnet_stake_quote`**: `GET /api/v1/subnets/{netuid}/stake-quote` had no MCP equivalent. Scope-checked against the native-staking epic (#5229/#5252) first — that epic only fences off write/transaction-building MCP tools; stake-quote is read-only pure math (no chain write, no custody), the same category every existing stake MCP tool already covers, so this is a genuine parity gap, not epic-scoped work. Resolves live AMM pool reserves via the same economics tier `get_subnet_economics` already uses, then delegates all validation/math to the existing `computeStakeQuote` (`src/stake-quote.mjs`) — same error codes the REST route surfaces (`invalid_amount`, `invalid_direction`, `insufficient_liquidity`).

**`call_hash` filter**: `list_extrinsics` was missing the `call_hash` filter its REST counterpart (`GET /api/v1/extrinsics`) already supports — flagged by a stale comment in `mcpExtrinsicsListRequest` calling it out as REST-only (#4322). Now forwarded through like every other REST-parity filter on this tool.

## Test plan

- [x] 7 new tests for `get_subnet_stake_quote`: stake quote, unstake quote, direction defaults to stake, root-subnet (netuid 0) 1:1 zero-impact quote, invalid amount, invalid direction, insufficient liquidity
- [x] 2 existing `list_extrinsics` tests extended to cover `call_hash` (D1-empty-feed pass-through + Postgres-tier query-param forwarding)
- [x] `npm run lint` clean
- [x] `npx prettier --check src/mcp-server.mjs tests/mcp-server.test.mjs` clean
- [x] `npx vitest run tests/mcp-server.test.mjs` — 1004/1004 pass