### PR TITLE
fix(ui): stop CopyableCode overflowing off-screen on mobile (#5308)

### DIFF
--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -261,7 +261,7 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
           </FieldRow>
           <FieldRow label="Author">
             {block.author ? (
-              <CopyableCode value={block.author} truncate={false} />
+              <CopyableCode value={block.author} truncate={false} className="max-w-full" />
             ) : (
               <span className="text-ink-muted">—</span>
             )}

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -246,7 +246,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
             </span>
           </FieldRow>
           <FieldRow label="Call">
-            <span className="font-mono text-sm text-ink-strong">
+            <span className="font-mono text-sm text-ink-strong break-all">
               {extrinsicCall(extrinsic.call_module, extrinsic.call_function)}
             </span>
           </FieldRow>

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -218,7 +218,11 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
         <dl className="rounded border border-border bg-card divide-y divide-border">
           <FieldRow label="Extrinsic hash">
             {extrinsic.extrinsic_hash ? (
-              <CopyableCode value={extrinsic.extrinsic_hash} truncate={false} />
+              <CopyableCode
+                value={extrinsic.extrinsic_hash}
+                truncate={false}
+                className="max-w-full"
+              />
             ) : (
               <span className="text-ink-muted">—</span>
             )}
@@ -248,7 +252,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
           </FieldRow>
           <FieldRow label="Signer">
             {extrinsic.signer ? (
-              <CopyableCode value={extrinsic.signer} truncate={false} />
+              <CopyableCode value={extrinsic.signer} truncate={false} className="max-w-full" />
             ) : (
               <span className="text-ink-muted">—</span>
             )}

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -241,8 +241,8 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
               Cross-subnet performance, nominators, and staking history for one Bittensor validator
               hotkey.
             </span>
-            <span className="inline-flex max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
-              <CopyableCode value={hotkey} truncate={false} />
+            <span className="inline-flex max-w-full min-w-0 rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
+              <CopyableCode value={hotkey} truncate={false} className="max-w-full" />
             </span>
           </span>
         }


### PR DESCRIPTION
## Summary
`CopyableCode` renders as an `inline-flex` button that sizes to its content. With `truncate={false}` (the `sm:break-all` wrap mode) and **no width-constraining class**, the button grows to the full length of a 48–64-char hash/address. On a 375px viewport the box runs off the right screen edge — the value is cut mid-string with **no ellipsis and the copy button pushed off-screen (unreachable)**. It's clipped by the body, so there's no scrollbar to hint at it — it just silently overflows off-screen.

`EndpointSnippet` already avoids this by passing a width class (`className="w-full"`); the same page's already-fixed sites use `className="max-w-full"` (`blocks.$ref.tsx:168` block-hash hero, `accounts.$ss58.tsx:205` ss58). This PR applies that established fix to the remaining unconstrained call sites.

## Change
Add `className="max-w-full"` to each overflowing `CopyableCode` (caps width at the container so the inner `truncate` engages on narrow viewports, while still hugging content when it fits — desktop is unchanged):

| File | Field | Fix |
| --- | --- | --- |
| `routes/validators.$hotkey.tsx:245` | hotkey (hero) | `max-w-full` on `CopyableCode` **+** wrapper `max-w-fit` → `max-w-full min-w-0` (the pill hugged content, so the child had nothing to cap against) |
| `routes/blocks.$ref.tsx:264` | author | `max-w-full` |
| `routes/extrinsics.$hash.tsx:221` | extrinsic hash | `max-w-full` |
| `routes/extrinsics.$hash.tsx:251` | signer | `max-w-full` |

The issue listed 5 sites; `blocks.$ref.tsx` block-hash was already fixed upstream (hero now uses `max-w-full`, and the details-row hash became a `shortHash` span per #5343) — so this addresses the 4 that remain. I also checked `schemas.tsx:198` (openapi URL, same `truncate={false}` pattern): it does **not** overflow (its `PageHero` actions slot constrains it), so it's correctly left alone.

**Also (`routes/extrinsics.$hash.tsx:249`):** the neighbouring **Call** value (`SubtensorModule.commit_timelocked_mechanism_weights`) is a plain `font-mono` span with no break opportunity, so it overflowed the details row the same way. Added `break-all` — matching what this page's hero render of the same value (line 176) and the block/parent-hash spans already use — so it now wraps within the cell (measured: right edge −36px inside the 375px viewport, was off-screen).

## Measurement (375px, live dev server, real production data)
Per fixed element: the button's right edge relative to the 375px viewport (positive = sticks off-screen), and whether the inner text actually truncates (ellipsis):

| Field | Before | After |
| --- | --- | --- |
| validators hotkey | **+7px off-screen**, no ellipsis | −29px inside, **ellipsis ✓** |
| blocks author | **+23px off-screen**, no ellipsis | −33px inside, **ellipsis ✓** |
| extrinsics hash | **+142px off-screen**, no ellipsis | −33px inside, **ellipsis ✓** |
| extrinsics signer | **+23px off-screen**, no ellipsis | −33px inside, **ellipsis ✓** |

Every fixed field goes from *cut off past the screen edge with its copy button unreachable* to *bounded inside the viewport with an ellipsis and a visible copy button.*

## Verification
- `typecheck` / `test` (710) / `build` (apps/ui) — pass · `eslint` on the 3 files (LF-normalized) — 0 errors
- Desktop/tablet unchanged: `max-w-full` only caps width, so wide viewports still show the full value hugging its box.

## Screenshots
The **Extrinsic details** card (holds two of the four fixes: hash + signer). Before = boxes run off the right edge, value cut mid-string, copy button off-screen; After = bounded boxes with an ellipsis and a reachable copy button. Desktop/tablet are unaffected (the value fits, so the box hugs it).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v2/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v2/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v1/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v2/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5308/v2/after-mobile-dark.png)<br><sub>after</sub> |

Closes #5308
