### PR TITLE
feat(ui): wire subnet recycled-TAO stat

### DIFF
--- a/apps/ui/src/components/metagraphed/economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/economics-panel.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   economicsQuery,
+  subnetRecycledQuery,
   subnetStakeMovesQuery,
   subnetStakeTransfersQuery,
   subnetTrajectoryQuery,
@@ -110,6 +111,24 @@ function StakeTransfersTile({ netuid }: { netuid: number }) {
   );
 }
 
+// #4339/8.4: cumulative TAO recycled for registration on this subnet, queried
+// live from the chain (600s KV cache on the backend) rather than the
+// account_events log-layer aggregations the sibling stake tiles above use --
+// see subnet-recycled.mjs's header for why. recycled_tao stays "—" (not "0")
+// on an RPC failure, since 0 is a real, distinct value here.
+function RecycledTaoTile({ netuid }: { netuid: number }) {
+  const { data: res, isPending, isError } = useQuery(subnetRecycledQuery(netuid));
+  const recycled = res?.data.recycled_tao;
+  const value = isError
+    ? "—"
+    : isPending && recycled == null
+      ? "…"
+      : recycled == null
+        ? "—"
+        : formatTao(recycled);
+  return <StatTile eyebrow="Recycled TAO" value={value} hint="cumulative · live RPC" />;
+}
+
 export function EconomicsPanel({ netuid }: { netuid: number }) {
   const { data: res, isPending } = useQuery(economicsQuery());
   const e = res?.data.find((x) => x.netuid === netuid);
@@ -182,6 +201,7 @@ export function EconomicsPanel({ netuid }: { netuid: number }) {
           value={e.registration_cost_tao != null ? `${e.registration_cost_tao} τ` : "—"}
           hint={e.registration_allowed === false ? "closed" : "open"}
         />
+        <RecycledTaoTile netuid={netuid} />
         <StakeMovesTile netuid={netuid} />
         <StakeTransfersTile netuid={netuid} />
       </div>

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -182,6 +182,7 @@ import type {
   SubnetHyperparamsHistory,
   SubnetHyperparamsHistoryEntry,
   SubnetStakeQuote,
+  SubnetRecycled,
   SubnetIdentityHistory,
   SubnetWeightSetter,
   SubnetWeightSetters,
@@ -4924,6 +4925,30 @@ export const subnetStakeQuoteQuery = (
     },
     enabled: Number.isFinite(amount) && amount > 0,
     staleTime: STALE_SHORT,
+  });
+
+// #4339/8.4: the live cumulative TAO recycled for registration on one subnet,
+// queried live from the chain (600s KV cache on the backend) — a single
+// snapshot, no pagination. recycled_tao stays null on RPC failure rather than
+// coercing to 0, since 0 is a real, distinct value (zero registrations ever).
+export const subnetRecycledQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-recycled", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/subnets/${netuid}/recycled`, { signal });
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+          netuid: firstFiniteNumber(d.netuid) ?? netuid,
+          recycled_tao: coerceFiniteNumber(d.recycled_tao) ?? null,
+          queried_at: firstString(d.queried_at) ?? null,
+        } as SubnetRecycled,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<SubnetRecycled>;
+    },
+    staleTime: STALE_MED,
   });
 
 // #1302: per-subnet on-chain history — daily neuron/validator counts, total

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1660,6 +1660,17 @@ export interface SubnetStakeQuote {
   is_root: boolean;
 }
 
+/** The live cumulative TAO recycled for registration on one subnet (#4339/8.4),
+ * from GET /api/v1/subnets/{netuid}/recycled — queried live from the chain's
+ * RAORecycledForRegistration storage map (600s KV cache). recycled_tao is
+ * null only on RPC failure (schema-stable), a real 0 for zero registrations. */
+export interface SubnetRecycled {
+  schema_version: number;
+  netuid: number;
+  recycled_tao: number | null;
+  queried_at: string | null;
+}
+
 /** Append-only on-chain identity timeline for one subnet (#1647), newest first. */
 export interface SubnetIdentityHistory {
   schema_version: number;

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -1703,6 +1703,7 @@ function ApiPanel({ netuid }: { netuid: number }) {
       label: "stake-quote",
       path: `/api/v1/subnets/${netuid}/stake-quote?amount=100&direction=stake`,
     },
+    { label: "recycled", path: `/api/v1/subnets/${netuid}/recycled` },
     { label: "health", path: `/api/v1/subnets/${netuid}/health` },
     { label: "agent-catalog", path: `/api/v1/agent-catalog/${netuid}` },
     { label: "artifact", path: `/metagraph/subnets/${netuid}.json` },


### PR DESCRIPTION
## Summary

Wires the `GET /api/v1/subnets/{netuid}/recycled` endpoint (#4339/8.4) — live on the backend (live-RPC, 600s KV cache), zero frontend consumer — into a new "Recycled TAO" tile on the subnet detail page.

## What changed

- `apps/ui/src/lib/metagraphed/types.ts`: `SubnetRecycled` type.
- `apps/ui/src/lib/metagraphed/queries.ts`: `subnetRecycledQuery`. `recycled_tao` stays `null` (rendered as "—") on an RPC failure rather than coercing to `0`, since `0` is a real, distinct value (zero registrations ever) for this endpoint.
- `apps/ui/src/components/metagraphed/economics-panel.tsx`: new `RecycledTaoTile`, placed directly after the existing "Registration" tile in `EconomicsPanel`'s stat grid — recycled TAO is registration-adjacent, and this keeps the change self-contained to one existing panel rather than adding a new `SectionAnchor` to the (already dense) subnet-detail route file.
- `apps/ui/src/routes/subnets.$netuid.tsx`: one `EndpointSnippet` row.

Verified end-to-end against the live API on subnet 1 (Apex): 102.6k τ cumulative recycled.

## Screenshots

`/subnets/1` overview tab, scrolled to the Economics section where the new tile attaches (right after Registration). Before = `main`, After = this branch.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-recycled-tao-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npm run typecheck --workspace=apps/ui`
- `npm run lint --workspace=apps/ui` (0 errors; pre-existing `react-refresh/only-export-components` warnings unrelated)
- `npm run format:check --workspace=apps/ui`
- `npm test --workspace=apps/ui` (753 passed)
- `npm run build --workspace=apps/ui`
- Manual verification against the live dev server + live API on subnet 1

**Merge-order note:** this PR and #5483 (24h volume) both edit `subnets.$netuid.tsx`'s `EndpointSnippet` rows array; whichever merges second will need a trivial one-line rebase.

Refs #5360 — 4 of 5 remaining PRs for that issue.
