### PR TITLE
feat(registry): add SN93 Bitcast whitepaper docs surface

### DIFF
--- a/registry/subnets/bitcast.json
+++ b/registry/subnets/bitcast.json
@@ -219,6 +219,25 @@
         "https://github.com/bitcast-network/bitcast/blob/main/setup.py"
       ],
       "url": "https://raw.githubusercontent.com/bitcast-network/bitcast/main/min_compute.yml"
+    },
+    {
+      "id": "sn-93-bitcast-whitepaper-docs",
+      "name": "Bitcast whitepaper",
+      "kind": "docs",
+      "url": "https://www.bitcast.network/whitepaper.pdf",
+      "provider": "bitcast-network",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/bitcast-network/bitcast",
+        "https://www.bitcast.network/"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Public no-auth whitepaper (PDF) for SN93 Bitcast, served at www.bitcast.network/whitepaper.pdf on the official Bitcast website (the same operator as the registered stats.bitcast.network / creator.bitcast.network surfaces). A machine-readable document describing the subnet's design — content-attention incentive mechanism, miner/validator roles, and scoring. Distinct in URL and kind from the API/dashboard surfaces already registered."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enriches **SN93 Bitcast** (issue #5180) with a machine-usable **docs** surface: the official Bitcast whitepaper (PDF).

- **url:** https://www.bitcast.network/whitepaper.pdf (public, no-auth — verified HTTP 200, application/pdf, ~742 KB)
- **kind:** docs (distinct in URL and kind from the API/dashboard surfaces already registered)
- **source_urls:** https://github.com/bitcast-network/bitcast (official SN93 repo) + https://www.bitcast.network/ (official website)

The whitepaper documents the subnet's design (content-attention incentive mechanism, miner/validator roles, scoring) — a machine-readable primary source for agents building on Bitcast.

## Validation
- `npm run validate:surface -- registry/subnets/bitcast.json` → passed (12 surfaces)
- `npm run scan:public-safety` → no findings for this file
- `npx prettier --check` → clean

Closes #5180