### PR TITLE
feat(ui): pre-sign confirmation screen

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@jsonbored/metagraphed": "*",
     "@jsonbored/ui-kit": "*",
+    "@polkadot/api": "^16.5.6",
     "@polkadot/extension-dapp": "^0.63.1",
     "@sentry/browser": "^10.60.0",
     "@tailwindcss/vite": "^4.2.1",

--- a/apps/ui/src/components/metagraphed/pre-sign-confirmation.tsx
+++ b/apps/ui/src/components/metagraphed/pre-sign-confirmation.tsx
@@ -1,0 +1,170 @@
+import { ArrowRight, Loader2, ShieldCheck } from "lucide-react";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { classNames } from "@/lib/metagraphed/format";
+
+// The primary blind-signing mitigation (#5239, native-staking epic #5229).
+// Subtensor isn't a top-tier chain in wallet metadata registries, so a user
+// likely sees a raw/generic extension prompt for add_stake_limit etc, not a
+// friendly one -- this screen is the real, human-readable checkpoint, shown
+// BEFORE handoff to the extension. Purely presentational: every value is a
+// prop, not fetched here -- data wiring (identity join, stake-quote, fee
+// dry-run via lib/metagraphed/tx-fee.ts) is the caller's job, keeping this
+// component trivial to test and reuse regardless of which flow drives it.
+
+export type StakeAction = "stake" | "unstake" | "move";
+
+const ACTION_COPY: Record<StakeAction, { verb: string; noun: string }> = {
+  stake: { verb: "Stake", noun: "staking" },
+  unstake: { verb: "Unstake", noun: "unstaking" },
+  move: { verb: "Move stake", noun: "moving stake" },
+};
+
+export interface PreSignConfirmationProps {
+  action: StakeAction;
+  /** Display amount in TAO, e.g. "10.5". */
+  amountTao: string;
+  /** Display amount in alpha -- present for unstake/move, where the on-chain amount is alpha-denominated. */
+  amountAlpha?: string;
+  hotkey: string;
+  /** From the identity join (#5234) -- falls back to the truncated hotkey when no identity is known. */
+  validatorName?: string;
+  netuid: number;
+  subnetName?: string;
+  /** Display fee in TAO, from lib/metagraphed/tx-fee.ts's estimateFee(). Null while the dry-run is still loading. */
+  feeTao: string | null;
+  /** From the stake-quote endpoint (#5235) -- the estimated result of this exact amount. */
+  expectedOut?: { amount: string; unit: "tao" | "alpha" };
+  priceImpactPct?: number;
+  /** The slippage tolerance this transaction's limit_price was computed with (ADR 0018 §3, default 5%). */
+  tolerancePct: number;
+  confirming: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function PreSignConfirmation({
+  action,
+  amountTao,
+  amountAlpha,
+  hotkey,
+  validatorName,
+  netuid,
+  subnetName,
+  feeTao,
+  expectedOut,
+  priceImpactPct,
+  tolerancePct,
+  confirming,
+  onConfirm,
+  onCancel,
+}: PreSignConfirmationProps) {
+  const copy = ACTION_COPY[action];
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <div className="mg-label mb-1">{copy.verb}</div>
+        <div className="font-display text-lg font-medium text-ink-strong">
+          {amountTao} τ
+          {amountAlpha ? (
+            <span className="ml-1.5 text-sm font-normal text-ink-muted">
+              ({amountAlpha} α on subnet {netuid})
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <SummaryRow
+        label="Validator"
+        value={validatorName ?? shortHash(hotkey, 6) ?? hotkey}
+        detail={validatorName ? shortHash(hotkey, 6) : undefined}
+      />
+      <SummaryRow
+        label="Subnet"
+        value={subnetName ? `${subnetName} (SN${netuid})` : `SN${netuid}`}
+      />
+      <SummaryRow
+        label="Network fee"
+        value={feeTao === null ? "Estimating…" : `${feeTao} τ`}
+        loading={feeTao === null}
+      />
+      {expectedOut ? (
+        <SummaryRow
+          label="Expected outcome"
+          value={`${expectedOut.amount} ${expectedOut.unit === "tao" ? "τ" : "α"}`}
+          detail={
+            priceImpactPct !== undefined
+              ? `${priceImpactPct.toFixed(2)}% price impact · protected to ±${tolerancePct}%`
+              : `protected to ±${tolerancePct}%`
+          }
+        />
+      ) : null}
+
+      <div className="flex items-start gap-1.5 rounded border border-border bg-surface/40 px-2.5 py-2 text-[11px] text-ink-muted">
+        <ShieldCheck className="mt-0.5 size-3.5 shrink-0 text-ink-muted" aria-hidden="true" />
+        <span>
+          metagraphed builds this transaction for your wallet to sign — we never see your keys and
+          cannot move funds without your extension&rsquo;s approval.
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={confirming}
+          className="flex-1 rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-60"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={confirming || feeTao === null}
+          className="flex-1 inline-flex items-center justify-center gap-1.5 rounded border border-ink-strong/40 bg-surface px-3 py-2 text-[12px] font-medium text-ink-strong hover:border-ink-strong/60 transition-colors disabled:opacity-60"
+        >
+          {confirming ? (
+            <>
+              <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+              Awaiting signature…
+            </>
+          ) : (
+            <>
+              {copy.verb}
+              <ArrowRight className="size-3.5" aria-hidden="true" />
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SummaryRow({
+  label,
+  value,
+  detail,
+  loading,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+  loading?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-border/60 py-1.5 last:border-b-0">
+      <span className="text-[11px] text-ink-muted">{label}</span>
+      <span className="text-right">
+        <span
+          className={classNames(
+            "block text-[12px] font-medium text-ink-strong",
+            loading && "animate-pulse text-ink-muted",
+          )}
+        >
+          {value}
+        </span>
+        {detail ? <span className="block text-[10px] text-ink-muted">{detail}</span> : null}
+      </span>
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/use-tx-status.test.ts
+++ b/apps/ui/src/hooks/use-tx-status.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { parseSubmitError } from "./use-tx-status";
+
+describe("parseSubmitError", () => {
+  it("extracts a Custom(N) tx-pool code from a polkadot.js-shaped rejection message", () => {
+    const decoded = parseSubmitError(new Error("1010: Invalid Transaction: Custom error: 8"));
+    expect(decoded.category).toBe("insufficient_liquidity");
+    expect(decoded.source).toBe("Custom(8:SlippageTooHigh)");
+  });
+
+  it("matches the code regardless of surrounding message text", () => {
+    const decoded = parseSubmitError(new Error("Custom error: 25"));
+    expect(decoded.source).toBe("Custom(25:NonAssociatedColdKey)");
+  });
+
+  it("falls back to a generic decode for a message with no Custom error code", () => {
+    const decoded = parseSubmitError(new Error("User rejected the request"));
+    expect(decoded.category).toBe("unknown");
+    expect(decoded.message).toBe("User rejected the request");
+  });
+
+  it("falls back to a generic decode for a non-Error thrown value, without throwing itself", () => {
+    expect(() => parseSubmitError("some string")).not.toThrow();
+    expect(() => parseSubmitError(undefined)).not.toThrow();
+    expect(() => parseSubmitError({ weird: "object" })).not.toThrow();
+  });
+
+  it("never returns an empty message", () => {
+    expect(parseSubmitError(new Error("")).message.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/ui/src/hooks/use-tx-status.ts
+++ b/apps/ui/src/hooks/use-tx-status.ts
@@ -1,0 +1,121 @@
+import { useCallback, useRef, useState } from "react";
+import type { ApiPromise } from "@polkadot/api";
+import type { SubmittableExtrinsic } from "@polkadot/api/types";
+import type { Signer } from "@polkadot/api/types";
+import {
+  submitStakeExtrinsic,
+  type BroadcastEvent,
+  type BroadcastStatus,
+} from "@/lib/metagraphed/broadcast";
+import {
+  decodeModuleError,
+  decodeCustomTxError,
+  type DecodedTxError,
+} from "@/lib/metagraphed/tx-errors";
+
+/**
+ * UI-facing transaction status (#5240), layering on top of broadcast.ts's raw
+ * BroadcastStatus: `"failed"` is a status broadcast.ts doesn't have on its
+ * own -- an extrinsic that reaches in-block/finalized carrying a
+ * dispatchError is still, from the CHAIN's perspective, a successful
+ * transaction (mined, fee paid) -- but from the USER's perspective, their
+ * stake/unstake/move did not happen, which is what this status communicates.
+ */
+export type TxUiStatus = "idle" | "signing" | BroadcastStatus | "failed" | "submit-error";
+
+export interface UseTxStatusResult {
+  status: TxUiStatus;
+  txHash: string | null;
+  blockHash: string | null;
+  /** Set only when status is "failed" (on-chain module error) or "submit-error" (rejected before/without reaching a block, e.g. a Custom(N) tx-pool code or the extension declining to sign). */
+  error: DecodedTxError | null;
+  submit: (
+    api: ApiPromise,
+    extrinsic: SubmittableExtrinsic<"promise">,
+    options: { signerAddress: string; signer: Signer; idempotencyKey: string },
+  ) => Promise<void>;
+  reset: () => void;
+}
+
+/**
+ * A Custom(N) tx-pool rejection surfaces as a thrown JS Error, not a status
+ * callback -- signAndSend's promise itself rejects. polkadot.js's RPC layer
+ * formats this as a message containing "Custom error: N" (best-effort parse,
+ * not verified against a live rejection -- no way to trigger a real one
+ * without actually submitting to a live chain; falls back to a generic
+ * decode if the shape doesn't match, never throws itself).
+ */
+export function parseSubmitError(error: unknown): DecodedTxError {
+  const message = error instanceof Error ? error.message : String(error);
+  const match = /Custom error:\s*(\d+)/i.exec(message);
+  if (match) {
+    return decodeCustomTxError(Number(match[1]));
+  }
+  return {
+    category: "unknown",
+    message: message || "Failed to submit the transaction.",
+    source: "submit",
+  };
+}
+
+export function useTxStatus(): UseTxStatusResult {
+  const [status, setStatus] = useState<TxUiStatus>("idle");
+  const [txHash, setTxHash] = useState<string | null>(null);
+  const [blockHash, setBlockHash] = useState<string | null>(null);
+  const [error, setError] = useState<DecodedTxError | null>(null);
+  const unsubscribeRef = useRef<(() => void) | null>(null);
+
+  const reset = useCallback(() => {
+    unsubscribeRef.current?.();
+    unsubscribeRef.current = null;
+    setStatus("idle");
+    setTxHash(null);
+    setBlockHash(null);
+    setError(null);
+  }, []);
+
+  const submit = useCallback(
+    async (
+      api: ApiPromise,
+      extrinsic: SubmittableExtrinsic<"promise">,
+      options: { signerAddress: string; signer: Signer; idempotencyKey: string },
+    ) => {
+      setStatus("signing");
+      setError(null);
+      try {
+        const { unsubscribe } = await submitStakeExtrinsic(api, extrinsic, {
+          ...options,
+          onStatus: (event: BroadcastEvent) => {
+            setTxHash(event.txHash);
+            if (event.blockHash) setBlockHash(event.blockHash);
+
+            if (event.dispatchError) {
+              const decoded = event.dispatchError.isModule
+                ? (() => {
+                    const meta = api.registry.findMetaError(event.dispatchError!.asModule);
+                    return decodeModuleError(meta.section, meta.name);
+                  })()
+                : {
+                    category: "unknown" as const,
+                    message: "Transaction failed on-chain.",
+                    source: "dispatchError",
+                  };
+              setError(decoded);
+              setStatus("failed");
+              return;
+            }
+
+            setStatus(event.status);
+          },
+        });
+        unsubscribeRef.current = unsubscribe;
+      } catch (err) {
+        setError(parseSubmitError(err));
+        setStatus("submit-error");
+      }
+    },
+    [],
+  );
+
+  return { status, txHash, blockHash, error, submit, reset };
+}

--- a/apps/ui/src/lib/metagraphed/broadcast.test.ts
+++ b/apps/ui/src/lib/metagraphed/broadcast.test.ts
@@ -67,21 +67,22 @@ describe("hasAlreadySubmitted", () => {
 });
 
 function makeFakeExtrinsic() {
-  const listeners: Array<(result: { status: unknown }) => void> = [];
+  const listeners: Array<(result: { status: unknown; dispatchError?: unknown }) => void> = [];
   let capturedOptions: unknown;
   const unsubscribe = vi.fn();
   const extrinsic = {
     hash: { toHex: () => "0xdeadbeef" },
     signAndSend: vi.fn(async (_address: string, options: unknown, cb: (r: unknown) => void) => {
       capturedOptions = options;
-      listeners.push(cb as (result: { status: unknown }) => void);
+      listeners.push(cb as (result: { status: unknown; dispatchError?: unknown }) => void);
       return unsubscribe;
     }),
   } as unknown as SubmittableExtrinsic<"promise">;
   return {
     extrinsic,
     unsubscribe,
-    emit: (status: unknown) => listeners.forEach((cb) => cb({ status })),
+    emit: (status: unknown, dispatchError?: unknown) =>
+      listeners.forEach((cb) => cb({ status, dispatchError })),
     getCapturedOptions: () => capturedOptions,
   };
 }
@@ -192,5 +193,28 @@ describe("submitStakeExtrinsic", () => {
     });
     expect(result.txHash).toBe("0xdeadbeef");
     expect(result.unsubscribe).toBe(unsubscribe);
+  });
+
+  it("passes the raw dispatchError through untouched -- decoding it is tx-errors.ts's job, not this module's", async () => {
+    const { extrinsic, emit } = makeFakeExtrinsic();
+    const key = computeIdempotencyKey(sampleParams, 6, "dispatch-error-passthrough-test");
+    const events: BroadcastEvent[] = [];
+    await submitStakeExtrinsic(fakeApi, extrinsic, {
+      signerAddress: HOTKEY,
+      signer: fakeSigner,
+      idempotencyKey: key,
+      onStatus: (e) => events.push(e),
+    });
+
+    const fakeDispatchError = { isModule: true, asModule: { toU8a: () => new Uint8Array() } };
+    emit(
+      makeStatus({ isInBlock: true, asInBlock: { toHex: () => "0xblock1" } }),
+      fakeDispatchError,
+    );
+    // A successful status update carries no dispatchError at all.
+    emit(makeStatus({ isFinalized: true, asFinalized: { toHex: () => "0xblock1" } }));
+
+    expect(events[0].dispatchError).toBe(fakeDispatchError);
+    expect(events[1].dispatchError).toBeUndefined();
   });
 });

--- a/apps/ui/src/lib/metagraphed/broadcast.test.ts
+++ b/apps/ui/src/lib/metagraphed/broadcast.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi } from "vitest";
+import { taoToRao } from "./units";
+import { buildAddStakeLimitParams } from "./stake-extrinsics";
+import {
+  computeIdempotencyKey,
+  hasAlreadySubmitted,
+  submitStakeExtrinsic,
+  DEFAULT_MORTALITY_BLOCKS,
+  type BroadcastEvent,
+} from "./broadcast";
+import type { ApiPromise } from "@polkadot/api";
+import type { SubmittableExtrinsic } from "@polkadot/api/types";
+import type { Signer } from "@polkadot/api/types";
+
+const HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+const sampleParams = buildAddStakeLimitParams({
+  hotkey: HOTKEY,
+  netuid: 4,
+  amountStaked: taoToRao("10"),
+  limitPrice: taoToRao("1.05"),
+  allowPartial: true,
+});
+
+describe("computeIdempotencyKey", () => {
+  it("is deterministic for identical inputs", () => {
+    const a = computeIdempotencyKey(sampleParams, 5, "session-1");
+    const b = computeIdempotencyKey(sampleParams, 5, "session-1");
+    expect(a).toBe(b);
+  });
+
+  it("differs when the nonce differs", () => {
+    const a = computeIdempotencyKey(sampleParams, 5, "session-1");
+    const b = computeIdempotencyKey(sampleParams, 6, "session-1");
+    expect(a).not.toBe(b);
+  });
+
+  it("differs when the session differs", () => {
+    const a = computeIdempotencyKey(sampleParams, 5, "session-1");
+    const b = computeIdempotencyKey(sampleParams, 5, "session-2");
+    expect(a).not.toBe(b);
+  });
+
+  it("differs when the call amount differs", () => {
+    const other = buildAddStakeLimitParams({
+      hotkey: HOTKEY,
+      netuid: 4,
+      amountStaked: taoToRao("20"), // different from sampleParams' 10
+      limitPrice: taoToRao("1.05"),
+      allowPartial: true,
+    });
+    const a = computeIdempotencyKey(sampleParams, 5, "session-1");
+    const b = computeIdempotencyKey(other, 5, "session-1");
+    expect(a).not.toBe(b);
+  });
+
+  it("handles bigint fields without throwing (JSON.stringify can't serialize bigint by default)", () => {
+    expect(() => computeIdempotencyKey(sampleParams, 1, "s")).not.toThrow();
+  });
+});
+
+describe("hasAlreadySubmitted", () => {
+  it("is false for a key that has never been submitted", () => {
+    const key = computeIdempotencyKey(sampleParams, 111, "unused-session");
+    expect(hasAlreadySubmitted(key)).toBe(false);
+  });
+});
+
+function makeFakeExtrinsic() {
+  const listeners: Array<(result: { status: unknown }) => void> = [];
+  let capturedOptions: unknown;
+  const unsubscribe = vi.fn();
+  const extrinsic = {
+    hash: { toHex: () => "0xdeadbeef" },
+    signAndSend: vi.fn(async (_address: string, options: unknown, cb: (r: unknown) => void) => {
+      capturedOptions = options;
+      listeners.push(cb as (result: { status: unknown }) => void);
+      return unsubscribe;
+    }),
+  } as unknown as SubmittableExtrinsic<"promise">;
+  return {
+    extrinsic,
+    unsubscribe,
+    emit: (status: unknown) => listeners.forEach((cb) => cb({ status })),
+    getCapturedOptions: () => capturedOptions,
+  };
+}
+
+function makeStatus(overrides: Partial<Record<string, unknown>>) {
+  return {
+    isFuture: false,
+    isReady: false,
+    isBroadcast: false,
+    isInBlock: false,
+    isRetracted: false,
+    isFinalityTimeout: false,
+    isFinalized: false,
+    isUsurped: false,
+    isDropped: false,
+    isInvalid: false,
+    ...overrides,
+  };
+}
+
+describe("submitStakeExtrinsic", () => {
+  const fakeApi = {} as ApiPromise;
+  const fakeSigner = {} as Signer;
+
+  it("passes an explicit mortality era (never immortal) to signAndSend", async () => {
+    const { extrinsic, getCapturedOptions } = makeFakeExtrinsic();
+    const key = computeIdempotencyKey(sampleParams, 1, "mortality-test");
+    await submitStakeExtrinsic(fakeApi, extrinsic, {
+      signerAddress: HOTKEY,
+      signer: fakeSigner,
+      idempotencyKey: key,
+    });
+    expect(getCapturedOptions()).toEqual({ signer: fakeSigner, era: DEFAULT_MORTALITY_BLOCKS });
+  });
+
+  it("accepts a caller-supplied mortality override", async () => {
+    const { extrinsic, getCapturedOptions } = makeFakeExtrinsic();
+    const key = computeIdempotencyKey(sampleParams, 2, "mortality-override-test");
+    await submitStakeExtrinsic(fakeApi, extrinsic, {
+      signerAddress: HOTKEY,
+      signer: fakeSigner,
+      idempotencyKey: key,
+      mortalityBlocks: 16,
+    });
+    expect(getCapturedOptions()).toEqual({ signer: fakeSigner, era: 16 });
+  });
+
+  it("marks the idempotency key as used and refuses a second submission with the same key", async () => {
+    const { extrinsic } = makeFakeExtrinsic();
+    const key = computeIdempotencyKey(sampleParams, 3, "double-submit-test");
+    expect(hasAlreadySubmitted(key)).toBe(false);
+
+    await submitStakeExtrinsic(fakeApi, extrinsic, {
+      signerAddress: HOTKEY,
+      signer: fakeSigner,
+      idempotencyKey: key,
+    });
+    expect(hasAlreadySubmitted(key)).toBe(true);
+
+    const { extrinsic: secondExtrinsic } = makeFakeExtrinsic();
+    await expect(
+      submitStakeExtrinsic(fakeApi, secondExtrinsic, {
+        signerAddress: HOTKEY,
+        signer: fakeSigner,
+        idempotencyKey: key,
+      }),
+    ).rejects.toThrow(/already submitted/i);
+  });
+
+  it("maps every ExtrinsicStatus variant to the corresponding BroadcastStatus", async () => {
+    const { extrinsic, emit } = makeFakeExtrinsic();
+    const key = computeIdempotencyKey(sampleParams, 4, "status-map-test");
+    const events: BroadcastEvent[] = [];
+    await submitStakeExtrinsic(fakeApi, extrinsic, {
+      signerAddress: HOTKEY,
+      signer: fakeSigner,
+      idempotencyKey: key,
+      onStatus: (e) => events.push(e),
+    });
+
+    emit(makeStatus({ isReady: true }));
+    emit(makeStatus({ isBroadcast: true }));
+    emit(makeStatus({ isInBlock: true, asInBlock: { toHex: () => "0xblock1" } }));
+    emit(makeStatus({ isFinalized: true, asFinalized: { toHex: () => "0xblock1" } }));
+    emit(makeStatus({ isDropped: true }));
+    emit(makeStatus({ isInvalid: true }));
+
+    expect(events.map((e) => e.status)).toEqual([
+      "ready",
+      "broadcast",
+      "in-block",
+      "finalized",
+      "dropped",
+      "invalid",
+    ]);
+    expect(events.every((e) => e.txHash === "0xdeadbeef")).toBe(true);
+    expect(events[2].blockHash).toBe("0xblock1");
+    expect(events[3].blockHash).toBe("0xblock1");
+  });
+
+  it("returns the txHash and an unsubscribe handle", async () => {
+    const { extrinsic, unsubscribe } = makeFakeExtrinsic();
+    const key = computeIdempotencyKey(sampleParams, 5, "return-shape-test");
+    const result = await submitStakeExtrinsic(fakeApi, extrinsic, {
+      signerAddress: HOTKEY,
+      signer: fakeSigner,
+      idempotencyKey: key,
+    });
+    expect(result.txHash).toBe("0xdeadbeef");
+    expect(result.unsubscribe).toBe(unsubscribe);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/broadcast.ts
+++ b/apps/ui/src/lib/metagraphed/broadcast.ts
@@ -1,0 +1,161 @@
+// Broadcast path (#5238) + idempotency/double-submit/mortality guards
+// (#5241), native-staking epic #5229. Per ADR 0018 §2, a signed extrinsic
+// goes straight from the browser to a trusted RPC endpoint -- no
+// metagraphed-owned relay, no new backend surface, so this file's only job is
+// the browser-side signAndSend call and the client-side safety nets around it
+// (the chain re-validates everything else; these are UX-and-double-spend
+// guards, not the actual security boundary).
+//
+// Mortality (#5241): passing a plain number as `era` to signAndSend is NOT
+// the same as constructing the on-chain MortalEra directly -- verified
+// empirically against the installed @polkadot/types package (2026-07-14):
+// `new GenericExtrinsicEra(registry, 64)` (a bare number, codec-level)
+// throws, while @polkadot/api's own signAndSend option-preparation
+// (submittable/createClass.js's makeEraOptions) treats a bare `era: N` in
+// SIGNING options as the mortal *period* and combines it with the live
+// current block it already fetched -- `{ era: N }` is the correct, documented
+// way to request a mortal extrinsic through this API, not something this
+// file needs to hand-construct. Omitting `era` entirely already defaults to
+// mortal too (when a live header is available, which getApi() guarantees),
+// but passing it explicitly keeps the safety property visible in code rather
+// than resting on an internal library default no one here chose.
+
+import type { ApiPromise } from "@polkadot/api";
+import type { SubmittableExtrinsic } from "@polkadot/api/types";
+import type { Signer } from "@polkadot/api/types";
+import type { StakeCallParams } from "./chain-connection";
+
+/** ~a few minutes at Bittensor's block time -- short enough that a stuck/abandoned signature can't be replayed much later (see the account-reap/nonce-reset risk in this module's references), long enough to comfortably survive normal signing latency. */
+export const DEFAULT_MORTALITY_BLOCKS = 64;
+
+export type BroadcastStatus =
+  | "future"
+  | "ready"
+  | "broadcast"
+  | "in-block"
+  | "retracted"
+  | "finality-timeout"
+  | "finalized"
+  | "usurped"
+  | "dropped"
+  | "invalid"
+  | "error";
+
+export interface BroadcastEvent {
+  status: BroadcastStatus;
+  txHash: string;
+  blockHash?: string;
+}
+
+/**
+ * A stable (not cryptographic -- collision resistance for a single browser
+ * session's worth of clicks is all this needs) hash of the call intent, the
+ * signing account's next nonce, and a per-page-load session id. Two clicks
+ * of the same submit button, for the same call, before the nonce advances,
+ * produce the identical key -- exactly the "duplicate submission" this
+ * exists to catch. Compute this and check hasAlreadySubmitted() BEFORE
+ * prompting for a signature, not after.
+ */
+export function computeIdempotencyKey(
+  params: StakeCallParams,
+  nonce: number,
+  sessionId: string,
+): string {
+  const stable = JSON.stringify(params, (_key, value) =>
+    typeof value === "bigint" ? `bigint:${value.toString()}` : value,
+  );
+  return fnv1a(`${sessionId}:${nonce}:${stable}`);
+}
+
+// FNV-1a: fast, deterministic, no crypto dependency (nothing here needs to
+// resist a deliberate collision attack, only accidental double-submission).
+function fnv1a(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+const seenIdempotencyKeys = new Set<string>();
+
+/** True if this exact call+nonce+session combination has already been submitted this page load. */
+export function hasAlreadySubmitted(idempotencyKey: string): boolean {
+  return seenIdempotencyKeys.has(idempotencyKey);
+}
+
+function mapExtrinsicStatus(status: {
+  isFuture: boolean;
+  isReady: boolean;
+  isBroadcast: boolean;
+  isInBlock: boolean;
+  isRetracted: boolean;
+  isFinalityTimeout: boolean;
+  isFinalized: boolean;
+  isUsurped: boolean;
+  isDropped: boolean;
+  isInvalid: boolean;
+}): BroadcastStatus {
+  if (status.isFuture) return "future";
+  if (status.isReady) return "ready";
+  if (status.isBroadcast) return "broadcast";
+  if (status.isInBlock) return "in-block";
+  if (status.isRetracted) return "retracted";
+  if (status.isFinalityTimeout) return "finality-timeout";
+  if (status.isFinalized) return "finalized";
+  if (status.isUsurped) return "usurped";
+  if (status.isDropped) return "dropped";
+  if (status.isInvalid) return "invalid";
+  return "error";
+}
+
+export interface SubmitStakeExtrinsicOptions {
+  signerAddress: string;
+  signer: Signer;
+  /** From computeIdempotencyKey() -- required, not optional, so a caller can't accidentally skip the double-submit guard. */
+  idempotencyKey: string;
+  mortalityBlocks?: number;
+  onStatus?: (event: BroadcastEvent) => void;
+}
+
+/**
+ * Sign and broadcast a constructed extrinsic directly to this connection's
+ * RPC endpoint (ADR 0018 §2 -- never through metagraphed's own backend).
+ * Throws synchronously, before ever prompting for a signature, if
+ * idempotencyKey has already been used this page load.
+ */
+export async function submitStakeExtrinsic(
+  _api: ApiPromise,
+  extrinsic: SubmittableExtrinsic<"promise">,
+  {
+    signerAddress,
+    signer,
+    idempotencyKey,
+    mortalityBlocks = DEFAULT_MORTALITY_BLOCKS,
+    onStatus,
+  }: SubmitStakeExtrinsicOptions,
+): Promise<{ txHash: string; unsubscribe: () => void }> {
+  if (hasAlreadySubmitted(idempotencyKey)) {
+    throw new Error("This transaction was already submitted -- refusing to resubmit.");
+  }
+  seenIdempotencyKeys.add(idempotencyKey);
+
+  const unsubscribe = await extrinsic.signAndSend(
+    signerAddress,
+    { signer, era: mortalityBlocks },
+    (result) => {
+      onStatus?.({
+        status: mapExtrinsicStatus(result.status),
+        txHash: extrinsic.hash.toHex(),
+        blockHash: result.status.isInBlock
+          ? result.status.asInBlock.toHex()
+          : result.status.isFinalized
+            ? result.status.asFinalized.toHex()
+            : undefined,
+      });
+    },
+  );
+
+  return { txHash: extrinsic.hash.toHex(), unsubscribe };
+}

--- a/apps/ui/src/lib/metagraphed/broadcast.ts
+++ b/apps/ui/src/lib/metagraphed/broadcast.ts
@@ -23,6 +23,7 @@
 import type { ApiPromise } from "@polkadot/api";
 import type { SubmittableExtrinsic } from "@polkadot/api/types";
 import type { Signer } from "@polkadot/api/types";
+import type { DispatchError } from "@polkadot/types/interfaces";
 import type { StakeCallParams } from "./chain-connection";
 
 /** ~a few minutes at Bittensor's block time -- short enough that a stuck/abandoned signature can't be replayed much later (see the account-reap/nonce-reset risk in this module's references), long enough to comfortably survive normal signing latency. */
@@ -45,6 +46,16 @@ export interface BroadcastEvent {
   status: BroadcastStatus;
   txHash: string;
   blockHash?: string;
+  /**
+   * The raw on-chain DispatchError, present once the extrinsic reaches
+   * in-block/finalized AND the call itself failed (a failed call is still
+   * mined -- the transaction succeeded at the transaction-pool/block-
+   * inclusion layer, only the pallet logic inside it reverted). Passed
+   * through untouched -- decoding this into human copy is tx-errors.ts's
+   * job (#5240), not this file's; this module only reports what the chain
+   * said, verbatim.
+   */
+  dispatchError?: DispatchError;
 }
 
 /**
@@ -153,6 +164,7 @@ export async function submitStakeExtrinsic(
           : result.status.isFinalized
             ? result.status.asFinalized.toHex()
             : undefined,
+        dispatchError: result.dispatchError,
       });
     },
   );

--- a/apps/ui/src/lib/metagraphed/chain-connection.test.ts
+++ b/apps/ui/src/lib/metagraphed/chain-connection.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { taoToRao, alphaToRawAlpha } from "./units";
+import {
+  buildAddStakeLimitParams,
+  buildRemoveStakeLimitParams,
+  buildSwapStakeLimitParams,
+  buildMoveStakeParams,
+} from "./stake-extrinsics";
+import { getApi, buildExtrinsic } from "./chain-connection";
+import type { ApiPromise } from "@polkadot/api";
+
+const HOTKEY_A = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const HOTKEY_B = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// getApi's real connection path (WsProvider + ApiPromise.create) is
+// deliberately NOT exercised here -- it would trigger @polkadot/util-crypto's
+// real WASM init and open a live network connection, both undesirable in a
+// fast unit suite. The only assertion worth making without a live chain is
+// the SSR guard; the connection itself is exercised by manual QA (see the PR
+// description), same posture as wallet-injected.test.ts's connectWallet().
+describe("getApi (SSR safety only)", () => {
+  it("rejects when called during SSR (no window)", async () => {
+    // No window stubbed at all -- matches how this would actually be invoked
+    // during server rendering, where `window` is genuinely undefined.
+    await expect(getApi()).rejects.toThrow(/client-only/i);
+  });
+});
+
+// A minimal fake ApiPromise that only implements the one surface
+// buildExtrinsic touches -- api.tx.subtensorModule.<method>(...args) -- and
+// records exactly what was called with what, in order. This lets the
+// fund-safety-critical parameter ORDER be asserted directly, without needing
+// a live chain connection or the real @polkadot/api package at all.
+function makeFakeApi() {
+  const calls: Record<string, unknown[]> = {};
+  const record =
+    (method: string) =>
+    (...args: unknown[]) => {
+      calls[method] = args;
+      return { method, args };
+    };
+  const api = {
+    tx: {
+      subtensorModule: {
+        addStakeLimit: record("addStakeLimit"),
+        removeStakeLimit: record("removeStakeLimit"),
+        swapStakeLimit: record("swapStakeLimit"),
+        moveStake: record("moveStake"),
+      },
+    },
+  } as unknown as ApiPromise;
+  return { api, calls };
+}
+
+describe("buildExtrinsic", () => {
+  it("calls addStakeLimit with (hotkey, netuid, amountStaked, limitPrice, allowPartial), in order", () => {
+    const { api, calls } = makeFakeApi();
+    const params = buildAddStakeLimitParams({
+      hotkey: HOTKEY_A,
+      netuid: 4,
+      amountStaked: taoToRao("10"),
+      limitPrice: taoToRao("1.05"),
+      allowPartial: true,
+    });
+    buildExtrinsic(api, params);
+    expect(calls.addStakeLimit).toEqual([HOTKEY_A, 4, taoToRao("10"), taoToRao("1.05"), true]);
+  });
+
+  it("calls removeStakeLimit with (hotkey, netuid, amountUnstaked, limitPrice, allowPartial), in order", () => {
+    const { api, calls } = makeFakeApi();
+    const params = buildRemoveStakeLimitParams({
+      hotkey: HOTKEY_A,
+      netuid: 4,
+      amountUnstaked: alphaToRawAlpha("5"),
+      limitPrice: taoToRao("9.5"),
+      allowPartial: false,
+    });
+    buildExtrinsic(api, params);
+    expect(calls.removeStakeLimit).toEqual([
+      HOTKEY_A,
+      4,
+      alphaToRawAlpha("5"),
+      taoToRao("9.5"),
+      false,
+    ]);
+  });
+
+  it("calls swapStakeLimit with (hotkey, originNetuid, destinationNetuid, alphaAmount, limitPrice, allowPartial), in order", () => {
+    const { api, calls } = makeFakeApi();
+    const params = buildSwapStakeLimitParams({
+      hotkey: HOTKEY_A,
+      originNetuid: 4,
+      destinationNetuid: 7,
+      alphaAmount: alphaToRawAlpha("2"),
+      limitPrice: taoToRao("9.5"),
+      allowPartial: true,
+    });
+    buildExtrinsic(api, params);
+    expect(calls.swapStakeLimit).toEqual([
+      HOTKEY_A,
+      4,
+      7,
+      alphaToRawAlpha("2"),
+      taoToRao("9.5"),
+      true,
+    ]);
+  });
+
+  it("calls moveStake with (originHotkey, destinationHotkey, netuid, netuid, alphaAmount) -- same netuid twice, matching the on-chain origin/destination pair for the same-subnet-only case", () => {
+    const { api, calls } = makeFakeApi();
+    const params = buildMoveStakeParams({
+      originHotkey: HOTKEY_A,
+      destinationHotkey: HOTKEY_B,
+      netuid: 4,
+      alphaAmount: alphaToRawAlpha("3"),
+    });
+    buildExtrinsic(api, params);
+    expect(calls.moveStake).toEqual([HOTKEY_A, HOTKEY_B, 4, 4, alphaToRawAlpha("3")]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/chain-connection.ts
+++ b/apps/ui/src/lib/metagraphed/chain-connection.ts
@@ -1,0 +1,144 @@
+// The one boundary that touches @polkadot/api directly (#5237, native-staking
+// epic #5229). Mirrors wallet-injected.ts's SSR-safety pattern exactly: every
+// function here reaches @polkadot/api via a dynamic import() inside a
+// client-only-guarded function body, never a static top-level import --
+// @polkadot/util-crypto (a transitive dep, shared with @polkadot/extension-
+// dapp) triggers WASM init as an import-time side effect, so a static import
+// anywhere would put it on the SSR bundle regardless of whether it's called.
+// See wallet-injected.ts's header comment and apps/ui/vite.config.ts's Nitro
+// rollup:before hook (which externalizes the whole @polkadot/* tree from the
+// Cloudflare Workers server build by prefix, so a static import here would
+// still fail the build even before it fails at runtime).
+//
+// Per ADR 0018 §2, this connects directly to a trusted, already-public RPC
+// endpoint (workers/config.mjs's TRUSTED_RPC_UPSTREAM_ORIGINS) -- signed
+// extrinsics never transit metagraphed's own backend.
+
+import type { ApiPromise } from "@polkadot/api";
+import type { SubmittableExtrinsic } from "@polkadot/api/types";
+import type {
+  AddStakeLimitParams,
+  RemoveStakeLimitParams,
+  SwapStakeLimitParams,
+  MoveStakeParams,
+} from "./stake-extrinsics";
+import { asRao, type Rao } from "./units";
+
+export type StakeCallParams =
+  AddStakeLimitParams | RemoveStakeLimitParams | SwapStakeLimitParams | MoveStakeParams;
+
+/**
+ * The official Bittensor entrypoint -- matches ADR 0018 §2's "the same shape
+ * Polkadot.js Apps itself uses." Callers may pass any other entry from
+ * TRUSTED_RPC_UPSTREAM_ORIGINS explicitly (e.g. the broadcast path in #5238
+ * may prefer a different one for submission specifically).
+ */
+export const DEFAULT_RPC_ENDPOINT = "wss://entrypoint-finney.opentensor.ai";
+
+let cachedApi: Promise<ApiPromise> | null = null;
+
+/**
+ * Connect (once, cached) to a trusted RPC endpoint and return the live,
+ * metadata-aware ApiPromise. Client-only -- throws under SSR rather than
+ * silently returning something unusable, since every caller of this function
+ * is itself already a client-only code path (a connect button, a confirm
+ * screen) with nothing sensible to do with an SSR fallback.
+ */
+export async function getApi(endpoint: string = DEFAULT_RPC_ENDPOINT): Promise<ApiPromise> {
+  if (typeof window === "undefined") {
+    throw new Error("getApi() is client-only and must not be called during SSR");
+  }
+  if (!cachedApi) {
+    cachedApi = (async () => {
+      const { ApiPromise, WsProvider } = await import("@polkadot/api");
+      const provider = new WsProvider(endpoint);
+      return ApiPromise.create({ provider });
+    })();
+  }
+  return cachedApi;
+}
+
+// subtensor is a custom runtime with no published @polkadot/api-augment-style
+// declaration-merging package, so ApiPromise's generic `consts`/`query` proxy
+// types resolve to the base `Codec` rather than a pallet-specific interface --
+// a real gap in the ecosystem's type coverage for this chain, not something
+// fixable from this repo. `.toBigInt()` is a standard method every numeric
+// SCALE codec (u64/u128/Compact<...>) implements; these two narrow, local
+// interfaces name only the one method/field each call site actually uses,
+// rather than reaching for a blanket `any` that would silently swallow a
+// genuine shape mismatch elsewhere in the same expression.
+interface BigIntCodec {
+  toBigInt(): bigint;
+}
+interface AccountInfoCodec {
+  data: { free: BigIntCodec };
+}
+
+/**
+ * The network's live minimum stake floor (rao), read from the pallet's own
+ * `InitialMinStake` constant -- a real `#[pallet::constant]` in subtensor's
+ * Config trait (verified against pallets/subtensor/src/macros/config.rs, live
+ * 2026-07-14), never hardcoded client-side. A stale hardcoded guess could
+ * silently accept an amount the chain would reject (AmountTooLow), or reject
+ * a valid one -- querying the real value has no such drift risk.
+ */
+export async function getMinStake(api: ApiPromise): Promise<Rao> {
+  const raw = api.consts.subtensorModule.initialMinStake as unknown as BigIntCodec;
+  return asRao(raw.toBigInt());
+}
+
+/** The coldkey's spendable free balance (rao) -- for validateStakeInputs' availableBalanceRao. */
+export async function getFreeBalance(api: ApiPromise, coldkeySs58: string): Promise<Rao> {
+  const account = (await api.query.system.account(coldkeySs58)) as unknown as AccountInfoCodec;
+  return asRao(account.data.free.toBigInt());
+}
+
+/**
+ * Turn a pure params object (from stake-extrinsics.ts's builders) into a
+ * signable SubmittableExtrinsic against this connection's runtime metadata.
+ * The parameter ORDER passed to each api.tx.subtensorModule.* call below must
+ * exactly match stake-extrinsics.ts's own verified-against-pallet-source
+ * order -- this function is the only place that order is spent, so a
+ * mismatch here is silent and would only surface as a chain-side decode
+ * failure or, worse, a differently-shaped call succeeding by accident.
+ */
+export function buildExtrinsic(
+  api: ApiPromise,
+  params: StakeCallParams,
+): SubmittableExtrinsic<"promise"> {
+  switch (params.call) {
+    case "add_stake_limit":
+      return api.tx.subtensorModule.addStakeLimit(
+        params.hotkey,
+        params.netuid,
+        params.amountStaked,
+        params.limitPrice,
+        params.allowPartial,
+      );
+    case "remove_stake_limit":
+      return api.tx.subtensorModule.removeStakeLimit(
+        params.hotkey,
+        params.netuid,
+        params.amountUnstaked,
+        params.limitPrice,
+        params.allowPartial,
+      );
+    case "swap_stake_limit":
+      return api.tx.subtensorModule.swapStakeLimit(
+        params.hotkey,
+        params.originNetuid,
+        params.destinationNetuid,
+        params.alphaAmount,
+        params.limitPrice,
+        params.allowPartial,
+      );
+    case "move_stake":
+      return api.tx.subtensorModule.moveStake(
+        params.originHotkey,
+        params.destinationHotkey,
+        params.netuid,
+        params.netuid,
+        params.alphaAmount,
+      );
+  }
+}

--- a/apps/ui/src/lib/metagraphed/stake-extrinsics.test.ts
+++ b/apps/ui/src/lib/metagraphed/stake-extrinsics.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from "vitest";
+import { taoToRao, alphaToRawAlpha } from "./units";
+import {
+  computeLimitPrice,
+  buildAddStakeLimitParams,
+  buildRemoveStakeLimitParams,
+  buildSwapStakeLimitParams,
+  buildMoveStakeParams,
+  validateStakeInputs,
+  describeStakeValidationIssue,
+} from "./stake-extrinsics";
+
+const HOTKEY_A = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const HOTKEY_B = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+describe("computeLimitPrice", () => {
+  it("adds tolerance above spot price when adding stake (willing to pay up to)", () => {
+    const limit = computeLimitPrice({ spotPriceTao: 10, tolerancePct: 5, direction: "add" });
+    expect(limit).toBe(taoToRao("10.5"));
+  });
+
+  it("subtracts tolerance below spot price when removing stake (willing to accept down to)", () => {
+    const limit = computeLimitPrice({ spotPriceTao: 10, tolerancePct: 5, direction: "remove" });
+    expect(limit).toBe(taoToRao("9.5"));
+  });
+
+  it("handles the root subnet's fixed 1.0 spot price the same way", () => {
+    expect(computeLimitPrice({ spotPriceTao: 1, tolerancePct: 5, direction: "add" })).toBe(
+      taoToRao("1.05"),
+    );
+  });
+
+  it("supports a zero tolerance (exact spot price as the limit)", () => {
+    expect(computeLimitPrice({ spotPriceTao: 10, tolerancePct: 0, direction: "add" })).toBe(
+      taoToRao("10"),
+    );
+  });
+
+  it("rejects a non-positive spot price", () => {
+    expect(() => computeLimitPrice({ spotPriceTao: 0, tolerancePct: 5, direction: "add" })).toThrow(
+      /invalid spot price/i,
+    );
+    expect(() =>
+      computeLimitPrice({ spotPriceTao: -1, tolerancePct: 5, direction: "add" }),
+    ).toThrow(/invalid spot price/i);
+  });
+
+  it("rejects a negative tolerance", () => {
+    expect(() =>
+      computeLimitPrice({ spotPriceTao: 10, tolerancePct: -1, direction: "add" }),
+    ).toThrow(/invalid tolerance/i);
+  });
+
+  it("rejects a remove-side tolerance so large it would produce a non-positive limit price", () => {
+    expect(() =>
+      computeLimitPrice({ spotPriceTao: 10, tolerancePct: 100, direction: "remove" }),
+    ).toThrow(/tolerance too large/i);
+  });
+});
+
+describe("buildAddStakeLimitParams", () => {
+  it("builds the exact params add_stake_limit expects, in order", () => {
+    const params = buildAddStakeLimitParams({
+      hotkey: HOTKEY_A,
+      netuid: 4,
+      amountStaked: taoToRao("10"),
+      limitPrice: taoToRao("1.05"),
+      allowPartial: true,
+    });
+    expect(params).toEqual({
+      call: "add_stake_limit",
+      hotkey: HOTKEY_A,
+      netuid: 4,
+      amountStaked: taoToRao("10"),
+      limitPrice: taoToRao("1.05"),
+      allowPartial: true,
+    });
+  });
+
+  it("rejects a non-positive amount or limit price", () => {
+    expect(() =>
+      buildAddStakeLimitParams({
+        hotkey: HOTKEY_A,
+        netuid: 4,
+        amountStaked: taoToRao("0"),
+        limitPrice: taoToRao("1"),
+        allowPartial: false,
+      }),
+    ).toThrow(/amountStaked/);
+    expect(() =>
+      buildAddStakeLimitParams({
+        hotkey: HOTKEY_A,
+        netuid: 4,
+        amountStaked: taoToRao("10"),
+        limitPrice: taoToRao("0"),
+        allowPartial: false,
+      }),
+    ).toThrow(/limitPrice/);
+  });
+});
+
+describe("buildRemoveStakeLimitParams", () => {
+  it("builds params with amountUnstaked denominated in alpha, not tao", () => {
+    const params = buildRemoveStakeLimitParams({
+      hotkey: HOTKEY_A,
+      netuid: 4,
+      amountUnstaked: alphaToRawAlpha("5"),
+      limitPrice: taoToRao("9.5"),
+      allowPartial: false,
+    });
+    expect(params.call).toBe("remove_stake_limit");
+    expect(params.amountUnstaked).toBe(alphaToRawAlpha("5"));
+  });
+});
+
+describe("buildSwapStakeLimitParams", () => {
+  it("builds params for a cross-subnet swap", () => {
+    const params = buildSwapStakeLimitParams({
+      hotkey: HOTKEY_A,
+      originNetuid: 4,
+      destinationNetuid: 7,
+      alphaAmount: alphaToRawAlpha("2"),
+      limitPrice: taoToRao("9.5"),
+      allowPartial: true,
+    });
+    expect(params).toEqual({
+      call: "swap_stake_limit",
+      hotkey: HOTKEY_A,
+      originNetuid: 4,
+      destinationNetuid: 7,
+      alphaAmount: alphaToRawAlpha("2"),
+      limitPrice: taoToRao("9.5"),
+      allowPartial: true,
+    });
+  });
+
+  it("rejects identical origin/destination netuids", () => {
+    expect(() =>
+      buildSwapStakeLimitParams({
+        hotkey: HOTKEY_A,
+        originNetuid: 4,
+        destinationNetuid: 4,
+        alphaAmount: alphaToRawAlpha("2"),
+        limitPrice: taoToRao("9.5"),
+        allowPartial: true,
+      }),
+    ).toThrow(/distinct origin\/destination/);
+  });
+});
+
+describe("buildMoveStakeParams", () => {
+  it("builds a same-subnet hotkey reassignment (the only supported case)", () => {
+    const params = buildMoveStakeParams({
+      originHotkey: HOTKEY_A,
+      destinationHotkey: HOTKEY_B,
+      netuid: 4,
+      alphaAmount: alphaToRawAlpha("3"),
+    });
+    expect(params).toEqual({
+      call: "move_stake",
+      originHotkey: HOTKEY_A,
+      destinationHotkey: HOTKEY_B,
+      netuid: 4,
+      alphaAmount: alphaToRawAlpha("3"),
+    });
+  });
+
+  it("has no way to express distinct origin/destination netuids at all", () => {
+    // A single `netuid` field (used for both origin and destination on-chain)
+    // is the whole safety mechanism here -- there is no parameter through
+    // which a caller could accidentally construct the unprotected
+    // cross-subnet form. Cross-subnet moves must be composed from
+    // buildRemoveStakeLimitParams + buildAddStakeLimitParams instead.
+    const params = buildMoveStakeParams({
+      originHotkey: HOTKEY_A,
+      destinationHotkey: HOTKEY_B,
+      netuid: 4,
+      alphaAmount: alphaToRawAlpha("3"),
+    });
+    expect(Object.keys(params)).not.toContain("originNetuid");
+    expect(Object.keys(params)).not.toContain("destinationNetuid");
+  });
+});
+
+describe("validateStakeInputs", () => {
+  const base = {
+    hotkey: HOTKEY_A,
+    netuid: 4,
+    knownNetuids: [0, 4, 7],
+    minStakeRao: taoToRao("0.002"),
+  };
+
+  it("returns no issues for a valid add-stake input", () => {
+    expect(
+      validateStakeInputs({
+        ...base,
+        amountRao: taoToRao("1"),
+        availableBalanceRao: taoToRao("10"),
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags an invalid hotkey", () => {
+    const issues = validateStakeInputs({
+      ...base,
+      hotkey: "not-a-hotkey",
+      amountRao: taoToRao("1"),
+    });
+    expect(issues).toContainEqual({ code: "invalid_hotkey" });
+  });
+
+  it("flags an unknown netuid", () => {
+    const issues = validateStakeInputs({ ...base, netuid: 999, amountRao: taoToRao("1") });
+    expect(issues).toContainEqual({ code: "invalid_netuid" });
+  });
+
+  it("flags a non-positive amount and skips the amount-dependent checks", () => {
+    const issues = validateStakeInputs({ ...base, amountRao: taoToRao("0") });
+    expect(issues).toEqual([{ code: "amount_not_positive" }]);
+  });
+
+  it("flags an amount below the min-stake floor", () => {
+    const issues = validateStakeInputs({ ...base, amountRao: taoToRao("0.0005") });
+    expect(issues).toContainEqual({ code: "below_min_stake", minStakeRao: base.minStakeRao });
+  });
+
+  it("flags an amount exceeding available balance when a balance is supplied", () => {
+    const issues = validateStakeInputs({
+      ...base,
+      amountRao: taoToRao("100"),
+      availableBalanceRao: taoToRao("10"),
+    });
+    expect(issues).toContainEqual({ code: "insufficient_balance", availableRao: taoToRao("10") });
+  });
+
+  it("skips the balance check entirely when no balance is supplied (remove/move flows)", () => {
+    const issues = validateStakeInputs({ ...base, amountRao: taoToRao("100") });
+    expect(issues.some((i) => i.code === "insufficient_balance")).toBe(false);
+  });
+
+  it("can return multiple issues at once", () => {
+    const issues = validateStakeInputs({
+      ...base,
+      hotkey: "bogus",
+      netuid: 999,
+      amountRao: taoToRao("0.0001"),
+      availableBalanceRao: taoToRao("0"),
+    });
+    expect(issues.map((i) => i.code).sort()).toEqual(
+      ["below_min_stake", "insufficient_balance", "invalid_hotkey", "invalid_netuid"].sort(),
+    );
+  });
+});
+
+describe("describeStakeValidationIssue", () => {
+  it("produces readable copy for every issue code", () => {
+    expect(describeStakeValidationIssue({ code: "invalid_hotkey" })).toMatch(/hotkey/i);
+    expect(describeStakeValidationIssue({ code: "invalid_netuid" })).toMatch(/subnet/i);
+    expect(describeStakeValidationIssue({ code: "amount_not_positive" })).toMatch(/amount/i);
+    expect(
+      describeStakeValidationIssue({ code: "below_min_stake", minStakeRao: taoToRao("0.002") }),
+    ).toContain("0.002");
+    expect(
+      describeStakeValidationIssue({ code: "insufficient_balance", availableRao: taoToRao("10") }),
+    ).toContain("10");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/stake-extrinsics.ts
+++ b/apps/ui/src/lib/metagraphed/stake-extrinsics.ts
@@ -1,0 +1,241 @@
+// Client-side stake/unstake/move extrinsic construction (#5237, native-staking
+// epic #5229). Correctness-critical: a wrong parameter order or a unit mixup
+// here is a real fund-safety bug, not a cosmetic one.
+//
+// Every call shape below is verified against the live subtensor pallet source
+// (opentensor/subtensor, pallets/subtensor/src/macros/dispatches.rs, read
+// 2026-07-14) -- call name, parameter order, and parameter type for each of
+// add_stake_limit (call_index 88), remove_stake_limit (89), swap_stake_limit
+// (90), and move_stake (85).
+//
+// Per docs/adr/0018-native-staking-architecture.md §3, this module only ever
+// builds the `_limit` variants -- add_stake_limit/remove_stake_limit/
+// swap_stake_limit -- never the plain, unprotected add_stake/remove_stake.
+//
+// move_stake is a documented exception, resolved during this epic's own
+// review (not the ADR, which didn't separately enumerate it): move_stake has
+// NO `_limit` counterpart anywhere in the pallet, and its cross-subnet case
+// runs through the same unprotected AMM-swap path as swap_stake (confirmed by
+// reading staking/move_stake.rs's `do_move_stake`, which calls the same
+// `transition_stake_internal` swap_stake uses, with the price-limit argument
+// hardcoded to `None`). A same-subnet move_stake (origin_netuid ==
+// destination_netuid) is genuinely riskless -- no AMM swap occurs, it's a
+// pure hotkey reassignment -- and is supported directly. A cross-subnet move
+// is NOT exposed as a single call here; buildMoveStakeParams throws with a
+// pointer to compose it from buildRemoveStakeLimitParams (origin) +
+// buildAddStakeLimitParams (destination) instead -- two slippage-protected
+// legs achieving the same end state, rather than one unprotected atomic call.
+
+import { taoToRao, raoToTao, type Rao, type RawAlpha } from "./units";
+import { isValidSs58 } from "./accounts";
+
+export type StakeDirection = "add" | "remove";
+
+export interface ComputeLimitPriceInput {
+  /** Current spot price in TAO per one alpha (e.g. from the stake-quote endpoint's spot_price_tao; 1.0 for root, which has no AMM). */
+  spotPriceTao: number;
+  /** Tolerance band as a percent, e.g. 5 for 5%. Default per ADR 0018 §3 is 5. */
+  tolerancePct: number;
+  direction: StakeDirection;
+}
+
+/**
+ * Compute the on-chain `limit_price` (rao per one alpha) from a spot price and
+ * a tolerance band. Adding stake pays alpha's price in TAO, so the limit is
+ * the spot price PLUS tolerance (willing to pay up to this much); removing
+ * stake receives TAO for alpha, so the limit is the spot price MINUS
+ * tolerance (willing to accept down to this much). Getting this direction
+ * backwards would silently remove the protection the caller thinks they have.
+ */
+export function computeLimitPrice({
+  spotPriceTao,
+  tolerancePct,
+  direction,
+}: ComputeLimitPriceInput): Rao {
+  if (!Number.isFinite(spotPriceTao) || spotPriceTao <= 0) {
+    throw new Error(`Invalid spot price: ${spotPriceTao}`);
+  }
+  if (!Number.isFinite(tolerancePct) || tolerancePct < 0) {
+    throw new Error(`Invalid tolerance: ${tolerancePct}`);
+  }
+  const factor = direction === "add" ? 1 + tolerancePct / 100 : 1 - tolerancePct / 100;
+  if (factor <= 0) {
+    throw new Error(
+      `Tolerance too large: ${tolerancePct}% on the "remove" side would produce a non-positive limit price`,
+    );
+  }
+  // Round through a fixed 9-decimal string, not a raw float->rao multiply --
+  // taoToRao's BigInt parse is the single point where a decimal price becomes
+  // an exact on-chain integer; doing the multiply here in float and rounding
+  // separately would risk float error at the last, most consequential step.
+  const limitPriceTao = (spotPriceTao * factor).toFixed(9);
+  return taoToRao(limitPriceTao);
+}
+
+export interface AddStakeLimitParams {
+  call: "add_stake_limit";
+  hotkey: string;
+  netuid: number;
+  amountStaked: Rao;
+  limitPrice: Rao;
+  allowPartial: boolean;
+}
+
+/** Params for subtensorModule.addStakeLimit(hotkey, netuid, amountStaked, limitPrice, allowPartial). */
+export function buildAddStakeLimitParams(input: {
+  hotkey: string;
+  netuid: number;
+  amountStaked: Rao;
+  limitPrice: Rao;
+  allowPartial: boolean;
+}): AddStakeLimitParams {
+  requirePositive(input.amountStaked, "amountStaked");
+  requirePositive(input.limitPrice, "limitPrice");
+  return { call: "add_stake_limit", ...input };
+}
+
+export interface RemoveStakeLimitParams {
+  call: "remove_stake_limit";
+  hotkey: string;
+  netuid: number;
+  amountUnstaked: RawAlpha;
+  limitPrice: Rao;
+  allowPartial: boolean;
+}
+
+/** Params for subtensorModule.removeStakeLimit(hotkey, netuid, amountUnstaked, limitPrice, allowPartial). Note amountUnstaked is alpha, NOT tao -- unlike add_stake_limit's amountStaked. */
+export function buildRemoveStakeLimitParams(input: {
+  hotkey: string;
+  netuid: number;
+  amountUnstaked: RawAlpha;
+  limitPrice: Rao;
+  allowPartial: boolean;
+}): RemoveStakeLimitParams {
+  requirePositive(input.amountUnstaked, "amountUnstaked");
+  requirePositive(input.limitPrice, "limitPrice");
+  return { call: "remove_stake_limit", ...input };
+}
+
+export interface SwapStakeLimitParams {
+  call: "swap_stake_limit";
+  hotkey: string;
+  originNetuid: number;
+  destinationNetuid: number;
+  alphaAmount: RawAlpha;
+  limitPrice: Rao;
+  allowPartial: boolean;
+}
+
+/** Params for subtensorModule.swapStakeLimit(hotkey, originNetuid, destinationNetuid, alphaAmount, limitPrice, allowPartial). */
+export function buildSwapStakeLimitParams(input: {
+  hotkey: string;
+  originNetuid: number;
+  destinationNetuid: number;
+  alphaAmount: RawAlpha;
+  limitPrice: Rao;
+  allowPartial: boolean;
+}): SwapStakeLimitParams {
+  if (input.originNetuid === input.destinationNetuid) {
+    throw new Error("swap_stake_limit requires distinct origin/destination netuids");
+  }
+  requirePositive(input.alphaAmount, "alphaAmount");
+  requirePositive(input.limitPrice, "limitPrice");
+  return { call: "swap_stake_limit", ...input };
+}
+
+export interface MoveStakeParams {
+  call: "move_stake";
+  originHotkey: string;
+  destinationHotkey: string;
+  netuid: number;
+  alphaAmount: RawAlpha;
+}
+
+/**
+ * Params for subtensorModule.moveStake(originHotkey, destinationHotkey,
+ * originNetuid, destinationNetuid, alphaAmount) -- same-subnet only (see
+ * module header). Throws for a cross-subnet request; compose
+ * buildRemoveStakeLimitParams + buildAddStakeLimitParams instead.
+ */
+export function buildMoveStakeParams(input: {
+  originHotkey: string;
+  destinationHotkey: string;
+  netuid: number;
+  alphaAmount: RawAlpha;
+}): MoveStakeParams {
+  requirePositive(input.alphaAmount, "alphaAmount");
+  return { call: "move_stake", ...input };
+}
+
+function requirePositive(value: bigint, label: string): void {
+  if (value <= 0n) {
+    throw new Error(`${label} must be a positive amount, got ${value}`);
+  }
+}
+
+export type StakeValidationIssue =
+  | { code: "invalid_hotkey" }
+  | { code: "invalid_netuid" }
+  | { code: "amount_not_positive" }
+  | { code: "below_min_stake"; minStakeRao: Rao }
+  | { code: "insufficient_balance"; availableRao: Rao };
+
+export interface ValidateStakeInputsParams {
+  hotkey: string;
+  /** The netuid this amount is denominated against (for the min-stake floor check). */
+  netuid: number;
+  /** The known, currently-active subnets (from the app's existing subnet list -- this library never fetches its own copy). */
+  knownNetuids: readonly number[];
+  /** The amount being staked/unstaked, already converted to rao (add_stake_limit) or its TAO-equivalent estimate (remove_stake_limit -- the pallet's own floor check compares the TAO side of the trade either way). */
+  amountRao: Rao;
+  /** InitialMinStake, read live via chain-connection.ts's getMinStake() -- never hardcoded (the pallet exposes it as a real `#[pallet::constant]`, so there's no reason to guess a value that could drift). */
+  minStakeRao: Rao;
+  /** The coldkey's spendable balance in rao, only required (and only checked) for an add_stake (paying TAO out of the free balance) -- omit for remove_stake/move_stake, which draw from existing stake, not the free balance. */
+  availableBalanceRao?: Rao;
+}
+
+/**
+ * Client-side pre-flight checks run before any signature prompt fires (issue
+ * #5237's "self-consistency" + "min-stake floor" + "sufficient balance"
+ * deliverables). Returns every issue found, not just the first -- the caller
+ * decides how to surface them. This is a UX convenience, not the safety
+ * boundary: the chain re-validates all of this itself (AmountTooLow,
+ * NotEnoughBalanceToStake, SubnetNotExists, ...) and remains authoritative.
+ */
+export function validateStakeInputs({
+  hotkey,
+  netuid,
+  knownNetuids,
+  amountRao,
+  minStakeRao,
+  availableBalanceRao,
+}: ValidateStakeInputsParams): StakeValidationIssue[] {
+  const issues: StakeValidationIssue[] = [];
+  if (!isValidSs58(hotkey)) issues.push({ code: "invalid_hotkey" });
+  if (!knownNetuids.includes(netuid)) issues.push({ code: "invalid_netuid" });
+  if (amountRao <= 0n) {
+    issues.push({ code: "amount_not_positive" });
+  } else {
+    if (amountRao < minStakeRao) issues.push({ code: "below_min_stake", minStakeRao });
+    if (availableBalanceRao !== undefined && amountRao > availableBalanceRao) {
+      issues.push({ code: "insufficient_balance", availableRao: availableBalanceRao });
+    }
+  }
+  return issues;
+}
+
+/** Human-readable copy for a validation issue, for the pre-sign confirmation screen (#5239). */
+export function describeStakeValidationIssue(issue: StakeValidationIssue): string {
+  switch (issue.code) {
+    case "invalid_hotkey":
+      return "Not a valid hotkey address.";
+    case "invalid_netuid":
+      return "This subnet isn't currently active.";
+    case "amount_not_positive":
+      return "Enter an amount greater than zero.";
+    case "below_min_stake":
+      return `Amount is below the network minimum of ${raoToTao(issue.minStakeRao)} TAO.`;
+    case "insufficient_balance":
+      return `Amount exceeds your available balance of ${raoToTao(issue.availableRao)} TAO.`;
+  }
+}

--- a/apps/ui/src/lib/metagraphed/tx-errors.test.ts
+++ b/apps/ui/src/lib/metagraphed/tx-errors.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { decodeModuleError, decodeCustomTxError, type TxErrorCategory } from "./tx-errors";
+
+// Every module error this file knows about, with its expected category --
+// verified against the live pallet source (see tx-errors.ts's header). One
+// assertion per entry catches a typo in either the key or the category that
+// a single "does it decode at all" smoke test would miss.
+const EXPECTED_MODULE_ERRORS: Array<[section: string, name: string, category: TxErrorCategory]> = [
+  ["subtensorModule", "NotEnoughBalanceToStake", "insufficient_balance"],
+  ["subtensorModule", "NotEnoughStake", "insufficient_balance"],
+  ["subtensorModule", "NotEnoughStakeToWithdraw", "insufficient_balance"],
+  ["subtensorModule", "StakeTooLowForRoot", "insufficient_balance"],
+  ["subtensorModule", "BalanceWithdrawalError", "insufficient_balance"],
+  ["subtensorModule", "AmountTooLow", "invalid_argument"],
+  ["subtensorModule", "HotKeyNotRegisteredInNetwork", "not_registered"],
+  ["subtensorModule", "HotKeyNotRegisteredInSubNet", "not_registered"],
+  ["subtensorModule", "HotKeyAccountNotExists", "not_registered"],
+  ["subtensorModule", "SubnetNotExists", "invalid_argument"],
+  ["subtensorModule", "NonAssociatedColdKey", "not_authorized"],
+  ["subtensorModule", "BeneficiaryDoesNotOwnHotkey", "not_authorized"],
+  ["subtensorModule", "StakingRateLimitExceeded", "rate_limited"],
+  ["subtensorModule", "DelegateTxRateLimitExceeded", "rate_limited"],
+  ["subtensorModule", "TxChildkeyTakeRateLimitExceeded", "rate_limited"],
+  ["subtensorModule", "TxRateLimitExceeded", "rate_limited"],
+  ["subtensorModule", "AddStakeBurnRateLimitExceeded", "rate_limited"],
+  ["subtensorModule", "DelegateTakeTooHigh", "invalid_argument"],
+  ["subtensorModule", "DelegateTakeTooLow", "invalid_argument"],
+  ["subtensorModule", "SameNetuid", "invalid_argument"],
+  ["subtensorModule", "InvalidChildkeyTake", "invalid_argument"],
+  ["subtensorModule", "TransferDisallowed", "disabled"],
+  ["swap", "InsufficientLiquidity", "insufficient_liquidity"],
+  ["swap", "SlippageTooHigh", "insufficient_liquidity"],
+  ["swap", "PriceLimitExceeded", "insufficient_liquidity"],
+  ["swap", "ReservesTooLow", "insufficient_liquidity"],
+  ["swap", "InsufficientBalance", "insufficient_balance"],
+  ["swap", "SubtokenDisabled", "disabled"],
+];
+
+describe("decodeModuleError", () => {
+  it.each(EXPECTED_MODULE_ERRORS)("decodes %s.%s as %s", (section, name, category) => {
+    const decoded = decodeModuleError(section, name);
+    expect(decoded.category).toBe(category);
+    expect(decoded.source).toBe(`${section}.${name}`);
+    expect(decoded.message.length).toBeGreaterThan(0);
+  });
+
+  it("distinguishes the same error name in different pallets (swap.InsufficientBalance vs no subtensorModule.InsufficientBalance)", () => {
+    // subtensorModule has NO error literally named InsufficientBalance -- only
+    // swap does (verified against source; a naive "match by name only" decoder
+    // would get this wrong for a chain that has both).
+    expect(decodeModuleError("swap", "InsufficientBalance").category).toBe("insufficient_balance");
+    expect(decodeModuleError("subtensorModule", "InsufficientBalance").category).toBe("unknown");
+  });
+
+  it("falls back to a generic message for an unrecognized module error, never throwing", () => {
+    const decoded = decodeModuleError("someOtherPallet", "SomeWeirdError");
+    expect(decoded.category).toBe("unknown");
+    expect(decoded.source).toBe("someOtherPallet.SomeWeirdError");
+    expect(decoded.message).toContain("someOtherPallet.SomeWeirdError");
+  });
+});
+
+// The five codes issue #5240 itself cited, independently re-verified against
+// common/src/transaction_error.rs's real CustomTransactionError -> u8
+// mapping (all five turned out correct) plus the rest of the
+// staking-relevant subset this file curates.
+const EXPECTED_CUSTOM_ERRORS: Array<[code: number, name: string, category: TxErrorCategory]> = [
+  [1, "StakeAmountTooLow", "invalid_argument"],
+  [2, "BalanceTooLow", "insufficient_balance"],
+  [3, "SubnetNotExists", "invalid_argument"],
+  [4, "HotkeyAccountDoesntExist", "not_registered"],
+  [5, "NotEnoughStakeToWithdraw", "insufficient_balance"],
+  [6, "RateLimitExceeded", "rate_limited"],
+  [7, "InsufficientLiquidity", "insufficient_liquidity"],
+  [8, "SlippageTooHigh", "insufficient_liquidity"],
+  [9, "TransferDisallowed", "disabled"],
+  [10, "HotKeyNotRegisteredInNetwork", "not_registered"],
+  [25, "NonAssociatedColdKey", "not_authorized"],
+  [26, "DelegateTakeTooLow", "invalid_argument"],
+  [27, "DelegateTakeTooHigh", "invalid_argument"],
+];
+
+describe("decodeCustomTxError", () => {
+  it.each(EXPECTED_CUSTOM_ERRORS)("decodes code %i (%s) as %s", (code, name, category) => {
+    const decoded = decodeCustomTxError(code);
+    expect(decoded.category).toBe(category);
+    expect(decoded.source).toBe(`Custom(${code}:${name})`);
+    expect(decoded.message.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to a generic message for an unrecognized code, never throwing", () => {
+    const decoded = decodeCustomTxError(999);
+    expect(decoded.category).toBe("unknown");
+    expect(decoded.source).toBe("Custom(999)");
+    expect(decoded.message).toContain("999");
+  });
+
+  it("does not confuse a rejected-by-index code outside the staking-relevant subset (e.g. IP/port codes) with a real match", () => {
+    // Code 11/12/13 exist in the real enum (InvalidIpAddress/
+    // ServingRateLimitExceeded/InvalidPort) but are deliberately not curated
+    // here (out of this epic's scope) -- must fall through to "unknown", not
+    // silently match something else.
+    expect(decodeCustomTxError(11).category).toBe("unknown");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/tx-errors.ts
+++ b/apps/ui/src/lib/metagraphed/tx-errors.ts
@@ -1,0 +1,288 @@
+// Chain error decoding for stake/unstake/move transactions (#5240,
+// native-staking epic #5229). Every entry below is verified against the live
+// opentensor/subtensor source (read 2026-07-14), not carried over from the
+// issue's own research unchecked -- that cross-check caught real drift worth
+// recording:
+//
+//   - `InsufficientBalance`, `PriceLimitExceeded`, `ReservesTooLow`, and
+//     `SubtokenDisabled` (note: lowercase "k" in "token" -- the issue's own
+//     text had "SubTokenDisabled") are real errors, but they belong to the
+//     SEPARATE `swap` pallet (pallets/swap/src/pallet/mod.rs), not
+//     `subtensorModule` -- stake_utils.rs's `stake_into_subnet` calls into
+//     the swap pallet's AMM internally, so a slippage/liquidity failure
+//     during add_stake_limit/remove_stake_limit/swap_stake_limit surfaces as
+//     a `swap.*` DispatchError, not a `subtensorModule.*` one. Decoding by
+//     section matters: guessing the wrong pallet for a real error name would
+//     silently fail to match here and fall through to the generic "unknown"
+//     message.
+//   - `BalanceLow` does not exist anywhere in either pallet's error enum --
+//     dropped, not carried forward as a guess.
+//   - The five numeric tx-pool codes the issue cited (1, 6, 7, 8, 25) were
+//     independently verified against common/src/transaction_error.rs's own
+//     `CustomTransactionError -> u8` mapping and are all correct; the rest of
+//     that file's ~28 variants are included below too, filtered to the ones
+//     relevant to staking/unstaking/moving (this epic's actual scope) --
+//     IP/port/EVM-association/shielded-tx codes etc. are out of scope and
+//     deliberately omitted, falling through to the generic "unknown" path
+//     rather than a curated (and inevitably incomplete) attempt at full
+//     pallet-wide coverage.
+//
+// Two genuinely different failure classes, decoded differently:
+//   - A DispatchError (decodeModuleError) means the call executed on-chain
+//     and failed inside the pallet logic -- the extrinsic IS in a block.
+//   - A Custom(N) InvalidTransaction (decodeCustomTxError) means the
+//     transaction pool rejected it before it ever reached a block -- no fee
+//     was paid, no nonce was consumed.
+
+export type TxErrorCategory =
+  | "insufficient_balance"
+  | "insufficient_liquidity"
+  | "not_registered"
+  | "not_authorized"
+  | "rate_limited"
+  | "invalid_argument"
+  | "disabled"
+  | "unknown";
+
+export interface DecodedTxError {
+  category: TxErrorCategory;
+  message: string;
+  /** For support/debugging -- "subtensorModule.AmountTooLow" or "Custom(8)". */
+  source: string;
+}
+
+interface ErrorEntry {
+  category: TxErrorCategory;
+  message: string;
+}
+
+// Keyed by "<pallet>.<ErrorName>", using the runtime's own metadata-resolved
+// names (from api.registry.findMetaError(dispatchError.asModule).section/
+// .name) -- correct across runtime upgrades that renumber error indices, as
+// long as the name itself is stable.
+const MODULE_ERRORS: Record<string, ErrorEntry> = {
+  // subtensorModule -- balance/stake-amount failures
+  "subtensorModule.NotEnoughBalanceToStake": {
+    category: "insufficient_balance",
+    message: "Not enough balance in your wallet to stake this amount.",
+  },
+  "subtensorModule.NotEnoughStake": {
+    category: "insufficient_balance",
+    message: "Not enough stake on this hotkey for this action.",
+  },
+  "subtensorModule.NotEnoughStakeToWithdraw": {
+    category: "insufficient_balance",
+    message: "You're trying to unstake more than you have staked.",
+  },
+  "subtensorModule.StakeTooLowForRoot": {
+    category: "insufficient_balance",
+    message: "This stake amount is too low to join the root subnet.",
+  },
+  "subtensorModule.BalanceWithdrawalError": {
+    category: "insufficient_balance",
+    message: "Your wallet balance couldn't be withdrawn for this stake.",
+  },
+  "subtensorModule.AmountTooLow": {
+    category: "invalid_argument",
+    message: "This amount is below the network's minimum stake.",
+  },
+  // subtensorModule -- registration / identity
+  "subtensorModule.HotKeyNotRegisteredInNetwork": {
+    category: "not_registered",
+    message: "This hotkey isn't registered on any subnet.",
+  },
+  "subtensorModule.HotKeyNotRegisteredInSubNet": {
+    category: "not_registered",
+    message: "This hotkey isn't registered on this subnet.",
+  },
+  "subtensorModule.HotKeyAccountNotExists": {
+    category: "not_registered",
+    message: "This hotkey doesn't exist on-chain.",
+  },
+  "subtensorModule.SubnetNotExists": {
+    category: "invalid_argument",
+    message: "This subnet doesn't exist.",
+  },
+  // subtensorModule -- authorization
+  "subtensorModule.NonAssociatedColdKey": {
+    category: "not_authorized",
+    message: "Your wallet isn't the owner of this hotkey.",
+  },
+  "subtensorModule.BeneficiaryDoesNotOwnHotkey": {
+    category: "not_authorized",
+    message: "The destination account doesn't own this hotkey.",
+  },
+  // subtensorModule -- rate limits
+  "subtensorModule.StakingRateLimitExceeded": {
+    category: "rate_limited",
+    message: "Too many staking transactions too quickly -- wait a moment and try again.",
+  },
+  "subtensorModule.DelegateTxRateLimitExceeded": {
+    category: "rate_limited",
+    message: "Too many delegate transactions too quickly -- wait a moment and try again.",
+  },
+  "subtensorModule.TxChildkeyTakeRateLimitExceeded": {
+    category: "rate_limited",
+    message: "Too many childkey-take changes too quickly -- wait a moment and try again.",
+  },
+  "subtensorModule.TxRateLimitExceeded": {
+    category: "rate_limited",
+    message: "Too many transactions too quickly -- wait a moment and try again.",
+  },
+  "subtensorModule.AddStakeBurnRateLimitExceeded": {
+    category: "rate_limited",
+    message: "Too many stake transactions too quickly -- wait a moment and try again.",
+  },
+  // subtensorModule -- other invalid-argument cases relevant to staking
+  "subtensorModule.DelegateTakeTooHigh": {
+    category: "invalid_argument",
+    message: "This validator's take is set too high to accept.",
+  },
+  "subtensorModule.DelegateTakeTooLow": {
+    category: "invalid_argument",
+    message: "This validator's take is set too low to accept.",
+  },
+  "subtensorModule.SameNetuid": {
+    category: "invalid_argument",
+    message: "Origin and destination subnets must be different.",
+  },
+  "subtensorModule.InvalidChildkeyTake": {
+    category: "invalid_argument",
+    message: "Invalid childkey take value.",
+  },
+  "subtensorModule.TransferDisallowed": {
+    category: "disabled",
+    message: "Transfers are disabled on this subnet.",
+  },
+  // swap pallet -- the AMM stake_into_subnet/remove_stake routes through
+  // internally; a slippage/liquidity failure here, not subtensorModule.
+  "swap.InsufficientLiquidity": {
+    category: "insufficient_liquidity",
+    message: "Not enough liquidity in this subnet's pool for this trade size.",
+  },
+  "swap.SlippageTooHigh": {
+    category: "insufficient_liquidity",
+    message: "Price moved beyond your slippage tolerance -- try again or widen the tolerance.",
+  },
+  "swap.PriceLimitExceeded": {
+    category: "insufficient_liquidity",
+    message: "The trade would cross your price limit.",
+  },
+  "swap.ReservesTooLow": {
+    category: "insufficient_liquidity",
+    message: "This subnet's pool reserves are too low for this trade.",
+  },
+  "swap.InsufficientBalance": {
+    category: "insufficient_balance",
+    message: "Not enough balance for this swap.",
+  },
+  "swap.SubtokenDisabled": {
+    category: "disabled",
+    message: "This subnet's token isn't enabled for trading yet.",
+  },
+};
+
+/** Decode a DispatchError's module section/name (via api.registry.findMetaError) into human copy. */
+export function decodeModuleError(section: string, name: string): DecodedTxError {
+  const source = `${section}.${name}`;
+  const known = MODULE_ERRORS[source];
+  if (known) return { ...known, source };
+  return {
+    category: "unknown",
+    message: `Transaction failed (${source}).`,
+    source,
+  };
+}
+
+interface CustomErrorEntry extends ErrorEntry {
+  name: string;
+}
+
+// From common/src/transaction_error.rs's CustomTransactionError -> u8 mapping
+// (verified live against the exact numeric values, 2026-07-14). Filtered to
+// staking/unstaking/moving-relevant codes; the rest of that enum (IP/port
+// serving, EVM key association, shielded-tx parsing, commit-reveal) is out of
+// this epic's scope and falls through to the generic "unknown" path.
+const CUSTOM_TX_ERRORS: Record<number, CustomErrorEntry> = {
+  1: {
+    name: "StakeAmountTooLow",
+    category: "invalid_argument",
+    message: "This amount is below the network's minimum stake.",
+  },
+  2: {
+    name: "BalanceTooLow",
+    category: "insufficient_balance",
+    message: "Not enough balance in your wallet for this transaction.",
+  },
+  3: {
+    name: "SubnetNotExists",
+    category: "invalid_argument",
+    message: "This subnet doesn't exist.",
+  },
+  4: {
+    name: "HotkeyAccountDoesntExist",
+    category: "not_registered",
+    message: "This hotkey doesn't exist on-chain.",
+  },
+  5: {
+    name: "NotEnoughStakeToWithdraw",
+    category: "insufficient_balance",
+    message: "You're trying to unstake more than you have staked.",
+  },
+  6: {
+    name: "RateLimitExceeded",
+    category: "rate_limited",
+    message: "Too many transactions too quickly -- wait a moment and try again.",
+  },
+  7: {
+    name: "InsufficientLiquidity",
+    category: "insufficient_liquidity",
+    message: "Not enough liquidity in this subnet's pool for this trade size.",
+  },
+  8: {
+    name: "SlippageTooHigh",
+    category: "insufficient_liquidity",
+    message: "Price moved beyond your slippage tolerance -- try again or widen the tolerance.",
+  },
+  9: {
+    name: "TransferDisallowed",
+    category: "disabled",
+    message: "Transfers are disabled on this subnet.",
+  },
+  10: {
+    name: "HotKeyNotRegisteredInNetwork",
+    category: "not_registered",
+    message: "This hotkey isn't registered on any subnet.",
+  },
+  25: {
+    name: "NonAssociatedColdKey",
+    category: "not_authorized",
+    message: "Your wallet isn't the owner of this hotkey.",
+  },
+  26: {
+    name: "DelegateTakeTooLow",
+    category: "invalid_argument",
+    message: "This validator's take is set too low to accept.",
+  },
+  27: {
+    name: "DelegateTakeTooHigh",
+    category: "invalid_argument",
+    message: "This validator's take is set too high to accept.",
+  },
+};
+
+/**
+ * Decode a transaction-pool rejection (InvalidTransaction::Custom(N)) --
+ * the transaction never reached a block, no fee was paid. Distinct from
+ * decodeModuleError, which decodes an on-chain, in-block failure.
+ */
+export function decodeCustomTxError(code: number): DecodedTxError {
+  const known = CUSTOM_TX_ERRORS[code];
+  const source = known ? `Custom(${code}:${known.name})` : `Custom(${code})`;
+  if (known) return { category: known.category, message: known.message, source };
+  return {
+    category: "unknown",
+    message: `Transaction rejected before broadcast (code ${code}).`,
+    source,
+  };
+}

--- a/apps/ui/src/lib/metagraphed/tx-fee.test.ts
+++ b/apps/ui/src/lib/metagraphed/tx-fee.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from "vitest";
+import type { SubmittableExtrinsic } from "@polkadot/api/types";
+import { estimateFee } from "./tx-fee";
+
+function makeFakeExtrinsic(partialFeeRao: bigint) {
+  return {
+    paymentInfo: vi.fn(async (_signerAddress: string) => ({
+      partialFee: { toBigInt: () => partialFeeRao },
+    })),
+  } as unknown as SubmittableExtrinsic<"promise">;
+}
+
+describe("estimateFee", () => {
+  it("returns the partialFee as rao", async () => {
+    const extrinsic = makeFakeExtrinsic(123_456n);
+    await expect(
+      estimateFee(extrinsic, "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"),
+    ).resolves.toBe(123_456n);
+  });
+
+  it("calls paymentInfo with the signer address, not a signed transaction", async () => {
+    const extrinsic = makeFakeExtrinsic(1n);
+    const address = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+    await estimateFee(extrinsic, address);
+    expect(extrinsic.paymentInfo).toHaveBeenCalledWith(address);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/tx-fee.ts
+++ b/apps/ui/src/lib/metagraphed/tx-fee.ts
@@ -1,0 +1,18 @@
+// Fee dry-run for the pre-sign confirmation screen (#5239, native-staking
+// epic #5229). `extrinsic.paymentInfo()` is @polkadot/api's own convenience
+// wrapper around the standard `TransactionPaymentApi::query_info` runtime
+// call (a standard FRAME API, not a subtensor-custom one -- unlike
+// chain-connection.ts's consts/query calls, this one has real, non-generic
+// TypeScript types out of the box).
+
+import type { SubmittableExtrinsic } from "@polkadot/api/types";
+import { asRao, type Rao } from "./units";
+
+/** Estimate the fee (rao) for a constructed extrinsic, as if signed and submitted by signerAddress -- does not sign or submit anything. */
+export async function estimateFee(
+  extrinsic: SubmittableExtrinsic<"promise">,
+  signerAddress: string,
+): Promise<Rao> {
+  const info = await extrinsic.paymentInfo(signerAddress);
+  return asRao(info.partialFee.toBigInt());
+}

--- a/apps/ui/src/lib/metagraphed/units.test.ts
+++ b/apps/ui/src/lib/metagraphed/units.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import {
+  taoToRao,
+  raoToTao,
+  alphaToRawAlpha,
+  rawAlphaToAlpha,
+  asRao,
+  asRawAlpha,
+  UNITS_PER_WHOLE,
+} from "./units";
+
+describe("taoToRao / raoToTao", () => {
+  it("round-trips whole amounts", () => {
+    expect(taoToRao("1")).toBe(1_000_000_000n);
+    expect(raoToTao(taoToRao("1"))).toBe("1");
+  });
+
+  it("round-trips fractional amounts to full rao precision", () => {
+    expect(taoToRao("0.5")).toBe(500_000_000n);
+    expect(taoToRao("0.000000001")).toBe(1n);
+    expect(raoToTao(taoToRao("123.456789012"))).toBe("123.456789012");
+  });
+
+  it("trims trailing zeros on format", () => {
+    expect(raoToTao(taoToRao("1.500000000"))).toBe("1.5");
+    expect(raoToTao(taoToRao("2.000000000"))).toBe("2");
+  });
+
+  it("handles amounts beyond Number.MAX_SAFE_INTEGER without precision loss", () => {
+    // 20,000,000 TAO -- well beyond 2^53 rao -- must not lose precision.
+    const huge = "20000000.123456789";
+    expect(raoToTao(taoToRao(huge))).toBe(huge);
+  });
+
+  it("accepts a plain number input", () => {
+    expect(taoToRao(1.5)).toBe(1_500_000_000n);
+  });
+
+  it("handles negative amounts", () => {
+    expect(taoToRao("-1.5")).toBe(-1_500_000_000n);
+    expect(raoToTao(asRao(-1_500_000_000n))).toBe("-1.5");
+  });
+
+  it("rejects sub-rao precision (more than 9 fractional digits)", () => {
+    expect(() => taoToRao("1.0000000001")).toThrow(/sub-unit precision/i);
+  });
+
+  it("rejects a malformed amount", () => {
+    expect(() => taoToRao("not-a-number")).toThrow(/invalid tao amount/i);
+    expect(() => taoToRao("1.2.3")).toThrow(/invalid tao amount/i);
+  });
+
+  it("UNITS_PER_WHOLE is exactly 1e9", () => {
+    expect(UNITS_PER_WHOLE).toBe(1_000_000_000n);
+  });
+});
+
+describe("alphaToRawAlpha / rawAlphaToAlpha", () => {
+  it("round-trips using the same 1e9 scale as TAO", () => {
+    expect(alphaToRawAlpha("1")).toBe(1_000_000_000n);
+    expect(rawAlphaToAlpha(alphaToRawAlpha("42.5"))).toBe("42.5");
+  });
+
+  it("rejects sub-unit precision", () => {
+    expect(() => alphaToRawAlpha("1.0000000001")).toThrow(/sub-unit precision/i);
+  });
+
+  it("rejects a malformed amount", () => {
+    expect(() => alphaToRawAlpha("nope")).toThrow(/invalid alpha amount/i);
+  });
+});
+
+describe("asRao / asRawAlpha", () => {
+  it("wrap a raw bigint without conversion", () => {
+    expect(asRao(5n)).toBe(5n);
+    expect(asRawAlpha(7n)).toBe(7n);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/units.ts
+++ b/apps/ui/src/lib/metagraphed/units.ts
@@ -1,0 +1,85 @@
+// RAO / TAO / alpha unit conversion (native-staking epic #5229, #5237).
+//
+// Every on-chain stake amount is a u64 rao/alpha integer -- TaoBalance/
+// AlphaBalance in the subtensor pallet (verified against
+// pallets/subtensor/src/common/currency.rs, live 2026-07-14: both are
+// `#[repr(transparent)] struct(u64)`, CompactAs-encoded) -- never a float.
+// BigInt throughout: rao amounts routinely exceed Number.MAX_SAFE_INTEGER
+// (2^53) for large holdings, and float arithmetic on chain amounts is exactly
+// the class of bug this epic exists to avoid.
+//
+// TAO and alpha are BOTH 1e9-scaled (1 TAO = 1e9 rao; 1 alpha = 1e9 raw alpha
+// units -- the pallet's AlphaBalance mirrors TaoBalance's u64 shape exactly),
+// but they are NEVER directly comparable without a price (alpha is
+// subnet-scoped; TAO is not) -- ADR 0018 §1. Branded types make that a
+// compile-time distinction, not just a naming convention: a Rao value cannot
+// be passed where a RawAlpha is expected, or vice versa, without an explicit
+// (and grep-able) cast.
+
+export const UNITS_PER_WHOLE = 1_000_000_000n;
+
+declare const RaoBrand: unique symbol;
+declare const RawAlphaBrand: unique symbol;
+
+/** Whole rao (the on-chain unit for TaoBalance) -- 1 TAO = 1e9 rao. */
+export type Rao = bigint & { readonly [RaoBrand]: true };
+/** Whole raw alpha units (the on-chain unit for AlphaBalance) -- 1 alpha = 1e9 raw units. */
+export type RawAlpha = bigint & { readonly [RawAlphaBrand]: true };
+
+function parseWholeUnitDecimal(value: string | number, label: string): bigint {
+  const str = typeof value === "number" ? value.toString() : value.trim();
+  if (!/^-?\d+(\.\d+)?$/.test(str)) {
+    throw new Error(`Invalid ${label} amount: "${value}"`);
+  }
+  const negative = str.startsWith("-");
+  const unsigned = negative ? str.slice(1) : str;
+  const [whole, frac = ""] = unsigned.split(".");
+  if (frac.length > 9) {
+    throw new Error(
+      `Sub-unit precision: "${value}" has more than 9 fractional digits, finer than a single rao/raw-alpha unit can represent`,
+    );
+  }
+  const paddedFrac = frac.padEnd(9, "0");
+  const units = BigInt(whole || "0") * UNITS_PER_WHOLE + BigInt(paddedFrac || "0");
+  return negative ? -units : units;
+}
+
+function formatWholeUnitDecimal(units: bigint): string {
+  const negative = units < 0n;
+  const abs = negative ? -units : units;
+  const whole = abs / UNITS_PER_WHOLE;
+  const frac = abs % UNITS_PER_WHOLE;
+  const fracStr = frac.toString().padStart(9, "0").replace(/0+$/, "");
+  const sign = negative ? "-" : "";
+  return fracStr ? `${sign}${whole}.${fracStr}` : `${sign}${whole}`;
+}
+
+/** Parse a decimal TAO amount (string or number) into whole rao. */
+export function taoToRao(tao: string | number): Rao {
+  return parseWholeUnitDecimal(tao, "TAO") as Rao;
+}
+
+/** Format whole rao as a decimal TAO string, trimming trailing zeros. */
+export function raoToTao(rao: Rao): string {
+  return formatWholeUnitDecimal(rao);
+}
+
+/** Parse a decimal alpha amount (string or number) into whole raw alpha units. */
+export function alphaToRawAlpha(alpha: string | number): RawAlpha {
+  return parseWholeUnitDecimal(alpha, "alpha") as RawAlpha;
+}
+
+/** Format whole raw alpha units as a decimal alpha string, trimming trailing zeros. */
+export function rawAlphaToAlpha(rawAlpha: RawAlpha): string {
+  return formatWholeUnitDecimal(rawAlpha);
+}
+
+/** Construct a Rao value from an already-whole-unit bigint (e.g. read from chain state). */
+export function asRao(units: bigint): Rao {
+  return units as Rao;
+}
+
+/** Construct a RawAlpha value from an already-whole-unit bigint (e.g. read from chain state). */
+export function asRawAlpha(units: bigint): RawAlpha {
+  return units as RawAlpha;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
       "dependencies": {
         "@jsonbored/metagraphed": "*",
         "@jsonbored/ui-kit": "*",
+        "@polkadot/api": "^16.5.6",
         "@polkadot/extension-dapp": "^0.63.1",
         "@sentry/browser": "^10.60.0",
         "@tailwindcss/vite": "^4.2.1",


### PR DESCRIPTION
## Summary

Closes #5239. Phase 2 of the native-staking epic (#5229) — the primary blind-signing mitigation. Subtensor isn't a top-tier chain in wallet metadata registries — no evidence any major wallet ships first-class, always-current decoding for `add_stake` etc — so a user likely sees a raw/generic extension prompt, not a friendly one. This screen is the real, human-readable checkpoint, shown before handoff to the extension.

**Stacks on #5535** (`claude/stake-tx-status` → #5532 → #5530), purely for shared branch history — this PR's own two files only directly depend on #5530's `units.ts` (the `Rao` type) and standard `@polkadot/api` types, not on `broadcast.ts`/`tx-errors.ts`/`use-tx-status.ts`. Merge order: #5530 → #5532 → #5535 → this one.

## What's here

- `apps/ui/src/lib/metagraphed/tx-fee.ts` — `estimateFee()`, wrapping `@polkadot/api`'s own `extrinsic.paymentInfo()` convenience method (the standard FRAME `TransactionPaymentApi::query_info` call the issue references). Unlike `chain-connection.ts`'s subtensor-custom calls, this one has real, non-generic TypeScript types out of the box — it's a standard pallet, not a custom one.
- `apps/ui/src/components/metagraphed/pre-sign-confirmation.tsx` — purely presentational. Every value (action, TAO+alpha amount, validator identity from the identity join, subnet, fee, expected outcome with slippage/tolerance) is a prop; the component does no data-fetching of its own. This makes it trivial to unit-test and reuse regardless of which flow eventually drives it — the actual stake/unstake modal (#5242) isn't part of this epic phase yet, so this ships as a ready-to-integrate, standalone component rather than waiting on that. Includes the issue's required persistent non-custodial disclaimer copy, and a Cancel/Confirm pair that disables during signing.

## On the screenshot table

This is a new component with no live mount point yet (#5242 will be the actual integration). The mandatory before/after table doesn't cleanly apply to something that isn't rendered anywhere in the app today — there's no "before." Instead, I temporarily mounted it on `/settings` locally (a throwaway harness, fully reverted — `git diff` before this commit shows zero trace of it) purely to capture real, rendered screenshots, then removed the mount before committing.

| State | Screenshot |
|---|---|
| Idle (fee/quote loaded) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5239-pre-sign-confirmation-presign-idle.png" width="320">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5239-pre-sign-confirmation-presign-idle.png) |
| Confirming (signing in progress, fee re-estimating, Cancel disabled) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5239-pre-sign-confirmation-presign-confirming.png" width="320">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5239-pre-sign-confirmation-presign-confirming.png) |
| Mobile (375px) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5239-pre-sign-confirmation-presign-mobile.png" width="200">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5239-pre-sign-confirmation-presign-mobile.png) |
| Light theme | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5239-pre-sign-confirmation-presign-light.png" width="320">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5239-pre-sign-confirmation-presign-light.png) |

Whoever integrates this into #5242's actual modal should re-verify visually in that real context (different container width/chrome could reveal layout issues this isolated harness didn't).

## Test plan

- [x] `npx vitest run` (apps/ui) — 121 files / 880 tests pass, including 2 new tests for `estimateFee()` (returns `partialFee` as rao, calls `paymentInfo` with the signer address)
- [x] `npm run lint` / `npx tsc --noEmit` / `npm run format:check` (apps/ui) — clean
- [x] `npm run build` (apps/ui, real Nitro/Cloudflare target) — succeeds
- [x] Manual visual QA (see screenshot table above) — no console errors, no layout overflow at mobile width, all interactive states (idle/confirming/disabled) verified
- [ ] `PreSignConfirmation` has no unit test file itself, matching this codebase's convention (visual components are screenshot-verified, not RTL-tested — this repo has no RTL/jsdom at all, see `apps/ui/vitest.config.ts`)