### PR TITLE
feat(ui): unify Validators and Leaderboards with Subnets ranked-list controls (#5344)

### DIFF
--- a/apps/ui/src/components/metagraphed/leaderboards-saved-views.tsx
+++ b/apps/ui/src/components/metagraphed/leaderboards-saved-views.tsx
@@ -1,0 +1,133 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { Scale, UserMinus, type LucideIcon } from "lucide-react";
+import { classNames } from "@/lib/metagraphed/format";
+
+type Focus = "weights" | "deregistrations";
+
+type Patch = {
+  focus: Focus;
+  window: "7d" | "30d";
+  weightsSort?: string;
+  weightsOrder?: "asc" | "desc";
+  deregSort?: string;
+  deregOrder?: "asc" | "desc";
+};
+
+type Preset = {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  patch: Patch;
+  hint?: string;
+};
+
+// `focus` makes chips mutually exclusive — without it, the default
+// weightsSort + deregSort both match their ·7d presets at once (#5344 mobile).
+const PRESETS: Preset[] = [
+  {
+    id: "weights-7d",
+    label: "Weights · 7d",
+    icon: Scale,
+    patch: {
+      focus: "weights",
+      window: "7d",
+      weightsSort: "weight_sets",
+      weightsOrder: "desc",
+    },
+    hint: "highest weight-setting activity this week",
+  },
+  {
+    id: "weights-30d",
+    label: "Weights · 30d",
+    icon: Scale,
+    patch: {
+      focus: "weights",
+      window: "30d",
+      weightsSort: "weight_sets",
+      weightsOrder: "desc",
+    },
+    hint: "highest weight-setting activity this month",
+  },
+  {
+    id: "dereg-7d",
+    label: "Dereg · 7d",
+    icon: UserMinus,
+    patch: {
+      focus: "deregistrations",
+      window: "7d",
+      deregSort: "deregistrations",
+      deregOrder: "desc",
+    },
+    hint: "most evictions this week",
+  },
+  {
+    id: "dereg-30d",
+    label: "Dereg · 30d",
+    icon: UserMinus,
+    patch: {
+      focus: "deregistrations",
+      window: "30d",
+      deregSort: "deregistrations",
+      deregOrder: "desc",
+    },
+    hint: "most evictions this month",
+  },
+];
+
+function matches(search: Record<string, unknown>, patch: Patch) {
+  return Object.entries(patch).every(([k, v]) => String(search[k] ?? "") === String(v));
+}
+
+/** Preset window/sort chips for /leaderboards — mirrors SubnetsSavedViews (#5344). */
+export function LeaderboardsSavedViews() {
+  const search = useSearch({ from: "/leaderboards" }) as Record<string, unknown>;
+  const navigate = useNavigate({ from: "/leaderboards" });
+
+  return (
+    <div className="mb-4 md:mb-6">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted shrink-0">
+          Saved views
+        </span>
+        <span aria-hidden className="h-px flex-1 min-w-0 bg-border/60" />
+      </div>
+      <div className="flex flex-wrap justify-start gap-1.5">
+        {PRESETS.map((p) => {
+          const active = matches(search, p.patch);
+          const Icon = p.icon;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              title={p.hint}
+              onClick={() => {
+                navigate({
+                  search: (prev: Record<string, unknown>) => ({ ...prev, ...p.patch }) as never,
+                  replace: true,
+                });
+                // Nudge into the focused board after the URL lands.
+                window.setTimeout(() => {
+                  document
+                    .getElementById(
+                      p.patch.focus === "weights" ? "weights-board" : "deregistrations-board",
+                    )
+                    ?.scrollIntoView({ behavior: "smooth", block: "start" });
+                }, 40);
+              }}
+              className={classNames(
+                "inline-flex h-7 shrink-0 items-center gap-1.5 rounded-full border px-2.5 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                active
+                  ? "border-accent bg-primary-soft text-ink-strong"
+                  : "border-border bg-card text-ink-muted hover:border-accent/50 hover:text-ink-strong",
+              )}
+              aria-pressed={active}
+            >
+              <Icon className="size-3" aria-hidden />
+              {p.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/validator-columns.test.ts
+++ b/apps/ui/src/components/metagraphed/validator-columns.test.ts
@@ -76,4 +76,13 @@ describe("VALIDATOR_COLUMNS", () => {
       expect(headers).toContain(h);
     }
   });
+
+  it("maps sortable headers to unique GlobalValidatorSort fields (#5344)", () => {
+    const fields = VALIDATOR_COLUMNS.map((c) => c.sortField).filter(Boolean);
+    expect(fields.length).toBeGreaterThan(0);
+    expect(new Set(fields).size).toBe(fields.length);
+    for (const h of ["Active subnets", "UIDs", "Dominance", "Total stake", "Total emission"]) {
+      expect(VALIDATOR_COLUMNS.find((c) => c.header === h)?.sortField).toBeDefined();
+    }
+  });
 });

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -5,11 +5,21 @@ import { formatNumber } from "@/lib/metagraphed/format";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
 import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
-import type { GlobalValidator } from "@/lib/metagraphed/types";
+import type { GlobalValidator, GlobalValidatorSort } from "@/lib/metagraphed/types";
 
-const TH_BASE = "px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted";
-const TD_BASE = "px-3 py-2 font-mono text-[11px]";
+const TH_BASE = "font-mono text-[10px] uppercase tracking-widest text-ink-muted";
+const TD_BASE = "font-mono";
 const TD_NUM = `${TD_BASE} text-right tabular-nums`;
+
+/** Row/header padding for the density toggle (#5344). */
+export function validatorTablePad(density: "comfortable" | "compact"): string {
+  return density === "compact" ? "px-2 py-1.5" : "px-3 py-2";
+}
+
+/** Mono cell size for the density toggle (#5344). */
+export function validatorTableMono(density: "comfortable" | "compact"): string {
+  return density === "compact" ? "text-[10px]" : "text-[11px]";
+}
 
 /**
  * One column of the global-validators table. Both the `<thead>` and every
@@ -17,9 +27,14 @@ const TD_NUM = `${TD_BASE} text-right tabular-nums`;
  * count are equal by construction — the header/cell misalignment that #5307
  * fixed (12 headers over 9 cells, columns showing another column's data) is
  * structurally impossible here. `header` values are unique (asserted in tests).
+ *
+ * Optional `sortField` marks columns that get a clickable `SortHeader` (#5344).
+ * Padding / mono size are applied at render via `validatorTablePad` /
+ * `validatorTableMono` so density can change without duplicating column defs.
  */
 export interface ValidatorColumn {
   header: string;
+  sortField?: GlobalValidatorSort;
   thClassName: string;
   tdClassName: string;
   cell: (v: GlobalValidator) => ReactNode;
@@ -27,8 +42,10 @@ export interface ValidatorColumn {
 
 const numeric = (
   header: string,
-): Pick<ValidatorColumn, "header" | "thClassName" | "tdClassName"> => ({
+  sortField?: GlobalValidatorSort,
+): Pick<ValidatorColumn, "header" | "sortField" | "thClassName" | "tdClassName"> => ({
   header,
+  sortField,
   thClassName: `${TH_BASE} text-right`,
   tdClassName: `${TD_NUM} text-ink`,
 });
@@ -88,9 +105,12 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     // apy_estimate (#2551) is a 0..1 fraction; formatApyPct takes a percentage.
     cell: (v) => formatApyPct(v.apy_estimate != null ? v.apy_estimate * 100 : null),
   },
-  { ...numeric("Active subnets"), cell: (v) => formatNumber(v.subnet_count) },
   {
-    ...numeric("UIDs"),
+    ...numeric("Active subnets", "subnet_count"),
+    cell: (v) => formatNumber(v.subnet_count),
+  },
+  {
+    ...numeric("UIDs", "uid_count"),
     tdClassName: `${TD_NUM} text-ink-muted`,
     cell: (v) => formatNumber(v.uid_count),
   },
@@ -100,12 +120,12 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     cell: (v) => (v.nominator_count != null ? formatNumber(v.nominator_count) : "—"),
   },
   {
-    ...numeric("Dominance"),
+    ...numeric("Dominance", "stake_dominance"),
     cell: (v) => (v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"),
   },
-  { ...numeric("Total stake"), cell: (v) => taoCompact(v.total_stake_tao) },
+  { ...numeric("Total stake", "total_stake"), cell: (v) => taoCompact(v.total_stake_tao) },
   {
-    ...numeric("Total emission"),
+    ...numeric("Total emission", "total_emission"),
     tdClassName: `${TD_NUM} text-ink-muted`,
     cell: (v) => taoCompact(v.total_emission_tao),
   },

--- a/apps/ui/src/components/metagraphed/validators-saved-views.tsx
+++ b/apps/ui/src/components/metagraphed/validators-saved-views.tsx
@@ -1,0 +1,113 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+
+import { Layers, Coins, Flame, Scale, Shield, TrendingUp, type LucideIcon } from "lucide-react";
+import { classNames } from "@/lib/metagraphed/format";
+import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
+
+type Patch = {
+  sort?: GlobalValidatorSort;
+  order?: "asc" | "desc";
+};
+
+type Preset = {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  patch: Patch;
+  hint?: string;
+};
+
+const PRESETS: Preset[] = [
+  {
+    id: "subnets",
+    label: "Most subnets",
+    icon: Layers,
+    patch: { sort: "subnet_count", order: "desc" },
+    hint: "broadest footprint first",
+  },
+  {
+    id: "stake",
+    label: "Top stake",
+    icon: Coins,
+    patch: { sort: "total_stake", order: "desc" },
+    hint: "highest total stake",
+  },
+  {
+    id: "emission",
+    label: "Top emission",
+    icon: Flame,
+    patch: { sort: "total_emission", order: "desc" },
+    hint: "highest total emission",
+  },
+  {
+    id: "dominance",
+    label: "Highest dominance",
+    icon: TrendingUp,
+    patch: { sort: "stake_dominance", order: "desc" },
+    hint: "share of network stake",
+  },
+  {
+    id: "trust",
+    label: "Highest trust",
+    icon: Shield,
+    patch: { sort: "avg_validator_trust", order: "desc" },
+    hint: "average validator trust",
+  },
+  {
+    id: "uids",
+    label: "Most UIDs",
+    icon: Scale,
+    patch: { sort: "uid_count", order: "desc" },
+    hint: "most validator UIDs",
+  },
+];
+
+function matches(search: Record<string, unknown>, patch: Patch) {
+  return Object.entries(patch).every(([k, v]) => String(search[k] ?? "") === String(v));
+}
+
+/** Preset sort chips for /validators — mirrors SubnetsSavedViews (#5344). */
+export function ValidatorsSavedViews() {
+  const search = useSearch({ from: "/validators/" }) as Record<string, unknown>;
+  const navigate = useNavigate({ from: "/validators/" });
+
+  return (
+    <div className="-mt-2 mb-6">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          Saved views
+        </span>
+        <span aria-hidden className="h-px flex-1 bg-border/60" />
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {PRESETS.map((p) => {
+          const active = matches(search, p.patch);
+          const Icon = p.icon;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              title={p.hint}
+              onClick={() =>
+                navigate({
+                  search: (prev: Record<string, unknown>) => ({ ...prev, ...p.patch }) as never,
+                  replace: true,
+                })
+              }
+              className={classNames(
+                "inline-flex h-7 items-center gap-1.5 rounded-full border px-2.5 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                active
+                  ? "border-accent bg-primary-soft text-ink-strong"
+                  : "border-border bg-card text-ink-muted hover:border-accent/50 hover:text-ink-strong",
+              )}
+              aria-pressed={active}
+            >
+              <Icon className="size-3" aria-hidden />
+              {p.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -8,20 +8,50 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { PageHero, BrandIcon, TimeAgo, StatTile } from "@jsonbored/ui-kit";
+import {
+  PageHero,
+  BrandIcon,
+  TimeAgo,
+  StatTile,
+  DensityToggle,
+  ShareButton,
+  type Density,
+} from "@jsonbored/ui-kit";
+import { ariaSort, SearchInput, SortHeader } from "@/components/metagraphed/table-controls";
+import { LeaderboardsSavedViews } from "@/components/metagraphed/leaderboards-saved-views";
 import {
   chainDeregistrationsQuery,
   chainWeightsQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { useIsMobile } from "@/hooks/use-mobile";
 import type { Subnet } from "@/lib/metagraphed/types";
+
+const WEIGHTS_SORT = ["netuid", "weight_sets", "distinct_setters", "sets_per_setter"] as const;
+const DEREG_SORT = [
+  "netuid",
+  "deregistrations",
+  "distinct_deregistered_hotkeys",
+  "deregistrations_per_hotkey",
+] as const;
 
 const leaderboardsSearchSchema = z.object({
   window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+  q: fallback(z.string(), "").default(""),
+  density: fallback(z.enum(["comfortable", "compact"]), "comfortable").default("comfortable"),
+  // Exclusive saved-view focus so Weights·7d and Dereg·7d don't both light up
+  // when both boards sit on their default sorts (#5344).
+  focus: fallback(z.enum(["", "weights", "deregistrations"]), "").default(""),
+  weightsSort: fallback(z.enum(WEIGHTS_SORT), "weight_sets").default("weight_sets"),
+  weightsOrder: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
+  deregSort: fallback(z.enum(DEREG_SORT), "deregistrations").default("deregistrations"),
+  deregOrder: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
 });
 
 type LeaderboardWindow = z.infer<typeof leaderboardsSearchSchema>["window"];
+type WeightsSort = (typeof WEIGHTS_SORT)[number];
+type DeregSort = (typeof DEREG_SORT)[number];
 
 export const Route = createFileRoute("/leaderboards")({
   validateSearch: zodValidator(leaderboardsSearchSchema),
@@ -44,7 +74,6 @@ export const Route = createFileRoute("/leaderboards")({
   component: LeaderboardsPage,
 });
 
-const TH = "px-4 py-2.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
 const WINDOW_BTN_ACTIVE =
   "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent";
 const WINDOW_BTN =
@@ -55,40 +84,96 @@ const WINDOW_BTN =
 function LeaderboardsPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
-  const win = search.window;
+  const isMobile = useIsMobile();
+  const win = search.window as LeaderboardWindow;
+  const q = typeof search.q === "string" ? search.q : "";
+  const weightsSort = (search.weightsSort as WeightsSort) ?? "weight_sets";
+  const weightsOrder = search.weightsOrder === "asc" ? "asc" : "desc";
+  const deregSort = (search.deregSort as DeregSort) ?? "deregistrations";
+  const deregOrder = search.deregOrder === "asc" ? "asc" : "desc";
+  const effectiveDensity: Density =
+    search.density === "compact" || search.density === "comfortable"
+      ? search.density
+      : isMobile
+        ? "compact"
+        : "comfortable";
+
+  const setDensity = (d: Density) =>
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, density: d }) as never,
+      replace: true,
+    });
 
   return (
     <AppShell>
       <PageHero
+        className="mb-6 md:mb-10"
         eyebrow="Explorer"
         live
         title="Leaderboards"
         description="Network-wide chain activity boards — ranked by subnet from live chain-direct analytics."
+        actions={
+          <div className="flex flex-wrap items-center gap-2">
+            <DensityToggle value={effectiveDensity} onChange={setDensity} />
+            <ShareButton />
+          </div>
+        }
       />
-      <div className="flex flex-wrap items-center justify-end gap-2">
-        <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Window
-        </span>
-        {(["7d", "30d"] as const).map((w) => (
-          <button
-            key={w}
-            type="button"
-            onClick={() => navigate({ search: { window: w } })}
-            className={w === win ? WINDOW_BTN_ACTIVE : WINDOW_BTN}
-          >
-            {w}
-          </button>
-        ))}
+      <LeaderboardsSavedViews />
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+        <SearchInput
+          value={q}
+          onChange={(v) =>
+            navigate({
+              search: (prev: Record<string, unknown>) => ({ ...prev, q: v }) as never,
+              replace: true,
+              resetScroll: false,
+            })
+          }
+          placeholder="Filter by subnet name or netuid…"
+          className="w-full min-w-0 sm:max-w-xs sm:flex-1"
+        />
+        <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
+          <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Window
+          </span>
+          {(["7d", "30d"] as const).map((w) => (
+            <button
+              key={w}
+              type="button"
+              onClick={() =>
+                navigate({
+                  search: (prev: Record<string, unknown>) => ({ ...prev, window: w }) as never,
+                })
+              }
+              className={w === win ? WINDOW_BTN_ACTIVE : WINDOW_BTN}
+            >
+              {w}
+            </button>
+          ))}
+        </div>
       </div>
       <div className="space-y-12">
         <QueryErrorBoundary>
           <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
-            <WeightSettingLeaderboard win={win} />
+            <WeightSettingLeaderboard
+              win={win}
+              q={q}
+              density={effectiveDensity}
+              sort={weightsSort}
+              order={weightsOrder}
+            />
           </Suspense>
         </QueryErrorBoundary>
         <QueryErrorBoundary>
           <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
-            <DeregistrationsLeaderboard win={win} />
+            <DeregistrationsLeaderboard
+              win={win}
+              q={q}
+              density={effectiveDensity}
+              sort={deregSort}
+              order={deregOrder}
+            />
           </Suspense>
         </QueryErrorBoundary>
       </div>
@@ -108,15 +193,79 @@ function useSubnetById(): Map<number, Subnet> {
   }, [snRes]);
 }
 
-function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
+function matchesSubnetFilter(netuid: number, subnet: Subnet | undefined, q: string): boolean {
+  const needle = q.trim().toLowerCase();
+  if (!needle) return true;
+  if (String(netuid).includes(needle)) return true;
+  const name = (subnet?.name ?? "").toLowerCase();
+  const slug = (typeof subnet?.slug === "string" ? subnet.slug : "").toLowerCase();
+  return name.includes(needle) || slug.includes(needle);
+}
+
+function cmpNum(a: number | null | undefined, b: number | null | undefined, order: "asc" | "desc") {
+  const av = a ?? Number.NEGATIVE_INFINITY;
+  const bv = b ?? Number.NEGATIVE_INFINITY;
+  return order === "asc" ? av - bv : bv - av;
+}
+
+function WeightSettingLeaderboard({
+  win,
+  q,
+  density,
+  sort,
+  order,
+}: {
+  win: LeaderboardWindow;
+  q: string;
+  density: Density;
+  sort: WeightsSort;
+  order: "asc" | "desc";
+}) {
+  const navigate = useNavigate({ from: Route.fullPath });
   const { data: boardRes } = useSuspenseQuery(chainWeightsQuery(win));
   const subnetById = useSubnetById();
   const board = boardRes.data;
   const network = board.network;
   const dist = board.intensity_distribution;
+  const compact = density === "compact";
+  const cellPad = compact ? "px-3 py-1.5" : "px-4 py-2.5";
+  const monoSize = compact ? "text-[10px]" : "text-[11px]";
+
+  const onSort = (field: string) => {
+    if (!(WEIGHTS_SORT as readonly string[]).includes(field)) return;
+    navigate({
+      search: (prev: { weightsSort?: string; weightsOrder?: "asc" | "desc" }) =>
+        ({
+          ...prev,
+          weightsSort: field,
+          weightsOrder: prev.weightsSort === field && prev.weightsOrder === "desc" ? "asc" : "desc",
+        }) as never,
+      replace: true,
+    });
+  };
+
+  const rows = useMemo(() => {
+    const filtered = board.subnets.filter((row) =>
+      matchesSubnetFilter(row.netuid, subnetById.get(row.netuid), q),
+    );
+    const sorted = [...filtered].sort((a, b) => {
+      switch (sort) {
+        case "netuid":
+          return cmpNum(a.netuid, b.netuid, order);
+        case "distinct_setters":
+          return cmpNum(a.distinct_setters, b.distinct_setters, order);
+        case "sets_per_setter":
+          return cmpNum(a.sets_per_setter, b.sets_per_setter, order);
+        case "weight_sets":
+        default:
+          return cmpNum(a.weight_sets, b.weight_sets, order);
+      }
+    });
+    return sorted;
+  }, [board.subnets, subnetById, q, sort, order]);
 
   return (
-    <div className="space-y-8">
+    <div id="weights-board" className="space-y-8 scroll-mt-20">
       <div>
         <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
           Weight-setting activity
@@ -163,6 +312,11 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
           description="The chain poller has not indexed any WeightsSet events for this window yet, or no validators set weights."
           lastChecked={board.observed_at ?? undefined}
         />
+      ) : rows.length === 0 ? (
+        <EmptyState
+          title="No subnets match this filter"
+          description={`No weight-setting rows for “${q.trim()}”.`}
+        />
       ) : (
         <section className="rounded-lg border border-border bg-card">
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
@@ -170,7 +324,8 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
               Per-subnet rankings
             </span>
             <span className="font-mono text-[11px] text-ink-muted">
-              {formatNumber(board.subnet_count)} subnets
+              {formatNumber(rows.length)}
+              {q.trim() ? ` of ${formatNumber(board.subnet_count)}` : ""} subnets
               {board.observed_at ? (
                 <>
                   {" "}
@@ -223,32 +378,82 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
           </div>
           <div className="hidden md:block overflow-x-auto">
             <table className="w-full text-left text-sm">
-              <thead>
+              <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
                 <tr>
-                  <th className={TH}>Rank</th>
-                  <th className={TH}>Subnet</th>
-                  <th className={`${TH} text-right`}>Weight-sets</th>
-                  <th className={`${TH} text-right`}>Distinct setters</th>
-                  <th className={`${TH} text-right`}>Per setter</th>
+                  <th className={cellPad}>Rank</th>
+                  <th className={cellPad} aria-sort={ariaSort(sort === "netuid", order)}>
+                    <SortHeader
+                      label="Subnet"
+                      field="netuid"
+                      active={sort === "netuid"}
+                      order={order}
+                      onSort={onSort}
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(sort === "weight_sets", order)}
+                  >
+                    <SortHeader
+                      label="Weight-sets"
+                      field="weight_sets"
+                      active={sort === "weight_sets"}
+                      order={order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(sort === "distinct_setters", order)}
+                  >
+                    <SortHeader
+                      label="Distinct setters"
+                      field="distinct_setters"
+                      active={sort === "distinct_setters"}
+                      order={order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(sort === "sets_per_setter", order)}
+                  >
+                    <SortHeader
+                      label="Per setter"
+                      field="sets_per_setter"
+                      active={sort === "sets_per_setter"}
+                      order={order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
-                {board.subnets.map((row, i) => {
+                {rows.map((row, i) => {
                   const subnet = subnetById.get(row.netuid);
                   const name = subnet?.name ?? `Subnet ${row.netuid}`;
                   return (
-                    <tr key={row.netuid} className="hover:bg-surface/40">
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    <tr key={row.netuid} className="mg-row-accent hover:bg-surface/40">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-muted",
+                          monoSize,
+                        )}
+                      >
                         {i + 1}
                       </td>
-                      <td className="px-4 py-2.5">
+                      <td className={cellPad}>
                         <Link
                           to="/subnets/$netuid"
                           params={{ netuid: row.netuid }}
                           className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
                         >
                           <BrandIcon
-                            size={18}
+                            size={compact ? 16 : 18}
                             name={name}
                             fallback={row.netuid}
                             netuid={row.netuid}
@@ -257,13 +462,31 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
                           <span className="truncate text-sm text-ink-strong">{name}</span>
                         </Link>
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-strong",
+                          monoSize,
+                        )}
+                      >
                         {formatNumber(row.weight_sets)}
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-muted",
+                          monoSize,
+                        )}
+                      >
                         {formatNumber(row.distinct_setters)}
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-muted",
+                          monoSize,
+                        )}
+                      >
                         {row.sets_per_setter != null ? row.sets_per_setter.toFixed(2) : "—"}
                       </td>
                     </tr>
@@ -278,14 +501,62 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
   );
 }
 
-function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
+function DeregistrationsLeaderboard({
+  win,
+  q,
+  density,
+  sort,
+  order,
+}: {
+  win: LeaderboardWindow;
+  q: string;
+  density: Density;
+  sort: DeregSort;
+  order: "asc" | "desc";
+}) {
+  const navigate = useNavigate({ from: Route.fullPath });
   const { data: boardRes } = useSuspenseQuery(chainDeregistrationsQuery(win));
   const subnetById = useSubnetById();
   const board = boardRes.data;
   const network = board.network;
+  const compact = density === "compact";
+  const cellPad = compact ? "px-3 py-1.5" : "px-4 py-2.5";
+  const monoSize = compact ? "text-[10px]" : "text-[11px]";
+
+  const onSort = (field: string) => {
+    if (!(DEREG_SORT as readonly string[]).includes(field)) return;
+    navigate({
+      search: (prev: { deregSort?: string; deregOrder?: "asc" | "desc" }) =>
+        ({
+          ...prev,
+          deregSort: field,
+          deregOrder: prev.deregSort === field && prev.deregOrder === "desc" ? "asc" : "desc",
+        }) as never,
+      replace: true,
+    });
+  };
+
+  const rows = useMemo(() => {
+    const filtered = board.subnets.filter((row) =>
+      matchesSubnetFilter(row.netuid, subnetById.get(row.netuid), q),
+    );
+    return [...filtered].sort((a, b) => {
+      switch (sort) {
+        case "netuid":
+          return cmpNum(a.netuid, b.netuid, order);
+        case "distinct_deregistered_hotkeys":
+          return cmpNum(a.distinct_deregistered_hotkeys, b.distinct_deregistered_hotkeys, order);
+        case "deregistrations_per_hotkey":
+          return cmpNum(a.deregistrations_per_hotkey, b.deregistrations_per_hotkey, order);
+        case "deregistrations":
+        default:
+          return cmpNum(a.deregistrations, b.deregistrations, order);
+      }
+    });
+  }, [board.subnets, subnetById, q, sort, order]);
 
   return (
-    <div className="space-y-8">
+    <div id="deregistrations-board" className="space-y-8 scroll-mt-20">
       <div>
         <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
           Deregistrations
@@ -328,6 +599,11 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
           description="The chain poller has not indexed any NeuronDeregistered events for this window yet, or eviction activity was zero."
           lastChecked={board.observed_at ?? undefined}
         />
+      ) : rows.length === 0 ? (
+        <EmptyState
+          title="No subnets match this filter"
+          description={`No deregistration rows for “${q.trim()}”.`}
+        />
       ) : (
         <section className="rounded-lg border border-border bg-card">
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
@@ -335,7 +611,8 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
               Per-subnet rankings
             </span>
             <span className="font-mono text-[11px] text-ink-muted">
-              {formatNumber(board.subnet_count)} subnets
+              {formatNumber(rows.length)}
+              {q.trim() ? ` of ${formatNumber(board.subnet_count)}` : ""} subnets
               {board.observed_at ? (
                 <>
                   {" "}
@@ -385,32 +662,82 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
           </div>
           <div className="hidden md:block overflow-x-auto">
             <table className="w-full text-left text-sm">
-              <thead>
+              <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
                 <tr>
-                  <th className={TH}>Rank</th>
-                  <th className={TH}>Subnet</th>
-                  <th className={`${TH} text-right`}>Deregistrations</th>
-                  <th className={`${TH} text-right`}>Distinct hotkeys</th>
-                  <th className={`${TH} text-right`}>Per hotkey</th>
+                  <th className={cellPad}>Rank</th>
+                  <th className={cellPad} aria-sort={ariaSort(sort === "netuid", order)}>
+                    <SortHeader
+                      label="Subnet"
+                      field="netuid"
+                      active={sort === "netuid"}
+                      order={order}
+                      onSort={onSort}
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(sort === "deregistrations", order)}
+                  >
+                    <SortHeader
+                      label="Deregistrations"
+                      field="deregistrations"
+                      active={sort === "deregistrations"}
+                      order={order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(sort === "distinct_deregistered_hotkeys", order)}
+                  >
+                    <SortHeader
+                      label="Distinct hotkeys"
+                      field="distinct_deregistered_hotkeys"
+                      active={sort === "distinct_deregistered_hotkeys"}
+                      order={order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(sort === "deregistrations_per_hotkey", order)}
+                  >
+                    <SortHeader
+                      label="Per hotkey"
+                      field="deregistrations_per_hotkey"
+                      active={sort === "deregistrations_per_hotkey"}
+                      order={order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
-                {board.subnets.map((row, i) => {
+                {rows.map((row, i) => {
                   const subnet = subnetById.get(row.netuid);
                   const name = subnet?.name ?? `Subnet ${row.netuid}`;
                   return (
-                    <tr key={row.netuid} className="hover:bg-surface/40">
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                    <tr key={row.netuid} className="mg-row-accent hover:bg-surface/40">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-muted",
+                          monoSize,
+                        )}
+                      >
                         {i + 1}
                       </td>
-                      <td className="px-4 py-2.5">
+                      <td className={cellPad}>
                         <Link
                           to="/subnets/$netuid"
                           params={{ netuid: row.netuid }}
                           className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
                         >
                           <BrandIcon
-                            size={18}
+                            size={compact ? 16 : 18}
                             name={name}
                             fallback={row.netuid}
                             netuid={row.netuid}
@@ -419,13 +746,31 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
                           <span className="truncate text-sm text-ink-strong">{name}</span>
                         </Link>
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-strong",
+                          monoSize,
+                        )}
+                      >
                         {formatNumber(row.deregistrations)}
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-muted",
+                          monoSize,
+                        )}
+                      >
                         {formatNumber(row.distinct_deregistered_hotkeys)}
                       </td>
-                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                      <td
+                        className={classNames(
+                          cellPad,
+                          "text-right font-mono tabular-nums text-ink-muted",
+                          monoSize,
+                        )}
+                      >
                         {row.deregistrations_per_hotkey != null
                           ? row.deregistrations_per_hotkey.toFixed(2)
                           : "—"}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -1,27 +1,29 @@
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
+import { Suspense, useMemo } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { PageHero, ShareButton } from "@jsonbored/ui-kit";
+import { DensityToggle, PageHero, ShareButton, type Density } from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { ariaSort, SortHeader } from "@/components/metagraphed/table-controls";
+import { ValidatorsSavedViews } from "@/components/metagraphed/validators-saved-views";
+import {
+  VALIDATOR_COLUMNS,
+  validatorTableMono,
+  validatorTablePad,
+} from "@/components/metagraphed/validator-columns";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
-import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
-import { shortHash } from "@/lib/metagraphed/blocks";
+import { classNames, formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
-import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { ValidatorCardList } from "@/components/metagraphed/validator-card-list";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
-import { VALIDATOR_COLUMNS } from "@/components/metagraphed/validator-columns";
-import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
+import { useIsMobile } from "@/hooks/use-mobile";
+import type { GlobalValidator, GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 // The full GlobalValidatorSort set the /api/v1/validators endpoint accepts.
-// Stake / emission / dominance / trust get their own columns in #3359; this
-// baseline page only renders hotkey identity + subnet/UID counts (#3360 adds the
-// dedicated active-subnet column), but every sort key stays selectable.
 const validatorSortKeys = [
   "subnet_count",
   "uid_count",
@@ -42,8 +44,54 @@ const SORT_LABELS: Record<GlobalValidatorSort, string> = {
   max_validator_trust: "Max trust",
 };
 
+/** Numeric value for the active GlobalValidatorSort key (API field names differ slightly). */
+function validatorSortValue(v: GlobalValidator, sort: GlobalValidatorSort): number | null {
+  switch (sort) {
+    case "subnet_count":
+      return v.subnet_count;
+    case "uid_count":
+      return v.uid_count;
+    case "stake_dominance":
+      return v.stake_dominance;
+    case "total_stake":
+      return v.total_stake_tao;
+    case "total_emission":
+      return v.total_emission_tao;
+    case "avg_validator_trust":
+      return v.avg_validator_trust;
+    case "max_validator_trust":
+      return v.max_validator_trust;
+  }
+}
+
+/**
+ * Client-side order for the URL `order` param. The validators API always ranks
+ * descending for the selected sort key; we re-sort the returned page so ascending
+ * is a true field sort (nulls last, hotkey tie-break) rather than a list reverse.
+ */
+function compareValidators(
+  a: GlobalValidator,
+  b: GlobalValidator,
+  sort: GlobalValidatorSort,
+  order: "asc" | "desc",
+): number {
+  const av = validatorSortValue(a, sort);
+  const bv = validatorSortValue(b, sort);
+  if (av == null && bv == null) return a.hotkey.localeCompare(b.hotkey);
+  if (av == null) return 1;
+  if (bv == null) return -1;
+  if (av !== bv) {
+    const cmp = av < bv ? -1 : 1;
+    return order === "asc" ? cmp : -cmp;
+  }
+  return a.hotkey.localeCompare(b.hotkey);
+}
+
 const validatorsSearchSchema = z.object({
   sort: fallback(z.enum(validatorSortKeys), "subnet_count").default("subnet_count"),
+  // API ranks desc; URL `order` re-sorts the returned page client-side (#5344).
+  order: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
+  density: fallback(z.enum(["comfortable", "compact"]), "comfortable").default("comfortable"),
 });
 
 export const Route = createFileRoute("/validators/")({
@@ -69,7 +117,35 @@ export const Route = createFileRoute("/validators/")({
 function ValidatorsPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
-  const sort = search.sort ?? "subnet_count";
+  const isMobile = useIsMobile();
+  const sort = (search.sort as GlobalValidatorSort) ?? "subnet_count";
+  const order = search.order === "asc" ? "asc" : "desc";
+  const effectiveDensity: Density =
+    search.density === "compact" || search.density === "comfortable"
+      ? search.density
+      : isMobile
+        ? "compact"
+        : "comfortable";
+
+  const setDensity = (d: Density) =>
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, density: d }) as never,
+      replace: true,
+    });
+
+  const onSort = (field: string) => {
+    if (!(validatorSortKeys as readonly string[]).includes(field)) return;
+    navigate({
+      search: (prev: { sort?: string; order?: "asc" | "desc" }) =>
+        ({
+          ...prev,
+          sort: field,
+          order: prev.sort === field && prev.order === "desc" ? "asc" : "desc",
+        }) as never,
+      replace: true,
+    });
+  };
+
   return (
     <AppShell>
       <PageHero
@@ -77,20 +153,18 @@ function ValidatorsPage() {
         live
         title="Validators"
         description="Network-wide validator directory — hotkeys ranked across all Bittensor subnets, computed live from the chain-direct metagraph."
-        actions={<ShareButton />}
+        actions={
+          <>
+            <DensityToggle value={effectiveDensity} onChange={setDensity} />
+            <ShareButton />
+          </>
+        }
       />
       <ValidatorGuide />
+      <ValidatorsSavedViews />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>
-          <ValidatorsTable
-            sort={sort}
-            onSortChange={(v) =>
-              navigate({
-                search: (prev: Record<string, unknown>) => ({ ...prev, sort: v }) as never,
-                replace: true,
-              })
-            }
-          />
+          <ValidatorsTable sort={sort} order={order} density={effectiveDensity} onSort={onSort} />
         </Suspense>
       </QueryErrorBoundary>
       <div className="mt-6" id="validator-subnet-heatmap">
@@ -105,42 +179,26 @@ function ValidatorsPage() {
   );
 }
 
-function SortSelect({
-  value,
-  onChange,
-}: {
-  value: GlobalValidatorSort;
-  onChange: (v: GlobalValidatorSort) => void;
-}) {
-  return (
-    <label className="inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs">
-      <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">Sort</span>
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value as GlobalValidatorSort)}
-        className="bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        aria-label="Sort validators"
-      >
-        {validatorSortKeys.map((k) => (
-          <option key={k} value={k}>
-            {SORT_LABELS[k]}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
 function ValidatorsTable({
   sort,
-  onSortChange,
+  order,
+  density,
+  onSort,
 }: {
   sort: GlobalValidatorSort;
-  onSortChange: (v: GlobalValidatorSort) => void;
+  order: "asc" | "desc";
+  density: Density;
+  onSort: (field: string) => void;
 }) {
   const res = useSuspenseQuery(validatorsQuery({ sort })).data;
-  const validators = res.data.validators;
   const generatedAt = res.meta?.generated_at ?? null;
+  const validators = useMemo(
+    () => [...res.data.validators].sort((a, b) => compareValidators(a, b, sort, order)),
+    [res.data.validators, sort, order],
+  );
+
+  const pad = validatorTablePad(density);
+  const mono = validatorTableMono(density);
 
   return (
     <div className="space-y-3">
@@ -153,28 +211,42 @@ function ValidatorsTable({
 
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span className="font-mono text-[11px] text-ink-muted">
-          {formatNumber(validators.length)} validators · ranked by {SORT_LABELS[sort]}
+          {formatNumber(validators.length)} validators · ranked by {SORT_LABELS[sort]} ({order})
         </span>
-        <SortSelect value={sort} onChange={onSortChange} />
       </div>
 
       {validators.length > 0 ? (
         <div className="hidden md:block overflow-x-auto rounded-lg border border-border">
           <table className="w-full text-left text-sm">
-            <thead className="bg-surface/50">
+            <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
               <tr>
                 {VALIDATOR_COLUMNS.map((col) => (
-                  <th key={col.header} className={col.thClassName}>
-                    {col.header}
+                  <th
+                    key={col.header}
+                    className={classNames(pad, col.thClassName)}
+                    aria-sort={col.sortField ? ariaSort(sort === col.sortField, order) : undefined}
+                  >
+                    {col.sortField ? (
+                      <SortHeader
+                        label={col.header}
+                        field={col.sortField}
+                        active={sort === col.sortField}
+                        order={order}
+                        onSort={onSort}
+                        align="right"
+                      />
+                    ) : (
+                      col.header
+                    )}
                   </th>
                 ))}
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
               {validators.map((v) => (
-                <tr key={v.hotkey} className="hover:bg-surface/40">
+                <tr key={v.hotkey} className="mg-row-accent hover:bg-surface/40">
                   {VALIDATOR_COLUMNS.map((col) => (
-                    <td key={col.header} className={col.tdClassName}>
+                    <td key={col.header} className={classNames(pad, mono, col.tdClassName)}>
                       {col.cell(v)}
                     </td>
                   ))}


### PR DESCRIPTION
## Summary
- Canonical ranked-list model is Subnets': clickable `SortHeader` column headers + density toggle + saved-view presets.
- Validators: replaces the standalone `<select>` sort with URL-backed column header sorts (`sort`/`order`), a density toggle, and saved-view chips; keeps `VALIDATOR_COLUMNS` (#5391) so header/cell alignment stays 1:1.
- Leaderboards: adds the same controls — per-board sortable headers, density, subnet name/netuid filter, and saved-view presets for weight-set / deregistration rankings across 7d/30d.
- Ascending order on Validators re-sorts the API page by the active field (nulls last, hotkey tie-break) instead of reversing the desc list.

Closes #5344

## Test plan
- [ ] `/validators` — click Active subnets / Stake / Trust headers; order toggles asc↔desc; density changes row padding
- [ ] `/validators` — saved-view chips update URL sort/order and highlight when active
- [ ] `/leaderboards` — sort Weight-sets / Deregistrations headers; density + filter by subnet name/netuid
- [ ] `/leaderboards` — saved views switch window + board sort presets
- [ ] `/subnets` unchanged (canonical reference)
- [x] eslint on changed files — 0 errors
- [x] prettier on changed files
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `validator-columns` unit tests

## Screenshots

### Validator

[Validator.webm](https://github.com/user-attachments/assets/ba9fcba2-ca87-49cf-8358-9466549453f9)

### Leaderboards

[Leaderboards.webm](https://github.com/user-attachments/assets/2bf8c9cf-b7b0-41d3-a5fe-4da940b75f39)
