### PR TITLE
feat(ui): wire account identity section

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -41,6 +41,7 @@ import type {
   AccountServing,
   AccountServingSubnet,
   AccountBalance,
+  AccountIdentity,
   AccountDay,
   AccountEvent,
   AccountEventsPage,
@@ -2433,6 +2434,41 @@ export const accountBalanceQuery = (ss58: string) =>
       } as ApiResult<AccountBalance>;
     },
     staleTime: STALE_SHORT,
+  });
+
+/**
+ * Personal (coldkey) on-chain identity for one account (#4324/5.1), from
+ * account_identity via Postgres (D1 frozen fallback). has_identity is false
+ * for the common case — most accounts never call set_identity — so every
+ * field but `account`/`has_identity` stays null rather than erroring.
+ */
+export const accountIdentityQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-identity", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/identity`, {
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+          account: firstString(d.account) ?? ss58,
+          has_identity: booleanValue(d.has_identity) ?? false,
+          name: firstString(d.name) ?? null,
+          url: firstString(d.url) ?? null,
+          github: firstString(d.github) ?? null,
+          image: firstString(d.image) ?? null,
+          discord: firstString(d.discord) ?? null,
+          description: firstString(d.description) ?? null,
+          additional: firstString(d.additional) ?? null,
+          captured_at: firstString(d.captured_at) ?? null,
+        } as AccountIdentity,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountIdentity>;
+    },
+    staleTime: STALE_MED,
   });
 
 /** Extrinsics this account signed (by signer), newest-first (#264). */

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1373,6 +1373,25 @@ export interface AccountSummary {
   [key: string]: unknown;
 }
 
