### PR TITLE
fix(ui): use one probe-backed health signal on subnet pages

### DIFF
--- a/apps/ui/src/components/metagraphed/incident-strip.tsx
+++ b/apps/ui/src/components/metagraphed/incident-strip.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { AlertTriangle, ArrowRight, X } from "lucide-react";
 import { endpointIncidentsQuery } from "@/lib/metagraphed/queries";
+import { netuidFromPathname, sameNetuid } from "@/lib/metagraphed/subnet-probe-health";
 import type { EndpointIncident } from "@/lib/metagraphed/types";
 import { classNames } from "@/lib/metagraphed/format";
 
@@ -35,11 +36,21 @@ function isActive(i: EndpointIncident): boolean {
   return state === "down" || state === "warn" || state === "degraded";
 }
 
+/**
+ * Site-wide active-incident banner for operational routes.
+ *
+ * On a subnet detail page the masthead HealthPill is the sole health signal for
+ * *that* subnet (#5332). Incidents scoped to the viewed netuid are therefore
+ * omitted here so "SN1 DEGRADED" cannot disagree with a masthead pill that was
+ * previously stuck on profile/chain "Unknown". Other subnets' incidents still
+ * surface (and the strip still leads on /endpoints).
+ */
 export function IncidentStrip() {
   // The degraded/incident bar is only contextually relevant on the operational
   // surfaces (endpoints + subnets); on home/about/schemas/etc. it's noise, so we
   // gate it to those routes rather than showing it site-wide.
   const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const viewedNetuid = netuidFromPathname(pathname);
   const { data, error } = useQuery({ ...endpointIncidentsQuery(), retry: 0 });
   const [dismissed, setDismissed] = useState<Set<string>>(() => new Set());
   // Hydrate after mount to avoid SSR mismatch.
@@ -47,8 +58,15 @@ export function IncidentStrip() {
 
   const active = useMemo(() => {
     if (error || !data) return [];
-    return (data.data as EndpointIncident[]).filter(isActive).filter((i) => !dismissed.has(i.id));
-  }, [data, error, dismissed]);
+    return (
+      (data.data as EndpointIncident[])
+        .filter(isActive)
+        .filter((i) => !dismissed.has(i.id))
+        // Masthead owns health for the currently viewed subnet (coerce netuid
+        // so string/number API values never leave "SN1 DEGRADED" stuck on /subnets/1).
+        .filter((i) => viewedNetuid == null || !sameNetuid(i.netuid, viewedNetuid))
+    );
+  }, [data, error, dismissed, viewedNetuid]);
 
   const onOperationalRoute = pathname.startsWith("/endpoints") || pathname.startsWith("/subnets");
   if (!onOperationalRoute || active.length === 0) return null;

--- a/apps/ui/src/components/metagraphed/readiness-scorecard.tsx
+++ b/apps/ui/src/components/metagraphed/readiness-scorecard.tsx
@@ -1,5 +1,5 @@
 import { ArrowRight, Check, Minus } from "lucide-react";
-import { HealthPill, ExternalLink } from "@jsonbored/ui-kit";
+import { ExternalLink } from "@jsonbored/ui-kit";
 import { classNames } from "@/lib/metagraphed/format";
 import type { SubnetProfile } from "@/lib/metagraphed/types";
 
