### PR TITLE
feat(registry): add SN62 Ridges miner CLI config schema data-artifact surface (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,31 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-miner-cli-config",
+      "kind": "data-artifact",
+      "name": "Ridges miner CLI config schema",
+      "notes": "Public no-auth machine-readable miner-CLI configuration module (miners/cli/config.py) committed in the official ridgesai/ridges repository, defining the SN62 Ridges single-agent miner configuration schema, defaults, and TOML persistence (default workspace ~/.ridges, config path ~/.config/ridges/miner.toml, recent-agent limits, and the dataclass fields the CLI reads/writes). Pinned to an immutable commit. Verified 200, SS58-clean, no keys or secrets. Ridges publishes a source repo and backend API but no verified standalone static data artifact; this fills that gap.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "source_urls": [
+        "https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/miners/cli/config.py",
+        "https://github.com/ridgesai/ridges"
+      ],
+      "url": "https://raw.githubusercontent.com/ridgesai/ridges/06459e91e0e219dec56dfa98109967ec1c739700/miners/cli/config.py"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Summary

Adds one new `community` data-artifact surface to SN62 Ridges (`registry/subnets/ridges.json`): the **miner CLI config schema** module (`miners/cli/config.py`) from the official repository.

Ridges currently registers a source repo and backend API but no standalone static data artifact — this fills the exact gap issue #4069 asks for.

## Surface

- **id:** `sn-62-ridges-miner-cli-config`
- **kind:** `data-artifact`
- **url:** `https://raw.githubusercontent.com/ridgesai/ridges/06459e91e0e219dec56dfa98109967ec1c739700/miners/cli/config.py` — public, no-auth, HTTP 200, pinned to an immutable commit
- **provider:** `ridges`
- **source_url:** the same file's GitHub blob at the pinned commit + the registered `source_repo`

## What it is

`miners/cli/config.py` — the SN62 Ridges single-agent miner CLI configuration schema, defaults, and TOML persistence: default workspace (`~/.ridges`), config path (`~/.config/ridges/miner.toml`), recent-agent limits, and the dataclass fields the CLI reads/writes. A machine-readable reference for how miners are configured. Contains no keys or secrets. Served from `raw.githubusercontent.com` (a static, always-available host).

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/ridges.json` — passed (4 surfaces)
- Verified with no auth header: 200, SS58-clean.

One focused change: one surface appended to one subnet file; nothing else touched.

Closes #4069
