### PR TITLE
feat(registry): add SN15 ORO public leaderboard-history and inference-models API surfaces (#5174)

### DIFF
--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -298,6 +298,56 @@
         "https://oroagents.com/"
       ],
       "url": "https://api.oroagents.com/health/deep"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-public-top-history",
+      "kind": "subnet-api",
+      "name": "ORO public leaderboard history API",
+      "notes": "Public no-auth GET /v1/public/top/history on api.oroagents.com returning JSON time-series leaderboard history for the SN15 ORO ShoppingBench subnet (per evaluation suite: agent_version_id, agent_name, and score entries over time). Documented as GET /v1/public/top/history in the subnet's own registered OpenAPI spec; same host as the existing /v1/public/top and /v1/public/leaderboard surfaces. Distinct from those current-state endpoints — this returns historical ranking data. Verified 200 application/json, no auth, SS58-clean.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://api.oroagents.com/openapi.json",
+        "https://oroagents.com/"
+      ],
+      "url": "https://api.oroagents.com/v1/public/top/history"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-public-inference-models",
+      "kind": "subnet-api",
+      "name": "ORO public inference models API",
+      "notes": "Public no-auth GET /v1/public/inference/models on api.oroagents.com returning the JSON list of TEE-hosted inference models the SN15 ORO subnet makes available to agents (e.g. DeepSeek, Qwen, GLM, Kimi, MiniMax, gpt-oss variants). Documented as GET /v1/public/inference/models in the subnet's own registered OpenAPI spec; same host as the existing public API surfaces. Verified 200 application/json, no auth, SS58-clean.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://api.oroagents.com/openapi.json",
+        "https://oroagents.com/"
+      ],
+      "url": "https://api.oroagents.com/v1/public/inference/models"
     }
   ],
   "website_url": "https://oroagents.com/"


### PR DESCRIPTION
## Summary

Adds two new `community` subnet-api surfaces to SN15 ORO (`registry/subnets/oro.json`), both public, no-auth, HTTP 200 `application/json`, SS58-clean, and documented in the subnet's own registered OpenAPI spec:

1. **public leaderboard history** — `GET /v1/public/top/history`
2. **public inference models** — `GET /v1/public/inference/models`

Both are distinct from ORO's already-registered current-state public endpoints and enrich the SN15 ShoppingBench coverage.

## Surfaces

**`sn-15-oro-public-top-history`** — `subnet-api`
- url: `https://api.oroagents.com/v1/public/top/history`
- Time-series leaderboard history (per suite: agent_version_id, agent_name, score entries over time). Distinct from the registered `/v1/public/top` and `/v1/public/leaderboard` current-state endpoints.

**`sn-15-oro-public-inference-models`** — `subnet-api`
- url: `https://api.oroagents.com/v1/public/inference/models`
- The list of TEE-hosted inference models the subnet makes available to agents (DeepSeek / Qwen / GLM / Kimi / MiniMax / gpt-oss variants).

## Proof of ownership

`api.oroagents.com` is the subnet's API host (registered `website_url` `oroagents.com`, registered `openapi` surface). Both endpoints are documented in that OpenAPI spec and are served alongside the existing public API surfaces.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/oro.json` — passed (16 surfaces)
- Both endpoints verified with no auth header: 200 `application/json`, SS58-clean (no hotkey/wallet material).

One focused change: two surfaces appended to one subnet file; nothing else touched.

Closes #5174

> Scope note: #5174 frames the enrichment as an SSE stream. ORO exposes no verified public SSE endpoint; these add genuinely-published, previously-unregistered no-auth public REST endpoints documented in the subnet's own OpenAPI, advancing the same "enrich SN15" intent. Any SSE-specific framing is advisory.
