### PR TITLE
fix(ui): enlarge the incident banner's dismiss button touch target

### DIFF
--- a/apps/ui/src/components/metagraphed/incident-strip.tsx
+++ b/apps/ui/src/components/metagraphed/incident-strip.tsx
@@ -131,7 +131,7 @@ export function IncidentStrip() {
             });
           }}
           aria-label="Dismiss incident"
-          className="shrink-0 inline-flex size-5 items-center justify-center rounded text-ink-muted hover:text-ink-strong hover:bg-surface"
+          className="shrink-0 inline-flex size-8 items-center justify-center rounded text-ink-muted hover:text-ink-strong hover:bg-surface"
         >
           <X className="size-3" />
         </button>


### PR DESCRIPTION
## Summary

`apps/ui/src/components/metagraphed/incident-strip.tsx` sized the dismiss button at `size-5` (20×20px) around a `size-3` icon, with no larger hit area — on a banner that appears above the fold on `/endpoints` and `/subnets`, sitting in a dense single-row flex next to truncating text (an easy mis-tap, right beside the message it could obscure).

Bump the dismiss button to `size-8` (32×32px), keeping the icon centered. This meaningfully enlarges the tap target from the 20px original while staying compact enough not to disturb the incident bar's dense single-row layout (the issue's stated concern).

`eslint` · `prettier --check` — clean.

Closes #5334

## Template Used

- Backend/code change (`apps/ui` presentational component)

## Screenshots

The incident strip only renders during an active incident, so it's shown here as a faithful standalone render of the exact bar markup (alert icon + "Network Warning" + message + View + dismiss). The dashed outline is **illustrative only** — it reveals the dismiss button's tap target so the 20px → 32px change is visible; the icon and the bar's single-row layout are otherwise unchanged.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5334-mobile-dark-after.png)<br><sub>after</sub> |
