### PR TITLE
feat(registry): add SN74 Gittensor language-weights data-artifact

### DIFF
--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -420,6 +420,25 @@
         "https://api.gittensor.io/swagger"
       ],
       "url": "https://api.gittensor.io/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-language-weights",
+      "kind": "data-artifact",
+      "name": "Gittensor programming-language scoring weights",
+      "notes": "Public no-auth machine-readable JSON from the official SN74 Gittensor repository (entrius/gittensor), pinned to an immutable commit. Maps each programming language to the scoring weight the validators apply when evaluating miners' code contributions (e.g. per-language weight multipliers). Static data artifact documenting the subnet's language-weighting scoring parameters.",
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/entrius/gittensor",
+        "https://github.com/entrius/gittensor/blob/a5b21df92d123f9bd5fe63cea05d98c13d20fa8f/gittensor/validator/weights/programming_languages.json"
+      ],
+      "url": "https://raw.githubusercontent.com/entrius/gittensor/a5b21df92d123f9bd5fe63cea05d98c13d20fa8f/gittensor/validator/weights/programming_languages.json"
     }
   ],
   "website_url": "https://gittensor.io/"


### PR DESCRIPTION
## Summary

Enriches **SN74 Gittensor** (issue #1275) with a machine-usable **data-artifact**: the validators' programming-language scoring weights, pinned to an immutable commit.

- **url:** https://raw.githubusercontent.com/entrius/gittensor/a5b21df92d123f9bd5fe63cea05d98c13d20fa8f/gittensor/validator/weights/programming_languages.json (public, no-auth — HTTP 200, ~5.7 KB JSON)
- **kind:** data-artifact (static machine-readable scoring parameters from the official SN74 repo)
- **source_urls:** the official SN74 repo https://github.com/entrius/gittensor + the pinned blob
- Maps each programming language to the weight validators apply when scoring miners' code contributions — the subnet's language-weighting scoring parameters.

## Validation
- `npm run validate:surface -- registry/subnets/gittensor.json` → passed (21 surfaces)
- `npm run scan:public-safety` → no findings for this file
- `npx prettier --check` → clean

Closes #1275