### PR TITLE
feat(ui): align settings hero KPIs with utility pages (#5346)

### DIFF
--- a/apps/ui/src/routes/settings.tsx
+++ b/apps/ui/src/routes/settings.tsx
@@ -22,13 +22,26 @@ export const Route = createFileRoute("/settings")({
   component: SettingsPage,
 });
 
+/**
+ * Utility-page family treatment (#5346): PageHero KPI strip only, matching
+ * sibling routes (`/schemas`, `/health`, …). Forms below stay unchanged.
+ * dense — form page; skip Share row so the strip sits closer to the title.
+ */
 function SettingsPage() {
   return (
     <AppShell>
       <PageHero
-        eyebrow="Developer"
+        dense
+        eyebrow="Operations"
         title="Developer settings"
-        description="Self-service webhook subscription management against the public subscription API. Nothing here is stored server-side beyond the subscription record itself — there is no account model."
+        description="Webhook subscription API — create, look up, delete. Token-gated; no account model."
+        caption="settings / v1"
+        kpis={[
+          { label: "Create", value: "POST", hint: "token" },
+          { label: "Lookup", value: "GET", hint: "by id" },
+          { label: "Delete", value: "DELETE", hint: "secret" },
+          { label: "Accounts", value: "None" },
+        ]}
       />
       <WebhookSubscriptionManager />
       <ApiSourceFooter paths={["/api/v1/webhooks/subscriptions"]} />

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2108,6 +2108,7 @@ function PageHero({
   description,
   actions,
   kpis,
+  dense = false,
   aside,
   caption = "registry / v1",
   className
@@ -2116,7 +2117,8 @@ function PageHero({
     "section",
     {
       className: classNames(
-        "mg-hero-slab relative mb-12 md:mb-16 pt-12 md:pt-20 pb-10 md:pb-14",
+        "mg-hero-slab relative pt-12 md:pt-20",
+        dense ? "mb-4 md:mb-6 pb-0" : "mb-12 md:mb-16 pb-10 md:pb-14",
         className
       ),
       children: [
@@ -2129,18 +2131,36 @@ function PageHero({
             ] }) : null,
             /* @__PURE__ */ jsxRuntime.jsx("h1", { className: "mg-fade-in mg-fade-in-delay-1 mt-4 font-display text-[2.5rem] sm:text-5xl md:text-[3.75rem] font-semibold leading-[1.02] tracking-[-0.025em] text-ink-strong", children: title }),
             description ? /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mg-fade-in mg-fade-in-delay-2 mt-5 max-w-xl text-base md:text-lg text-ink-muted leading-relaxed", children: description }) : null,
-            actions ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-fade-in mg-fade-in-delay-3 mt-6 flex flex-wrap items-center gap-2", children: actions }) : null
+            actions ? /* @__PURE__ */ jsxRuntime.jsx(
+              "div",
+              {
+                className: classNames(
+                  "mg-fade-in mg-fade-in-delay-3 flex flex-wrap items-center gap-2",
+                  dense ? "mt-3" : "mt-6"
+                ),
+                children: actions
+              }
+            ) : null
           ] }),
           aside ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-fade-in mg-fade-in-delay-2 hidden md:block shrink-0", children: aside }) : null
         ] }),
-        kpis && kpis.length > 0 ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-fade-in mg-fade-in-delay-3 mg-kpi-strip mt-12 md:mt-16", children: kpis.map((k) => /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted", children: k.label }),
-          /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
-            /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-display text-2xl md:text-[1.75rem] font-semibold tabular-nums text-ink-strong leading-none tracking-[-0.01em]", children: k.value }),
-            k.hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: k.hint }) : null
-          ] }),
-          k.chart ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mt-2.5 -ml-0.5", children: k.chart }) : null
-        ] }, k.label)) }) : null
+        kpis && kpis.length > 0 ? /* @__PURE__ */ jsxRuntime.jsx(
+          "div",
+          {
+            className: classNames(
+              "mg-fade-in mg-fade-in-delay-3 mg-kpi-strip",
+              dense ? "mt-4 md:mt-5" : "mt-12 md:mt-16"
+            ),
+            children: kpis.map((k) => /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
+              /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted", children: k.label }),
+              /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
+                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-display text-2xl md:text-[1.75rem] font-semibold tabular-nums text-ink-strong leading-none tracking-[-0.01em]", children: k.value }),
+                k.hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: k.hint }) : null
+              ] }),
+              k.chart ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mt-2.5 -ml-0.5", children: k.chart }) : null
+            ] }, k.label))
+          }
+        ) : null
       ]
     }
   );

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2079,6 +2079,7 @@ function PageHero({
   description,
   actions,
   kpis,
+  dense = false,
   aside,
   caption = "registry / v1",
   className
@@ -2087,7 +2088,8 @@ function PageHero({
     "section",
     {
       className: classNames(
-        "mg-hero-slab relative mb-12 md:mb-16 pt-12 md:pt-20 pb-10 md:pb-14",
+        "mg-hero-slab relative pt-12 md:pt-20",
+        dense ? "mb-4 md:mb-6 pb-0" : "mb-12 md:mb-16 pb-10 md:pb-14",
         className
       ),
       children: [
@@ -2100,18 +2102,36 @@ function PageHero({
             ] }) : null,
             /* @__PURE__ */ jsx("h1", { className: "mg-fade-in mg-fade-in-delay-1 mt-4 font-display text-[2.5rem] sm:text-5xl md:text-[3.75rem] font-semibold leading-[1.02] tracking-[-0.025em] text-ink-strong", children: title }),
             description ? /* @__PURE__ */ jsx("p", { className: "mg-fade-in mg-fade-in-delay-2 mt-5 max-w-xl text-base md:text-lg text-ink-muted leading-relaxed", children: description }) : null,
-            actions ? /* @__PURE__ */ jsx("div", { className: "mg-fade-in mg-fade-in-delay-3 mt-6 flex flex-wrap items-center gap-2", children: actions }) : null
+            actions ? /* @__PURE__ */ jsx(
+              "div",
+              {
+                className: classNames(
+                  "mg-fade-in mg-fade-in-delay-3 flex flex-wrap items-center gap-2",
+                  dense ? "mt-3" : "mt-6"
+                ),
+                children: actions
+              }
+            ) : null
           ] }),
           aside ? /* @__PURE__ */ jsx("div", { className: "mg-fade-in mg-fade-in-delay-2 hidden md:block shrink-0", children: aside }) : null
         ] }),
