### PR TITLE
feat(ui): align settings hero KPIs with utility pages (#5346)

### DIFF
--- a/apps/ui/src/routes/settings.tsx
+++ b/apps/ui/src/routes/settings.tsx
@@ -22,13 +22,26 @@ export const Route = createFileRoute("/settings")({
   component: SettingsPage,
 });
 
+/**
+ * Utility-page family treatment: PageHero KPI strip only, matching sibling
+ * routes (`/schemas`, `/health`, …). Forms below stay unchanged.
+ * dense — form page; tighter strip-to-title spacing before the forms.
+ */
 function SettingsPage() {
   return (
     <AppShell>
       <PageHero
-        eyebrow="Developer"
+        dense
+        eyebrow="Operations"
         title="Developer settings"
-        description="Self-service webhook subscription management against the public subscription API. Nothing here is stored server-side beyond the subscription record itself — there is no account model."
+        description="Webhook subscription API — create, look up, delete. Token-gated; no account model."
+        caption="settings / v1"
+        kpis={[
+          { label: "Create", value: "POST", hint: "token" },
+          { label: "Lookup", value: "GET", hint: "by id" },
+          { label: "Delete", value: "DELETE", hint: "secret" },
+          { label: "Accounts", value: "None" },
+        ]}
       />
       <WebhookSubscriptionManager />
       <ApiSourceFooter paths={["/api/v1/webhooks/subscriptions"]} />

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2112,6 +2112,7 @@ function PageHero({
   description,
   actions,
   kpis,
+  dense = false,
   aside,
   caption = "registry / v1",
   className
@@ -2120,7 +2121,8 @@ function PageHero({
     "section",
     {
       className: classNames(
-        "mg-hero-slab relative mb-12 md:mb-16 pt-12 md:pt-20 pb-10 md:pb-14",
+        "mg-hero-slab relative pt-12 md:pt-20",
+        dense ? "mb-4 md:mb-6 pb-0" : "mb-12 md:mb-16 pb-10 md:pb-14",
         className
       ),
       children: [
@@ -2133,18 +2135,36 @@ function PageHero({
             ] }) : null,
             /* @__PURE__ */ jsxRuntime.jsx("h1", { className: "mg-fade-in mg-fade-in-delay-1 mt-4 font-display text-[2.5rem] sm:text-5xl md:text-[3.75rem] font-semibold leading-[1.02] tracking-[-0.025em] text-ink-strong", children: title }),
             description ? /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mg-fade-in mg-fade-in-delay-2 mt-5 max-w-xl text-base md:text-lg text-ink-muted leading-relaxed", children: description }) : null,
-            actions ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-fade-in mg-fade-in-delay-3 mt-6 flex flex-wrap items-center gap-2", children: actions }) : null
+            actions ? /* @__PURE__ */ jsxRuntime.jsx(
+              "div",
+              {
+                className: classNames(
+                  "mg-fade-in mg-fade-in-delay-3 flex flex-wrap items-center gap-2",
+                  dense ? "mt-3" : "mt-6"
+                ),
+                children: actions
+              }
+            ) : null
           ] }),
           aside ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-fade-in mg-fade-in-delay-2 hidden md:block shrink-0", children: aside }) : null
         ] }),
-        kpis && kpis.length > 0 ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mg-fade-in mg-fade-in-delay-3 mg-kpi-strip mt-12 md:mt-16", children: kpis.map((k) => /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted", children: k.label }),
-          /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
-            /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-display text-2xl md:text-[1.75rem] font-semibold tabular-nums text-ink-strong leading-none tracking-[-0.01em]", children: k.value }),
-            k.hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: k.hint }) : null
-          ] }),
-          k.chart ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mt-2.5 -ml-0.5", children: k.chart }) : null
-        ] }, k.label)) }) : null
+        kpis && kpis.length > 0 ? /* @__PURE__ */ jsxRuntime.jsx(
+          "div",
+          {
+            className: classNames(
+              "mg-fade-in mg-fade-in-delay-3 mg-kpi-strip",
+              dense ? "mt-4 md:mt-5" : "mt-12 md:mt-16"
+            ),
+            children: kpis.map((k) => /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
+              /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted", children: k.label }),
+              /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
+                /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-display text-2xl md:text-[1.75rem] font-semibold tabular-nums text-ink-strong leading-none tracking-[-0.01em]", children: k.value }),
+                k.hint ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: k.hint }) : null
+              ] }),
+              k.chart ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mt-2.5 -ml-0.5", children: k.chart }) : null
+            ] }, k.label))
+          }
+        ) : null
       ]
     }
   );

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2083,6 +2083,7 @@ function PageHero({
   description,
   actions,
   kpis,
+  dense = false,
   aside,
   caption = "registry / v1",
   className
@@ -2091,7 +2092,8 @@ function PageHero({
     "section",
     {
       className: classNames(
-        "mg-hero-slab relative mb-12 md:mb-16 pt-12 md:pt-20 pb-10 md:pb-14",
+        "mg-hero-slab relative pt-12 md:pt-20",
+        dense ? "mb-4 md:mb-6 pb-0" : "mb-12 md:mb-16 pb-10 md:pb-14",
         className
       ),
       children: [
@@ -2104,18 +2106,36 @@ function PageHero({
             ] }) : null,
             /* @__PURE__ */ jsx("h1", { className: "mg-fade-in mg-fade-in-delay-1 mt-4 font-display text-[2.5rem] sm:text-5xl md:text-[3.75rem] font-semibold leading-[1.02] tracking-[-0.025em] text-ink-strong", children: title }),
             description ? /* @__PURE__ */ jsx("p", { className: "mg-fade-in mg-fade-in-delay-2 mt-5 max-w-xl text-base md:text-lg text-ink-muted leading-relaxed", children: description }) : null,
-            actions ? /* @__PURE__ */ jsx("div", { className: "mg-fade-in mg-fade-in-delay-3 mt-6 flex flex-wrap items-center gap-2", children: actions }) : null
+            actions ? /* @__PURE__ */ jsx(
+              "div",
+              {
+                className: classNames(
+                  "mg-fade-in mg-fade-in-delay-3 flex flex-wrap items-center gap-2",
+                  dense ? "mt-3" : "mt-6"
+                ),
+                children: actions
+              }
+            ) : null
           ] }),
           aside ? /* @__PURE__ */ jsx("div", { className: "mg-fade-in mg-fade-in-delay-2 hidden md:block shrink-0", children: aside }) : null
         ] }),
