### PR TITLE
feat(registry): add SN66 Ninja tau agent files manifest data-artifact surface (#466)

### DIFF
--- a/registry/subnets/ninja.json
+++ b/registry/subnets/ninja.json
@@ -230,6 +230,31 @@
       },
       "source_urls": ["https://github.com/unarbos/ninja/blob/main/README.md"],
       "url": "https://ninja66.ai/api/submissions"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-66-ninja-agent-files-manifest",
+      "kind": "data-artifact",
+      "name": "Ninja tau agent files manifest",
+      "notes": "Public no-auth machine-readable JSON manifest listing the canonical set of source files that constitute a valid SN66 Ninja (tau) agent submission (agent.py plus the agent/ package modules: agent_loop.py, criteria.py, environment.py, guards.py, model.py, prompts.py, repo_diff.py, ...). Published in the official unarbos/ninja miner-harness repository at tau_agent_files.json and used by the harness to assemble/validate an agent's file set. Pinned to an immutable commit. Contains only relative file paths — no code, hotkeys, or secrets. Verified 200, SS58-clean.",
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "unarbos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://github.com/unarbos/ninja/blob/a6ce013deadeba964f9874ffc5ce5b4857c068cf/tau_agent_files.json",
+        "https://github.com/unarbos/ninja/blob/main/README.md"
+      ],
+      "url": "https://raw.githubusercontent.com/unarbos/ninja/a6ce013deadeba964f9874ffc5ce5b4857c068cf/tau_agent_files.json"
     }
   ],
   "website_url": "https://ninja.arbos.life/"


### PR DESCRIPTION
## Summary

Adds one new `community` data-artifact surface to SN66 Ninja (`registry/subnets/ninja.json`): the **tau agent files manifest** at `tau_agent_files.json` in the official miner-harness repository.

## Surface

- **id:** `sn-66-ninja-agent-files-manifest`
- **kind:** `data-artifact`
- **url:** `https://raw.githubusercontent.com/unarbos/ninja/a6ce013deadeba964f9874ffc5ce5b4857c068cf/tau_agent_files.json` — public, no-auth, HTTP 200 JSON, pinned to an immutable commit
- **provider:** `unarbos`
- **source_url:** the same file's GitHub blob at the pinned commit + the repo README

## What it is

The canonical machine-readable manifest listing the source files that constitute a valid SN66 Ninja (tau) agent submission — `agent.py` plus the `agent/` package modules (`agent_loop.py`, `criteria.py`, `environment.py`, `guards.py`, `model.py`, `prompts.py`, `repo_diff.py`, …). The official `unarbos/ninja` miner harness uses it to assemble and validate an agent's file set. Contains only relative file paths — no code, hotkeys, or secrets. Distinct from the registered `ninja66.ai/api/submissions` metadata endpoint.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/ninja.json` — passed (11 surfaces)
- Verified with no auth header: 200, SS58-clean.

One focused change: one surface appended to one subnet file; nothing else touched.

Closes #466

> Scope note: #466 frames the enrichment as an OpenAPI/Swagger spec. Ninja's live API host currently serves no verified public OpenAPI document; this adds a genuinely-published machine-readable protocol manifest from the official repo, advancing the same "enrich SN66" intent. Any OpenAPI-specific framing is advisory.
