### PR TITLE
feat(ui): wallet-connect integration (client-side, read-only)

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@jsonbored/metagraphed": "*",
     "@jsonbored/ui-kit": "*",
+    "@polkadot/extension-dapp": "^0.63.1",
     "@sentry/browser": "^10.60.0",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-query": "^5.83.0",

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -29,6 +29,7 @@ import {
   SheetTitle,
 } from "@jsonbored/ui-kit";
 import { SettingsPopover } from "./settings-popover";
+import { WalletConnectButton } from "./wallet-connect";
 import { classNames } from "@/lib/metagraphed/format";
 import { freshnessQuery, buildQuery } from "@/lib/metagraphed/queries";
 import { NavMegaMenu, MobileMegaMenu } from "./nav-mega-menu";
@@ -162,6 +163,13 @@ export function AppShell({ children }: { children: ReactNode }) {
                 <div className="hidden md:inline-flex lg:hidden xl:inline-flex">
                   <SettingsPopover />
                 </div>
+                {/* Wallet-connect (#5236) is a secondary action for now (read-only,
+                    no signing yet) — same responsive treatment as the developer-
+                    settings link/SettingsPopover above, not a fourth unconditional
+                    icon alongside ApiDrawerTrigger/NetworkSwitcher. */}
+                <div className="hidden md:inline-flex lg:hidden xl:inline-flex">
+                  <WalletConnectButton />
+                </div>
                 {/* At lg the mega-menu appears and the trailing icons no longer
                     fit; fold the secondary actions into one popover until xl
                     restores the room (#3985). */}
@@ -240,6 +248,12 @@ export function AppShell({ children }: { children: ReactNode }) {
                   <Webhook className="size-3.5" aria-hidden="true" /> Developer settings
                 </Link>
                 <SettingsPopover />
+                {/* #5236: mobile has no other wallet-connect entry point (the
+                    header trigger is `hidden` below `md`, and folding it into
+                    HeaderActionsMenu doesn't help either -- that's ALSO
+                    `hidden` below `lg`) -- without this it would be
+                    unreachable below `md` entirely. */}
+                <WalletConnectButton />
               </div>
               <div className="mt-auto border-t border-border pt-3">
                 <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted mb-1.5">

--- a/apps/ui/src/components/metagraphed/header-actions-menu.tsx
+++ b/apps/ui/src/components/metagraphed/header-actions-menu.tsx
@@ -4,6 +4,7 @@ import { Code2, MoreHorizontal, Webhook } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@jsonbored/ui-kit";
 import { useApiSourceCtx } from "@/lib/metagraphed/api-source-context";
 import { SettingsPanel } from "./settings-popover";
+import { WalletConnectPanel } from "./wallet-connect";
 
 /**
  * Consolidated header actions for the mid-desktop range (lg–xl). Once the
@@ -53,6 +54,10 @@ export function HeaderActionsMenu() {
             <Webhook className="size-3.5 shrink-0 text-ink-muted" aria-hidden="true" />
             <span>Developer settings</span>
           </Link>
+        </div>
+        <div>
+          <div className="mg-label mb-1.5">Wallet</div>
+          <WalletConnectPanel />
         </div>
         <SettingsPanel />
       </PopoverContent>

--- a/apps/ui/src/components/metagraphed/wallet-connect.tsx
+++ b/apps/ui/src/components/metagraphed/wallet-connect.tsx
@@ -1,0 +1,262 @@
+import { useState } from "react";
+import {
+  Wallet,
+  Check,
+  Copy,
+  LogOut,
+  Loader2,
+  ShieldCheck,
+  ExternalLink as ExternalLinkIcon,
+} from "lucide-react";
+import { Popover, PopoverTrigger, safeExternalUrl } from "@jsonbored/ui-kit";
+import { ClampedPopoverContent } from "./clamped-popover-content";
+import { EmptyState } from "./states";
+import { useWallet } from "@/hooks/use-wallet";
+import { useCopy } from "@/hooks/use-copy";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { classNames } from "@/lib/metagraphed/format";
+import type { InjectedAccountWithMeta } from "@/lib/metagraphed/wallet-injected";
+
+// Non-custodial staking rail #5236 — read-only wallet connect (web3Enable →
+// web3Accounts → pick → persist). NO signing here; that's a later issue (#5237+),
+// see docs/adr/0018-native-staking-architecture.md. Deliberately distinct wording
+// from (but consistent with) the About page's non-custodial disclaimer (PR #5282) —
+// this copy is scoped to what THIS step does, not the product overall.
+const DISCLAIMER =
+  "metagraphed never sees your keys. Connecting only shares your public address — signing (a later step) always happens in your wallet, never on our servers.";
+
+const SUPPORTED_WALLETS = [
+  { label: "Polkadot{.js}", href: "https://polkadot.js.org/extension/" },
+  { label: "Talisman", href: "https://talisman.xyz/" },
+  { label: "SubWallet", href: "https://subwallet.app/" },
+];
+
+/**
+ * Header trigger + popover. Icon-only when disconnected, shows the truncated
+ * connected address when connected (matches NetworkSwitcher's active-state
+ * treatment).
+ */
+export function WalletConnectButton() {
+  const { wallet, status } = useWallet();
+  const [open, setOpen] = useState(false);
+  const connected = status === "connected" && wallet;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={connected ? `Wallet connected: ${wallet.address}` : "Connect wallet"}
+          title={connected ? `Connected · ${wallet.source} · ${wallet.address}` : "Connect wallet"}
+          className={classNames(
+            "inline-flex items-center gap-1.5 rounded border px-2 py-1.5 min-h-11 text-[11px] font-mono transition-colors",
+            connected
+              ? "border-ink-strong/40 bg-surface text-ink-strong"
+              : "border-border bg-card text-ink-muted hover:text-ink-strong hover:border-ink/30",
+          )}
+        >
+          <Wallet className="size-3.5" aria-hidden="true" />
+          {connected ? <span>{shortHash(wallet.address, 4)}</span> : null}
+        </button>
+      </PopoverTrigger>
+      <ClampedPopoverContent align="end" className="w-80 p-3">
+        <WalletConnectPanel onConnected={() => setOpen(false)} />
+      </ClampedPopoverContent>
+    </Popover>
+  );
+}
+
+/**
+ * The connect/picker/connected content, without the popover chrome — split out
+ * from WalletConnectButton (mirrors SettingsPopover/SettingsPanel) so it can be
+ * reused wherever wallet state needs to be surfaced without duplicating markup.
+ */
+export function WalletConnectPanel({ onConnected }: { onConnected?: () => void }) {
+  const { wallet, status, accounts, error, hasExtension, connect, selectAccount, disconnect } =
+    useWallet();
+
+  if (status === "connected" && wallet) {
+    return <ConnectedView wallet={wallet} onDisconnect={disconnect} />;
+  }
+
+  if (status === "picking") {
+    return (
+      <AccountPicker
+        accounts={accounts}
+        onSelect={(account) => {
+          selectAccount(account);
+          onConnected?.();
+        }}
+      />
+    );
+  }
+
+  if (!hasExtension || status === "no-extension") {
+    return <NoExtensionView />;
+  }
+
+  return (
+    <div className="space-y-3">
+      <Disclaimer />
+      {status === "no-accounts" ? (
+        <div className="rounded border border-border bg-surface/40 px-2 py-1.5 text-[11px] text-ink-muted">
+          No accounts available — open your wallet extension and make sure at least one account is
+          shared with this site.
+        </div>
+      ) : null}
+      {status === "error" ? (
+        <div
+          role="alert"
+          className="rounded border border-health-down/30 bg-health-down/5 px-2 py-1.5 text-[11px] text-health-down"
+        >
+          {error ?? "Failed to connect wallet."}
+        </div>
+      ) : null}
+      <button
+        type="button"
+        onClick={async () => {
+          await connect();
+        }}
+        disabled={status === "connecting"}
+        className="w-full inline-flex items-center justify-center gap-1.5 rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-60"
+      >
+        {status === "connecting" ? (
+          <>
+            <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+            Connecting…
+          </>
+        ) : (
+          <>
+            <Wallet className="size-3.5" aria-hidden="true" />
+            Connect Wallet
+          </>
+        )}
+      </button>
+    </div>
+  );
+}
+
+function Disclaimer() {
+  return (
+    <div className="flex items-start gap-1.5 text-[10px] text-ink-muted">
+      <ShieldCheck className="mt-0.5 size-3 shrink-0 text-ink-muted" aria-hidden="true" />
+      <span>{DISCLAIMER}</span>
+    </div>
+  );
+}
+
+function NoExtensionView() {
+  return (
+    <div className="space-y-3">
+      <Disclaimer />
+      <EmptyState
+        title="No wallet extension found"
+        description="Install a supported extension, then reopen this menu."
+      />
+      <ul className="space-y-1">
+        {SUPPORTED_WALLETS.map((w) => {
+          const href = safeExternalUrl(w.href);
+          if (!href) return null;
+          return (
+            <li key={w.label}>
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-between gap-2 rounded border border-border bg-card px-2 py-1.5 text-[11px] text-ink-strong hover:border-ink/30 transition-colors"
+              >
+                {w.label}
+                <ExternalLinkIcon className="size-3 text-ink-muted" aria-hidden="true" />
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function AccountPicker({
+  accounts,
+  onSelect,
+}: {
+  accounts: InjectedAccountWithMeta[];
+  onSelect: (account: InjectedAccountWithMeta) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="mg-label mb-1">Choose an account</div>
+      <ul className="space-y-1">
+        {accounts.map((account) => (
+          <li key={account.address}>
+            <button
+              type="button"
+              onClick={() => onSelect(account)}
+              className="w-full flex items-center gap-2 rounded border border-border bg-card px-2 py-1.5 text-left transition-colors hover:border-ink/30 min-h-9"
+            >
+              <span className="min-w-0 flex-1">
+                <span className="block text-[12px] font-medium text-ink-strong truncate">
+                  {account.meta.name || shortHash(account.address, 6)}
+                </span>
+                <span className="block text-[10px] text-ink-muted truncate">
+                  {shortHash(account.address, 6)} · {account.meta.source}
+                </span>
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ConnectedView({
+  wallet,
+  onDisconnect,
+}: {
+  wallet: { address: string; source: string };
+  onDisconnect: () => void;
+}) {
+  const { copied, copy } = useCopy({ label: "address" });
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded border border-ink-strong/40 bg-surface px-2 py-2">
+        <div className="flex items-center gap-2">
+          <Check className="size-3.5 text-health-ok shrink-0" aria-hidden="true" />
+          <span className="min-w-0 flex-1">
+            <span className="block text-[12px] font-medium text-ink-strong font-mono truncate">
+              {shortHash(wallet.address, 6)}
+            </span>
+            <span className="block text-[10px] text-ink-muted">Connected via {wallet.source}</span>
+          </span>
+          <button
+            type="button"
+            onClick={() => copy(wallet.address)}
+            aria-label="Copy address"
+            title="Copy address"
+            className="shrink-0 rounded p-1 text-ink-muted hover:text-ink-strong"
+          >
+            {copied ? (
+              <Check className="size-3.5 text-health-ok" aria-hidden="true" />
+            ) : (
+              <Copy className="size-3.5" aria-hidden="true" />
+            )}
+          </button>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onDisconnect}
+        className="w-full inline-flex items-center justify-center gap-1.5 rounded border border-border bg-card px-3 py-1.5 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+      >
+        <LogOut className="size-3.5" aria-hidden="true" />
+        Disconnect
+      </button>
+      <p className="flex items-start gap-1.5 text-[9px] text-ink-muted">
+        <ShieldCheck className="mt-0.5 size-2.5 shrink-0" aria-hidden="true" />
+        <span>metagraphed never sees your keys.</span>
+      </p>
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/use-wallet.test.ts
+++ b/apps/ui/src/hooks/use-wallet.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { InjectedAccountWithMeta } from "@/lib/metagraphed/wallet-injected";
+
+import { resolveConnectOutcome, toConnectedWallet, isStaleWallet } from "./use-wallet";
+
+const ADDR_A = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const ADDR_B = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+function account(address: string, source = "polkadot-js"): InjectedAccountWithMeta {
+  return { address, meta: { name: "Alice", source } };
+}
+
+describe("resolveConnectOutcome", () => {
+  it("resolves to no-accounts for an empty list", () => {
+    expect(resolveConnectOutcome([])).toEqual({ status: "no-accounts" });
+  });
+
+  it("auto-picks the single account when exactly one is available", () => {
+    const acc = account(ADDR_A);
+    expect(resolveConnectOutcome([acc])).toEqual({ status: "connected", account: acc });
+  });
+
+  it("resolves to picking when more than one account is available", () => {
+    expect(resolveConnectOutcome([account(ADDR_A), account(ADDR_B)])).toEqual({
+      status: "picking",
+    });
+  });
+});
+
+describe("toConnectedWallet", () => {
+  it("keeps only the address and source", () => {
+    expect(toConnectedWallet(account(ADDR_A, "talisman"))).toEqual({
+      address: ADDR_A,
+      source: "talisman",
+    });
+  });
+
+  it("falls back to 'unknown' when the extension doesn't report a source", () => {
+    const acc: InjectedAccountWithMeta = { address: ADDR_A, meta: { name: "Alice", source: "" } };
+    expect(toConnectedWallet(acc)).toEqual({ address: ADDR_A, source: "unknown" });
+  });
+});
+
+describe("isStaleWallet", () => {
+  it("is false when the persisted address is still exposed", () => {
+    const wallet = { address: ADDR_A, source: "polkadot-js" };
+    expect(isStaleWallet(wallet, [account(ADDR_A), account(ADDR_B)])).toBe(false);
+  });
+
+  it("is true when the persisted address is no longer exposed", () => {
+    const wallet = { address: ADDR_A, source: "polkadot-js" };
+    expect(isStaleWallet(wallet, [account(ADDR_B)])).toBe(true);
+  });
+
+  it("is true when the fresh account list is empty", () => {
+    const wallet = { address: ADDR_A, source: "polkadot-js" };
+    expect(isStaleWallet(wallet, [])).toBe(true);
+  });
+});

--- a/apps/ui/src/hooks/use-wallet.ts
+++ b/apps/ui/src/hooks/use-wallet.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  getConnectedWallet,
+  setConnectedWallet,
+  onConnectedWalletChange,
+  type ConnectedWallet,
+} from "@/lib/metagraphed/wallet";
+import {
+  hasInjectedWallet,
+  connectWallet,
+  type InjectedAccountWithMeta,
+} from "@/lib/metagraphed/wallet-injected";
+
+export type WalletStatus =
+  "idle" | "connecting" | "no-extension" | "no-accounts" | "picking" | "connected" | "error";
+
+/** How many accounts a connectWallet() call returned determines the next UI state. */
+export function resolveConnectOutcome(accounts: InjectedAccountWithMeta[]): {
+  status: "no-accounts" | "picking" | "connected";
+  account?: InjectedAccountWithMeta;
+} {
+  if (accounts.length === 0) return { status: "no-accounts" };
+  if (accounts.length === 1) return { status: "connected", account: accounts[0] };
+  return { status: "picking" };
+}
+
+/**
+ * The minimal persisted shape for a picked/auto-picked injected account.
+ * `meta.source` is typed as a required string, but falls back to "unknown" in
+ * case a misbehaving extension reports an empty one — this is a system
+ * boundary (third-party extension data), not a case the type can rule out.
+ */
+export function toConnectedWallet(account: InjectedAccountWithMeta): ConnectedWallet {
+  return { address: account.address, source: account.meta.source || "unknown" };
+}
+
+/**
+ * True when a persisted wallet's address is no longer among a freshly-fetched
+ * account list — the extension was uninstalled, or this site's access was
+ * revoked, since the address was last persisted.
+ */
+export function isStaleWallet(
+  wallet: ConnectedWallet,
+  accounts: InjectedAccountWithMeta[],
+): boolean {
+  return !accounts.some((account) => account.address === wallet.address);
+}
+
+/**
+ * The wallet-connect flow (#5236): connect → pick an account (if more than one) →
+ * persist. Read-only — never constructs or signs anything (see wallet-injected.ts's
+ * header comment and docs/adr/0018-native-staking-architecture.md).
+ */
+export function useWallet() {
+  const [wallet, setWallet] = useState<ConnectedWallet | null>(() => getConnectedWallet());
+  const [status, setStatus] = useState<WalletStatus>(() => (wallet ? "connected" : "idle"));
+  const [accounts, setAccounts] = useState<InjectedAccountWithMeta[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(
+    () =>
+      onConnectedWalletChange((next) => {
+        setWallet(next);
+        setStatus(next ? "connected" : "idle");
+      }),
+    [],
+  );
+
+  // Re-verify a persisted wallet is still exposed on mount, client-only. An
+  // extension can be uninstalled or have this site's access revoked between
+  // visits; blindly trusting the persisted value would show a falsely-connected
+  // UI. Best-effort — a transient failure here keeps the persisted wallet as-is
+  // rather than disconnecting on a fluke.
+  useEffect(() => {
+    const persisted = getConnectedWallet();
+    if (!persisted) return;
+    let cancelled = false;
+    connectWallet()
+      .then((fresh) => {
+        if (!cancelled && isStaleWallet(persisted, fresh)) {
+          setConnectedWallet(null);
+        }
+      })
+      .catch(() => {
+        /* best-effort re-verify; keep the persisted wallet on a transient failure */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const connect = useCallback(async () => {
+    if (!hasInjectedWallet()) {
+      setStatus("no-extension");
+      return;
+    }
+    setStatus("connecting");
+    setError(null);
+    try {
+      const fresh = await connectWallet();
+      setAccounts(fresh);
+      const outcome = resolveConnectOutcome(fresh);
+      setStatus(outcome.status);
+      if (outcome.status === "connected" && outcome.account) {
+        setConnectedWallet(toConnectedWallet(outcome.account));
+      }
+    } catch (err) {
+      setStatus("error");
+      setError(err instanceof Error ? err.message : "Failed to connect wallet");
+    }
+  }, []);
+
+  const selectAccount = useCallback((account: InjectedAccountWithMeta) => {
+    setConnectedWallet(toConnectedWallet(account));
+    setStatus("connected");
+  }, []);
+
+  const disconnect = useCallback(() => {
+    setConnectedWallet(null);
+    setAccounts([]);
+    setStatus("idle");
+  }, []);
+
+  return {
+    wallet,
+    status,
+    accounts,
+    error,
+    hasExtension: hasInjectedWallet(),
+    connect,
+    selectAccount,
+    disconnect,
+  };
+}

--- a/apps/ui/src/lib/metagraphed/wallet-injected.test.ts
+++ b/apps/ui/src/lib/metagraphed/wallet-injected.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { hasInjectedWallet, connectWallet } from "./wallet-injected";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("hasInjectedWallet", () => {
+  it("is false when window is undefined (SSR)", () => {
+    expect(hasInjectedWallet()).toBe(false);
+  });
+
+  it("is false when window.injectedWeb3 is absent", () => {
+    vi.stubGlobal("window", {});
+    expect(hasInjectedWallet()).toBe(false);
+  });
+
+  it("is false when window.injectedWeb3 is an empty object", () => {
+    vi.stubGlobal("window", { injectedWeb3: {} });
+    expect(hasInjectedWallet()).toBe(false);
+  });
+
+  it("is true when at least one extension has injected a provider", () => {
+    vi.stubGlobal("window", { injectedWeb3: { "polkadot-js": {} } });
+    expect(hasInjectedWallet()).toBe(true);
+  });
+});
+
+// connectWallet's only path exercised here is its SSR early return. The real
+// dynamic-import path (loading @polkadot/extension-dapp, which transitively
+// triggers @polkadot/util-crypto's WASM init) is deliberately NOT exercised in this
+// unit suite — that would defeat the point of keeping it off the SSR/unit-test
+// critical path. Real coverage for the connect flow is manual QA with an actual
+// browser extension (Polkadot.js / Talisman / SubWallet); see the PR description.
+describe("connectWallet (SSR safety only)", () => {
+  it("resolves to an empty array under SSR without ever touching @polkadot/extension-dapp", async () => {
+    // No window stubbed at all — matches how this module is actually invoked during
+    // server rendering, where `window` is genuinely undefined, not merely falsy.
+    await expect(connectWallet()).resolves.toEqual([]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/wallet-injected.ts
+++ b/apps/ui/src/lib/metagraphed/wallet-injected.ts
@@ -1,0 +1,48 @@
+// The one boundary in this codebase that touches @polkadot/extension-dapp (#5236,
+// native-staking epic #5229, wallet standard locked by docs/adr/0018). Everything in
+// this file is written so that no @polkadot/* code can ever be reached during SSR:
+//
+//   - @polkadot/util-crypto (a transitive dep of extension-dapp) auto-triggers WASM
+//     init as an IMPORT-TIME side effect, not gated behind calling any function — so
+//     even a top-level `import { web3Enable } from "@polkadot/extension-dapp"` would
+//     be unsafe in an SSR bundle regardless of whether the functions are called.
+//   - The fix: every function below that touches the package does so via a dynamic
+//     `import()` INSIDE the function body, after a `typeof window === "undefined"`
+//     early return. React SSR never executes event handlers or the bodies of
+//     `useEffect` callbacks, so as long as callers only invoke these from one of
+//     those (never from a component's render body), the dynamic import is never
+//     reached during server rendering — this holds independent of how the Nitro/
+//     Cloudflare Workers build bundles the eventually-imported package.
+//   - `hasInjectedWallet()` needs no import at all — it only reads window.injectedWeb3,
+//     which every compliant extension injects synchronously on page load — so the
+//     "no extension installed" UI state can render without ever loading the
+//     @polkadot/extension-dapp chunk.
+//
+// `import type` below is compile-time only and erased entirely by the TypeScript
+// compiler — it emits no runtime import statement, so it costs nothing and carries
+// zero SSR risk.
+
+import type { InjectedAccountWithMeta } from "@polkadot/extension-inject/types";
+
+export type { InjectedAccountWithMeta };
+
+/** True when at least one browser extension has injected a Web3 provider. Safe in both SSR and CSR. */
+export function hasInjectedWallet(): boolean {
+  if (typeof window === "undefined") return false;
+  const injected = (window as { injectedWeb3?: Record<string, unknown> }).injectedWeb3;
+  return !!injected && Object.keys(injected).length > 0;
+}
+
+/**
+ * Enable all injected extensions and return every account they expose. Resolves to
+ * an empty array under SSR, or if no extension is installed / no account is shared.
+ * Call only from a client-only path (a useEffect body or an event handler) — never
+ * from a component's render body.
+ */
+export async function connectWallet(): Promise<InjectedAccountWithMeta[]> {
+  if (typeof window === "undefined") return [];
+  const { web3Enable, web3Accounts } = await import("@polkadot/extension-dapp");
+  const extensions = await web3Enable("Metagraphed");
+  if (extensions.length === 0) return [];
+  return web3Accounts();
+}

--- a/apps/ui/src/lib/metagraphed/wallet.test.ts
+++ b/apps/ui/src/lib/metagraphed/wallet.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// A minimal browser `window` for the CSR paths, matching config.test.ts's makeWindow:
+// an EventTarget (so add/remove/dispatch work) plus a Map-backed localStorage.
+function makeWindow(seed: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(seed));
+  const win = new EventTarget() as EventTarget & {
+    localStorage: Storage;
+    store: Map<string, string>;
+  };
+  win.store = store;
+  win.localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: () => null,
+    get length() {
+      return store.size;
+    },
+  };
+  return win;
+}
+
+const ADDR_A = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const ADDR_B = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+// wallet.ts caches at module scope, so resetModules + a re-import is the only way to
+// observe first-read behavior deterministically — same pattern as config.test.ts's
+// freshConfig. Stub `window` BEFORE importing so any import-time read sees it.
+async function freshWallet(win?: ReturnType<typeof makeWindow>) {
+  vi.resetModules();
+  if (win) vi.stubGlobal("window", win);
+  return import("./wallet");
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("getConnectedWallet / setConnectedWallet (CSR: caching, persistence, broadcast)", () => {
+  it("reads a persisted wallet on first call, then serves it from cache", async () => {
+    const win = makeWindow({
+      "metagraphed:wallet": JSON.stringify({ address: ADDR_A, source: "polkadot-js" }),
+    });
+    const wallet = await freshWallet(win);
+    expect(wallet.getConnectedWallet()).toEqual({ address: ADDR_A, source: "polkadot-js" });
+    // Mutating storage after the first (caching) read must NOT change the served value.
+    win.store.set("metagraphed:wallet", JSON.stringify({ address: ADDR_B, source: "talisman" }));
+    expect(wallet.getConnectedWallet()).toEqual({ address: ADDR_A, source: "polkadot-js" });
+  });
+
+  it("defaults to null when nothing is persisted", async () => {
+    const wallet = await freshWallet(makeWindow());
+    expect(wallet.getConnectedWallet()).toBeNull();
+  });
+
+  it("ignores malformed JSON, falling back to null", async () => {
+    const wallet = await freshWallet(makeWindow({ "metagraphed:wallet": "{not json" }));
+    expect(wallet.getConnectedWallet()).toBeNull();
+  });
+
+  it("ignores a persisted value with an invalid ss58 address, falling back to null", async () => {
+    const wallet = await freshWallet(
+      makeWindow({
+        "metagraphed:wallet": JSON.stringify({ address: "not-an-address", source: "talisman" }),
+      }),
+    );
+    expect(wallet.getConnectedWallet()).toBeNull();
+  });
+
+  it("ignores a persisted value with an empty/missing source, falling back to null", async () => {
+    const wallet = await freshWallet(
+      makeWindow({
+        "metagraphed:wallet": JSON.stringify({ address: ADDR_A, source: "" }),
+      }),
+    );
+    expect(wallet.getConnectedWallet()).toBeNull();
+    const wallet2 = await freshWallet(
+      makeWindow({ "metagraphed:wallet": JSON.stringify({ address: ADDR_A }) }),
+    );
+    expect(wallet2.getConnectedWallet()).toBeNull();
+  });
+
+  it("setConnectedWallet persists a valid wallet, updates the cache, and broadcasts it", async () => {
+    const win = makeWindow();
+    const wallet = await freshWallet(win);
+    const seen: Array<{ address: string; source: string } | null> = [];
+    const off = wallet.onConnectedWalletChange((next) => seen.push(next));
+    wallet.setConnectedWallet({ address: ADDR_A, source: "subwallet-js" });
+    expect(wallet.getConnectedWallet()).toEqual({ address: ADDR_A, source: "subwallet-js" });
+    expect(win.store.get("metagraphed:wallet")).toBe(
+      JSON.stringify({ address: ADDR_A, source: "subwallet-js" }),
+    );
+    expect(seen).toEqual([{ address: ADDR_A, source: "subwallet-js" }]);
+    // After unsubscribing, further changes are not delivered.
+    off();
+    wallet.setConnectedWallet({ address: ADDR_B, source: "talisman" });
+    expect(seen).toEqual([{ address: ADDR_A, source: "subwallet-js" }]);
+  });
+
+  it("setConnectedWallet(null) disconnects: removes the persisted key and broadcasts null", async () => {
+    const win = makeWindow({
+      "metagraphed:wallet": JSON.stringify({ address: ADDR_A, source: "polkadot-js" }),
+    });
+    const wallet = await freshWallet(win);
+    const seen: Array<{ address: string; source: string } | null> = [];
+    wallet.onConnectedWalletChange((next) => seen.push(next));
+    wallet.setConnectedWallet(null);
+    expect(wallet.getConnectedWallet()).toBeNull();
+    expect(win.store.has("metagraphed:wallet")).toBe(false);
+    expect(seen).toEqual([null]);
+  });
+
+  it("setConnectedWallet with an invalid wallet falls back to disconnected (null)", async () => {
+    const wallet = await freshWallet(makeWindow());
+    // @ts-expect-error deliberately malformed input
+    wallet.setConnectedWallet({ address: "bogus" });
+    expect(wallet.getConnectedWallet()).toBeNull();
+  });
+});
+
+describe("SSR safety (no window)", () => {
+  it("defaults to null and returns a no-op unsubscriber when window is undefined", async () => {
+    const wallet = await freshWallet(); // no window stubbed
+    expect(wallet.getConnectedWallet()).toBeNull();
+    expect(typeof wallet.onConnectedWalletChange(() => {})).toBe("function");
+    // The setter must not throw without a window.
+    expect(() =>
+      wallet.setConnectedWallet({ address: ADDR_A, source: "polkadot-js" }),
+    ).not.toThrow();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/wallet.ts
+++ b/apps/ui/src/lib/metagraphed/wallet.ts
@@ -1,0 +1,83 @@
+// Wallet-connect persistence (#5236, native-staking epic #5229). Read-only connect
+// flow — the address persisted here is never used to sign anything; the wallet
+// standard (@polkadot/extension-dapp injection) and the "no signing in v1 connect"
+// scope are both locked by docs/adr/0018-native-staking-architecture.md. This module
+// has zero @polkadot/* imports by design — see lib/metagraphed/wallet-injected.ts for
+// the actual extension boundary.
+
+import { isValidSs58 } from "./accounts";
+
+export interface ConnectedWallet {
+  /** ss58 account address, the only identifier ever persisted. */
+  address: string;
+  /** account.meta.source from web3Accounts(), e.g. "polkadot-js" | "talisman" | "subwallet-js". */
+  source: string;
+}
+
+const STORAGE_KEY = "metagraphed:wallet";
+const EVT = "metagraphed:wallet-changed";
+
+// Unlike config.ts's API base / network (where the default is a truthy value, so a
+// falsy cache slot unambiguously means "not yet read"), this module's default state
+// IS null (disconnected) — a plain `ConnectedWallet | null` cache can't distinguish
+// "not yet read" from "read as disconnected." `undefined` = unread, `null` = read and
+// disconnected, matching the single-read-then-cache guarantee config.ts's cache gives.
+let cached: ConnectedWallet | null | undefined;
+
+function isConnectedWallet(value: unknown): value is ConnectedWallet {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.address === "string" &&
+    isValidSs58(v.address) &&
+    typeof v.source === "string" &&
+    v.source.length > 0
+  );
+}
+
+function readStored(): ConnectedWallet | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return isConnectedWallet(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Currently connected wallet (address + extension source), or null if disconnected. Safe in both SSR and CSR. */
+export function getConnectedWallet(): ConnectedWallet | null {
+  if (cached !== undefined) return cached;
+  const next = readStored();
+  cached = next;
+  return next;
+}
+
+/**
+ * Connect (persist) or disconnect (pass null) a wallet. Dispatches an event
+ * subscribers can react to. Disconnecting removes the localStorage key entirely
+ * rather than storing a null sentinel, matching config.ts's "default value removes
+ * the key" convention — disconnected genuinely is this module's default state.
+ */
+export function setConnectedWallet(wallet: ConnectedWallet | null) {
+  const next = wallet && isConnectedWallet(wallet) ? wallet : null;
+  cached = next;
+  if (typeof window !== "undefined") {
+    try {
+      if (next === null) window.localStorage.removeItem(STORAGE_KEY);
+      else window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      /* ignore */
+    }
+    window.dispatchEvent(new CustomEvent(EVT, { detail: next }));
+  }
+}
+
+export function onConnectedWalletChange(cb: (next: ConnectedWallet | null) => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const handler = (e: Event) => cb((e as CustomEvent<ConnectedWallet | null>).detail);
+  window.addEventListener(EVT, handler);
+  return () => window.removeEventListener(EVT, handler);
+}

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -4,7 +4,8 @@
 //     componentTagger (dev-only), VITE_* env injection, @ path alias, React/TanStack dedupe,
 //     error logger plugins, and sandbox detection (port/host/strictPort).
 // You can pass additional config via defineConfig({ vite: { ... }, etc... }) if needed.
-import { defineConfig } from "@lovable.dev/vite-tanstack-config";
+import { defineConfig, type LovableViteTanstackOptions } from "@lovable.dev/vite-tanstack-config";
+import type { NitroPluginConfig } from "nitro/vite";
 
 export default defineConfig({
   tanstackStart: {
@@ -19,5 +20,55 @@ export default defineConfig({
   // ENOENT. That broke production deploys: metagraph.sh kept serving a stale
   // build while merged PRs never shipped. Forcing it on generates the
   // cloudflare worker bundle + merged wrangler.json everywhere.
-  nitro: true,
+  //
+  // #5236: @polkadot/extension-dapp is only ever reached via a dynamic
+  // import() inside a client-only function body (lib/metagraphed/
+  // wallet-injected.ts), guarded by `typeof window === "undefined"` — never
+  // executed during SSR or in the actual Nitro build output. But Nitro drives
+  // its OWN Rollup build for the deployed server bundle (a third Vite
+  // "environment" alongside client/ssr, confirmed via node_modules/nitro/dist/
+  // vite.mjs), which still walks the dynamic-import graph to resolve it for
+  // chunking purposes — and one of its transitive deps
+  // (@polkadot/x-textdecoder) has a package exports map Rollup's resolver
+  // can't parse, hard-failing the build (confirmed live 2026-07-14) even
+  // though the code path is unreachable at runtime. A top-level
+  // `vite: { ssr: { external } }` does NOT reach this Nitro-specific build
+  // step (confirmed by testing — same failure persisted).
+  //
+  // A plain top-level `nitro: { rollupConfig: { external: fn } }` also isn't
+  // safe here: the cloudflare-module preset sets up its OWN externals for
+  // Cloudflare/Node builtins (`cloudflare:workers`, etc.) via a `unenv`-based
+  // mechanism inside its `build:before` hook (enableNodeCompat,
+  // node_modules/nitro/dist/_presets.mjs) — a raw config-level `external`
+  // fully REPLACES that rather than composing with it (confirmed live: doing
+  // so broke `cloudflare:workers` resolution, a real regression). The
+  // `rollup:before` hook fires immediately before the actual Rollup call, once
+  // every preset/module hook (including the unenv one) has already finished
+  // configuring `rollupConfig.external` — wrapping the value already sitting
+  // there at that point, instead of setting it earlier, preserves everything
+  // Nitro itself needs while adding the one exception this feature needs.
+  // Matching by prefix rather than an explicit package list so a transitive
+  // @polkadot/* addition later (e.g. #5237's own @polkadot/api usage) doesn't
+  // silently reintroduce this same failure.
+  //
+  // @lovable.dev/vite-tanstack-config's own `nitro` option type is a
+  // deliberately narrow subset (preset/output/cloudflare only — see its own
+  // doc comment: "File an issue if you need more") that doesn't expose
+  // `hooks`, even though the value is passed straight through to nitro/vite's
+  // real `nitro()` plugin, which does support it. Cast through the actual
+  // upstream `NitroPluginConfig` type rather than `any` so this stays
+  // type-checked against Nitro's real config shape.
+  nitro: {
+    hooks: {
+      "rollup:before": (_nitro, rollupConfig) => {
+        const prevExternal = rollupConfig.external;
+        rollupConfig.external = (id: string, parentId: string | undefined, isResolved: boolean) => {
+          if (id.startsWith("@polkadot/")) return true;
+          if (typeof prevExternal === "function") return prevExternal(id, parentId, isResolved);
+          if (Array.isArray(prevExternal)) return prevExternal.includes(id);
+          return false;
+        };
+      },
+    },
+  } satisfies NitroPluginConfig as unknown as LovableViteTanstackOptions["nitro"],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
       "dependencies": {
         "@jsonbored/metagraphed": "*",
         "@jsonbored/ui-kit": "*",
+        "@polkadot/extension-dapp": "^0.63.1",
         "@sentry/browser": "^10.60.0",
         "@tailwindcss/vite": "^4.2.1",
         "@tanstack/react-query": "^5.83.0",
@@ -2437,6 +2438,33 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
@@ -2871,6 +2899,654 @@
       },
       "bin": {
         "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot-api/json-rpc-provider": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.0.1.tgz",
+      "integrity": "sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/json-rpc-provider-proxy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.1.0.tgz",
+      "integrity": "sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/metadata-builders": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.3.2.tgz",
+      "integrity": "sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/observable-client": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.3.2.tgz",
+      "integrity": "sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/metadata-builders": "0.3.2",
+        "@polkadot-api/substrate-bindings": "0.6.0",
+        "@polkadot-api/utils": "0.1.0"
+      },
+      "peerDependencies": {
+        "@polkadot-api/substrate-client": "0.1.4",
+        "rxjs": ">=7.8.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.6.0.tgz",
+      "integrity": "sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@noble/hashes": "^1.3.1",
+        "@polkadot-api/utils": "0.1.0",
+        "@scure/base": "^1.1.1",
+        "scale-ts": "^1.6.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-client": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.1.4.tgz",
+      "integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "0.0.1",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
+    "node_modules/@polkadot-api/utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.1.0.tgz",
+      "integrity": "sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot/api": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-16.5.6.tgz",
+      "integrity": "sha512-5h/X3pY8WpqGk4XTaiIUjKD6Pnk8k4bJ6EIwPKLP8/kfFWKSOenpN6ggZxANr+Qj+RgXrp4TxJVcuhXSiBh9Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-augment": "16.5.6",
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/api-derive": "16.5.6",
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/rpc-provider": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/types-known": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-16.5.6.tgz",
+      "integrity": "sha512-bunJF1c3nIuDtU6iwa+reTt9U47Y8iOC8Gw7PfANlZmLJmO/XVXnWc3JJLM+g9ESDn2raHJELeWBFVOXQrbtUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-16.5.6.tgz",
+      "integrity": "sha512-eBLIv86ZZY4t5OrobVoGC+QXbErOGlBpI2rJI5OMvTNPoVvtEoI++u+wwRScjkOZaUhXyQikd+0Uv71qr3xnsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-derive": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-16.5.6.tgz",
+      "integrity": "sha512-cHdvPvhYFch18uPTcuOZJ8VceOfercod2fi4xCnHJAmattzlgj9qCgnOoxdmBS9GZ403ZyRHOjBuUwZy/IsUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api": "16.5.6",
+        "@polkadot/api-augment": "16.5.6",
+        "@polkadot/api-base": "16.5.6",
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-dapp": {
+      "version": "0.63.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/extension-dapp/-/extension-dapp-0.63.1.tgz",
+      "integrity": "sha512-/HHvyVOg7Z8LNtzS4yt2CUSp3wLRayW3eG5lhUDXVQrNlzIY6O7XwyRABDIIBfEOJ6UEknxZBz0ieeu5cFJfeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/extension-inject": "0.63.1",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/api": "*",
+        "@polkadot/util": "*",
+        "@polkadot/util-crypto": "*"
+      }
+    },
+    "node_modules/@polkadot/extension-inject": {
+      "version": "0.63.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/extension-inject/-/extension-inject-0.63.1.tgz",
+      "integrity": "sha512-C8xOP9ixgNnvjEDYFxGVCFPBlGX7nXNYjeDK1WH1bRvnh6FCv5J4IMS3MvMadQErYrrhcqz1zQy8MR3iLQZpEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api": "^16.5.6",
+        "@polkadot/rpc-provider": "^16.5.6",
+        "@polkadot/types": "^16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "@polkadot/x-global": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/api": "*",
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/keyring": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
+      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/networks": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.3.tgz",
+      "integrity": "sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "14.0.3",
+        "@substrate/ss58-registry": "^1.51.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-16.5.6.tgz",
+      "integrity": "sha512-vlrNvl2VtU09jZV/AvH7jBb/cNUO+dWu8Xj9pId5ctSUnZHm8o8wRk9ekyieKP57OUoKMd8+VScwMKd624SxTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-core": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.5.6.tgz",
+      "integrity": "sha512-l6od++WlvKH4mw5mtsIh2AhiBs3H+TtdOoUHVLCx/R9il7+gl+arltzZ8vBuffyh/O+uQ36lI8yUoD1g4gi1tA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-augment": "16.5.6",
+        "@polkadot/rpc-provider": "16.5.6",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-16.5.6.tgz",
+      "integrity": "sha512-46sHIjKYr4aSzBCfbyqtCwuP8MMJ3jOp0xx9eggOGbKyP8Z0j0Cp+1nNkZUYzehcdGjjrmCxCbQp17wc6cj4zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-support": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "@polkadot/x-fetch": "^14.0.3",
+        "@polkadot/x-global": "^14.0.3",
+        "@polkadot/x-ws": "^14.0.3",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.3.1",
+        "nock": "^13.5.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@substrate/connect": "0.8.11"
+      }
+    },
+    "node_modules/@polkadot/types": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-16.5.6.tgz",
+      "integrity": "sha512-X/sfMHJS4RkRhnsc4CQqzUy7BM/s2y71TrBFHPYAjs2q/rbZ/BwvBk70SrUiSa0+iRRn3RewbBZm+AB8CbkdKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/types-augment": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-augment": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-16.5.6.tgz",
+      "integrity": "sha512-QN5UrluUZCVgknUDW0gps/FRQ13Qgm24w53pCd2HgD0nmTtXDt9D4psjWwx5JkGTkUAvpzFWwN41bkxAeCiV6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-codec": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.5.6.tgz",
+      "integrity": "sha512-3tzUv1LZOL97IlQmko4dqbfRC0cg9IQ2QAHRVoDIWsXrVovp1V3kPdP0o6e3I8T2XB9IlbabK91v+ZiIxhGMZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^14.0.3",
+        "@polkadot/x-bigint": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-create": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.5.6.tgz",
+      "integrity": "sha512-g7g3hrjpz4KgqQqei9PU0JY9fsFHBmThWALZk5pWB32vyDyDcXZiyhH3agDhqfmzQiolTW2FuvcNJxgS634J1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-known": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-16.5.6.tgz",
+      "integrity": "sha512-c78NcVO3LIvi4xzxB39WewE+80I4jOYUtPBaB4AzSMespEwIr92VTeX3KzFWuutxDXLSPqeVfXhaAhBB0NssiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/networks": "^14.0.3",
+        "@polkadot/types": "16.5.6",
+        "@polkadot/types-codec": "16.5.6",
+        "@polkadot/types-create": "16.5.6",
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-support": {
+      "version": "16.5.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-16.5.6.tgz",
+      "integrity": "sha512-Hqpa/hCvXZXUTUiJMAE55UXpzAeCVLaFlzzXQXLkne0vhmv3/JkWcBnX755a/b9+C4b3MKEz2i0tSKLsa3DldA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^14.0.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
+      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.3",
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-randomvalues": "14.0.3",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot/wasm-bridge": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.5.4.tgz",
+      "integrity": "sha512-6xaJVvoZbnbgpQYXNw9OHVNWjXmtcoPcWh7hlwx3NpfiLkkjljj99YS+XGZQlq7ks2fVCg7FbfknkNb8PldDaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.5.4.tgz",
+      "integrity": "sha512-1seyClxa7Jd7kQjfnCzTTTfYhTa/KUTDUaD3DMHBk5Q4ZUN1D1unJgX+v1aUeXSPxmzocdZETPJJRZjhVOqg9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-init": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-asmjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.5.4.tgz",
+      "integrity": "sha512-ZYwxQHAJ8pPt6kYk9XFmyuFuSS+yirJLonvP+DYbxOrARRUHfN4nzp4zcZNXUuaFhpbDobDSFn6gYzye6BUotA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-init": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.5.4.tgz",
+      "integrity": "sha512-U6s4Eo2rHs2n1iR01vTz/sOQ7eOnRPjaCsGWhPV+ZC/20hkVzwPAhiizu/IqMEol4tO2yiSheD4D6bn0KxUJhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-wasm": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.5.4.tgz",
+      "integrity": "sha512-PsHgLsVTu43eprwSvUGnxybtOEuHPES6AbApcs7y5ZbM2PiDMzYbAjNul098xJK/CPtrxZ0ePDFnaQBmIJyTFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.5.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-util": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.5.4.tgz",
+      "integrity": "sha512-hqPpfhCpRAqCIn/CYbBluhh0TXmwkJnDRjxrU9Bnqtw9nMNa97D8JuOjdd2pi0rxm+eeLQ/f1rQMp71RMM9t4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-bigint": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.3.tgz",
+      "integrity": "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-fetch": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-14.0.3.tgz",
+      "integrity": "sha512-695c5aPBPtYcnn2zM+u0mXgyNHINlO0qGlGcJq3/0t5NVRZv5KZhk7NNm6antOay9uUjGG40F/r+LPzDT3QamA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "node-fetch": "^3.3.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-global": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
+      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
+      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.3",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-ws": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-14.0.3.tgz",
+      "integrity": "sha512-tOPdkMye3iuXnuFtdNg5+iSu7Cz9LRL8z5psMuZpUpThMYChGsS2pDFtNvXOKU8ohhO+frY9VdJ9VBg1WL9Iug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "14.0.3",
+        "tslib": "^2.8.0",
+        "ws": "^8.18.0"
       },
       "engines": {
         "node": ">=18"
@@ -4253,6 +4929,40 @@
         "win32"
       ]
     },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/sr25519": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
+      "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.2",
+        "@noble/hashes": "~1.8.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/sr25519/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@sentry/browser": {
       "version": "10.63.0",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.63.0.tgz",
@@ -4370,6 +5080,59 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@substrate/connect": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.11.tgz",
+      "integrity": "sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==",
+      "deprecated": "versions below 1.x are no longer maintained",
+      "license": "GPL-3.0-only",
+      "optional": true,
+      "dependencies": {
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "@substrate/light-client-extension-helpers": "^1.0.0",
+        "smoldot": "2.0.26"
+      }
+    },
+    "node_modules/@substrate/connect-extension-protocol": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.2.2.tgz",
+      "integrity": "sha512-t66jwrXA0s5Goq82ZtjagLNd7DPGCNjHeehRlE/gcJmJ+G56C0W+2plqOMRicJ8XGR1/YFnUSEqUFiSNbjGrAA==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/connect-known-chains": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.10.3.tgz",
+      "integrity": "sha512-OJEZO1Pagtb6bNE3wCikc2wrmvEU5x7GxFFLqqbz1AJYYxSlrPCGu4N2og5YTExo4IcloNMQYFRkBGue0BKZ4w==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/light-client-extension-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-1.0.0.tgz",
+      "integrity": "sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "^0.0.1",
+        "@polkadot-api/json-rpc-provider-proxy": "^0.1.0",
+        "@polkadot-api/observable-client": "^0.3.0",
+        "@polkadot-api/substrate-client": "^0.1.2",
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.5",
+        "rxjs": "^7.8.1"
+      },
+      "peerDependencies": {
+        "smoldot": "2.x"
+      }
+    },
+    "node_modules/@substrate/ss58-registry": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.51.0.tgz",
+      "integrity": "sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.2",
@@ -5313,6 +6076,15 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/bn.js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -5356,7 +6128,6 @@
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -5984,6 +6755,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bn.js": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+      "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
@@ -6354,6 +7131,15 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/db0": {
       "version": "0.3.4",
@@ -6858,6 +7644,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -6936,6 +7728,29 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fetchdts": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/fetchdts/-/fetchdts-0.1.7.tgz",
@@ -7010,6 +7825,18 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -7442,6 +8269,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7938,6 +8771,15 @@
         "ufo": "^1.6.3"
       }
     },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8052,6 +8894,58 @@
         "zephyr-agent": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-releases": {
@@ -8559,6 +9453,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8787,6 +9690,15 @@
       "integrity": "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==",
       "license": "MIT"
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/satori": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/satori/-/satori-0.15.2.tgz",
@@ -8808,6 +9720,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/scale-ts": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/scale-ts/-/scale-ts-1.6.1.tgz",
+      "integrity": "sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -8936,6 +9855,16 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/smoldot": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.26.tgz",
+      "integrity": "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==",
+      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
+      "optional": true,
+      "dependencies": {
+        "ws": "^8.8.1"
+      }
     },
     "node_modules/sonner": {
       "version": "2.0.7",
@@ -9937,7 +10866,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -10444,6 +11372,15 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
@@ -10565,7 +11502,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary

Closes #5236. Phase 2 of the native-staking epic (#5229) — the client-side, **read-only** wallet-connect flow: `web3Enable` → `web3Accounts` → account picker → persisted address, explicit disconnect. No signing anywhere in this PR; that's #5237+, per the wallet standard and scope locked in `docs/adr/0018-native-staking-architecture.md`.

## What's here

- `apps/ui/src/lib/metagraphed/wallet.ts` — localStorage persistence, mirrors `config.ts`'s pattern exactly (SSR-safe, cached, validated via `isValidSs58`, broadcast via `CustomEvent`).
- `apps/ui/src/lib/metagraphed/wallet-injected.ts` — the **one** file that touches `@polkadot/extension-dapp`, via a dynamic `import()` inside a `typeof window === "undefined"`-guarded function. `@polkadot/util-crypto` (a transitive dep) triggers WASM init as an import-time side effect, so a static import anywhere would be unsafe even if unused — this keeps the whole dependency tree out of both the SSR bundle and the initial client bundle (verified: it loads as its own ~278KB lazy chunk, only fetched after clicking "Connect Wallet").
- `apps/ui/src/hooks/use-wallet.ts` — the connect → pick-account (if >1) → persist flow, plus a background re-verify-on-mount that silently disconnects a stale persisted wallet (extension uninstalled/access revoked since last visit).
- `apps/ui/src/components/metagraphed/wallet-connect.tsx` — header trigger + panel, reusing `Popover`/`ClampedPopoverContent`/`EmptyState` — no new UI primitives.
- Mounted in `app-shell.tsx`: header slot (`md`–`lg`, `xl`+, matching `SettingsPopover`'s existing responsive treatment — not a fourth always-visible icon, to avoid the header-overflow class of bug tracked in #3985) **and** the mobile nav sheet (the only place it's reachable below `md`). Folded into `header-actions-menu.tsx` for the `lg`–`xl` range, reusing `WalletConnectPanel` directly rather than nesting a second Popover.
- `vite.config.ts` — a Nitro `rollup:before` hook marking `@polkadot/*` external for the Cloudflare Workers server build specifically. A top-level `vite.ssr.external` doesn't reach Nitro's own build step; a naive `nitro.rollupConfig.external` override broke `cloudflare:workers` resolution (it replaces, not composes with, the preset's own `unenv`-based externalization) — the hook wraps whatever's already configured instead of replacing it.

## Test plan

- [x] `npx vitest run` (apps/ui) — 114 files / 775 tests pass
- [x] `npm run lint` / `npm run typecheck` / `npm run format:check` (apps/ui) — clean (one pre-existing, unrelated `EntityHero` type error in `providers.$slug.tsx`)
- [x] `npm run build` (apps/ui, real Nitro/Cloudflare target) — succeeds; confirmed no `@polkadot`/`wasm-crypto` code in the SSR output (`.output/server/`), confirmed the polkadot bundle is a genuinely separate, lazily-loaded client chunk (network-verified: only fetched on click, not on page load)
- [x] Root repo: `npm run lint`, `npm run format:check`, `npm run validate`, `npx vitest run` (273 files / 8183 tests), `node scripts/scan-public-safety.mjs` — all pass
- [x] Manual QA in a real browser (no extension installed in this environment) — verified the "no extension found" empty state, the `lg`-breakpoint fold into the "more actions" menu (no overflow), and the mobile nav-sheet entry point
- [ ] Manual QA with a real Polkadot.js/Talisman/SubWallet extension — no such extension is available in this environment; the connect → picker → connected → disconnect states are otherwise untested end-to-end (unit tests cover the pure logic; the actual `web3Enable`/`web3Accounts` call is deliberately not exercised in the unit suite, since doing so would trigger the same WASM init this PR keeps off the critical path)

## Screenshots

<table>
<tr><th>Viewport · Theme</th><th>Before</th><th>After</th></tr>
<tr>
<td>Desktop · Light</td>
<td><a href="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-before-desktop-light.png"><img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-before-desktop-light.png" width="260"></a><br><sub>before</sub></td>
<td><a href="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-after-desktop-light.png"><img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-after-desktop-light.png" width="260"></a><br><sub>after</sub></td>
</tr>
<tr>
<td>Desktop · Dark</td>
<td><a href="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-before-desktop-dark.png"><img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-before-desktop-dark.png" width="260"></a><br><sub>before</sub></td>
<td><a href="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-after-desktop-dark.png"><img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-after-desktop-dark.png" width="260"></a><br><sub>after</sub></td>
</tr>
<tr>
<td>Mobile · Light<br><sub>(nav sheet opened — the only reachable entry point below <code>md</code>)</sub></td>
<td><a href="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-before-mobile-menu-light.png"><img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-before-mobile-menu-light.png" width="260"></a><br><sub>before</sub></td>
<td><a href="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-after-mobile-menu-light.png"><img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-after-mobile-menu-light.png" width="260"></a><br><sub>after</sub></td>
</tr>
<tr>
<td>Mobile · Dark<br><sub>(nav sheet opened)</sub></td>
<td><a href="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-before-mobile-menu-dark.png"><img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-before-mobile-menu-dark.png" width="260"></a><br><sub>before</sub></td>
<td><a href="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-after-mobile-menu-dark.png"><img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-wallet-connect-after-mobile-menu-dark.png" width="260"></a><br><sub>after</sub></td>
</tr>
</table>

Tablet (768px) skipped: it renders the wallet trigger identically to Desktop (both are outside the `lg`-only fold range, `md:inline-flex lg:hidden xl:inline-flex`) — a tablet row would be a pixel-for-pixel duplicate of the desktop row above. The `lg` (1024–1279px) fold-into-`header-actions-menu` state was verified manually in-browser (no header overflow) but isn't in this static table since it's a third distinct trigger location, not a viewport variant of the same one — happy to add a capture of it if useful.

## Known follow-ups (not blocking, out of scope for this issue)

- `header-actions-menu.tsx`'s popover (`lg`–`xl` fold) uses the base `PopoverContent`, not the viewport-clamped `ClampedPopoverContent` `NetworkSwitcher`/`SettingsPopover` use — pre-existing, and this PR's added "Wallet" section makes an already-long panel slightly longer. Worth a follow-up if it proves to overflow short viewports in practice.
- No automated coverage exists for the actual `web3Enable`/`web3Accounts` call path (deliberately, to avoid triggering real WASM init in the unit suite) — real coverage is manual QA with a browser extension.