### PR TITLE
feat(registry): add SN80 dogelayer chain type registry data-artifact

### DIFF
--- a/registry/subnets/dogelayer.json
+++ b/registry/subnets/dogelayer.json
@@ -66,6 +66,25 @@
         "https://github.com/dogelayer-ai/dogelayer"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/80"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-80-dogelayer-chain-types",
+      "kind": "data-artifact",
+      "name": "dogelayer chain type registry",
+      "notes": "Public no-auth machine-readable chain type registry (types.json) from the official SN80 dogelayer repository (dogelayer-ai/dogelayer), pinned to an immutable commit. Defines the SCALE-encoded type definitions the subnet's core uses to decode on-chain data. Static JSON artifact useful for agents decoding SN80 chain state.",
+      "provider": "dogelayer",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/dogelayer-ai/dogelayer",
+        "https://github.com/dogelayer-ai/dogelayer/blob/2d29e575c50c5328787405a46080e827e0cff33d/dogelayer/core/chain_data/types.json"
+      ],
+      "url": "https://raw.githubusercontent.com/dogelayer-ai/dogelayer/2d29e575c50c5328787405a46080e827e0cff33d/dogelayer/core/chain_data/types.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enriches **SN80 dogelayer** (issue #4098) with a machine-usable **data-artifact**: the subnet's chain type registry (`types.json`), pinned to an immutable commit.

- **url:** https://raw.githubusercontent.com/dogelayer-ai/dogelayer/2d29e575c50c5328787405a46080e827e0cff33d/dogelayer/core/chain_data/types.json (public, no-auth — HTTP 200, JSON)
- **kind:** data-artifact (static machine-readable file from the official SN80 repo)
- **source_urls:** the official SN80 repo https://github.com/dogelayer-ai/dogelayer + the pinned blob
- Defines the SCALE-encoded type definitions the subnet's core uses to decode on-chain data — useful for agents decoding SN80 chain state.

## Validation
- `npm run validate:surface -- registry/subnets/dogelayer.json` → passed (4 surfaces)
- `npm run scan:public-safety` → no findings for this file
- `npx prettier --check` → clean

Closes #4098