### PR TITLE
chore(postgres): add retention/prune policy for rpc_proxy_events

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -869,8 +869,20 @@ export async function rollupDailyUptime(env, overrides = {}) {
 export async function pruneHealthHistory(env, overrides = {}) {
   const now = overrides.now || (() => Date.now());
   const db = overrides.db || env.METAGRAPH_HEALTH_DB;
-  if (!db?.prepare) return { pruned: false };
   const cutoff = now() - (overrides.retentionMs || HISTORY_RETENTION_MS);
+  const result = await pruneD1HealthHistory(db, cutoff);
+  // #5497 gap-closure: the Postgres mirror of rpc_proxy_events (#4832) has no
+  // equivalent retention -- best-effort and independent of the D1 outcome
+  // above (unconditional, not nested inside the try/catch below), same
+  // "each store's prune is its own best-effort" shape as rollupDailyUptime's
+  // Postgres mirror further down, whose own tests assert the Postgres sync
+  // still fires even when the D1 side threw.
+  await syncRpcProxyEventsPruneToPostgres(env, cutoff);
+  return result;
+}
+
+async function pruneD1HealthHistory(db, cutoff) {
+  if (!db?.prepare) return { pruned: false };
   try {
     const result = await db
       .prepare(`DELETE FROM surface_checks WHERE checked_at < ?`)
@@ -890,6 +902,35 @@ export async function pruneHealthHistory(env, overrides = {}) {
     return { pruned: true, cutoff, changes: result?.meta?.changes ?? null };
   } catch {
     return { pruned: false };
+  }
+}
+
+// #5497: mirrors pruneHealthHistory's D1 rpc_proxy_events delete into the
+// Postgres copy (#4832's read-resilience gap-closure), via the DATA_API
+// service binding -- same shape as syncSubnetSnapshotToPostgres below.
+// Best-effort: never throws, and a failure here must never block the D1
+// prune above (the primary contract).
+export async function syncRpcProxyEventsPruneToPostgres(env, cutoff) {
+  if (!env?.DATA_API || !env?.RPC_USAGE_SYNC_SECRET) {
+    return { synced: false, reason: "unavailable" };
+  }
+  try {
+    const upstream = await env.DATA_API.fetch(
+      new Request("https://api.metagraph.sh/api/v1/internal/rpc-usage-prune", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-rpc-usage-sync-token": env.RPC_USAGE_SYNC_SECRET,
+        },
+        body: JSON.stringify({ cutoff }),
+      }),
+    );
+    if (!upstream.ok) {
+      return { synced: false, reason: `status_${upstream.status}` };
+    }
+    return { synced: true };
+  } catch {
+    return { synced: false, reason: "fetch_failed" };
   }
 }
 

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -81,6 +81,12 @@ const healthChecksSyncFailure = vi.hoisted(() => ({ error: null }));
 const healthUptimeRollupSyncFailure = vi.hoisted(() => ({ error: null }));
 const subnetSnapshotSyncFailure = vi.hoisted(() => ({ error: null }));
 const rpcUsageSyncFailure = vi.hoisted(() => ({ error: null }));
+// State for the rpc-usage-prune write route's tests only (#5497
+// gap-closure) -- a failure hook mirroring rpcUsageSyncFailure above, plus
+// a controllable row count since this route's DELETE has no RETURNING
+// clause (a plain array's mockRows.current wouldn't simulate `.count`).
+const rpcUsagePruneFailure = vi.hoisted(() => ({ error: null }));
+const rpcUsagePruneCount = vi.hoisted(() => ({ current: 0 }));
 // State for the featured_validators read (#5166) tests only -- lets a test
 // simulate the table not existing yet (pre-migration) without touching any
 // other query's mock plumbing.
