### PR TITLE
feat(registry): add SN69 ain min_compute data-artifact

### DIFF
--- a/registry/subnets/ain.json
+++ b/registry/subnets/ain.json
@@ -65,6 +65,25 @@
         "https://github.com/HeraldMedia/herald/blob/4de1577e82b74807d4081c3f61edffaee9ed718a/README.md"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/69"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-69-ain-min-compute",
+      "kind": "data-artifact",
+      "name": "ain minimum compute requirements",
+      "notes": "Public no-auth machine-readable min_compute.yml from the official SN69 ain (Herald) repository (HeraldMedia/herald), pinned to an immutable commit. Specifies the minimum CPU and RAM requirements for running SN69 miners and validators. Static YAML artifact useful for agents provisioning subnet nodes.",
+      "provider": "herald",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/HeraldMedia/herald",
+        "https://github.com/HeraldMedia/herald/blob/4de1577e82b74807d4081c3f61edffaee9ed718a/min_compute.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/HeraldMedia/herald/4de1577e82b74807d4081c3f61edffaee9ed718a/min_compute.yml"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enriches **SN69 ain** (issue #4078) with a machine-usable **data-artifact**: the subnet's `min_compute.yml`, pinned to an immutable commit.

- **url:** https://raw.githubusercontent.com/HeraldMedia/herald/4de1577e82b74807d4081c3f61edffaee9ed718a/min_compute.yml (public, no-auth — HTTP 200, YAML)
- **kind:** data-artifact (static machine-readable spec from the official SN69 repo)
- **source_urls:** the official SN69 (Herald) repo https://github.com/HeraldMedia/herald + the pinned blob
- Specifies the minimum CPU/RAM requirements for SN69 miners and validators — useful for agents provisioning subnet nodes.

## Validation
- `npm run validate:surface -- registry/subnets/ain.json` → passed (3 surfaces)
- `npm run scan:public-safety` → no findings for this file
- `npx prettier --check` → clean

Closes #4078