-        kpis && kpis.length > 0 ? /* @__PURE__ */ jsx("div", { className: "mg-fade-in mg-fade-in-delay-3 mg-kpi-strip mt-12 md:mt-16", children: kpis.map((k) => /* @__PURE__ */ jsxs("div", { children: [
-          /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted", children: k.label }),
-          /* @__PURE__ */ jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
-            /* @__PURE__ */ jsx("span", { className: "font-display text-2xl md:text-[1.75rem] font-semibold tabular-nums text-ink-strong leading-none tracking-[-0.01em]", children: k.value }),
-            k.hint ? /* @__PURE__ */ jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: k.hint }) : null
-          ] }),
-          k.chart ? /* @__PURE__ */ jsx("div", { className: "mt-2.5 -ml-0.5", children: k.chart }) : null
-        ] }, k.label)) }) : null
+        kpis && kpis.length > 0 ? /* @__PURE__ */ jsx(
+          "div",
+          {
+            className: classNames(
+              "mg-fade-in mg-fade-in-delay-3 mg-kpi-strip",
+              dense ? "mt-4 md:mt-5" : "mt-12 md:mt-16"
+            ),
+            children: kpis.map((k) => /* @__PURE__ */ jsxs("div", { children: [
+              /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted", children: k.label }),
+              /* @__PURE__ */ jsxs("div", { className: "mt-1.5 flex items-baseline gap-2", children: [
+                /* @__PURE__ */ jsx("span", { className: "font-display text-2xl md:text-[1.75rem] font-semibold tabular-nums text-ink-strong leading-none tracking-[-0.01em]", children: k.value }),
+                k.hint ? /* @__PURE__ */ jsx("span", { className: "font-mono text-[11px] text-ink-muted", children: k.hint }) : null
+              ] }),
+              k.chart ? /* @__PURE__ */ jsx("div", { className: "mt-2.5 -ml-0.5", children: k.chart }) : null
+            ] }, k.label))
+          }
+        ) : null
       ]
     }
   );

