### PR TITLE
fix(registry): correct dead source_repo and BitAds website/docs URLs (#5479)

### DIFF
--- a/registry/subnets/actual.json
+++ b/registry/subnets/actual.json
@@ -14,7 +14,7 @@
   "website_url": "https://actual.inc/",
   "docs_url": null,
   "dashboard_url": "https://backprop.finance/dtao/subnets/95-actual",
-  "source_repo": "https://github.com/actual-computer/actual-subnet-95",
+  "source_repo": null,
   "baseline_excluded_surface_ids": [
     "sn-95-taomarketcap-source-repo",
     "sn-95-taomarketcap-website",

--- a/registry/subnets/bitads.json
+++ b/registry/subnets/bitads.json
@@ -11,9 +11,9 @@
     "official-source-repo",
     "official-website"
   ],
-  "website_url": "https://bitads.ai/",
-  "docs_url": "https://bitads.ai/docs",
-  "source_repo": "https://github.com/FirstTensorLabs/BitAds",
+  "website_url": null,
+  "docs_url": null,
+  "source_repo": "https://github.com/study-service/BitAds.ai",
   "dashboard_url": "https://taomarketcap.com/subnets/16",
   "baseline_excluded_surface_ids": [
     "sn-16-taomarketcap-source-repo",
@@ -25,7 +25,7 @@
     "sn-16-website-common-swagger",
     "sn-16-website-common-swagger-json"
   ],
-  "notes": "Reviewed overlay for SN16 BitAds using the official BitAds website, docs page, and source repository. Common API/OpenAPI/Swagger paths currently return website HTML instead of machine-readable API/schema responses, so they are excluded as content mismatches.",
+  "notes": "Reviewed overlay for SN16 BitAds. Top-level source_repo now points at the live study-service/BitAds.ai successor (FirstTensorLabs/BitAds returns 404). The bitads.ai website/docs domain no longer resolves (DNS dead), so website_url and docs_url are nulled. Common API/OpenAPI/Swagger paths previously returned website HTML instead of machine-readable API/schema responses and remain excluded.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -33,12 +33,12 @@
     "verified_at": "2026-06-08T20:25:00.000Z",
     "source_count": 5,
     "gap_notes": [
-      "Official website, docs page, and source repository are verified live.",
-      "Common API, health, OpenAPI, Swagger JSON, and Swagger UI paths return marketing-site HTML rather than API/schema payloads.",
+      "Live source repository is study-service/BitAds.ai; FirstTensorLabs/BitAds returns 404.",
+      "bitads.ai website and docs domain currently do not resolve (DNS dead); website_url and docs_url nulled.",
+      "Common API, health, OpenAPI, Swagger JSON, and Swagger UI paths previously returned marketing-site HTML rather than API/schema payloads.",
       "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ]
   },
   "surfaces": [

--- a/registry/subnets/efficientfrontier.json
+++ b/registry/subnets/efficientfrontier.json
@@ -12,8 +12,8 @@
     "gap_notes": [
       "SignalPlus website is live and is tracked as the team/project website.",
       "The subnet mining app currently returns a 403/auth-challenge response to simple probes and is expected to appear degraded rather than healthy.",
-      "Previously discovered GitHub source repository currently returns 404.",
-      "No verified live source repository yet.",
+      "Previously discovered EfficientFrontier-SignalPlus/EfficientFrontier repository currently returns 404.",
+      "Top-level source_repo now points at the live oxylok/53-EfficientFrontier successor (also registered as sn-53-signalplus-source-repo).",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
@@ -28,10 +28,10 @@
   "dashboard_url": "https://t.signalplus.com/mining",
   "name": "EfficientFrontier",
   "netuid": 53,
-  "notes": "Reviewed overlay for SN53 EfficientFrontier by SignalPlus. The SignalPlus company website is live; the mining app surface returns an auth/challenge-style response to simple probes. The previously discovered EfficientFrontier source repository currently returns 404 and is not promoted.",
+  "notes": "Reviewed overlay for SN53 EfficientFrontier by SignalPlus. The SignalPlus company website is live; the mining app surface returns an auth/challenge-style response to simple probes. The previously discovered EfficientFrontier-SignalPlus/EfficientFrontier repository returns 404; top-level source_repo now points at the live oxylok/53-EfficientFrontier successor.",
   "schema_version": 1,
   "slug": "efficientfrontier",
-  "source_repo": "https://github.com/EfficientFrontier-SignalPlus/EfficientFrontier",
+  "source_repo": "https://github.com/oxylok/53-EfficientFrontier",
   "status": "active",
   "surfaces": [
     {

--- a/registry/subnets/groundlayer.json
+++ b/registry/subnets/groundlayer.json
@@ -5,7 +5,7 @@
   "slug": "sn-20",
   "status": "active",
   "categories": ["baseline-curated", "capital-markets", "identity-reviewed"],
-  "source_repo": "https://github.com/RogueTensor/comingsoon",
+  "source_repo": null,
   "dashboard_url": "https://taomarketcap.com/subnets/20",
   "website_url": "https://www.groundlayer.xyz/",
   "baseline_excluded_surface_ids": [

--- a/registry/subnets/satori.json
+++ b/registry/subnets/satori.json
@@ -25,7 +25,7 @@
   "notes": "Reviewed overlay for SN119 Satori. Public directories describe the subnet, but the previously listed Satori119/Satori repository currently returns 404 and no official website, API, OpenAPI schema, or docs site is verified.",
   "schema_version": 1,
   "slug": "satori",
-  "source_repo": "https://github.com/Satori119/Satori",
+  "source_repo": null,
   "status": "active",
   "surfaces": [
     {


### PR DESCRIPTION
## Summary

Aligns top-level `source_repo` (and BitAds `website_url`/`docs_url`) with each subnet file’s own review conclusions for the five manifests named in issue 5479.

Closes #5479

## Template Used

backend-code (registry identity-field correction; not a community surface append)

## What Changed

- `registry/subnets/actual.json` — `source_repo` → `null`
- `registry/subnets/groundlayer.json` — `source_repo` → `null`
- `registry/subnets/satori.json` — `source_repo` → `null`
- `registry/subnets/efficientfrontier.json` — `source_repo` → `https://github.com/oxylok/53-EfficientFrontier`; notes/`gap_notes` no longer claim “no live source repo”
- `registry/subnets/bitads.json` — `source_repo` → `https://github.com/study-service/BitAds.ai`; `website_url`/`docs_url` → `null` (DNS-dead `bitads.ai`); notes/`gap_notes` updated

No `surfaces[]` additions or removals. No probe toggles.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5479`)
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state
- [x] No generated artifacts touched
- [x] No R2-only/high-churn detail artifacts committed
- [x] No public API/OpenAPI/schema changes

## Validation

```bash
npm run validate:surface -- registry/subnets/actual.json registry/subnets/bitads.json registry/subnets/efficientfrontier.json registry/subnets/groundlayer.json registry/subnets/satori.json
npm run scan:public-safety
git diff --check
```

Re-verified:

- `https://github.com/study-service/BitAds.ai` → 200
- `https://github.com/oxylok/53-EfficientFrontier` → 200
- `bitads.ai` / `docs.bitads.ai` → DNS unreachable

## Expected Outcome

Top-level registry identity fields no longer advertise dead GitHub/website URLs that the manifests’ own notes already documented as dead.
