### PR TITLE
fix(ui): surface each subnet's missing-kind count on the mobile coverage matrix (#5310)

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
@@ -3,6 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { reviewProfileCompletenessQuery, subnetsQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
+import { coverageMissingSummary } from "@/lib/metagraphed/coverage-summary";
 import { InfoTooltip } from "@jsonbored/ui-kit";
 import type { Subnet } from "@/lib/metagraphed/types";
 
@@ -148,47 +149,62 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
             </tr>
           </thead>
           <tbody>
-            {rows.map((r) => (
-              <tr
-                key={r.netuid}
-                className="border-b border-border last:border-b-0 hover:bg-paper/30"
-              >
-                <td className="sticky left-0 z-10 bg-card px-3 py-1.5 border-r border-border text-ink-strong">
-                  <Link
-                    to="/subnets/$netuid"
-                    params={{ netuid: r.netuid }}
-                    className="inline-flex items-center gap-1.5 hover:text-accent"
-                  >
-                    <span className="font-mono text-[10px] text-ink-muted">SN{r.netuid}</span>
-                    <span className="truncate max-w-[160px]">{r.name}</span>
-                  </Link>
-                </td>
-                {KINDS.map((k) => {
-                  const cell = r.cells[k];
-                  const tone = CELL_TONE[cell];
-                  return (
-                    <td key={k} className="p-1 align-middle">
-                      <Link
-                        to="/subnets/$netuid"
-                        params={{ netuid: r.netuid }}
-                        search={{ tab: "surfaces" }}
-                        className={classNames(
-                          "block h-6 w-full rounded transition-all hover:ring-2",
-                          tone.bg,
-                          tone.ring,
-                        )}
-                        title={`${tone.label} · ${k} · SN${r.netuid}`}
-                      >
-                        <span className="sr-only">{`${k} ${tone.label}`}</span>
-                      </Link>
-                    </td>
-                  );
-                })}
-                <td className="px-2 py-1.5 text-right tabular-nums text-ink-strong">
-                  {Math.round(r.completeness * 100)}%
-                </td>
-              </tr>
-            ))}
+            {rows.map((r) => {
+              const summary = coverageMissingSummary(r.missingCount);
+              return (
+                <tr
+                  key={r.netuid}
+                  className="border-b border-border last:border-b-0 hover:bg-paper/30"
+                >
+                  <td className="sticky left-0 z-10 bg-card px-3 py-1.5 border-r border-border text-ink-strong">
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: r.netuid }}
+                      className="inline-flex items-center gap-1.5 hover:text-accent"
+                    >
+                      <span className="font-mono text-[10px] text-ink-muted">SN{r.netuid}</span>
+                      <span className="truncate max-w-[160px]">{r.name}</span>
+                    </Link>
+                    {/* Below lg the kind columns (the real gaps) scroll off-screen
+                      and every on-screen cell reads "present", so a mobile user
+                      sees false full coverage. Surface the missing count here in
+                      the sticky first column, where it's always visible (#5310). */}
+                    <span
+                      className={classNames(
+                        "mt-0.5 block text-[9px] uppercase tracking-[0.12em] lg:hidden",
+                        summary.complete ? "text-health-ok" : "text-health-down",
+                      )}
+                    >
+                      {summary.label}
+                    </span>
+                  </td>
+                  {KINDS.map((k) => {
+                    const cell = r.cells[k];
+                    const tone = CELL_TONE[cell];
+                    return (
+                      <td key={k} className="p-1 align-middle">
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: r.netuid }}
+                          search={{ tab: "surfaces" }}
+                          className={classNames(
+                            "block h-6 w-full rounded transition-all hover:ring-2",
+                            tone.bg,
+                            tone.ring,
+                          )}
+                          title={`${tone.label} · ${k} · SN${r.netuid}`}
+                        >
+                          <span className="sr-only">{`${k} ${tone.label}`}</span>
+                        </Link>
+                      </td>
+                    );
+                  })}
+                  <td className="px-2 py-1.5 text-right tabular-nums text-ink-strong">
+                    {Math.round(r.completeness * 100)}%
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/apps/ui/src/lib/metagraphed/coverage-summary.test.ts
+++ b/apps/ui/src/lib/metagraphed/coverage-summary.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { coverageMissingSummary } from "./coverage-summary";
+
+describe("coverageMissingSummary", () => {
+  it("reports 'all present' when nothing is missing", () => {
+    expect(coverageMissingSummary(0)).toEqual({ label: "all present", complete: true });
+  });
+
+  it("reports the count when kinds are missing", () => {
+    expect(coverageMissingSummary(1)).toEqual({ label: "1 missing", complete: false });
+    expect(coverageMissingSummary(5)).toEqual({ label: "5 missing", complete: false });
+  });
+
+  it("clamps negative / fractional / non-finite counts", () => {
+    expect(coverageMissingSummary(-3)).toEqual({ label: "all present", complete: true });
+    expect(coverageMissingSummary(2.9)).toEqual({ label: "2 missing", complete: false });
+    expect(coverageMissingSummary(Number.NaN)).toEqual({ label: "all present", complete: true });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/coverage-summary.ts
+++ b/apps/ui/src/lib/metagraphed/coverage-summary.ts
@@ -1,0 +1,20 @@
+export interface CoverageMissingSummary {
+  /** Compact label, e.g. "5 missing" or "all present". */
+  label: string;
+  /** True when nothing is missing — drives the ok (vs. down) tone. */
+  complete: boolean;
+}
+
+/**
+ * Summarize a subnet's missing-kind count for the coverage matrix. Below `lg`
+ * the matrix's kind columns (the real gaps) scroll off-screen, so the sticky
+ * first column shows this instead — a mobile reader can tell a subnet has gaps
+ * without blindly scrolling (#5310). Kept pure so the count/label mapping is
+ * unit-tested apart from the DOM.
+ */
+export function coverageMissingSummary(missingCount: number): CoverageMissingSummary {
+  const n = Number.isFinite(missingCount) ? Math.max(0, Math.floor(missingCount)) : 0;
+  return n === 0
+    ? { label: "all present", complete: true }
+    : { label: `${n} missing`, complete: false };
+}


### PR DESCRIPTION
## Summary

Closes #5310

On /gaps the coverage matrix lays its 9 kind columns out in an `overflow-x-auto` grid. Below the desktop breakpoint only the first few columns fit, and they all read **present** — while the columns that are the point of the widget (the real gaps: dashboard/data/sdk/example/rpc) scroll off-screen. A mobile reader sees what looks like full coverage when it isn't.

This surfaces each subnet's missing-kind count in the **sticky first column** — `5 missing` (tinted red) or `all present` (tinted green) — shown only below `lg`, where the kind cells aren't all on screen. A mobile reader can now tell at a glance whether a subnet has gaps without blindly scrolling. Desktop is unchanged (the full matrix already fits).

The count/label mapping is a pure, unit-tested `coverageMissingSummary` helper (`coverage-summary.ts`).

## Gates

typecheck OK - unit tests OK (`coverage-summary.test.ts`, 3 new) - eslint `.` OK (0 errors) - prettier OK

## Screenshots

Captured with Playwright at the three SKILL viewports (375x812 / 768x1024 / 1280x800), each theme forced via `mg-theme`, fixed-viewport, on /gaps against the live dev server. Below `lg`, the after adds the per-subnet missing count in the sticky first column; desktop is unchanged.

| Viewport - Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5310/after-mobile-dark.png)<br><sub>after</sub> |
