### PR TITLE
feat(registry): add SN107 Minos public knowledge pack manifest and min compute artifacts (#463)

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -57,6 +57,56 @@
         "https://taomarketcap.com/subnets/107"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/107"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-public-knowledge-pack",
+      "kind": "data-artifact",
+      "name": "Minos SN107 public knowledge pack manifest",
+      "notes": "Public no-auth machine-readable YAML manifest of the SN107 Minos public knowledge pack, published in the official minos-protocol/minos_subnet repository at docs/ai-assistant/memory-pack/manifest.yaml. Self-declares privacy: public_only and describes the subnet's public knowledge graph for miners, validators, and agent runtimes (name, version 1.0.0, published providers, and bootstrap scripts). Pinned to an immutable commit. Verified 200, SS58-clean.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/8310571d70b06af760b8d26bd705476b0624008f/docs/ai-assistant/memory-pack/manifest.yaml",
+        "https://github.com/minos-protocol/minos_subnet"
+      ],
+      "url": "https://raw.githubusercontent.com/minos-protocol/minos_subnet/8310571d70b06af760b8d26bd705476b0624008f/docs/ai-assistant/memory-pack/manifest.yaml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-min-compute",
+      "kind": "data-artifact",
+      "name": "Minos minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official minos-protocol/minos_subnet repository as min_compute.yml. Documents the SN107 Minos operator CPU/GPU/memory/storage/network floors. Pinned to an immutable commit. Verified 200, SS58-clean.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet/blob/b1d773e9f8fb0d16c314a89af731f2e00856121a/min_compute.yml",
+        "https://github.com/minos-protocol/minos_subnet"
+      ],
+      "url": "https://raw.githubusercontent.com/minos-protocol/minos_subnet/b1d773e9f8fb0d16c314a89af731f2e00856121a/min_compute.yml"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary

Adds two new `community` data-artifact surfaces to SN107 Minos (`registry/subnets/minos.json`), both public, no-auth, SS58-clean, and pinned to immutable commits:

1. **public knowledge pack manifest** — `docs/ai-assistant/memory-pack/manifest.yaml`
2. **minimum compute requirements** — `min_compute.yml`

Minos currently registers only two API surfaces (`api.theminos.ai/health` and the TaoMarketCap snapshot) and has no first-party data artifact; these add genuine machine-readable files from the official repo.

## Surfaces

**`sn-107-minos-public-knowledge-pack`** — `data-artifact`
- url: `https://raw.githubusercontent.com/minos-protocol/minos_subnet/8310571d70b06af760b8d26bd705476b0624008f/docs/ai-assistant/memory-pack/manifest.yaml` — 200
- The subnet's public knowledge-pack manifest, which self-declares `privacy: public_only` and describes the Minos SN107 public knowledge graph (name, version 1.0.0, published providers, bootstrap scripts) for miners, validators, and agent runtimes.

**`sn-107-minos-min-compute`** — `data-artifact`
- url: `https://raw.githubusercontent.com/minos-protocol/minos_subnet/b1d773e9f8fb0d16c314a89af731f2e00856121a/min_compute.yml` — 200
- The SN107 operator minimum/recommended hardware specification (miner + validator CPU/GPU/memory/storage/network floors) at the repo root.

## Proof of ownership

Both files live in `minos-protocol/minos_subnet`, the subnet's registered `source_repo`. Each is pinned to the commit that last modified it and verified 200 with no auth header, SS58-clean.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/minos.json` — passed (4 surfaces)

One focused change: two surfaces appended to one subnet file; nothing else touched.

Closes #463

> Scope note: #463 frames the enrichment as an OpenAPI/Swagger spec. Minos exposes no verified public OpenAPI document (the `/v2/*` task endpoints require hotkey auth); these add genuinely-published, explicitly public-safe machine-readable artifacts from the official repo, advancing the same "enrich SN107" intent. Any OpenAPI-specific framing is advisory.
