### PR TITLE
fix(schemas): enforce provider-submission.schema.json on the intake fixture

### DIFF
--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -151,17 +151,26 @@ const subnetSchema = await readJson(
 const candidateSchema = await readJson(
   path.join(repoRoot, "schemas/candidate-surface.schema.json"),
 );
+const providerSubmissionSchema = await readJson(
+  path.join(repoRoot, "schemas/provider-submission.schema.json"),
+);
 const openapi = await readJson(
   path.join(repoRoot, "public/metagraph/openapi.json"),
 );
 
-for (const schema of [providerSchema, subnetSchema, candidateSchema]) {
+for (const schema of [
+  providerSchema,
+  subnetSchema,
+  candidateSchema,
+  providerSubmissionSchema,
+]) {
   ajv.addSchema(schema, schema.$id);
 }
 const explicitlyRegisteredSchemaIds = new Set([
   providerSchema.$id,
   subnetSchema.$id,
   candidateSchema.$id,
+  providerSubmissionSchema.$id,
 ]);
 for (const schemaPath of await listJsonFiles(path.join(repoRoot, "schemas"))) {
   const schema = await readJson(schemaPath);
@@ -183,6 +192,7 @@ const validators = {
   provider: ajv.getSchema(providerSchema.$id),
   subnet: ajv.getSchema(subnetSchema.$id),
   candidate: ajv.getSchema(candidateSchema.$id),
+  providerSubmission: ajv.getSchema(providerSubmissionSchema.$id),
 };
 
 const errors = [];
@@ -198,6 +208,19 @@ for (const subnet of await loadSubnets()) {
 for (const candidate of await loadCandidates()) {
   validate(validators.candidate, candidate, `candidate:${candidate.id}`);
 }
+
+// #5476: enforce the direct-provider-profile intake fixture against its actual
+// schema (patterns, additionalProperties:false, the nested provider sub-schema)
+// rather than validate-intake.mjs's weaker presence-only checks. The authority
+// narrowing to community/provider-claimed stays enforced there, on top of this.
+const providerSubmissionExample = await readJson(
+  path.join(repoRoot, "docs/examples/submissions/direct-provider-profile.json"),
+);
+validate(
+  validators.providerSubmission,
+  providerSubmissionExample,
+  "direct-provider-profile example",
+);
 
 for (const artifact of await artifactValidationTargets()) {
   const validator = compileComponentValidator(artifact.schema_ref);

--- a/tests/provider-submission-schema.test.mjs
+++ b/tests/provider-submission-schema.test.mjs
@@ -1,0 +1,69 @@
+// #5476: provider-submission.schema.json documents the direct-provider-profile
+// intake shape with real constraints (submitted_by / submitted_by_url patterns,
+// additionalProperties:false at both levels, a nested provider that must satisfy
+// provider.schema.json) but was never compiled/validated against anything — only
+// validate-intake.mjs's weaker presence-only checks touched the fixture. These
+// tests exercise the schema directly: the shipped example fixture must pass, and
+// each class of violation the schema newly catches must fail.
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { readJson, repoRoot } from "../scripts/lib.mjs";
+
+const ajv = new Ajv2020({
+  strict: false,
+  validateFormats: true,
+  allErrors: true,
+});
+addFormats(ajv);
+for (const rel of [
+  "schemas/components/01-enums.schema.json",
+  "schemas/provider.schema.json",
+  "schemas/provider-submission.schema.json",
+]) {
+  ajv.addSchema(await readJson(path.join(repoRoot, rel)));
+}
+const validate = ajv.getSchema(
+  "https://metagraph.sh/schemas/provider-submission.schema.json",
+);
+const GOOD = await readJson(
+  path.join(repoRoot, "docs/examples/submissions/direct-provider-profile.json"),
+);
+
+describe("provider-submission.schema.json enforcement (#5476)", () => {
+  test("the shipped direct-provider-profile example fixture is valid", () => {
+    assert.equal(validate(GOOD), true, JSON.stringify(validate.errors));
+  });
+
+  test("rejects an invalid submitted_by pattern (underscore)", () => {
+    const bad = structuredClone(GOOD);
+    bad.submission.submitted_by = "bad_underscore";
+    assert.equal(validate(bad), false);
+  });
+
+  test("rejects a submitted_by_url that isn't a github.com/<user> URL", () => {
+    const bad = structuredClone(GOOD);
+    bad.submission.submitted_by_url = "https://gitlab.com/someone";
+    assert.equal(validate(bad), false);
+  });
+
+  test("rejects an unknown extra top-level property (additionalProperties:false)", () => {
+    const bad = structuredClone(GOOD);
+    bad.stray = "nope";
+    assert.equal(validate(bad), false);
+  });
+
+  test("rejects a non-URI provider.website_url", () => {
+    const bad = structuredClone(GOOD);
+    bad.provider.website_url = "not a url";
+    assert.equal(validate(bad), false);
+  });
+
+  test("rejects an unknown provider.kind (not in the ProviderKind enum)", () => {
+    const bad = structuredClone(GOOD);
+    bad.provider.kind = "not-a-real-kind";
+    assert.equal(validate(bad), false);
+  });
+});


### PR DESCRIPTION
## Summary

`schemas/provider-submission.schema.json` documents the direct-provider-profile intake shape with real constraints — `submitted_by` / `submitted_by_url` patterns, `additionalProperties: false` at both the top level and `submission`, and a nested `provider` that must satisfy `schemas/provider.schema.json` (id pattern, `website_url` `format: uri`, `kind` ∈ the `ProviderKind` enum). But a repo-wide grep shows the file is never compiled or validated against anything: the only thing touching its subject matter is `scripts/validate-intake.mjs`'s `checkExampleProviderSubmission`, which does presence-only checks and never verifies any of those patterns/formats/enums — so a bad `submitted_by`, a non-URI `website_url`, an unknown `kind`, or a stray extra property would silently pass CI.

## Fix

Register `provider-submission.schema.json` in `scripts/validate-schemas.mjs` alongside the existing `provider`/`subnet`/`candidate` schemas, and validate the `docs/examples/submissions/direct-provider-profile.json` example fixture against it via the same ajv `validate(...)` path those records already use (the schema `$ref`s `provider.schema.json`, which is already registered there, so it resolves cleanly).

- `validate-intake.mjs` is left intact, preserving its intentional narrowing of `authority` to `["community", "provider-claimed"]` (a deliberate tightening on top of the schema's full `Authority` enum) — the schema validation supplements it, it doesn't replace it.
- No schema file or generated artifact changes; the shipped fixture already satisfies the strict schema (verified), so this only *adds* enforcement.

Adds `tests/provider-submission-schema.test.mjs` asserting the shipped fixture is valid and that each newly-caught violation class fails: bad `submitted_by` pattern, non-`github.com` `submitted_by_url`, extra top-level property, non-URI `website_url`, and unknown `kind`.

Verified: `validate:schemas` runs the new check with no new failures; `eslint` / `prettier` clean; the 6-test suite is green.

Closes #5476