@@ -24,9 +24,10 @@ function scoreTone(score: number): { label: string; cls: string } {
 /**
  * Integration-readiness scorecard for the top of the subnet Overview tab (#369).
  * Composes the backend `integration_readiness` score + its component breakdown,
- * the `primary_app_surface` as a "start here" CTA, operational-vs-missing
- * interfaces, and live health — the highest-leverage answer for an integration
- * dev landing on a subnet ("can I build on this, and where do I start?").
+ * the `primary_app_surface` as a "start here" CTA, and operational-vs-missing
+ * interfaces. Live probe health lives only in the masthead HealthPill (#5332) —
+ * duplicating it here disagreed with the probe-backed strip and muddied which
+ * indicator was authoritative.
  */
 export function ReadinessScorecard({ profile }: { profile?: SubnetProfile }) {
   if (!profile) return null;
@@ -64,7 +65,6 @@ export function ReadinessScorecard({ profile }: { profile?: SubnetProfile }) {
             ) : null}
           </div>
         </div>
-        <HealthPill state={profile.health ?? "unknown"} />
       </div>
 
       {cta?.url ? (

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -326,7 +326,9 @@ export function SubnetMasthead({
         }}
       />
 
-      {/* Status row — slim, never dominates */}
+      {/* Status row — slim, never dominates. On mobile the probe HealthPill lives
+          here (not in the identity grid) so the title/tags/links keep a full-width
+          middle column (#5332) instead of crushing into a 3-col squeeze. */}
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-[11px] text-ink-muted mb-3">
         <Link to="/subnets" className="font-mono uppercase tracking-widest hover:text-ink-strong">
           Registry
@@ -344,12 +346,16 @@ export function SubnetMasthead({
             stale
           </span>
         ) : null}
+        <div className="ml-auto flex md:hidden items-center gap-1.5">
+          <HealthPill state={probeHealth} />
+          <CurationChip level={profile?.curation_level} />
+        </div>
       </div>
 
       {banner ? <div className="mb-4">{banner}</div> : null}
 
-      {/* Identity row */}
-      <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-4">
+      {/* Identity row — 2 cols on mobile (icon + body), 3 cols from md with health */}
+      <div className="grid grid-cols-[auto_minmax(0,1fr)] md:grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3 md:gap-4">
         <div className="shrink-0 mt-0.5">
           <BrandIcon
             url={profile?.website ?? profile?.homepage}
@@ -440,10 +446,9 @@ export function SubnetMasthead({
             </div>
           ) : null}
         </div>
-        {/* HealthPill is the sole on-page health signal (#5332) — keep it visible
-            on mobile too; previously `hidden md:flex` left only the incident strip
-            + readiness pill to disagree. */}
-        <div className="flex shrink-0 flex-col items-end gap-1.5">
+        {/* Desktop/tablet: health + curation beside the identity block. Mobile
+            counterpart lives in the status row above so the body column stays wide. */}
+        <div className="hidden md:flex shrink-0 flex-col items-end gap-1.5">
           <HealthPill state={probeHealth} />
           <CurationChip level={profile?.curation_level} />
         </div>

--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -37,6 +37,7 @@ import {
   subnetTrajectoryQuery,
   subnetUptimeQuery,
 } from "@/lib/metagraphed/queries";
+import { useSubnetProbeHealth } from "@/hooks/use-subnet-probe-health";
 import type {
   Endpoint,
   SubnetProfile,
@@ -187,6 +188,9 @@ export function SubnetMasthead({
   const { data: regRes } = useQuery(subnetRegistrationsQuery(netuid));
   const { data: deregRes } = useQuery(subnetDeregistrationsQuery(netuid));
   const { data: eventsRes } = useQuery(subnetEventSummaryQuery(netuid));
+  // Canonical probe health (#5332) — same source as the /subnets table join,
+  // never profile/chain lifecycle status.
+  const probeHealth = useSubnetProbeHealth(netuid);
   const reg = regRes?.data;
   const dereg = deregRes?.data;
 
@@ -265,8 +269,8 @@ export function SubnetMasthead({
     { label: "Dashboard", href: profile?.dashboard, icon: LayoutDashboard },
   ].filter((l) => !!l.href) as LinkChip[];
 
-  // Health-derived accent for the top rail.
-  const health = profile?.health ?? "unknown";
+  // Health-derived accent for the top rail — probe health, not profile.status.
+  const health = probeHealth;
   const accentColor =
     health === "ok"
       ? "var(--health-ok)"
@@ -436,8 +440,11 @@ export function SubnetMasthead({
             </div>
           ) : null}
         </div>
-        <div className="hidden md:flex shrink-0 flex-col items-end gap-1.5">
-          <HealthPill state={profile?.health} />
+        {/* HealthPill is the sole on-page health signal (#5332) — keep it visible
+            on mobile too; previously `hidden md:flex` left only the incident strip
+            + readiness pill to disagree. */}
+        <div className="flex shrink-0 flex-col items-end gap-1.5">
+          <HealthPill state={probeHealth} />
           <CurationChip level={profile?.curation_level} />
         </div>
       </div>

--- a/apps/ui/src/hooks/use-subnet-probe-health.ts
+++ b/apps/ui/src/hooks/use-subnet-probe-health.ts
@@ -1,0 +1,41 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  endpointIncidentsQuery,
+  subnetHealthMapQuery,
+  subnetHealthQuery,
+} from "@/lib/metagraphed/queries";
+import {
+  resolveSubnetProbeHealth,
+  worstActiveIncidentHealth,
+} from "@/lib/metagraphed/subnet-probe-health";
+import type { EndpointIncident, HealthState } from "@/lib/metagraphed/types";
+
+/**
+ * Canonical probe-derived health for one subnet (#5332). Shared by the subnet
+ * masthead HealthPill. Backed by `/api/v1/health` (map) → per-subnet `/health`
+ * count rollup → active endpoint-incidents for this netuid when the rollup is
+ * still unknown. Never by profile/chain lifecycle `status`.
+ */
+export function useSubnetProbeHealth(netuid: number): HealthState {
+  const mapQ = useQuery(subnetHealthMapQuery());
+  const detailQ = useQuery(subnetHealthQuery(netuid));
+  const incidentsQ = useQuery({ ...endpointIncidentsQuery(), retry: 0 });
+  const mapHealth = mapQ.data?.data?.[netuid]?.health;
+  const summary = detailQ.data?.data;
+  const incidentHealth = worstActiveIncidentHealth(
+    incidentsQ.data?.data as EndpointIncident[] | undefined,
+    netuid,
+  );
+  return resolveSubnetProbeHealth({
+    mapHealth,
+    summary: summary
+      ? {
+          ok: summary.ok,
+          warn: summary.warn,
+          down: summary.down,
+          unknown: summary.unknown,
+        }
+      : undefined,
+    incidentHealth,
+  });
+}

--- a/apps/ui/src/lib/metagraphed/queries.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.test.ts
@@ -447,6 +447,22 @@ describe("normalizeSubnetProfile", () => {
     expect(out.endpoints).toEqual([]);
     expect(out.candidate_surfaces).toEqual([]);
   });
+
+  it("does not invent HealthState from chain lifecycle status (#5332)", () => {
+    // Real profile payloads carry subnet.status = "active" (chain), not probe
+    // health. Mapping that through statusToHealth used to pin the masthead
+    // HealthPill on "unknown" while the incident strip correctly showed degraded.
+    const out = normalizeSubnetProfile(profilePayload, 7);
+    expect(out.health).toBeUndefined();
+  });
+
+  it("preserves probe health when the profile payload carries it (#5332)", () => {
+    const payload = {
+      ...profilePayload,
+      subnet: { ...profilePayload.subnet, health: "degraded" },
+    };
+    expect(normalizeSubnetProfile(payload, 7).health).toBe("warn");
+  });
 });
 
 describe("normalizeGap", () => {

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -4318,7 +4318,11 @@ export function normalizeSubnetProfile(raw: unknown, netuid: number): SubnetProf
   const repo = pickStr(links.source_repo, subnet.source_repo);
   const dashboard = pickStr(links.dashboard_url, subnet.dashboard_url);
 
-  const status = statusToHealth((subnet.status as string) ?? (profile.status as string));
+  // Probe health is overlay-only (`subnetHealthMapQuery` / `subnetHealthQuery`).
+  // Never map chain lifecycle `status` ("active") through statusToHealth — that
+  // collides with HealthState and left page pills stuck on "unknown" (#5332).
+  const probeHealth =
+    statusToHealth(subnet.health) ?? statusToHealth(profile.health) ?? statusToHealth(root.health);
 
   return {
     netuid: (subnet.netuid as number) ?? (profile.netuid as number) ?? netuid,
@@ -4377,7 +4381,9 @@ export function normalizeSubnetProfile(raw: unknown, netuid: number): SubnetProf
     surfaces: (root.surfaces as Surface[]) ?? [],
     endpoints: (root.endpoints as Endpoint[]) ?? [],
     candidate_surfaces: (root.candidate_surfaces as Candidate[]) ?? [],
-    health: status,
+    // Optional only when the profile payload itself carries probe health; page
+    // chrome should prefer useSubnetProbeHealth / resolveSubnetProbeHealth.
+    health: probeHealth,
   } as SubnetProfile;
 }
 
@@ -6642,10 +6648,18 @@ function normalizeIncident(raw: unknown): EndpointIncident {
     (isHealthState(i.state) ? i.state : undefined) ??
     "unknown";
   const ended = i.state === "resolved" || i.resolved_at;
+  const netuidRaw = i.netuid;
+  const netuid =
+    typeof netuidRaw === "number" && Number.isInteger(netuidRaw)
+      ? netuidRaw
+      : typeof netuidRaw === "string" && /^\d+$/.test(netuidRaw)
+        ? Number(netuidRaw)
+        : undefined;
   return {
     ...(i as object),
     id: asString(i.id) ?? "",
     endpoint_id: asString(i.endpoint_id),
+    netuid,
     state: stateHealth,
     message: asString(i.message) ?? asString(i.reason),
     started_at: asString(i.started_at) ?? asString(i.detected_at) ?? asString(i.observed_at),

--- a/apps/ui/src/lib/metagraphed/subnet-probe-health.test.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-probe-health.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  coerceNetuid,
+  healthSummaryToState,
+  netuidFromPathname,
+  resolveSubnetProbeHealth,
+  sameNetuid,
+  worstActiveIncidentHealth,
+} from "./subnet-probe-health";
+import type { EndpointIncident } from "./types";
+
+describe("healthSummaryToState", () => {
+  it("prefers down over warn/ok/unknown", () => {
+    expect(healthSummaryToState({ down: 1, warn: 2, ok: 3, unknown: 1 })).toBe("down");
+  });
+
+  it("prefers warn over ok/unknown when nothing is down", () => {
+    expect(healthSummaryToState({ down: 0, warn: 1, ok: 5, unknown: 0 })).toBe("warn");
+  });
+
+  it("returns ok when only ok surfaces are probed", () => {
+    expect(healthSummaryToState({ ok: 4, warn: 0, down: 0, unknown: 0 })).toBe("ok");
+  });
+
+  it("returns unknown for empty / missing counts", () => {
+    expect(healthSummaryToState(undefined)).toBe("unknown");
+    expect(healthSummaryToState({})).toBe("unknown");
+    expect(healthSummaryToState({ unknown: 2 })).toBe("unknown");
+  });
+});
+
+describe("resolveSubnetProbeHealth", () => {
+  it("prefers a concrete map health over the summary rollup", () => {
+    expect(
+      resolveSubnetProbeHealth({
+        mapHealth: "warn",
+        summary: { ok: 10, warn: 0, down: 0 },
+      }),
+    ).toBe("warn");
+  });
+
+  it("falls back to summary when the map has no entry", () => {
+    expect(
+      resolveSubnetProbeHealth({
+        mapHealth: undefined,
+        summary: { ok: 0, warn: 2, down: 0 },
+      }),
+    ).toBe("warn");
+  });
+
+  it("lets summary override a map 'unknown' when probes show a concrete state", () => {
+    expect(
+      resolveSubnetProbeHealth({
+        mapHealth: "unknown",
+        summary: { ok: 0, warn: 0, down: 1 },
+      }),
+    ).toBe("down");
+  });
+
+  it("falls back to active incident health when map+summary are unknown (#5332)", () => {
+    expect(
+      resolveSubnetProbeHealth({
+        mapHealth: "unknown",
+        summary: { ok: 0, warn: 0, down: 0 },
+        incidentHealth: "warn",
+      }),
+    ).toBe("warn");
+    expect(
+      resolveSubnetProbeHealth({
+        mapHealth: undefined,
+        incidentHealth: "down",
+      }),
+    ).toBe("down");
+  });
+
+  it("stays unknown when neither source has a concrete status", () => {
+    expect(resolveSubnetProbeHealth({})).toBe("unknown");
+    expect(resolveSubnetProbeHealth({ mapHealth: "unknown", summary: {} })).toBe("unknown");
+  });
+});
+
+describe("worstActiveIncidentHealth", () => {
+  const rows: EndpointIncident[] = [
+    { id: "a", netuid: 0, state: "warn", ended_at: null },
+    { id: "b", netuid: 0, state: "down", ended_at: null },
+    { id: "c", netuid: 1, state: "warn", ended_at: "2026-01-01T00:00:00Z" },
+    { id: "d", netuid: "43" as unknown as number, state: "warn", ended_at: null },
+  ];
+
+  it("returns the worst active incident for the asked netuid", () => {
+    expect(worstActiveIncidentHealth(rows, 0)).toBe("down");
+    expect(worstActiveIncidentHealth(rows, 1)).toBeUndefined();
+    expect(worstActiveIncidentHealth(rows, 43)).toBe("warn");
+  });
+});
+
+describe("sameNetuid / coerceNetuid", () => {
+  it("treats string and number netuids as equal", () => {
+    expect(sameNetuid(1, "1")).toBe(true);
+    expect(sameNetuid("0", 0)).toBe(true);
+    expect(sameNetuid(1, 2)).toBe(false);
+    expect(coerceNetuid("01")).toBe(1);
+  });
+});
+
+describe("netuidFromPathname", () => {
+  it("extracts the subnet id from a detail path", () => {
+    expect(netuidFromPathname("/subnets/1")).toBe(1);
+    expect(netuidFromPathname("/subnets/74")).toBe(74);
+  });
+
+  it("returns null off subnet detail routes", () => {
+    expect(netuidFromPathname("/subnets")).toBeNull();
+    expect(netuidFromPathname("/endpoints")).toBeNull();
+    expect(netuidFromPathname("/")).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/subnet-probe-health.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-probe-health.ts
@@ -1,0 +1,90 @@
+import type { EndpointIncident, HealthState, HealthSummary } from "./types";
+
+/**
+ * Authoritative subnet health for the UI: probe-derived status from
+ * `/api/v1/health` (per-subnet map), `/api/v1/subnets/{n}/health` (counts),
+ * and — when those are still unknown — active `/api/v1/endpoint-incidents` for
+ * that netuid (also probe-derived). Never invent HealthState from chain
+ * lifecycle `status` ("active") (#5332).
+ */
+
+export type SubnetProbeHealthCounts = Pick<HealthSummary, "ok" | "warn" | "down" | "unknown">;
+
+/** Worst-of rollup from per-surface probe counts (down > warn > ok > unknown). */
+export function healthSummaryToState(counts: SubnetProbeHealthCounts | undefined): HealthState {
+  if (!counts) return "unknown";
+  if ((counts.down ?? 0) > 0) return "down";
+  if ((counts.warn ?? 0) > 0) return "warn";
+  if ((counts.ok ?? 0) > 0) return "ok";
+  if ((counts.unknown ?? 0) > 0) return "unknown";
+  return "unknown";
+}
+
+/**
+ * Resolve the single canonical probe health for a subnet.
+ * Prefer the global health-map entry (same source as the /subnets table);
+ * fall back to rolling up the per-subnet health summary counts; then active
+ * endpoint incidents for that netuid when the rollup is still unknown.
+ */
+export function resolveSubnetProbeHealth(opts: {
+  mapHealth?: HealthState | null;
+  summary?: SubnetProbeHealthCounts | null;
+  incidentHealth?: HealthState | null;
+}): HealthState {
+  if (opts.mapHealth === "ok" || opts.mapHealth === "warn" || opts.mapHealth === "down") {
+    return opts.mapHealth;
+  }
+  if (opts.mapHealth === "unknown" || opts.mapHealth == null) {
+    const fromSummary = healthSummaryToState(opts.summary ?? undefined);
+    if (fromSummary !== "unknown") return fromSummary;
+    if (opts.incidentHealth === "down" || opts.incidentHealth === "warn") {
+      return opts.incidentHealth;
+    }
+    return "unknown";
+  }
+  return healthSummaryToState(opts.summary ?? undefined);
+}
+
+/** Coerce loose API netuid values so `"1" === 1` comparisons never miss. */
+export function coerceNetuid(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0) return value;
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    const n = Number(value);
+    return Number.isInteger(n) && n >= 0 ? n : null;
+  }
+  return null;
+}
+
+export function sameNetuid(a: unknown, b: unknown): boolean {
+  const left = coerceNetuid(a);
+  const right = coerceNetuid(b);
+  return left != null && right != null && left === right;
+}
+
+/**
+ * Worst active endpoint-incident severity for one netuid (down > warn).
+ * Incidents use the normalised UI state (`ok|warn|down|unknown`) after
+ * {@link normalizeIncident}; tolerate a few raw synonyms too.
+ */
+export function worstActiveIncidentHealth(
+  incidents: EndpointIncident[] | undefined,
+  netuid: number,
+): HealthState | undefined {
+  if (!incidents?.length) return undefined;
+  let worst: HealthState | undefined;
+  for (const i of incidents) {
+    if (!sameNetuid(i.netuid, netuid)) continue;
+    if (i.ended_at) continue;
+    const state = String(i.state ?? "").toLowerCase();
+    if (state === "down" || state === "failed") return "down";
+    if (state === "warn" || state === "degraded") worst = "warn";
+  }
+  return worst;
+}
+
+/** Parse `/subnets/{netuid}` from a pathname; null when not on a subnet page. */
+export function netuidFromPathname(pathname: string): number | null {
+  const m = /^\/subnets\/(\d+)(?:\/|$)/.exec(pathname);
+  if (!m) return null;
+  return coerceNetuid(m[1]);
+}


### PR DESCRIPTION
## Summary
- Make probe-derived subnet health the single page authority: `/api/v1/health` map → `/api/v1/subnets/{n}/health` counts → active endpoint-incidents for that netuid when still unknown (never chain lifecycle `status` → `Unknown`).
- Point the masthead `HealthPill` at that source (visible on mobile too); remove the duplicate pill from Integration Readiness; omit the viewed subnet from the incident strip so it cannot disagree with the masthead.
- Harden incident `netuid` matching (`sameNetuid` / coerce) so string/number API values cannot leave `SNn DEGRADED` stuck on `/subnets/n`.

Closes #5332

## Test plan
- [x] `/subnets/43`: before shows masthead `Unknown` + often `SN43 DEGRADED`; after shows concrete probe pill (`OK`/`Warn`) and strip does not claim SN43
- [ ] Hard-refresh before/after servers; confirm Integration Readiness has no health pill
- [x] `npm test --workspace=apps/ui -- --run src/lib/metagraphed/subnet-probe-health.test.ts src/lib/metagraphed/queries.test.ts`
- [x] `npm run typecheck --workspace=apps/ui`
- [ ] CI `ui` job green (lint + format + e2e + build)

## Screenshots
Capture `/subnets/43` only — viewport sizes below, not full page. Keyword: masthead pill `Unknown` → probe state; banner must not say `SN43 DEGRADED` on after.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/8f71dfc6-4bf5-4444-9415-2f0eb8856927" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/d30d98ab-4fec-4a96-8027-b307d4ae1f78" /> |
| Desktop · Dark   | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/b4eae85e-41d2-4fad-9940-9d5b7ecab6ad" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/5357126f-1b3c-4ad7-9ec2-41d10fbf0950" /> |
| Tablet · Light   | <img width="1177" height="760" alt="image" src="https://github.com/user-attachments/assets/a2211125-9732-42d4-94fe-6527dde6f703" /> | <img width="1177" height="760" alt="image" src="https://github.com/user-attachments/assets/39b37616-7154-4483-9554-9e71c5913da8" /> |
| Tablet · Dark    | <img width="1177" height="760" alt="image" src="https://github.com/user-attachments/assets/76aa6b66-cbf1-4559-a09e-19fb98f61f8f" /> | <img width="1177" height="760" alt="image" src="https://github.com/user-attachments/assets/0282a06a-d920-48ba-9289-8a6f60597a25" /> |
| Mobile · Light   | <img width="341" height="755" alt="image" src="https://github.com/user-attachments/assets/ad51589f-0eff-403e-ac35-cbf99a25aaca" /> | <img width="341" height="755" alt="image" src="https://github.com/user-attachments/assets/ef05b2c8-bb58-47f6-a066-98b524b39c2a" /> |
| Mobile · Dark    | <img width="341" height="755" alt="image" src="https://github.com/user-attachments/assets/5c020f2f-8389-437c-bf07-65800a4c6fb8" /> | <img width="341" height="755" alt="image" src="https://github.com/user-attachments/assets/d76f2550-f77a-40cc-ba25-846a3ef58288" /> |