### PR TITLE
fix(ui): add a mobile search trigger to the header drawer (#5319)

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -2,7 +2,7 @@ import { Link, useRouterState } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, Compass, Github, Menu, Rss, Webhook, X } from "lucide-react";
+import { ChevronRight, Compass, Github, Menu, Rss, Search, Webhook, X } from "lucide-react";
 import {
   API_BASE,
   DEFAULT_DISCORD_URL,
@@ -225,6 +225,18 @@ export function AppShell({ children }: { children: ReactNode }) {
                     <X className="size-4" />
                   </button>
                 </div>
+                {/* NavOmnibox is `hidden md:block` — below md there is otherwise
+                    no way to open search at all (#5319). */}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMobileOpen(false);
+                    setPaletteOpen(true);
+                  }}
+                  className="flex items-center gap-2 rounded border border-border bg-card px-3 py-2 text-[13px] text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors min-h-11"
+                >
+                  <Search className="size-3.5" aria-hidden="true" /> Search
+                </button>
                 <div className="mg-label inline-flex items-center gap-1">
                   <Compass className="size-3" /> Unofficial registry
                 </div>


### PR DESCRIPTION
## Summary

`NavOmnibox` (the header's search box) is `hidden md:block`, so below 768px there is no way to open global search at all. The command palette itself only opens via `⌘K`/`Ctrl+K`/`/` keydown or the omnibox's own "Full search" link — both unreachable without a physical keyboard, so mobile visitors had zero way to open search.

This is a regression from the fix shipped for #3454 (PR #5034): hiding the omnibox below `md` solved the squeeze problem it was filed against, but removed mobile search access altogether rather than replacing it with a compact trigger, which #3454's own body had proposed as one of two acceptable outcomes.

## What changed

Adds a **Search** entry at the top of the mobile hamburger drawer (`apps/ui/src/components/metagraphed/app-shell.tsx`), wired to the same `setPaletteOpen(true)` handler the command palette's keyboard shortcuts already use — clicking it closes the drawer and opens the same palette `⌘K`/`/` do.

**A header-level icon button was tried first** (next to the other header icons) but pushed the header's `scrollWidth` past its `clientWidth` at 375px, clipping the network switcher pill off the right edge — the header has no width headroom for a new persistent element at mobile width. The hamburger drawer does, so the fix lives there instead, matching the issue's own second suggested option ("in the mobile header (or inside the hamburger drawer)").

Tablet (≥768px) and desktop are unaffected — `NavOmnibox` is already visible there, so this only changes behavior below the `md` breakpoint.

## Screenshots

Verified the drawer opens the actual command palette end-to-end (not just visually present) before capturing.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile (375px) · Light — header (unchanged) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-mobile-light-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-mobile-light-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-mobile-light-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-mobile-light-after.png)<br><sub>no header regression</sub> |
| Mobile (375px) · Dark — header (unchanged) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-mobile-dark-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-mobile-dark-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-mobile-dark-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-mobile-dark-after.png) |
| Mobile (375px) · Light — drawer open | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-drawer-mobile-light-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-drawer-mobile-light-before.png)<br><sub>no search option</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-drawer-mobile-light-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-drawer-mobile-light-after.png)<br><sub>Search entry added</sub> |
| Mobile (375px) · Dark — drawer open | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-drawer-mobile-dark-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-drawer-mobile-dark-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-drawer-mobile-dark-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5319-drawer-mobile-dark-after.png) |

Tablet/desktop skipped — provably unaffected, since `NavOmnibox` is already visible at `≥md` and this change is scoped entirely inside the `md:hidden`-reachable hamburger drawer.

Closes #5319

## Deliverables (from the issue)

- [x] Add a search-icon trigger to the mobile header or hamburger drawer
- [x] Wire it to `setPaletteOpen(true)` (the same handler `⌘K`/`/` already use)

## Validation

- [x] `npm run lint --workspace=apps/ui` — 0 errors (pre-existing unrelated warnings only)
- [x] `npm run format:check --workspace=apps/ui` — clean
- [x] `npm run typecheck --workspace=apps/ui` — clean
- [x] `npm test --workspace=apps/ui` — 697/697 tests passing (100/100 files)
- [x] `npm run build --workspace=apps/ui` — builds cleanly
- [x] Manually verified the drawer's Search button opens the actual command palette (not just a visual check)