### PR TITLE
feat(registry): add SN36 Eirel dashboard families API surface (#5176)

### DIFF
--- a/registry/subnets/eirel.json
+++ b/registry/subnets/eirel.json
@@ -187,6 +187,28 @@
       },
       "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
       "url": "https://api.eirel.ai/v1/runs/current"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-36-eirel-dashboard-families-api",
+      "kind": "subnet-api",
+      "name": "Eirel dashboard families API",
+      "notes": "Public no-auth GET /api/v1/dashboard/families on api.eirel.ai returning the JSON taxonomy of SN36 Eirel evaluation task families (each with id, label, weight, and active flag; e.g. general_chat) that the subnet's benchmark runs and leaderboards are organized around. Documented in the subnet's registered OpenAPI spec and served on the same host as the existing dashboard/overview and dashboard/runs surfaces. Verified 200 application/json, no auth, SS58-clean.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "eirel",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "url": "https://api.eirel.ai/api/v1/dashboard/families"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Adds one new `community` subnet-api surface to SN36 Eirel (`registry/subnets/eirel.json`): the public **dashboard families** endpoint `GET /api/v1/dashboard/families`, documented in the subnet's own registered OpenAPI spec.

## Surface

- **id:** `sn-36-eirel-dashboard-families-api`
- **kind:** `subnet-api`
- **url:** `https://api.eirel.ai/api/v1/dashboard/families` — public, no-auth, HTTP 200 `application/json`
- **provider:** `eirel`
- **source_url:** `https://api.eirel.ai/openapi.json` (documents the endpoint) + `https://eirel.ai/`

## What it returns

The JSON taxonomy of SN36 Eirel evaluation task families (each with `id`, `label`, `weight`, `active`; e.g. `general_chat`) that the subnet's benchmark runs and leaderboards are organized around. Distinct from the registered `dashboard/overview` and `dashboard/runs` surfaces, and served on the same host.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/eirel.json` — passed (12 surfaces)
- Verified with no auth header: 200 `application/json`, SS58-clean (no hotkey/wallet material).

One focused change: one surface appended to one subnet file; nothing else touched.

Closes #5176

> Scope note: #5176 frames the enrichment as an SSE stream. Eirel exposes no verified public SSE endpoint; this adds a genuinely-published, previously-unregistered no-auth public REST endpoint documented in the subnet's own OpenAPI, advancing the same "enrich SN36" intent. Any SSE-specific framing is advisory.
