### PR TITLE
fix(ui-kit): give CopyButton a 44px minimum touch target

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1399,7 +1399,11 @@ function CopyButton({
       "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
       title: copied ? "Copied!" : `Copy ${label ?? "value"}`,
       className: classNames(
-        "shrink-0 inline-flex items-center justify-center rounded p-1 text-ink-muted hover:text-ink-strong transition-colors",
+        // min-h-11 min-w-11 gives the icon-only button the same 44px minimum
+        // touch target as every other header icon button in the shell (the
+        // convention list-shell.tsx documents); p-1 keeps the icon itself compact
+        // and centered within that hit area.
+        "shrink-0 inline-flex items-center justify-center rounded p-1 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong transition-colors",
         className
       ),
       children: /* @__PURE__ */ jsxRuntime.jsx(CopyIconToggle, { copied })

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1370,7 +1370,11 @@ function CopyButton({
       "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
       title: copied ? "Copied!" : `Copy ${label ?? "value"}`,
       className: classNames(
-        "shrink-0 inline-flex items-center justify-center rounded p-1 text-ink-muted hover:text-ink-strong transition-colors",
+        // min-h-11 min-w-11 gives the icon-only button the same 44px minimum
+        // touch target as every other header icon button in the shell (the
+        // convention list-shell.tsx documents); p-1 keeps the icon itself compact
+        // and centered within that hit area.
+        "shrink-0 inline-flex items-center justify-center rounded p-1 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong transition-colors",
         className
       ),
       children: /* @__PURE__ */ jsx(CopyIconToggle, { copied })

--- a/packages/ui-kit/src/components/metagraphed/copy-button.tsx
+++ b/packages/ui-kit/src/components/metagraphed/copy-button.tsx
@@ -24,7 +24,11 @@ export function CopyButton({
       aria-label={copied ? "Copied" : `Copy ${label ?? "value"}`}
       title={copied ? "Copied!" : `Copy ${label ?? "value"}`}
       className={classNames(
-        "shrink-0 inline-flex items-center justify-center rounded p-1 text-ink-muted hover:text-ink-strong transition-colors",
+        // min-h-11 min-w-11 gives the icon-only button the same 44px minimum
+        // touch target as every other header icon button in the shell (the
+        // convention list-shell.tsx documents); p-1 keeps the icon itself compact
+        // and centered within that hit area.
+        "shrink-0 inline-flex items-center justify-center rounded p-1 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong transition-colors",
         className,
       )}
     >


### PR DESCRIPTION
## Summary

`packages/ui-kit/src/components/metagraphed/copy-button.tsx` set only `p-1` padding around a `size-3` (12px) icon with no `min-h`/`min-w`, so the icon-only `CopyButton` rendered a **~20px touch target** — well under the **44px floor** every other header icon button in the shell uses, the convention `list-shell.tsx` documents ("All interactive elements should target min-h-11 for comfortable tap targets"). It's used broadly (registry ticker, mega-menu footer, table rows, hero copy affordances).

Add `min-h-11 min-w-11` (44px) to the button's own class list, exactly as the issue prescribes and matching its sibling header buttons. `p-1` keeps the glyph itself compact and centered within the larger hit area, so the icon's visual size is unchanged — only the clickable box grows.

- One-line source change; `packages/ui-kit/dist` regenerated (`npm run build --workspace=packages/ui-kit`) and committed in the same PR so `validate:contract-drift` / the ui-kit dist diff stays clean.
- `eslint` · `prettier --check` · `npm run typecheck --workspace=packages/ui-kit` — all clean.

Closes #5333

## Template Used

- Backend/code change (`packages/ui-kit` component)

## Screenshots

The dashed blue outline is **illustrative only** (not part of the component) — it reveals the actual clickable hit area so the ~20px → 44px change is visible; the copy glyph itself is unchanged. Shown in a representative bordered call-site row (mono value + copy affordance) at all three viewport widths so the enlarged button is verified not to break the row layout.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5333-mobile-dark-after.png)<br><sub>after</sub> |