-        kpis && kpis.length > 0 ? /* @__PURE__ */ jsx("div", { className: "mg-fade-in mg-fade-in-delay-3 mg-kpi-strip mt-12 md:mt-16", children: kpis.map((k) => /* @__PURE__ */ jsxs("div", { children: [
-          /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted", children: k.label }),
-          /* @__PURE__ */ jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
-            /* @__PURE__ */ jsx("span", { className: "font-display text-2xl md:text-[1.75rem] font-semibold tabular-nums text-ink-strong leading-none tracking-[-0.01em]", children: k.value }),
-            k.hint ? /* @__PURE__ */ jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: k.hint }) : null
-          ] }),
-          k.chart ? /* @__PURE__ */ jsx("div", { className: "mt-2.5 -ml-0.5", children: k.chart }) : null
-        ] }, k.label)) }) : null
+        kpis && kpis.length > 0 ? /* @__PURE__ */ jsx(
+          "div",
+          {
+            className: classNames(
+              "mg-fade-in mg-fade-in-delay-3 mg-kpi-strip",
+              dense ? "mt-4 md:mt-5" : "mt-12 md:mt-16"
+            ),
+            children: kpis.map((k) => /* @__PURE__ */ jsxs("div", { children: [
+              /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted", children: k.label }),
+              /* @__PURE__ */ jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
+                /* @__PURE__ */ jsx("span", { className: "font-display text-2xl md:text-[1.75rem] font-semibold tabular-nums text-ink-strong leading-none tracking-[-0.01em]", children: k.value }),
+                k.hint ? /* @__PURE__ */ jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: k.hint }) : null
+              ] }),
+              k.chart ? /* @__PURE__ */ jsx("div", { className: "mt-2.5 -ml-0.5", children: k.chart }) : null
+            ] }, k.label))
+          }
+        ) : null
       ]
     }
   );

