### PR TITLE
feat(ui): risk-disclosure and yield-window copy for validator APY surfaces

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validator-apy-panel.tsx
@@ -74,7 +74,11 @@ export function ValidatorApyPanel({
           exist for this validator.
         </p>
       ) : null}
-      <MethodologyCallout generatedAt={generatedAt ?? undefined} windowLabel="history windows" />
+      <MethodologyCallout
+        generatedAt={generatedAt ?? undefined}
+        windowLabel="history windows"
+        stakeRisk
+      />
       <p className="text-[11px] leading-relaxed text-ink-muted">
         Delegator APY annualizes the latest daily rewards-per-1k-τ rate from neuron_daily, net of
         validator take. Snapshot-tier emission can lag; server-side modelling (#2551) will replace

--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -31,7 +31,7 @@ const METRICS: Array<{ term: string; def: string }> = [
   },
   {
     term: "Est. APY",
-    def: "Annualized delegator yield estimated from emission÷stake, net of take. On the directory this uses the latest metagraph snapshot; on a validator detail page, 7d/30d/90d windows use daily neuron_daily history. Server-side modelling (#2551) will supersede these client estimates.",
+    def: "Annualized delegator yield estimated from emission÷stake, net of take — the latest captured rate scaled to a year, not a forecast of future returns. On the directory this uses the latest metagraph snapshot; on a validator detail page, 7d/30d/90d windows use daily neuron_daily history. Root stake (netuid 0) is TAO-denominated with no principal risk; alpha stake is price-exposed, so a positive nominal APY here can still net-lose TAO if the alpha token's price falls faster than the yield accrues. Server-side modelling (#2551) will supersede these client estimates.",
   },
   {
     term: "Nominators",
@@ -48,10 +48,6 @@ const METRICS: Array<{ term: string; def: string }> = [
   {
     term: "Total emission",
     def: "The TAO the validator earned over the window. Emission is split between the validator and its nominators via commission — it reflects reward flow, not profit.",
-  },
-  {
-    term: "Est. APY",
-    def: "An estimated annualized yield (#2551): projects the validator's most recently captured epoch payout across a full year, using each subnet's own epoch length. It's a snapshot-based estimate, not a forecast or a guarantee — it can swing between refreshes, especially for validators concentrated on short-epoch subnets. A dash means none of the validator's subnets have a captured epoch length yet.",
   },
   {
     term: "Validator trust (Sort)",

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -305,7 +305,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           icon={Zap}
           eyebrow="Est. APY"
           value={formatApyPct(snapshotApy)}
-          hint="snapshot · net of take"
+          hint="latest snapshot · net of take"
           truncate={false}
           className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
         />

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2968,7 +2968,8 @@ function PrimaryLinksRail({
 }
 function MethodologyCallout({
   generatedAt,
-  windowLabel
+  windowLabel,
+  stakeRisk
 }) {
   const [open, setOpen] = React3.useState(false);
   const freshLine = formatFreshness(generatedAt, windowLabel);
@@ -3035,7 +3036,11 @@ function MethodologyCallout({
           /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
             /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Verified vs. candidate" }),
             /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1", children: "Only curated surfaces feed donuts and the topology breakdown. Unverified leads live in the Candidates tab and never count toward health, completeness, or pool ratios." })
-          ] })
+          ] }),
+          stakeRisk ? /* @__PURE__ */ jsxRuntime.jsxs("div", { children: [
+            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Root vs. alpha risk" }),
+            /* @__PURE__ */ jsxRuntime.jsx("p", { className: "mt-1", children: "Root stake (netuid 0) is TAO-denominated with no principal risk \u2014 what you stake is what you can unstake. Alpha stake is price-exposed: it's held in the subnet's own token, so a positive nominal APY can still net-lose TAO if the alpha price falls faster than the yield accrues." })
+          ] }) : null
         ] }) : null
       ]
     }

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2939,7 +2939,8 @@ function PrimaryLinksRail({
 }
 function MethodologyCallout({
   generatedAt,
-  windowLabel
+  windowLabel,
+  stakeRisk
 }) {
   const [open, setOpen] = useState(false);
   const freshLine = formatFreshness(generatedAt, windowLabel);
@@ -3006,7 +3007,11 @@ function MethodologyCallout({
           /* @__PURE__ */ jsxs("div", { children: [
             /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Verified vs. candidate" }),
             /* @__PURE__ */ jsx("p", { className: "mt-1", children: "Only curated surfaces feed donuts and the topology breakdown. Unverified leads live in the Candidates tab and never count toward health, completeness, or pool ratios." })
-          ] })
+          ] }),
+          stakeRisk ? /* @__PURE__ */ jsxs("div", { children: [
+            /* @__PURE__ */ jsx("div", { className: "font-mono text-[10px] uppercase tracking-widest text-ink-strong", children: "Root vs. alpha risk" }),
+            /* @__PURE__ */ jsx("p", { className: "mt-1", children: "Root stake (netuid 0) is TAO-denominated with no principal risk \u2014 what you stake is what you can unstake. Alpha stake is price-exposed: it's held in the subnet's own token, so a positive nominal APY can still net-lose TAO if the alpha price falls faster than the yield accrues." })
+          ] }) : null
         ] }) : null
       ]
     }

