### PR TITLE
fix(ui): drop redundant Top fee payers BarMini

### DIFF
--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -1547,55 +1547,43 @@ function ExplorerDashboard() {
               </span>
             </div>
             {fees.top_fee_payers.length > 0 ? (
-              <>
-                <BarMini
-                  className="mb-4"
-                  data={[...fees.top_fee_payers]
-                    .sort((a, b) => b.total_fee_tao - a.total_fee_tao)
-                    .slice(0, 8)
-                    .map((p) => ({
-                      label: shortHash(p.signer) ?? p.signer,
-                      value: p.total_fee_tao,
-                    }))}
-                  formatValue={formatTao}
-                  ariaLabel="Top fee payers ranked by total fees paid this window"
-                />
-                <ExplorerLeaderboardTableShell leaderboardId={EXPLORER_LEADERBOARD_IDS.feePayers}>
-                  <thead>
-                    <tr>
-                      <th className={TH}>Account</th>
-                      <th className={`${TH} text-right`}>Fees</th>
-                      <th className={`${TH} text-right`}>Tips</th>
-                      <th className={`${TH} text-right`}>Txs</th>
+              // Table alone — the former BarMini restated the same ranked fee
+              // list with no distinct cut of the data (#5313).
+              <ExplorerLeaderboardTableShell leaderboardId={EXPLORER_LEADERBOARD_IDS.feePayers}>
+                <thead>
+                  <tr>
+                    <th className={TH}>Account</th>
+                    <th className={`${TH} text-right`}>Fees</th>
+                    <th className={`${TH} text-right`}>Tips</th>
+                    <th className={`${TH} text-right`}>Txs</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {fees.top_fee_payers.map((p) => (
+                    <tr key={p.signer} className="hover:bg-surface/40">
+                      <td className="px-4 py-2 font-mono text-[11px]">
+                        <Link
+                          to="/accounts/$ss58"
+                          params={{ ss58: p.signer }}
+                          className="text-ink-strong hover:text-accent hover:underline"
+                          title={p.signer}
+                        >
+                          {shortHash(p.signer) ?? p.signer}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
+                        {formatTao(p.total_fee_tao)}
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {formatTao(p.total_tip_tao)}
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {formatNumber(p.extrinsic_count)}
+                      </td>
                     </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border">
-                    {fees.top_fee_payers.map((p) => (
-                      <tr key={p.signer} className="hover:bg-surface/40">
-                        <td className="px-4 py-2 font-mono text-[11px]">
-                          <Link
-                            to="/accounts/$ss58"
-                            params={{ ss58: p.signer }}
-                            className="text-ink-strong hover:text-accent hover:underline"
-                            title={p.signer}
-                          >
-                            {shortHash(p.signer) ?? p.signer}
-                          </Link>
-                        </td>
-                        <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
-                          {formatTao(p.total_fee_tao)}
-                        </td>
-                        <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                          {formatTao(p.total_tip_tao)}
-                        </td>
-                        <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                          {formatNumber(p.extrinsic_count)}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </ExplorerLeaderboardTableShell>
-              </>
+                  ))}
+                </tbody>
+              </ExplorerLeaderboardTableShell>
             ) : (
               <EmptyState title="No fee payers in this window yet." />
             )}


### PR DESCRIPTION
## Summary

- Removes the `BarMini` chart above Explorer **Top fee payers** that restated the same ranked fee list already shown in the table (`apps/ui/src/routes/explorer.tsx`).
- Leaves the ranked fee-payers table as the single source of that list.

Closes #5313

## Screenshots

Fixed viewports only (375×812 / 768×1024 / 1280×800). Explorer → Fees tab → Top fee payers. Capture scrolls the section into view — never full-page.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src=https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-desktop-light-before.png width=260>](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-desktop-light-before.png)<br><sub>before — BarMini + table</sub> | [<img src=https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-desktop-light-after.png width=260>](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-desktop-light-after.png)<br><sub>after — table only</sub> |
| Desktop · Dark | [<img src=https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-desktop-dark-before.png width=260>](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-desktop-dark-before.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-desktop-dark-after.png width=260>](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src=https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-tablet-light-before.png width=260>](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-tablet-light-before.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-tablet-light-after.png width=260>](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src=https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-tablet-dark-before.png width=260>](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-tablet-dark-before.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-tablet-dark-after.png width=260>](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src=https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-mobile-light-before.png width=260>](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-mobile-light-before.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-mobile-light-after.png width=260>](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src=https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-mobile-dark-before.png width=260>](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-mobile-dark-before.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-mobile-dark-after.png width=260>](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5313-mobile-dark-after.png)<br><sub>after</sub> |

## Test plan

- [x] `npm run lint --workspace=apps/ui` (0 errors)
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=metagraphed-ui`
- [x] `npm run test --workspace=apps/ui` (718 tests)
- [ ] Confirm Fees → Top fee payers shows the ranked table once, with no duplicate BarMini