--- a/packages/ui-kit/src/components/metagraphed/page-hero.tsx
+++ b/packages/ui-kit/src/components/metagraphed/page-hero.tsx
@@ -17,6 +17,11 @@ interface Props {
   actions?: ReactNode;
   /** Hairline KPI strip rendered below the hero copy. */
   kpis?: KpiItem[];
+  /**
+   * Tighter spacing above the KPI strip and below the hero — for form/utility
+   * pages that flow straight into content (vs dashboard heroes with charts).
+   */
+  dense?: boolean;
   /** Optional right-side slot (chart, illustration). */
   aside?: ReactNode;
   /** Top-right mono caption (defaults to "registry / v1"). */
@@ -36,6 +41,7 @@ export function PageHero({
   description,
   actions,
   kpis,
+  dense = false,
   aside,
   caption = "registry / v1",
   className,
@@ -43,7 +49,8 @@ export function PageHero({
   return (
     <section
       className={classNames(
-        "mg-hero-slab relative mb-12 md:mb-16 pt-12 md:pt-20 pb-10 md:pb-14",
+        "mg-hero-slab relative pt-12 md:pt-20",
+        dense ? "mb-4 md:mb-6 pb-0" : "mb-12 md:mb-16 pb-10 md:pb-14",
         className,
       )}
     >
@@ -69,7 +76,12 @@ export function PageHero({
             </p>
           ) : null}
           {actions ? (
-            <div className="mg-fade-in mg-fade-in-delay-3 mt-6 flex flex-wrap items-center gap-2">
+            <div
+              className={classNames(
+                "mg-fade-in mg-fade-in-delay-3 flex flex-wrap items-center gap-2",
+                dense ? "mt-3" : "mt-6",
+              )}
+            >
               {actions}
             </div>
           ) : null}
@@ -82,7 +94,12 @@ export function PageHero({
       </div>
 
       {kpis && kpis.length > 0 ? (
-        <div className="mg-fade-in mg-fade-in-delay-3 mg-kpi-strip mt-12 md:mt-16">
+        <div
+          className={classNames(
+            "mg-fade-in mg-fade-in-delay-3 mg-kpi-strip",
+            dense ? "mt-4 md:mt-5" : "mt-12 md:mt-16",
+          )}
+        >
           {kpis.map((k) => (
             <div key={k.label}>
               <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">


### PR DESCRIPTION
## Summary

- Gives `/settings` the same utility-page weight as `/schemas` and `/health`: `PageHero` with Operations eyebrow, short caption, and a compact KPI strip (POST / GET / DELETE / Accounts).
- Adds optional `PageHero` `dense` spacing for form pages that flow straight into content (tighter KPI gap + bottom margin); settings uses it so the strip sits close to the title and forms.
- Leaves webhook create / look-up / delete forms unchanged — no second StatTile actions strip above the forms.

Resubmit of #5419: screenshots recaptured from matching local servers with the same webfonts (`document.fonts.ready`) and fixed viewports (1280×800 / 768×1024 / 375×812).

Closes #5346

## Template Used

Frontend/UI change (`apps/ui/**`)

## Test plan

- [x] `npx prettier --check` on touched sources
- [x] `npx eslint` on touched sources (0 errors)
- [x] `npm run typecheck --workspace=packages/ui-kit`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm run build --workspace=packages/ui-kit` (dist in lockstep)
- [x] Manual before/after: `8120/settings` vs `8121/settings` — KPI strip present; forms unchanged; spacing tight
- [ ] Capture 12 fixed-viewport before/after screenshots (3 viewports × 2 themes × before/after)

## Screenshots

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/45325f13-22b7-4154-96ce-f740160484e9" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/16333a70-3234-454e-844c-6704edc604f2" /> |
| Desktop · Dark | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/8fec08cf-20bf-4d55-afdf-672458e7f69f" /> | <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/039ccf8e-501e-4c87-b534-dc0360b326eb" /> |
| Tablet · Light | <img width="1177" height="760" alt="image" src="https://github.com/user-attachments/assets/d4d51064-e872-4354-9c4a-1a43465d9feb" /> | <img width="1177" height="760" alt="image" src="https://github.com/user-attachments/assets/2477bdef-3aa0-444c-9344-9604d35ae0c0" /> |
| Tablet · Dark | <img width="1177" height="760" alt="image" src="https://github.com/user-attachments/assets/671892e2-cc6e-47a9-af29-79a55bb3b403" /> | <img width="1177" height="760" alt="image" src="https://github.com/user-attachments/assets/b090e55c-b174-4371-8634-90511caf7ea1" /> |
| Mobile · Light | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/ffc3ab37-6734-4c84-ba73-9e8632e4a410" /> | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/a63cc777-7687-495b-8957-34b9217e8206" /> |
| Mobile · Dark | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/cd2a0653-622e-43ca-aa66-138ad4ae1918" /> | <img width="361" height="740" alt="image" src="https://github.com/user-attachments/assets/15e07beb-9e95-47ed-9e36-95c7c70470aa" /> |