### PR TITLE
docs(gardening): drop good first issue from the label convention

### DIFF
--- a/.claude/skills/contributor-pipeline-gardening/SKILL.md
+++ b/.claude/skills/contributor-pipeline-gardening/SKILL.md
@@ -67,8 +67,10 @@ Surface`, `Partner Flywheel Hardening`, or a new one if none fit) — this repo'
 4. Every new issue: correct milestone, a `gittensor:bug`/`gittensor:feature`/`gittensor:priority`
    label (this repo's own convention — priority isn't scarce here the way it is in gittensory, but
    still means "the maintainer actually wants this soon," don't apply it reflexively to everything),
-   `help wanted` (paired convention here too), and `good first issue` when genuinely scoped/documented
-   enough for a newcomer (a label gittensory doesn't use — apply it honestly, not as a default).
+   and `help wanted` (paired convention here too). Do NOT apply `good first issue` — it isn't a real
+   convention in this repo (the label doesn't exist here, confirmed 2026-07-14) and the maintainer
+   doesn't want it introduced. Only `gittensor:*` + `help wanted` matter for contributor-available
+   issues.
 5. Full body template — Context, Requirements, Deliverables, Expected Outcome, Links & Resources (see
    `reference.md`). Registry/surface-data contributions have their own distinct shape (one file per
    subnet, `registry/subnets/<slug>.json`) — don't template a data-contribution issue the same as a

--- a/.claude/skills/contributor-pipeline-gardening/reference.md
+++ b/.claude/skills/contributor-pipeline-gardening/reference.md
@@ -24,14 +24,15 @@ skill only covers issue-pipeline hygiene, not PR review mechanics.
   values as gittensory, **but `gittensor:priority` is used far more liberally here** (roughly a third
   of all open issues, often standalone with no `gittensor:feature`/`gittensor:bug` pairing). Follow
   this repo's existing density, don't artificially scarce it down to match gittensory.
-- `good first issue` — used on ~40% of open issues here (gittensory has no equivalent label). Apply
-  honestly: genuinely scoped, well-documented, low-context-needed work only.
 - `help wanted` — paired with points labels, same as gittensory.
 - `backend` / `frontend` — apply when the work is clearly one or the other; skip when it's genuinely
   both or neither (e.g. a pure docs/data issue).
 - `maintainer-only` — used on ~57% of open issues (81/142). Only ~14 of those also carry `roadmap`,
   so **don't assume the `roadmap`+`maintainer-only` pairing convention from gittensory applies here**
   — in this repo `maintainer-only` alone is a complete, sufficient signal.
+- `good first issue` is **not** a real convention here — the label doesn't exist in this repo
+  (confirmed 2026-07-14) and the maintainer doesn't want it added. Only `gittensor:*` + `help wanted`
+  (+ `backend`/`frontend` where clearly applicable) matter for contributor-available issues.
 - Never add anything beyond the above to a gardening-generated issue.
 
 ## What's safe to unleash


### PR DESCRIPTION
## Summary
- `.claude/skills/contributor-pipeline-gardening/reference.md` and `SKILL.md` describe `good first issue` as a real, distinct labeling convention for this repo, claiming it's used on ~40% of open issues. It isn't — the label doesn't exist in this repo at all (confirmed via `gh label list` and a GraphQL label query).
- The maintainer confirmed 2026-07-14 that only `gittensor:*` labels (bug/feature/priority) plus `help wanted` matter for contributor-available issues — `good first issue` should not be introduced.

## Changes
- Removed the `good first issue` guidance from both docs and replaced it with an explicit note that the label isn't a real convention here, so future gardening runs stop trying to apply it.

No product code changed — docs only.