### PR TITLE
fix(ui): add copy buttons to validator hotkey/coldkey identifiers (#5339)

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
@@ -37,18 +38,22 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
               >
                 {f.hotkeyShort}
               </Link>
+              <CopyButton value={v.hotkey} label="hotkey" />
             </div>
-            <div className="font-mono text-[11px] text-ink-muted">
+            <div className="flex items-center font-mono text-[11px] text-ink-muted">
               <span className="uppercase tracking-widest text-[10px]">coldkey </span>
               {v.coldkey ? (
-                <Link
-                  to="/accounts/$ss58"
-                  params={{ ss58: v.coldkey }}
-                  title={v.coldkey}
-                  className="hover:text-accent hover:underline"
-                >
-                  {f.coldkeyShort}
-                </Link>
+                <>
+                  <Link
+                    to="/accounts/$ss58"
+                    params={{ ss58: v.coldkey }}
+                    title={v.coldkey}
+                    className="hover:text-accent hover:underline"
+                  >
+                    {f.coldkeyShort}
+                  </Link>
+                  <CopyButton value={v.coldkey} label="coldkey" />
+                </>
               ) : (
                 "—"
               )}

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
@@ -50,14 +51,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     thClassName: TH_BASE,
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) => (
-      <Link
-        to="/validators/$hotkey"
-        params={{ hotkey: v.hotkey }}
-        className="text-ink-strong hover:text-accent hover:underline"
-        title={v.hotkey}
-      >
-        {shortHash(v.hotkey) ?? v.hotkey}
-      </Link>
+      <span className="inline-flex items-center gap-1">
+        <Link
+          to="/validators/$hotkey"
+          params={{ hotkey: v.hotkey }}
+          className="text-ink-strong hover:text-accent hover:underline"
+          title={v.hotkey}
+        >
+          {shortHash(v.hotkey) ?? v.hotkey}
+        </Link>
+        <CopyButton value={v.hotkey} label="hotkey" />
+      </span>
     ),
   },
   {
@@ -66,14 +70,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) =>
       v.coldkey ? (
-        <Link
-          to="/accounts/$ss58"
-          params={{ ss58: v.coldkey }}
-          className="hover:text-accent hover:underline"
-          title={v.coldkey}
-        >
-          {shortHash(v.coldkey) ?? v.coldkey}
-        </Link>
+        <span className="inline-flex items-center gap-1">
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: v.coldkey }}
+            className="hover:text-accent hover:underline"
+            title={v.coldkey}
+          >
+            {shortHash(v.coldkey) ?? v.coldkey}
+          </Link>
+          <CopyButton value={v.coldkey} label="coldkey" />
+        </span>
       ) : (
         "—"
       ),


### PR DESCRIPTION
## Summary

Closes #5339

The Validators directory exposed the hotkey/coldkey only through a `title` tooltip — unusable on touch/mobile — while Blocks and Extrinsics pair every hash/signer with a `CopyButton`. This adds the same `CopyButton` next to the hotkey and coldkey in **both** places the directory renders them:

- the desktop table columns (`validator-columns.tsx`, Hotkey + Coldkey cells), and
- the mobile card fallback (`validator-card-list.tsx`, #5320's `md:hidden` cards).

So the identifiers are copyable everywhere and consistent with the other index pages.

## Gates

typecheck OK - unit tests OK (`validator-columns.test.ts` still green) - eslint `.` OK (0 errors) - prettier OK

## Screenshots

Captured with Playwright at the three SKILL viewports (375x812 / 768x1024 / 1280x800), each theme forced via `mg-theme`, fixed-viewport, on /validators against the live dev server. Before: hotkey/coldkey are plain text. After: each is followed by a copy button (desktop table and mobile cards).

| Viewport - Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5339/after-mobile-dark.png)<br><sub>after</sub> |
