### PR TITLE
feat(ui): automated before/after screenshot capture tooling

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -338,9 +338,28 @@ one PR.
 ### Phase C2 — Screenshot contract (required for any visual change)
 
 **Non-negotiable for any PR that changes rendered output.** PRs without it are auto-closed — no
-exceptions. Follow the steps below exactly — a real PR (#3757) shipped 10 of its 12 screenshots at
-115,000–142,000px tall (a full-page capture bug, not a display issue) and sat unreviewable until
-recaptured. Don't repeat that.
+exceptions. A real PR (#3757) shipped 10 of its 12 screenshots at 115,000–142,000px tall (a
+full-page capture bug, not a display issue) and sat unreviewable until recaptured. Don't repeat
+that.
+
+**Recommended: automated capture (#3769).** `apps/ui/tests/e2e/capture-pr-screenshots.mjs`
+automates everything below — the two-worktree orchestration, fixed-viewport-only capture, explicit
+theme toggling, the 12-image matrix, and (with `--push`) hosting + the ready-to-paste markdown
+table:
+
+```sh
+npm run screenshots --workspace=apps/ui -- --route /subnets/1 --section volume-24h --prefix 5483-volume --push
+```
+
+Add `--section <id>` for a below-the-fold section anchor (omit to capture the page top), and
+`--fallback-section <id>` when `before` doesn't have that anchor yet (the common case for a new
+section — point it at the existing anchor the new one attaches after). Already have two dev
+servers running (e.g. mid-session in an AI coding tool)? Skip the orchestration and point at them
+directly: `--before-url http://localhost:8081 --after-url http://localhost:8080`. Run
+`npm run screenshots --workspace=apps/ui -- --help` for the full flag list.
+
+If the tool doesn't fit your case (a capture step needs manual intervention, or you're debugging
+the tool itself), the equivalent manual steps are below — same contract, same output.
 
 **1. Two dev servers — one for `before`, one for `after`.** Don't reuse a single server for both; run
 the `before` state from a separate worktree so nothing needs stashing/restoring mid-capture:
@@ -421,9 +440,7 @@ A PR confined to `apps/ui/src/lib/**` / `apps/ui/src/hooks/**` / test files, wit
 skips this entirely — it isn't rendering anything different.
 
 > The devcontainer (`.devcontainer/devcontainer.json`) preinstalls Node 22 + Playwright's Chromium, so
