### PR TITLE
feat(registry): add SN106 Nodexo bundled subnet config and SubnetConfig ABI artifacts (#4139)

### DIFF
--- a/registry/subnets/nodexo.json
+++ b/registry/subnets/nodexo.json
@@ -154,6 +154,56 @@
         "https://github.com/nodexo-ai/nodexo/blob/main/neurons/validator/validator.py"
       ],
       "url": "https://raw.githubusercontent.com/nodexo-ai/nodexo/main/chain_config_mainnet.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-106-nodexo-bundled-subnet-config",
+      "kind": "data-artifact",
+      "name": "Nodexo bundled subnet config",
+      "notes": "Public no-auth JSON operational configuration bundle for the SN106 Nodexo GPU-compute subnet, published in the official nodexo-ai/nodexo repository at common/bundled_subnet_config.json. Defines runtime policy (blacklist/active-rental-policy, endpoint-host rules, and other validator/miner operational parameters) that ships with the subnet software. Distinct from the mainnet EVM chain-config artifact already registered. Pinned to an immutable commit.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "nodexo",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://github.com/nodexo-ai/nodexo/blob/a461e3f96d3c4714d4e0311669a665086bb46f3e/common/bundled_subnet_config.json",
+        "https://github.com/nodexo-ai/nodexo"
+      ],
+      "url": "https://raw.githubusercontent.com/nodexo-ai/nodexo/a461e3f96d3c4714d4e0311669a665086bb46f3e/common/bundled_subnet_config.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-106-nodexo-subnetconfig-abi",
+      "kind": "data-artifact",
+      "name": "Nodexo SubnetConfig contract ABI",
+      "notes": "Public no-auth machine-readable Solidity ABI (JSON) for the SN106 Nodexo on-chain SubnetConfig contract, published in the official nodexo-ai/nodexo repository at abis/SubnetConfig.json. Describes the constructor, functions, and events of the EVM contract that holds the subnet's on-chain configuration referenced by the registered mainnet chain-config. Pinned to an immutable commit.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "nodexo",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://github.com/nodexo-ai/nodexo/blob/f104f2fa848da6bc7d02b7ac00a2c9a7f1a5af73/abis/SubnetConfig.json",
+        "https://github.com/nodexo-ai/nodexo"
+      ],
+      "url": "https://raw.githubusercontent.com/nodexo-ai/nodexo/f104f2fa848da6bc7d02b7ac00a2c9a7f1a5af73/abis/SubnetConfig.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds two new `community` data-artifact surfaces to SN106 Nodexo (`registry/subnets/nodexo.json`), both public, no-auth, and pinned to immutable commits:

1. **bundled subnet config** — `common/bundled_subnet_config.json`
2. **SubnetConfig contract ABI** — `abis/SubnetConfig.json`

Both are machine-readable JSON published in the official `nodexo-ai/nodexo` repository already registered as this subnet's `source_repo`, and are distinct from the `chain_config_mainnet.json` artifact already registered.

## Surfaces

**`sn-106-nodexo-bundled-subnet-config`** — `data-artifact`
- url: `https://raw.githubusercontent.com/nodexo-ai/nodexo/a461e3f96d3c4714d4e0311669a665086bb46f3e/common/bundled_subnet_config.json` — 200, 14 KB
- The subnet's operational config bundle (blacklist / active-rental policy, endpoint-host rules, validator/miner operational parameters) shipped with the subnet software.

**`sn-106-nodexo-subnetconfig-abi`** — `data-artifact`
- url: `https://raw.githubusercontent.com/nodexo-ai/nodexo/f104f2fa848da6bc7d02b7ac00a2c9a7f1a5af73/abis/SubnetConfig.json` — 200, 18 KB
- The machine-readable Solidity ABI of the on-chain `SubnetConfig` EVM contract that holds the subnet's on-chain configuration referenced by the registered mainnet chain-config.

## Proof of ownership

Both files live in `nodexo-ai/nodexo`, the subnet's registered `source_repo`. Each is pinned to the commit that last modified it and verified 200 with no auth header, SS58-clean.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/nodexo.json` — passed (9 surfaces)

One focused change: two surfaces appended to one subnet file; nothing else touched.

Closes #4139

> Scope note: #4139 frames the enrichment as an OpenAPI/Swagger spec. Nodexo serves no verified public OpenAPI document; these add the genuinely-published machine-readable subnet-config bundle and on-chain contract ABI from the official repo, advancing the same "enrich SN106" intent. Any OpenAPI-specific framing is advisory.
