### PR TITLE
fix(ui): collapse blocks/extrinsics filters on mobile

### DIFF
--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
-import type { HTMLAttributes } from "react";
-import { ArrowUp, ArrowDown, X, Filter } from "lucide-react";
+import { useId, useState, type HTMLAttributes, type ReactNode } from "react";
+import { ArrowUp, ArrowDown, ChevronDown, X, Filter } from "lucide-react";
 import { classNames } from "@/lib/metagraphed/format";
 
 /**
@@ -128,7 +128,7 @@ export function SelectFilter({
         // to font-mono so the value matches the label instead of falling back to
         // the sans body font, which reads as unstyled next to the mono label.
         className={classNames(
-          "min-w-0 truncate bg-transparent font-mono text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "min-w-0 truncate bg-transparent font-mono text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring min-h-7",
           fill ? "flex-1" : "",
         )}
       >
@@ -239,6 +239,78 @@ export function ResetFiltersButton({ active, onReset }: { active: boolean; onRes
     >
       <X className="size-3" /> Reset filters
     </button>
+  );
+}
+
+/**
+ * Compact row for selects / reset inside {@link CollapsibleFilters}.
+ * Mobile: keeps RESULT / per-page as side-by-side chips (not stretched bars).
+ * Desktop: `display: contents` so children join the normal flex wrap row.
+ */
+export function FilterActionRow({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 max-md:w-full md:contents">{children}</div>
+  );
+}
+
+/**
+ * Mobile filter disclosure for dense ListShell filter bars (#5323).
+ *
+ * On viewports below `md` the controls collapse behind a single "Filters"
+ * toggle (closed by default) so list data stays above the fold; when open
+ * text inputs stack full-width, while select chips stay compact via
+ * {@link FilterActionRow}. On `md+` an inner flex row mirrors ListShell's
+ * previous wrap behavior — mobile-only classes stay behind `max-md:`.
+ */
+export function CollapsibleFilters({
+  activeCount = 0,
+  children,
+}: {
+  /** Number of active filter values — shown as a badge on the mobile toggle. */
+  activeCount?: number;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+
+  return (
+    <>
+      <button
+        type="button"
+        className="md:hidden inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1.5 text-[11px] font-medium text-ink-strong hover:border-ink/30 min-h-9"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Filter className="size-3.5" aria-hidden />
+        Filters
+        {activeCount > 0 ? (
+          <span className="rounded-full bg-accent/15 px-1.5 font-mono text-[10px] tabular-nums text-accent">
+            {activeCount}
+          </span>
+        ) : null}
+        <ChevronDown
+          className={classNames(
+            "size-3.5 text-ink-muted transition-transform",
+            open && "rotate-180",
+          )}
+          aria-hidden
+        />
+      </button>
+      <div
+        id={panelId}
+        className={classNames(
+          // Desktop / tablet: same wrap row ListShell used before.
+          "md:flex md:flex-wrap md:items-center md:gap-2 md:min-w-0 md:flex-1",
+          // Mobile: closed = hidden; open = full-width input stack.
+          !open && "max-md:hidden",
+          open &&
+            "max-md:flex max-md:w-full max-md:flex-col max-md:gap-2 max-md:[&_input]:min-w-0 max-md:[&_input]:max-w-none max-md:[&_input]:w-full max-md:[&_input]:flex-none",
+        )}
+      >
+        {children}
+      </div>
+    </>
   );
 }
 

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -21,6 +21,8 @@ import {
   CopyableCode,
 } from "@jsonbored/ui-kit";
 import {
+  CollapsibleFilters,
+  FilterActionRow,
   PageSizeSelect,
   ResetFiltersButton,
   SearchInput,
@@ -224,17 +226,19 @@ function BlocksTable() {
   const goPrev = () => setSearch({ offset: Math.max(0, search.offset - search.limit) });
   const goNext = () => setSearch({ offset: search.offset + search.limit });
 
-  const filtersActive = Boolean(
-    search.author ||
-    search.spec_version ||
-    search.block_start ||
-    search.block_end ||
-    search.min_extrinsics ||
+  const filterValues = [
+    search.author,
+    search.spec_version,
+    search.block_start,
+    search.block_end,
+    search.min_extrinsics,
     search.min_events,
-  );
+  ];
+  const activeFilterCount = filterValues.filter(Boolean).length;
+  const filtersActive = activeFilterCount > 0;
 
   const filters = (
-    <>
+    <CollapsibleFilters activeCount={activeFilterCount}>
       <span
         className="font-mono text-[11px] text-ink-muted whitespace-nowrap"
         title="Blocks are listed newest first"
@@ -281,26 +285,28 @@ function BlocksTable() {
         inputMode="numeric"
         className="min-w-[120px] max-w-[140px] flex-none"
       />
-      <PageSizeSelect
-        value={search.limit}
-        onChange={(n) => setSearch({ limit: n, offset: 0 })}
-        options={[10, 25, 50, 100]}
-      />
-      <ResetFiltersButton
-        active={filtersActive}
-        onReset={() =>
-          setSearch({
-            author: "",
-            spec_version: "",
-            block_start: "",
-            block_end: "",
-            min_extrinsics: "",
-            min_events: "",
-            offset: 0,
-          })
-        }
-      />
-    </>
+      <FilterActionRow>
+        <PageSizeSelect
+          value={search.limit}
+          onChange={(n) => setSearch({ limit: n, offset: 0 })}
+          options={[10, 25, 50, 100]}
+        />
+        <ResetFiltersButton
+          active={filtersActive}
+          onReset={() =>
+            setSearch({
+              author: "",
+              spec_version: "",
+              block_start: "",
+              block_end: "",
+              min_extrinsics: "",
+              min_events: "",
+              offset: 0,
+            })
+          }
+        />
+      </FilterActionRow>
+    </CollapsibleFilters>
   );
 
   const emptyNode = (

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -9,6 +9,8 @@ import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import {
+  CollapsibleFilters,
+  FilterActionRow,
   PageSizeSelect,
   ResetFiltersButton,
   SearchInput,
@@ -191,12 +193,12 @@ function ExtrinsicsTable() {
   const rowKey = (x: Extrinsic) =>
     x.extrinsic_hash || `${x.block_number ?? "?"}-${x.extrinsic_index ?? "?"}`;
 
-  const filtersActive = Boolean(
-    search.signer || search.call_module || search.call_function || search.success,
-  );
+  const filterValues = [search.signer, search.call_module, search.call_function, search.success];
+  const activeFilterCount = filterValues.filter(Boolean).length;
+  const filtersActive = activeFilterCount > 0;
 
   const filters = (
-    <>
+    <CollapsibleFilters activeCount={activeFilterCount}>
       <SearchInput
         value={search.signer}
         onChange={(v) => setSearch({ signer: v, offset: 0 })}
@@ -212,33 +214,35 @@ function ExtrinsicsTable() {
         onChange={(v) => setSearch({ call_function: v, offset: 0 })}
         placeholder="Call function…"
       />
-      <SelectFilter
-        label="Result"
-        value={search.success}
-        onChange={(v) => setSearch({ success: v, offset: 0 })}
-        options={[
-          { value: "true", label: "ok" },
-          { value: "false", label: "fail" },
-        ]}
-      />
-      <PageSizeSelect
-        value={search.limit}
-        onChange={(n) => setSearch({ limit: n, offset: 0 })}
-        options={[10, 25, 50, 100]}
-      />
-      <ResetFiltersButton
-        active={filtersActive}
-        onReset={() =>
-          setSearch({
-            signer: "",
-            call_module: "",
-            call_function: "",
-            success: "",
-            offset: 0,
-          })
-        }
-      />
-    </>
+      <FilterActionRow>
+        <SelectFilter
+          label="Result"
+          value={search.success}
+          onChange={(v) => setSearch({ success: v, offset: 0 })}
+          options={[
+            { value: "true", label: "ok" },
+            { value: "false", label: "fail" },
+          ]}
+        />
+        <PageSizeSelect
+          value={search.limit}
+          onChange={(n) => setSearch({ limit: n, offset: 0 })}
+          options={[10, 25, 50, 100]}
+        />
+        <ResetFiltersButton
+          active={filtersActive}
+          onReset={() =>
+            setSearch({
+              signer: "",
+              call_module: "",
+              call_function: "",
+              success: "",
+              offset: 0,
+            })
+          }
+        />
+      </FilterActionRow>
+    </CollapsibleFilters>
   );
 
   const emptyNode = (


### PR DESCRIPTION
## Summary
- Collapse Blocks and Extrinsics filter bars behind a closed-by-default **Filters** disclosure on viewports below `md`, so list data can sit above the fold on 375px.
- When Filters is open on mobile: text inputs stack full-width; Result / per-page (and reset) stay compact chips via `FilterActionRow`.
- Desktop and tablet keep the original inline flex filter row (`max-md:`-scoped mobile styles only).

Closes #5323

## Test plan
- [x] `/blocks` @ 375px: Filters collapsed by default; expand shows stacked inputs + compact per-page
- [x] `/extrinsics` @ 375px: same; Result | per page on one row when open
- [x] Desktop / tablet (≥768): filter bar matches pre-change wrap layout (no vertical stack, no Filters toggle)
- [ ] Light + dark themes for the disclosure control
- [ ] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [ ] `npm run typecheck --workspace=apps/ui && npm test --workspace=apps/ui`
- [ ] `npm run test:e2e --workspace=apps/ui && npm run build --workspace=apps/ui`

## Screenshots

Screenshots reused from closed PR #5434 (same change).

### Blocks (`/blocks`)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | <img width="260" alt="before" src="https://github.com/user-attachments/assets/8552e152-1afc-4bca-9726-5a597fb053fa" /> | <img width="260" alt="after" src="https://github.com/user-attachments/assets/9e2d38e6-559a-44f7-a781-89a6c4da6238" /> |
| Desktop · Dark   | <img width="260" alt="before" src="https://github.com/user-attachments/assets/242d1ccc-c7a9-44d6-87ee-3aa66e5b6b37" /> | <img width="260" alt="after" src="https://github.com/user-attachments/assets/e637bfe8-351d-452c-b3d9-ed36ebfacc4d" /> |
| Tablet · Light   | <img width="260" alt="before" src="https://github.com/user-attachments/assets/5415bf97-e875-4854-95c8-99eb7ae06ac5" /> | <img width="260" alt="after" src="https://github.com/user-attachments/assets/5415bf97-e875-4854-95c8-99eb7ae06ac5" /> |
| Tablet · Dark    | <img width="260" alt="before" src="https://github.com/user-attachments/assets/b0800870-59b4-4f47-8e93-33b3b1f65b4a" /> | <img width="260" alt="after" src="https://github.com/user-attachments/assets/b0800870-59b4-4f47-8e93-33b3b1f65b4a" /> |
| Mobile · Light   | <img width="260" alt="before" src="https://github.com/user-attachments/assets/f724a84d-9793-4843-bff0-1f3892bedd01" /> | <img width="260" alt="after" src="https://github.com/user-attachments/assets/c29c5cee-7ed4-4204-9d54-4632caf2110b" /> |
| Mobile · Dark    | <img width="260" alt="before" src="https://github.com/user-attachments/assets/abf7eae0-6815-4535-91dd-2ebe8ea9f686" /> | <img width="260" alt="after" src="https://github.com/user-attachments/assets/fab1865e-cbf2-4394-a9b8-fa659963400e" /> |

### Extrinsics (`/extrinsics`)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | <img width="260" alt="before" src="https://github.com/user-attachments/assets/0c65de0b-1b04-4b7e-b62b-04c9899f6cbc" /> | <img width="260" alt="after" src="https://github.com/user-attachments/assets/55207869-d3c7-4b71-aad3-61468f355f13" /> |
| Desktop · Dark   | <img width="260" alt="before" src="https://github.com/user-attachments/assets/d8d492df-5ec5-4cb9-9d33-6f8f2cc3bbe2" /> | <img width="260" alt="after" src="https://github.com/user-attachments/assets/4587a8e2-b7f4-4424-98a9-085b4a2acbc6" /> |
| Tablet · Light   | <img width="260" alt="before" src="https://github.com/user-attachments/assets/20e0af02-7ca7-4047-b8eb-db09c54a8ea3" /> | <img width="260" alt="after" src="https://github.com/user-attachments/assets/0c0c71c3-ea25-4e1e-9f8d-664e2fe7ad4f" /> |
| Tablet · Dark    | <img width="260" alt="before" src="https://github.com/user-attachments/assets/5d1b8e68-3260-499a-af50-e855a73b4eda" /> | <img width="260" alt="after" src="https://github.com/user-attachments/assets/a8e12631-8e26-45e7-b957-d69ccf5adc0e" /> |
| Mobile · Light   | <img width="260" alt="before" src="https://github.com/user-attachments/assets/a022b3a6-b2e1-43c1-bf37-06cca6f1cabf" /> | <img width="260" alt="after" src="https://github.com/user-attachments/assets/fa67e0a2-ce3c-4f07-9e9b-6d1b00076c0c" /> |
| Mobile · Dark    | <img width="260" alt="before" src="https://github.com/user-attachments/assets/92c8b2ac-758a-4e31-8ad4-d26ef37c45cc" /> | <img width="260" alt="after" src="https://github.com/user-attachments/assets/0f8e6e1c-88a1-4991-b4bf-ec828d28e52b" /> |