### PR TITLE
feat(ui): add a summary strip to /settings

### DIFF
--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
@@ -1,8 +1,9 @@
 import { useState, type FormEvent, type ReactNode } from "react";
 import { useMutation } from "@tanstack/react-query";
+import { KeyRound, Repeat2, Tags, UserX } from "lucide-react";
 import { apiFetch, ApiError } from "@/lib/metagraphed/client";
 import { classNames } from "@/lib/metagraphed/format";
-import { CopyableCode, SectionHeading } from "@jsonbored/ui-kit";
+import { CopyableCode, SectionHeading, StatTile } from "@jsonbored/ui-kit";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import type {
   WebhookDeliveryStatus,
@@ -52,9 +53,44 @@ function describeApiError(error: unknown): string {
 export function WebhookSubscriptionManager() {
   return (
     <div className="space-y-8">
+      <WebhookSummaryStrip />
       <CreateSubscriptionSection />
       <LookupSubscriptionSection />
       <DeleteSubscriptionSection />
+    </div>
+  );
+}
+
+/**
+ * There's no list-subscriptions endpoint (subscriptions are addressable only
+ * by id + secret, not enumerable — an intentional privacy boundary), so this
+ * can't summarize existing subscriptions the way sibling pages summarize live
+ * probe data. It instead surfaces the fixed facts about the subscription
+ * contract itself, giving this page the same KPI-strip visual weight as
+ * health/status/endpoints without inventing per-user metrics.
+ */
+function WebhookSummaryStrip() {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <StatTile
+        icon={Tags}
+        eyebrow="Change kinds"
+        value={String(CHANGE_KINDS.length)}
+        hint={CHANGE_KINDS.join(", ")}
+      />
+      <StatTile
+        icon={Repeat2}
+        eyebrow="Delivery"
+        value="At-least-once"
+        hint="idempotency-keyed retries"
+      />
+      <StatTile icon={KeyRound} eyebrow="Signing" value="HMAC-SHA256" hint="over the raw body" />
+      <StatTile
+        icon={UserX}
+        eyebrow="Account model"
+        value="None"
+        hint="secret-scoped, self-service"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- `/settings` was the odd one out among the utility pages (`health`, `status`, `gaps`, `endpoints`, `schemas`, `surfaces`, `explorer`): every sibling opens with a `PageHero`/KPI-card treatment, while Settings dropped straight from the hero into three plain forms with no summary strip.

## What Changed

- Added a light KPI-strip (`StatTile` × 4, the same primitive `endpoints.tsx`'s `EndpointsStatStrip` uses) to `WebhookSubscriptionManager`, rendered above the Create/Look up/Delete forms: change kinds tracked, delivery model, signing algorithm, account model.
- There's no list-subscriptions endpoint (subscriptions are addressable only by id + secret, not enumerable — an intentional privacy boundary, so there's nothing to probe the way `status`/`health` probe live surfaces). The strip surfaces the fixed facts about the subscription contract itself instead of inventing per-user metrics, giving the page the same visual weight as its siblings without fabricating data.
- The three form sections (`CreateSubscriptionSection`, `LookupSubscriptionSection`, `DeleteSubscriptionSection`) are untouched — same markup, same mutations, same validation.

## Screenshots

| Viewport · Theme | Before | After |
| ---- | ---- | ---- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5346-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (753 tests)
- [x] `npm run test:e2e --workspace=apps/ui` (24 tests, incl. `/settings` responsive-overflow at all 4 breakpoints)
- [x] `npm run build --workspace=apps/ui`

Closes #5346
