### PR TITLE
fix(ui): add copy affordance for hotkey/coldkey in the validators table

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
@@ -50,14 +51,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     thClassName: TH_BASE,
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) => (
-      <Link
-        to="/validators/$hotkey"
-        params={{ hotkey: v.hotkey }}
-        className="text-ink-strong hover:text-accent hover:underline"
-        title={v.hotkey}
-      >
-        {shortHash(v.hotkey) ?? v.hotkey}
-      </Link>
+      <span className="flex items-center gap-1.5">
+        <Link
+          to="/validators/$hotkey"
+          params={{ hotkey: v.hotkey }}
+          className="text-ink-strong hover:text-accent hover:underline"
+          title={v.hotkey}
+        >
+          {shortHash(v.hotkey) ?? v.hotkey}
+        </Link>
+        <CopyButton value={v.hotkey} label="hotkey" />
+      </span>
     ),
   },
   {
@@ -66,14 +70,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) =>
       v.coldkey ? (
-        <Link
-          to="/accounts/$ss58"
-          params={{ ss58: v.coldkey }}
-          className="hover:text-accent hover:underline"
-          title={v.coldkey}
-        >
-          {shortHash(v.coldkey) ?? v.coldkey}
-        </Link>
+        <span className="flex items-center gap-1.5">
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: v.coldkey }}
+            className="hover:text-accent hover:underline"
+            title={v.coldkey}
+          >
+            {shortHash(v.coldkey) ?? v.coldkey}
+          </Link>
+          <CopyButton value={v.coldkey} label="coldkey" />
+        </span>
       ) : (
         "—"
       ),


### PR DESCRIPTION
## Summary
The Validators index table exposed the full hotkey/coldkey only through a `title` tooltip — unusable on touch/mobile — while the **Blocks** and **Extrinsics** tables pair every identifier with a `CopyButton`. This adds a `CopyButton` next to the hotkey and coldkey values, matching that existing pattern.

## Change
- One file: `apps/ui/src/components/metagraphed/validator-columns.tsx` (the shared validator column definitions).
- `import { CopyButton } from "@jsonbored/ui-kit"` (same source Blocks/Extrinsics use).
- Hotkey and Coldkey column cells now wrap the `Link` + a `<CopyButton>` in a `flex items-center gap-1.5` span.
- No query/logic change; +23/−16.

## Screenshots
Captured on `/validators` with live validator data (SSR), three viewports × both themes. Theme forced via `localStorage["mg-theme"]`. **Before** = `upstream/main`; **After** = this branch. Programmatic check: **After = 40 hotkey/coldkey copy buttons** (20 rows × 2), **Before = 0**.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339v2-assets/5339v2/before-desktop-light.png) | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339v2-assets/5339v2/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339v2-assets/5339v2/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339v2-assets/5339v2/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339v2-assets/5339v2/before-tablet-light.png) | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339v2-assets/5339v2/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339v2-assets/5339v2/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339v2-assets/5339v2/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339v2-assets/5339v2/before-mobile-light.png) | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339v2-assets/5339v2/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339v2-assets/5339v2/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/lourincedaging0-commits/metagraphed/sn-5339v2-assets/5339v2/after-mobile-dark.png) |

> **Mobile note:** at `<md` the route hides the table and renders `ValidatorCardList` (out of this issue's scope), so the mobile before/after are identical by design; the copy-affordance change is visible at desktop/tablet where the table renders.

## Validation
- `tsc --noEmit` — no new type errors; `prettier --check` — clean.

Closes #5339