### PR TITLE
fix(ui): surface coverage-matrix gap count on narrow viewports

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
@@ -162,6 +162,18 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
                     <span className="font-mono text-[10px] text-ink-muted">SN{r.netuid}</span>
                     <span className="truncate max-w-[160px]">{r.name}</span>
                   </Link>
+                  {/* The kind columns scroll off-screen on narrow viewports, so a
+                      mobile user can't see the red "missing" cells that are the
+                      point of this widget. Surface the per-subnet gap count here,
+                      in the always-visible sticky column (#5310). */}
+                  <span
+                    className={classNames(
+                      "mt-0.5 block text-[10px] tabular-nums sm:hidden",
+                      r.missingCount > 0 ? "text-health-down" : "text-health-ok",
+                    )}
+                  >
+                    {r.missingCount > 0 ? `${r.missingCount} missing` : "complete"}
+                  </span>
                 </td>
                 {KINDS.map((k) => {
                   const cell = r.cells[k];


### PR DESCRIPTION
## Summary

The `/gaps` coverage matrix (`apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx`) renders a Subnet x 9-kind grid inside an `overflow-x-auto` container with a sticky first column. At 375px only the first four kind columns (docs/repo/openapi/endpoint) fit on screen, and those cells are usually green, so a mobile user read apparent full coverage. The dashboard/data/sdk/example/rpc columns -- the actual gaps this widget exists to show -- were scrolled off-screen with no fade, chevron, or scroll hint, so hidden red cells looked like no cells.

## What Changed

Added a mobile-only summary line inside the sticky first column, which stays visible at every width: `N missing` (red) when the row has gaps, `complete` (green) when it doesn't. It reuses the row's existing `missingCount`, so no new data or computation. The line is `sm:hidden`, so the full 9-column grid is untouched at `sm` and up. Chose the compact summary (deliverable option b) over a scroll-cue affordance because it answers the user's actual question -- does this subnet have gaps -- without requiring a horizontal scroll to find out.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Fixes #5310`) -- required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A -- no generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A -- frontend-only change under `apps/ui/`, no contract change.)

## Validation

Frontend-only change; the backend registry validators do not apply. `npm test` passes with no new failures against main.

## Notes

This is a visual change to `apps/ui/`, so per the repo's contribution rules it needs a before/after screenshot table and a manual review at 375px before merge -- hence the draft. The behavior to confirm: at 375px each subnet row shows its missing-count next to the name without scrolling; at `>=640px` the row is unchanged.

Fixes #5310