-> setup for the steps above is zero-config there. A scripted capture pipeline that automates the
-> screenshot-taking itself (tracked in #3769) doesn't exist yet — until it lands, follow the steps
-> manually.
+> setup for the steps above (manual or via the automated tool) is zero-config there.
 
 **Animated evidence (#4825) — for effects no static screenshot can show.** Required whenever the
 changed behavior is only visible in motion: a hover-triggered popover, a scroll-linked effect, a CSS

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,12 @@
 {
   "name": "metagraphed",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22-bookworm",
-  // Pinned (not @latest): postCreateCommand runs unattended on every container
-  // create, so an unpinned version would auto-execute whatever a compromised
-  // upstream publish contained. When #3769 lands Playwright as a real devDependency
-  // in apps/ui/package.json, re-pin this to match that version.
-  "postCreateCommand": "npm install && npx --yes playwright@1.61.1 install --with-deps chromium",
+  // Runs unattended on every container create -- `npm install` first resolves
+  // Playwright to the exact, lockfile-pinned version already vetted in
+  // apps/ui/package.json's devDependencies (#3769), then the local `npx
+  // playwright` (no version pin, no remote fetch) installs its browser
+  // binaries to match.
+  "postCreateCommand": "npm install && npx playwright install --with-deps chromium",
   "forwardPorts": [8080],
   "portsAttributes": {
     "8080": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -23,7 +23,8 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:update-baseline": "node tests/e2e/generate-overflow-baseline.mjs",
-    "test:e2e:record-har": "node tests/e2e/record-har.mjs"
+    "test:e2e:record-har": "node tests/e2e/record-har.mjs",
+    "screenshots": "node tests/e2e/capture-pr-screenshots.mjs"
   },
   "dependencies": {
     "@jsonbored/metagraphed": "*",

--- a/apps/ui/tests/e2e/capture-pr-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-pr-screenshots.mjs
@@ -131,6 +131,15 @@ function run(cmd, args, opts = {}) {
   return result.stdout.trim();
 }
 
+/** Prefers `origin/main` over local `main` -- a long-lived local checkout's
+ * `main` branch is very often stale (never fast-forwarded), which would
+ * silently point "before" at some arbitrary old commit instead of the real
+ * base. Falls back to local `main` only if there's no `origin` remote. */
+function resolveMainRef(cwd) {
+  const result = spawnSync("git", ["rev-parse", "--verify", "origin/main"], { cwd });
+  return result.status === 0 ? "origin/main" : "main";
+}
+
 function gitMergeBase(a, b, cwd) {
   return run("git", ["merge-base", a, b], { cwd });
 }
@@ -172,14 +181,19 @@ async function probeServerUp(url) {
   }
 }
 
-/** Spawns `npm run dev --workspace=apps/ui -- --port <port>` in `cwd`,
- * detached from this process's stdio so a slow/chatty dev server doesn't
- * flood the capture tool's own output. Caller is responsible for waiting on
- * readiness (waitForServer) and killing the returned child on cleanup. */
+/** Spawns `npm run dev -- --port <port>` with `cwd` already inside
+ * apps/ui (never `--workspace=apps/ui` here -- that flag resolves relative
+ * to a monorepo root, and `cwd` already points at the workspace itself, so
+ * combining them makes npm fail to find a nested "apps/ui" workspace and
+ * exit immediately). stdout is suppressed (a chatty dev server would flood
+ * the capture tool's own output) but stderr stays visible so a real startup
+ * failure doesn't just silently time out in waitForServer. Caller is
+ * responsible for waiting on readiness (waitForServer) and killing the
+ * returned child on cleanup. */
 function startDevServer(cwd, port) {
-  const child = spawn("npm", ["run", "dev", "--workspace=apps/ui", "--", "--port", String(port)], {
+  const child = spawn("npm", ["run", "dev", "--", "--port", String(port)], {
     cwd,
-    stdio: "ignore",
+    stdio: ["ignore", "ignore", "inherit"],
   });
   return child;
 }
@@ -251,6 +265,30 @@ async function setTheme(page, baseUrl, theme) {
   });
 }
 
+/** `networkidle` is the right wait condition (it's what lets a late-mounting
+ * chart or a client-side non-suspense query settle before capture -- see
+ * capture-operational-status-screenshots.mjs), but a just-spawned dev
+ * server's first hit on a route pays Vite's cold transform/optimize cost on
+ * top of the app's own data fetches, occasionally blowing past a single
+ * timeout. Retry once, then fall back to the cheaper `load` condition plus a
+ * fixed settle wait rather than failing the whole capture run outright. */
+async function gotoRoute(page, url) {
+  try {
+    await page.goto(url, { waitUntil: "networkidle", timeout: 60_000 });
+    return;
+  } catch (err) {
+    console.warn(`networkidle wait failed for ${url}, retrying once: ${err.message}`);
+  }
+  try {
+    await page.goto(url, { waitUntil: "networkidle", timeout: 60_000 });
+    return;
+  } catch (err) {
+    console.warn(`networkidle retry failed for ${url}, falling back to "load": ${err.message}`);
+  }
+  await page.goto(url, { waitUntil: "load", timeout: 60_000 });
+  await page.waitForTimeout(2000);
+}
+
 /** Scrolls `sectionId` into view, accounting for the sticky masthead's live
  * height, then re-scrolls once after a settle wait so late data-driven
  * layout shifts (queries resolving, charts mounting) don't push the target
@@ -293,7 +331,7 @@ async function captureVariant({
 
     for (const theme of THEMES) {
       await setTheme(page, baseUrl, theme);
-      await page.goto(`${baseUrl}${route}`, { waitUntil: "networkidle", timeout: 90_000 });
+      await gotoRoute(page, `${baseUrl}${route}`);
       // Let async, non-suspense queries (identity/balance/etc. -- anything
       // fetched client-side post-hydration) resolve before scrolling and
       // capturing, or the shot freezes on a loading skeleton.
@@ -425,7 +463,7 @@ async function main() {
 
   try {
     if (!skipOrchestration) {
-      const baseRef = args.baseRef || gitMergeBase("main", "HEAD", repoRoot);
+      const baseRef = args.baseRef || gitMergeBase(resolveMainRef(repoRoot), "HEAD", repoRoot);
       console.log(`Base ref for "before": ${baseRef}`);
 
       afterUrl = args.afterUrl ?? `http://localhost:${args.afterPort}`;
@@ -444,6 +482,16 @@ async function main() {
 
       console.log("Waiting for both dev servers to be ready...");
       await Promise.all([waitForServer(beforeUrl, "before"), waitForServer(afterUrl, "after")]);
+
+      // A dev server responding on / doesn't mean the target route is warm --
+      // Vite transforms each route's module graph lazily, on first hit. Pay
+      // that cold-start cost here (best-effort, errors ignored) instead of on
+      // the first real capture attempt below.
+      console.log(`Warming up ${args.route} on both servers...`);
+      await Promise.all([
+        fetch(`${beforeUrl}${args.route}`).catch(() => {}),
+        fetch(`${afterUrl}${args.route}`).catch(() => {}),
+      ]);
     }
 
     console.log(`\nCapturing "before" (${beforeUrl})...`);

--- a/apps/ui/tests/e2e/capture-pr-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-pr-screenshots.mjs
@@ -1,0 +1,493 @@
+/**
+ * Automated before/after screenshot capture for a visual apps/ui PR (#3769).
+ *
+ * Drives a headless browser through the full Phase C2 capture matrix (3
+ * viewports x 2 themes x before/after = 12 fixed-viewport PNGs, never
+ * fullPage -- a full-page capture is exactly what broke #3757) against two
+ * dev servers: one checked out at a base ref (default: the merge-base with
+ * main), one at the current working tree. Generalizes the one-off
+ * capture-*-screenshots.mjs scripts already in this directory (each hardcoded
+ * to one PR's route/selectors) into a reusable, route-agnostic tool, and adds
+ * the two-server orchestration none of them do.
+ *
+ * Usage:
+ *   node tests/e2e/capture-pr-screenshots.mjs --route /status
+ *   node tests/e2e/capture-pr-screenshots.mjs --route /subnets/1 \
+ *     --section volume-24h --prefix 5483-volume
+ *
+ * Fast path for iterative work (servers you're already running -- e.g. an AI
+ * coding tool mid-session, or a contributor who already has both dev servers
+ * up): skip the worktree/install/spawn dance entirely and point at them.
+ *   node tests/e2e/capture-pr-screenshots.mjs --route /status \
+ *     --before-url http://localhost:8081 --after-url http://localhost:8080
+ *
+ * Writes 12 PNGs to --out (default tmp/pr-screenshots/), named
+ * [<prefix>-]{before,after}-<viewport>-<theme>.png -- see SKILL.md Phase C2
+ * step 6 for the table this feeds. Pass --push to also push them to the
+ * `screenshots` branch on `origin` and print the ready-to-paste markdown
+ * table with real raw.githubusercontent.com URLs filled in.
+ *
+ * Flags:
+ *   --route <path>            required, e.g. /status or /subnets/1
+ *   --base-ref <ref>          default: git merge-base main HEAD
+ *   --section <id>            element id to scroll into view before
+ *                              capturing (omit to capture at page top)
+ *   --fallback-section <id>   section to scroll to on the "before" variant
+ *                              when --section doesn't exist there yet (the
+ *                              common case for a new section -- e.g. the
+ *                              existing anchor it attaches after)
+ *   --out <dir>               default: tmp/pr-screenshots
+ *   --prefix <name>           filename prefix, e.g. an issue number
+ *   --before-port / --after-port   default: 8081 / 8080
+ *   --before-url / --after-url     skip orchestration, use running servers
+ *   --keep-worktree           don't remove the before-ref worktree on exit
+ *   --push                    push results to the `screenshots` branch and
+ *                              print the PR markdown table
+ */
+import { spawn, spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readdir, copyFile, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const repoRoot = fileURLToPath(new URL("../../../../", import.meta.url));
+const THEME_STORAGE_KEY = "mg-theme";
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const THEMES = ["light", "dark"];
+const SERVER_READY_TIMEOUT_MS = 90_000;
+const SERVER_POLL_INTERVAL_MS = 500;
+
+function parseArgs(argv) {
+  const parsed = {
+    route: null,
+    baseRef: null,
+    section: null,
+    fallbackSection: null,
+    out: "tmp/pr-screenshots",
+    prefix: "",
+    beforePort: 8081,
+    afterPort: 8080,
+    beforeUrl: null,
+    afterUrl: null,
+    keepWorktree: false,
+    push: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--route") parsed.route = argv[++i];
+    else if (a === "--base-ref") parsed.baseRef = argv[++i];
+    else if (a === "--section") parsed.section = argv[++i];
+    else if (a === "--fallback-section") parsed.fallbackSection = argv[++i];
+    else if (a === "--out") parsed.out = argv[++i];
+    else if (a === "--prefix") parsed.prefix = argv[++i];
+    else if (a === "--before-port") parsed.beforePort = Number(argv[++i]);
+    else if (a === "--after-port") parsed.afterPort = Number(argv[++i]);
+    else if (a === "--before-url") parsed.beforeUrl = argv[++i];
+    else if (a === "--after-url") parsed.afterUrl = argv[++i];
+    else if (a === "--keep-worktree") parsed.keepWorktree = true;
+    else if (a === "--push") parsed.push = true;
+    else if (a === "--help" || a === "-h") parsed.help = true;
+  }
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage: node tests/e2e/capture-pr-screenshots.mjs --route <path> [options]
+
+Required:
+  --route <path>            Route to capture, e.g. /status or /subnets/1
+
+Options:
+  --base-ref <ref>          Base ref for "before" (default: merge-base with main)
+  --section <id>            Element id to scroll into view (default: page top)
+  --fallback-section <id>   Fallback scroll target for "before" when --section
+                             doesn't exist there yet
+  --out <dir>                Output directory (default: tmp/pr-screenshots)
+  --prefix <name>            Filename prefix, e.g. an issue number
+  --before-port <n>          Port for the before-ref server (default: 8081)
+  --after-port <n>           Port for the after (current tree) server (default: 8080)
+  --before-url <url>         Skip orchestration, use an already-running server
+  --after-url <url>          Skip orchestration, use an already-running server
+  --keep-worktree            Don't remove the before-ref worktree afterward
+  --push                     Push results to the \`screenshots\` branch on
+                              \`origin\` and print the PR markdown table
+  --help                     Show this message
+`);
+}
+
+function run(cmd, args, opts = {}) {
+  const result = spawnSync(cmd, args, { encoding: "utf8", ...opts });
+  if (result.status !== 0) {
+    throw new Error(
+      `${cmd} ${args.join(" ")} failed (${result.status}):\n${result.stderr || result.stdout}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function gitMergeBase(a, b, cwd) {
+  return run("git", ["merge-base", a, b], { cwd });
+}
+
+/** True when the lockfile is unchanged between baseRef and HEAD -- when it
+ * is, copying the current tree's already-installed node_modules into the
+ * before-worktree is equivalent to a fresh install but skips a slow
+ * (and, on a mismatched local Node/native-toolchain, occasionally broken --
+ * see the `sharp` native-build gotcha) `npm install`. */
+function lockfileUnchanged(baseRef) {
+  const result = spawnSync("git", ["diff", "--quiet", baseRef, "HEAD", "--", "package-lock.json"], {
+    cwd: repoRoot,
+  });
+  return result.status === 0;
+}
+
+async function waitForServer(url, label) {
+  const deadline = Date.now() + SERVER_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
+      if (res.ok || res.status < 500) return;
+    } catch {
+      // not up yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, SERVER_POLL_INTERVAL_MS));
+  }
+  throw new Error(
+    `${label} server at ${url} did not become ready within ${SERVER_READY_TIMEOUT_MS}ms`,
+  );
+}
+
+async function probeServerUp(url) {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
+    return res.ok || res.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+/** Spawns `npm run dev --workspace=apps/ui -- --port <port>` in `cwd`,
+ * detached from this process's stdio so a slow/chatty dev server doesn't
+ * flood the capture tool's own output. Caller is responsible for waiting on
+ * readiness (waitForServer) and killing the returned child on cleanup. */
+function startDevServer(cwd, port) {
+  const child = spawn("npm", ["run", "dev", "--workspace=apps/ui", "--", "--port", String(port)], {
+    cwd,
+    stdio: "ignore",
+  });
+  return child;
+}
+
+function killServer(child) {
+  if (!child || child.killed) return;
+  child.kill("SIGTERM");
+}
+
+/** Creates a throwaway worktree at baseRef, wires up node_modules (copy if
+ * the lockfile matches HEAD, fresh install otherwise -- see
+ * lockfileUnchanged), and starts its dev server. Mirrors SKILL.md Phase C2
+ * step 1's manual two-worktree flow. */
+async function setupBeforeWorktree(baseRef, port) {
+  const worktreeDir = await mkdtemp(path.join(os.tmpdir(), "metagraphed-before-"));
+  console.log(`Creating before-worktree at ${baseRef} -> ${worktreeDir}`);
+  run("git", ["worktree", "add", "--detach", worktreeDir, baseRef], { cwd: repoRoot });
+
+  if (lockfileUnchanged(baseRef)) {
+    console.log("package-lock.json unchanged since base ref -- copying node_modules (fast path)");
+    for (const rel of [
+      "node_modules",
+      "apps/ui/node_modules",
+      "packages/client/node_modules",
+      "packages/ui-kit/node_modules",
+    ]) {
+      const src = path.join(repoRoot, rel);
+      const dest = path.join(worktreeDir, rel);
+      if (await dirExists(src)) {
+        run("cp", ["-R", src, dest]);
+      }
+    }
+  } else {
+    console.log(
+      "package-lock.json changed since base ref -- running npm install (this may take a while)",
+    );
+    run("npm", ["install"], { cwd: worktreeDir, stdio: "inherit" });
+  }
+
+  const child = startDevServer(path.join(worktreeDir, "apps/ui"), port);
+  return { worktreeDir, child };
+}
+
+async function dirExists(p) {
+  try {
+    const info = await stat(p);
+    return info.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function removeWorktree(worktreeDir) {
+  console.log(`Removing before-worktree ${worktreeDir}`);
+  const result = spawnSync("git", ["worktree", "remove", worktreeDir, "--force"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    console.warn(`Could not cleanly remove worktree (continuing): ${result.stderr}`);
+  }
+}
+
+async function setTheme(page, baseUrl, theme) {
+  await page.goto(`${baseUrl}/`, { waitUntil: "domcontentloaded" });
+  await page.evaluate(({ key, value }) => localStorage.setItem(key, value), {
+    key: THEME_STORAGE_KEY,
+    value: theme,
+  });
+}
+
+/** Scrolls `sectionId` into view, accounting for the sticky masthead's live
+ * height, then re-scrolls once after a settle wait so late data-driven
+ * layout shifts (queries resolving, charts mounting) don't push the target
+ * back out of frame -- mirrors capture-operational-status-screenshots.mjs. */
+async function scrollToSection(page, sectionId) {
+  const scroll = () =>
+    page.evaluate((id) => {
+      const section = document.getElementById(id);
+      if (!section) return false;
+      const header = document.querySelector("header");
+      const clearance = (header?.getBoundingClientRect().bottom ?? 0) + 12;
+      const top = section.getBoundingClientRect().top + window.scrollY - clearance;
+      window.scrollTo({ top: Math.max(0, top), behavior: "instant" });
+      return true;
+    }, sectionId);
+
+  const found = await scroll();
+  if (!found) return false;
+  await page.waitForTimeout(500);
+  await scroll();
+  await page.waitForTimeout(300);
+  return true;
+}
+
+async function captureVariant({
+  browser,
+  baseUrl,
+  variant,
+  route,
+  section,
+  fallbackSection,
+  outDir,
+  prefix,
+}) {
+  for (const viewport of VIEWPORTS) {
+    const context = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+    });
+    const page = await context.newPage();
+
+    for (const theme of THEMES) {
+      await setTheme(page, baseUrl, theme);
+      await page.goto(`${baseUrl}${route}`, { waitUntil: "networkidle", timeout: 90_000 });
+      // Let async, non-suspense queries (identity/balance/etc. -- anything
+      // fetched client-side post-hydration) resolve before scrolling and
+      // capturing, or the shot freezes on a loading skeleton.
+      await page.waitForTimeout(1200);
+
+      if (section) {
+        const found = await scrollToSection(page, section);
+        if (!found && fallbackSection) {
+          await scrollToSection(page, fallbackSection);
+        }
+      }
+      await page.waitForTimeout(200);
+
+      const name = [prefix, variant, viewport.name, theme].filter(Boolean).join("-");
+      const file = path.join(outDir, `${name}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+    }
+    await context.close();
+  }
+}
+
+async function pushScreenshots(outDir, files) {
+  const originUrl = run("git", ["remote", "get-url", "origin"], { cwd: repoRoot });
+  const match = originUrl.match(/[/:]([^/:]+)\/([^/]+?)(?:\.git)?$/);
+  if (!match) throw new Error(`Could not parse owner/repo from origin URL: ${originUrl}`);
+  const [, owner, repo] = match;
+
+  const pushWorktreeDir = await mkdtemp(path.join(os.tmpdir(), "metagraphed-screenshots-"));
+  run("git", ["fetch", "origin"], { cwd: repoRoot });
+  const remoteHasBranch =
+    spawnSync("git", ["ls-remote", "--exit-code", "--heads", "origin", "screenshots"], {
+      cwd: repoRoot,
+    }).status === 0;
+
+  if (remoteHasBranch) {
+    run("git", ["worktree", "add", pushWorktreeDir, "origin/screenshots", "-B", "screenshots"], {
+      cwd: repoRoot,
+    });
+  } else {
+    run("git", ["worktree", "add", "--detach", pushWorktreeDir, "origin/main"], { cwd: repoRoot });
+    run("git", ["checkout", "--orphan", "screenshots"], { cwd: pushWorktreeDir });
+    run("git", ["rm", "-rf", "--quiet", "."], { cwd: pushWorktreeDir });
+  }
+
+  for (const file of files) {
+    await copyFile(path.join(outDir, file), path.join(pushWorktreeDir, file));
+  }
+  run("git", ["add", ...files], { cwd: pushWorktreeDir });
+  run(
+    "git",
+    [
+      "-c",
+      "user.name=metagraphed-screenshot-tool",
+      "-c",
+      "user.email=noreply@metagraph.sh",
+      "commit",
+      "-m",
+      `screenshots: ${files[0]?.replace(/-(before|after)-.*/, "") || "capture"}`,
+    ],
+    {
+      cwd: pushWorktreeDir,
+    },
+  );
+
+  // Rebase-and-retry once in case another push landed on the branch in the
+  // meantime (a real, observed race when multiple contributors/AI sessions
+  // use this branch concurrently).
+  try {
+    run("git", ["push", "origin", "screenshots"], { cwd: pushWorktreeDir });
+  } catch {
+    run("git", ["fetch", "origin", "screenshots"], { cwd: pushWorktreeDir });
+    run("git", ["rebase", "origin/screenshots"], { cwd: pushWorktreeDir });
+    run("git", ["push", "origin", "screenshots"], { cwd: pushWorktreeDir });
+  }
+
+  removeWorktree(pushWorktreeDir);
+
+  console.log("\nPushed. Markdown table:\n");
+  const byViewportTheme = new Map();
+  for (const file of files) {
+    const m = file.match(/-(before|after)-(mobile|tablet|desktop)-(light|dark)\.png$/);
+    if (!m) continue;
+    const [, variant, viewport, theme] = m;
+    const key = `${viewport}-${theme}`;
+    const entry = byViewportTheme.get(key) ?? {};
+    entry[variant] = file;
+    byViewportTheme.set(key, entry);
+  }
+  const order = [
+    "desktop-light",
+    "desktop-dark",
+    "tablet-light",
+    "tablet-dark",
+    "mobile-light",
+    "mobile-dark",
+  ];
+  console.log("| Viewport · Theme | Before | After |");
+  console.log("| --- | --- | --- |");
+  for (const key of order) {
+    const entry = byViewportTheme.get(key);
+    if (!entry?.before || !entry?.after) continue;
+    const [viewport, theme] = key.split("-");
+    const label = `${viewport[0].toUpperCase()}${viewport.slice(1)} · ${theme[0].toUpperCase()}${theme.slice(1)}`;
+    const beforeUrl = `https://raw.githubusercontent.com/${owner}/${repo}/screenshots/${entry.before}`;
+    const afterUrl = `https://raw.githubusercontent.com/${owner}/${repo}/screenshots/${entry.after}`;
+    console.log(
+      `| ${label} | [<img src="${beforeUrl}" width="260">](${beforeUrl})<br><sub>before</sub> | [<img src="${afterUrl}" width="260">](${afterUrl})<br><sub>after</sub> |`,
+    );
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || !args.route) {
+    printHelp();
+    process.exit(args.help ? 0 : 1);
+  }
+
+  const outDir = path.resolve(repoRoot, args.out);
+  await mkdir(outDir, { recursive: true });
+
+  const skipOrchestration = Boolean(args.beforeUrl && args.afterUrl);
+  let beforeWorktree = null;
+  let beforeServer = null;
+  let afterServer = null;
+  let beforeUrl = args.beforeUrl;
+  let afterUrl = args.afterUrl;
+
+  try {
+    if (!skipOrchestration) {
+      const baseRef = args.baseRef || gitMergeBase("main", "HEAD", repoRoot);
+      console.log(`Base ref for "before": ${baseRef}`);
+
+      afterUrl = args.afterUrl ?? `http://localhost:${args.afterPort}`;
+      const afterAlreadyUp = await probeServerUp(afterUrl);
+      if (afterAlreadyUp) {
+        console.log(`Reusing already-running "after" server at ${afterUrl}`);
+      } else {
+        console.log(`Starting "after" server (current tree) on port ${args.afterPort}`);
+        afterServer = startDevServer(path.join(repoRoot, "apps/ui"), args.afterPort);
+      }
+
+      const before = await setupBeforeWorktree(baseRef, args.beforePort);
+      beforeWorktree = before.worktreeDir;
+      beforeServer = before.child;
+      beforeUrl = `http://localhost:${args.beforePort}`;
+
+      console.log("Waiting for both dev servers to be ready...");
+      await Promise.all([waitForServer(beforeUrl, "before"), waitForServer(afterUrl, "after")]);
+    }
+
+    console.log(`\nCapturing "before" (${beforeUrl})...`);
+    const browser = await chromium.launch();
+    await captureVariant({
+      browser,
+      baseUrl: beforeUrl,
+      variant: "before",
+      route: args.route,
+      section: args.section,
+      fallbackSection: args.fallbackSection,
+      outDir,
+      prefix: args.prefix,
+    });
+
+    console.log(`\nCapturing "after" (${afterUrl})...`);
+    await captureVariant({
+      browser,
+      baseUrl: afterUrl,
+      variant: "after",
+      route: args.route,
+      section: args.section,
+      fallbackSection: null,
+      outDir,
+      prefix: args.prefix,
+    });
+    await browser.close();
+
+    console.log(`\n12 screenshots written to ${outDir}`);
+
+    if (args.push) {
+      const files = (await readdir(outDir)).filter((f) => f.endsWith(".png"));
+      await pushScreenshots(outDir, files);
+    }
+  } finally {
+    killServer(beforeServer);
+    killServer(afterServer);
+    if (beforeWorktree && !args.keepWorktree) {
+      removeWorktree(beforeWorktree);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Builds `apps/ui/tests/e2e/capture-pr-screenshots.mjs`: a route-agnostic, fully-automated before/after screenshot capture tool, replacing the manual two-worktree/twelve-screenshot dance in SKILL.md Phase C2 with a single command.

## What changed

- **New script** — generalizes the 5 existing one-off `capture-*-screenshots.mjs` scripts already in `apps/ui/tests/e2e/` (each hardcoded to one PR's route/selectors) into a reusable tool, and adds the two-server orchestration none of them do:
  - Spins up a throwaway worktree at a base ref (default: `origin/main` merge-base), copies `node_modules` when the lockfile is unchanged (fast path — falls back to `npm install` when it isn't), starts its dev server.
  - Starts (or reuses, if already running — mirrors `playwright.config.ts`'s own `reuseExistingServer` pattern) the "after" server on the current tree.
  - Captures the full 3-viewport × 2-theme × before/after matrix, fixed-viewport only (never `fullPage`), with the same explicit `mg-theme` localStorage toggle and section-scroll-with-settle logic as the existing scripts.
  - Cleans up both servers and the worktree on exit (including on error).
  - `--push` (optional): pushes the 12 files to the `screenshots` branch on `origin` and prints the ready-to-paste PR markdown table with real `raw.githubusercontent.com` URLs.
  - Fast path for iterative work: `--before-url`/`--after-url` skip orchestration entirely and point at servers you already have running.
- `apps/ui/package.json`: `npm run screenshots` alias.
- **SKILL.md Phase C2**: now leads with the automated tool as the primary path; the existing manual steps stay as documented fallback (same contract either way).
- **`.devcontainer/devcontainer.json`**: removed the stale "when #3769 lands" comment and swapped the floating `npx --yes playwright@1.61.1` remote fetch for the local, lockfile-pinned `@playwright/test` binary now that it's a real devDependency (it already was, independent of this issue — added for the `test:e2e` responsive-overflow check — so acceptance criterion 1 was already satisfied; this PR just closes the loop on the devcontainer's own comment/pin referencing it).

## Testing

Ran the full tool twice end-to-end (not just unit-level): `--route /status` (the exact route from #3757's original failure) and `--route /subnets/1`, both producing all 12 files with real, correctly-rendered content and exact fixed-viewport dimensions (375×812 / 768×1024 / 1280×800 — confirmed via `file`, not just eyeballed) — not the 115K–142K px `fullPage` failure mode #3757 shipped.

Two real bugs surfaced only by running it for real, not from reading the code:
1. `startDevServer` combined `--workspace=apps/ui` with a `cwd` already inside `apps/ui`, so npm silently failed to find a nested workspace and the dev server never actually started — invisible because stdio was fully suppressed. Fixed by dropping the flag (cwd already resolves it) and keeping stderr visible (`stdio: ["ignore", "ignore", "inherit"]`) so a real startup failure surfaces instead of just timing out.
2. The base-ref default used local `main` (`git merge-base main HEAD`), which is very commonly stale in a long-lived checkout — silently pointed "before" at an arbitrary old commit. Now prefers `origin/main`.

Also hardened route navigation against a freshly-spawned server's cold-start cost (Vite transforms each route's module graph lazily, on first hit) — a warm-up request before the real capture loop, plus retry + `load`-based fallback if `networkidle` still times out — after hitting a real (transient) timeout on `/status` against a just-started worktree server during testing.

**Not live-tested:** `--push`. The git plumbing (fetch, orphan-branch-if-new, add/commit, push-with-rebase-retry-on-conflict) mirrors the exact manual sequence I've run by hand ~5 times this session pushing real PR screenshots to this repo's `screenshots` branch, but I didn't want to pollute that shared branch with throwaway test commits to verify it live. Flagging for extra scrutiny on review.

## Acceptance criteria (from #3769)

- [x] `apps/ui/package.json` has a Playwright devDependency (already did, independent of this issue)
- [x] A documented script produces exactly 12 correctly-sized (fixed-viewport, not full-page) PNGs for a given route + base ref
- [x] Output naming matches the SKILL.md convention (`[prefix-]{before,after}-{viewport}-{theme}.png`)
- [x] SKILL.md Phase C2 updated to point at the new script
- [x] Running against `/status` produces images in the correct dimension range, not the 115K–142K px failure mode
- [ ] Devcontainer stretch goal — already existed before this issue (not something this PR added), just tidied its stale comment/pin

## Validation

- `npm run typecheck --workspace=apps/ui`
- `npm run lint --workspace=apps/ui` (0 errors; pre-existing warnings unrelated)
- `npm run format:check --workspace=apps/ui`
- `npm test --workspace=apps/ui` (775 passed)
- `npm run build --workspace=apps/ui`
- Two full end-to-end runs of the tool itself (see Testing above)

Closes #3769.
