### PR TITLE
docs(gardening): correct contributor-available target to per-repo, not combined

### DIFF
--- a/.claude/skills/contributor-pipeline-gardening/SKILL.md
+++ b/.claude/skills/contributor-pipeline-gardening/SKILL.md
@@ -48,9 +48,12 @@ Surface`, `Partner Flywheel Hardening`, or a new one if none fit) — this repo'
 
 ## Pass 2 — backlog top-up
 
-1. Compute the **combined** contributor-available count across both gittensory/loopover and
-   metagraphed before deciding how much to generate here — the 30-50/day target is a combined total,
-   not per-repo (confirmed with the maintainer 2026-07-14).
+1. Compute this repo's own contributor-available count (unassigned, no `maintainer-only`, carries a
+   `gittensor:*` label) before deciding how much to generate here — the target is **50-100+ open
+   contributor-available issues, independently per repo**. This is NOT a combined/shared pool with
+   gittensory/loopover; each repo is judged on its own backlog and must clear the bar on its own
+   merits, focused on that repo's actual goals (corrected by the maintainer 2026-07-14 — an earlier
+   version of this doc wrongly said "combined total, not per-repo").
 2. This repo's contributor-availability query needs `gittensor:priority` counted alongside
    `gittensor:feature`/`gittensor:bug` — unlike gittensory, metagraphed frequently uses
    `gittensor:priority` as a **standalone** points label (54 of 59 `gittensor:priority` issues here


### PR DESCRIPTION
## Summary

- `.claude/skills/contributor-pipeline-gardening/SKILL.md` previously said the contributor-available
  issue target ("the 30-50/day target") was a **combined total** across gittensory/loopover and
  metagraphed, not per-repo.
- The repo owner corrected this on 2026-07-14: the target is actually **50-100+ open
  contributor-available issues per repo, independently** — each repo (unassigned, no
  `maintainer-only`, carries a `gittensor:*` label) is judged on its own backlog, not a shared/combined
  pool between the two repos.
- This PR fixes the doc to match the corrected guidance.

## Test plan

- [x] Grepped both `SKILL.md` and `reference.md` in `.claude/skills/contributor-pipeline-gardening/`
      for any remaining "combined"/"30-50"/"per-repo" language — only the corrected text remains
      (`reference.md` had no matching language to begin with).
- [x] Targeted diff only, no unrelated content changed.