### PR TITLE
fix(ui): add copy affordance for hotkey/coldkey in the validators table

### DIFF
--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { PageHero, ShareButton } from "@jsonbored/ui-kit";
+import { CopyButton, PageHero, ShareButton } from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
@@ -198,18 +198,22 @@ function ValidatorsTable({
                       >
                         {shortHash(v.hotkey) ?? v.hotkey}
                       </Link>
+                      <CopyButton value={v.hotkey} label="hotkey" />
                     </div>
                   </td>
                   <td className="px-3 py-2 font-mono text-[11px] text-ink-muted">
                     {v.coldkey ? (
-                      <Link
-                        to="/accounts/$ss58"
-                        params={{ ss58: v.coldkey }}
-                        className="hover:text-accent hover:underline"
-                        title={v.coldkey}
-                      >
-                        {shortHash(v.coldkey) ?? v.coldkey}
-                      </Link>
+                      <span className="flex items-center gap-1.5">
+                        <Link
+                          to="/accounts/$ss58"
+                          params={{ ss58: v.coldkey }}
+                          className="hover:text-accent hover:underline"
+                          title={v.coldkey}
+                        >
+                          {shortHash(v.coldkey) ?? v.coldkey}
+                        </Link>
+                        <CopyButton value={v.coldkey} label="coldkey" />
+                      </span>
                     ) : (
                       "—"
                     )}


### PR DESCRIPTION
## Summary
The Validators index table exposed the full hotkey/coldkey only through a `title` tooltip — unusable on touch/mobile — while the **Blocks** and **Extrinsics** index tables pair every hash/identifier with a `CopyButton`. This adds a `CopyButton` next to the hotkey and coldkey values, matching that existing pattern.

## Change
- One file: `apps/ui/src/routes/validators.index.tsx`.
- `import { CopyButton } from "@jsonbored/ui-kit"` (the same source Blocks/Extrinsics use).
- `<CopyButton value={v.hotkey} label="hotkey" />` next to the hotkey `Link`; `<CopyButton value={v.coldkey} label="coldkey" />` next to the coldkey `Link` (wrapped in a `flex items-center gap-1.5` span, matching the hotkey cell).
- No query/logic change; +13/−9.

## Screenshots
Captured on `/validators` with live validator data, three viewports × both themes. Theme forced via `localStorage["mg-theme"]`. **Before** = `upstream/main`; **After** = this branch. Programmatic check: **After = 40 copy controls/page** (20 rows × hotkey+coldkey), **Before = 0**.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339-assets/5339/before-desktop-light.png) | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339-assets/5339/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339-assets/5339/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339-assets/5339/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339-assets/5339/before-tablet-light.png) | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339-assets/5339/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339-assets/5339/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339-assets/5339/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339-assets/5339/before-mobile-light.png) | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339-assets/5339/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339-assets/5339/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339-assets/5339/after-mobile-dark.png) |

> **Note on mobile:** at `<md` the `/validators` route hides the table (`hidden md:block`) and renders `ValidatorCardList` instead — a component outside this issue's scope (the deliverable targets the table at `validators.index.tsx`). The mobile before/after are therefore identical by design; the copy-affordance change is visible at desktop/tablet where the table renders.

## Validation
- `tsc --noEmit` — no new type errors in `validators.index.tsx`.
- `prettier --check` — clean.

Closes #5339