### PR TITLE
feat(registry): add SN43 Graphite minimum compute requirements data artifact

### DIFF
--- a/registry/subnets/graphite.json
+++ b/registry/subnets/graphite.json
@@ -199,6 +199,24 @@
         "https://api.graphite-ai.net/docs"
       ],
       "url": "https://api.graphite-ai.net/api/v1/miners/stats"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-43-graphite-min-compute",
+      "kind": "data-artifact",
+      "name": "Graphite minimum compute requirements",
+      "notes": "Public no-auth min_compute.yml committed at the root of SN43 Graphite's official GraphiteAI/Graphite-Subnet repository — the minimum and recommended hardware specification (CPU, RAM, storage, OS, and network bandwidth) for running a Graphite miner or validator. Served read-only via raw.githubusercontent from the same official repo registered as the subnet's source-repo; a standalone machine-readable reference artifact distinct from the existing Graphite past-problems dataset and API surfaces.",
+      "provider": "graphite-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "lourincedaging0-commits"
+      },
+      "source_urls": [
+        "https://github.com/GraphiteAI/Graphite-Subnet/blob/main/min_compute.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/GraphiteAI/Graphite-Subnet/main/min_compute.yml"
     }
   ],
   "website_url": "https://graphite-ai.net/"


### PR DESCRIPTION
## Summary
Enriches **SN43 Graphite** with a public, no-auth machine-readable **data artifact**: its minimum-compute specification.

## Surface
- **kind:** `data-artifact`
- **url:** `https://raw.githubusercontent.com/GraphiteAI/Graphite-Subnet/main/min_compute.yml`
- The minimum + recommended hardware spec (CPU / RAM / storage / OS / network bandwidth) for running a Graphite miner or validator.
- **provider:** `graphite-ai` · authority community · review.state community-submitted.

## Proof (host ↔ subnet)
- Committed at the **root of the subnet's official `GraphiteAI/Graphite-Subnet`** repository — the same repo registered as SN43's `source_repo`.
- Distinct from the already-registered Graphite past-problems dataset and API surfaces (this is a standalone hardware-requirements reference).

## Change
- One file: `registry/subnets/graphite.json` — appends exactly one surface. **Append-only** (`+18 / -0`); no edits to existing surfaces.

## Validation
- `node scripts/validate-surface.mjs registry/subnets/graphite.json` → *Surface validation passed: 9 surface(s)*
- `node scripts/scan-public-safety.mjs` → *Public-safety scan passed*
- `prettier --check` → *All matched files use Prettier code style*
- Live probe: `GET .../min_compute.yml` → **HTTP 200**, no auth.

Closes #5193