### PR TITLE
fix(nav): restore global search access on mobile (#5319)

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -2,7 +2,7 @@ import { Link, useRouterState } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, Compass, Github, Menu, Rss, Webhook, X } from "lucide-react";
+import { ChevronRight, Compass, Github, Menu, Rss, Search, Webhook, X } from "lucide-react";
 import {
   API_BASE,
   DEFAULT_DISCORD_URL,
@@ -225,6 +225,27 @@ export function AppShell({ children }: { children: ReactNode }) {
                     <X className="size-4" />
                   </button>
                 </div>
+                {/* Below md the NavOmnibox is hidden entirely (it can't shrink to
+                    a usable width on phones — #5034) and the command palette only
+                    opens via ⌘K / "/" keydown, so mobile visitors had no way to
+                    open global search at all (#5319). The top bar is already full
+                    at 375px (menu + wordmark + network switcher), so the search
+                    entry lives here in the drawer: close the sheet and open the
+                    same palette the keyboard shortcuts use. */}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMobileOpen(false);
+                    setPaletteOpen(true);
+                  }}
+                  className="inline-flex items-center gap-2 rounded border border-border bg-card px-3 py-2.5 text-[13px] text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors min-h-11"
+                >
+                  <Search className="size-4 shrink-0" aria-hidden="true" />
+                  <span>Search everything</span>
+                  <kbd className="ml-auto rounded border border-border bg-surface px-1.5 py-0.5 font-mono text-[10px] text-ink-muted">
+                    /
+                  </kbd>
+                </button>
                 <div className="mg-label inline-flex items-center gap-1">
                   <Compass className="size-3" /> Unofficial registry
                 </div>


### PR DESCRIPTION
## Summary
On phones there was **no way to open global search at all.** `NavOmnibox` is wrapped in `hidden md:block` (removed from the DOM below 768px — the #5034 fix for the squeeze problem), and the command palette only opens via `⌘K` / `Ctrl+K` / `/` keydown or the omnibox's "Full search" link — all unreachable without a physical keyboard. A mobile visitor had zero entry point to the palette.

## Change (`apps/ui/src/components/metagraphed/app-shell.tsx`)
Add a **"Search everything" entry at the top of the mobile hamburger drawer** that closes the sheet and opens the very same command palette the keyboard shortcuts use (`setPaletteOpen(true)`):

```tsx
<button type="button" onClick={() => { setMobileOpen(false); setPaletteOpen(true); }} …>
  <Search … /> <span>Search everything</span> <kbd>/</kbd>
</button>
```

**Why the drawer and not a header icon:** at 375px the top bar is already full-width (hamburger + the `Metagraphed` wordmark + network switcher) — the `flex-1` search slot collapses to 0, so a header icon either overflows onto the wordmark or has to drop below the 40px touch-target minimum. The drawer is one of the two locations the issue calls out, adds no crowding to the top row, and puts search as the first item users see when they open the menu. `md+` is unchanged — the omnibox still handles search there, so exactly one affordance exists at every width.

## Verification
- **Functional (Playwright, 375px):** open drawer → tap "Search everything" → command palette opens with its input focused and the drawer closes. Confirmed.
- `md`/desktop unchanged: no header search button added; the omnibox remains the sole search affordance at ≥768px.
- Top-row layout unchanged (the pre-existing 6px sub-pixel overflow is identical with and without this change).
- `typecheck` / `test` (697) / `build` (apps/ui) — pass · `eslint` on the changed file (LF-normalized) — 0 errors

## Screenshots
Mobile & tablet show the **hamburger drawer** (where the entry lives): Before = no search anywhere in the drawer; After = the "Search everything" button at the top. Desktop is unaffected (it already has the omnibox), shown for completeness.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-mobile-dark.png)<br><sub>after</sub> |

**The palette actually opens on tap (375px)** — the point of the fix:

| Light | Dark |
| --- | --- |
| [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-palette-mobile-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-palette-mobile-light.png) | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-palette-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5319/v1/after-palette-mobile-dark.png) |

Closes #5319
