### PR TITLE
feat(ui): wire subnet 24h-volume section

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -191,6 +191,7 @@ import type {
   SubnetStakeTransfers,
   SubnetRegistrations,
   SubnetStakeFlow,
+  SubnetAlphaVolume,
   SubnetMovers,
   SubnetMover,
   MetagraphNeuron,
@@ -4498,6 +4499,47 @@ export const subnetStakeFlowQuery = (netuid: number, window = "30d") =>
         signal,
       });
       return { data: normalizeSubnetStakeFlow(netuid, res.data), meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
+// #4339/8.1: rolling 24h buy/sell alpha volume scorecard, summed live from the
+// same account_events stream as stake-flow. A cold store returns all-zero
+// totals (never 404); sentiment_ratio/vol_mcap_ratio stay null rather than 0
+// when their inputs are unavailable (0 is a real "no lean"/"no data" value).
+function normalizeSubnetAlphaVolume(netuid: number, raw: unknown): SubnetAlphaVolume {
+  const d = isRecord(raw) ? raw : {};
+  const sentiment = firstString(d.sentiment);
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    netuid: firstFiniteNumber(d.netuid) ?? netuid,
+    window: firstString(d.window) ?? "24h",
+    buy_volume_alpha: coerceFiniteNumber(d.buy_volume_alpha) ?? 0,
+    sell_volume_alpha: coerceFiniteNumber(d.sell_volume_alpha) ?? 0,
+    total_volume_alpha: coerceFiniteNumber(d.total_volume_alpha) ?? 0,
+    buy_volume_tao: coerceFiniteNumber(d.buy_volume_tao) ?? 0,
+    sell_volume_tao: coerceFiniteNumber(d.sell_volume_tao) ?? 0,
+    total_volume_tao: coerceFiniteNumber(d.total_volume_tao) ?? 0,
+    buy_count: firstFiniteNumber(d.buy_count) ?? 0,
+    sell_count: firstFiniteNumber(d.sell_count) ?? 0,
+    net_volume_alpha: coerceFiniteNumber(d.net_volume_alpha) ?? 0,
+    sentiment_ratio: coerceFiniteNumber(d.sentiment_ratio) ?? null,
+    sentiment: sentiment === "bullish" || sentiment === "bearish" ? sentiment : "neutral",
+    vol_mcap_ratio: coerceFiniteNumber(d.vol_mcap_ratio) ?? null,
+  };
+}
+
+// GET /api/v1/subnets/{netuid}/volume (#4339/8.1): rolling 24h buy vs sell
+// alpha volume, unsigned (buy + sell, never netted) — a market-depth figure,
+// distinct from the cumulative subnet_volume_tao already shown in economics.
+export const subnetAlphaVolumeQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-alpha-volume", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetAlphaVolume>>(`/api/v1/subnets/${netuid}/volume`, {
+        signal,
+      });
+      return { data: normalizeSubnetAlphaVolume(netuid, res.data), meta: res.meta, url: res.url };
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1801,6 +1801,27 @@ export interface SubnetStakeFlow {
   unstake_events: number;
 }
 
