### PR TITLE
feat(registry): add SN77 Liquidity API index subnet-api surface (#4093)

### DIFF
--- a/registry/subnets/liquidity.json
+++ b/registry/subnets/liquidity.json
@@ -45,6 +45,31 @@
         "https://github.com/creativebuilds/sn77/blob/master/README.md"
       ],
       "url": "https://77.creativebuilds.io/weights"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-77-liquidity-api-index",
+      "kind": "subnet-api",
+      "name": "Liquidity API index",
+      "notes": "Public no-auth GET / on 77.creativebuilds.io returning a machine-readable JSON index of the SN77 Liquidity validator REST API — a self-documenting endpoint catalog ({message, endpoints:[{path, method, description, ...}]}) covering the voting (/updateVotes), pools, positions, weights, miners, and holders routes. This is the live counterpart of the repository's validator/api-server-docs.json and the closest machine-readable API description the subnet publishes. Distinct from the registered /pools and /weights data surfaces. Verified 200 application/json, no auth, SS58-clean.",
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
+      "provider": "liquidity",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://github.com/creativebuilds/sn77/blob/master/validator/api-server-docs.json",
+        "https://github.com/creativebuilds/sn77/blob/master/README.md"
+      ],
+      "url": "https://77.creativebuilds.io/"
     }
   ],
   "source_repo": "https://github.com/creativebuilds/sn77",


### PR DESCRIPTION
## Summary

Adds one new `community` subnet-api surface to SN77 Liquidity (`registry/subnets/liquidity.json`): the live **API index** at `GET /` on `77.creativebuilds.io`, a machine-readable self-documenting endpoint catalog for the subnet's validator REST API.

## Surface

- **id:** `sn-77-liquidity-api-index`
- **kind:** `subnet-api`
- **url:** `https://77.creativebuilds.io/` — public, no-auth, HTTP 200 `application/json`
- **provider:** `liquidity`
- **source_url:** the repo's `validator/api-server-docs.json` (the committed copy of this catalog) + the README

## What it returns

A JSON index of the SN77 Liquidity validator API — `{message, endpoints:[{path, method, description, ...}]}` — cataloging the voting (`/updateVotes`), pools, positions, weights, miners, and holders routes. It is the live counterpart of the repository's `validator/api-server-docs.json` and the closest machine-readable API description the subnet publishes. Distinct from the already-registered `/pools` and `/weights` surfaces.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/liquidity.json` — passed (3 surfaces)
- Verified with no auth header: 200 `application/json`, SS58-clean (no hotkey/wallet material).

One focused change: one surface appended to one subnet file; nothing else touched.

Closes #4093

> Scope note: #4093 frames the enrichment as an OpenAPI/Swagger spec. SN77 serves no formal OpenAPI document, but publishes this machine-readable self-documenting API endpoint index (live, and committed as `validator/api-server-docs.json`); it advances the same "enrich SN77" intent. Any OpenAPI-specific framing is advisory.
