### PR TITLE
feat(registry): add SN56 Gradients challenger code-review config data-artifact

### DIFF
--- a/registry/subnets/gradients.json
+++ b/registry/subnets/gradients.json
@@ -290,6 +290,25 @@
       },
       "source_urls": ["https://api.gradients.io/openapi.json"],
       "url": "https://api.gradients.io/auditing/tasks"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-56-gradients-challenger-review-config",
+      "kind": "data-artifact",
+      "name": "Gradients challenger code-review config",
+      "notes": "Public no-auth machine-readable JSON config from the official SN56 Gradients (G.O.D) validator repository (gradients-ai/G.O.D), pinned to an immutable commit. Defines the forensic code-review policy the validators apply to challenger repositories in the training tournament — the system prompt and rules used to detect cheating (undeclared external datasets, benchmark leakage, external pretrained weights). Static artifact documenting the subnet's anti-cheat evaluation logic.",
+      "provider": "gradients",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/gradients-ai/G.O.D",
+        "https://github.com/gradients-ai/G.O.D/blob/f0d3a1b790b0a34009ead27707916ae19e5e7201/validator/infrastructure/challenger_code_review_config.json"
+      ],
+      "url": "https://raw.githubusercontent.com/gradients-ai/G.O.D/f0d3a1b790b0a34009ead27707916ae19e5e7201/validator/infrastructure/challenger_code_review_config.json"
     }
   ],
   "website_url": "https://www.gradients.io/"


### PR DESCRIPTION
## Summary

Enriches **SN56 Gradients** (issue #5175) with a machine-usable **data-artifact**: the validator's challenger code-review config JSON, pinned to an immutable commit.

- **url:** https://raw.githubusercontent.com/gradients-ai/G.O.D/f0d3a1b790b0a34009ead27707916ae19e5e7201/validator/infrastructure/challenger_code_review_config.json (public, no-auth — HTTP 200, ~1.5 KB JSON)
- **kind:** data-artifact (static machine-readable config from the official SN56 repo)
- **source_urls:** the official SN56 repo https://github.com/gradients-ai/G.O.D + the pinned blob
- Defines the forensic code-review policy validators apply to challenger repositories in the training tournament (rules for detecting undeclared datasets, benchmark leakage, external pretrained weights) — documents the subnet's anti-cheat evaluation logic.

## Validation
- `npm run validate:surface -- registry/subnets/gradients.json` → passed (14 surfaces)
- `npm run scan:public-safety` → no findings for this file
- `npx prettier --check` → clean

Closes #5175