### PR TITLE
fix(ui): normalize the mobile Open-menu button to the 44px header touch-target floor (#5335)

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -138,7 +138,7 @@ export function AppShell({ children }: { children: ReactNode }) {
           >
             <div className="max-w-shell-max mx-auto px-4 md:px-8 flex h-nav items-center gap-3">
               <button
-                className="lg:hidden rounded-md p-2 text-ink hover:bg-surface min-h-10 min-w-10 inline-flex items-center justify-center"
+                className="lg:hidden rounded-md p-2 text-ink hover:bg-surface min-h-11 min-w-11 inline-flex items-center justify-center"
                 onClick={() => setMobileOpen(true)}
                 aria-label="Open menu"
               >


### PR DESCRIPTION
## Summary

Closes #5335

The mobile "Open menu" hamburger (`app-shell.tsx`) used `min-h-10 min-w-10` (40px), while every sibling header control — `NetworkSwitcher`, `SettingsPopover`, `HeaderActionsMenu` — uses `min-h-11 min-w-11` (44px, the WCAG 2.5.5 floor). This normalizes the hamburger to the same 44px tap target.

## Scope note

The issue's second deliverable (the drawer "Close menu" button, previously at `app-shell.tsx:223`) **no longer exists**: the mobile drawer was since refactored into a proper focus-trapping dialog with built-in Escape-to-close (#5336),
removing the hand-rolled close button. So the Open-menu button is the only remaining control that was below the 44px floor.

## Changes
- `components/metagraphed/app-shell.tsx` — Open-menu button `min-h-10 min-w-10`
  → `min-h-11 min-w-11` (1 line).

## Screenshots

**Detail — measured tap target** (dashed outline + measured size, overlaid for the screenshot only). The Open-menu hit area grows from **40×40 → 44×44 px**:

| Theme | Before (40×40) | After (44×44) |
| --- | --- | --- |
| Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger-detail/before-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger-detail/after-mobile-light.png) |
| Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger-detail/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger-detail/after-mobile-dark.png) |

**Full coverage — header at every viewport × theme** (required 6-combo set). The hamburger is `lg:hidden`, so the change applies on mobile/tablet; desktop rows show the header unchanged (button hidden) but are included for completeness:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger/before-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger/after-mobile-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger/before-tablet-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger/after-tablet-dark.png) |
| Desktop · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger/before-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5335-hamburger/after-desktop-dark.png) |


## Validation
- `tsc --noEmit` ✓ · `eslint` ✓ · `prettier --check` (3.9.4, LF) ✓ · `vitest` (737) ✓ · `build` ✓
- **`test:e2e` responsive-overflow: 24/24, incl. all routes' header at 375px** — the larger tap target adds no overflow
- 1 file; rebased to **0-behind `main`**
