### PR TITLE
fix(health): repoint dead chain_events heartbeat at Postgres

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -493,25 +493,23 @@ describe("/health readiness", () => {
     assert.match(res.headers.get("cache-control"), /max-age=/);
   });
 
-  test("reports chain-event index freshness (#1361)", async () => {
+  test("reports chain-event index freshness (#1361, #5357)", async () => {
     const atMs = Date.now() - 18_000; // latest indexed event ~18s ago
-    const preparedSql = [];
+    const requestedUrls = [];
     const env = createLocalArtifactEnv({
       METAGRAPH_CONTROL: makeKv({
         "metagraph:latest": { published_at: new Date().toISOString() },
       }),
-      METAGRAPH_HEALTH_DB: {
-        prepare(sql) {
-          preparedSql.push(sql);
-          return {
-            bind() {
-              return {
-                async all() {
-                  return { results: [{ block: 8461200, at: atMs }] };
-                },
-              };
-            },
-          };
+      DATA_API: {
+        async fetch(request) {
+          requestedUrls.push(request.url);
+          return new Response(
+            JSON.stringify({
+              count: 1,
+              events: [{ block_number: 8461200, observed_at: atMs }],
+            }),
+            { status: 200 },
+          );
         },
       },
     });
@@ -526,29 +524,27 @@ describe("/health readiness", () => {
       `age_seconds out of range: ${body.chain_events.age_seconds}`,
     );
     assert.ok(body.chain_events.latest_event_at.startsWith("20"));
-    assert.deepEqual(preparedSql, [
-      "SELECT block_number AS block, observed_at AS at FROM account_events " +
-        "ORDER BY observed_at DESC LIMIT 1",
-    ]);
+    assert.deepEqual(
+      requestedUrls.map((u) => new URL(u).pathname + new URL(u).search),
+      ["/api/v1/chain-events?limit=1"],
+    );
   });
 
-  test("chain_events treats blank or zero observed_at as absent (#1361)", async () => {
+  test("chain_events treats blank or zero observed_at as absent (#1361, #5357)", async () => {
     for (const at of ["", "   ", 0, "0"]) {
       const env = createLocalArtifactEnv({
         METAGRAPH_CONTROL: makeKv({
           "metagraph:latest": { published_at: new Date().toISOString() },
         }),
-        METAGRAPH_HEALTH_DB: {
-          prepare() {
-            return {
-              bind() {
-                return {
-                  async all() {
-                    return { results: [{ block: 8461200, at }] };
-                  },
-                };
-              },
-            };
+        DATA_API: {
+          async fetch() {
+            return new Response(
+              JSON.stringify({
+                count: 1,
+                events: [{ block_number: 8461200, observed_at: at }],
+              }),
+              { status: 200 },
+            );
           },
         },
       });
@@ -559,22 +555,16 @@ describe("/health readiness", () => {
     }
   });
 
-  test("chain_events is schema-stable nulls when the event tier is cold (#1361)", async () => {
+  test("chain_events is schema-stable nulls when the event tier is cold (#1361, #5357)", async () => {
     const env = createLocalArtifactEnv({
       METAGRAPH_CONTROL: makeKv({
         "metagraph:latest": { published_at: new Date().toISOString() },
       }),
-      METAGRAPH_HEALTH_DB: {
-        prepare() {
-          return {
-            bind() {
-              return {
-                async all() {
-                  return { results: [] }; // empty account_events tier
-                },
-              };
-            },
-          };
+      DATA_API: {
+        async fetch() {
+          return new Response(JSON.stringify({ count: 0, events: [] }), {
+            status: 200,
+          }); // empty chain_events tier
         },
       },
     });
@@ -586,7 +576,7 @@ describe("/health readiness", () => {
     assert.equal(body.chain_events.age_seconds, null);
   });
 
-  test("chain_events is null when no health DB is bound (#1361)", async () => {
+  test("chain_events is null when no DATA_API is bound (#1361, #5357)", async () => {
     const env = {
       ASSETS: {
         async fetch() {
@@ -596,6 +586,25 @@ describe("/health readiness", () => {
     };
     const res = await handleRequest(req("/health"), env, {});
     assert.equal((await res.json()).chain_events, null);
+  });
+
+  test("chain_events is schema-stable nulls when DATA_API returns a non-2xx response (#5357)", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: makeKv({
+        "metagraph:latest": { published_at: new Date().toISOString() },
+      }),
+      DATA_API: {
+        async fetch() {
+          return new Response("upstream error", { status: 500 });
+        },
+      },
+    });
+    const res = await handleRequest(req("/health"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.chain_events.latest_indexed_block, null);
+    assert.equal(body.chain_events.latest_event_at, null);
+    assert.equal(body.chain_events.age_seconds, null);
   });
 
   test("HEAD /health returns no body", async () => {

--- a/tests/health-chain-events-cache.test.mjs
+++ b/tests/health-chain-events-cache.test.mjs
@@ -2,31 +2,35 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 import { CHAIN_EVENTS_DB_TTL_MS, readChainEventsDb } from "../workers/api.mjs";
 
-function mkDbEnv(row = { block: 100, at: 1_700_000_000_000 }) {
+// readChainEventsDb reads the chain-events heartbeat from the Postgres
+// chain_events tier via the DATA_API service binding (#5357) — the D1
+// `account_events` table it used to query was fully dropped by #4772.
+
+function mkDataApiEnv(
+  row = { block_number: 100, observed_at: 1_700_000_000_000 },
+) {
   let queries = 0;
   return {
     get queries() {
       return queries;
     },
-    METAGRAPH_HEALTH_DB: {
-      prepare() {
-        return {
-          bind() {
-            return {
-              async all() {
-                queries += 1;
-                return { results: row ? [row] : [] };
-              },
-            };
-          },
-        };
+    DATA_API: {
+      async fetch() {
+        queries += 1;
+        return new Response(
+          JSON.stringify({
+            count: row ? 1 : 0,
+            events: row ? [row] : [],
+          }),
+          { status: 200 },
+        );
       },
     },
   };
 }
 
-test("readChainEventsDb memoizes within the TTL — one D1 query for repeated calls", async () => {
-  const env = mkDbEnv();
+test("readChainEventsDb memoizes within the TTL — one DATA_API fetch for repeated calls", async () => {
+  const env = mkDataApiEnv();
   const t0 = 5_000_000;
   const a = await readChainEventsDb(env, t0);
   const b = await readChainEventsDb(env, t0 + 1000);
@@ -38,12 +42,16 @@ test("readChainEventsDb memoizes within the TTL — one D1 query for repeated ca
   );
 
   await readChainEventsDb(env, t0 + CHAIN_EVENTS_DB_TTL_MS + 1);
-  assert.equal(env.queries, 2, "an expired memo triggers a fresh D1 query");
+  assert.equal(
+    env.queries,
+    2,
+    "an expired memo triggers a fresh DATA_API fetch",
+  );
 });
 
 test("readChainEventsDb never cross-reads a different env (isolation safety)", async () => {
-  const envA = mkDbEnv({ block: 10, at: 1_000 });
-  const envB = mkDbEnv({ block: 20, at: 2_000 });
+  const envA = mkDataApiEnv({ block_number: 10, observed_at: 1_000 });
+  const envB = mkDataApiEnv({ block_number: 20, observed_at: 2_000 });
   const t0 = 6_000_000;
   const a = await readChainEventsDb(envA, t0);
   const b = await readChainEventsDb(envB, t0);
@@ -53,7 +61,7 @@ test("readChainEventsDb never cross-reads a different env (isolation safety)", a
   assert.equal(envB.queries, 1);
 });
 
-test("readChainEventsDb returns null when health_db binding is absent", async () => {
+test("readChainEventsDb returns null when the DATA_API binding is absent", async () => {
   const result = await readChainEventsDb({}, 7_000_000);
   assert.equal(result, null);
 });
@@ -61,18 +69,12 @@ test("readChainEventsDb returns null when health_db binding is absent", async ()
 test("readChainEventsDb does not cache a null result (no sticky cold miss)", async () => {
   let queries = 0;
   const env = {
-    METAGRAPH_HEALTH_DB: {
-      prepare() {
-        return {
-          bind() {
-            return {
-              async all() {
-                queries += 1;
-                return { results: [] };
-              },
-            };
-          },
-        };
+    DATA_API: {
+      async fetch() {
+        queries += 1;
+        return new Response(JSON.stringify({ count: 0, events: [] }), {
+          status: 200,
+        });
       },
     },
   };
@@ -80,4 +82,76 @@ test("readChainEventsDb does not cache a null result (no sticky cold miss)", asy
   await readChainEventsDb(env, t0);
   await readChainEventsDb(env, t0 + 1000);
   assert.equal(queries, 2, "a null result must not be memoized");
+});
+
+test("readChainEventsDb returns null (not cached) when DATA_API responds non-2xx", async () => {
+  let queries = 0;
+  const env = {
+    DATA_API: {
+      async fetch() {
+        queries += 1;
+        return new Response("upstream error", { status: 500 });
+      },
+    },
+  };
+  const t0 = 9_000_000;
+  const a = await readChainEventsDb(env, t0);
+  const b = await readChainEventsDb(env, t0 + 1000);
+  assert.equal(a, null);
+  assert.equal(b, null);
+  assert.equal(queries, 2, "a non-2xx response must not be memoized");
+});
+
+test("readChainEventsDb returns null (not cached) when DATA_API.fetch throws", async () => {
+  let queries = 0;
+  const env = {
+    DATA_API: {
+      async fetch() {
+        queries += 1;
+        throw new Error("network error");
+      },
+    },
+  };
+  const t0 = 10_000_000;
+  const a = await readChainEventsDb(env, t0);
+  const b = await readChainEventsDb(env, t0 + 1000);
+  assert.equal(a, null);
+  assert.equal(b, null);
+  assert.equal(queries, 2, "a thrown fetch error must not be memoized");
+});
+
+test("readChainEventsDb returns null when the response body's events isn't an array", async () => {
+  const env = {
+    DATA_API: {
+      async fetch() {
+        return new Response(JSON.stringify({ count: 0, events: null }), {
+          status: 200,
+        });
+      },
+    },
+  };
+  const result = await readChainEventsDb(env, 11_500_000);
+  assert.equal(result, null);
+});
+
+test("readChainEventsDb defaults block/observed_at to null when the row omits them", async () => {
+  const env = mkDataApiEnv({ block_number: null, observed_at: undefined });
+  const result = await readChainEventsDb(env, 11_750_000);
+  assert.deepEqual(result, { block: null, at: null });
+});
+
+test("readChainEventsDb returns null when DATA_API responds with invalid JSON", async () => {
+  let queries = 0;
+  const env = {
+    DATA_API: {
+      async fetch() {
+        queries += 1;
+        return new Response("not json", { status: 200 });
+      },
+    },
+  };
+  const t0 = 11_000_000;
+  const result = await readChainEventsDb(env, t0);
+  assert.equal(result, null);
+  assert.equal(queries, 1);
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -43,7 +43,6 @@ import {
 } from "./request-handlers/discovery.mjs";
 import {
   configureAnalytics,
-  d1All,
   d1Runner,
   handleBulkHealthTrends,
   handleChainActivity,
@@ -3093,9 +3092,16 @@ export async function readEconomicsCurrentKv(env, now = Date.now()) {
 }
 
 // Chain-events index heartbeat read. Memoized per-isolate at a short TTL so
-// repeated /health probes on warm isolates don't issue a billed D1 query per
-// request. Null results are not cached (cold/unbound store stays re-queried).
-// Keyed on env so tests / multi-binding callers never cross-read.
+// repeated /health probes on warm isolates don't issue a billed Postgres query
+// (via the DATA_API service binding) per request. Null results are not cached
+// (cold/unbound store stays re-queried). Keyed on env so tests / multi-binding
+// callers never cross-read.
+//
+// This used to query D1's `account_events` table directly, but that table was
+// fully dropped by #4772 (D1 chain-data write-path retirement) — the live
+// chain_events tier now lives in Postgres, reached through the DATA_API
+// service binding, the same way handleChainEventsProxy (above) and
+// dataApiFetchJson (src/data-api-mcp.mjs) already read it (#5357).
 export const CHAIN_EVENTS_DB_TTL_MS = 30_000;
 let chainEventsDbMemo = { env: null, value: null, expiresAt: 0 };
 
@@ -3103,14 +3109,25 @@ export async function readChainEventsDb(env, now = Date.now()) {
   if (chainEventsDbMemo.env === env && now < chainEventsDbMemo.expiresAt) {
     return chainEventsDbMemo.value;
   }
-  if (!env?.METAGRAPH_HEALTH_DB?.prepare) return null;
-  const rows = await d1All(
-    env,
-    "SELECT block_number AS block, observed_at AS at FROM account_events " +
-      "ORDER BY observed_at DESC LIMIT 1",
-    [],
-  );
-  const value = rows[0] || null;
+  if (!env?.DATA_API?.fetch) return null;
+  let value = null;
+  try {
+    const response = await env.DATA_API.fetch(
+      new Request("https://d/api/v1/chain-events?limit=1"),
+    );
+    if (response.ok) {
+      const body = await response.json();
+      const row = Array.isArray(body?.events) ? body.events[0] : null;
+      if (row) {
+        value = {
+          block: row.block_number ?? null,
+          at: row.observed_at ?? null,
+        };
+      }
+    }
+  } catch {
+    value = null;
+  }
   if (value !== null) {
     chainEventsDbMemo = { env, value, expiresAt: now + CHAIN_EVENTS_DB_TTL_MS };
   }
@@ -3677,6 +3694,7 @@ async function handleHealthRequest(request, env) {
     r2: Boolean(env.METAGRAPH_ARCHIVE?.get),
     kv: Boolean(env.METAGRAPH_CONTROL?.get),
     health_db: Boolean(env.METAGRAPH_HEALTH_DB?.prepare),
+    data_api: Boolean(env.DATA_API?.fetch),
   };
 
   // Data freshness — the event-driven data publish (ADR 0007) advances the KV
@@ -3720,7 +3738,7 @@ async function handleHealthRequest(request, env) {
   // observability (does NOT gate the HTTP status, like operational_health);
   // best-effort + null on a cold/unbound store.
   let chainEvents = null;
-  if (bindings.health_db) {
+  if (bindings.data_api) {
     const chainEventsRow = await readChainEventsDb(env);
     const chainEventsAtMs = chainEventsRow ? Number(chainEventsRow.at) : NaN;
     // Blank/zero observed_at cells coerce via Number("") → 0; treat as absent


### PR DESCRIPTION
## Summary

Closes #5357 (task #59 from the production-readiness audit).

`readChainEventsDb` (`workers/api.mjs`) queried `account_events` via D1 for the `/health` chain_events heartbeat. That table was fully dropped by #4772 (D1 chain-data write-path retirement), so every `/health` call fired a doomed D1 query against a table that no longer exists, the error was silently logged and swallowed, and the heartbeat has permanently returned `null` since #4772 merged — `age_seconds` could never be non-null in production.

## Fix

Repointed at the live Postgres `chain_events` tier via the existing `DATA_API` service binding, reusing the already-public `GET /api/v1/chain-events?limit=1` route — the same pattern `handleChainEventsProxy` and `dataApiFetchJson` already use. Kept the 30-second in-isolate memoization and "null is never cached" behavior unchanged. Switched the heartbeat's binding-presence gate from `bindings.health_db` (D1 — still the correct gate for the other tables this file reads from D1, e.g. `rpc_proxy_events`/`surface_checks`/`surface_status`, untouched) to `bindings.data_api`.

## Test plan

- [x] Rewrote `tests/health-chain-events-cache.test.mjs`'s 4 existing cases to mock `env.DATA_API.fetch`; added 5 new cases for full branch coverage: DATA_API non-2xx response, thrown fetch, invalid JSON body, `events` not an array, and block/observed_at defaulting to null when the row omits them
- [x] Updated `tests/api-coverage.test.mjs`'s 4 existing `/health` chain_events cases to mock `DATA_API.fetch` and assert the requested URL; added a non-2xx case
- [x] `npm run lint` clean
- [x] `npx prettier --check` clean on the 3 changed files
- [x] `npx vitest run tests/health-chain-events-cache.test.mjs tests/api-coverage.test.mjs` — 258/258 pass
- [x] Verified every changed line/branch in `workers/api.mjs` is covered via direct `lcov.info` BRDA analysis (no partial branches remain in the diff range)