### PR TITLE
fix(ui): collapse blocks/extrinsics filters on mobile

### DIFF
--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
-import type { HTMLAttributes } from "react";
-import { ArrowUp, ArrowDown, X, Filter } from "lucide-react";
+import { useId, useState, type HTMLAttributes, type ReactNode } from "react";
+import { ArrowUp, ArrowDown, ChevronDown, X, Filter } from "lucide-react";
 import { classNames } from "@/lib/metagraphed/format";
 
 /**
@@ -128,7 +128,7 @@ export function SelectFilter({
         // to font-mono so the value matches the label instead of falling back to
         // the sans body font, which reads as unstyled next to the mono label.
         className={classNames(
-          "min-w-0 truncate bg-transparent font-mono text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "min-w-0 truncate bg-transparent font-mono text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring min-h-7",
           fill ? "flex-1" : "",
         )}
       >
@@ -239,6 +239,78 @@ export function ResetFiltersButton({ active, onReset }: { active: boolean; onRes
     >
       <X className="size-3" /> Reset filters
     </button>
+  );
+}
+
+/**
+ * Compact row for selects / reset inside {@link CollapsibleFilters}.
+ * Mobile: keeps RESULT / per-page as side-by-side chips (not stretched bars).
+ * Desktop: `display: contents` so children join the normal flex wrap row.
+ */
+export function FilterActionRow({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 max-md:w-full md:contents">{children}</div>
+  );
+}
+
+/**
+ * Mobile filter disclosure for dense ListShell filter bars (#5323).
+ *
+ * On viewports below `md` the controls collapse behind a single "Filters"
+ * toggle (closed by default) so list data stays above the fold; when open
+ * text inputs stack full-width, while select chips stay compact via
+ * {@link FilterActionRow}. On `md+` an inner flex row mirrors ListShell's
+ * previous wrap behavior ??? mobile-only classes stay behind `max-md:`.
+ */
+export function CollapsibleFilters({
+  activeCount = 0,
+  children,
+}: {
+  /** Number of active filter values ??? shown as a badge on the mobile toggle. */
+  activeCount?: number;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+
+  return (
+    <>
+      <button
+        type="button"
+        className="md:hidden inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1.5 text-[11px] font-medium text-ink-strong hover:border-ink/30 min-h-9"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Filter className="size-3.5" aria-hidden />
+        Filters
+        {activeCount > 0 ? (
+          <span className="rounded-full bg-accent/15 px-1.5 font-mono text-[10px] tabular-nums text-accent">
+            {activeCount}
+          </span>
+        ) : null}
+        <ChevronDown
+          className={classNames(
+            "size-3.5 text-ink-muted transition-transform",
+            open && "rotate-180",
+          )}
+          aria-hidden
+        />
+      </button>
+      <div
+        id={panelId}
+        className={classNames(
+          // Desktop / tablet: same wrap row ListShell used before.
+          "md:flex md:flex-wrap md:items-center md:gap-2 md:min-w-0 md:flex-1",
+          // Mobile: closed = hidden; open = full-width input stack.
+          !open && "max-md:hidden",
+          open &&
+            "max-md:flex max-md:w-full max-md:flex-col max-md:gap-2 max-md:[&_input]:min-w-0 max-md:[&_input]:max-w-none max-md:[&_input]:w-full max-md:[&_input]:flex-none",
+        )}
+      >
+        {children}
+      </div>
+    </>
   );
 }
 

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -21,6 +21,8 @@ import {
   CopyableCode,
 } from "@jsonbored/ui-kit";
 import {
+  CollapsibleFilters,
+  FilterActionRow,
   PageSizeSelect,
   ResetFiltersButton,
   SearchInput,
@@ -224,17 +226,19 @@ function BlocksTable() {
   const goPrev = () => setSearch({ offset: Math.max(0, search.offset - search.limit) });
   const goNext = () => setSearch({ offset: search.offset + search.limit });
 
-  const filtersActive = Boolean(
-    search.author ||
-    search.spec_version ||
-    search.block_start ||
-    search.block_end ||
-    search.min_extrinsics ||
+  const filterValues = [
+    search.author,
+    search.spec_version,
+    search.block_start,
+    search.block_end,
+    search.min_extrinsics,
     search.min_events,
-  );
+  ];
+  const activeFilterCount = filterValues.filter(Boolean).length;
+  const filtersActive = activeFilterCount > 0;
 
   const filters = (
-    <>
+    <CollapsibleFilters activeCount={activeFilterCount}>
       <span
         className="font-mono text-[11px] text-ink-muted whitespace-nowrap"
         title="Blocks are listed newest first"
@@ -281,26 +285,28 @@ function BlocksTable() {
         inputMode="numeric"
         className="min-w-[120px] max-w-[140px] flex-none"
       />
-      <PageSizeSelect
-        value={search.limit}
-        onChange={(n) => setSearch({ limit: n, offset: 0 })}
-        options={[10, 25, 50, 100]}
-      />
-      <ResetFiltersButton
-        active={filtersActive}
-        onReset={() =>
-          setSearch({
-            author: "",
-            spec_version: "",
-            block_start: "",
-            block_end: "",
-            min_extrinsics: "",
-            min_events: "",
-            offset: 0,
-          })
-        }
-      />
-    </>
+      <FilterActionRow>
+        <PageSizeSelect
+          value={search.limit}
+          onChange={(n) => setSearch({ limit: n, offset: 0 })}
+          options={[10, 25, 50, 100]}
+        />
+        <ResetFiltersButton
+          active={filtersActive}
+          onReset={() =>
+            setSearch({
+              author: "",
+              spec_version: "",
+              block_start: "",
+              block_end: "",
+              min_extrinsics: "",
+              min_events: "",
+              offset: 0,
+            })
+          }
+        />
+      </FilterActionRow>
+    </CollapsibleFilters>
   );
 
   const emptyNode = (

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -9,6 +9,8 @@ import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import {
+  CollapsibleFilters,
+  FilterActionRow,
   PageSizeSelect,
   ResetFiltersButton,
   SearchInput,
@@ -191,12 +193,12 @@ function ExtrinsicsTable() {
   const rowKey = (x: Extrinsic) =>
     x.extrinsic_hash || `${x.block_number ?? "?"}-${x.extrinsic_index ?? "?"}`;
 
-  const filtersActive = Boolean(
-    search.signer || search.call_module || search.call_function || search.success,
-  );
+  const filterValues = [search.signer, search.call_module, search.call_function, search.success];
+  const activeFilterCount = filterValues.filter(Boolean).length;
+  const filtersActive = activeFilterCount > 0;
 
   const filters = (
-    <>
+    <CollapsibleFilters activeCount={activeFilterCount}>
       <SearchInput
         value={search.signer}
         onChange={(v) => setSearch({ signer: v, offset: 0 })}
@@ -212,33 +214,35 @@ function ExtrinsicsTable() {
         onChange={(v) => setSearch({ call_function: v, offset: 0 })}
         placeholder="Call function…"
       />
-      <SelectFilter
-        label="Result"
-        value={search.success}
-        onChange={(v) => setSearch({ success: v, offset: 0 })}
-        options={[
-          { value: "true", label: "ok" },
-          { value: "false", label: "fail" },
-        ]}
-      />
-      <PageSizeSelect
-        value={search.limit}
-        onChange={(n) => setSearch({ limit: n, offset: 0 })}
-        options={[10, 25, 50, 100]}
-      />
-      <ResetFiltersButton
-        active={filtersActive}
-        onReset={() =>
-          setSearch({
-            signer: "",
-            call_module: "",
-            call_function: "",
-            success: "",
-            offset: 0,
-          })
-        }
-      />
-    </>
+      <FilterActionRow>
+        <SelectFilter
+          label="Result"
+          value={search.success}
+          onChange={(v) => setSearch({ success: v, offset: 0 })}
+          options={[
+            { value: "true", label: "ok" },
+            { value: "false", label: "fail" },
+          ]}
+        />
+        <PageSizeSelect
+          value={search.limit}
+          onChange={(n) => setSearch({ limit: n, offset: 0 })}
+          options={[10, 25, 50, 100]}
+        />
+        <ResetFiltersButton
+          active={filtersActive}
+          onReset={() =>
+            setSearch({
+              signer: "",
+              call_module: "",
+              call_function: "",
+              success: "",
+              offset: 0,
+            })
+          }
+        />
+      </FilterActionRow>
+    </CollapsibleFilters>
   );
 
   const emptyNode = (


### PR DESCRIPTION
## Summary
- Collapse Blocks and Extrinsics filter bars behind a closed-by-default **Filters** disclosure on viewports below `md`, so list data can sit above the fold on 375px.
- When Filters is open on mobile: text inputs stack full-width; Result / per-page (and reset) stay compact chips via `FilterActionRow`.
- Desktop and tablet keep the original inline flex filter row (`max-md:`-scoped mobile styles only).

Closes #5323

## Test plan
- [ ] `/blocks` @ 375px: Filters collapsed by default; expand shows stacked inputs + compact per-page
- [ ] `/extrinsics` @ 375px: same; Result | per page on one row when open
- [ ] Desktop / tablet (≥768): filter bar matches pre-change wrap layout (no vertical stack, no Filters toggle)
- [ ] Light + dark themes for the disclosure control
- [ ] Capture screenshots only after `document.fonts.ready` (avoid fallback-font before/after mismatch)
- [ ] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [ ] `npm run typecheck --workspace=apps/ui && npm test --workspace=apps/ui`
- [ ] `npm run test:e2e --workspace=apps/ui && npm run build --workspace=apps/ui`

## Screenshots

Captures wait for brand fonts (`document.fonts.ready`) so before/after use the same typefaces.

### Blocks (`/blocks`)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/2b61a2f0-fcfb-4f98-98c7-4e0dd894fd9a" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/11e02f56-e685-4892-a3d5-84522d844548" /> |
| Desktop · Dark   | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/5d1668a6-cb2d-47f2-bb29-2d2f99ea808e" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/8f7870d9-3aa9-4389-ade7-0b71c4298904" /> |
| Tablet · Light   | <img width="1227" height="869" alt="image" src="https://github.com/user-attachments/assets/bb3c8f92-a547-4432-bcd5-05c338d6b38a" /> | <img width="1227" height="869" alt="image" src="https://github.com/user-attachments/assets/5aeae3fa-4f22-44f7-a952-8222db9507a9" /> |
| Tablet · Dark    | <img width="1227" height="869" alt="image" src="https://github.com/user-attachments/assets/f64dbf05-12a2-41b7-b270-26466d238b5e" /> | <img width="1227" height="869" alt="image" src="https://github.com/user-attachments/assets/6a561278-e4d4-4173-ba4b-4f2e87aa2748" /> |
| Mobile · Light   | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/e4c9c765-0c51-4278-8e06-6f6fa4b3e99d" /> | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/36ad48ec-1630-4cd0-b787-89e74807b6e4" /> |
| Mobile · Dark    | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/02a6be77-30c7-4099-87e9-e086eaf35083" /> | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/a07f3f77-7295-47c7-99e4-aa0cdcf48489" /> |

### Extrinsics (`/extrinsics`)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/3fa76184-3bc3-4fbc-a4df-c89134429189" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/9bff63c2-75d7-47b5-bbe6-6903d7878d9c" /> |
| Desktop · Dark   | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/7254a316-533f-44c4-a1c7-f133141a0ca7" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/04375f6a-5816-4acc-8295-3310d85a26cb" /> |
| Tablet · Light   | <img width="1227" height="869" alt="image" src="https://github.com/user-attachments/assets/60bec7d8-3481-4a9f-a28f-f6f87ed2ff3c" /> | <img width="1227" height="869" alt="image" src="https://github.com/user-attachments/assets/79eddba2-6938-4b68-b275-fdeaf2d7db09" /> |
| Tablet · Dark    | <img width="1227" height="869" alt="image" src="https://github.com/user-attachments/assets/d4a86c26-d0a7-44a7-9b20-3e9762870d82" /> | <img width="1227" height="869" alt="image" src="https://github.com/user-attachments/assets/a4af4c68-8e83-4cbc-995e-9df48677111a" /> |
| Mobile · Light   | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/b754fab7-6fd1-45dd-af1c-ec98b9a29842" /> | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/f00b6bac-1bbc-4dc5-82bb-a13a88159ce6" /> |
| Mobile · Dark    | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/85ff4d90-ae17-468c-89e7-7f5350a1ce79" /> |<img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/b94438ec-95f8-4e1d-9df1-00d8eb527ce8" /> |