### PR TITLE
feat(registry): add SN107 Minos docs llms-full.txt data-artifact

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -57,6 +57,25 @@
         "https://taomarketcap.com/subnets/107"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/107"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-docs-llms-full-txt",
+      "kind": "data-artifact",
+      "name": "Minos docs llms-full.txt index",
+      "notes": "Public no-auth machine-readable llms-full.txt full-text index of the official SN107 Minos documentation, served at docs.theminos.ai (the docs subdomain of the registered official website theminos.ai, same operator as the api.theminos.ai surface). A ~70 KB agent-consumable Markdown map of the Minos docs — architecture, miner/validator roles, and the scoring loop. The document self-identifies as 'Minos (SN107)'. Distinct in URL and kind from the api.theminos.ai endpoints already registered.",
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet",
+        "https://theminos.ai/"
+      ],
+      "url": "https://docs.theminos.ai/llms-full.txt"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary

Enriches **SN107 Minos** (issue #463) with a machine-usable **data-artifact**: the official Minos documentation's `llms-full.txt` full-text index.

- **url:** https://docs.theminos.ai/llms-full.txt (public, no-auth — HTTP 200, ~70 KB, `text/plain` Markdown)
- **kind:** data-artifact (agent-consumable full-text docs index)
- **source_urls:** https://github.com/minos-protocol/minos_subnet (official SN107 repo) + https://theminos.ai/ (official website; docs.theminos.ai is its docs subdomain)
- **Self-identifies as SN107:** the document states "Minos (SN107) is a merit-based competition…".

An llms-full.txt index is an agent-native map of the subnet's docs (architecture, miner/validator roles, scoring loop) — exactly the machine-usable coverage the registry seeks. Distinct in URL and kind from the api.theminos.ai surface already registered.

## Validation
- `npm run validate:surface -- registry/subnets/minos.json` → passed (3 surfaces)
- `npm run scan:public-safety` → no findings for this file
- `npx prettier --check` → clean

Closes #463