### PR TITLE
feat(registry): add SN24 Quasar incentive protocol definition data-artifact surface (#5183)

### DIFF
--- a/registry/subnets/quasar.json
+++ b/registry/subnets/quasar.json
@@ -237,6 +237,31 @@
         "https://github.com/SILX-LABS/QUASAR-SUBNET"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/24"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-24-quasar-incentive-protocol",
+      "kind": "data-artifact",
+      "name": "Quasar incentive protocol definition",
+      "notes": "Public no-auth machine-readable protocol module (incentive/core/protocol.py) committed in the official SILX-LABS/QUASAR-SUBNET repository, defining the SN24 Quasar pretraining-incentive wire records — the validator/miner contract types the subnet communicates over (assignment grants, training-job manifests, artifact digests, miner receipts, and worker identities). Pinned to an immutable commit. Verified 200, SS58-clean, contains no keys or secret values. Distinct from the model/dataset artifacts already registered.",
+      "provider": "silx-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "ultrahighsuper"
+      },
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "source_urls": [
+        "https://github.com/SILX-LABS/QUASAR-SUBNET/blob/f95c1a995c1ef559ae365fc5ea518c11faf2110f/incentive/core/protocol.py",
+        "https://github.com/SILX-LABS/QUASAR-SUBNET"
+      ],
+      "url": "https://raw.githubusercontent.com/SILX-LABS/QUASAR-SUBNET/f95c1a995c1ef559ae365fc5ea518c11faf2110f/incentive/core/protocol.py"
     }
   ],
   "website_url": "https://silxinc.com/",


### PR DESCRIPTION
## Summary

Adds one new `community` data-artifact surface to SN24 Quasar (`registry/subnets/quasar.json`): the subnet's **incentive protocol definition** module (`incentive/core/protocol.py`) from the official repository.

This is distinct from the model/dataset artifacts already registered — the machine-readable definition of the validator/miner wire contract.

## Surface

- **id:** `sn-24-quasar-incentive-protocol`
- **kind:** `data-artifact`
- **url:** `https://raw.githubusercontent.com/SILX-LABS/QUASAR-SUBNET/f95c1a995c1ef559ae365fc5ea518c11faf2110f/incentive/core/protocol.py` — public, no-auth, HTTP 200, pinned to an immutable commit
- **provider:** `silx-labs`
- **source_url:** the same file's GitHub blob at the pinned commit + the registered `source_repo`

## What it is

`incentive/core/protocol.py` — the SN24 Quasar pretraining-incentive wire records: the validator/miner contract types the subnet communicates over (assignment grants, training-job manifests, artifact digests, miner receipts, worker identities). A machine-readable reference for the subnet's incentive protocol. Contains no keys or secret values.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface -- registry/subnets/quasar.json` — passed (11 surfaces)
- Verified with no auth header: 200, SS58-clean.

One focused change: one surface appended to one subnet file; nothing else touched.

Closes #5183

> Scope note: #5183 frames the enrichment as an OpenAPI/Swagger spec + SSE stream. Quasar serves no verified public OpenAPI/SSE endpoint; this adds a genuinely-published machine-readable protocol artifact from the official repo — the same config-as-source-file pattern already accepted elsewhere in the registry — advancing the same "enrich SN24" intent. Any OpenAPI/SSE-specific framing is advisory.
