### PR TITLE
fix(ui): dedupe most-active accounts on /accounts index

### DIFF
--- a/apps/ui/src/components/metagraphed/top-active-account-row.tsx
+++ b/apps/ui/src/components/metagraphed/top-active-account-row.tsx
@@ -1,0 +1,53 @@
+import { Link } from "@tanstack/react-router";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { formatNumber } from "@/lib/metagraphed/format";
+import {
+  TOP_ACTIVE_ACCOUNTS_LIST_CLASS,
+  TOP_ACTIVE_ACCOUNT_LINK_CLASS,
+  formatTopActiveShare,
+  type TopActiveAccountRow,
+} from "./top-active-accounts-ranking";
+
+type TopActiveAccountRowLinkProps = {
+  row: TopActiveAccountRow;
+};
+
+/**
+ * Single ranked account row — account short-hash link + tx count + cohort share.
+ * Replaces the duplicated BarMini + pill list pair on `/accounts` (#5315).
+ */
+export function TopActiveAccountRowLink({ row }: TopActiveAccountRowLinkProps) {
+  const label = shortHash(row.ss58) ?? row.ss58;
+  return (
+    <Link
+      to="/accounts/$ss58"
+      params={{ ss58: row.ss58 }}
+      title={row.ss58}
+      className={TOP_ACTIVE_ACCOUNT_LINK_CLASS}
+      data-testid="top-active-account-row"
+      preload="intent"
+    >
+      <span className="min-w-0 truncate">{label}</span>
+      <span className="shrink-0 tabular-nums text-ink-muted">
+        {formatNumber(row.txCount)} tx
+        <span className="ml-2 text-ink-muted/70">{formatTopActiveShare(row.shareOfTop)}</span>
+      </span>
+    </Link>
+  );
+}
+
+type TopActiveAccountsListProps = {
+  rows: TopActiveAccountRow[];
+};
+
+export function TopActiveAccountsList({ rows }: TopActiveAccountsListProps) {
+  return (
+    <ul className={TOP_ACTIVE_ACCOUNTS_LIST_CLASS} data-testid="top-active-accounts-list">
+      {rows.map((row) => (
+        <li key={row.ss58}>
+          <TopActiveAccountRowLink row={row} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/ui/src/components/metagraphed/top-active-accounts-ranking.test.ts
+++ b/apps/ui/src/components/metagraphed/top-active-accounts-ranking.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  TOP_ACTIVE_ACCOUNTS_LIMIT,
+  TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS,
+  buildTopActiveAccountRows,
+  formatTopActiveShare,
+} from "./top-active-accounts-ranking";
+
+describe("top-active-accounts ranking (#5315)", () => {
+  const sample = [
+    { signer: "5AAA", tx_count: 100 },
+    { signer: "5BBB", tx_count: 50 },
+    { signer: "5CCC", tx_count: 50 },
+    { signer: "5DDD", tx_count: 10 },
+  ];
+
+  it("exposes the default limit and activity window", () => {
+    expect(TOP_ACTIVE_ACCOUNTS_LIMIT).toBe(12);
+    expect(TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS).toBe(7);
+  });
+
+  it("slices to the requested limit and computes cohort share", () => {
+    const rows = buildTopActiveAccountRows(sample, 3);
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toEqual({ ss58: "5AAA", txCount: 100, shareOfTop: 0.5 });
+    expect(rows[1].shareOfTop).toBeCloseTo(0.25);
+    expect(rows[2].shareOfTop).toBeCloseTo(0.25);
+  });
+
+  it("returns an empty list when there are no signers", () => {
+    expect(buildTopActiveAccountRows([])).toEqual([]);
+  });
+
+  it("clamps a zero limit to an empty slice", () => {
+    expect(buildTopActiveAccountRows(sample, 0)).toEqual([]);
+  });
+
+  it("formats shares as compact percentages", () => {
+    expect(formatTopActiveShare(0)).toBe("0%");
+    expect(formatTopActiveShare(0.5)).toBe("50%");
+    expect(formatTopActiveShare(1)).toBe("100%");
+    expect(formatTopActiveShare(Number.NaN)).toBe("0%");
+  });
+});

--- a/apps/ui/src/components/metagraphed/top-active-accounts-ranking.ts
+++ b/apps/ui/src/components/metagraphed/top-active-accounts-ranking.ts
@@ -1,0 +1,58 @@
+/**
+ * Ranking helpers for the Accounts index "Most active accounts" widget (#5315).
+ *
+ * Previously the page rendered both a `BarMini` chart and an identical pill
+ * list of the same signers / tx counts. Keep a single navigable list so the
+ * ranking is shown once with account + tx count clearly linked.
+ *
+ * @see https://github.com/JSONbored/metagraphed/issues/5315
+ */
+
+/** How many top accounts the activity ranking shows. */
+export const TOP_ACTIVE_ACCOUNTS_LIMIT = 12;
+
+/** Window the `/api/v1/chain/signers` ranking covers (matches the query default). */
+export const TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS = 7;
+
+export type TopActiveAccountInput = {
+  signer: string;
+  tx_count: number;
+};
+
+export type TopActiveAccountRow = {
+  ss58: string;
+  txCount: number;
+  /** Share of the top-N cohort's tx total (0–1); useful for optional progress UI. */
+  shareOfTop: number;
+};
+
+/**
+ * Take the top `limit` signers (already ranked by tx_count desc from the API)
+ * and attach cohort share so the list can optionally show intensity without a
+ * second chart of the same ranking.
+ */
+export function buildTopActiveAccountRows(
+  signers: readonly TopActiveAccountInput[],
+  limit: number = TOP_ACTIVE_ACCOUNTS_LIMIT,
+): TopActiveAccountRow[] {
+  const top = signers.slice(0, Math.max(0, limit));
+  const total = top.reduce((sum, s) => sum + Math.max(0, s.tx_count), 0);
+  return top.map((s) => ({
+    ss58: s.signer,
+    txCount: s.tx_count,
+    shareOfTop: total > 0 ? s.tx_count / total : 0,
+  }));
+}
+
+/** Format a 0–1 share as a compact percentage for dense mono UI. */
+export function formatTopActiveShare(share: number): string {
+  if (!Number.isFinite(share) || share <= 0) return "0%";
+  if (share >= 0.995) return "100%";
+  return `${Math.round(share * 100)}%`;
+}
+
+/** Layout class tokens for the ranked list shell. */
+export const TOP_ACTIVE_ACCOUNTS_LIST_CLASS = "flex flex-col gap-1.5";
+
+export const TOP_ACTIVE_ACCOUNT_LINK_CLASS =
+  "group flex w-full items-center justify-between gap-3 rounded border border-border bg-paper/40 px-3 py-2 font-mono text-[11px] text-ink-strong hover:border-ink/30 hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 min-h-11";

--- a/apps/ui/src/components/metagraphed/top-active-accounts.tsx
+++ b/apps/ui/src/components/metagraphed/top-active-accounts.tsx
@@ -1,0 +1,29 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { chainSignersQuery } from "@/lib/metagraphed/queries";
+import { TopActiveAccountsList } from "./top-active-account-row";
+import {
+  TOP_ACTIVE_ACCOUNTS_LIMIT,
+  buildTopActiveAccountRows,
+} from "./top-active-accounts-ranking";
+
+/**
+ * Top accounts ranked by extrinsics signed in the last 7 days (#5315).
+ *
+ * Shown once as a navigable list (account + tx count + share of the top-N
+ * cohort). The previous BarMini + identical pill list pairing was removed so
+ * the ranking is not duplicated across two visual forms.
+ */
+export function TopActiveAccounts() {
+  const signers = useSuspenseQuery(chainSignersQuery()).data.data.signers;
+  const rows = buildTopActiveAccountRows(signers, TOP_ACTIVE_ACCOUNTS_LIMIT);
+
+  if (rows.length === 0) {
+    return (
+      <p className="font-mono text-[12px] text-ink-muted">
+        No account activity in this window yet.
+      </p>
+    );
+  }
+
+  return <TopActiveAccountsList rows={rows} />;
+}

--- a/apps/ui/src/routes/accounts.index.tsx
+++ b/apps/ui/src/routes/accounts.index.tsx
@@ -1,16 +1,14 @@
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Suspense, useState } from "react";
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { Search } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { PageHero, BarMini, type BarMiniDatum } from "@jsonbored/ui-kit";
+import { TopActiveAccounts } from "@/components/metagraphed/top-active-accounts";
+import { TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS } from "@/components/metagraphed/top-active-accounts-ranking";
+import { PageHero } from "@jsonbored/ui-kit";
 import { isValidSs58 } from "@/lib/metagraphed/accounts";
-import { chainSignersQuery } from "@/lib/metagraphed/queries";
-import { shortHash } from "@/lib/metagraphed/blocks";
-import { formatNumber } from "@/lib/metagraphed/format";
 
 export const Route = createFileRoute("/accounts/")({
   head: () => ({
@@ -31,57 +29,6 @@ export const Route = createFileRoute("/accounts/")({
   }),
   component: AccountsPage,
 });
-
-/** How many top accounts the activity ranking shows. */
-const TOP_ACCOUNTS = 12;
-/** Window the `/api/v1/chain/signers` ranking covers (matches the query default). */
-const ACTIVITY_WINDOW_DAYS = 7;
-
-/**
- * Top accounts ranked by extrinsics signed in the last 7 days, sourced from the
- * same `/api/v1/chain/signers` feed the explorer's "Most active accounts" table
- * uses — surfaced here as a `BarMini` ranking so the accounts index opens on a
- * live leaderboard instead of a blank lookup box. Each account is a link through
- * to its detail page.
- */
-function TopActiveAccounts() {
-  const signers = useSuspenseQuery(chainSignersQuery()).data.data.signers;
-  const top = signers.slice(0, TOP_ACCOUNTS);
-
-  if (top.length === 0) {
-    return (
-      <p className="font-mono text-[12px] text-ink-muted">
-        No account activity in this window yet.
-      </p>
-    );
-  }
-
-  const bars: BarMiniDatum[] = top.map((s) => ({
-    label: shortHash(s.signer) ?? s.signer,
-    value: s.tx_count,
-  }));
-
-  return (
-    <>
-      <BarMini data={bars} />
-      <ul className="mt-4 flex flex-wrap gap-2">
-        {top.map((s) => (
-          <li key={s.signer}>
-            <Link
-              to="/accounts/$ss58"
-              params={{ ss58: s.signer }}
-              title={s.signer}
-              className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-1 font-mono text-[10px] text-ink-strong hover:border-ink/30 hover:text-accent"
-            >
-              {shortHash(s.signer) ?? s.signer}
-              <span className="tabular-nums text-ink-muted">{formatNumber(s.tx_count)} tx</span>
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </>
-  );
-}
 
 function AccountsPage() {
   const navigate = useNavigate();
@@ -141,13 +88,16 @@ function AccountsPage() {
             : "Paste a hotkey or coldkey ss58 address to view its activity."}
         </p>
       </form>
-      <section className="mx-auto mt-10 w-full max-w-2xl rounded-lg border border-border bg-card p-5">
+      <section
+        className="mx-auto mt-10 w-full max-w-2xl rounded-lg border border-border bg-card p-5"
+        data-testid="top-active-accounts-section"
+      >
         <h2 className="mb-1 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
           Most active accounts
         </h2>
         <p className="mb-4 font-mono text-[11px] text-ink-muted">
-          Ranked by extrinsics signed on-chain in the last {ACTIVITY_WINDOW_DAYS} days — jump
-          straight to an account below.
+          Ranked by extrinsics signed on-chain in the last {TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS} days —
+          jump straight to an account below.
         </p>
         <QueryErrorBoundary>
           <Suspense fallback={<Skeleton className="h-40 w-full" />}>

--- a/apps/ui/tests/e2e/capture-top-active-accounts-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-top-active-accounts-screenshots.mjs
@@ -1,0 +1,85 @@
+/**
+ * Capture /accounts "Most active accounts" screenshots for #5315.
+ *
+ * Scrolls the ranking section into the fixed viewport (3 sizes × 2 themes).
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8101 VARIANT=before node tests/e2e/capture-top-active-accounts-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8102 VARIANT=after  node tests/e2e/capture-top-active-accounts-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/top-active-accounts-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8102";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const VIEWPORT_FILTER = process.env.VIEWPORT_FILTER;
+const ALL_VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const VIEWPORTS = VIEWPORT_FILTER
+  ? ALL_VIEWPORTS.filter((v) => v.name === VIEWPORT_FILTER)
+  : ALL_VIEWPORTS;
+const THEMES = ["light", "dark"];
+const SCROLL_OFFSET_PX = 96;
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function openAccountsRanking(page) {
+  await page.goto(`${BASE_URL}/accounts`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 8000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+
+  const heading = page.getByRole("heading", { name: "Most active accounts" });
+  await heading.waitFor({ state: "visible", timeout: 90_000 });
+
+  await page.evaluate((offset) => {
+    const headings = [...document.querySelectorAll("h2")];
+    const target = headings.find((h) => h.textContent?.trim() === "Most active accounts");
+    if (!target) return;
+    const top = target.getBoundingClientRect().top + window.scrollY - offset;
+    window.scrollTo({ top: Math.max(0, top), behavior: "instant" });
+  }, SCROLL_OFFSET_PX);
+
+  await page.waitForTimeout(300);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await setTheme(page, theme);
+      await openAccountsRanking(page);
+      const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+      await context.close();
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Remove the redundant `BarMini` on `/accounts` that restated the same top-12 signers as the pill list beneath it (#5315).
- Keep a single navigable ranking (account short-hash + tx count + share of the top-N cohort) extracted into `TopActiveAccounts` / ranking helpers.
- Add unit tests and a Playwright capture script for Path C2 screenshots.

Closes #5315

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-before-desktop-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-before-desktop-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-after-desktop-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-before-desktop-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-before-desktop-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-after-desktop-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-before-tablet-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-before-tablet-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-after-tablet-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-before-tablet-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-before-tablet-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-after-tablet-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-before-mobile-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-before-mobile-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-after-mobile-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-before-mobile-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-before-mobile-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-after-mobile-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5315-after-mobile-dark.png)<br><sub>after</sub> |

## Test plan

- [x] `npm test --workspace=apps/ui` (715 tests, including 5 new ranking helpers)
- [x] `npm run typecheck --workspace=apps/ui`
- [x] Changed-file eslint + prettier pass (LF-normalized)
- [ ] CI: `lint`, `format:check`, `test`, `test:e2e`, `build`, codecov