### PR TITLE
fix(ui): hide redundant provider hero slug subtitle (#5317)

### DIFF
--- a/apps/ui/src/lib/metagraphed/provider-display.test.ts
+++ b/apps/ui/src/lib/metagraphed/provider-display.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { providerSlugSubtitle } from "./provider-display";
+
+describe("providerSlugSubtitle", () => {
+  it("hides the subtitle when name and slug are the same string case-insensitively", () => {
+    expect(providerSlugSubtitle("404-GEN", "404-gen")).toBeNull();
+    expect(providerSlugSubtitle("chutes", "chutes")).toBeNull();
+  });
+
+  it("shows the slug when the name meaningfully differs", () => {
+    expect(providerSlugSubtitle("Chutes AI", "chutes")).toBe("chutes");
+    expect(providerSlugSubtitle("404 GEN Labs", "404-gen")).toBe("404-gen");
+  });
+
+  it("hides the subtitle when there is no usable name (title falls back to slug)", () => {
+    expect(providerSlugSubtitle(null, "chutes")).toBeNull();
+    expect(providerSlugSubtitle(undefined, "chutes")).toBeNull();
+    expect(providerSlugSubtitle("", "chutes")).toBeNull();
+    expect(providerSlugSubtitle("    ", "chutes")).toBeNull();
+  });
+
+  it("ignores surrounding whitespace when comparing", () => {
+    expect(providerSlugSubtitle("  404-gen  ", "404-gen")).toBeNull();
+    expect(providerSlugSubtitle("Acme", "  acme  ")).toBeNull();
+  });
+
+  it("returns the untrimmed slug for display when it differs", () => {
+    expect(providerSlugSubtitle("Acme", "acme-labs")).toBe("acme-labs");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/provider-display.ts
+++ b/apps/ui/src/lib/metagraphed/provider-display.ts
@@ -1,0 +1,15 @@
+/**
+ * Decide what the provider hero should show as its slug subtitle.
+ *
+ * The hero title falls back to the slug when a provider has no display name
+ * (`name ?? slug`), so echoing the slug in the subtitle is redundant whenever
+ * the displayed title already is the slug — e.g. a provider named "404-GEN"
+ * with slug "404-gen" would otherwise render "404-GEN · 404-gen".
+ *
+ * Returns the slug to render as the subtitle, or `null` when it would only
+ * repeat the displayed title (matched case-insensitively).
+ */
+export function providerSlugSubtitle(name: string | null | undefined, slug: string): string | null {
+  const displayTitle = name?.trim() ? name.trim() : slug;
+  return displayTitle.toLowerCase() === slug.trim().toLowerCase() ? null : slug;
+}

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -24,6 +24,7 @@ import { useHashScroll } from "@/components/metagraphed/use-hash-scroll";
 import { providerQuery, providerEndpointsQuery, subnetsQuery } from "@/lib/metagraphed/queries";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
+import { providerSlugSubtitle } from "@/lib/metagraphed/provider-display";
 import type { Endpoint, Subnet } from "@/lib/metagraphed/types";
 
 type SearchParams = { tab?: string };
@@ -104,6 +105,7 @@ function ProviderShell({ slug }: { slug: string }) {
   const tab = useActiveTab("overview");
   useHashScroll(tab, SECTION_TO_TAB);
   const stale = meta?.stale || isStaleFreshness(meta?.generated_at);
+  const slugSubtitle = providerSlugSubtitle(p?.name, slug);
 
   return (
     <>
@@ -127,7 +129,7 @@ function ProviderShell({ slug }: { slug: string }) {
           </span>
         }
         title={p?.name ?? slug}
-        subtitle={<>· {slug}</>}
+        subtitle={slugSubtitle ? <>· {slugSubtitle}</> : null}
         description={p?.notes}
         links={<PrimaryLinksRail website={p?.website ?? p?.homepage} docs={p?.docs} />}
         stats={[


### PR DESCRIPTION
## Summary

Closes #5317

The provider hero sets `title={p?.name ?? slug}` and then always rendered `subtitle={<>· {slug}</>}`. For providers whose display name matches the slug case-insensitively — e.g. **404-GEN** / `404-gen` — the hero printed the same string twice: **404-GEN · 404-gen**. The same redundancy hits when `name` is missing (title already falls back to the slug).

This adds a pure `providerSlugSubtitle(name, slug)` helper that returns the slug only when it meaningfully differs from the displayed title (case-insensitive, trimmed), otherwise `null`, and gates the hero subtitle on it.

## Changes
- `lib/metagraphed/provider-display.ts` (+ test) — pure helper (match / differ / blank name / whitespace)
- `routes/providers.$slug.tsx` — wire the helper into `ProfileHero` subtitle

## Gates
typecheck ✓ · unit tests ✓ (702, 5 new) · prettier ✓ · eslint ✓ (0 errors) · build ✓

## Screenshots

Page: `/providers/404-gen`. Look next to the H1 — **before** shows muted `· 404-gen`; **after** is title-only.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/e7a9f86b-e32e-425a-a88b-9cb8e32f0437" /> | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/96d36237-4810-43be-ac14-e0274c6c6959" /> |
| Desktop · Dark | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/2119bb13-3917-4858-b493-5d5872a45337" /> | <img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/bae9d784-f2e2-40a0-a867-d635ec80b61d" /> |
  | Tablet · Light | <img width="1093" height="805" alt="image" src="https://github.com/user-attachments/assets/239e2516-a5da-4e9b-bc59-d42cc5fc3069" /> | <img width="1093" height="805" alt="image" src="https://github.com/user-attachments/assets/2da5be43-c132-43b0-8d3b-36dd64914080" /> |
| Tablet · Dark | <img width="1093" height="805" alt="image" src="https://github.com/user-attachments/assets/1df947ad-4756-463c-9018-47562353d633" /> | <img width="1093" height="805" alt="image" src="https://github.com/user-attachments/assets/77a436a6-3335-4bde-a2db-bde60d4a00ba" /> |
| Mobile · Light | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/a201b328-650f-4322-bd7a-8c12d2bf2681" /> | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/922e65f5-7c48-4556-91a6-5de97cee50c1" /> |
| Mobile · Dark | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/68fe6e42-59a1-4559-b54c-8d42e50cc05e" /> | <img width="383" height="787" alt="image" src="https://github.com/user-attachments/assets/2e27fef3-a52e-41d2-8dc6-eb496e9015ad" /> |