### PR TITLE
feat(registry): add SN23 Trishool litepaper docs surface

### DIFF
--- a/registry/subnets/trishool.json
+++ b/registry/subnets/trishool.json
@@ -121,8 +121,29 @@
         "https://github.com/TrishoolAI/trishool-phase2/blob/main/tri-check/data/submission_schema.json"
       ],
       "url": "https://raw.githubusercontent.com/TrishoolAI/trishool-phase2/main/tri-check/data/submission_schema.json"
+    },
+    {
+      "id": "sn-23-trishool-litepaper-docs",
+      "name": "Trishool litepaper",
+      "kind": "docs",
+      "url": "https://litepaper.trishool.ai/",
+      "provider": "trishool",
+      "auth_required": false,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/TrishoolAI/trishool-phase2",
+        "https://trishool.ai/"
+      ],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "notes": "Public no-auth Trishool litepaper (PDF) for SN23, served at litepaper.trishool.ai — a dedicated subdomain of the registered official website trishool.ai (same operator as the api.trishool.ai and docs.trishool.ai surfaces). A machine-readable primary-source document describing the subnet's design, mechanism, and roles. Distinct in URL from the docs.trishool.ai API documentation already registered."
     }
   ],
-  "social": { "x": "https://x.com/trishoolai" },
+  "social": {
+    "x": "https://x.com/trishoolai"
+  },
   "contact": "nav@astroware.ai"
 }


### PR DESCRIPTION
## Summary

Enriches **SN23 Trishool** (issue #465) with a machine-usable **docs** surface: the official Trishool litepaper (PDF).

- **url:** https://litepaper.trishool.ai/ (public, no-auth — verified HTTP 200, application/pdf, ~281 KB, `%PDF-`)
- **kind:** docs (a dedicated litepaper subdomain of the official trishool.ai; distinct in URL from the docs.trishool.ai API docs already registered)
- **source_urls:** https://github.com/TrishoolAI/trishool-phase2 (official SN23 repo) + https://trishool.ai/ (official website)

The litepaper is a primary-source document describing the subnet's design, mechanism, and miner/validator roles — a machine-readable reference for agents integrating Trishool.

## Validation
- `npm run validate:surface -- registry/subnets/trishool.json` → passed (6 surfaces)
- `npm run scan:public-safety` → no findings for this file
- `npx prettier --check` → clean

Closes #465