### PR TITLE
feat(registry): add SN42 Gopher TikTok transcription dataset data-artifact

### DIFF
--- a/registry/subnets/gopher.json
+++ b/registry/subnets/gopher.json
@@ -184,6 +184,25 @@
         "submitted_by": "davion-knight"
       },
       "notes": "Public Gopher-Lab HuggingFace dataset of X/Twitter trending-topics scraped by the SN42 Gopher data network, not gated. The subnet-42 repo (source) declares the Bittensor subnet and the Gopher-Lab HF org matches the operator's gopher-lab GitHub org. Distinct from the subnet's registered web-scrape example dataset."
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-42-gopher-tiktok-transcription-dataset",
+      "kind": "data-artifact",
+      "name": "Gopher TikTok most-shared video transcription dataset",
+      "notes": "Public no-auth Hugging Face dataset published by the official SN42 Gopher team org (Gopher-Lab): transcriptions of the most-shared TikTok videos, distributed as CSV. An example output of the subnet's social-media scraping and transcription pipeline, in the same Gopher-Lab dataset family as the Bittensor whitepaper webscrape and X/Twitter trending-topics datasets already registered for SN42.",
+      "provider": "gopher-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/gopher-lab/subnet-42",
+        "https://huggingface.co/Gopher-Lab"
+      ],
+      "url": "https://huggingface.co/datasets/Gopher-Lab/TikTok_Most_Shared_Video_Transcription_Example"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enriches **SN42 Gopher** (issue #4048) with a machine-usable **data-artifact**: a public Hugging Face dataset published by the official Gopher team org.

- **url:** https://huggingface.co/datasets/Gopher-Lab/TikTok_Most_Shared_Video_Transcription_Example (public, no-auth — HTTP 200; CSV data files)
- **kind:** data-artifact
- **source_urls:** the official SN42 repo https://github.com/gopher-lab/subnet-42 + the team's HF org https://huggingface.co/Gopher-Lab
- Transcriptions of the most-shared TikTok videos — an example output of the subnet's social-media scraping/transcription pipeline. Same **Gopher-Lab** dataset family as the `Bittensor_Whitepaper_Webscrape_Example` and `X_Twitter_Trending_Topics_August2025` datasets already registered for SN42.

## Validation
- `npm run validate:surface -- registry/subnets/gopher.json` → passed
- `npm run scan:public-safety` → no findings for this file
- `npx prettier --check` → clean

Closes #4048