### PR TITLE
fix(ui): drop the redundant validator identity chip when there's no identity (#5311)

### DIFF
--- a/apps/ui/src/lib/metagraphed/validator-identity.test.ts
+++ b/apps/ui/src/lib/metagraphed/validator-identity.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { hasValidatorIdentity } from "./validator-identity";
+import type { ColdkeyIdentity } from "./types";
+
+const base: ColdkeyIdentity = {
+  has_identity: false,
+  name: null,
+  url: null,
+  github: null,
+  image: null,
+  discord: null,
+  description: null,
+  additional: null,
+  captured_at: null,
+};
+
+describe("hasValidatorIdentity", () => {
+  it("is true when the coldkey declares an identity with a name", () => {
+    expect(hasValidatorIdentity({ ...base, has_identity: true, name: "Foundry" })).toBe(true);
+  });
+
+  it("is false when there is no declared identity", () => {
+    expect(hasValidatorIdentity({ ...base, has_identity: false, name: "Foundry" })).toBe(false);
+  });
+
+  it("is false when the identity is declared but has no usable name", () => {
+    expect(hasValidatorIdentity({ ...base, has_identity: true, name: null })).toBe(false);
+    expect(hasValidatorIdentity({ ...base, has_identity: true, name: "" })).toBe(false);
+    expect(hasValidatorIdentity({ ...base, has_identity: true, name: "   " })).toBe(false);
+  });
+
+  it("is false for null/undefined identity", () => {
+    expect(hasValidatorIdentity(null)).toBe(false);
+    expect(hasValidatorIdentity(undefined)).toBe(false);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/validator-identity.ts
+++ b/apps/ui/src/lib/metagraphed/validator-identity.ts
@@ -1,0 +1,11 @@
+import type { ColdkeyIdentity } from "./types";
+
+/**
+ * Whether a validator's coldkey carries a real, displayable operator identity
+ * (declared on-chain AND with a non-empty name). When this is false the hero's
+ * title, the identity chip, and the copyable hotkey would all just repeat the
+ * same hotkey, so callers gate the redundant chip on this predicate.
+ */
+export function hasValidatorIdentity(identity: ColdkeyIdentity | null | undefined): boolean {
+  return Boolean(identity?.has_identity && identity.name && identity.name.trim());
+}

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -23,6 +23,7 @@ import { validatorDetailQuery, validatorNominatorsQuery } from "@/lib/metagraphe
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
+import { hasValidatorIdentity } from "@/lib/metagraphed/validator-identity";
 import {
   annualizedDelegatorApyPct,
   formatApyPct,
@@ -211,10 +212,10 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
   const sourceRef = ss58PathSegment(hotkey);
   const detailRes = useSuspenseQuery(validatorDetailQuery(hotkey)).data;
   const detail = detailRes.data;
+  const identity = detail.coldkey_identity;
+  const hasIdentity = hasValidatorIdentity(identity);
   const displayName =
-    detail.coldkey_identity?.has_identity && detail.coldkey_identity.name
-      ? detail.coldkey_identity.name
-      : (shortHash(hotkey, 8) ?? "Validator");
+    hasIdentity && identity?.name ? identity.name : (shortHash(hotkey, 8) ?? "Validator");
   const snapshotApy = annualizedDelegatorApyPct(
     detail.total_emission_tao,
     detail.total_stake_tao,
@@ -229,14 +230,17 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         title={displayName}
         description={
           <span className="block space-y-4">
-            <span className="flex flex-wrap items-center gap-3">
-              <ValidatorIdentityChip hotkey={hotkey} identity={detail.coldkey_identity} size={40} />
-              {detail.coldkey_identity?.has_identity ? (
+            {/* With no declared operator identity the chip would only repeat the
+                hotkey already shown as the title and in the copyable field
+                below, so it's dropped when there's nothing extra to show (#5311). */}
+            {hasIdentity ? (
+              <span className="flex flex-wrap items-center gap-3">
+                <ValidatorIdentityChip hotkey={hotkey} identity={identity} size={40} />
                 <span className="text-[11px] text-ink-muted">
                   Operator identity is declared on the coldkey — not hotkey-specific (#5234).
                 </span>
-              ) : null}
-            </span>
+              </span>
+            ) : null}
             <span className="block max-w-2xl text-sm text-ink-muted">
               Cross-subnet performance, nominators, and staking history for one Bittensor validator
               hotkey.


### PR DESCRIPTION
## Summary

Closes #5311

On the validator detail hero (`validators.$hotkey.tsx`), when the coldkey declares **no operator identity** the same hotkey was rendered three times above the fold — as the H1 title (short hash), again by `ValidatorIdentityChip` (a generic avatar + the same short hash), and a third time in the copyable field — plus a fourth time in the breadcrumb on wider viewports. The chip added nothing the title and copy field didn't already show.

The identity chip (and its coldkey-identity note) is now gated on a new pure `hasValidatorIdentity` predicate, so it renders **only when there's a real, named on-chain identity** (a logo + operator name worth showing). With no identity the chip is dropped and the title + copyable hotkey stand alone. The predicate also backs the title's own name/short-hash fallback, removing the duplicated `has_identity && name` logic.

Validators **with** a declared identity are unchanged (the chip still shows the operator logo + name).

## Gates

typecheck OK - unit tests OK (`validator-identity.test.ts`, 4 new) - eslint `.` OK (0 errors) - prettier OK

## Screenshots

Captured with Playwright at the three SKILL viewports (375x812 / 768x1024 / 1280x800), each theme forced via `mg-theme`, fixed-viewport (never full-page), on a real no-identity validator (`5FLoWCD…Rv8m`) against the live dev server. Before shows the redundant "avatar + short-hash" chip between the title and the copyable hotkey; after drops it.

| Viewport - Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5311/after-mobile-dark.png)<br><sub>after</sub> |
