### PR TITLE
fix(ui): give error/empty-state action buttons a min touch height

### DIFF
--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -79,7 +79,7 @@ export function ErrorState({
         {onRetry ? (
           <button
             onClick={onRetry}
-            className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
+            className="inline-flex min-h-9 items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
           >
             <RefreshCw className="size-3" /> Retry
           </button>
@@ -89,7 +89,7 @@ export function ErrorState({
             href={safeUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-muted hover:border-ink/30 hover:text-ink-strong"
+            className="inline-flex min-h-9 items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-muted hover:border-ink/30 hover:text-ink-strong"
           >
             <ExternalLinkIcon className="size-3" /> Open API URL
           </a>
@@ -148,7 +148,7 @@ export function EmptyState({
         <a
           href={actionHref}
           {...(action.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-          className="mt-3 inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
+          className="mt-3 inline-flex min-h-9 items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
         >
           {action.label}
           {action.external ? <ExternalLinkIcon className="size-3" /> : null}


### PR DESCRIPTION
## Summary

`apps/ui/src/components/metagraphed/states.tsx` sized the `ErrorState` **Retry** / **"Open API URL"** buttons and the `EmptyState` action link purely by `px-2.5 py-1` around `text-[11px]`, with **no min-height** — a ~24px tap target, shorter than the taller pill `TableState` (`@jsonbored/ui-kit`) uses and than the app's other row-action buttons, which standardize on `min-h-9`. This is the affordance shown site-wide whenever a panel's data fetch fails.

Add `min-h-9` to the three buttons (states.tsx:82, 92, 151) so they meet a comfortable minimum touch height, matching the established row-action pattern. The glyph and padding are unchanged — only the button's minimum height grows.

`eslint` · `prettier --check` · `typecheck` — clean.

Closes #5338

## Template Used

- Backend/code change (`apps/ui` presentational component)

## Screenshots

`ErrorState` renders only on a live data-fetch failure, so it's shown here as a faithful standalone render of the exact component markup (title + `Retry` + `Open API URL`). The dashed outline is **illustrative only** — it reveals each button's touch height so the ~24px → 36px (`min-h-9`) change is visible; the glyphs and padding are unchanged.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5338-mobile-dark-after.png)<br><sub>after</sub> |