--- a/packages/ui-kit/src/components/metagraphed/page-hero.tsx
+++ b/packages/ui-kit/src/components/metagraphed/page-hero.tsx
@@ -17,6 +17,11 @@ interface Props {
   actions?: ReactNode;
   /** Hairline KPI strip rendered below the hero copy. */
   kpis?: KpiItem[];
+  /**
+   * Tighter spacing above the KPI strip and below the hero — for form/utility
+   * pages that flow straight into content (vs dashboard heroes with charts).
+   */
+  dense?: boolean;
   /** Optional right-side slot (chart, illustration). */
   aside?: ReactNode;
   /** Top-right mono caption (defaults to "registry / v1"). */
@@ -36,6 +41,7 @@ export function PageHero({
   description,
   actions,
   kpis,
+  dense = false,
   aside,
   caption = "registry / v1",
   className,
@@ -43,7 +49,8 @@ export function PageHero({
   return (
     <section
       className={classNames(
-        "mg-hero-slab relative mb-12 md:mb-16 pt-12 md:pt-20 pb-10 md:pb-14",
+        "mg-hero-slab relative pt-12 md:pt-20",
+        dense ? "mb-4 md:mb-6 pb-0" : "mb-12 md:mb-16 pb-10 md:pb-14",
         className,
       )}
     >
@@ -69,7 +76,12 @@ export function PageHero({
             </p>
           ) : null}
           {actions ? (
-            <div className="mg-fade-in mg-fade-in-delay-3 mt-6 flex flex-wrap items-center gap-2">
+            <div
+              className={classNames(
+                "mg-fade-in mg-fade-in-delay-3 flex flex-wrap items-center gap-2",
+                dense ? "mt-3" : "mt-6",
+              )}
+            >
               {actions}
             </div>
           ) : null}
@@ -82,7 +94,12 @@ export function PageHero({
       </div>
 
       {kpis && kpis.length > 0 ? (
-        <div className="mg-fade-in mg-fade-in-delay-3 mg-kpi-strip mt-12 md:mt-16">
+        <div
+          className={classNames(
+            "mg-fade-in mg-fade-in-delay-3 mg-kpi-strip",
+            dense ? "mt-4 md:mt-5" : "mt-12 md:mt-16",
+          )}
+        >
           {kpis.map((k) => (
             <div key={k.label}>
               <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">


### PR DESCRIPTION
## Summary

- Gives `/settings` the same utility-page weight as `/schemas` and `/health`: `PageHero` with Operations eyebrow, short caption, and a compact KPI strip (POST / GET / DELETE / Accounts).
- Adds optional `PageHero` `dense` spacing for form pages that flow straight into content (tighter KPI gap + bottom margin); settings uses it so the strip sits close to the title and forms.
- Leaves webhook create / look-up / delete forms unchanged — no second StatTile actions strip above the forms.

Closes #5346

## Template Used

Frontend/UI change (`apps/ui/**`)

## Test plan

- [x] `npx prettier --check` on touched sources
- [x] `npx eslint` on touched sources (0 errors)
- [x] `npm run typecheck --workspace=packages/ui-kit`
- [x] Manual before/after: `8101/settings` vs `8100/settings` — KPI strip present; forms unchanged; spacing tight
- [ ] Capture 12 fixed-viewport before/after screenshots (3 viewports × 2 themes × before/after)

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/2e2e662b-e7e6-409c-a720-624af845d71f" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/c7180fd8-5c59-4a28-915a-31aca9267f17" /> |
| Desktop · Dark | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/fd214fe8-ee5a-4e92-927f-fc6535d2c02f" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/e6d3b63e-6e9f-49ef-b8ee-98ed0e8f898e" /> |
| Tablet · Light | <img width="1177" height="760" alt="image" src="https://github.com/user-attachments/assets/4fe2fdfe-1585-437c-9c56-595f89a91959" /> | <img width="1177" height="760" alt="image" src="https://github.com/user-attachments/assets/f57fc649-750e-47b1-a5d4-d79dec2d8d09" /> |
| Tablet · Dark | <img width="1177" height="760" alt="image" src="https://github.com/user-attachments/assets/1b975f0a-1f97-4179-80d6-e9c5b35ee45d" /> | <img width="1177" height="760" alt="image" src="https://github.com/user-attachments/assets/fd8162a9-e751-4a27-842b-902881cfb019" /> |
| Mobile · Light | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/13414137-f528-42ea-9797-fdaa73bef096" /> | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/ade1954f-8deb-4818-9970-b5837a11fda7" /> |
| Mobile · Dark | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/d69dce00-31b2-41f8-bd88-58d39190827a" /> | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/69ab6680-9149-4563-91d0-34e54e199e7a" /> |