### PR TITLE
fix(ui): make the schemas drift-activity list a capped, readable digest

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
@@ -12,6 +12,12 @@ interface Props {
   fromPath: string;
 }
 
+// #5314: the schema-drift matrix below is the primary, complete view, so this
+// list is a "recent changes" digest — show only the top handful of drifting
+// schemas by default (highest change-weight, most recent) with an opt-in to
+// reveal the rest, rather than dumping every drifting row.
+const DRIFT_DIGEST_LIMIT = 10;
+
 /**
  * Compact, scannable list of schema drift activity. Replaces the pill-row
  * ribbon — drifting schemas sit on top with a change-weight bar, additive /
@@ -22,6 +28,7 @@ interface Props {
 export function DriftActivity({ schemas, fromPath }: Props) {
   const navigate = useNavigate({ from: fromPath as "/schemas" });
   const [scope, setScope] = useState<"drifting" | "all">("drifting");
+  const [showAllDrift, setShowAllDrift] = useState(false);
 
   const { drifting, stable } = useMemo(() => {
     const drifting = schemas
@@ -34,6 +41,8 @@ export function DriftActivity({ schemas, fromPath }: Props) {
   }, [schemas]);
 
   const visibleStable = scope === "all" ? stable : [];
+  const visibleDrifting = showAllDrift ? drifting : drifting.slice(0, DRIFT_DIGEST_LIMIT);
+  const hiddenDriftCount = drifting.length - visibleDrifting.length;
   const total = schemas.length;
 
   if (total === 0) {
@@ -116,11 +125,22 @@ export function DriftActivity({ schemas, fromPath }: Props) {
           />
         </div>
       ) : (
-        <ul className="divide-y divide-border/60">
-          {drifting.map((s) => (
-            <DriftRow key={s.id} schema={s} onClick={() => openDrift(s.id)} />
-          ))}
-        </ul>
+        <>
+          <ul className="divide-y divide-border/60">
+            {visibleDrifting.map((s) => (
+              <DriftRow key={s.id} schema={s} onClick={() => openDrift(s.id)} />
+            ))}
+          </ul>
+          {drifting.length > DRIFT_DIGEST_LIMIT ? (
+            <button
+              type="button"
+              onClick={() => setShowAllDrift((v) => !v)}
+              className="flex w-full items-center justify-center gap-1 border-t border-border/60 px-4 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:bg-surface hover:text-ink-strong"
+            >
+              {showAllDrift ? "Show recent only" : `Show all ${drifting.length} drifting`}
+            </button>
+          ) : null}
+        </>
       )}
 
       {/* Stable list (toggled) */}
@@ -164,7 +184,7 @@ function DriftRow({ schema, onClick }: { schema: SchemaInfo; onClick: () => void
         <WeightBar weight={w} tone="warn" />
         <div className="min-w-0">
           <div className="flex items-center gap-2">
-            <span className="truncate font-display text-[13px] font-medium text-ink-strong">
+            <span className="min-w-0 break-words font-display text-[13px] font-medium text-ink-strong">
               {label}
             </span>
             {schema.netuid != null ? (

--- a/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
@@ -42,7 +42,6 @@ export function DriftActivity({ schemas, fromPath }: Props) {
 
   const visibleStable = scope === "all" ? stable : [];
   const visibleDrifting = showAllDrift ? drifting : drifting.slice(0, DRIFT_DIGEST_LIMIT);
-  const hiddenDriftCount = drifting.length - visibleDrifting.length;
   const total = schemas.length;
 
   if (total === 0) {


### PR DESCRIPTION
Closes #5314

## What

The Schemas page's "Drift activity" list (`analytics/drift-activity.tsx`) dumped all 38 drifting schemas with names CSS-truncated to unreadable fragments ("sn-1-ape…") on mobile — directly above the Schema drift matrix that already restates the same drift-status data as the primary, complete view.

- **Cap the drifting list to a ~10-item digest** by default (`DRIFT_DIGEST_LIMIT = 10`, top change-weight / most-recent), with a **"Show all N drifting"** toggle to expand.
- **Fix the truncated names** — the drift-row name now uses `break-words` instead of `truncate`, so it reads fully at every width (visible on mobile, where the column is narrow).
- The `schema-drift-matrix` remains the primary, complete view (unchanged).

Single file, +25/−4.

## Verify

`lint` (0 errors) · `format:check` · `typecheck` · `test` (714 pass) · `build` — all green.

## Screenshots

The name-truncation fix is visible at **mobile** width (the desktop column is wide enough that names weren't truncated either way); the cap is a behavioral change shown by the shorter list + toggle.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5314-before-mobile-light.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5314-after-mobile-light.png" width="300"> |
| Mobile · Dark | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5314-before-mobile-dark.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5314-after-mobile-dark.png" width="300"> |
| Tablet · Light | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5314-before-tablet-light.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5314-after-tablet-light.png" width="300"> |
| Tablet · Dark | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5314-before-tablet-dark.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5314-after-tablet-dark.png" width="300"> |
| Desktop · Light | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5314-before-desktop-light.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5314-after-desktop-light.png" width="300"> |
| Desktop · Dark | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5314-before-desktop-dark.png" width="300"> | <img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/sn5314-after-desktop-dark.png" width="300"> |
