### PR TITLE
fix(registry): correct 5 subnets' dead source_repo fields (#5479)

### DIFF
--- a/registry/subnets/actual.json
+++ b/registry/subnets/actual.json
@@ -14,7 +14,7 @@
   "website_url": "https://actual.inc/",
   "docs_url": null,
   "dashboard_url": "https://backprop.finance/dtao/subnets/95-actual",
-  "source_repo": "https://github.com/actual-computer/actual-subnet-95",
+  "source_repo": null,
   "baseline_excluded_surface_ids": [
     "sn-95-taomarketcap-source-repo",
     "sn-95-taomarketcap-website",

--- a/registry/subnets/bitads.json
+++ b/registry/subnets/bitads.json
@@ -11,9 +11,9 @@
     "official-source-repo",
     "official-website"
   ],
-  "website_url": "https://bitads.ai/",
-  "docs_url": "https://bitads.ai/docs",
-  "source_repo": "https://github.com/FirstTensorLabs/BitAds",
+  "website_url": null,
+  "docs_url": null,
+  "source_repo": "https://github.com/study-service/BitAds.ai",
   "dashboard_url": "https://taomarketcap.com/subnets/16",
   "baseline_excluded_surface_ids": [
     "sn-16-taomarketcap-source-repo",
@@ -25,7 +25,7 @@
     "sn-16-website-common-swagger",
     "sn-16-website-common-swagger-json"
   ],
-  "notes": "Reviewed overlay for SN16 BitAds using the official BitAds website, docs page, and source repository. Common API/OpenAPI/Swagger paths currently return website HTML instead of machine-readable API/schema responses, so they are excluded as content mismatches.",
+  "notes": "Reviewed overlay for SN16 BitAds. The former bitads.ai website/docs domain no longer resolves (DNS lame delegation — the domain's own nameservers refuse the query), so website_url/docs_url are nulled until a live domain is confirmed. The operator's active code has moved from FirstTensorLabs/BitAds (now 404) to study-service/BitAds.ai (live), which is now the registered source_repo. Common API/OpenAPI/Swagger paths previously returned website HTML instead of machine-readable API/schema responses, so they are excluded as content mismatches.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -33,7 +33,8 @@
     "verified_at": "2026-06-08T20:25:00.000Z",
     "source_count": 5,
     "gap_notes": [
-      "Official website, docs page, and source repository are verified live.",
+      "The bitads.ai website and docs domain currently fails to resolve (DNS lame delegation) and is nulled until it recovers or a replacement domain is confirmed.",
+      "The former FirstTensorLabs/BitAds source repository now returns 404; the live successor repository is study-service/BitAds.ai.",
       "Common API, health, OpenAPI, Swagger JSON, and Swagger UI paths return marketing-site HTML rather than API/schema payloads.",
       "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
@@ -56,12 +57,12 @@
         "https://github.com/FirstTensorLabs/BitAds"
       ],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
+        "expect": "html"
       },
-      "notes": "Official BitAds website."
+      "rate_limit_notes": "Not probe-enabled because bitads.ai currently fails to resolve (DNS lame delegation — the domain's nameservers refuse queries); marked degraded until the domain recovers or a replacement is confirmed.",
+      "notes": "Official BitAds website (bitads.ai domain currently unresolvable)."
     },
     {
       "id": "sn-16-bitads-docs",
@@ -74,12 +75,12 @@
       "public_safe": true,
       "source_urls": ["https://bitads.ai/docs"],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
+        "expect": "html"
       },
-      "notes": "Official BitAds documentation page."
+      "rate_limit_notes": "Not probe-enabled because the bitads.ai domain currently fails to resolve (DNS lame delegation); marked degraded until it recovers or a replacement is confirmed.",
+      "notes": "Official BitAds documentation page (bitads.ai domain currently unresolvable)."
     },
     {
       "id": "sn-16-bitads-source",
@@ -92,12 +93,12 @@
       "public_safe": true,
       "source_urls": ["https://github.com/FirstTensorLabs/BitAds"],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
+        "expect": "any"
       },