@@ -209,6 +215,12 @@ vi.mock("postgres", () => ({
         return Promise.reject(rpcUsageSyncFailure.error);
       }
       if (
+        rpcUsagePruneFailure.error &&
+        /DELETE FROM rpc_proxy_events\b/.test(text)
+      ) {
+        return Promise.reject(rpcUsagePruneFailure.error);
+      }
+      if (
         subnetIdentitySyncFailure.error &&
         /INSERT INTO subnet_identity_history\b/.test(text)
       ) {
@@ -246,6 +258,9 @@ vi.mock("postgres", () => ({
       }
       if (/DELETE FROM neurons/.test(text)) {
         return Promise.resolve(neuronsSyncPruneRows.current);
+      }
+      if (/DELETE FROM rpc_proxy_events\b/.test(text)) {
+        return Promise.resolve({ count: rpcUsagePruneCount.current });
       }
       if (/SELECT DISTINCT ON \(netuid\) netuid, hyperparams_hash/.test(text)) {
         return Promise.resolve(subnetHyperparamsLatestHashes.current);
@@ -377,6 +392,8 @@ beforeEach(() => {
   subnetSnapshotSyncFailure.error = null;
   healthUptimeRollupSyncFailure.error = null;
   rpcUsageSyncFailure.error = null;
+  rpcUsagePruneFailure.error = null;
+  rpcUsagePruneCount.current = 0;
   featuredValidatorsQueryFailure.error = null;
   accountIdentityJoinRows.current = [];
   accountIdentityJoinQueryFailure.error = null;
@@ -6763,5 +6780,107 @@ test("rpc-usage-sync maps a DB failure to a clean 502 instead of throwing", asyn
   const res = await postRpcUsageEvent(rpcUsageEvent(), {
     secret: RPC_USAGE_SYNC_SECRET,
   });
+  expect(res.status).toBe(502);
+});
+
+function postRpcUsagePrune(body, { secret, raw } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret !== undefined) headers["x-rpc-usage-sync-token"] = secret;
+  return req("/api/v1/internal/rpc-usage-prune", {
+    method: "POST",
+    headers,
+    body:
+      raw !== undefined
+        ? raw
+        : JSON.stringify(body ?? { cutoff: 1_718_000_000_000 }),
+  });
+}
+
+test("rpc-usage-prune rejects a missing or wrong token (401)", async () => {
+  const wrong = await postRpcUsagePrune(undefined, { secret: "wrong" });
+  expect(wrong.status).toBe(401);
+  const missing = await postRpcUsagePrune();
+  expect(missing.status).toBe(401);
+});
+
+test("rpc-usage-prune is disabled (503) when RPC_USAGE_SYNC_SECRET is not configured", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/rpc-usage-prune", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-rpc-usage-sync-token": RPC_USAGE_SYNC_SECRET,
+      },
+      body: JSON.stringify({ cutoff: 1_718_000_000_000 }),
+    }),
+    { HYPERDRIVE: { connectionString: "postgres://mock" } },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("rpc-usage-prune returns 503 when the HYPERDRIVE binding is unavailable", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/rpc-usage-prune", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-rpc-usage-sync-token": RPC_USAGE_SYNC_SECRET,
+      },
+      body: JSON.stringify({ cutoff: 1_718_000_000_000 }),
+    }),
+    { RPC_USAGE_SYNC_SECRET },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("rpc-usage-prune rejects malformed JSON (400)", async () => {
+  const res = await postRpcUsagePrune(null, {
+    secret: RPC_USAGE_SYNC_SECRET,
+    raw: "{not json",
+  });
+  expect(res.status).toBe(400);
+});
+
+test("rpc-usage-prune rejects a body missing a finite cutoff (400)", async () => {
+  const missing = await postRpcUsagePrune(
+    {},
+    { secret: RPC_USAGE_SYNC_SECRET },
+  );
+  expect(missing.status).toBe(400);
+  const nonNumeric = await postRpcUsagePrune(
+    { cutoff: "not-a-number" },
+    { secret: RPC_USAGE_SYNC_SECRET },
+  );
+  expect(nonNumeric.status).toBe(400);
+  const array = await postRpcUsagePrune([1_718_000_000_000], {
+    secret: RPC_USAGE_SYNC_SECRET,
+  });
+  expect(array.status).toBe(400);
+});
+
+test("rpc-usage-prune deletes rows older than cutoff and reports rows_deleted", async () => {
+  rpcUsagePruneCount.current = 5;
+  const res = await postRpcUsagePrune(
+    { cutoff: 1_718_000_000_000 },
+    { secret: RPC_USAGE_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, rows_deleted: 5 });
+  expect(queryText()).toMatch(
+    /DELETE FROM rpc_proxy_events WHERE observed_at < /,
+  );
+  const call = sqlCalls.at(-1);
+  expect(call.values).toEqual([1_718_000_000_000]);
+});
+
+test("rpc-usage-prune maps a DB failure to a clean 502 instead of throwing", async () => {
+  rpcUsagePruneFailure.error = new Error("connection reset");
+  const res = await postRpcUsagePrune(
+    { cutoff: 1_718_000_000_000 },
+    { secret: RPC_USAGE_SYNC_SECRET },
+  );
   expect(res.status).toBe(502);
 });

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -13,6 +13,7 @@ import {
   runHealthProber,
   syncHealthChecksToPostgres,
   syncHealthUptimeRollupToPostgres,
+  syncRpcProxyEventsPruneToPostgres,
   workerResolvedUrlSafetyGuard,
   workerWebSocketConnector,
 } from "../src/health-prober.mjs";
@@ -1917,6 +1918,139 @@ describe("pruneHealthHistory edge paths", () => {
     const result = await pruneHealthHistory({}, { now: () => 0, db });
     assert.equal(result.pruned, true);
     assert.equal(result.changes, null);
+  });
+});
+
+describe("syncRpcProxyEventsPruneToPostgres", () => {
+  test("returns unavailable when DATA_API is not bound", async () => {
+    assert.deepEqual(await syncRpcProxyEventsPruneToPostgres({}, 1), {
+      synced: false,
+      reason: "unavailable",
+    });
+  });
+
+  test("returns unavailable when RPC_USAGE_SYNC_SECRET is not configured", async () => {
+    const env = { DATA_API: { fetch: async () => new Response("{}") } };
+    assert.deepEqual(await syncRpcProxyEventsPruneToPostgres(env, 1), {
+      synced: false,
+      reason: "unavailable",
+    });
+  });
+
+  test("reports the upstream status when the DATA_API response isn't ok", async () => {
+    const env = {
+      DATA_API: { fetch: async () => new Response("nope", { status: 502 }) },
+      RPC_USAGE_SYNC_SECRET: "test-secret",
+    };
+    assert.deepEqual(await syncRpcProxyEventsPruneToPostgres(env, 1), {
+      synced: false,
+      reason: "status_502",
+    });
+  });
+
+  test("returns fetch_failed when DATA_API.fetch throws", async () => {
+    const env = {
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+      RPC_USAGE_SYNC_SECRET: "test-secret",
+    };
+    assert.deepEqual(await syncRpcProxyEventsPruneToPostgres(env, 1), {
+      synced: false,
+      reason: "fetch_failed",
+    });
+  });
+
+  test("posts the cutoff to rpc-usage-prune with the token header on success", async () => {
+    let request;
+    const env = {
+      DATA_API: {
+        fetch: async (req) => {
+          request = req;
+          return new Response("{}", { status: 200 });
+        },
+      },
+      RPC_USAGE_SYNC_SECRET: "test-secret",
+    };
+    const result = await syncRpcProxyEventsPruneToPostgres(env, 12_345);
+    assert.deepEqual(result, { synced: true });
+    assert.ok(request);
+    assert.equal(request.method, "POST");
+    assert.equal(
+      request.url,
+      "https://api.metagraph.sh/api/v1/internal/rpc-usage-prune",
+    );
+    assert.equal(request.headers.get("x-rpc-usage-sync-token"), "test-secret");
+    const body = await request.json();
+    assert.equal(body.cutoff, 12_345);
+  });
+});
+
+describe("syncRpcProxyEventsPruneToPostgres via pruneHealthHistory", () => {
+  test("no-ops (no DATA_API call) when DATA_API is not bound", async () => {
+    const result = await pruneHealthHistory(
+      { METAGRAPH_HEALTH_DB: makeDb() },
+      { now: () => 5_000 },
+    );
+    assert.equal(result.pruned, true);
+  });
+
+  test("posts the cutoff to rpc-usage-prune with the token header", async () => {
+    let request;
+    const env = {
+      METAGRAPH_HEALTH_DB: makeDb(),
+      DATA_API: {
+        fetch: async (req) => {
+          request = req;
+          return new Response("{}", { status: 200 });
+        },
+      },
+      RPC_USAGE_SYNC_SECRET: "test-secret",
+    };
+    const result = await pruneHealthHistory(env, {
+      now: () => 100_000_000,
+      retentionMs: 1000,
+    });
+    assert.equal(result.pruned, true);
+    assert.ok(request);
+    assert.equal(request.headers.get("x-rpc-usage-sync-token"), "test-secret");
+    const body = await request.json();
+    assert.equal(body.cutoff, 100_000_000 - 1000);
+  });
+
+  test("a DATA_API failure never affects pruneHealthHistory's own result", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: makeDb(),
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+      RPC_USAGE_SYNC_SECRET: "test-secret",
+    };
+    const result = await pruneHealthHistory(env, { now: () => 5_000 });
+    assert.equal(result.pruned, true);
+  });
+
+  test("still attempts the Postgres prune when D1's own prune fails", async () => {
+    let called = false;
+    const db = {
+      prepare() {
+        throw new Error("d1 unavailable");
+      },
+    };
+    const env = {
+      METAGRAPH_HEALTH_DB: db,
+      DATA_API: {
+        fetch: async () => ((called = true), new Response("{}")),
+      },
+      RPC_USAGE_SYNC_SECRET: "test-secret",
+    };
+    const result = await pruneHealthHistory(env, { now: () => 5_000 });
+    assert.equal(result.pruned, false);
+    assert.equal(called, true);
   });
 });
 

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2605,6 +2605,59 @@ async function handleRpcUsageEventSync(request, env) {
   }
 }
 
