### PR TITLE
feat(registry): add SN95 Actual model-registry index and llms.txt artifacts (#4122)

### DIFF
--- a/registry/subnets/actual.json
+++ b/registry/subnets/actual.json
@@ -94,6 +94,53 @@
       },
       "source_urls": ["https://actual.inc/"],
       "url": "https://actual.inc/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-95-actual-model-registry-index",
+      "kind": "data-artifact",
+      "name": "Actual model registry public index",
+      "notes": "Public no-auth machine-readable JSON index of the SN95 Actual model registry, served at models.actual.inc/index.json (schemaVersion \"actual.modelRegistry.publicIndex.v1\", carrying generatedAt and a registry object of available GGUF models). This is the machine-readable counterpart to the browser-facing models.actual.inc/ registry page already registered — a distinct URL returning structured JSON rather than HTML. Verified 200 application/json.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "actual-computer",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://actual.inc/",
+        "https://models.actual.inc/index.json"
+      ],
+      "url": "https://models.actual.inc/index.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-95-actual-llms-txt",
+      "kind": "data-artifact",
+      "name": "Actual Computer llms.txt agent index",
+      "notes": "Public no-auth machine-readable llms.txt served at actual.inc/llms.txt for SN95 Actual Computer — an agent/LLM-facing Markdown runbook describing the private-inference product (install one binary, authorize a device, get OpenAI/Anthropic-compatible local APIs) and pointing to the install, register, and model-registry resources; content begins '# Actual Computer'. Distinct from the model-registry surfaces (a different URL and a text/markdown artifact). A companion llms-full.txt exists at the same host.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "actual-computer",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": ["https://actual.inc/", "https://actual.inc/llms.txt"],
+      "url": "https://actual.inc/llms.txt"
     }
   ],
   "contact": "subnet@actual.inc"


### PR DESCRIPTION
## Summary

Adds two new `community` surfaces to SN95 Actual (`registry/subnets/actual.json`), both public, no-auth, and verified live:

1. **model registry public index** (`data-artifact`) — `https://models.actual.inc/index.json`
2. **llms.txt agent index** (`data-artifact`) — `https://actual.inc/llms.txt`

These close the file's gap notes for a verified machine-readable artifact on SN95.

## Surfaces

**`sn-95-actual-model-registry-index`** — `data-artifact`
- url: `https://models.actual.inc/index.json` — 200 `application/json`, `schemaVersion: "actual.modelRegistry.publicIndex.v1"` with `generatedAt` + a `registry` of available GGUF models
- The machine-readable counterpart to the browser-facing `models.actual.inc/` registry page already registered — a distinct URL returning structured JSON rather than HTML.

**`sn-95-actual-llms-txt`** — `data-artifact`
- url: `https://actual.inc/llms.txt` — 200 `text/markdown`
- An agent/LLM-facing runbook for the private-inference product; content begins `# Actual Computer`. Distinct URL and format from the model-registry surfaces.

## Proof of ownership

`actual.inc` is the subnet's registered `website_url`; `models.actual.inc` is its model-registry host already registered in this manifest. Both new artifacts are served from those official hosts.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/actual.json` — passed (5 surfaces)
- Both URLs verified with no auth header: 200, correct content-type, SS58-clean.

One focused change: two surfaces appended to one subnet file; nothing else touched.

Closes #4122

> Scope note: #4122 frames the enrichment as an OpenAPI/Swagger spec. Actual's common OpenAPI/Swagger/docs paths redirect to login and are already excluded in this manifest (`baseline_excluded_surface_ids`); no public OpenAPI document is served. These add the genuinely-published machine-readable model-registry index and agent llms.txt, advancing the same "enrich SN95" intent. Any OpenAPI-specific framing is advisory.
