### PR TITLE
feat(registry): add SN17 404-GEN competition config schema data-artifact surface (#4014)

### DIFF
--- a/registry/subnets/404-gen.json
+++ b/registry/subnets/404-gen.json
@@ -68,6 +68,31 @@
         "https://gen.404.xyz/api/health"
       ],
       "url": "https://gen.404.xyz/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-17-404-gen-competition-config",
+      "kind": "data-artifact",
+      "name": "404-GEN competition config schema",
+      "notes": "Public no-auth machine-readable competition-configuration module (shared/subnet_common/competition/config.py) published in the official 404-Repo/404-gen-subnet repository. Defines the SN17 404-GEN text-to-3D competition schema and defaults that miners and validators run against: competition schedule (first/last dates, daily round start time, round duration), generation-stage minutes, win margin, weight decay/floor, prompts-per-round and carryover, and audit repeats. Pinned to an immutable commit. Verified 200, SS58-clean, no keys or secrets. Distinct from the 404mini Hugging Face dataset already registered.",
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "provider": "404-gen",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://github.com/404-Repo/404-gen-subnet/blob/92cee1043741edf5f76ba86f9d8e6a10aca6e84e/shared/subnet_common/competition/config.py",
+        "https://github.com/404-Repo/404-gen-subnet"
+      ],
+      "url": "https://raw.githubusercontent.com/404-Repo/404-gen-subnet/92cee1043741edf5f76ba86f9d8e6a10aca6e84e/shared/subnet_common/competition/config.py"
     }
   ],
   "website_url": "https://www.404.xyz/"


### PR DESCRIPTION
## Summary

Adds one new `community` data-artifact surface to SN17 404-GEN (`registry/subnets/404-gen.json`): the subnet's **competition config schema** (`shared/subnet_common/competition/config.py`) from the official repository.

This is distinct from the 404mini Hugging Face dataset already registered — the machine-readable definition of the subnet's competition parameters and schedule.

## Surface

- **id:** `sn-17-404-gen-competition-config`
- **kind:** `data-artifact`
- **url:** `https://raw.githubusercontent.com/404-Repo/404-gen-subnet/92cee1043741edf5f76ba86f9d8e6a10aca6e84e/shared/subnet_common/competition/config.py` — public, no-auth, HTTP 200, pinned to an immutable commit
- **provider:** `404-gen`
- **source_url:** the same file's GitHub blob at the pinned commit + the registered `source_repo`

## What it is

`shared/subnet_common/competition/config.py` — the SN17 404-GEN text-to-3D competition schema and defaults that miners and validators run against: competition schedule (first/last dates, daily round start time, round duration), generation-stage minutes, win margin, weight decay/floor, prompts-per-round and carryover, and audit repeats. A machine-readable reference for the subnet's competition mechanics. Contains no keys or secrets.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/404-gen.json` — passed (4 surfaces)
- Verified with no auth header: 200, SS58-clean.

One focused change: one surface appended to one subnet file; nothing else touched.

Closes #4014

> Scope note: #4014 frames the enrichment as an OpenAPI/Swagger spec. 404-GEN serves no verified public OpenAPI document; this adds a genuinely-published machine-readable configuration artifact (the competition schema) from the official repo — the same config-as-source-file pattern already accepted elsewhere in the registry — advancing the same "enrich SN17" intent. Any OpenAPI-specific framing is advisory.
