### PR TITLE
infra(webhooks): rate-limit POST/DELETE /api/v1/webhooks/subscriptions (#5473)

### DIFF
--- a/tests/webhooks-worker.test.mjs
+++ b/tests/webhooks-worker.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { describe, test, vi } from "vitest";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import { handleRequest } from "../workers/api.mjs";
 
@@ -400,6 +400,109 @@ describe("webhook subscription routes", () => {
       res.headers.get("access-control-allow-headers"),
       /x-metagraph-webhook-secret/,
     );
+  });
+});
+
+// #5473: create + delete are gated by WEBHOOK_SUBSCRIPTION_RATE_LIMITER (a
+// no-op when the binding is absent). Mirrors the alert-trigger-create suite:
+// within-limit success, over-limit 429 with the standard header family, and
+// unbound-binding no-op.
+describe("webhook subscription rate limiting", () => {
+  const allow = () => ({ limit: vi.fn(async () => ({ success: true })) });
+  const reject = () => ({ limit: vi.fn(async () => ({ success: false })) });
+
+  test("create: 429 with the rate-limit header family when the limiter rejects, and nothing is persisted", async () => {
+    const kv = makeKv();
+    const limiter = reject();
+    const res = await postSub(
+      envWith(kv, { WEBHOOK_SUBSCRIPTION_RATE_LIMITER: limiter }),
+      { url: "https://hooks.example.com/mg" },
+    );
+    assert.equal(res.status, 429);
+    assert.equal(
+      (await res.json()).error.code,
+      "webhook_subscription_rate_limited",
+    );
+    assert.equal(res.headers.get("retry-after"), "60");
+    assert.equal(res.headers.get("x-ratelimit-limit"), "10");
+    assert.equal(res.headers.get("x-ratelimit-policy"), "10;w=60");
+    assert.equal(res.headers.get("x-ratelimit-remaining"), "0");
+    assert.equal(limiter.limit.mock.calls.length, 1);
+    // No KV row written for a rate-limited create.
+    assert.equal(kv.store.size, 0);
+  });
+
+  test("create: 201 when the limiter allows the request", async () => {
+    const kv = makeKv();
+    const limiter = allow();
+    const res = await postSub(
+      envWith(kv, { WEBHOOK_SUBSCRIPTION_RATE_LIMITER: limiter }),
+      { url: "https://hooks.example.com/mg" },
+    );
+    assert.equal(res.status, 201);
+    assert.equal(limiter.limit.mock.calls.length, 1);
+  });
+
+  test("create: skips the limiter entirely when the binding is unbound (local dev/CI)", async () => {
+    const res = await postSub(envWith(makeKv()), {
+      url: "https://hooks.example.com/mg",
+    });
+    assert.equal(res.status, 201);
+  });
+
+  test("create: rejects unauthenticated callers before consulting the limiter", async () => {
+    const limiter = reject();
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url: "https://hooks.example.com/mg" }),
+      }),
+      envWith(makeKv(), { WEBHOOK_SUBSCRIPTION_RATE_LIMITER: limiter }),
+      {},
+    );
+    assert.equal(res.status, 401);
+    assert.equal(limiter.limit.mock.calls.length, 0);
+  });
+
+  test("delete: 429 when the limiter rejects, and the subscription survives", async () => {
+    const kv = makeKv();
+    const created = await (
+      await postSub(envWith(kv), { url: "https://hooks.example.com/mg" })
+    ).json();
+    const id = created.data.id;
+    const limiter = reject();
+    const res = await handleRequest(
+      req(`/api/v1/webhooks/subscriptions/${id}`, {
+        method: "DELETE",
+        headers: { "x-metagraph-webhook-secret": created.data.secret },
+      }),
+      envWith(kv, { WEBHOOK_SUBSCRIPTION_RATE_LIMITER: limiter }),
+      {},
+    );
+    assert.equal(res.status, 429);
+    assert.equal(limiter.limit.mock.calls.length, 1);
+    assert.equal(kv.store.has(`webhooks:sub:${id}`), true);
+  });
+
+  test("delete: 200 when the limiter allows the request", async () => {
+    const kv = makeKv();
+    const created = await (
+      await postSub(envWith(kv), { url: "https://hooks.example.com/mg" })
+    ).json();
+    const id = created.data.id;
+    const limiter = allow();
+    const res = await handleRequest(
+      req(`/api/v1/webhooks/subscriptions/${id}`, {
+        method: "DELETE",
+        headers: { "x-metagraph-webhook-secret": created.data.secret },
+      }),
+      envWith(kv, { WEBHOOK_SUBSCRIPTION_RATE_LIMITER: limiter }),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.equal(limiter.limit.mock.calls.length, 1);
+    assert.equal(kv.store.has(`webhooks:sub:${id}`), false);
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -3797,6 +3797,38 @@ async function handleWebhookRequest(request, env, url) {
   );
 }
 
+// Per-client abuse control for the two webhook-subscription MUTATION routes
+// (POST create, DELETE remove). Both authenticate with a SHARED static secret
+// -- the create token, or a subscription's own secret for delete -- rather than
+// a per-user credential, and each successful POST persists a KV row
+// (expirationTtl WEBHOOK_TTL_SECONDS), so a token-holding caller could otherwise
+// script unbounded create/delete churn. 10 requests / 60s per client IP, keyed
+// on a single shared bucket so create+delete together are bounded -- the same
+// posture handleAlertTriggerCreate applies to its structurally identical
+// shared-secret route. Optional-chained so it's a no-op when the binding is
+// absent (local dev/CI), matching every other rate-limiter in this codebase.
+const WEBHOOK_SUBSCRIPTION_RATE_LIMIT = { limit: 10, windowSeconds: 60 };
+
+async function webhookSubscriptionRateLimited(request, env) {
+  if (!env.WEBHOOK_SUBSCRIPTION_RATE_LIMITER?.limit) return null;
+  const { success } = await env.WEBHOOK_SUBSCRIPTION_RATE_LIMITER.limit({
+    key: `webhook-sub:${resolveClientIp(request)}`,
+  });
+  if (success) return null;
+  return errorResponse(
+    "webhook_subscription_rate_limited",
+    "Too many webhook subscription requests from this client; slow down.",
+    429,
+    {},
+    {
+      "retry-after": String(WEBHOOK_SUBSCRIPTION_RATE_LIMIT.windowSeconds),
+      "x-ratelimit-limit": String(WEBHOOK_SUBSCRIPTION_RATE_LIMIT.limit),
+      "x-ratelimit-policy": `${WEBHOOK_SUBSCRIPTION_RATE_LIMIT.limit};w=${WEBHOOK_SUBSCRIPTION_RATE_LIMIT.windowSeconds}`,
+      "x-ratelimit-remaining": "0",
+    },
+  );
+}
+
 async function createWebhookSubscription(request, env) {
   // Authenticate BEFORE touching the request body. An unauthenticated or
   // wrong-token caller must be rejected (503 when disabled, else 401) before we
@@ -3808,6 +3840,12 @@ async function createWebhookSubscription(request, env) {
   if (!authorized.ok) {
     return authorized.response;
   }
+
+  // Abuse control sits right after auth and before we read/parse the body, so a
+  // token-holding caller can't script unbounded subscription creation -- while
+  // still rejecting unauthenticated callers first (they never reach the limiter).
+  const rateLimited = await webhookSubscriptionRateLimited(request, env);
+  if (rateLimited) return rateLimited;
 
   if (
     Number(request.headers.get("content-length") || 0) > MAX_WEBHOOK_BODY_BYTES
@@ -3978,6 +4016,13 @@ async function deleteWebhookSubscription(request, env, id) {
       400,
     );
   }
+  // Share create's per-IP budget: gated before the KV lookup so a flood of
+  // delete attempts can't drive unbounded reads. Delete authenticates with the
+  // subscription's own secret (checked below), so the limiter is the only
+  // volume bound on unauthenticated attempts.
+  const rateLimited = await webhookSubscriptionRateLimited(request, env);
+  if (rateLimited) return rateLimited;
+
   const record = await readWebhookSubscription(env, id);
   if (!record) {
     return errorResponse(

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -489,5 +489,20 @@
         "period": 60,
       },
     },
+    // Per-client abuse control for the webhook-subscription MUTATION routes
+    // (POST create + DELETE remove, #5473). Both authenticate with a SHARED
+    // static secret rather than a per-user credential, and each successful POST
+    // persists a KV row, so a token-holding caller could otherwise script
+    // unbounded create/delete churn. 10 requests / 60s per client IP — matching
+    // the alert-trigger-create limiter's posture for the same shared-secret
+    // shape. Skipped when the binding is absent (local dev/CI).
+    {
+      "name": "WEBHOOK_SUBSCRIPTION_RATE_LIMITER",
+      "namespace_id": "1006",
+      "simple": {
+        "limit": 10,
+        "period": 60,
+      },
+    },
   ],
 }


### PR DESCRIPTION
## Summary
`createWebhookSubscription` (`POST /api/v1/webhooks/subscriptions`) and `deleteWebhookSubscription` (`DELETE …/{id}`) authenticate with a **shared static secret** (the subscription token; the per-subscription secret for delete) — not a per-user credential — yet neither consulted a rate-limiter. Each successful `POST` persists a KV row (`expirationTtl: WEBHOOK_TTL_SECONDS`), so a caller holding the shared token could script **unbounded** subscription create/delete churn. None of the Worker's five existing `ratelimits` bindings covered this route, so it was missing from config, not just skipped at runtime.

This mirrors the fix already applied to the structurally identical `handleAlertTriggerCreate` (same "shared static secret, not per-user credential" shape).

## Change

**`wrangler.jsonc`** — new dedicated binding, following the existing block:
```jsonc
{ "name": "WEBHOOK_SUBSCRIPTION_RATE_LIMITER", "namespace_id": "1006",
  "simple": { "limit": 10, "period": 60 } }
```
`10 / 60s` per client IP — matching the alert-trigger-create limiter's posture for the same persistent-row-creation shape.

**`workers/api.mjs`** — a small shared guard, `webhookSubscriptionRateLimited(request, env)`:
- Optional-chained on `env.WEBHOOK_SUBSCRIPTION_RATE_LIMITER?.limit`, so it's a **no-op when the binding is unbound** (local dev/CI) — the convention every other limiter here uses.
- Keyed on `` `webhook-sub:${resolveClientIp(request)}` `` — a **single shared bucket** so create+delete together are bounded per client.
- On rejection returns a `429` with the **standard header family** (`retry-after`, `x-ratelimit-limit`, `x-ratelimit-policy`, `x-ratelimit-remaining`), the exact shape used by `handleAccountBalance` / the `DATA_RATE_LIMITER` gate in this same file.

Gate placement:
- **create** — right **after auth, before body parsing**, preserving the documented auth-before-body ordering: unauthenticated callers still `401` before the limiter is ever consulted.
- **delete** — after id-format validation and **before the KV lookup**, so a flood of delete attempts can't drive unbounded reads. (Scoped delete in as well, since the expected outcome is that a caller "cannot create **or delete** an unbounded number.")

The binding is named `…_RATE_LIMITER` rather than the issue's illustrative `…_CREATE_RATE_LIMITER` because it deliberately covers both mutation routes.

## Tests (`tests/webhooks-worker.test.mjs`, mirroring the alert-trigger-create suite)
Six new cases:
- create: **429** when the limiter rejects — asserts the full header family and that **no KV row is persisted**
- create: **201** when the limiter allows (limiter consulted exactly once)
- create: **no-op** when the binding is unbound (local dev/CI) → still 201
- create: **unauthenticated caller 401s before the limiter is consulted** (`limit` called 0 times)
- delete: **429** when the limiter rejects — the subscription **survives**
- delete: **200** when the limiter allows — the row is removed

## Verification
- `tests/webhooks-worker.test.mjs` — **37 passed** (incl. the 6 new); `tests/alert-triggers-route.test.mjs`, `account-balance` — pass
- `eslint` + `prettier --check` on all three changed files — clean
- Introduces **zero** new test failures: the pre-existing failures in `worker-runtime` / `batch-ratelimit` are a stale local codegen artifact (`api-components.schema.json`) present identically on a clean `main` checkout without this change, and are regenerated by CI's build step.

Closes #5473
