### PR TITLE
feat(ui): wire Download CSV into the global validators leaderboard (#5482)

### DIFF
--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -4,11 +4,12 @@ import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { PageHero, ShareButton } from "@jsonbored/ui-kit";
+import { PageHero, ShareButton, DownloadCsvButton } from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
@@ -70,6 +71,10 @@ function ValidatorsPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
   const sort = search.sort ?? "subnet_count";
+  // Mirror the sibling ranked-list pages (subnets/blocks/surfaces): export the
+  // current view as CSV. DownloadCsvButton appends `format=csv`; the backend's
+  // handleGlobalValidators already serves it (#5482).
+  const validatorsCsvUrl = buildUrl("/api/v1/validators", { sort });
   return (
     <AppShell>
       <PageHero
@@ -77,7 +82,12 @@ function ValidatorsPage() {
         live
         title="Validators"
         description="Network-wide validator directory — hotkeys ranked across all Bittensor subnets, computed live from the chain-direct metagraph."
-        actions={<ShareButton />}
+        actions={
+          <>
+            <DownloadCsvButton url={validatorsCsvUrl} />
+            <ShareButton />
+          </>
+        }
       />
       <ValidatorGuide />
       <QueryErrorBoundary>


### PR DESCRIPTION
## Summary

Closes #5482

The network-wide validators leaderboard was the only ranked-list route whose `PageHero` exposed
just a `ShareButton` — every sibling (subnets, blocks, extrinsics, surfaces, …) also offers a CSV
export. The backend already serves it (`handleGlobalValidators` returns CSV on `?format=csv`), so
this is a pure frontend wire-up: a `DownloadCsvButton` beside the ShareButton, pointed at
`/api/v1/validators` with the active sort so the export matches the on-screen ranking.

## Verification
Confirmed `GET /api/v1/validators?sort=…&format=csv` returns `200 text/csv` with the real header
row (`hotkey,coldkey,coldkey_count,subnet_count,…`).

## Gates
typecheck ✓ · unit tests ✓ · prettier ✓ · build ✓ · responsive-overflow e2e ✓ (24/24)

## Screenshots

Before/after of the validators PageHero — the export affordance appears beside "Share view" at
every viewport without crowding.

| Viewport · Theme | Before (Share only) | After (+ Download CSV) |
| --- | --- | --- |
| Mobile · Light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5482-validators-csv/before-mobile-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5482-validators-csv/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5482-validators-csv/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5482-validators-csv/after-mobile-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5482-validators-csv/before-tablet-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5482-validators-csv/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5482-validators-csv/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5482-validators-csv/after-tablet-dark.png) |
| Desktop · Light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5482-validators-csv/before-desktop-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5482-validators-csv/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5482-validators-csv/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5482-validators-csv/after-desktop-dark.png) |