+/** Personal (coldkey) on-chain identity for one account (#4324/5.1), from
+ * /api/v1/accounts/{ss58}/identity — distinct from subnet identity and from
+ * the validator directory's coldkey-identity join. has_identity is false
+ * (every field null) for the common case: an account that never called
+ * set_identity. Schema-stable, never a 404. */
+export interface AccountIdentity {
+  schema_version: number;
+  account: string;
+  has_identity: boolean;
+  name: string | null;
+  url: string | null;
+  github: string | null;
+  image: string | null;
+  discord: string | null;
+  description: string | null;
+  additional: string | null;
+  captured_at: string | null;
+}
+
 /** One hotkey-keyed daily activity row from /api/v1/accounts/{ss58}/history. */
 export interface AccountDay {
   day: string;

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -14,6 +14,9 @@ import {
   Coins,
   Fingerprint,
   Gauge,
+  Github,
+  Globe,
+  MessageCircle,
   Radar,
   RefreshCw,
   Rows3,
@@ -38,6 +41,7 @@ import {
   StatTile,
   BarMini,
   DownloadCsvButton,
+  ExternalLink,
 } from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { AccountHistoryChart } from "@/components/metagraphed/account-history-chart";
@@ -52,6 +56,7 @@ import {
   accountRegistrationsQuery,
   accountWeightSettersQuery,
   accountBalanceQuery,
+  accountIdentityQuery,
   accountEventsQuery,
   accountExtrinsicsQuery,
   accountPrometheusQuery,
@@ -271,6 +276,8 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
         />
       </div>
 
+      <AccountIdentitySection ss58={ss58} />
+
       <SectionAnchor
         id="history"
         title="Daily activity"
@@ -376,6 +383,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
           rows={[
             { label: "summary", path: `/api/v1/accounts/${sourceRef}` },
             { label: "balance", path: `/api/v1/accounts/${sourceRef}/balance` },
+            { label: "identity", path: `/api/v1/accounts/${sourceRef}/identity` },
             { label: "history", path: `/api/v1/accounts/${sourceRef}/history` },
             { label: "events", path: `/api/v1/accounts/${sourceRef}/events` },
             { label: "subnets", path: `/api/v1/accounts/${sourceRef}/subnets` },
@@ -390,6 +398,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       <ApiSourceFooter
         paths={[
           `/api/v1/accounts/${sourceRef}`,
+          `/api/v1/accounts/${sourceRef}/identity`,
           `/api/v1/accounts/${sourceRef}/history`,
           `/api/v1/accounts/${sourceRef}/events`,
           `/api/v1/accounts/${sourceRef}/subnets`,
@@ -1373,6 +1382,90 @@ function AccountPortfolioSection({ ss58 }: { ss58: string }) {
           </tbody>
         </table>
       </DataPanel>
+    </SectionAnchor>
+  );
+}
+
+// #4324/5.1: personal (coldkey) on-chain identity for this account, from a
+// set_identity call — distinct from subnet identity and from the validator
+// directory's coldkey-identity join. has_identity is false for the common
+// case (most accounts never set one), so the section renders nothing rather
+// than an empty card. Non-blocking: while it loads or if it fails, the rest
+// of the account page is unaffected.
+function AccountIdentitySection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountIdentityQuery(ss58));
+  const identity = result.data?.data;
+  const SUBTITLE = "On-chain personal identity this account registered via set_identity.";
+
+  if (result.isPending && !identity) {
+    return <AccountFeedSectionSkeleton id="identity" title="Identity" subtitle={SUBTITLE} />;
+  }
+  if (result.isError) {
+    return (
+      <SectionAnchor id="identity" title="Identity" subtitle={SUBTITLE} tone="accent">
+        <TableState
+          variant="error"
+          title="Could not load identity"
+          description="The identity tier is optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+  if (!identity || !identity.has_identity) return null;
+
+  return (
+    <SectionAnchor
+      id="identity"
+      title="Identity"
+      subtitle={SUBTITLE}
+      tone="accent"
+      info="GET /api/v1/accounts/{ss58}/identity — the coldkey's own on-chain identity, distinct from subnet identity and the validator directory's coldkey-identity join."
+    >
+      <div className="rounded-2xl border border-border/80 bg-card/95 p-5 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.55)]">
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <span className="font-display text-lg font-semibold text-ink-strong">
+            {identity.name ?? "Unnamed identity"}
+          </span>
+          {identity.captured_at ? (
+            <span className="font-mono text-[11px] text-ink-muted">
+              captured <TimeAgo at={identity.captured_at} />
+            </span>
+          ) : null}
+        </div>
+        {identity.description ? (
+          <p className="mt-2 text-sm text-ink-muted">{identity.description}</p>
+        ) : null}
+        {identity.url || identity.github || identity.discord || identity.image ? (
+          <div className="mt-3 flex flex-wrap gap-3 text-[11px]">
+            {identity.url ? (
+              <ExternalLink href={identity.url} className="text-accent-text hover:underline">
+                <Globe className="size-3.5 shrink-0" aria-hidden /> website
+              </ExternalLink>
+            ) : null}
+            {identity.github ? (
+              <ExternalLink href={identity.github} className="text-accent-text hover:underline">
+                <Github className="size-3.5 shrink-0" aria-hidden /> github
+              </ExternalLink>
+            ) : null}
+            {identity.image ? (
+              <ExternalLink href={identity.image} className="text-accent-text hover:underline">
+                image
+              </ExternalLink>
+            ) : null}
+            {identity.discord ? (
+              <span className="inline-flex items-center gap-1 text-ink-muted">
+                <MessageCircle className="size-3.5 shrink-0" aria-hidden />
+                {identity.discord}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+        {identity.additional ? (
+          <p className="mt-2 font-mono text-[11px] text-ink-muted">{identity.additional}</p>
+        ) : null}
+      </div>
     </SectionAnchor>
   );
 }


### PR DESCRIPTION
## Summary

Wires the `GET /api/v1/accounts/{ss58}/identity` endpoint (#4324/5.4) — live on the backend, zero frontend consumer — into a new "Identity" section on the account detail page.

**Scope note:** #5360's title also names "account history" as a gap, but that was already fully wired via `AccountHistoryChart`/`accountHistoryQuery` (the "Daily activity" section, `apps/ui/src/routes/accounts.$ss58.tsx:274-283`) before this issue was filed — confirmed by `git log` on that component predating the issue's creation date. Nothing to do there; this PR only wires the genuinely-missing identity endpoint.

## What changed

- `apps/ui/src/lib/metagraphed/types.ts`: `AccountIdentity` type.
- `apps/ui/src/lib/metagraphed/queries.ts`: `accountIdentityQuery`, mirroring the existing `accountBalanceQuery` pattern (same `ss58PathSegment` path-building, same non-blocking `useQuery` shape).
- `apps/ui/src/routes/accounts.$ss58.tsx`: new `AccountIdentitySection`, placed right after the hero stat-tile grid and before "Daily activity". Renders nothing when `has_identity` is false (the common case — most accounts never call `set_identity`), matching the empty-state convention every other optional-enrichment section on this page already uses. When set, shows the identity name, description, captured-at timestamp, and any of url/github/image/discord that are present (each individually optional). Reuses the existing `ExternalLink` component for the social links, which already sanitizes against private/localhost/non-http(s) URLs.

Distinct from two adjacent, already-wired "identity" systems this could be confused with: `ColdkeyIdentity` (keyed by **hotkey**, joined into the validator directory, rendered on `validators.$hotkey.tsx`) and subnet identity (`SubnetIdentitiesV3`, rendered on `subnets.$netuid.tsx`). This is the coldkey's own personal identity — a third, separate system.

Verified end-to-end against the live API: account `5HCFWvRqzSHWRPecN7q8J6c7aKQnrCZTMHstPv39xL1wgDHh` (`has_identity: true`, name "Owner1") renders the section correctly; a random account with `has_identity: false` renders nothing (confirmed the section is fully absent from the DOM, not an empty card).

## Screenshots

`/accounts/5HCFWvRqzSHWRPecN7q8J6c7aKQnrCZTMHstPv39xL1wgDHh` (an account with a real on-chain identity set), scrolled to where the new section attaches, right after the hero stat grid. Before = `main`, After = this branch.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5360-account-identity-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npm run typecheck --workspace=apps/ui`
- `npm run lint --workspace=apps/ui` (0 errors; pre-existing `react-refresh/only-export-components` warnings unrelated)
- `npm run format:check --workspace=apps/ui`
- `npm test --workspace=apps/ui` (753 passed)
- `npm run build --workspace=apps/ui`
- Manual verification against the live dev server + live API for both the has-identity and no-identity cases

Closes #5360 — final PR in this sweep (see the issue for the other 4).
