### PR TITLE
fix(ui): collapse blocks/extrinsics filters on mobile

### DIFF
--- a/apps/ui/capture-ex-open.mjs
+++ b/apps/ui/capture-ex-open.mjs
@@ -1,0 +1,37 @@
+import { chromium } from "playwright";
+import path from "path";
+import fs from "fs";
+
+const OUT = "D:/Bittensor/SN74/Peter/metagraphed-screenshots-tmp";
+fs.mkdirSync(OUT, { recursive: true });
+const browser = await chromium.launch({ channel: "chrome", headless: true });
+const context = await browser.newContext({
+  viewport: { width: 375, height: 812 },
+  deviceScaleFactor: 1,
+});
+const page = await context.newPage();
+await page.addInitScript(() => localStorage.setItem("mg-theme", "light"));
+await page.goto("http://127.0.0.1:8100/extrinsics", {
+  waitUntil: "networkidle",
+  timeout: 60000,
+});
+await page.waitForTimeout(1500);
+await page.getByRole("button", { name: /Filters/i }).click();
+await page.waitForTimeout(400);
+const bar = page.locator(".sticky.top-nav").first();
+await bar.scrollIntoViewIfNeeded();
+const box = await bar.boundingBox();
+const file = path.join(OUT, "verify-extrinsics-filters-open.png");
+if (box) {
+  await page.screenshot({
+    path: file,
+    clip: {
+      x: 0,
+      y: Math.max(0, box.y - 4),
+      width: 375,
+      height: Math.min(320, box.height + 16),
+    },
+  });
+}
+console.log("wrote", file, "h=", box?.height);
+await browser.close();

