### PR TITLE
fix(ui): add a CopyButton to the validators hotkey/coldkey columns (#5339)

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
@@ -50,14 +51,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     thClassName: TH_BASE,
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) => (
-      <Link
-        to="/validators/$hotkey"
-        params={{ hotkey: v.hotkey }}
-        className="text-ink-strong hover:text-accent hover:underline"
-        title={v.hotkey}
-      >
-        {shortHash(v.hotkey) ?? v.hotkey}
-      </Link>
+      <span className="inline-flex min-w-0 items-center gap-1">
+        <Link
+          to="/validators/$hotkey"
+          params={{ hotkey: v.hotkey }}
+          className="truncate text-ink-strong hover:text-accent hover:underline"
+          title={v.hotkey}
+        >
+          {shortHash(v.hotkey) ?? v.hotkey}
+        </Link>
+        <CopyButton value={v.hotkey} label="hotkey" />
+      </span>
     ),
   },
   {
@@ -66,14 +70,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) =>
       v.coldkey ? (
-        <Link
-          to="/accounts/$ss58"
-          params={{ ss58: v.coldkey }}
-          className="hover:text-accent hover:underline"
-          title={v.coldkey}
-        >
-          {shortHash(v.coldkey) ?? v.coldkey}
-        </Link>
+        <span className="inline-flex min-w-0 items-center gap-1">
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: v.coldkey }}
+            className="truncate hover:text-accent hover:underline"
+            title={v.coldkey}
+          >
+            {shortHash(v.coldkey) ?? v.coldkey}
+          </Link>
+          <CopyButton value={v.coldkey} label="coldkey" />
+        </span>
       ) : (
         "—"
       ),


### PR DESCRIPTION
## Summary

The global Validators table (`VALIDATOR_COLUMNS` in `apps/ui/src/components/metagraphed/validator-columns.tsx`) exposed the hotkey and coldkey values with only a `title` tooltip — no copy affordance, so on touch/mobile there is no way to copy an identifier. This is inconsistent with the Blocks and Extrinsics index tables, which pair every hash/signer with a `CopyButton`.

This adds a `CopyButton` next to the Hotkey and Coldkey values, matching the existing pattern (`blocks.index.tsx`, `extrinsics.index.tsx`).

Closes #5339

## Change

- Import `CopyButton` from `@jsonbored/ui-kit` (same source Blocks/Extrinsics use).
- Wrap the Hotkey cell's `<Link>` in `inline-flex min-w-0 items-center gap-1` and append `<CopyButton value={v.hotkey} label="hotkey" />` — the link truncates, the button stays visible.
- Same for the Coldkey cell (only when a coldkey is present; the `"—"` fallback is unchanged).

No data, sorting, routing, or column-set changes; column `header` values are untouched so the header/cell-count invariant (and its test) still holds. The mobile card view (`ValidatorCardList`) is a separate surface tracked by #5320 and is out of scope here.

## Screenshots

`/validators` table, hotkey/coldkey columns. **Before** = tooltip-only (no copy). **After** = a copy button next to each identifier. Desktop (1280) / tablet (768) show the table; mobile (375) renders the card view (unchanged here).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop 1280 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/before-desktop-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/after-desktop-light.png) |
| Desktop 1280 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/after-desktop-dark.png) |
| Tablet 768 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/before-tablet-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/after-tablet-light.png) |
| Tablet 768 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/after-tablet-dark.png) |
| Mobile 375 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/before-mobile-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/after-mobile-light.png) |
| Mobile 375 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/after-mobile-dark.png) |

## Validation

- `npx tsc --noEmit` (apps/ui) → clean
- `npm test` (apps/ui) → 753 tests passed (111 files)
