### PR TITLE
feat(registry): add SN40 Chunking subnet protocol definition data-artifact surface (#4044)

### DIFF
--- a/registry/subnets/chunking.json
+++ b/registry/subnets/chunking.json
@@ -114,6 +114,31 @@
         "https://github.com/salahawk/chunking_subnet"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/40"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-40-chunking-protocol",
+      "kind": "data-artifact",
+      "name": "Chunking subnet protocol definition",
+      "notes": "Public no-auth machine-readable protocol module (chunking/protocol.py) committed in the official salahawk/chunking_subnet repository, defining the Bittensor synapse schema SN40 Chunking miners and validators communicate over — the document/chunk request and response contract for the subnet's text-chunking task. Pinned to an immutable commit. Verified 200, SS58-clean, no keys or secrets. Distinct from the min_compute spec already registered.",
+      "provider": "vectorchat",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "source_urls": [
+        "https://github.com/salahawk/chunking_subnet/blob/29ed38c60aac356717d3e1dfc3e7c3627158bff4/chunking/protocol.py",
+        "https://github.com/salahawk/chunking_subnet"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "url": "https://raw.githubusercontent.com/salahawk/chunking_subnet/29ed38c60aac356717d3e1dfc3e7c3627158bff4/chunking/protocol.py"
     }
   ],
   "website_url": "https://subnet.chunking.com/"


### PR DESCRIPTION
## Summary

Adds one new `community` data-artifact surface to SN40 Chunking (`registry/subnets/chunking.json`): the subnet's **protocol definition** module (`chunking/protocol.py`) from the official repository.

This is distinct from the min_compute spec already registered — the machine-readable schema of the request/response contract miners and validators exchange.

## Surface

- **id:** `sn-40-chunking-protocol`
- **kind:** `data-artifact`
- **url:** `https://raw.githubusercontent.com/salahawk/chunking_subnet/29ed38c60aac356717d3e1dfc3e7c3627158bff4/chunking/protocol.py` — public, no-auth, HTTP 200, pinned to an immutable commit
- **provider:** `vectorchat`
- **source_url:** the same file's GitHub blob at the pinned commit + the registered `source_repo`

## What it is

`chunking/protocol.py` — the Bittensor synapse schema SN40 Chunking communicates over: the document/chunk request and response contract for the subnet's text-chunking task. A machine-readable reference for the subnet's on-wire protocol. Contains no keys or secrets.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/chunking.json` — passed (5 surfaces)
- Verified with no auth header: 200, SS58-clean.

One focused change: one surface appended to one subnet file; nothing else touched.

Closes #4044

> Scope note: #4044 frames the enrichment as an OpenAPI/Swagger spec. Chunking serves no verified public OpenAPI document; this adds a genuinely-published machine-readable protocol artifact from the official repo — the same config-as-source-file pattern already accepted elsewhere in the registry — advancing the same "enrich SN40" intent. Any OpenAPI-specific framing is advisory.
