### PR TITLE
feat(ui): wire subnet stake-quote calculator

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -181,6 +181,7 @@ import type {
   SubnetHyperparametersDetail,
   SubnetHyperparamsHistory,
   SubnetHyperparamsHistoryEntry,
+  SubnetStakeQuote,
   SubnetIdentityHistory,
   SubnetWeightSetter,
   SubnetWeightSetters,
@@ -4878,6 +4879,51 @@ export const subnetHyperparamsHistoryQuery = (netuid: number) =>
       };
     },
     staleTime: STALE_MED,
+  });
+
+// #5235: read-only constant-product stake/unstake slippage quote for one
+// subnet, computed live against the subnet's AMM pool reserves. Unlike the
+// other subnet queries above, this one is user-input-driven (a free-text
+// amount): `enabled` gates on a valid positive amount so no request fires
+// for an empty/zero/negative field, and errors (400 invalid_amount, 422
+// insufficient_liquidity) are left to propagate as an ApiError for the
+// caller to render, rather than swallowed into a schema-stable zero --
+// unlike the other subnet endpoints, a failed quote has no meaningful
+// zero-value fallback to show the user.
+export const subnetStakeQuoteQuery = (
+  netuid: number,
+  amount: number,
+  direction: "stake" | "unstake",
+) =>
+  queryOptions({
+    queryKey: k("subnet-stake-quote", netuid, amount, direction),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/subnets/${netuid}/stake-quote`, {
+        params: { amount, direction },
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+          netuid: firstFiniteNumber(d.netuid) ?? netuid,
+          direction: d.direction === "unstake" ? "unstake" : "stake",
+          amount: coerceFiniteNumber(d.amount) ?? amount,
+          expected_out: coerceFiniteNumber(d.expected_out) ?? 0,
+          expected_out_unit: d.expected_out_unit === "tao" ? "tao" : "alpha",
+          spot_price_tao: coerceFiniteNumber(d.spot_price_tao) ?? 0,
+          effective_price_tao: coerceFiniteNumber(d.effective_price_tao) ?? 0,
+          price_impact_pct: coerceFiniteNumber(d.price_impact_pct) ?? 0,
+          tao_in_pool_tao: coerceFiniteNumber(d.tao_in_pool_tao) ?? null,
+          alpha_in_pool: coerceFiniteNumber(d.alpha_in_pool) ?? null,
+          is_root: booleanValue(d.is_root) ?? false,
+        } as SubnetStakeQuote,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<SubnetStakeQuote>;
+    },
+    enabled: Number.isFinite(amount) && amount > 0,
+    staleTime: STALE_SHORT,
   });
 
 // #1302: per-subnet on-chain history — daily neuron/validator counts, total

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1640,6 +1640,26 @@ export interface SubnetHyperparamsHistory {
   next_cursor: string | null;
 }
 
+/** Read-only constant-product stake/unstake slippage quote for one subnet
+ * (#5235), from GET /api/v1/subnets/{netuid}/stake-quote?amount=&direction=.
+ * Pure math against the subnet's AMM pool reserves — no chain write, no
+ * custody. tao_in_pool_tao/alpha_in_pool are null for the root subnet
+ * (netuid 0, which has no AMM and returns a 1:1 zero-impact quote instead). */
+export interface SubnetStakeQuote {
+  schema_version: number;
+  netuid: number;
+  direction: "stake" | "unstake";
+  amount: number;
+  expected_out: number;
+  expected_out_unit: "alpha" | "tao";
+  spot_price_tao: number;
+  effective_price_tao: number;
+  price_impact_pct: number;
+  tao_in_pool_tao: number | null;
+  alpha_in_pool: number | null;
+  is_root: boolean;
+}
+
 /** Append-only on-chain identity timeline for one subnet (#1647), newest first. */
 export interface SubnetIdentityHistory {
   schema_version: number;

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -2,17 +2,19 @@ import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
 import { Suspense, useState, type ReactNode } from "react";
 import {
+  AlertCircle,
   AlertTriangle,
   ArrowDownToLine,
   ArrowLeftRight,
   ArrowUpFromLine,
+  Calculator,
+  Minus,
+  TrendingDown,
+  TrendingUp,
   Waves,
   Activity,
   ChevronDown,
   Filter,
-  Minus,
-  TrendingDown,
-  TrendingUp,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import {
@@ -43,6 +45,7 @@ import {
 import { taoCompact } from "@/components/metagraphed/neuron-table";
 import { ReadinessScorecard } from "@/components/metagraphed/readiness-scorecard";
 import { EndpointList } from "@/components/metagraphed/endpoint-list";
+import { SearchInput } from "@/components/metagraphed/table-controls";
 import { SurfaceFixture } from "@/components/metagraphed/surface-fixture";
 import { VerifySurfaceButton } from "@/components/metagraphed/verify-surface-button";
 import { ReliabilityPanel } from "@/components/metagraphed/reliability-panel";
@@ -76,6 +79,7 @@ import {
   subnetHyperparametersQuery,
   subnetHyperparamsHistoryQuery,
   subnetAlphaVolumeQuery,
+  subnetStakeQuoteQuery,
 } from "@/lib/metagraphed/queries";
 import { isStaleFreshness, formatNumber, classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -199,6 +203,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   incidents: "overview",
   economics: "overview",
   "volume-24h": "overview",
+  "stake-quote": "overview",
   reliability: "overview",
   lineage: "overview",
   evidence: "overview",
@@ -417,6 +422,18 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
         <QueryErrorBoundary>
           <AlphaVolumeScorecard netuid={netuid} />
         </QueryErrorBoundary>
+      </SectionAnchor>
+
+      {/* 5a3 — Stake-quote calculator (#5235): a read-only constant-product
+          slippage estimate against the subnet's live AMM reserves. Pure math,
+          no chain write — the same swap math the chain itself uses. */}
+      <SectionAnchor
+        id="stake-quote"
+        title="Stake-quote calculator"
+        subtitle="Estimate the slippage and price impact of a stake or unstake before it happens."
+        info="GET /api/v1/subnets/{netuid}/stake-quote?amount=&direction=stake|unstake — a read-only constant-product AMM estimate against the subnet's live pool reserves. Pure math, no chain write, no custody."
+      >
+        <StakeQuoteCalculator netuid={netuid} />
       </SectionAnchor>
 
       {/* 5b — On-chain network history (#1302): daily neuron/validator counts,
@@ -711,6 +728,127 @@ function AlphaVolumeScorecard({ netuid }: { netuid: number }) {
             : "no volume yet"
         }
       />
+    </div>
+  );
+}
+
+const STAKE_QUOTE_DIRECTIONS = ["stake", "unstake"] as const;
+
+// Same precision rule as accounts.$ss58.tsx's fmtAlphaPrice — the same
+// alpha_price_tao-scale unit shown there and in subnet-price-ticker.tsx.
+function fmtQuotePrice(v: number): string {
+  if (!Number.isFinite(v)) return "—";
+  if (v < 0.001) return v.toExponential(2);
+  return v < 1 ? v.toFixed(4) : v.toFixed(3);
+}
+
+// #5235: read-only constant-product stake/unstake slippage calculator — the
+// one genuinely new interaction pattern on this page (a free-text amount
+// driving a live query, no existing precedent elsewhere in the app). Direction
+// gates the input/output units: "stake" takes a TAO amount and quotes alpha
+// out; "unstake" takes an alpha amount and quotes TAO out (mirrors the
+// chain's own swap direction, see src/stake-quote.mjs).
+function StakeQuoteCalculator({ netuid }: { netuid: number }) {
+  const [amountInput, setAmountInput] = useState("");
+  const [direction, setDirection] = useState<(typeof STAKE_QUOTE_DIRECTIONS)[number]>("stake");
+  const amount = Number(amountInput);
+  const hasValidAmount = amountInput.trim() !== "" && Number.isFinite(amount) && amount > 0;
+  const result = useQuery(subnetStakeQuoteQuery(netuid, hasValidAmount ? amount : 0, direction));
+  const quote = result.data?.data;
+  const inputUnit = direction === "stake" ? "τ" : "α";
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-col gap-1">
+          {/* SearchInput sets its own aria-label from `placeholder` -- this is a
+              visual label only, not `<label htmlFor>`, since SearchInput has no
+              `id` prop to associate with. */}
+          <span
+            aria-hidden="true"
+            className="font-mono text-[10px] uppercase tracking-widest text-ink-muted"
+          >
+            Amount ({inputUnit})
+          </span>
+          <SearchInput
+            value={amountInput}
+            onChange={setAmountInput}
+            placeholder={`0.00 ${inputUnit}`}
+            inputMode="decimal"
+            className="w-40 flex-none font-mono tabular-nums"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            Direction
+          </span>
+          <div
+            role="tablist"
+            aria-label="Stake or unstake"
+            className="inline-flex items-center rounded-md border border-border bg-card p-0.5"
+          >
+            {STAKE_QUOTE_DIRECTIONS.map((d) => {
+              const active = d === direction;
+              return (
+                <button
+                  key={d}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  onClick={() => setDirection(d)}
+                  className={classNames(
+                    "min-h-8 rounded px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest transition-colors",
+                    active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong",
+                  )}
+                >
+                  {d}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {!hasValidAmount ? (
+        <p className="font-mono text-[11px] text-ink-muted">
+          Enter an amount to estimate slippage against the subnet's live pool reserves.
+        </p>
+      ) : result.isError ? (
+        <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down">
+          <AlertCircle className="size-3.5 shrink-0" aria-hidden />
+          {result.error instanceof Error ? result.error.message : "Could not compute a quote."}
+        </p>
+      ) : result.isPending ? (
+        <p className="font-mono text-[11px] text-ink-muted">Calculating…</p>
+      ) : quote ? (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <StatTile
+            icon={Calculator}
+            eyebrow={`Expected ${quote.expected_out_unit}`}
+            value={`${formatNumber(quote.expected_out)} ${quote.expected_out_unit === "tao" ? "τ" : "α"}`}
+            hint={quote.is_root ? "root subnet · 1:1" : "live reserves"}
+          />
+          <StatTile
+            icon={Waves}
+            eyebrow="Spot price"
+            value={`${fmtQuotePrice(quote.spot_price_tao)} τ`}
+            hint="before this swap"
+          />
+          <StatTile
+            icon={ArrowLeftRight}
+            eyebrow="Effective price"
+            value={`${fmtQuotePrice(quote.effective_price_tao)} τ`}
+            hint="average, this swap"
+          />
+          <StatTile
+            icon={quote.price_impact_pct > 0 ? TrendingDown : Minus}
+            eyebrow="Price impact"
+            tone={quote.price_impact_pct > 5 ? "down" : "default"}
+            value={`${quote.price_impact_pct.toFixed(2)}%`}
+            hint={quote.is_root ? "no AMM · zero impact" : "vs spot price"}
+          />
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -1561,6 +1699,10 @@ function ApiPanel({ netuid }: { netuid: number }) {
       path: `/api/v1/subnets/${netuid}/hyperparameters/history`,
     },
     { label: "volume", path: `/api/v1/subnets/${netuid}/volume` },
+    {
+      label: "stake-quote",
+      path: `/api/v1/subnets/${netuid}/stake-quote?amount=100&direction=stake`,
+    },
     { label: "health", path: `/api/v1/subnets/${netuid}/health` },
     { label: "agent-catalog", path: `/api/v1/agent-catalog/${netuid}` },
     { label: "artifact", path: `/metagraph/subnets/${netuid}.json` },


### PR DESCRIPTION
## Summary

Wires the `GET /api/v1/subnets/{netuid}/stake-quote` endpoint (#5235) — live on the backend, zero frontend consumer — into a new "Stake-quote calculator" section on the subnet detail page's overview tab.

## What changed

- `apps/ui/src/lib/metagraphed/types.ts`: `SubnetStakeQuote` type.
- `apps/ui/src/lib/metagraphed/queries.ts`: `subnetStakeQuoteQuery(netuid, amount, direction)` — user-input-driven, `enabled` gates on a valid positive amount (mirrors the existing `searchQuery`/`semanticSearchQuery` pattern of embedding `enabled` in the factory), errors propagate as `ApiError` for the component to render rather than being swallowed into a schema-stable zero (a failed quote has no meaningful zero-value fallback).
- `apps/ui/src/routes/subnets.$netuid.tsx`: new `StakeQuoteCalculator` — a free-text amount input (reusing the existing `SearchInput` from `table-controls.tsx`) plus a hand-rolled stake/unstake segmented toggle, driving a live 4-tile result (expected out, spot price, effective price, price impact). This is the one genuinely new interaction pattern among the #5360 gaps — no existing amount-input-drives-a-live-query precedent existed anywhere in `apps/ui`. `packages/ui-kit`'s `SegmentedToggle` primitive isn't part of that package's public export surface, so the toggle stays self-contained in `apps/ui` rather than expanding that package's API for one PR.

Verified end-to-end against the live API on subnet 1 (Apex): staking 100 τ quotes 11,724.965 α expected out, 0.0085 τ spot/effective price, 0.39% price impact — all computed live from the subnet's actual AMM pool reserves.

## Screenshots

`/subnets/1` overview tab, scrolled to the new section with `100` typed into the amount field to show the live, populated result (falls back to the Economics anchor on `before`, since the section doesn't exist yet there). Before = `main`, After = this branch.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-stake-quote-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npm run typecheck --workspace=apps/ui`
- `npm run lint --workspace=apps/ui` (0 errors; pre-existing `react-refresh/only-export-components` warnings unrelated)
- `npm run format:check --workspace=apps/ui`
- `npm test --workspace=apps/ui` (750 passed)
- `npm run build --workspace=apps/ui`
- Manual verification against the live dev server + live API on subnet 1, including typing an amount and confirming the live quote

Refs #5360 — 3 of 5 remaining PRs for that issue.
