### PR TITLE
fix(schemas): enforce provider-submission.schema.json via ajv in validate-intake

### DIFF
--- a/scripts/validate-intake.mjs
+++ b/scripts/validate-intake.mjs
@@ -1,3 +1,5 @@
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { listJsonFilesRecursive, readJson, repoRoot } from "./lib.mjs";
@@ -45,6 +47,23 @@ const directProviderExample = await readJson(
 const statusReportExample = await readJson(
   path.join(repoRoot, "docs/examples/submissions/status-report.json"),
 );
+
+const ajv = new Ajv2020({
+  allErrors: true,
+  allowUnionTypes: true,
+  strict: false,
+  validateFormats: true,
+});
+addFormats(ajv);
+const providerSchema = await readJson(
+  path.join(repoRoot, "schemas/provider.schema.json"),
+);
+ajv.addSchema(providerSchema, providerSchema.$id);
+const providerSubmissionSchema = await readJson(
+  path.join(repoRoot, "schemas/provider-submission.schema.json"),
+);
+const validateProviderSubmission = ajv.compile(providerSubmissionSchema);
+
 const errors = [];
 
 // The per-surface community-candidate intake lane is retired — surfaces now live
@@ -206,21 +225,29 @@ function checkExampleProvider(provider) {
 }
 
 function checkExampleProviderSubmission(document) {
-  if (document?.schema_version !== 1 || !document?.provider) {
-    errors.push(
-      "direct provider profile example: missing schema_version or provider",
-    );
+  if (!validateProviderSubmission(document)) {
+    for (const error of validateProviderSubmission.errors || []) {
+      errors.push(
+        `direct provider profile example${error.instancePath}: ${error.message}`,
+      );
+    }
     return;
   }
+  // Cross-field consistency (submitted_by_url must point at submitted_by)
+  // isn't expressible as a single-field schema pattern, so it stays a
+  // hand-rolled check on top of the schema-driven validation above.
   if (
-    document?.submission?.submitted_by_url !==
-    `https://github.com/${document?.submission?.submitted_by}`
+    document.submission.submitted_by_url !==
+    `https://github.com/${document.submission.submitted_by}`
   ) {
     errors.push(
       "direct provider profile example: submitted_by_url must match submitted_by",
     );
   }
-  checkExampleProvider(document.provider);
+  // Deliberately narrower than provider.schema.json's full 4-value Authority
+  // enum: a self-submitted direct-provider-profile can't claim "official" or
+  // "registry-observed" (those are reserved for maintainer/registry-curated
+  // authority), even though the schema itself allows all four.
   if (
     !["community", "provider-claimed"].includes(document.provider.authority)
   ) {

--- a/tests/validate-intake-provider-submission.test.mjs
+++ b/tests/validate-intake-provider-submission.test.mjs
@@ -1,0 +1,102 @@
+// Regression coverage for #5476: schemas/provider-submission.schema.json was
+// never compiled/enforced anywhere — validate-intake.mjs's
+// checkExampleProviderSubmission() only did hand-rolled presence checks, so a
+// direct-provider-profile.json example violating the real schema (bad
+// submitted_by pattern, a stray top-level property, etc.) silently passed.
+// validate-intake.mjs now compiles provider-submission.schema.json with ajv
+// and validates the example fixture against it.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, test } from "vitest";
+import { repoRoot } from "../scripts/lib.mjs";
+
+const fixturePath = path.join(
+  repoRoot,
+  "docs/examples/submissions/direct-provider-profile.json",
+);
+
+function runNode(args) {
+  try {
+    const stdout = execFileSync(process.execPath, args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return { status: 0, output: stdout };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      output: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+    };
+  }
+}
+
+describe("validate-intake.mjs: provider-submission schema enforcement", () => {
+  let originalContents;
+
+  afterEach(() => {
+    if (originalContents !== undefined) {
+      writeFileSync(fixturePath, originalContents);
+      originalContents = undefined;
+    }
+  });
+
+  test("passes on the unmodified example fixture", () => {
+    const { status, output } = runNode(["scripts/validate-intake.mjs"]);
+    assert.equal(status, 0, output);
+  });
+
+  test("fails when submitted_by violates the schema's pattern", () => {
+    originalContents = readFileSync(fixturePath, "utf8");
+    const document = JSON.parse(originalContents);
+    document.submission.submitted_by = "bad user!";
+    writeFileSync(fixturePath, JSON.stringify(document, null, 2));
+
+    const { status, output } = runNode(["scripts/validate-intake.mjs"]);
+
+    assert.equal(status, 1);
+    assert.match(output, /submission\/submitted_by/);
+    assert.match(output, /must match pattern/);
+  });
+
+  test("fails on a stray unknown top-level property", () => {
+    originalContents = readFileSync(fixturePath, "utf8");
+    const document = JSON.parse(originalContents);
+    document.unexpected_field = "nope";
+    writeFileSync(fixturePath, JSON.stringify(document, null, 2));
+
+    const { status, output } = runNode(["scripts/validate-intake.mjs"]);
+
+    assert.equal(status, 1);
+    assert.match(output, /must NOT have additional properties/);
+  });
+
+  test("fails when provider.website_url is not a valid URI", () => {
+    originalContents = readFileSync(fixturePath, "utf8");
+    const document = JSON.parse(originalContents);
+    document.provider.website_url = "not-a-url";
+    writeFileSync(fixturePath, JSON.stringify(document, null, 2));
+
+    const { status, output } = runNode(["scripts/validate-intake.mjs"]);
+
+    assert.equal(status, 1);
+    assert.match(output, /provider\/website_url/);
+  });
+
+  test("fails when provider.authority is outside the submission-narrowed set despite being schema-valid", () => {
+    originalContents = readFileSync(fixturePath, "utf8");
+    const document = JSON.parse(originalContents);
+    // "official" is a valid value in provider.schema.json's full Authority
+    // enum, but direct-provider-profile submissions are deliberately
+    // narrowed to community/provider-claimed only.
+    document.provider.authority = "official";
+    writeFileSync(fixturePath, JSON.stringify(document, null, 2));
+
+    const { status, output } = runNode(["scripts/validate-intake.mjs"]);
+
+    assert.equal(status, 1);
+    assert.match(output, /authority must be community or provider-claimed/);
+  });
+});


### PR DESCRIPTION
## Summary

- `schemas/provider-submission.schema.json` was never compiled or enforced by anything — `validate-intake.mjs`'s `checkExampleProviderSubmission()` only did hand-rolled presence checks that covered far less than the schema documents (no `submitted_by` pattern check, no `website_url`/`kind` validation, no `additionalProperties: false` enforcement).

## What Changed

- `scripts/validate-intake.mjs` now compiles `schemas/provider-submission.schema.json` with ajv (mirroring the existing pattern in `scripts/validate-schemas.mjs`) and validates `docs/examples/submissions/direct-provider-profile.json` against it.
- The old presence-only checks are replaced by the schema-driven validation. Two checks that aren't expressible as JSON Schema stay as hand-rolled checks on top of it: the `submitted_by_url` must match `submitted_by` cross-field check, and the intentional narrowing of `authority` to `community`/`provider-claimed` (stricter than `provider.schema.json`'s full 4-value enum, since a self-submitted profile can't claim `official`/`registry-observed`).
- Added `tests/validate-intake-provider-submission.test.mjs`, asserting the fixture passes as-is and fails when mutated to violate the schema (bad `submitted_by` pattern, a stray top-level property, a non-URI `website_url`) or the authority narrowing.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5476`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (No generated artifacts touched — `schemas/` itself is unchanged; only the intake validator's enforcement path changed.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No schema changes — this PR only wires up enforcement of an existing schema.)

## Validation

- [ ] `npm run check` — lint/format/`validate:docs` all pass; `pipeline:check`'s `r2:manifest:dry-run` step fails locally on a clean checkout of `main` too (stale committed `r2-manifest.json` vs. current registry state, a publish-pipeline-owned artifact this PR doesn't touch — see `SKILL.md` Phase B3), unrelated to this change.
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage` (274 files / 8198 tests passed)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

Closes #5476