+/** Rolling 24h buy/sell alpha volume for one subnet, from
+ * /api/v1/subnets/{netuid}/volume (#4339/8.1). Unsigned (buy + sell, never
+ * netted); fixed 24h window, no ?window= param. */
+export interface SubnetAlphaVolume {
+  schema_version: number;
+  netuid: number;
+  window: string;
+  buy_volume_alpha: number;
+  sell_volume_alpha: number;
+  total_volume_alpha: number;
+  buy_volume_tao: number;
+  sell_volume_tao: number;
+  total_volume_tao: number;
+  buy_count: number;
+  sell_count: number;
+  net_volume_alpha: number;
+  sentiment_ratio: number | null;
+  sentiment: "bullish" | "bearish" | "neutral";
+  vol_mcap_ratio: number | null;
+}
+
 /** One subnet's movement over the comparison window on the /subnets/movers board. */
 export interface SubnetMover {
   netuid: number;

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -4,11 +4,15 @@ import { Suspense, useState, type ReactNode } from "react";
 import {
   AlertTriangle,
   ArrowDownToLine,
+  ArrowLeftRight,
   ArrowUpFromLine,
   Waves,
   Activity,
   ChevronDown,
   Filter,
+  Minus,
+  TrendingDown,
+  TrendingUp,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import {
@@ -71,6 +75,7 @@ import {
   subnetStakeFlowQuery,
   subnetHyperparametersQuery,
   subnetHyperparamsHistoryQuery,
+  subnetAlphaVolumeQuery,
 } from "@/lib/metagraphed/queries";
 import { isStaleFreshness, formatNumber, classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -193,6 +198,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   "health-trends": "overview",
   incidents: "overview",
   economics: "overview",
+  "volume-24h": "overview",
   reliability: "overview",
   lineage: "overview",
   evidence: "overview",
@@ -397,6 +403,20 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
         info="Live chain economics from the Bittensor metagraph — emission share, alpha price, stake, validator/miner counts, and subnet volume."
       >
         <EconomicsPanel netuid={netuid} />
+      </SectionAnchor>
+
+      {/* 5a2 — Rolling 24h alpha volume (#4339/8.1): a distinct windowed
+          market-depth figure from economics' cumulative subnet_volume_tao
+          tile above — buy vs sell, unsigned, always a fixed 24h window. */}
+      <SectionAnchor
+        id="volume-24h"
+        title="24h Volume"
+        subtitle="Rolling 24h buy vs sell alpha volume — a windowed market-depth figure, distinct from the cumulative volume shown in Economics."
+        info="GET /api/v1/subnets/{netuid}/volume — unsigned buy + sell alpha volume summed from the account_events stream over a fixed 24h window (not netted, no ?window= param)."
+      >
+        <QueryErrorBoundary>
+          <AlphaVolumeScorecard netuid={netuid} />
+        </QueryErrorBoundary>
       </SectionAnchor>
 
       {/* 5b — On-chain network history (#1302): daily neuron/validator counts,
@@ -646,6 +666,52 @@ function SurfacesPanel({ netuid }: { netuid: number }) {
         </Suspense>
       </QueryErrorBoundary>
     </SectionAnchor>
+  );
+}
+
+// #4339/8.1: rolling 24h buy/sell alpha volume scorecard. A cold store returns
+// all-zero totals (never 404) — non-blocking (useQuery, not suspense) so a
+// slow/failed fetch never stalls the rest of the overview tab.
+function AlphaVolumeScorecard({ netuid }: { netuid: number }) {
+  const { data: res } = useQuery(subnetAlphaVolumeQuery(netuid));
+  const card = res?.data;
+  if (!card) return null;
+  const sentimentIcon =
+    card.sentiment === "bullish" ? TrendingUp : card.sentiment === "bearish" ? TrendingDown : Minus;
+  const sentimentTone: "ok" | "down" | "default" =
+    card.sentiment === "bullish" ? "ok" : card.sentiment === "bearish" ? "down" : "default";
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <StatTile
+        icon={ArrowLeftRight}
+        eyebrow="Total volume"
+        value={`${taoCompact(card.total_volume_tao)} τ`}
+        hint={`${formatNumber(card.buy_count + card.sell_count)} txns · ${card.window}`}
+      />
+      <StatTile
+        icon={ArrowDownToLine}
+        eyebrow="Buy volume"
+        value={`${taoCompact(card.buy_volume_tao)} τ`}
+        hint={`${formatNumber(card.buy_count)} buys`}
+      />
+      <StatTile
+        icon={ArrowUpFromLine}
+        eyebrow="Sell volume"
+        value={`${taoCompact(card.sell_volume_tao)} τ`}
+        hint={`${formatNumber(card.sell_count)} sells`}
+      />
+      <StatTile
+        icon={sentimentIcon}
+        eyebrow="Sentiment"
+        tone={sentimentTone}
+        value={card.sentiment}
+        hint={
+          card.sentiment_ratio != null
+            ? `ratio ${card.sentiment_ratio.toFixed(2)}`
+            : "no volume yet"
+        }
+      />
+    </div>
   );
 }
 
@@ -1494,6 +1560,7 @@ function ApiPanel({ netuid }: { netuid: number }) {
       label: "hyperparameters-history",
       path: `/api/v1/subnets/${netuid}/hyperparameters/history`,
     },
+    { label: "volume", path: `/api/v1/subnets/${netuid}/volume` },
     { label: "health", path: `/api/v1/subnets/${netuid}/health` },
     { label: "agent-catalog", path: `/api/v1/agent-catalog/${netuid}` },
     { label: "artifact", path: `/metagraph/subnets/${netuid}.json` },


### PR DESCRIPTION
## Summary

Wires the `GET /api/v1/subnets/{netuid}/volume` endpoint (#4339/8.1) — live on the backend, zero frontend consumer — into a new "24h Volume" section on the subnet detail page's overview tab.

## What changed

- `apps/ui/src/lib/metagraphed/types.ts`: `SubnetAlphaVolume` type.
- `apps/ui/src/lib/metagraphed/queries.ts`: `subnetAlphaVolumeQuery`, mirroring the existing `subnetStakeFlowQuery` normalizer shape.
- `apps/ui/src/routes/subnets.$netuid.tsx`: new `AlphaVolumeScorecard` (4-tile grid: total/buy/sell volume + sentiment), placed between the existing Economics and Network history sections. Added an `EndpointSnippet` row and a `SECTION_TO_TAB` deep-link entry.

**Naming note:** `EconomicsPanel` already shows a `subnet_volume_tao` stat tile labeled "Volume" — that's a different, cumulative figure from a different endpoint. This section is explicitly titled "24h Volume" with a subtitle calling out the distinction, and its magnitude is visibly different (hundreds of τ vs. the economics tile's hundreds-of-thousands τ), so the two don't read as duplicates.

Verified end-to-end against the live API on subnet 1 (Apex): 682.08 τ total (299.33 buy / 382.75 sell), sentiment neutral.

## Screenshots

`/subnets/1` overview tab, scrolled to the new section (falls back to the Economics anchor on `before`, since the section doesn't exist yet there). Before = `main` (commit 34269f25), After = this branch.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-alpha-volume-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npm run typecheck --workspace=apps/ui`
- `npm run lint --workspace=apps/ui` (0 errors; pre-existing `react-refresh/only-export-components` warnings unrelated)
- `npm run format:check --workspace=apps/ui`
- `npm test --workspace=apps/ui` (742 passed)
- `npm run build --workspace=apps/ui`
- Manual verification against the live dev server + live API on subnet 1

Refs #5360 — 2 of 5 remaining PRs for that issue.
