### PR TITLE
feat(registry): add SN94 Bitsota problem config and Capacitor ABI artifacts (#5178)

### DIFF
--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -160,6 +160,56 @@
         "https://bitsota.ai/docs/autoresearch-backend-routes"
       ],
       "url": "https://autoresearch.bitsota.com/api/v1/disclaimer"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-problem-config",
+      "kind": "data-artifact",
+      "name": "Bitsota problem config",
+      "notes": "Public no-auth JSON problem/task configuration for the SN94 Bitsota subnet, published in the official AlveusLabs/SN94-BitSota repository at problem_config.json. Defines the mining/validation problem parameters (task counts, seeds, and GUI/continuous-mining notes) used by miners and validators. Pinned to an immutable commit. Verified 200 application/json, SS58-clean.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://github.com/AlveusLabs/SN94-BitSota/blob/61f81b32054a7ed502faa319b97b90b80b897c13/problem_config.json",
+        "https://github.com/AlveusLabs/SN94-BitSota"
+      ],
+      "url": "https://raw.githubusercontent.com/AlveusLabs/SN94-BitSota/61f81b32054a7ed502faa319b97b90b80b897c13/problem_config.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-capacitor-abi",
+      "kind": "data-artifact",
+      "name": "Bitsota Capacitor contract ABI",
+      "notes": "Public no-auth machine-readable Solidity ABI (JSON) for the SN94 Bitsota on-chain Capacitor contract, published in the official AlveusLabs/SN94-BitSota repository at capacitor_abi.json. Describes the contract's constructor inputs, functions, and events used by the subnet's on-chain settlement flow. Pinned to an immutable commit. Verified 200, SS58-clean.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://github.com/AlveusLabs/SN94-BitSota/blob/9a91af33b69a42ea9c124ea8a7ea4f05203fde04/capacitor_abi.json",
+        "https://github.com/AlveusLabs/SN94-BitSota"
+      ],
+      "url": "https://raw.githubusercontent.com/AlveusLabs/SN94-BitSota/9a91af33b69a42ea9c124ea8a7ea4f05203fde04/capacitor_abi.json"
     }
   ],
   "contact": "info@bitsota.ai"


### PR DESCRIPTION
## Summary

Adds two new `community` data-artifact surfaces to SN94 Bitsota (`registry/subnets/bitsota.json`), both public, no-auth, SS58-clean, and pinned to immutable commits:

1. **problem config** — `problem_config.json`
2. **Capacitor contract ABI** — `capacitor_abi.json`

Both are machine-readable JSON published in the official `AlveusLabs/SN94-BitSota` repository already registered as this subnet's `source_repo`, and are distinct from the `autoresearch.bitsota.com` API surfaces already registered.

## Surfaces

**`sn-94-bitsota-problem-config`** — `data-artifact`
- url: `https://raw.githubusercontent.com/AlveusLabs/SN94-BitSota/61f81b32054a7ed502faa319b97b90b80b897c13/problem_config.json` — 200 `application/json`
- The subnet's mining/validation problem configuration (task counts, seeds, continuous-mining notes) consumed by miners and validators.

**`sn-94-bitsota-capacitor-abi`** — `data-artifact`
- url: `https://raw.githubusercontent.com/AlveusLabs/SN94-BitSota/9a91af33b69a42ea9c124ea8a7ea4f05203fde04/capacitor_abi.json` — 200 JSON
- The machine-readable Solidity ABI of the on-chain `Capacitor` contract used in the subnet's on-chain settlement flow.

## Proof of ownership

Both files live in `AlveusLabs/SN94-BitSota`, the subnet's registered `source_repo`. Each is pinned to the commit that last modified it and verified 200 with no auth header, SS58-clean.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/bitsota.json` — passed (9 surfaces)

One focused change: two surfaces appended to one subnet file; nothing else touched.

Closes #5178

> Scope note: #5178 frames the enrichment as an SSE stream. Bitsota exposes no verified public SSE endpoint; these add genuinely-published machine-readable config and on-chain ABI artifacts from the official repo, advancing the same "enrich SN94" intent. Any SSE-specific framing is advisory.
