### PR TITLE
fix(ui): drop the redundant provider slug subtitle when it matches the name

### DIFF
--- a/apps/ui/src/lib/metagraphed/provider-hero-fields.test.ts
+++ b/apps/ui/src/lib/metagraphed/provider-hero-fields.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowProviderSlugSubtitle } from "./provider-hero-fields";
+
+describe("shouldShowProviderSlugSubtitle", () => {
+  it("hides the subtitle when the name is a case-folded repeat of the slug", () => {
+    expect(shouldShowProviderSlugSubtitle("404-GEN", "404-gen")).toBe(false);
+    expect(shouldShowProviderSlugSubtitle("acme", "acme")).toBe(false);
+  });
+
+  it("shows the subtitle when the name meaningfully differs from the slug", () => {
+    expect(shouldShowProviderSlugSubtitle("Acme Labs", "acme")).toBe(true);
+  });
+
+  it("hides the subtitle when there's no name (title already falls back to the slug)", () => {
+    expect(shouldShowProviderSlugSubtitle(undefined, "acme")).toBe(false);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/provider-hero-fields.ts
+++ b/apps/ui/src/lib/metagraphed/provider-hero-fields.ts
@@ -1,0 +1,9 @@
+/**
+ * Whether the provider hero's slug subtitle is worth rendering — skipped
+ * when it's just a case-folded repeat of the display name (e.g. name
+ * "404-GEN" next to slug "404-gen" reads as the same string twice).
+ */
+export function shouldShowProviderSlugSubtitle(name: string | undefined, slug: string): boolean {
+  if (!name) return false;
+  return name.toLowerCase() !== slug.toLowerCase();
+}

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -24,6 +24,7 @@ import { useHashScroll } from "@/components/metagraphed/use-hash-scroll";
 import { providerQuery, providerEndpointsQuery, subnetsQuery } from "@/lib/metagraphed/queries";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
+import { shouldShowProviderSlugSubtitle } from "@/lib/metagraphed/provider-hero-fields";
 import type { Endpoint, Subnet } from "@/lib/metagraphed/types";
 
 type SearchParams = { tab?: string };
@@ -127,7 +128,7 @@ function ProviderShell({ slug }: { slug: string }) {
           </span>
         }
         title={p?.name ?? slug}
-        subtitle={<>· {slug}</>}
+        subtitle={shouldShowProviderSlugSubtitle(p?.name, slug) ? <>· {slug}</> : null}
         description={p?.notes}
         links={<PrimaryLinksRail website={p?.website ?? p?.homepage} docs={p?.docs} />}
         stats={[


### PR DESCRIPTION
## Summary

`EntityHero` on the provider detail page always rendered `· {slug}` next to the title, even when
the provider's `name` is a case-folded repeat of its own `slug`. For SN17's "404-GEN" provider
(`slug: "404-gen"`) the hero read **"404-GEN · 404-gen"** — the same string twice.

Added `shouldShowProviderSlugSubtitle(name, slug)` (`apps/ui/src/lib/metagraphed/provider-hero-fields.ts`)
and used it to gate the subtitle in `apps/ui/src/routes/providers.$slug.tsx`. The subtitle is now
skipped when `name` is missing (the title already falls back to the slug in that case) or when
`name` matches `slug` case-insensitively; it still renders for every provider whose name and slug
genuinely differ.

## Screenshots

Captured against the live dev server with real production data, provider `404-gen` (`/providers/404-gen`),
fixed viewports, forced theme via `mg-theme` + reload.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5317-mobile-dark-after.png)<br><sub>after</sub> |

## Validation

- `npm run lint --workspace=apps/ui` — clean (pre-existing warnings only, no errors)
- `npm run format:check --workspace=apps/ui` — clean
- `npm run typecheck --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 740 passed, including new `provider-hero-fields.test.ts` covering
  the matching-case, differing-name, and no-name branches

Closes #5317
