### PR TITLE
fix(ui): add copy buttons to validators table hotkey/coldkey cells

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
@@ -37,18 +38,22 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
               >
                 {f.hotkeyShort}
               </Link>
+              <CopyButton value={v.hotkey} label="hotkey" />
             </div>
-            <div className="font-mono text-[11px] text-ink-muted">
+            <div className="flex items-center gap-1 font-mono text-[11px] text-ink-muted">
               <span className="uppercase tracking-widest text-[10px]">coldkey </span>
               {v.coldkey ? (
-                <Link
-                  to="/accounts/$ss58"
-                  params={{ ss58: v.coldkey }}
-                  title={v.coldkey}
-                  className="hover:text-accent hover:underline"
-                >
-                  {f.coldkeyShort}
-                </Link>
+                <>
+                  <Link
+                    to="/accounts/$ss58"
+                    params={{ ss58: v.coldkey }}
+                    title={v.coldkey}
+                    className="hover:text-accent hover:underline"
+                  >
+                    {f.coldkeyShort}
+                  </Link>
+                  <CopyButton value={v.coldkey} label="coldkey" />
+                </>
               ) : (
                 "—"
               )}

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
@@ -50,14 +51,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     thClassName: TH_BASE,
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) => (
-      <Link
-        to="/validators/$hotkey"
-        params={{ hotkey: v.hotkey }}
-        className="text-ink-strong hover:text-accent hover:underline"
-        title={v.hotkey}
-      >
-        {shortHash(v.hotkey) ?? v.hotkey}
-      </Link>
+      <span className="inline-flex items-center gap-1 min-w-0">
+        <Link
+          to="/validators/$hotkey"
+          params={{ hotkey: v.hotkey }}
+          className="text-ink-strong hover:text-accent hover:underline"
+          title={v.hotkey}
+        >
+          {shortHash(v.hotkey) ?? v.hotkey}
+        </Link>
+        <CopyButton value={v.hotkey} label="hotkey" />
+      </span>
     ),
   },
   {
@@ -66,14 +70,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) =>
       v.coldkey ? (
-        <Link
-          to="/accounts/$ss58"
-          params={{ ss58: v.coldkey }}
-          className="hover:text-accent hover:underline"
-          title={v.coldkey}
-        >
-          {shortHash(v.coldkey) ?? v.coldkey}
-        </Link>
+        <span className="inline-flex items-center gap-1 min-w-0">
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: v.coldkey }}
+            className="hover:text-accent hover:underline"
+            title={v.coldkey}
+          >
+            {shortHash(v.coldkey) ?? v.coldkey}
+          </Link>
+          <CopyButton value={v.coldkey} label="coldkey" />
+        </span>
       ) : (
         "—"
       ),

--- a/apps/ui/tests/e2e/capture-validator-copy-button-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-validator-copy-button-screenshots.mjs
@@ -1,0 +1,98 @@
+/**
+ * Capture validators-table copy-button screenshots for #5339 (Path C2 contract).
+ * Fixed viewport only — never fullPage or element crops.
+ *
+ * Usage (with a dev server running — pass its base URL explicitly):
+ *   UI_BASE_URL=http://127.0.0.1:4001 VARIANT=before node tests/e2e/capture-validator-copy-button-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:4002 VARIANT=after node tests/e2e/capture-validator-copy-button-screenshots.mjs
+ *
+ * Writes to tmp/validator-copy-button-screenshots/5339-{viewport}-{theme}-{variant}.png
+ */
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/validator-copy-button-screenshots");
+const VALIDATORS_FIXTURE = JSON.parse(
+  await readFile(new URL("./fixtures/global-validators-screenshot.json", import.meta.url), "utf8"),
+);
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:4001";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function installFixtures(page) {
+  await page.route("**/api/v1/validators**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/validators")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(VALIDATORS_FIXTURE),
+      });
+      return;
+    }
+    await route.continue();
+  });
+}
+
+async function openDirectoryView(page) {
+  await page.goto(`${BASE_URL}/validators`, { waitUntil: "networkidle", timeout: 90_000 });
+  await page
+    .locator("table, [class*='rounded-lg'][class*='border']")
+    .first()
+    .waitFor({ state: "visible", timeout: 30_000 });
+  await page.evaluate(() => {
+    const isVisible = (el) => !!el && el.getClientRects().length > 0;
+    const table = document.querySelector("table");
+    const card = document.querySelector("dl")?.closest("div");
+    const target = isVisible(table) ? table : isVisible(card) ? card : null;
+    if (!target) return;
+    const top = target.getBoundingClientRect().top + window.scrollY - 72;
+    window.scrollTo({ top: Math.max(0, top), behavior: "instant" });
+  });
+  await page.waitForTimeout(300);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    const context = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+    });
+    const page = await context.newPage();
+    await installFixtures(page);
+
+    for (const theme of THEMES) {
+      await setTheme(page, theme);
+      await openDirectoryView(page);
+      const file = path.join(OUT_DIR, `5339-${viewport.name}-${theme}-${VARIANT}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+    }
+
+    await context.close();
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

The Validators table only exposed hotkey/coldkey via a `title` tooltip, which is unusable on touch/mobile and inconsistent with the Blocks/Extrinsics tables, which pair every hash/signer with a `CopyButton`. Wires the existing `CopyButton` primitive into the hotkey and coldkey cells, matching that established pattern, on both the desktop table and the mobile card fallback (#5320) so the affordance is consistent across breakpoints.

## What Changed

- `apps/ui/src/components/metagraphed/validator-columns.tsx`: import `CopyButton` from `@jsonbored/ui-kit`; wrap the Hotkey and Coldkey cells' `<Link>` in an `inline-flex` span alongside a `CopyButton`, same shape as `blocks.index.tsx`'s Hash cell.
- `apps/ui/src/components/metagraphed/validator-card-list.tsx`: same treatment for the mobile card list's hotkey/coldkey rows, so the card fallback stays consistent with the desktop table.
- `apps/ui/tests/e2e/capture-validator-copy-button-screenshots.mjs`: capture script for the before/after screenshots below (reuses the existing `global-validators-screenshot.json` fixture also used by `capture-validator-delegate-screenshots.mjs`).

## Validation

- `npm run lint --workspace=apps/ui`
- `npm run typecheck --workspace=apps/ui`
- `npm test --workspace=apps/ui` (722 tests passing)
- `npm run format:check --workspace=apps/ui`

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5339-mobile-dark-after.png)<br><sub>after</sub> |

Closes #5339
