### PR TITLE
fix(registry): document 5 subnets' degraded website/dashboard URLs (#5480)

### DIFF
--- a/registry/subnets/8-ball.json
+++ b/registry/subnets/8-ball.json
@@ -14,7 +14,7 @@
   "website_url": "https://8ball125.com/",
   "docs_url": "https://github.com/Barbariandev/8Ball_miner#readme",
   "source_repo": "https://github.com/Barbariandev/8Ball_miner",
-  "notes": "Reviewed overlay for SN125 8 Ball. The public website is live and the public miner/source repository documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
+  "notes": "Reviewed overlay for SN125 8 Ball. The 8ball125.com website currently returns HTTP 502 to simple probes (checked twice) and is marked degraded until it recovers; the public miner/source repository (live) documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -22,7 +22,7 @@
     "verified_at": "2026-06-08T15:00:00.000Z",
     "source_count": 7,
     "gap_notes": [
-      "Official website and miner/source repository are verified live.",
+      "The 8ball125.com website currently returns HTTP 502 to simple probes and is marked degraded until it recovers; the miner/source repository is verified live.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",

--- a/registry/subnets/ninja.json
+++ b/registry/subnets/ninja.json
@@ -12,6 +12,7 @@
   "contact": "tau@arbos.life",
   "curation": {
     "gap_notes": [
+      "The ninja.arbos.life website/dashboard host currently returns HTTP 404 to simple probes (checked twice with a browser UA) and is marked degraded until it recovers.",
       "Swagger/OpenAPI routes currently serve HTML UI only; no verified machine-readable schema URL yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
@@ -33,7 +34,7 @@
   ],
   "name": "ninja",
   "netuid": 66,
-  "notes": "Reviewed overlay for SN66 using the official Ninja/Unarbos website, tau workflow repository, miner harness repository, health endpoint, and Swagger UI. The obvious OpenAPI JSON paths currently serve HTML, so schema-backed status remains a gap.",
+  "notes": "Reviewed overlay for SN66 using the official Ninja/Unarbos website, tau workflow repository, miner harness repository, health endpoint, and Swagger UI. The ninja.arbos.life website/dashboard/swagger host currently returns HTTP 404 to simple probes and is marked degraded until it recovers; the tau/ninja source repositories remain live. The obvious OpenAPI JSON paths currently serve HTML, so schema-backed status remains a gap.",
   "schema_version": 1,
   "slug": "sn-66",
   "source_repo": "https://github.com/unarbos/tau",

--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -15,7 +15,7 @@
   "website_url": "https://oneoneone.io/",
   "source_repo": "https://github.com/oneoneone-io/subnet-111",
   "dashboard_url": "https://taomarketcap.com/subnets/111",
-  "notes": "Reviewed overlay for SN111 using the official oneoneone website and source repository. No official docs/API/OpenAPI surface is verified yet.",
+  "notes": "Reviewed overlay for SN111 using the official oneoneone website and source repository. The oneoneone.io website currently returns Cloudflare 530 (origin error) to simple probes (checked twice) and is marked degraded until it recovers; the source repository remains live. No official docs/API/OpenAPI surface is verified yet.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -23,6 +23,7 @@
     "verified_at": "2026-06-08T10:35:00.000Z",
     "source_count": 4,
     "gap_notes": [
+      "The oneoneone.io website currently returns Cloudflare 530 (origin error) to simple probes (checked twice) and is marked degraded until it recovers.",
       "No verified official docs URL yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified OpenAPI/Swagger schema yet.",

--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -34,7 +34,7 @@
     "verified_at": "2026-06-08T20:25:00.000Z",
     "source_count": 5,
     "gap_notes": [
-      "Official TaoFi pool page, docs, and Swap source repository are verified live.",
+      "Official TaoFi docs and Swap source repository are verified live; the TaoFi pool page (www.taofi.com/pool) currently returns HTTP 402 to simple probes (checked twice ~20s apart) and is marked degraded until it recovers.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
       "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",

--- a/registry/subnets/tensorclaw.json
+++ b/registry/subnets/tensorclaw.json
@@ -17,7 +17,7 @@
   "dashboard_url": "https://www.tensorclaw.ai/dashboard",
   "website_url": "https://www.tensorclaw.ai/",
   "baseline_excluded_surface_ids": ["sn-92-taomarketcap-website"],
-  "notes": "Reviewed overlay for SN92 using the live Tensorclaw Network website, dashboard, and source repository. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The website links https://github.com/tensorclaw/tensorclaw and the repository README identifies it as Bittensor Tensorclaw Subnet 92.",
+  "notes": "Reviewed overlay for SN92 using the Tensorclaw Network website, dashboard, and source repository. The tensorclaw.ai website and dashboard currently return Cloudflare 521 ('web server is down') to simple probes (checked twice) and are marked degraded until they recover. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The website links https://github.com/tensorclaw/tensorclaw and the repository README identifies it as Bittensor Tensorclaw Subnet 92.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -26,7 +26,7 @@
     "source_count": 6,
     "gap_notes": [
       "Native chain name currently reports as luis while the public website identifies the project as Tensorclaw Network / Subnet 92.",
-      "Official website, dashboard, and source repository are verified live.",
+      "The tensorclaw.ai website and dashboard currently return Cloudflare 521 ('web server is down') to simple probes and are marked degraded until they recover; the source repository is verified live.",
       "No verified docs site yet beyond directory pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",


### PR DESCRIPTION
## Summary

Five subnet manifests describe a `website_url`/`dashboard_url` as "verified live" while the URL currently fails. Each was re-checked (browser UA, `-L`, twice) and is still down, so this PR brings each file's `notes`/`curation.gap_notes` in line with reality — dropping the stale "verified live" language and adding a plainly-worded degraded note naming the current status code, following the precedent already set by `taolend.json`/`nodexo.json`.

## Re-verification (all still failing)

| Subnet | URL | Status |
|---|---|---|
| SN10 Swap (`swap.json`) | `www.taofi.com/pool` | HTTP 402 |
| SN92 Tensorclaw (`tensorclaw.json`) | `tensorclaw.ai` + `/dashboard` | Cloudflare 521 |
| SN66 Ninja (`ninja.json`) | `ninja.arbos.life` | HTTP 404 |
| SN125 8 Ball (`8-ball.json`) | `8ball125.com` | HTTP 502 |
| SN111 oneoneone (`oneoneone.json`) | `oneoneone.io` | Cloudflare 530 |

## Scope

Curation text only: each file's top-level `notes` and/or `curation.gap_notes` now document the current degraded status instead of claiming the URL is "verified live". **No `surfaces[]` entries are touched** (no probe flags, URLs, or authority changed) and **no top-level identity fields** (`source_repo`, surface URLs) are changed — so this diff stays entirely clear of the native-chain dedup gate on website/source-repo surfaces. The URLs themselves are left in place, since the outages may be transient, exactly as the issue requests.

## Validation

- `npx prettier --check` — clean
- `npm run validate:surface` — passed (34 surfaces across 5 files)
- `npm run validate:schemas` — the only reported issue is the pre-existing `registry/native/finney-subnets.json` `total_stake_tao` live-data flake, unrelated to these files.

Closes #5480