--- a/packages/ui-kit/src/components/metagraphed/methodology-callout.tsx
+++ b/packages/ui-kit/src/components/metagraphed/methodology-callout.tsx
@@ -15,9 +15,12 @@ import {
 export function MethodologyCallout({
   generatedAt,
   windowLabel,
+  stakeRisk,
 }: {
   generatedAt?: string;
   windowLabel?: string;
+  /** Adds the root-vs-alpha risk section — pass on any panel that surfaces a yield/APY figure. */
+  stakeRisk?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const freshLine = formatFreshness(generatedAt, windowLabel);
@@ -101,6 +104,20 @@ export function MethodologyCallout({
               health, completeness, or pool ratios.
             </p>
           </div>
+          {stakeRisk ? (
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
+                Root vs. alpha risk
+              </div>
+              <p className="mt-1">
+                Root stake (netuid 0) is TAO-denominated with no principal risk
+                — what you stake is what you can unstake. Alpha stake is
+                price-exposed: it's held in the subnet's own token, so a
+                positive nominal APY can still net-lose TAO if the alpha price
+                falls faster than the yield accrues.
+              </p>
+            </div>
+          ) : null}
         </div>
       ) : null}
     </aside>


### PR DESCRIPTION
Part of #5229. Runs the non-advisory risk-framing pass across the validator directory and detail page's yield surfaces, reusing the existing `MethodologyCallout` component rather than building a new one.

## What changed

- `MethodologyCallout` (`packages/ui-kit`) gains an optional `stakeRisk` section — root stake (netuid 0) is TAO-denominated with no principal risk, alpha stake is price-exposed and can net-lose TAO despite a positive nominal APY. `ValidatorApyPanel` passes `stakeRisk` so this shows adjacent to every APY figure on a validator's detail page.
- The validator directory's "How to evaluate a validator" guide had two conflicting `Est. APY` glossary entries — an older one (from before the emission÷stake methodology landed) still described the estimate as "projects the validator's most recently captured epoch payout across a full year," i.e. framed as a projection. Removed the stale duplicate and folded the root/alpha risk copy and "not a forecast of future returns" framing into the surviving entry.
- The validator detail page's summary APY tile said only "snapshot · net of take," which reads as an unlabeled window. Changed to "latest snapshot · net of take" for clarity — the 7d/30d/90d panel below it was already explicitly windowed.

## Deliverables (from the issue)

- [x] Root = "no principal risk, TAO-denominated" vs. alpha = "price-exposed, can net-lose TAO despite positive nominal APY" copy, adjacent to every APY figure.
- [x] Every yield figure is labeled with its window (7d/30d/90d panel headers were already explicit; the snapshot tile and directory glossary now say so too) and none are framed as a projection/forecast.
- [x] Reused `methodology-callout.tsx` — no new component.

## Screenshots

3 viewports × 2 themes × before/after, captured against the two changed routes (`/validators/:hotkey` and `/validators`).

### Validator detail — summary stat tile (`hint` copy)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-stat-tile-mobile-dark-after.png)<br><sub>after</sub> |

### Validator detail — APY panel methodology callout, expanded (new "Root vs. alpha risk" section)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validator-apy-mobile-dark-after.png)<br><sub>after</sub> |

### Validator directory guide, expanded (`Est. APY` entry, deduped + reworded)

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5247-validators-guide-mobile-dark-after.png)<br><sub>after</sub> |

## Test plan

- `npm run typecheck`, `npm run lint`, `npm test` green in both `apps/ui` and `packages/ui-kit` (753 + 57 tests passing).
- Manually verified both changed routes in a local dev server against the screenshots above, both themes, all three breakpoints.

Closes #5247