--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
-import type { HTMLAttributes } from "react";
-import { ArrowUp, ArrowDown, X, Filter } from "lucide-react";
+import { useId, useState, type HTMLAttributes, type ReactNode } from "react";
+import { ArrowUp, ArrowDown, ChevronDown, X, Filter } from "lucide-react";
 import { classNames } from "@/lib/metagraphed/format";
 
 /**
@@ -239,6 +239,68 @@ export function ResetFiltersButton({ active, onReset }: { active: boolean; onRes
     >
       <X className="size-3" /> Reset filters
     </button>
+  );
+}
+
+/**
+ * Mobile filter disclosure for dense ListShell filter bars (#5323).
+ *
+ * On viewports below `md` the controls collapse behind a single "Filters"
+ * toggle (closed by default) so list data stays above the fold; when open
+ * they lay out as a 2-column grid. On `md+` the wrapper is `display: contents`
+ * so children participate in ListShell's existing flex row unchanged.
+ */
+export function CollapsibleFilters({
+  activeCount = 0,
+  children,
+}: {
+  /** Number of active filter values — shown as a badge on the mobile toggle. */
+  activeCount?: number;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+
+  return (
+    <>
+      <button
+        type="button"
+        className="md:hidden inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1.5 text-[11px] font-medium text-ink-strong hover:border-ink/30 min-h-9"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Filter className="size-3.5" aria-hidden />
+        Filters
+        {activeCount > 0 ? (
+          <span className="rounded-full bg-accent/15 px-1.5 font-mono text-[10px] tabular-nums text-accent">
+            {activeCount}
+          </span>
+        ) : null}
+        <ChevronDown
+          className={classNames(
+            "size-3.5 text-ink-muted transition-transform",
+            open && "rotate-180",
+          )}
+          aria-hidden
+        />
+      </button>
+      <div
+        id={panelId}
+        className={classNames(
+          // Desktop: unwrap so children join ListShell's flex row.
+          "md:contents",
+          open
+            ? // Mobile open: 2-col grid. Force inputs to fit (SearchInput
+              // defaults to min-w-[180px], which blows out a 2-col cell).
+              "w-full grid grid-cols-2 gap-2 [&_input]:min-w-0 [&_input]:max-w-none [&_input]:w-full [&_input]:flex-none [&>span]:col-span-2 [&>button]:col-span-2 [&>label]:col-span-2"
+            : // Mobile closed: hide the panel entirely.
+              "hidden",
+        )}
+      >
+        {children}
+      </div>
+    </>
   );
 }
 

--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -247,8 +247,9 @@ export function ResetFiltersButton({ active, onReset }: { active: boolean; onRes
  *
  * On viewports below `md` the controls collapse behind a single "Filters"
  * toggle (closed by default) so list data stays above the fold; when open
- * they lay out as a 2-column grid. On `md+` the wrapper is `display: contents`
- * so children participate in ListShell's existing flex row unchanged.
+ * they lay out as a 2-column grid. On `md+` an inner flex row mirrors
+ * ListShell's previous wrap behavior — mobile-only classes stay behind
+ * `max-md:` so tablet/desktop never inherit the grid/hidden styles.
  */
 export function CollapsibleFilters({
   activeCount = 0,
@@ -288,14 +289,13 @@ export function CollapsibleFilters({
       <div
         id={panelId}
         className={classNames(
-          // Desktop: unwrap so children join ListShell's flex row.
-          "md:contents",
-          open
-            ? // Mobile open: 2-col grid. Force inputs to fit (SearchInput
-              // defaults to min-w-[180px], which blows out a 2-col cell).
-              "w-full grid grid-cols-2 gap-2 [&_input]:min-w-0 [&_input]:max-w-none [&_input]:w-full [&_input]:flex-none [&>span]:col-span-2 [&>button]:col-span-2 [&>label]:col-span-2"
-            : // Mobile closed: hide the panel entirely.
-              "hidden",
+          // Desktop / tablet: same wrap row ListShell used before (do not use
+          // display:contents — it lost to unscoped grid/hidden in practice).
+          "md:flex md:flex-wrap md:items-center md:gap-2 md:min-w-0 md:flex-1",
+          // Mobile: closed = hidden; open = 2-col grid. All scoped to max-md.
+          !open && "max-md:hidden",
+          open &&
+            "max-md:grid max-md:w-full max-md:grid-cols-2 max-md:gap-2 max-md:[&_input]:min-w-0 max-md:[&_input]:max-w-none max-md:[&_input]:w-full max-md:[&_input]:flex-none max-md:[&>span]:col-span-2 max-md:[&>button]:col-span-2 max-md:[&>label]:col-span-2",
         )}
       >
         {children}

--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -128,7 +128,7 @@ export function SelectFilter({
         // to font-mono so the value matches the label instead of falling back to
         // the sans body font, which reads as unstyled next to the mono label.
         className={classNames(
-          "min-w-0 truncate bg-transparent font-mono text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "min-w-0 truncate bg-transparent font-mono text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring min-h-7",
           fill ? "flex-1" : "",
         )}
       >
@@ -243,13 +243,24 @@ export function ResetFiltersButton({ active, onReset }: { active: boolean; onRes
 }
 
 /**
+ * Compact row for selects / reset inside {@link CollapsibleFilters}.
+ * Mobile: keeps RESULT / per-page as side-by-side chips (not stretched bars).
+ * Desktop: `display: contents` so children join the normal flex wrap row.
+ */
+export function FilterActionRow({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 max-md:w-full md:contents">{children}</div>
+  );
+}
+
+/**
  * Mobile filter disclosure for dense ListShell filter bars (#5323).
  *
  * On viewports below `md` the controls collapse behind a single "Filters"
  * toggle (closed by default) so list data stays above the fold; when open
- * they lay out as a 2-column grid. On `md+` an inner flex row mirrors
- * ListShell's previous wrap behavior — mobile-only classes stay behind
- * `max-md:` so tablet/desktop never inherit the grid/hidden styles.
+ * text inputs stack full-width, while select chips stay compact via
+ * {@link FilterActionRow}. On `md+` an inner flex row mirrors ListShell's
+ * previous wrap behavior — mobile-only classes stay behind `max-md:`.
  */
 export function CollapsibleFilters({
   activeCount = 0,
@@ -289,13 +300,12 @@ export function CollapsibleFilters({
       <div
         id={panelId}
         className={classNames(
-          // Desktop / tablet: same wrap row ListShell used before (do not use
-          // display:contents — it lost to unscoped grid/hidden in practice).
+          // Desktop / tablet: same wrap row ListShell used before.
           "md:flex md:flex-wrap md:items-center md:gap-2 md:min-w-0 md:flex-1",
-          // Mobile: closed = hidden; open = 2-col grid. All scoped to max-md.
+          // Mobile: closed = hidden; open = full-width input stack.
           !open && "max-md:hidden",
           open &&
-            "max-md:grid max-md:w-full max-md:grid-cols-2 max-md:gap-2 max-md:[&_input]:min-w-0 max-md:[&_input]:max-w-none max-md:[&_input]:w-full max-md:[&_input]:flex-none max-md:[&>span]:col-span-2 max-md:[&>button]:col-span-2 max-md:[&>label]:col-span-2",
+            "max-md:flex max-md:w-full max-md:flex-col max-md:gap-2 max-md:[&_input]:min-w-0 max-md:[&_input]:max-w-none max-md:[&_input]:w-full max-md:[&_input]:flex-none",
         )}
       >
         {children}

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -21,6 +21,7 @@ import {
   CopyableCode,
 } from "@jsonbored/ui-kit";
 import {
+  CollapsibleFilters,
   PageSizeSelect,
   ResetFiltersButton,
   SearchInput,
@@ -224,17 +225,19 @@ function BlocksTable() {
   const goPrev = () => setSearch({ offset: Math.max(0, search.offset - search.limit) });
   const goNext = () => setSearch({ offset: search.offset + search.limit });
 
-  const filtersActive = Boolean(
-    search.author ||
-    search.spec_version ||
-    search.block_start ||
-    search.block_end ||
-    search.min_extrinsics ||
+  const filterValues = [
+    search.author,
+    search.spec_version,
+    search.block_start,
+    search.block_end,
+    search.min_extrinsics,
     search.min_events,
-  );
+  ];
+  const activeFilterCount = filterValues.filter(Boolean).length;
+  const filtersActive = activeFilterCount > 0;
 
   const filters = (
-    <>
+    <CollapsibleFilters activeCount={activeFilterCount}>
       <span
         className="font-mono text-[11px] text-ink-muted whitespace-nowrap"
         title="Blocks are listed newest first"
@@ -300,7 +303,7 @@ function BlocksTable() {
           })
         }
       />
-    </>
+    </CollapsibleFilters>
   );
 
   const emptyNode = (

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -22,6 +22,7 @@ import {
 } from "@jsonbored/ui-kit";
 import {
   CollapsibleFilters,
+  FilterActionRow,
   PageSizeSelect,
   ResetFiltersButton,
   SearchInput,
@@ -284,25 +285,27 @@ function BlocksTable() {
         inputMode="numeric"
         className="min-w-[120px] max-w-[140px] flex-none"
       />
-      <PageSizeSelect
-        value={search.limit}
-        onChange={(n) => setSearch({ limit: n, offset: 0 })}
-        options={[10, 25, 50, 100]}
-      />
-      <ResetFiltersButton
-        active={filtersActive}
-        onReset={() =>
-          setSearch({
-            author: "",
-            spec_version: "",
-            block_start: "",
-            block_end: "",
-            min_extrinsics: "",
-            min_events: "",
-            offset: 0,
-          })
-        }
-      />
+      <FilterActionRow>
+        <PageSizeSelect
+          value={search.limit}
+          onChange={(n) => setSearch({ limit: n, offset: 0 })}
+          options={[10, 25, 50, 100]}
+        />
+        <ResetFiltersButton
+          active={filtersActive}
+          onReset={() =>
+            setSearch({
+              author: "",
+              spec_version: "",
+              block_start: "",
+              block_end: "",
+              min_extrinsics: "",
+              min_events: "",
+              offset: 0,
+            })
+          }
+        />
+      </FilterActionRow>
     </CollapsibleFilters>
   );
 

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -9,6 +9,7 @@ import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import {
+  CollapsibleFilters,
   PageSizeSelect,
   ResetFiltersButton,
   SearchInput,
@@ -191,12 +192,12 @@ function ExtrinsicsTable() {
   const rowKey = (x: Extrinsic) =>
     x.extrinsic_hash || `${x.block_number ?? "?"}-${x.extrinsic_index ?? "?"}`;
 
-  const filtersActive = Boolean(
-    search.signer || search.call_module || search.call_function || search.success,
-  );
+  const filterValues = [search.signer, search.call_module, search.call_function, search.success];
+  const activeFilterCount = filterValues.filter(Boolean).length;
+  const filtersActive = activeFilterCount > 0;
 
   const filters = (
-    <>
+    <CollapsibleFilters activeCount={activeFilterCount}>
       <SearchInput
         value={search.signer}
         onChange={(v) => setSearch({ signer: v, offset: 0 })}
@@ -238,7 +239,7 @@ function ExtrinsicsTable() {
           })
         }
       />
-    </>
+    </CollapsibleFilters>
   );
 
   const emptyNode = (

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -10,6 +10,7 @@ import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import {
   CollapsibleFilters,
+  FilterActionRow,
   PageSizeSelect,
   ResetFiltersButton,
   SearchInput,
@@ -213,32 +214,34 @@ function ExtrinsicsTable() {
         onChange={(v) => setSearch({ call_function: v, offset: 0 })}
         placeholder="Call function…"
       />
-      <SelectFilter
-        label="Result"
-        value={search.success}
-        onChange={(v) => setSearch({ success: v, offset: 0 })}
-        options={[
-          { value: "true", label: "ok" },
-          { value: "false", label: "fail" },
-        ]}
-      />
-      <PageSizeSelect
-        value={search.limit}
-        onChange={(n) => setSearch({ limit: n, offset: 0 })}
-        options={[10, 25, 50, 100]}
-      />
-      <ResetFiltersButton
-        active={filtersActive}
-        onReset={() =>
-          setSearch({
-            signer: "",
-            call_module: "",
-            call_function: "",
-            success: "",
-            offset: 0,
-          })
-        }
-      />
+      <FilterActionRow>
+        <SelectFilter
+          label="Result"
+          value={search.success}
+          onChange={(v) => setSearch({ success: v, offset: 0 })}
+          options={[
+            { value: "true", label: "ok" },
+            { value: "false", label: "fail" },
+          ]}
+        />
+        <PageSizeSelect
+          value={search.limit}
+          onChange={(n) => setSearch({ limit: n, offset: 0 })}
+          options={[10, 25, 50, 100]}
+        />
+        <ResetFiltersButton
+          active={filtersActive}
+          onReset={() =>
+            setSearch({
+              signer: "",
+              call_module: "",
+              call_function: "",
+              success: "",
+              offset: 0,
+            })
+          }
+        />
+      </FilterActionRow>
     </CollapsibleFilters>
   );
 


### PR DESCRIPTION
## Summary
- Collapse Blocks and Extrinsics filter bars behind a closed-by-default **Filters** disclosure on viewports below `md`, so list data can sit above the fold on 375px.
- When Filters is open on mobile: text inputs stack full-width; Result / per-page (and reset) stay compact chips via `FilterActionRow`.
- Desktop and tablet keep the original inline flex filter row (`max-md:`-scoped mobile styles only).

Closes #5323

## Test plan
- [x] `/blocks` @ 375px: Filters collapsed by default; expand shows stacked inputs + compact per-page
- [x] `/extrinsics` @ 375px: same; Result | per page on one row when open
- [x] Desktop / tablet (≥768): filter bar matches pre-change wrap layout (no vertical stack, no Filters toggle)
- [ ] Light + dark themes for the disclosure control
- [ ] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [ ] `npm run typecheck --workspace=apps/ui && npm test --workspace=apps/ui`
- [ ] `npm run test:e2e --workspace=apps/ui && npm run build --workspace=apps/ui`

## Screenshots

### Blocks (`/blocks`)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  |  <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/8552e152-1afc-4bca-9726-5a597fb053fa" />  | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/9e2d38e6-559a-44f7-a781-89a6c4da6238" /> |
| Desktop · Dark   | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/242d1ccc-c7a9-44d6-87ee-3aa66e5b6b37" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/e637bfe8-351d-452c-b3d9-ed36ebfacc4d" /> |
| Tablet · Light   | <img width="1048" height="760" alt="image" src="https://github.com/user-attachments/assets/5415bf97-e875-4854-95c8-99eb7ae06ac5" /> | <img width="1048" height="760" alt="image" src="https://github.com/user-attachments/assets/5415bf97-e875-4854-95c8-99eb7ae06ac5" /> |
| Tablet · Dark    | <img width="1048" height="760" alt="image" src="https://github.com/user-attachments/assets/b0800870-59b4-4f47-8e93-33b3b1f65b4a" /> | <img width="1048" height="760" alt="image" src="https://github.com/user-attachments/assets/b0800870-59b4-4f47-8e93-33b3b1f65b4a" /> |
| Mobile · Light   | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/f724a84d-9793-4843-bff0-1f3892bedd01" /> | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/c29c5cee-7ed4-4204-9d54-4632caf2110b" /> |
| Mobile · Dark    | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/abf7eae0-6815-4535-91dd-2ebe8ea9f686" /> | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/fab1865e-cbf2-4394-a9b8-fa659963400e" /> |

### Extrinsics (`/extrinsics`)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/0c65de0b-1b04-4b7e-b62b-04c9899f6cbc" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/55207869-d3c7-4b71-aad3-61468f355f13" /> |
| Desktop · Dark   | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/d8d492df-5ec5-4cb9-9d33-6f8f2cc3bbe2" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/4587a8e2-b7f4-4424-98a9-085b4a2acbc6" /> |
| Tablet · Light   | <img width="1083" height="760" alt="image" src="https://github.com/user-attachments/assets/20e0af02-7ca7-4047-b8eb-db09c54a8ea3" /> | <img width="1087" height="760" alt="image" src="https://github.com/user-attachments/assets/0c0c71c3-ea25-4e1e-9f8d-664e2fe7ad4f" /> |
| Tablet · Dark    | <img width="1083" height="760" alt="image" src="https://github.com/user-attachments/assets/5d1b8e68-3260-499a-af50-e855a73b4eda" /> | <img width="1087" height="760" alt="image" src="https://github.com/user-attachments/assets/a8e12631-8e26-45e7-b957-d69ccf5adc0e" /> |
| Mobile · Light   | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/a022b3a6-b2e1-43c1-bf37-06cca6f1cabf" /> | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/fa67e0a2-ce3c-4f07-9e9b-6d1b00076c0c" /> |
| Mobile · Dark    | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/92c8b2ac-758a-4e31-8ad4-d26ef37c45cc" /> | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/0f8e6e1c-88a1-4991-b4bf-ec828d28e52b" /> |