+// --- POST /api/v1/internal/rpc-usage-prune (#5497 gap-closure) -----------
+//
+// The Postgres mirror of rpc_proxy_events written by handleRpcUsageEventSync
+// above has no retention of its own (D1's copy is pruned to a 30-day hot
+// window on the hourly maintenance cron; Postgres just grew unbounded).
+// Called from src/health-prober.mjs's pruneHealthHistory
+// (syncRpcProxyEventsPruneToPostgres), on the same cron, right after the D1
+// prune -- reuses the rpc-usage-sync token/secret (same trust boundary: both
+// routes write to the same table, no reason for a second secret).
+async function handleRpcUsageEventPrune(request, env) {
+  if (!env.RPC_USAGE_SYNC_SECRET) {
+    return writeJson(
+      { error: "rpc-usage sync is not provisioned on this deployment" },
+      503,
+    );
+  }
+  const provided = request.headers.get(RPC_USAGE_SYNC_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, env.RPC_USAGE_SYNC_SECRET)) {
+    return writeJson(
+      { error: `provide a valid ${RPC_USAGE_SYNC_TOKEN_HEADER} header` },
+      401,
+    );
+  }
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
+  }
+
+  let body;
+  try {
+    body = JSON.parse(await request.text());
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  if (!body || typeof body !== "object" || !Number.isFinite(body.cutoff)) {
+    return writeJson({ error: "cutoff must be a finite number" }, 400);
+  }
+
+  const sql = postgres(env.HYPERDRIVE.connectionString, {
+    max: 5,
+    prepare: false,
+    fetch_types: false,
+  });
+
+  try {
+    const result = await sql`
+      DELETE FROM rpc_proxy_events WHERE observed_at < ${body.cutoff}`;
+    return writeJson({ ok: true, rows_deleted: result.count });
+  } catch (err) {
+    console.error("data-api rpc-usage-prune write failed:", err);
+    return writeJson({ error: "write failed" }, 502);
+  }
+}
+
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
     status,
