### PR TITLE
feat(registry): add SN37 Aurelius ScenarioConfig JSON Schema data artifact

### DIFF
--- a/registry/subnets/aurelius.json
+++ b/registry/subnets/aurelius.json
@@ -142,6 +142,24 @@
         "https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/data/seed_dataset.jsonl"
       ],
       "url": "https://raw.githubusercontent.com/Aurelius-Protocol/Aurelius-Protocol/main/data/seed_dataset.jsonl"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-37-aurelius-scenario-schema",
+      "kind": "data-artifact",
+      "name": "Aurelius ScenarioConfig JSON Schema",
+      "notes": "Public no-auth JSON Schema (title \"ScenarioConfig\", \"Aurelius moral dilemma scenario configuration v1\") committed at aurelius/common/schema_v1.json in SN37 Aurelius's official Aurelius-Protocol repository. It is the formal machine-readable contract every moral-dilemma scenario config in the subnet's scoring pipeline conforms to — the schema the existing seed_dataset.jsonl records validate against. Served read-only via raw.githubusercontent from the same official repo registered as the subnet's source-repo; distinct from that seed-dataset artifact (this is the schema, that is the data).",
+      "provider": "aurelius",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "lourincedaging0-commits"
+      },
+      "source_urls": [
+        "https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/aurelius/common/schema_v1.json"
+      ],
+      "url": "https://raw.githubusercontent.com/Aurelius-Protocol/Aurelius-Protocol/main/aurelius/common/schema_v1.json"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary
Enriches **SN37 Aurelius** with a public, no-auth machine-readable **data artifact**: the subnet's formal JSON Schema.

## Surface
- **kind:** `data-artifact`
- **url:** `https://raw.githubusercontent.com/Aurelius-Protocol/Aurelius-Protocol/main/aurelius/common/schema_v1.json`
- A JSON Schema (`title: "ScenarioConfig"`, *"Aurelius moral dilemma scenario configuration v1"*) — the machine-readable contract every scenario config in the subnet's scoring pipeline conforms to.
- **provider:** `aurelius` · authority community · review.state community-submitted.

## Proof (host ↔ subnet)
- Committed in the subnet's **official `Aurelius-Protocol/Aurelius-Protocol`** repository — the same repo registered as SN37's `source_repo`.
- Distinct from the already-registered `data/seed_dataset.jsonl` data-artifact: this is the **schema**, that is the **data** those records validate against.

## Change
- One file: `registry/subnets/aurelius.json` — appends exactly one surface. **Append-only** (`+18 / -0`); no edits to existing surfaces.

## Validation
- `node scripts/validate-surface.mjs registry/subnets/aurelius.json` → *Surface validation passed: 8 surface(s)*
- `node scripts/scan-public-safety.mjs` → *Public-safety scan passed*
- `prettier --check` → *All matched files use Prettier code style*
- Live probe: `GET .../schema_v1.json` → **HTTP 200**, valid JSON Schema, no auth.

Closes #5181