### PR TITLE
feat(registry): add SN53 EfficientFrontier min_compute data-artifact

### DIFF
--- a/registry/subnets/efficientfrontier.json
+++ b/registry/subnets/efficientfrontier.json
@@ -138,6 +138,25 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/53"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-53-efficientfrontier-min-compute",
+      "kind": "data-artifact",
+      "name": "EfficientFrontier minimum compute requirements",
+      "notes": "Public no-auth machine-readable min_compute.yml from the SN53 EfficientFrontier subnet repository (oxylok/53-EfficientFrontier — the repo the file's existing surfaces already cite), pinned to an immutable commit. Specifies the minimum and recommended CPU, GPU, memory, storage, and network requirements for running SN53 miners and validators. Static YAML artifact useful for agents provisioning subnet nodes.",
+      "provider": "signalplus",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/oxylok/53-EfficientFrontier",
+        "https://github.com/oxylok/53-EfficientFrontier/blob/be5d620ced30b34b41c0e33b6a8a76121747d005/_sdk/min_compute.yml"
+      ],
+      "url": "https://raw.githubusercontent.com/oxylok/53-EfficientFrontier/be5d620ced30b34b41c0e33b6a8a76121747d005/_sdk/min_compute.yml"
     }
   ],
   "website_url": "https://www.signalplus.com/"


### PR DESCRIPTION
## Summary

Enriches **SN53 EfficientFrontier** (issue #4058) with a machine-usable **data-artifact**: the subnet's `min_compute.yml`, pinned to an immutable commit.

- **url:** https://raw.githubusercontent.com/oxylok/53-EfficientFrontier/be5d620ced30b34b41c0e33b6a8a76121747d005/_sdk/min_compute.yml (public, no-auth — HTTP 200, ~4 KB YAML)
- **kind:** data-artifact (static machine-readable spec)
- **source_urls:** https://github.com/oxylok/53-EfficientFrontier — the SN53 repo this file's existing surfaces already cite — plus the pinned blob
- Specifies the minimum/recommended CPU, GPU, memory, storage, and network requirements for SN53 miners and validators.

## Validation
- `npm run validate:surface -- registry/subnets/efficientfrontier.json` → passed
- `npm run scan:public-safety` → no findings for this file
- `npx prettier --check` → clean

Closes #4058