### PR TITLE
fix(data-api): honor the documented 1000 events cap on the Postgres tier

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -1211,6 +1211,39 @@ test("GET /api/v1/accounts/:ss58/events with no matching rows returns a schema-s
   expect(body.next_cursor).toBeNull();
 });
 
+// #5474: the three events feeds document a <=1000 / default-100 profile at their
+// entities.mjs handlers, but the Postgres tier (which always wins in production
+// after the D1 retirement) used to silently re-cap them at the local 200/50 via
+// clampLimit. clampEventsLimit now applies the shared FEED_PAGINATION so the
+// effective, production-serving cap matches the documentation.
+test("GET /api/v1/accounts/:ss58/events honors the documented 1000 feed cap, not the local 200 (#5474)", async () => {
+  mockRows.current = [];
+  const res = await req(`/api/v1/accounts/${SS58}/events?limit=1000`);
+  expect(res.status).toBe(200);
+  expect((await res.json()).limit).toBe(1000);
+});
+
+test("GET /api/v1/subnets/:netuid/events honors the documented 1000 feed cap (#5474)", async () => {
+  mockRows.current = [];
+  const res = await req("/api/v1/subnets/4/events?limit=1000");
+  expect(res.status).toBe(200);
+  expect((await res.json()).limit).toBe(1000);
+});
+
+test("GET /api/v1/blocks/:ref/events honors the documented 1000 feed cap (#5474)", async () => {
+  mockQueue.current = [[], [{ block_number: 8586300 }], []];
+  const res = await req("/api/v1/blocks/8586300/events?limit=1000");
+  expect(res.status).toBe(200);
+  expect((await res.json()).data.limit).toBe(1000);
+});
+
+test("events feeds fall back to the documented default of 100, not the local 50 (#5474)", async () => {
+  mockRows.current = [];
+  const res = await req(`/api/v1/accounts/${SS58}/events`);
+  expect(res.status).toBe(200);
+  expect((await res.json()).limit).toBe(100);
+});
+
 test("GET /api/v1/accounts/:ss58/extrinsics matches the signer column only, not hotkey/coldkey", async () => {
   mockRows.current = [EXTRINSIC_ROW];
   const res = await req(`/api/v1/accounts/${SS58}/extrinsics`);

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2798,6 +2798,15 @@ function clampBlockLimit(raw) {
   return clampRequestLimit(raw, BLOCK_PAGINATION);
 }
 
+// The account/block/subnet events feeds document a <=1000 / default-100 profile
+// (FEED_PAGINATION) at their entities.mjs handlers; use the shared profile here
+// too so the Postgres-tier path (which always wins in production, #4772/#4909)
+// doesn't silently re-cap them at the local clampLimit's 200 (#5474). The local
+// clampLimit still governs the non-events routes (extrinsics/transfers/chain-events).
+function clampEventsLimit(raw) {
+  return clampRequestLimit(raw, FEED_PAGINATION);
+}
+
 function clampOffset(raw) {
   return clampRequestOffset(raw);
 }
@@ -3521,7 +3530,7 @@ export default {
         );
         if (blockRefEvents) {
           const ref = decodeURIComponent(blockRefEvents[1]);
-          const limit = clampLimit(url.searchParams.get("limit"));
+          const limit = clampEventsLimit(url.searchParams.get("limit"));
           const offset = clampOffset(url.searchParams.get("offset"));
           const blockNumber = await resolveBlockNumberPg(sql, ref);
           const rows =
@@ -3844,7 +3853,7 @@ export default {
         );
         if (acctEvents) {
           const ss58 = decodeURIComponent(acctEvents[1]);
-          const limit = clampLimit(url.searchParams.get("limit"));
+          const limit = clampEventsLimit(url.searchParams.get("limit"));
           const offset = clampOffset(url.searchParams.get("offset"));
           const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
           const kind = url.searchParams.get("kind") || null;
@@ -3891,7 +3900,7 @@ export default {
         );
         if (subnetEventsRoute) {
           const netuid = Number(subnetEventsRoute[1]);
-          const limit = clampLimit(url.searchParams.get("limit"));
+          const limit = clampEventsLimit(url.searchParams.get("limit"));
           const offset = clampOffset(url.searchParams.get("offset"));
           const cursor = decodeCursor(url.searchParams.get("cursor"), 2);
           const kind = url.searchParams.get("kind") || null;


### PR DESCRIPTION
## Summary

The `account`/`block`/`subnet` events feeds document a `<=1000` / default-100 pagination profile (`FEED_PAGINATION`) at their `entities.mjs` handlers, and the OpenAPI documents all three routes' `limit` as `maximum: 1000`. But `workers/data-api.mjs` — which `tryPostgresTier` forwards the original request to, and which **always wins in production** after the D1 events path was retired (#4772 / #4909) — re-parsed `limit` through a local `clampLimit` capped at `MAX_LIMIT = 200 / DEFAULT_LIMIT = 50`. So 200 was the *unconditional* effective cap in production, despite every route documenting and appearing to enforce 1000.

## Fix

Add `clampEventsLimit` (mirroring the existing `clampBlockLimit`'s use of the shared `request-params.mjs` profile) and apply it to the three events routes only:

- `GET /api/v1/accounts/{ss58}/events`
- `GET /api/v1/blocks/{ref}/events`
- `GET /api/v1/subnets/{netuid}/events`

The local `clampLimit` (200/50) still governs the non-events routes it also served (`/accounts/{ss58}/extrinsics`, `/accounts/{ss58}/transfers`, `/chain-events`), which are out of scope here.

The OpenAPI/contract already documents these three routes at `maximum: 1000`, so no schema change is needed — the runtime now matches the contract rather than the other way around.

Adds four regression tests: the effective cap (`?limit=1000` → `limit: 1000`) for each of the three routes, and the corrected default (`limit: 100`, not 50). Full `data-api` suite (446 tests) green; every changed line is covered.

Closes #5474
