### PR TITLE
fix(ui): add ShareButton + ApiSourceFooter to subnet & provider detail pages (#5481)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -51,6 +51,8 @@ interface Props {
   generatedAt?: string;
   stale?: boolean;
   banner?: ReactNode;
+  /** Header actions (e.g. ShareButton), rendered top-right of the identity row. */
+  actions?: ReactNode;
   uptimePct?: number | null;
   evidenceCount?: number;
 }
@@ -167,6 +169,7 @@ export function SubnetMasthead({
   generatedAt,
   stale,
   banner,
+  actions,
   uptimePct,
   evidenceCount,
 }: Props) {
@@ -369,26 +372,29 @@ export function SubnetMasthead({
           />
         </div>
         <div className="min-w-0">
-          <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-            <h1 className="font-display text-2xl md:text-3xl font-semibold tracking-[-0.01em] text-ink-strong truncate">
-              {name}
-            </h1>
-            {profile?.symbol ? (
-              <span className="font-mono text-sm text-ink-muted">{profile.symbol}</span>
-            ) : null}
-            {profile?.subnet_type ? (
-              <span className="rounded border border-border bg-surface/40 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted">
-                {profile.subnet_type}
-              </span>
-            ) : null}
-            {categories.map((c) => (
-              <span
-                key={c}
-                className="rounded border border-border/60 bg-paper px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted"
-              >
-                {c}
-              </span>
-            ))}
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <h1 className="font-display text-2xl md:text-3xl font-semibold tracking-[-0.01em] text-ink-strong truncate">
+                {name}
+              </h1>
+              {profile?.symbol ? (
+                <span className="font-mono text-sm text-ink-muted">{profile.symbol}</span>
+              ) : null}
+              {profile?.subnet_type ? (
+                <span className="rounded border border-border bg-surface/40 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted">
+                  {profile.subnet_type}
+                </span>
+              ) : null}
+              {categories.map((c) => (
+                <span
+                  key={c}
+                  className="rounded border border-border/60 bg-paper px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted"
+                >
+                  {c}
+                </span>
+              ))}
+            </div>
+            {actions ? <div className="shrink-0">{actions}</div> : null}
           </div>
           {description ? (
             <p className="mt-2 text-sm text-ink-muted max-w-3xl leading-relaxed line-clamp-2">

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -16,7 +16,9 @@ import {
   PrimaryLinksRail,
   CopyableCode,
   SectionAnchor,
+  ShareButton,
 } from "@jsonbored/ui-kit";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { EndpointsGlance } from "@/components/metagraphed/endpoints-glance";
 import { EndpointList } from "@/components/metagraphed/endpoint-list";
@@ -130,6 +132,7 @@ function ProviderShell({ slug }: { slug: string }) {
         title={p?.name ?? slug}
         subtitle={shouldShowProviderSlugSubtitle(p?.name, slug) ? <>· {slug}</> : null}
         description={p?.notes}
+        actions={<ShareButton />}
         links={<PrimaryLinksRail website={p?.website ?? p?.homepage} docs={p?.docs} />}
         stats={[
           { label: "Endpoints", value: formatNumber(summary?.endpoint_count) },
@@ -171,6 +174,10 @@ function ProviderShell({ slug }: { slug: string }) {
           {summary?.by_layer ? <BreakdownCard title="By layer" data={summary.by_layer} /> : null}
         </aside>
       </div>
+
+      <ApiSourceFooter
+        paths={[`/api/v1/providers/${slug}`, `/api/v1/providers/${slug}/endpoints`]}
+      />
     </>
   );
 }

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -34,7 +34,9 @@ import {
   MethodologyCallout,
   StatTile,
   RealtimeFreshness,
+  ShareButton,
 } from "@jsonbored/ui-kit";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
 import { ReadinessScorecard } from "@/components/metagraphed/readiness-scorecard";
 import { EndpointList } from "@/components/metagraphed/endpoint-list";
@@ -259,6 +261,7 @@ function ProfileShell({ netuid }: { netuid: number }) {
           generatedAt={meta?.generated_at}
           stale={stale}
           evidenceCount={evidenceCount}
+          actions={<ShareButton />}
           banner={
             stale ? (
               <StaleBanner
@@ -315,6 +318,14 @@ function ProfileShell({ netuid }: { netuid: number }) {
           ) : null}
           {tab === "api" ? <ApiPanel netuid={netuid} /> : null}
         </div>
+
+        <ApiSourceFooter
+          paths={[
+            `/api/v1/subnets/${netuid}/profile`,
+            `/api/v1/subnets/${netuid}/surfaces`,
+            `/api/v1/subnets/${netuid}/endpoints`,
+          ]}
+        />
       </SubnetFilterProvider>
     </TimeRangeProvider>
   );


### PR DESCRIPTION
## Summary

The subnet (`/subnets/$netuid`) and provider (`/providers/$slug`) detail pages were the only entity-detail routes **missing both the `ShareButton` and the `ApiSourceFooter`** that every other detail page (accounts, blocks, extrinsics, validators) already has — so there was no share affordance and no citation of the JSON endpoints powering the page.

This adds parity:

- **`providers.$slug`** — pass `actions={<ShareButton />}` to `EntityHero`; render `ApiSourceFooter` citing `/api/v1/providers/{slug}` and `.../endpoints`.
- **`subnet-masthead`** — add an optional `actions` slot (top-right of the identity row), mirroring `EntityHero`'s API.
- **`subnets.$netuid`** — pass `actions={<ShareButton />}` to the masthead; render `ApiSourceFooter` citing the profile / surfaces / endpoints endpoints.

Purely additive — reuses the shared `ShareButton` and `ApiSourceFooter` components already used across the app. No new dependencies.

Closes #5481

## Subnet detail — masthead ShareButton

| Viewport · Theme | Before | After |
| --- | --- | --- |
| mobile · light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/subnet-masthead-before-mobile-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/subnet-masthead-after-mobile-light.png) |
| mobile · dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/subnet-masthead-before-mobile-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/subnet-masthead-after-mobile-dark.png) |
| tablet · light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/subnet-masthead-before-tablet-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/subnet-masthead-after-tablet-light.png) |
| tablet · dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/subnet-masthead-before-tablet-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/subnet-masthead-after-tablet-dark.png) |
| desktop · light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/subnet-masthead-before-desktop-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/subnet-masthead-after-desktop-light.png) |
| desktop · dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/subnet-masthead-before-desktop-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/subnet-masthead-after-desktop-dark.png) |

## Provider detail — hero ShareButton

| Viewport · Theme | Before | After |
| --- | --- | --- |
| mobile · light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/provider-hero-before-mobile-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/provider-hero-after-mobile-light.png) |
| mobile · dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/provider-hero-before-mobile-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/provider-hero-after-mobile-dark.png) |
| tablet · light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/provider-hero-before-tablet-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/provider-hero-after-tablet-light.png) |
| tablet · dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/provider-hero-before-tablet-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/provider-hero-after-tablet-dark.png) |
| desktop · light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/provider-hero-before-desktop-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/provider-hero-after-desktop-light.png) |
| desktop · dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/provider-hero-before-desktop-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/provider-hero-after-desktop-dark.png) |

## ApiSourceFooter (page bottom · desktop)

| Page · Theme | Before | After |
| --- | --- | --- |
| subnet · light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/footer-subnet-before-desktop-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/footer-subnet-after-desktop-light.png) |
| subnet · dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/footer-subnet-before-desktop-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/footer-subnet-after-desktop-dark.png) |
| provider · light | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/footer-provider-before-desktop-light.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/footer-provider-after-desktop-light.png) |
| provider · dark | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/footer-provider-before-desktop-dark.png) | ![](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/5481-share-footer/footer-provider-after-desktop-dark.png) |

## Testing

- `npm run lint` / typecheck — clean
- `npm test` — pass
- responsive-overflow e2e (375 / 768 / 1280 × light+dark) — **24/24 passing**, incl. `/subnets/1`
- `npm run build` + bundle budget — pass

Screenshots captured from a single dev server via file-swap (identical fonts/layout between before & after).
