### PR TITLE
fix(schemas): add examples to remaining Provider URL fields

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5492,13 +5492,22 @@ export interface components {
             authority: components["schemas"]["Authority"];
             /** @description Shared-team cluster id (registrable domain of team_url/website_url, else the provider id) grouping providers run by the same team (issue #347). */
             cluster_id?: string;
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://example.com/contact
+             */
             contact_url?: string;
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://docs.example.com
+             */
             docs_url?: string;
             /** @description Number of live endpoints attributed to this provider. */
             endpoint_count?: number;
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://github.com/example
+             */
             github_url?: string;
             id: string;
             kind: components["schemas"]["ProviderKind"];
@@ -5517,22 +5526,40 @@ export interface components {
             schema_version: 1;
             /** @description Structured social links: a curated provider override, else borrowed from the single subnet this provider operates. Display-only; never feeds completeness. */
             social?: {
-                /** Format: uri */
+                /**
+                 * Format: uri
+                 * @example https://reddit.com/r/example
+                 */
                 reddit?: string;
-                /** Format: uri */
+                /**
+                 * Format: uri
+                 * @example https://t.me/example
+                 */
                 telegram?: string;
-                /** Format: uri */
+                /**
+                 * Format: uri
+                 * @example https://x.com/example
+                 */
                 x?: string;
-                /** Format: uri */
+                /**
+                 * Format: uri
+                 * @example https://youtube.com/@example
+                 */
                 youtube?: string;
             };
             /** @description Number of distinct subnets this provider operates (netuids.length). */
             subnet_count?: number;
             /** @description Number of curated surfaces attributed to this provider. */
             surface_count?: number;
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://example.com/team
+             */
             team_url?: string;
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://example.com
+             */
             website_url: string;
         };
         ProviderArtifact: components["schemas"]["ArtifactBase"] & ({

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -11690,10 +11690,16 @@
             "type": "string"
           },
           "contact_url": {
+            "examples": [
+              "https://example.com/contact"
+            ],
             "format": "uri",
             "type": "string"
           },
           "docs_url": {
+            "examples": [
+              "https://docs.example.com"
+            ],
             "format": "uri",
             "type": "string"
           },
@@ -11703,6 +11709,9 @@
             "type": "integer"
           },
           "github_url": {
+            "examples": [
+              "https://github.com/example"
+            ],
             "format": "uri",
             "type": "string"
           },
@@ -11748,21 +11757,33 @@
             "description": "Structured social links: a curated provider override, else borrowed from the single subnet this provider operates. Display-only; never feeds completeness.",
             "properties": {
               "reddit": {
+                "examples": [
+                  "https://reddit.com/r/example"
+                ],
                 "format": "uri",
                 "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
                 "type": "string"
               },
               "telegram": {
+                "examples": [
+                  "https://t.me/example"
+                ],
                 "format": "uri",
                 "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
                 "type": "string"
               },
               "x": {
+                "examples": [
+                  "https://x.com/example"
+                ],
                 "format": "uri",
                 "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
                 "type": "string"
               },
               "youtube": {
+                "examples": [
+                  "https://youtube.com/@example"
+                ],
                 "format": "uri",
                 "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
                 "type": "string"
@@ -11781,10 +11802,16 @@
             "type": "integer"
           },
           "team_url": {
+            "examples": [
+              "https://example.com/team"
+            ],
             "format": "uri",
             "type": "string"
           },
           "website_url": {
+            "examples": [
+              "https://example.com"
+            ],
             "format": "uri",
             "type": "string"
           }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5492,13 +5492,22 @@ export interface components {
             authority: components["schemas"]["Authority"];
             /** @description Shared-team cluster id (registrable domain of team_url/website_url, else the provider id) grouping providers run by the same team (issue #347). */
             cluster_id?: string;
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://example.com/contact
+             */
             contact_url?: string;
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://docs.example.com
+             */
             docs_url?: string;
             /** @description Number of live endpoints attributed to this provider. */
             endpoint_count?: number;
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://github.com/example
+             */
             github_url?: string;
             id: string;
             kind: components["schemas"]["ProviderKind"];
@@ -5517,22 +5526,40 @@ export interface components {
             schema_version: 1;
             /** @description Structured social links: a curated provider override, else borrowed from the single subnet this provider operates. Display-only; never feeds completeness. */
             social?: {
-                /** Format: uri */
+                /**
+                 * Format: uri
+                 * @example https://reddit.com/r/example
+                 */
                 reddit?: string;
-                /** Format: uri */
+                /**
+                 * Format: uri
+                 * @example https://t.me/example
+                 */
                 telegram?: string;
-                /** Format: uri */
+                /**
+                 * Format: uri
+                 * @example https://x.com/example
+                 */
                 x?: string;
-                /** Format: uri */
+                /**
+                 * Format: uri
+                 * @example https://youtube.com/@example
+                 */
                 youtube?: string;
             };
             /** @description Number of distinct subnets this provider operates (netuids.length). */
             subnet_count?: number;
             /** @description Number of curated surfaces attributed to this provider. */
             surface_count?: number;
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://example.com/team
+             */
             team_url?: string;
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://example.com
+             */
             website_url: string;
         };
         ProviderArtifact: components["schemas"]["ArtifactBase"] & ({

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -11668,10 +11668,16 @@
             "type": "string"
           },
           "contact_url": {
+            "examples": [
+              "https://example.com/contact"
+            ],
             "format": "uri",
             "type": "string"
           },
           "docs_url": {
+            "examples": [
+              "https://docs.example.com"
+            ],
             "format": "uri",
             "type": "string"
           },
@@ -11681,6 +11687,9 @@
             "type": "integer"
           },
           "github_url": {
+            "examples": [
+              "https://github.com/example"
+            ],
             "format": "uri",
             "type": "string"
           },
@@ -11726,21 +11735,33 @@
             "description": "Structured social links: a curated provider override, else borrowed from the single subnet this provider operates. Display-only; never feeds completeness.",
             "properties": {
               "reddit": {
+                "examples": [
+                  "https://reddit.com/r/example"
+                ],
                 "format": "uri",
                 "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
                 "type": "string"
               },
               "telegram": {
+                "examples": [
+                  "https://t.me/example"
+                ],
                 "format": "uri",
                 "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
                 "type": "string"
               },
               "x": {
+                "examples": [
+                  "https://x.com/example"
+                ],
                 "format": "uri",
                 "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
                 "type": "string"
               },
               "youtube": {
+                "examples": [
+                  "https://youtube.com/@example"
+                ],
                 "format": "uri",
                 "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
                 "type": "string"
@@ -11759,10 +11780,16 @@
             "type": "integer"
           },
           "team_url": {
+            "examples": [
+              "https://example.com/team"
+            ],
             "format": "uri",
             "type": "string"
           },
           "website_url": {
+            "examples": [
+              "https://example.com"
+            ],
             "format": "uri",
             "type": "string"
           }

--- a/schemas/components/03-providers.schema.json
+++ b/schemas/components/03-providers.schema.json
@@ -32,15 +32,18 @@
           },
           "website_url": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "examples": ["https://example.com"]
           },
           "docs_url": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "examples": ["https://docs.example.com"]
           },
           "github_url": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "examples": ["https://github.com/example"]
           },
           "logo_url": {
             "type": "string",
@@ -57,32 +60,38 @@
               "x": {
                 "type": "string",
                 "format": "uri",
-                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "examples": ["https://x.com/example"]
               },
               "telegram": {
                 "type": "string",
                 "format": "uri",
-                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "examples": ["https://t.me/example"]
               },
               "reddit": {
                 "type": "string",
                 "format": "uri",
-                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "examples": ["https://reddit.com/r/example"]
               },
               "youtube": {
                 "type": "string",
                 "format": "uri",
-                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "examples": ["https://youtube.com/@example"]
               }
             }
           },
           "team_url": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "examples": ["https://example.com/team"]
           },
           "contact_url": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "examples": ["https://example.com/contact"]
           },
           "authority": {
             "$ref": "#/components/schemas/Authority"

--- a/schemas/provider.schema.json
+++ b/schemas/provider.schema.json
@@ -35,15 +35,18 @@
     },
     "website_url": {
       "type": "string",
-      "format": "uri"
+      "format": "uri",
+      "examples": ["https://example.com"]
     },
     "docs_url": {
       "type": "string",
-      "format": "uri"
+      "format": "uri",
+      "examples": ["https://docs.example.com"]
     },
     "github_url": {
       "type": "string",
-      "format": "uri"
+      "format": "uri",
+      "examples": ["https://github.com/example"]
     },
     "logo_url": {
       "type": "string",
@@ -60,32 +63,38 @@
         "x": {
           "type": "string",
           "format": "uri",
-          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+          "examples": ["https://x.com/example"]
         },
         "telegram": {
           "type": "string",
           "format": "uri",
-          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+          "examples": ["https://t.me/example"]
         },
         "reddit": {
           "type": "string",
           "format": "uri",
-          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+          "examples": ["https://reddit.com/r/example"]
         },
         "youtube": {
           "type": "string",
           "format": "uri",
-          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+          "examples": ["https://youtube.com/@example"]
         }
       }
     },
     "team_url": {
       "type": "string",
-      "format": "uri"
+      "format": "uri",
+      "examples": ["https://example.com/team"]
     },
     "contact_url": {
       "type": "string",
-      "format": "uri"
+      "format": "uri",
+      "examples": ["https://example.com/contact"]
     },
     "authority": {
       "enum": ["official", "provider-claimed", "community", "registry-observed"]


### PR DESCRIPTION
## What

`Provider.logo_url` (`schemas/components/03-providers.schema.json`, mirrored in
`schemas/provider.schema.json`) carries an `examples` hint, but every sibling URL-typed field on the
same object did not: `website_url`, `docs_url`, `github_url`, `team_url`, `contact_url`, and the
nested `social.x` / `social.telegram` / `social.reddit` / `social.youtube`.

This adds an `examples` array to each of those fields, in `logo_url`'s style (a single realistic URL
string), consistent with each field's own `pattern`/`format` constraint (e.g. `social.x` looks like an
X/Twitter profile URL, not a generic domain).

## Why

Every URL-typed field on `Provider` should carry the same documentation hint that `logo_url` already
has — the inconsistency meant most of the generated OpenAPI schema for `Provider` had no example
value at all, only `logo_url` did.

## How this was verified

- `npm run build` — regenerated `openapi.json`, `types.d.ts`, `packages/contract/index.d.ts`,
  `schemas/api-components.schema.json` from the edited source schemas; diffs are limited to the new
  `examples` fields.
- `npm run validate:contract-drift` — passed
- `npm run validate:schemas` — passed
- `npm run validate:openapi` — passed
- `npm run validate` — passed (129 subnets, 133 providers, 1602 surfaces, 2037 candidates)
- `npm run lint` / `npm run format:check` — passed
- `npm test` — 273 test files / 8183 tests passed

No behavior changes — this only adds documentation-level `examples` to the schema; the
operation-level examples generated per API call (`src/openapi-sample.mjs`) are untouched.

Closes #5477
