### PR TITLE
fix(ui): enlarge the incident-strip dismiss button to a size-8 tap target (#5334)

### DIFF
--- a/apps/ui/src/components/metagraphed/incident-strip.tsx
+++ b/apps/ui/src/components/metagraphed/incident-strip.tsx
@@ -131,9 +131,9 @@ export function IncidentStrip() {
             });
           }}
           aria-label="Dismiss incident"
-          className="shrink-0 inline-flex size-5 items-center justify-center rounded text-ink-muted hover:text-ink-strong hover:bg-surface"
+          className="-my-1 shrink-0 inline-flex size-8 items-center justify-center rounded text-ink-muted hover:text-ink-strong hover:bg-surface"
         >
-          <X className="size-3" />
+          <X className="size-3.5" />
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

The active-incident banner's dismiss button (`incident-strip.tsx`) was a `size-5` (20×20px) target with a `size-3` icon and no min-height, sitting in a dense single-row flex next to truncating text on `/endpoints` and `/subnets` — an easy mis-tap, well under a comfortable touch target.

This enlarges it to `size-8` (32×32px), per the issue.

Closes #5334

## Change

- Dismiss button: `size-5` → `size-8`, icon `size-3` → `size-3.5`.
- Added `-my-1` so the taller (32px) hit area doesn't increase the dense banner row's height — the layout at the single-row flex is unchanged, only the button's tappable area grows.

Two className tweaks; no behavior, data, or markup structure change.

## Screenshots

`/endpoints` incident banner (synthetic active incident injected for a deterministic capture). **Before** = the cramped `size-5` × dismiss. **After** = the `size-8` × with the same row height. Mobile (375) / tablet (768) / desktop (1280), light + dark; cropped to the banner.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop 1280 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5334/5334/before-desktop-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5334/5334/after-desktop-light.png) |
| Desktop 1280 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5334/5334/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5334/5334/after-desktop-dark.png) |
| Tablet 768 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5334/5334/before-tablet-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5334/5334/after-tablet-light.png) |
| Tablet 768 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5334/5334/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5334/5334/after-tablet-dark.png) |
| Mobile 375 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5334/5334/before-mobile-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5334/5334/after-mobile-light.png) |
| Mobile 375 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5334/5334/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5334/5334/after-mobile-dark.png) |

## Validation

- `npx tsc --noEmit` (apps/ui) → clean
- `npm test` (apps/ui) → 753 tests passed (111 files)
