### PR TITLE
fix(api): distinct alert-trigger error codes + rate-limit header forwarding (#5475)

### DIFF
--- a/tests/alert-triggers-proxy.test.mjs
+++ b/tests/alert-triggers-proxy.test.mjs
@@ -252,6 +252,8 @@ test("maps each upstream status to a distinct, condition-specific error code", a
   assert.equal(await codeFor(401), "alert_trigger_unauthorized");
   assert.equal(await codeFor(404), "alert_trigger_not_found");
   assert.equal(await codeFor(413), "alert_trigger_payload_too_large");
+  assert.equal(await codeFor(429), "alert_trigger_rate_limited");
+  assert.equal(await codeFor(502), "alert_triggers_unavailable");
   assert.equal(await codeFor(503), "alert_triggers_unavailable");
   // An unmapped status still falls back to the generic code.
   assert.equal(await codeFor(418), "alert_trigger_request_failed");

--- a/tests/alert-triggers-proxy.test.mjs
+++ b/tests/alert-triggers-proxy.test.mjs
@@ -186,3 +186,96 @@ test("returns 502 when the upstream response body is unreadable", async () => {
   assert.equal(res.status, 502);
   assert.equal((await res.json()).error.code, "alert_triggers_unavailable");
 });
+
+// #5475: distinct error code per upstream failure condition + rate-limit header
+// forwarding, instead of collapsing everything into alert_trigger_request_failed
+// and dropping the headers.
+test("maps a 429 upstream to alert_trigger_rate_limited and forwards the rate-limit header family end-to-end", async () => {
+  const res = await handleRequest(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": "t" },
+      body: {},
+    }),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response(
+            JSON.stringify({
+              error: "too many alert trigger creation requests; slow down",
+            }),
+            {
+              status: 429,
+              headers: {
+                "retry-after": "60",
+                "x-ratelimit-limit": "10",
+                "x-ratelimit-policy": "10;w=60",
+                "x-ratelimit-remaining": "0",
+              },
+            },
+          );
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 429);
+  assert.equal((await res.json()).error.code, "alert_trigger_rate_limited");
+  assert.equal(res.headers.get("retry-after"), "60");
+  assert.equal(res.headers.get("x-ratelimit-limit"), "10");
+  assert.equal(res.headers.get("x-ratelimit-policy"), "10;w=60");
+  assert.equal(res.headers.get("x-ratelimit-remaining"), "0");
+});
+
+test("maps each upstream status to a distinct, condition-specific error code", async () => {
+  const codeFor = async (status) => {
+    const res = await handleRequest(
+      req("/api/v1/alerts/triggers/1", {
+        method: "DELETE",
+        headers: { "x-alert-trigger-owner-token": "t" },
+      }),
+      {
+        DATA_API: {
+          fetch() {
+            return new Response(JSON.stringify({ error: "upstream said no" }), {
+              status,
+            });
+          },
+        },
+      },
+      {},
+    );
+    assert.equal(res.status, status);
+    return (await res.json()).error.code;
+  };
+  assert.equal(await codeFor(400), "alert_trigger_invalid");
+  assert.equal(await codeFor(401), "alert_trigger_unauthorized");
+  assert.equal(await codeFor(404), "alert_trigger_not_found");
+  assert.equal(await codeFor(413), "alert_trigger_payload_too_large");
+  assert.equal(await codeFor(503), "alert_triggers_unavailable");
+  // An unmapped status still falls back to the generic code.
+  assert.equal(await codeFor(418), "alert_trigger_request_failed");
+});
+
+test("does not attach rate-limit headers when the upstream error carries none", async () => {
+  const res = await handleRequest(
+    req("/api/v1/alerts/triggers/1", {
+      method: "DELETE",
+      headers: { "x-alert-trigger-owner-token": "t" },
+    }),
+    {
+      DATA_API: {
+        fetch() {
+          return new Response(JSON.stringify({ error: "no such trigger" }), {
+            status: 404,
+          });
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 404);
+  assert.equal((await res.json()).error.code, "alert_trigger_not_found");
+  assert.equal(res.headers.get("retry-after"), null);
+  assert.equal(res.headers.get("x-ratelimit-limit"), null);
+});

--- a/tests/alert-triggers-route.test.mjs
+++ b/tests/alert-triggers-route.test.mjs
@@ -265,6 +265,12 @@ test("create: 429 when ALERT_TRIGGER_CREATE_RATE_LIMITER rejects the request, wi
   assert.equal(res.status, 429);
   assert.equal(sqlCalls.length, 0);
   assert.equal(limiter.limit.mock.calls.length, 1);
+  // #5475: the 429 now carries the standard rate-limit header family so the
+  // api.mjs proxy (and clients) can honour the back-off.
+  assert.equal(res.headers.get("retry-after"), "60");
+  assert.equal(res.headers.get("x-ratelimit-limit"), "10");
+  assert.equal(res.headers.get("x-ratelimit-policy"), "10;w=60");
+  assert.equal(res.headers.get("x-ratelimit-remaining"), "0");
 });
 
 test("create: 201 when ALERT_TRIGGER_CREATE_RATE_LIMITER allows the request", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -748,6 +748,40 @@ async function handleChainEventsProxy(request, env, url) {
 // auth (creation token / per-trigger owner token) and routing itself --
 // mirrors handleChainEventsProxy's envelope-translation shape above, just
 // generalized past GET.
+// Distinct error code per upstream failure condition instead of collapsing
+// every non-2xx into one generic `alert_trigger_request_failed`, following the
+// one-code-per-condition convention handleAccountBalance/handleSubnetRecycled
+// already use (#5475). The upstream (data-api handleAlertTriggersRoute) returns
+// a plain `{ error: "message" }` with no code of its own, so we key off status.
+function alertTriggerErrorCode(status) {
+  switch (status) {
+    case 400:
+      return "alert_trigger_invalid";
+    case 401:
+      return "alert_trigger_unauthorized";
+    case 404:
+      return "alert_trigger_not_found";
+    case 413:
+      return "alert_trigger_payload_too_large";
+    case 429:
+      return "alert_trigger_rate_limited";
+    case 502:
+    case 503:
+      return "alert_triggers_unavailable";
+    default:
+      return "alert_trigger_request_failed";
+  }
+}
+
+// Rate-limit family the proxy forwards from an upstream error so clients can
+// honour back-off; the proxy otherwise strips every upstream header.
+const FORWARDED_RATE_LIMIT_HEADERS = [
+  "retry-after",
+  "x-ratelimit-limit",
+  "x-ratelimit-remaining",
+  "x-ratelimit-policy",
+];
+
 async function handleAlertTriggersProxy(request, env) {
   if (!env.DATA_API) {
     return errorResponse(
@@ -768,12 +802,19 @@ async function handleAlertTriggersProxy(request, env) {
     );
   }
   if (!upstream.ok) {
+    const extraHeaders = {};
+    for (const name of FORWARDED_RATE_LIMIT_HEADERS) {
+      const value = upstream.headers.get(name);
+      if (value != null) extraHeaders[name] = value;
+    }
     return errorResponse(
-      "alert_trigger_request_failed",
+      alertTriggerErrorCode(upstream.status),
       typeof body?.error === "string"
         ? body.error
         : "The alert triggers tier returned an error.",
       upstream.status,
+      {},
+      extraHeaders,
     );
   }
   return dataResponse(env, body, upstream.status);

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -497,10 +497,13 @@ const NEURONS_SYNC_BOOLEAN_COLUMNS = new Set([
 // Separate from the read path's json() -- a write ack must never carry the
 // GET routes' `cache-control: public, max-age=10` (or the CORS wildcard,
 // meaningless for a service-binding-only route).
-function writeJson(data, status = 200) {
+function writeJson(data, status = 200, extraHeaders = {}) {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { "content-type": "application/json; charset=utf-8" },
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...extraHeaders,
+    },
   });
 }
 
@@ -2932,6 +2935,11 @@ function requireAlertTriggerOwner(request, storedOwnerToken) {
   return writeJson({ error: "no such trigger" }, 404);
 }
 
+// Policy for the create rate-limiter's 429 header family. Mirrors the
+// ALERT_TRIGGER_CREATE_RATE_LIMITER binding in wrangler.data.jsonc (10/60s) so
+// the advertised headers match the enforced limit. (#5475)
+const ALERT_TRIGGER_CREATE_RATE_LIMIT = { limit: 10, windowSeconds: 60 };
+
 async function handleAlertTriggerCreate(request, env) {
   const configured = env.ALERT_TRIGGER_CREATE_TOKEN;
   if (!configured) {
@@ -2961,9 +2969,18 @@ async function handleAlertTriggerCreate(request, env) {
       key: resolveClientIp(request),
     });
     if (!success) {
+      // Carry the standard rate-limit header family so callers (and the api.mjs
+      // proxy that forwards this response) can detect throttling and honour the
+      // back-off -- matching handleAccountBalance/handleSubnetRecycled (#5475).
       return writeJson(
         { error: "too many alert trigger creation requests; slow down" },
         429,
+        {
+          "retry-after": String(ALERT_TRIGGER_CREATE_RATE_LIMIT.windowSeconds),
+          "x-ratelimit-limit": String(ALERT_TRIGGER_CREATE_RATE_LIMIT.limit),
+          "x-ratelimit-policy": `${ALERT_TRIGGER_CREATE_RATE_LIMIT.limit};w=${ALERT_TRIGGER_CREATE_RATE_LIMIT.windowSeconds}`,
+          "x-ratelimit-remaining": "0",
+        },
       );
     }
   }


### PR DESCRIPTION
## Summary
`handleAlertTriggersProxy` (`workers/api.mjs`) forwards every method for `/api/v1/alerts/triggers*` to the data Worker and, on any non-2xx upstream response, collapsed **all** failure modes — malformed id (400), bad token (401), no such trigger (404), oversized body (413), rate-limited (429), upstream failure (502/503) — into one `alert_trigger_request_failed` code, differing only by HTTP status. It also dropped every upstream header, so any rate-limit headers were lost. And the 429 itself started information-poor at the source: `handleAlertTriggerCreate`'s rate-limit branch (`workers/data-api.mjs`) returned a bare `{ error }` with **no** `retry-after` / `x-ratelimit-*` headers at all.

This brings the route up to the one-code-per-condition + full-header-family convention already set by `handleAccountBalance` and `handleSubnetRecycled`.

## Change

**`workers/data-api.mjs`**
- `writeJson(data, status, extraHeaders = {})` — optional header map (backward-compatible; all existing calls unaffected).
- `handleAlertTriggerCreate`'s 429 now carries the standard rate-limit header family (`retry-after`, `x-ratelimit-limit`, `x-ratelimit-policy`, `x-ratelimit-remaining`), driven by a new `ALERT_TRIGGER_CREATE_RATE_LIMIT = { limit: 10, windowSeconds: 60 }` constant that mirrors the `ALERT_TRIGGER_CREATE_RATE_LIMITER` binding in `wrangler.data.jsonc` — so the advertised numbers match the enforced limit.

**`workers/api.mjs`** (`handleAlertTriggersProxy`)
- `alertTriggerErrorCode(status)` maps each upstream status to a distinct code: `alert_trigger_invalid` (400), `alert_trigger_unauthorized` (401), `alert_trigger_not_found` (404), `alert_trigger_payload_too_large` (413), `alert_trigger_rate_limited` (429), `alert_triggers_unavailable` (502/503), and the generic `alert_trigger_request_failed` as a fallback. The upstream returns a plain `{ error: "message" }` with no code of its own, so keying off status is the right seam.
- On error, forwards the rate-limit header family from the upstream response via `errorResponse`'s `extraHeaders` (only headers that are actually present are copied, so non-rate-limited errors stay clean).

`ErrorEnvelope.code` is `type: string` (not an enum), so no schema change is needed for the new codes.

## Tests
- `tests/alert-triggers-route.test.mjs` — the create-429 test now asserts the full header family on the source response.
- `tests/alert-triggers-proxy.test.mjs` — three new cases:
  - **429 end-to-end:** a create-rate-limited upstream → the proxy responds with `alert_trigger_rate_limited` **and** the forwarded `retry-after` / `x-ratelimit-*` headers (the deliverable's headline case).
  - each upstream status (400/401/404/413/503, plus an unmapped 418 → generic) maps to its distinct code.
  - an upstream error with no rate-limit headers → the proxy attaches none.

## Verification
- `tests/alert-triggers-route.test.mjs` (52) + `tests/alert-triggers-proxy.test.mjs` (11) — **63 pass**, incl. the new cases; `tests/data-api.test.mjs` — pass.
- `eslint` + `prettier --check` on all four changed files — clean.
- Introduces **zero** new test failures: the pre-existing `worker-runtime` (12) / `api-coverage` (46) failures come from a stale local codegen artifact (`api-components.schema.json`) and are present identically on a clean `main` checkout without this change; CI regenerates it in its build step.

Closes #5475