@@ -3333,6 +3386,12 @@ export default {
       url.pathname === "/api/v1/internal/rpc-usage-sync"
     ) {
       return handleRpcUsageEventSync(request, env);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/rpc-usage-prune"
+    ) {
+      return handleRpcUsageEventPrune(request, env);
     }
     // #4984 Part 1: multi-method (POST/GET/PATCH/DELETE), so it can't join
     // the exact-path-and-method checks above -- handleAlertTriggersRoute


### PR DESCRIPTION
## Summary
- `rpc_proxy_events` has never had a retention/prune policy on the Postgres mirror, so it grows unbounded (#5497)
- Extend `pruneHealthHistory`'s existing D1-prune + best-effort-Postgres-sync pattern: the D1 deletes are refactored into `pruneD1HealthHistory`, and the new `syncRpcProxyEventsPruneToPostgres` call runs unconditionally alongside it — independent of D1's own success/failure, matching the established `rollupDailyUptime` best-effort mirror pattern (D1 is primary/authoritative, Postgres is a read-resilience mirror per #4832)
- Add the internal `POST /api/v1/internal/rpc-usage-prune` route on the data-api worker: validates the shared sync secret/token, deletes rows by `cutoff`, and reports `rows_deleted`

## Test plan
- [x] New unit tests for `syncRpcProxyEventsPruneToPostgres` (standalone + integration via `pruneHealthHistory`), including the critical case that the Postgres prune still fires when D1's own prune fails
- [x] New tests for the `rpc-usage-prune` route: auth (401), config guards (503), malformed/invalid body (400), success (200 + `rows_deleted`), DB failure (502)
- [x] `npx vitest run tests/health-prober.test.mjs tests/data-api.test.mjs` — 551/551 passed
- [x] Full `npm run test:coverage` — 8218/8218 passed, coverage floors intact
- [x] `npm run lint` / `npx prettier --check` clean
- [x] `npm run validate` clean (after a fresh `npm run build`)

Closes #5497