### PR TITLE
feat(ui): wire subnet hyperparameters-history section

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -178,6 +178,8 @@ import type {
   SubnetHistoryPoint,
   SubnetHyperparameters,
   SubnetHyperparametersDetail,
+  SubnetHyperparamsHistory,
+  SubnetHyperparamsHistoryEntry,
   SubnetIdentityHistory,
   SubnetWeightSetter,
   SubnetWeightSetters,
@@ -4739,6 +4741,63 @@ export const subnetHyperparametersQuery = (netuid: number) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<SubnetHyperparametersDetail>;
+    },
+    staleTime: STALE_MED,
+  });
+
+// #4309/1.6: one historic hyperparameter snapshot in a subnet's append-only
+// change timeline. Discarded (like the sibling identity-history normalizer)
+// when the stable `hyperparams_hash` keyset anchor is missing.
+function normalizeSubnetHyperparamsHistoryEntry(
+  raw: unknown,
+): SubnetHyperparamsHistoryEntry | null {
+  if (!isRecord(raw)) return null;
+  const hash = firstString(raw.hyperparams_hash);
+  if (hash == null) return null;
+  return {
+    block_number: firstFiniteNumber(raw.block_number) ?? null,
+    observed_at: firstString(raw.observed_at) ?? null,
+    hyperparameters: normalizeSubnetHyperparameters(raw.hyperparameters),
+    hyperparams_hash: hash,
+  };
+}
+
+const MAX_SUBNET_HYPERPARAMS_HISTORY_ENTRIES = 1000;
+
+function normalizeSubnetHyperparamsHistory(netuid: number, raw: unknown): SubnetHyperparamsHistory {
+  const rec = isRecord(raw) ? raw : {};
+  const entries = (Array.isArray(rec.entries) ? rec.entries : [])
+    .map(normalizeSubnetHyperparamsHistoryEntry)
+    .filter((entry): entry is SubnetHyperparamsHistoryEntry => entry != null)
+    .slice(0, MAX_SUBNET_HYPERPARAMS_HISTORY_ENTRIES);
+  return {
+    schema_version: firstFiniteNumber(rec.schema_version) ?? 1,
+    netuid: firstFiniteNumber(rec.netuid) ?? netuid,
+    entry_count: firstFiniteNumber(rec.entry_count) ?? entries.length,
+    entries,
+    limit: firstFiniteNumber(rec.limit) ?? null,
+    offset: firstFiniteNumber(rec.offset) ?? null,
+    next_cursor: firstString(rec.next_cursor) ?? null,
+  };
+}
+
+// GET /api/v1/subnets/{netuid}/hyperparameters/history (#4309/1.6): append-only
+// hyperparameter-change timeline for one subnet, newest first, from the
+// subnet_hyperparams_history Postgres tier. Forward-only — rows only exist
+// from when the diff-on-change write started running.
+export const subnetHyperparamsHistoryQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-hyperparams-history", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetHyperparamsHistory>>(
+        `/api/v1/subnets/${netuid}/hyperparameters/history`,
+        { signal },
+      );
+      return {
+        data: normalizeSubnetHyperparamsHistory(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1601,6 +1601,26 @@ export interface SubnetHyperparametersDetail {
   hyperparameters: SubnetHyperparameters | null;
 }
 
+/** One historic hyperparameter snapshot in a subnet's append-only change
+ * timeline, from GET /api/v1/subnets/{netuid}/hyperparameters/history. */
+export interface SubnetHyperparamsHistoryEntry {
+  block_number: number | null;
+  observed_at: string | null;
+  hyperparameters: SubnetHyperparameters | null;
+  hyperparams_hash: string;
+}
+
+/** Append-only hyperparameter-change timeline for one subnet, newest first. */
+export interface SubnetHyperparamsHistory {
+  schema_version: number;
+  netuid: number;
+  entry_count: number;
+  entries: SubnetHyperparamsHistoryEntry[];
+  limit: number | null;
+  offset: number | null;
+  next_cursor: string | null;
+}
+
 /** Append-only on-chain identity timeline for one subnet (#1647), newest first. */
 export interface SubnetIdentityHistory {
   schema_version: number;

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -1,12 +1,13 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
-import { Suspense, type ReactNode } from "react";
+import { Suspense, useState, type ReactNode } from "react";
 import {
   AlertTriangle,
   ArrowDownToLine,
   ArrowUpFromLine,
   Waves,
   Activity,
+  ChevronDown,
   Filter,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
@@ -69,6 +70,7 @@ import {
   subnetIdentityHistoryQuery,
   subnetStakeFlowQuery,
   subnetHyperparametersQuery,
+  subnetHyperparamsHistoryQuery,
 } from "@/lib/metagraphed/queries";
 import { isStaleFreshness, formatNumber, classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -203,6 +205,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   activity: "activity",
   identity: "identity",
   hyperparameters: "hyperparameters",
+  "hyperparameters-history": "hyperparameters",
   services: "services",
   "agent-readiness": "services",
   surfaces: "surfaces",
@@ -296,7 +299,12 @@ function ProfileShell({ netuid }: { netuid: number }) {
           {tab === "validators" ? <ValidatorsPanel netuid={netuid} /> : null}
           {tab === "activity" ? <ActivityPanel netuid={netuid} /> : null}
           {tab === "identity" ? <IdentityHistoryPanel netuid={netuid} /> : null}
-          {tab === "hyperparameters" ? <HyperparametersPanel netuid={netuid} /> : null}
+          {tab === "hyperparameters" ? (
+            <div className="space-y-8">
+              <HyperparametersPanel netuid={netuid} />
+              <HyperparamsHistoryPanel netuid={netuid} />
+            </div>
+          ) : null}
           {tab === "services" ? <CallableServicesPanel netuid={netuid} /> : null}
           {tab === "surfaces" ? <SurfacesPanel netuid={netuid} /> : null}
           {tab === "endpoints" ? <EndpointsPanel netuid={netuid} /> : null}
@@ -1483,6 +1491,10 @@ function ApiPanel({ netuid }: { netuid: number }) {
     { label: "endpoints", path: `/api/v1/subnets/${netuid}/endpoints` },
     { label: "candidates", path: `/api/v1/subnets/${netuid}/candidates` },
     { label: "gaps", path: `/api/v1/subnets/${netuid}/gaps` },
+    {
+      label: "hyperparameters-history",
+      path: `/api/v1/subnets/${netuid}/hyperparameters/history`,
+    },
     { label: "health", path: `/api/v1/subnets/${netuid}/health` },
     { label: "agent-catalog", path: `/api/v1/agent-catalog/${netuid}` },
     { label: "artifact", path: `/metagraph/subnets/${netuid}.json` },
@@ -1742,6 +1754,17 @@ function HyperparametersTable({ netuid }: { netuid: number }) {
           {res.data.block_number != null ? ` · block #${formatNumber(res.data.block_number)}` : ""}
         </p>
       ) : null}
+      <HyperparamGroupsTable h={h} />
+    </div>
+  );
+}
+
+// Shared full-detail render for one hyperparameter snapshot — used both for
+// the current-value table above and each expanded entry in the change-history
+// timeline below, since both are the same 33-field SubnetHyperparameters shape.
+function HyperparamGroupsTable({ h }: { h: SubnetHyperparameters }) {
+  return (
+    <div className="space-y-6">
       {HYPERPARAM_GROUPS.map((group) => (
         <div key={group.title} className="rounded-xl border border-border bg-card">
           <div className="border-b border-border px-4 py-2.5">
@@ -1760,6 +1783,78 @@ function HyperparametersTable({ netuid }: { netuid: number }) {
         </div>
       ))}
     </div>
+  );
+}
+
+/* ----------------------------- hyperparameters history ----------------------------- */
+
+function HyperparamsHistoryPanel({ netuid }: { netuid: number }) {
+  return (
+    <SectionAnchor
+      id="hyperparameters-history"
+      title="Hyperparameter history"
+      subtitle="Every recorded change to this subnet's consensus, economic, and governance settings, newest first."
+      info="GET /api/v1/subnets/{netuid}/hyperparameters/history — an append-only timeline of full hyperparameter snapshots, one entry per detected change. Forward-only: rows only exist from when this tier started tracking, so an established subnet may show fewer entries than its full history."
+    >
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+          <HyperparamsHistoryList netuid={netuid} />
+        </Suspense>
+      </QueryErrorBoundary>
+    </SectionAnchor>
+  );
+}
+
+function HyperparamsHistoryList({ netuid }: { netuid: number }) {
+  const { data: res } = useSuspenseQuery(subnetHyperparamsHistoryQuery(netuid));
+  const entries = res.data.entries;
+  const [expandedHash, setExpandedHash] = useState<string | null>(null);
+
+  if (entries.length === 0) {
+    return (
+      <EmptyState
+        title="No hyperparameter history yet"
+        description="This subnet has no recorded hyperparameter changes since this tier started tracking."
+      />
+    );
+  }
+
+  return (
+    <ol className="space-y-2">
+      {entries.map((entry) => {
+        const expanded = expandedHash === entry.hyperparams_hash;
+        return (
+          <li key={entry.hyperparams_hash} className="rounded-lg border border-border bg-card p-3">
+            <button
+              type="button"
+              onClick={() => setExpandedHash(expanded ? null : entry.hyperparams_hash)}
+              aria-expanded={expanded}
+              className="flex w-full flex-wrap items-baseline justify-between gap-2 text-left"
+            >
+              <span className="inline-flex items-center gap-1.5 font-display text-sm font-semibold text-ink-strong">
+                <ChevronDown
+                  aria-hidden
+                  className={classNames(
+                    "size-3.5 text-ink-muted transition-transform",
+                    expanded ? "rotate-180" : "",
+                  )}
+                />
+                {entry.observed_at ? <TimeAgo at={entry.observed_at} /> : "unknown time"}
+              </span>
+              <span className="font-mono text-[11px] text-ink-muted">
+                {entry.block_number != null ? `block #${formatNumber(entry.block_number)} · ` : ""}
+                {entry.hyperparams_hash.slice(0, 10)}
+              </span>
+            </button>
+            {expanded && entry.hyperparameters ? (
+              <div className="mt-3">
+                <HyperparamGroupsTable h={entry.hyperparameters} />
+              </div>
+            ) : null}
+          </li>
+        );
+      })}
+    </ol>
   );
 }
 


### PR DESCRIPTION
## Summary

Wires the `GET /api/v1/subnets/{netuid}/hyperparameters/history` endpoint (#4309) — live on the backend since 2026-07-08 with zero frontend consumer — into a new "Hyperparameter history" section on the subnet detail page's Hyperparameters tab.

## What changed

- `apps/ui/src/lib/metagraphed/types.ts`: `SubnetHyperparamsHistoryEntry` / `SubnetHyperparamsHistory` types.
- `apps/ui/src/lib/metagraphed/queries.ts`: `subnetHyperparamsHistoryQuery`, mirroring the existing `subnetIdentityHistoryQuery` normalizer shape.
- `apps/ui/src/routes/subnets.$netuid.tsx`: new `HyperparamsHistoryPanel`/`HyperparamsHistoryList` rendered below the existing current-value table in the `hyperparameters` tab. Each entry is a collapsed card (newest first); expanding one reveals the full 33-field snapshot via a `HyperparamGroupsTable` extracted from the existing `HyperparametersTable` render (shared by both the current-value view and each expanded history entry — same shape, no duplicated markup). Added an `EndpointSnippet` row and a `SECTION_TO_TAB` deep-link entry for the new section.

Verified end-to-end against the live API on subnet 1 (Apex), which has 2 real history entries.

## Screenshots

`/subnets/1?tab=hyperparameters`, scrolled to the hyperparameters-tab content where the new section attaches (right after the existing current-value table). Before = `main` (commit 88d7080c), After = this branch.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-hyperparams-history-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npm run build --workspace=packages/ui-kit` (regenerated stale local `.d.ts`)
- `npm run typecheck --workspace=apps/ui`
- `npm run lint --workspace=apps/ui` (0 errors; pre-existing `react-refresh/only-export-components` warnings unrelated to this change)
- `npm run format:check --workspace=apps/ui`
- `npm test --workspace=apps/ui` (737 passed)
- `npm run build --workspace=apps/ui`
- Manual verification against the live dev server + live API on subnet 1

Refs #5360 — 1 of 5 remaining PRs for that issue (the "account history" item was already fully wired before the issue was filed; see issue comment).
