### PR TITLE
fix(registry): stop claiming verified-live for 5 subnets with re-checked dead URLs

### DIFF
--- a/registry/subnets/8-ball.json
+++ b/registry/subnets/8-ball.json
@@ -14,7 +14,7 @@
   "website_url": "https://8ball125.com/",
   "docs_url": "https://github.com/Barbariandev/8Ball_miner#readme",
   "source_repo": "https://github.com/Barbariandev/8Ball_miner",
-  "notes": "Reviewed overlay for SN125 8 Ball. The public website is live and the public miner/source repository documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
+  "notes": "Reviewed overlay for SN125 8 Ball. The public website currently returns HTTP 502 to simple probes and should appear degraded until it recovers; the public miner/source repository documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -22,7 +22,7 @@
     "verified_at": "2026-06-08T15:00:00.000Z",
     "source_count": 7,
     "gap_notes": [
-      "Official website and miner/source repository are verified live.",
+      "Official website currently returns HTTP 502 to simple probes and should appear degraded until it recovers; the miner/source repository remains verified live.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
@@ -49,7 +49,7 @@
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official 8 Ball website linked from the public SN125 miner repository."
+      "notes": "Official 8 Ball website linked from the public SN125 miner repository. Current probe state is expected to show degraded while the origin returns HTTP 502 responses."
     },
     {
       "id": "sn-125-eightball-source-repo",

--- a/registry/subnets/ninja.json
+++ b/registry/subnets/ninja.json
@@ -12,6 +12,7 @@
   "contact": "tau@arbos.life",
   "curation": {
     "gap_notes": [
+      "Official website currently returns HTTP 404 to simple probes and should appear degraded until it recovers.",
       "Swagger/OpenAPI routes currently serve HTML UI only; no verified machine-readable schema URL yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
@@ -33,7 +34,7 @@
   ],
   "name": "ninja",
   "netuid": 66,
-  "notes": "Reviewed overlay for SN66 using the official Ninja/Unarbos website, tau workflow repository, miner harness repository, health endpoint, and Swagger UI. The obvious OpenAPI JSON paths currently serve HTML, so schema-backed status remains a gap.",
+  "notes": "Reviewed overlay for SN66 using the official Ninja/Unarbos website, tau workflow repository, miner harness repository, health endpoint, and Swagger UI. The website currently returns HTTP 404 to simple probes and should appear degraded until it recovers. The obvious OpenAPI JSON paths currently serve HTML, so schema-backed status remains a gap.",
   "schema_version": 1,
   "slug": "sn-66",
   "source_repo": "https://github.com/unarbos/tau",
@@ -45,7 +46,7 @@
       "id": "sn-66-ninja-website",
       "kind": "website",
       "name": "Ninja website",
-      "notes": "Official Ninja SN66 public website.",
+      "notes": "Official Ninja SN66 public website. Current probe state is expected to show degraded while the origin returns HTTP 404 responses.",
       "probe": {
         "enabled": true,
         "expect": "html",

--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -15,7 +15,7 @@
   "website_url": "https://oneoneone.io/",
   "source_repo": "https://github.com/oneoneone-io/subnet-111",
   "dashboard_url": "https://taomarketcap.com/subnets/111",
-  "notes": "Reviewed overlay for SN111 using the official oneoneone website and source repository. No official docs/API/OpenAPI surface is verified yet.",
+  "notes": "Reviewed overlay for SN111 using the official oneoneone website and source repository. The website currently returns a Cloudflare 530 error to simple probes and should appear degraded until it recovers. No official docs/API/OpenAPI surface is verified yet.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -23,6 +23,7 @@
     "verified_at": "2026-06-08T10:35:00.000Z",
     "source_count": 4,
     "gap_notes": [
+      "Official website currently returns a Cloudflare 530 error to simple probes and should appear degraded until it recovers.",
       "No verified official docs URL yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified OpenAPI/Swagger schema yet.",
@@ -47,7 +48,7 @@
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official oneoneone website."
+      "notes": "Official oneoneone website. Current probe state is expected to show degraded while the origin returns a Cloudflare 530 error."
     },
     {
       "id": "sn-111-oneoneone-source",

--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -26,7 +26,7 @@
     "sn-10-website-common-swagger-json",
     "sn-10-website-subdomain-docs-docs-taofi-com"
   ],
-  "notes": "Reviewed overlay for SN10 Swap using the TaoFi pool page, TaoFi docs, and Swap source repository. Common www.taofi.com API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
+  "notes": "Reviewed overlay for SN10 Swap using the TaoFi pool page, TaoFi docs, and Swap source repository. The pool page currently returns HTTP 402 to simple probes and should appear degraded until it recovers. Common www.taofi.com API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -34,7 +34,7 @@
     "verified_at": "2026-06-08T20:25:00.000Z",
     "source_count": 5,
     "gap_notes": [
-      "Official TaoFi pool page, docs, and Swap source repository are verified live.",
+      "TaoFi docs and Swap source repository are verified live; the pool page currently returns HTTP 402 to simple probes and should appear degraded until it recovers.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
       "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
@@ -62,7 +62,7 @@
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official TaoFi pool page for SN10 Swap."
+      "notes": "Official TaoFi pool page for SN10 Swap. Current probe state is expected to show degraded while the origin returns HTTP 402 responses."
     },
     {
       "id": "sn-10-taofi-docs",

--- a/registry/subnets/tensorclaw.json
+++ b/registry/subnets/tensorclaw.json
@@ -17,7 +17,7 @@
   "dashboard_url": "https://www.tensorclaw.ai/dashboard",
   "website_url": "https://www.tensorclaw.ai/",
   "baseline_excluded_surface_ids": ["sn-92-taomarketcap-website"],
-  "notes": "Reviewed overlay for SN92 using the live Tensorclaw Network website, dashboard, and source repository. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The website links https://github.com/tensorclaw/tensorclaw and the repository README identifies it as Bittensor Tensorclaw Subnet 92.",
+  "notes": "Reviewed overlay for SN92 using the Tensorclaw Network website, dashboard, and source repository. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The website links https://github.com/tensorclaw/tensorclaw and the repository README identifies it as Bittensor Tensorclaw Subnet 92. The website and dashboard currently return Cloudflare 521 errors to simple probes and should appear degraded until they recover.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -26,7 +26,7 @@
     "source_count": 6,
     "gap_notes": [
       "Native chain name currently reports as luis while the public website identifies the project as Tensorclaw Network / Subnet 92.",
-      "Official website, dashboard, and source repository are verified live.",
+      "Official website and dashboard currently return Cloudflare 521 errors to simple probes and should appear degraded until they recover; the source repository remains verified live.",
       "No verified docs site yet beyond directory pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
@@ -89,7 +89,7 @@
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Website identifies Tensorclaw Network as Bittensor Mainnet Subnet 92 and describes a decentralized LLM inference subnet for autonomous agents."
+      "notes": "Website identifies Tensorclaw Network as Bittensor Mainnet Subnet 92 and describes a decentralized LLM inference subnet for autonomous agents. Current probe state is expected to show degraded while the origin returns Cloudflare 521 errors."
     },
     {
       "id": "sn-92-tensorclaw-source-repo",
@@ -128,7 +128,7 @@
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Public live-demo page for SN92. The page uses Cloudflare Turnstile to unlock trial requests, so it is listed as an auth-gated dashboard surface rather than a public API."
+      "notes": "Public live-demo page for SN92. The page uses Cloudflare Turnstile to unlock trial requests, so it is listed as an auth-gated dashboard surface rather than a public API. Current probe state is expected to show degraded while the origin returns Cloudflare 521 errors."
     },
     {
       "auth_required": false,


### PR DESCRIPTION
## Context

Issue #5480 flagged five subnet manifests whose `notes`/`curation.gap_notes` claim a website/dashboard URL is "verified live" even though the URL currently errors out. Re-checked each one twice (~20s apart, browser UA, `-L` follow-redirects) and all five are still down:

| Subnet | Flagged URL | Status |
|---|---|---|
| `swap.json` (SN10) | `https://www.taofi.com/pool` | HTTP 402 |
| `tensorclaw.json` (SN92) | `https://www.tensorclaw.ai/` + `/dashboard` | Cloudflare 521 |
| `ninja.json` (SN66) | `https://ninja.arbos.life/` | HTTP 404 |
| `8-ball.json` (SN125) | `https://8ball125.com/` | HTTP 502 |
| `oneoneone.json` (SN111) | `https://oneoneone.io/` | Cloudflare 530 |

None of these look like permanent teardown (no DNS lame-delegation etc.), so per the issue's guidance I left the URLs in place and documented the degraded state instead, following the existing `taolend.json`/`nodexo.json` precedent.

## Changes

For each of the five files:
- Updated the top-level `notes` and `curation.gap_notes` to state the URL currently errors instead of claiming it's verified live.
- Updated the affected surface's own `notes` field to say the probe is expected to show degraded while the origin returns that error.
- Left everything else (other surfaces, `source_repo`, unaffected URLs) untouched — this is a notes/gap_notes accuracy fix only, no surface additions/removals.

## Verification

- `npm run validate:surface` — passes for all 5 files individually and for the full registry (838 surfaces / 129 files).
- `npm run scan:public-safety` — passes.
- `npm run validate` (full registry + API + OpenAPI checks) — passes.
- `npx vitest run tests/registry-identity.test.mjs tests/registry-coverage.test.mjs tests/registry-overlay.test.mjs tests/surface-verify.test.mjs` — 39/39 passing.
- Confirmed via `npm run build` that no other generated artifact needs to change for this diff (reverted the unrelated pre-existing `operational-surfaces.json` drift, which is synced separately by `sync-operational-surfaces.yml`).

Closes #5480
