### PR TITLE
fix(ui): add a CopyButton to validators hotkey/coldkey (table + mobile cards) (#5339)

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
@@ -37,18 +38,22 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
               >
                 {f.hotkeyShort}
               </Link>
+              <CopyButton value={v.hotkey} label="hotkey" />
             </div>
-            <div className="font-mono text-[11px] text-ink-muted">
+            <div className="flex min-w-0 items-center gap-1 font-mono text-[11px] text-ink-muted">
               <span className="uppercase tracking-widest text-[10px]">coldkey </span>
               {v.coldkey ? (
-                <Link
-                  to="/accounts/$ss58"
-                  params={{ ss58: v.coldkey }}
-                  title={v.coldkey}
-                  className="hover:text-accent hover:underline"
-                >
-                  {f.coldkeyShort}
-                </Link>
+                <>
+                  <Link
+                    to="/accounts/$ss58"
+                    params={{ ss58: v.coldkey }}
+                    title={v.coldkey}
+                    className="truncate hover:text-accent hover:underline"
+                  >
+                    {f.coldkeyShort}
+                  </Link>
+                  <CopyButton value={v.coldkey} label="coldkey" />
+                </>
               ) : (
                 "—"
               )}

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
@@ -50,14 +51,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     thClassName: TH_BASE,
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) => (
-      <Link
-        to="/validators/$hotkey"
-        params={{ hotkey: v.hotkey }}
-        className="text-ink-strong hover:text-accent hover:underline"
-        title={v.hotkey}
-      >
-        {shortHash(v.hotkey) ?? v.hotkey}
-      </Link>
+      <span className="inline-flex min-w-0 items-center gap-1">
+        <Link
+          to="/validators/$hotkey"
+          params={{ hotkey: v.hotkey }}
+          className="truncate text-ink-strong hover:text-accent hover:underline"
+          title={v.hotkey}
+        >
+          {shortHash(v.hotkey) ?? v.hotkey}
+        </Link>
+        <CopyButton value={v.hotkey} label="hotkey" />
+      </span>
     ),
   },
   {
@@ -66,14 +70,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) =>
       v.coldkey ? (
-        <Link
-          to="/accounts/$ss58"
-          params={{ ss58: v.coldkey }}
-          className="hover:text-accent hover:underline"
-          title={v.coldkey}
-        >
-          {shortHash(v.coldkey) ?? v.coldkey}
-        </Link>
+        <span className="inline-flex min-w-0 items-center gap-1">
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: v.coldkey }}
+            className="truncate hover:text-accent hover:underline"
+            title={v.coldkey}
+          >
+            {shortHash(v.coldkey) ?? v.coldkey}
+          </Link>
+          <CopyButton value={v.coldkey} label="coldkey" />
+        </span>
       ) : (
         "—"
       ),


### PR DESCRIPTION
## Summary

The global Validators directory exposed hotkey and coldkey values with only a `title` tooltip — unusable on touch/mobile — inconsistent with the Blocks and Extrinsics index pages, which pair every hash/signer with a `CopyButton`.

This adds a `CopyButton` next to the Hotkey and Coldkey identifiers in **both** presentations:

- the desktop/tablet table (`validator-columns.tsx`), and
- the **mobile card fallback** (`validator-card-list.tsx`, shown below `md`).

Closes #5339

> Re-opens the change from #5499, which was closed because its screenshots didn't show the affordance on mobile — the earlier version only touched the table (hidden below `md`), so the mobile card view was unchanged. This version covers the mobile cards too, and the mobile screenshots below show the copy buttons on each card.

## Change

- Import `CopyButton` from `@jsonbored/ui-kit` (same source Blocks/Extrinsics use) in both components.
- Table: wrap each of the Hotkey/Coldkey `<Link>`s in `inline-flex min-w-0 items-center gap-1` and append `<CopyButton value=… label=…>` (link truncates, button stays visible).
- Mobile card: same treatment for the card's hotkey and coldkey rows.

No data, sorting, routing, or column-set changes; column `header` values are untouched, so the header/cell-count invariant and its test still hold.

## Screenshots

`/validators`. **Before** = tooltip-only, no copy. **After** = a copy button on every hotkey/coldkey. Desktop (1280) / tablet (768) show the table; **mobile (375)** shows the card view (full page) — copy buttons now on every card.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop 1280 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/before-desktop-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/after-desktop-light.png) |
| Desktop 1280 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/after-desktop-dark.png) |
| Tablet 768 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/before-tablet-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/after-tablet-light.png) |
| Tablet 768 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/after-tablet-dark.png) |
| Mobile 375 · Light | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/before-mobile-light.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/after-mobile-light.png) |
| Mobile 375 · Dark | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/joaovictor91123/metagraphed/assets/5339/5339/after-mobile-dark.png) |

## Validation

- `npx tsc --noEmit` (apps/ui) → clean
- `npm test` (apps/ui) → 753 tests passed (111 files)
