### PR TITLE
feat(registry): add SN12 ComputeHorde map contract ABI data-artifact surface (#4009)

### DIFF
--- a/registry/subnets/compute-horde.json
+++ b/registry/subnets/compute-horde.json
@@ -151,6 +151,31 @@
         "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/validator/app/src/compute_horde_validator/validator/collateral_abi.json"
       ],
       "url": "https://raw.githubusercontent.com/backend-developers-ltd/ComputeHorde/master/validator/app/src/compute_horde_validator/validator/collateral_abi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-12-computehorde-map-abi",
+      "kind": "data-artifact",
+      "name": "ComputeHorde map contract ABI",
+      "notes": "Public no-auth machine-readable JSON ABI for ComputeHorde's on-chain Map smart contract, committed in the official backend-developers-ltd/ComputeHorde source repository (whose README declares \"Subnet 12 of Bittensor\") at compute_horde/compute_horde/smart_contracts/abi/map_abi.json. Describes the contract's constructor and function/event interface used by the SN12 smart-contract layer. Distinct from the collateral contract ABI already registered — a separate on-chain contract's machine-readable interface. Pinned to an immutable commit. Verified 200, SS58-clean.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "compute-horde",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/ComputeHorde/blob/2ab13d1b77c63d4f46eb1e5a7b65e51751de16d5/compute_horde/compute_horde/smart_contracts/abi/map_abi.json",
+        "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/backend-developers-ltd/ComputeHorde/2ab13d1b77c63d4f46eb1e5a7b65e51751de16d5/compute_horde/compute_horde/smart_contracts/abi/map_abi.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds one new `community` data-artifact surface to SN12 ComputeHorde (`registry/subnets/compute-horde.json`): the machine-readable **Map contract ABI** at `compute_horde/compute_horde/smart_contracts/abi/map_abi.json` in the official repository.

This is distinct from the collateral contract ABI already registered — a separate on-chain contract's interface.

## Surface

- **id:** `sn-12-computehorde-map-abi`
- **kind:** `data-artifact`
- **url:** `https://raw.githubusercontent.com/backend-developers-ltd/ComputeHorde/2ab13d1b77c63d4f46eb1e5a7b65e51751de16d5/compute_horde/compute_horde/smart_contracts/abi/map_abi.json` — public, no-auth, HTTP 200, pinned to an immutable commit
- **provider:** `compute-horde`
- **source_url:** the same file's GitHub blob at the pinned commit + the repo README (declares "Subnet 12 of Bittensor")

## What it is

The Solidity ABI (constructor + function/event interface) of ComputeHorde's on-chain `Map` smart contract, committed in `backend-developers-ltd/ComputeHorde`, the subnet's registered `source_repo`. A standalone machine-readable reference for the SN12 smart-contract layer, complementing the already-registered collateral-contract ABI.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/compute-horde.json` — passed (7 surfaces)
- Verified with no auth header: 200, SS58-clean.

One focused change: one surface appended to one subnet file; nothing else touched.

Closes #4009

> Scope note: #4009 frames the enrichment as an OpenAPI/Swagger spec. ComputeHorde's Facilitator API requires hotkey-signed auth beyond the public nonce endpoint and serves no verified public OpenAPI document; this adds a genuinely-published machine-readable on-chain contract ABI from the official repo, advancing the same "enrich SN12" intent. Any OpenAPI-specific framing is advisory.
