### PR TITLE
fix(ui): add a mobile back affordance to deep entity pages

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -2,7 +2,7 @@ import { Link, useRouterState } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, Compass, Github, Menu, Rss, Webhook } from "lucide-react";
+import { ChevronLeft, ChevronRight, Compass, Github, Menu, Rss, Webhook } from "lucide-react";
 import {
   API_BASE,
   DEFAULT_DISCORD_URL,
@@ -41,23 +41,13 @@ import { HeaderActionsMenu } from "./header-actions-menu";
 import { ApiSourceProvider } from "@/lib/metagraphed/api-source-context";
 import { IncidentStrip } from "./incident-strip";
 import { pushRecentVisit, visitFromPath } from "@/lib/metagraphed/recent-visits";
+import { buildCrumbs, parentCrumb } from "./breadcrumb-nav";
 
 // Brand links resolve from build-time env constants, but still run them through
 // the external-URL guard (with a known-good fallback) so a misconfigured
 // override can't inject an unsafe href — the same treatment the API links get.
 const GITHUB_HREF = safeExternalUrl(GITHUB_REPO) ?? DEFAULT_GITHUB_REPO;
 const DISCORD_HREF = safeExternalUrl(DISCORD_URL) ?? DEFAULT_DISCORD_URL;
-
-function buildCrumbs(pathname: string) {
-  const parts = pathname.split("/").filter(Boolean);
-  const crumbs: Array<{ label: string; to: string }> = [{ label: "Registry", to: "/" }];
-  let acc = "";
-  for (const p of parts) {
-    acc += "/" + p;
-    crumbs.push({ label: decodeURIComponent(p), to: acc });
-  }
-  return crumbs;
-}
 
 function Brand({ onNavigate }: { onNavigate?: () => void }) {
   return (
@@ -80,6 +70,7 @@ export function AppShell({ children }: { children: ReactNode }) {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const crumbs = useMemo(() => buildCrumbs(pathname), [pathname]);
+  const parent = useMemo(() => parentCrumb(crumbs), [crumbs]);
 
   // Close mobile sheet on route change
   useEffect(() => {
@@ -180,31 +171,46 @@ export function AppShell({ children }: { children: ReactNode }) {
               </div>
             </div>
             <RegistryTicker />
-            {/* Secondary breadcrumb row (desktop only, hidden on home) */}
+            {/* Secondary breadcrumb row (desktop) / compact back affordance (mobile), hidden on home */}
             {crumbs.length > 1 ? (
-              <div className="hidden md:block border-t border-border/70 bg-paper/60">
-                <div className="max-w-shell-max mx-auto px-4 md:px-8 h-9 flex items-center">
-                  <nav
-                    aria-label="Breadcrumb"
-                    className="flex items-center gap-1.5 text-xs text-ink-muted min-w-0"
-                  >
-                    {crumbs.map((c, i) => (
-                      <span key={c.to} className="flex items-center gap-1.5 min-w-0">
-                        {i > 0 ? <ChevronRight className="size-3 opacity-50" /> : null}
-                        <Link
-                          to={c.to}
-                          className={classNames(
-                            "truncate hover:text-ink-strong transition-colors font-mono uppercase tracking-widest text-[10px]",
-                            i === crumbs.length - 1 && "text-ink-strong",
-                          )}
-                        >
-                          {c.label}
-                        </Link>
-                      </span>
-                    ))}
-                  </nav>
+              <>
+                {parent ? (
+                  <div className="md:hidden border-t border-border/70 bg-paper/60">
+                    <div className="max-w-shell-max mx-auto px-4 h-9 flex items-center">
+                      <Link
+                        to={parent.to}
+                        className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink-strong transition-colors font-mono uppercase tracking-widest text-[10px]"
+                      >
+                        <ChevronLeft className="size-3" />
+                        {parent.label}
+                      </Link>
+                    </div>
+                  </div>
+                ) : null}
+                <div className="hidden md:block border-t border-border/70 bg-paper/60">
+                  <div className="max-w-shell-max mx-auto px-4 md:px-8 h-9 flex items-center">
+                    <nav
+                      aria-label="Breadcrumb"
+                      className="flex items-center gap-1.5 text-xs text-ink-muted min-w-0"
+                    >
+                      {crumbs.map((c, i) => (
+                        <span key={c.to} className="flex items-center gap-1.5 min-w-0">
+                          {i > 0 ? <ChevronRight className="size-3 opacity-50" /> : null}
+                          <Link
+                            to={c.to}
+                            className={classNames(
+                              "truncate hover:text-ink-strong transition-colors font-mono uppercase tracking-widest text-[10px]",
+                              i === crumbs.length - 1 && "text-ink-strong",
+                            )}
+                          >
+                            {c.label}
+                          </Link>
+                        </span>
+                      ))}
+                    </nav>
+                  </div>
                 </div>
-              </div>
+              </>
             ) : null}
           </header>
 

--- a/apps/ui/src/components/metagraphed/breadcrumb-nav.test.ts
+++ b/apps/ui/src/components/metagraphed/breadcrumb-nav.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { buildCrumbs, parentCrumb } from "./breadcrumb-nav";
+
+describe("buildCrumbs", () => {
+  it("returns just the registry root on the home page", () => {
+    expect(buildCrumbs("/")).toEqual([{ label: "Registry", to: "/" }]);
+  });
+
+  it("builds one crumb per path segment", () => {
+    expect(buildCrumbs("/validators")).toEqual([
+      { label: "Registry", to: "/" },
+      { label: "validators", to: "/validators" },
+    ]);
+  });
+
+  it("builds a full trail for a deep entity-detail route", () => {
+    expect(buildCrumbs("/validators/5F3sa2TJAWMqDhXG6jhV4N8ko9SxwGy8TpaNS1repo5EYjQX")).toEqual([
+      { label: "Registry", to: "/" },
+      { label: "validators", to: "/validators" },
+      {
+        label: "5F3sa2TJAWMqDhXG6jhV4N8ko9SxwGy8TpaNS1repo5EYjQX",
+        to: "/validators/5F3sa2TJAWMqDhXG6jhV4N8ko9SxwGy8TpaNS1repo5EYjQX",
+      },
+    ]);
+  });
+
+  it("decodes URL-encoded path segments", () => {
+    expect(buildCrumbs("/subnets/SN%2043")).toEqual([
+      { label: "Registry", to: "/" },
+      { label: "subnets", to: "/subnets" },
+      { label: "SN 43", to: "/subnets/SN%2043" },
+    ]);
+  });
+});
+
+describe("parentCrumb", () => {
+  it("is null on the root page (nothing to go back to)", () => {
+    expect(parentCrumb(buildCrumbs("/"))).toBeNull();
+  });
+
+  it("resolves the section index for a one-level page", () => {
+    expect(parentCrumb(buildCrumbs("/validators"))).toEqual({ label: "Registry", to: "/" });
+  });
+
+  it("resolves the section index for a deep entity-detail route", () => {
+    expect(parentCrumb(buildCrumbs("/validators/5abc"))).toEqual({
+      label: "validators",
+      to: "/validators",
+    });
+  });
+
+  it("resolves one level up regardless of depth", () => {
+    expect(parentCrumb(buildCrumbs("/subnets/43/history"))).toEqual({
+      label: "43",
+      to: "/subnets/43",
+    });
+  });
+});

--- a/apps/ui/src/components/metagraphed/breadcrumb-nav.ts
+++ b/apps/ui/src/components/metagraphed/breadcrumb-nav.ts
@@ -1,0 +1,18 @@
+export type Crumb = { label: string; to: string };
+
+export function buildCrumbs(pathname: string): Crumb[] {
+  const parts = pathname.split("/").filter(Boolean);
+  const crumbs: Crumb[] = [{ label: "Registry", to: "/" }];
+  let acc = "";
+  for (const p of parts) {
+    acc += "/" + p;
+    crumbs.push({ label: decodeURIComponent(p), to: acc });
+  }
+  return crumbs;
+}
+
+// The level directly above the current page — what the mobile back affordance
+// links to. Null on the root page, where there's nothing to go back to.
+export function parentCrumb(crumbs: Crumb[]): Crumb | null {
+  return crumbs.length > 1 ? crumbs[crumbs.length - 2] : null;
+}


### PR DESCRIPTION
## Summary

Closes #5324

`app-shell.tsx` gated the entire secondary breadcrumb row behind `hidden md:block`. On a deep entity page (e.g. `/validators/<hotkey>`) a mobile user had no in-page trail back up the hierarchy — only the browser back button or tapping the logo to go all the way home.

Adds a compact single-level "back" affordance (chevron + parent page label) on mobile in its place. The parent is resolved generically from the existing path-segment crumb list (now extracted into `breadcrumb-nav.ts` as `buildCrumbs`/`parentCrumb`), so it works the same way for every entity-detail route, not just validators. The desktop breadcrumb trail is unchanged — only its container split into a mobile-only row and the existing `hidden md:block` row.

## What Changed

- `apps/ui/src/components/metagraphed/breadcrumb-nav.ts` (new): extracted the pure `buildCrumbs` logic plus a new `parentCrumb` helper that resolves the level directly above the current page (`null` on the root).
- `apps/ui/src/components/metagraphed/app-shell.tsx`: imports the extracted helpers instead of a local `buildCrumbs`; renders a `md:hidden` back link (`ChevronLeft` + parent label, styled to match the existing `schemas.tsx` back-button pattern) alongside the unchanged `hidden md:block` desktop trail.
- `apps/ui/src/components/metagraphed/breadcrumb-nav.test.ts` (new): unit coverage for `buildCrumbs` (root, one-level, deep entity route, URL-decoding) and `parentCrumb` (root → null, one level, deep entity route, arbitrary depth).

## Gates

`lint` OK (0 errors) - `format:check` OK - `typecheck` OK - `test` OK (107 files, 726 tests, including 8 new in `breadcrumb-nav.test.ts`) - `test:e2e` OK (24/24, incl. `/subnets/1` responsive-overflow checks at all four breakpoints) - `build` OK

## Screenshots

Captured with Playwright at the three SKILL viewports (375x812 / 768x1024 / 1280x800), each theme forced via `mg-theme`, fixed-viewport (never full-page), against the live dev server with real production data (`/subnets/1`, a deep entity-detail route one level below the registry root). Mobile is the meaningful change (no trail -> back link); tablet and desktop are provably unaffected since the new element is `md:hidden` — captured anyway for completeness.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5324-after-mobile-dark.png)<br><sub>after</sub> |

**Note:** the `screenshots` branch on this fork has the 12 images committed locally (`5324-*.png`) but not yet pushed — push it (`git push origin screenshots`) alongside this branch before opening the PR, or the images above won't resolve.
