### PR TITLE
docs(gardening): fix prettier formatting in contributor-pipeline SKILL.md

### DIFF
--- a/.claude/skills/contributor-pipeline-gardening/SKILL.md
+++ b/.claude/skills/contributor-pipeline-gardening/SKILL.md
@@ -55,7 +55,7 @@ Surface`, `Partner Flywheel Hardening`, or a new one if none fit) — this repo'
    merits, focused on that repo's actual goals (corrected by the maintainer 2026-07-14 — an earlier
    version of this doc wrongly said "combined total, not per-repo"). **Exclude the "Enrich SNxxx"
    family (see below) from this count** — it's a separately-automated queue, not this skill's backlog.
-1a. **The "Enrich SN<netuid> ..." family (tracked via #427, ~20-30 issues at any time) is handled by
+   1a. **The "Enrich SN<netuid> ..." family (tracked via #427, ~20-30 issues at any time) is handled by
    a separate automation, not this skill.** Don't count them toward the 50-100 top-up target (filter
    out any issue whose title matches "Enrich SN" before comparing against the target), and don't
    generate more of them yourselves — that automation owns that queue. Pass 1's stale-sweep/hygiene


### PR DESCRIPTION
## Summary
- A recent edit to `.claude/skills/contributor-pipeline-gardening/SKILL.md` (#5536) left the "1a." list-continuation line's indentation out of sync with prettier's normalized form
- `Lint + format` runs `prettier --check .` repo-wide (not scoped to changed files), so this is currently failing the `checks` job on every open PR, including two unrelated ones I have open (#5537, #5539)

## Test plan
- [x] `npx prettier --check .` clean (repo-tracked files only — local `apps/indexer-rs/target/` build output is gitignored and not part of CI's checkout)