### PR TITLE
feat(registry): add SN107 Minos docs llms-full.txt data-artifact

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -57,6 +57,26 @@
         "https://taomarketcap.com/subnets/107"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/107"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-107-minos-docs-llms-full-txt",
+      "kind": "data-artifact",
+      "name": "Minos docs llms-full.txt index",
+      "notes": "Public no-auth machine-readable llms-full.txt full-text index of the official SN107 Minos documentation site (docs.theminos.ai, title 'Overview - Minos'), the documentation subdomain linked from the Minos homepage at theminos.ai. A ~70 KB agent-consumable Markdown map of the Minos docs covering the subnet architecture, miner and validator roles, and the scoring loop; the document self-identifies as 'Minos (SN107)'.",
+      "provider": "minos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/minos-protocol/minos_subnet",
+        "https://theminos.ai/",
+        "https://docs.theminos.ai/"
+      ],
+      "url": "https://docs.theminos.ai/llms-full.txt"
     }
   ],
   "contact": "contact@theminos.ai"


### PR DESCRIPTION
## Summary

Enriches **SN107 Minos** (issue #463) with a machine-usable **data-artifact**: the official Minos documentation's `llms-full.txt` full-text index.

- **url:** https://docs.theminos.ai/llms-full.txt (public, no-auth — HTTP 200, ~70 KB, `text/plain` Markdown)
- **kind:** data-artifact (agent-consumable full-text docs index)
- **provenance:** docs.theminos.ai is the documentation subdomain of the official Minos site theminos.ai (which links it from its homepage nav); the docs root title is "Overview - Minos" and the index self-identifies as "Minos (SN107)". source_urls: the official repo + https://theminos.ai/ + https://docs.theminos.ai/.

## Validation
- `npm run validate:surface -- registry/subnets/minos.json` → passed (3 surfaces)
- `npm run scan:public-safety` → no findings for this file
- `npx prettier --check` → clean

Closes #463