### PR TITLE
test: allow SN38 evidence_action after OpenAPI (tests-only)

### DIFF
--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -2386,7 +2386,16 @@ test("enrichment guidance ignores maintainer-excluded candidate URLs", () => {
   const colosseum = queue.queue.find((entry) => entry.netuid === 38);
 
   assert(colosseum, "expected SN38 colosseum enrichment queue entry");
-  assert.equal(colosseum.evidence_action, "submit-new-evidence");
+  // Keep accepting both pre- and post-OpenAPI states: registering ChronoLLM
+  // OpenAPI flips SN38 from submit-new-evidence to maintainer-review-existing-evidence.
+  // This test's intent is maintainer-excluded URL filtering, not that action pin.
+  assert.ok(
+    [
+      "submit-new-evidence",
+      "maintainer-review-existing-evidence",
+    ].includes(colosseum.evidence_action),
+    `unexpected SN38 evidence_action: ${colosseum.evidence_action}`,
+  );
   assert.equal(
     colosseum.sample_target_candidate_ids.includes(
       "sn-38-native-chain-website",

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -2390,10 +2390,9 @@ test("enrichment guidance ignores maintainer-excluded candidate URLs", () => {
   // OpenAPI flips SN38 from submit-new-evidence to maintainer-review-existing-evidence.
   // This test's intent is maintainer-excluded URL filtering, not that action pin.
   assert.ok(
-    [
-      "submit-new-evidence",
-      "maintainer-review-existing-evidence",
-    ].includes(colosseum.evidence_action),
+    ["submit-new-evidence", "maintainer-review-existing-evidence"].includes(
+      colosseum.evidence_action,
+    ),
     `unexpected SN38 evidence_action: ${colosseum.evidence_action}`,
   );
   assert.equal(


### PR DESCRIPTION
## Summary
- Loosen the SN38 `evidence_action` pin in `tests/artifacts.test.mjs` so maintainer-excluded candidate URL filtering still holds, while accepting both `submit-new-evidence` and `maintainer-review-existing-evidence`.
- Unblocks registry-only ChronoLLM OpenAPI Path A (#5491) without bundling test changes into the surface PR (content-lane rejects mixed-files).

No linked issue because: tests-only CI unblocker. Must not auto-close the ChronoLLM enrichment ticket before the registry PR lands.

## Test plan
- [x] Prettier + suite green for `tests/artifacts.test.mjs`
- [ ] After merge, rebase #5491 and confirm CI green on registry-only diff