### PR TITLE
fix(ui): stop the subnet overview strip restating the tab-bar counts (#5316)

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -472,11 +472,10 @@ function OverviewSummaryStrip({ netuid }: { netuid: number }) {
         {typeof health?.status === "string" ? <HealthPill state={health.status} /> : null}
         {typeof curation?.level === "string" ? <CurationChip level={curation.level} /> : null}
       </div>
-      <div className="grid grid-cols-3 gap-3">
-        <StatTile eyebrow="Surfaces" value={formatNumber(overview.counts?.surfaces ?? 0)} />
-        <StatTile eyebrow="Endpoints" value={formatNumber(overview.counts?.endpoints ?? 0)} />
-        <StatTile eyebrow="Candidates" value={formatNumber(overview.counts?.candidates ?? 0)} />
-      </div>
+      {/* Surface / endpoint / candidate counts are already shown (and stay
+          visible while scrolling) in the tab-bar badges above, so they're not
+          restated as StatTiles here — the strip keeps only the status/curation
+          chips and the top-gap hint the badges don't cover (#5316). */}
       {topGapHint ? (
         <p className="font-mono text-[11px] text-ink-muted">Top gap: {topGapHint}</p>
       ) : null}


### PR DESCRIPTION
## Summary

Closes #5316

On the subnet detail page the tab-bar badges already show **Surfaces / Endpoints / Candidates** counts and stay visible while scrolling (they're `sticky`), and `OverviewSummaryStrip` restated the identical three numbers as `StatTile`s a short scroll below — sourced from the `/overview` route but the same values.

This drops the redundant `StatTile` grid. The strip keeps the status / health / curation chips and the top-gap hint (which the badges don't cover), so the counts now appear once — in the tab badges.

## Gates

typecheck OK - eslint `.` OK (0 errors) - prettier OK. Pure JSX removal (no logic), so no unit test added — consistent with the other dedup fixes in this audit batch.

## Screenshots

Captured with Playwright at the three SKILL viewports (375x812 / 768x1024 / 1280x800), each theme forced via `mg-theme`, fixed-viewport (never full-page), on /subnets/1 (Apex — the subnet cited in the issue) against the live dev server. The sticky tab bar is pinned above; before shows the redundant SURFACES/ENDPOINTS/CANDIDATES tiles in the strip, after shows only the status chips + top-gap hint.

| Viewport - Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5316/after-mobile-dark.png)<br><sub>after</sub> |
