### PR TITLE
fix(registry): align dead source_repo fields with review conclusions (#5479)

### DIFF
--- a/registry/subnets/actual.json
+++ b/registry/subnets/actual.json
@@ -14,7 +14,7 @@
   "website_url": "https://actual.inc/",
   "docs_url": null,
   "dashboard_url": "https://backprop.finance/dtao/subnets/95-actual",
-  "source_repo": "https://github.com/actual-computer/actual-subnet-95",
+  "source_repo": null,
   "baseline_excluded_surface_ids": [
     "sn-95-taomarketcap-source-repo",
     "sn-95-taomarketcap-website",

--- a/registry/subnets/bitads.json
+++ b/registry/subnets/bitads.json
@@ -11,9 +11,9 @@
     "official-source-repo",
     "official-website"
   ],
-  "website_url": "https://bitads.ai/",
-  "docs_url": "https://bitads.ai/docs",
-  "source_repo": "https://github.com/FirstTensorLabs/BitAds",
+  "website_url": null,
+  "docs_url": null,
+  "source_repo": "https://github.com/study-service/BitAds.ai",
   "dashboard_url": "https://taomarketcap.com/subnets/16",
   "baseline_excluded_surface_ids": [
     "sn-16-taomarketcap-source-repo",
@@ -25,7 +25,7 @@
     "sn-16-website-common-swagger",
     "sn-16-website-common-swagger-json"
   ],
-  "notes": "Reviewed overlay for SN16 BitAds using the official BitAds website, docs page, and source repository. Common API/OpenAPI/Swagger paths currently return website HTML instead of machine-readable API/schema responses, so they are excluded as content mismatches.",
+  "notes": "Reviewed overlay for SN16 BitAds. Top-level source_repo now points at the live study-service/BitAds.ai successor (the older FirstTensorLabs/BitAds URL returns 404). The bitads.ai website/docs domain no longer resolves (DNS dead), so website_url and docs_url are nulled. Common API/OpenAPI/Swagger paths previously returned website HTML instead of machine-readable API/schema responses and remain excluded as content mismatches.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -33,12 +33,13 @@
     "verified_at": "2026-06-08T20:25:00.000Z",
     "source_count": 5,
     "gap_notes": [
-      "Official website, docs page, and source repository are verified live.",
-      "Common API, health, OpenAPI, Swagger JSON, and Swagger UI paths return marketing-site HTML rather than API/schema payloads.",
+      "Live source repository is study-service/BitAds.ai; FirstTensorLabs/BitAds returns 404.",
+      "bitads.ai website and docs domain currently do not resolve (DNS dead); website_url and docs_url nulled.",
+      "Official website and docs surfaces that pointed at bitads.ai reflect the same DNS-dead status; probes disabled.",
+      "Common API, health, OpenAPI, Swagger JSON, and Swagger UI paths previously returned marketing-site HTML rather than API/schema payloads.",
       "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ]
   },
   "surfaces": [
@@ -56,12 +57,12 @@
         "https://github.com/FirstTensorLabs/BitAds"
       ],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official BitAds website."
+      "notes": "Previously the official BitAds website at bitads.ai; the domain no longer resolves (DNS dead). Top-level website_url has been nulled; probe disabled pending a live replacement."
     },
     {
       "id": "sn-16-bitads-docs",
@@ -74,30 +75,30 @@
       "public_safe": true,
       "source_urls": ["https://bitads.ai/docs"],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official BitAds documentation page."
+      "notes": "Previously the official BitAds docs at bitads.ai/docs; the domain no longer resolves (DNS dead). Top-level docs_url has been nulled; probe disabled pending a live replacement."
     },
     {
       "id": "sn-16-bitads-source",
       "name": "BitAds source repository",
       "kind": "source-repo",
-      "url": "https://github.com/FirstTensorLabs/BitAds",
+      "url": "https://github.com/study-service/BitAds.ai",
       "provider": "bitads",
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/FirstTensorLabs/BitAds"],
+      "source_urls": ["https://github.com/study-service/BitAds.ai"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
         "expect": "any",
         "timeout_ms": 10000
       },
-      "notes": "Official BitAds source repository."
+      "notes": "Live BitAds source repository at study-service/BitAds.ai (replaces the dead FirstTensorLabs/BitAds URL)."
     },
     {
       "auth_required": false,
@@ -105,7 +106,7 @@
       "id": "sn-16-bitads-min-compute",
       "kind": "data-artifact",
       "name": "BitAds minimum compute requirements",
-      "notes": "Public no-auth machine-readable min_compute.yml specifying the minimum and recommended hardware (CPU/RAM/storage/OS and network bandwidth) to run an SN16 BitAds miner or validator, published in the official BitAds source repository study-service/BitAds.ai — whose README states 'netuid 16' and whose GitHub homepage is the registered bitads.ai website. A standalone machine-readable reference artifact the registry did not yet capture (the manifest's source_repo field points at the operator's older FirstTensorLabs/BitAds repo; the live code now lives at study-service/BitAds.ai).",
+      "notes": "Public no-auth machine-readable min_compute.yml specifying the minimum and recommended hardware (CPU/RAM/storage/OS and network bandwidth) to run an SN16 BitAds miner or validator, published in the live BitAds source repository study-service/BitAds.ai — whose README states 'netuid 16'. A standalone machine-readable reference artifact.",
       "provider": "bitads",
       "public_safe": true,
       "review": {

--- a/registry/subnets/efficientfrontier.json
+++ b/registry/subnets/efficientfrontier.json
@@ -12,8 +12,8 @@
     "gap_notes": [
       "SignalPlus website is live and is tracked as the team/project website.",
       "The subnet mining app currently returns a 403/auth-challenge response to simple probes and is expected to appear degraded rather than healthy.",
-      "Previously discovered GitHub source repository currently returns 404.",
-      "No verified live source repository yet.",
+      "Previously discovered EfficientFrontier-SignalPlus/EfficientFrontier repository currently returns 404.",
+      "Top-level source_repo updated to the live oxylok/53-EfficientFrontier successor also registered as sn-53-signalplus-source-repo.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
@@ -28,10 +28,10 @@
   "dashboard_url": "https://t.signalplus.com/mining",
   "name": "EfficientFrontier",
   "netuid": 53,
-  "notes": "Reviewed overlay for SN53 EfficientFrontier by SignalPlus. The SignalPlus company website is live; the mining app surface returns an auth/challenge-style response to simple probes. The previously discovered EfficientFrontier source repository currently returns 404 and is not promoted.",
+  "notes": "Reviewed overlay for SN53 EfficientFrontier by SignalPlus. The SignalPlus company website is live; the mining app surface returns an auth/challenge-style response to simple probes. The previously discovered EfficientFrontier-SignalPlus/EfficientFrontier repository returns 404. Top-level source_repo now points at the live community-verified successor https://github.com/oxylok/53-EfficientFrontier (already registered as sn-53-signalplus-source-repo).",
   "schema_version": 1,
   "slug": "efficientfrontier",
-  "source_repo": "https://github.com/EfficientFrontier-SignalPlus/EfficientFrontier",
+  "source_repo": "https://github.com/oxylok/53-EfficientFrontier",
   "status": "active",
   "surfaces": [
     {

--- a/registry/subnets/groundlayer.json
+++ b/registry/subnets/groundlayer.json
@@ -5,7 +5,7 @@
   "slug": "sn-20",
   "status": "active",
   "categories": ["baseline-curated", "capital-markets", "identity-reviewed"],
-  "source_repo": "https://github.com/RogueTensor/comingsoon",
+  "source_repo": null,
   "dashboard_url": "https://taomarketcap.com/subnets/20",
   "website_url": "https://www.groundlayer.xyz/",
   "baseline_excluded_surface_ids": [

--- a/registry/subnets/satori.json
+++ b/registry/subnets/satori.json
@@ -25,7 +25,7 @@
   "notes": "Reviewed overlay for SN119 Satori. Public directories describe the subnet, but the previously listed Satori119/Satori repository currently returns 404 and no official website, API, OpenAPI schema, or docs site is verified.",
   "schema_version": 1,
   "slug": "satori",
-  "source_repo": "https://github.com/Satori119/Satori",
+  "source_repo": null,
   "status": "active",
   "surfaces": [
     {


### PR DESCRIPTION
## Summary

Brings top-level `source_repo` (and BitAds website/docs URLs) in line with each file's own review conclusions for the five subnets named in #5479.

Closes #5479

## Template Used

backend-code (closest match — registry manifest field corrections, not a community surface append)

## What Changed

- `registry/subnets/actual.json` — `source_repo` → `null` (candidate still 404; no live replacement)
- `registry/subnets/groundlayer.json` — `source_repo` → `null` (same)
- `registry/subnets/satori.json` — `source_repo` → `null` (same)
- `registry/subnets/efficientfrontier.json` — `source_repo` → `https://github.com/oxylok/53-EfficientFrontier` (already registered as `sn-53-signalplus-source-repo`); notes/`gap_notes` updated so they no longer claim “no live source repo”
- `registry/subnets/bitads.json` — `source_repo` → `https://github.com/study-service/BitAds.ai`; `website_url`/`docs_url` nulled after DNS-dead recheck of `bitads.ai`; notes/`gap_notes` updated; official website/docs surface probes disabled; official source-repo surface URL pointed at the live successor; min-compute notes no longer claim the old dead top-level repo

No new `surfaces[]` entries added (native-chain dedup / issue scope).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5479`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (none touched)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (none)

## Validation

Commands run locally before opening:

```bash
npm run validate:surface -- registry/subnets/actual.json registry/subnets/bitads.json registry/subnets/efficientfrontier.json registry/subnets/groundlayer.json registry/subnets/satori.json
npm run scan:public-safety
git diff --check
```

Also re-verified:

- `GET`/`HEAD` `https://github.com/study-service/BitAds.ai` → 200
- `GET`/`HEAD` `https://github.com/oxylok/53-EfficientFrontier` → 200
- `bitads.ai` / `docs.bitads.ai` → DNS unreachable (lame/no resolution)

## Expected Outcome

Top-level registry identity fields no longer advertise dead GitHub URLs that the manifests' own notes already called out as dead.
