### PR TITLE
feat(registry): add SN91 Bitstarter subnet protocol definition data-artifact surface (#4118)

### DIFF
--- a/registry/subnets/bitstarter-1.json
+++ b/registry/subnets/bitstarter-1.json
@@ -190,6 +190,31 @@
         "https://github.com/AlphaCoreBittensor/alphacore/blob/main/modules/task_config.yaml"
       ],
       "url": "https://raw.githubusercontent.com/AlphaCoreBittensor/alphacore/main/modules/task_config.yaml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-91-alphacore-protocol",
+      "kind": "data-artifact",
+      "name": "AlphaCore subnet protocol definition",
+      "notes": "Public no-auth machine-readable protocol module (subnet/protocol.py) committed in SN91 Bitstarter's official AlphaCoreBittensor/alphacore repository, defining the Bittensor synapse/dendrite message schema the subnet's miners and validators communicate over (request/response fields for the task and scoring flow). Pinned to an immutable commit. Verified 200, SS58-clean, no keys or secrets. Distinct from the task-generation config already registered.",
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "provider": "alphacore",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://github.com/AlphaCoreBittensor/alphacore/blob/e65670c8b5eaa8046f6ce40a805aece4804198a2/subnet/protocol.py",
+        "https://github.com/AlphaCoreBittensor/alphacore"
+      ],
+      "url": "https://raw.githubusercontent.com/AlphaCoreBittensor/alphacore/e65670c8b5eaa8046f6ce40a805aece4804198a2/subnet/protocol.py"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Adds one new `community` data-artifact surface to SN91 Bitstarter (`registry/subnets/bitstarter-1.json`): the subnet's **protocol definition** module (`subnet/protocol.py`) from the official AlphaCore repository.

This is distinct from the task-generation config already registered — the machine-readable schema of the messages miners and validators exchange.

## Surface

- **id:** `sn-91-alphacore-protocol`
- **kind:** `data-artifact`
- **url:** `https://raw.githubusercontent.com/AlphaCoreBittensor/alphacore/e65670c8b5eaa8046f6ce40a805aece4804198a2/subnet/protocol.py` — public, no-auth, HTTP 200, pinned to an immutable commit
- **provider:** `alphacore`
- **source_url:** the same file's GitHub blob at the pinned commit + the registered `source_repo`

## What it is

`subnet/protocol.py` — the Bittensor synapse/dendrite message schema the SN91 Bitstarter subnet communicates over (the request/response fields for its task and scoring flow). A machine-readable reference for the subnet's on-wire protocol. Contains no keys or secrets.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/bitstarter-1.json` — passed (8 surfaces)
- Verified with no auth header: 200, SS58-clean.

One focused change: one surface appended to one subnet file; nothing else touched.

Closes #4118

> Scope note: #4118 frames the enrichment as an OpenAPI/Swagger spec. Bitstarter serves no verified public OpenAPI document; this adds a genuinely-published machine-readable protocol artifact from the official repo — the same config-as-source-file pattern already accepted elsewhere in the registry — advancing the same "enrich SN91" intent. Any OpenAPI-specific framing is advisory.