-      "notes": "Official BitAds source repository."
+      "rate_limit_notes": "Not probe-enabled because github.com/FirstTensorLabs/BitAds now returns 404; the operator's live successor repository is study-service/BitAds.ai (the registered top-level source_repo).",
+      "notes": "Former BitAds source repository (FirstTensorLabs/BitAds now returns 404; live code has moved to study-service/BitAds.ai)."
     },
     {
       "auth_required": false,

--- a/registry/subnets/efficientfrontier.json
+++ b/registry/subnets/efficientfrontier.json
@@ -31,7 +31,7 @@
   "notes": "Reviewed overlay for SN53 EfficientFrontier by SignalPlus. The SignalPlus company website is live; the mining app surface returns an auth/challenge-style response to simple probes. The previously discovered EfficientFrontier source repository currently returns 404 and is not promoted.",
   "schema_version": 1,
   "slug": "efficientfrontier",
-  "source_repo": "https://github.com/EfficientFrontier-SignalPlus/EfficientFrontier",
+  "source_repo": "https://github.com/oxylok/53-EfficientFrontier",
   "status": "active",
   "surfaces": [
     {

--- a/registry/subnets/groundlayer.json
+++ b/registry/subnets/groundlayer.json
@@ -5,7 +5,7 @@
   "slug": "sn-20",
   "status": "active",
   "categories": ["baseline-curated", "capital-markets", "identity-reviewed"],
-  "source_repo": "https://github.com/RogueTensor/comingsoon",
+  "source_repo": null,
   "dashboard_url": "https://taomarketcap.com/subnets/20",
   "website_url": "https://www.groundlayer.xyz/",
   "baseline_excluded_surface_ids": [

--- a/registry/subnets/satori.json
+++ b/registry/subnets/satori.json
@@ -25,7 +25,7 @@
   "notes": "Reviewed overlay for SN119 Satori. Public directories describe the subnet, but the previously listed Satori119/Satori repository currently returns 404 and no official website, API, OpenAPI schema, or docs site is verified.",
   "schema_version": 1,
   "slug": "satori",
-  "source_repo": "https://github.com/Satori119/Satori",
+  "source_repo": null,
   "status": "active",
   "surfaces": [
     {


### PR DESCRIPTION
## Summary

Fixes the top-level `source_repo` field on five subnet manifests whose own `notes`/`curation.gap_notes` already concluded the linked repository is dead, plus the BitAds website/docs domain which no longer resolves. Each change was re-verified live (GitHub API `GET /repos/{owner}/{repo}`; DNS-over-HTTPS for the domain).

## Changes

| File | Field | Before | After | Verification |
|---|---|---|---|---|
| `actual.json` (SN95) | `source_repo` | `actual-computer/actual-subnet-95` | `null` | repo 404; no known replacement |
| `groundlayer.json` (SN20) | `source_repo` | `RogueTensor/comingsoon` | `null` | repo 404; no known replacement |
| `satori.json` (SN119) | `source_repo` | `Satori119/Satori` | `null` | repo 404; no known replacement |
| `efficientfrontier.json` (SN53) | `source_repo` | `EfficientFrontier-SignalPlus/EfficientFrontier` | `oxylok/53-EfficientFrontier` | old 404; new 200 (the file's own community `source-repo` surface already cites this) |
| `bitads.json` (SN16) | `source_repo` | `FirstTensorLabs/BitAds` | `study-service/BitAds.ai` | old 404; new 200 (the file's own `sn-16-bitads-min-compute` surface already cites this as the live successor) |
| `bitads.json` (SN16) | `website_url`, `docs_url` | `bitads.ai/*` | `null` | `bitads.ai` DNS lame delegation — nameservers refuse the query (SERVFAIL) |

For `bitads.json` I also updated `notes`/`gap_notes` to drop the stale "verified live" language and document the DNS-dead domain + repo move, and set `probe.enabled: false` (with `rate_limit_notes`) on the three now-unreachable surfaces (`sn-16-bitads-website`, `sn-16-bitads-docs`, `sn-16-bitads-source`) so the health prober no longer misreports them — following the precedent in `taolend.json`/`nodexo.json`.

## Scope

Only the top-level `source_repo`/`website_url`/`docs_url` fields and the affected files' `notes`/`gap_notes`/degraded-surface probe flags are touched. No new `surfaces[]` entries were added and no surface URLs/authority changed, per the issue's guidance about the native-chain dedup gate.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface` — passed (23 surfaces across 5 files)
- `npm run validate:schemas` — the only reported issue is the pre-existing `registry/native/finney-subnets.json` `total_stake_tao` live-data flake, unrelated to these files.

Closes #5479
