### PR TITLE
infra(ci): add timeout-minutes guards to workflow jobs missing them

### DIFF
--- a/.github/workflows/discover-testnet-surfaces.yml
+++ b/.github/workflows/discover-testnet-surfaces.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   discover:
     runs-on: ubuntu-latest
+    timeout-minutes: 20 # network probe with per-request timeouts, bounded by subnet count
     permissions:
       contents: read
     steps:

--- a/.github/workflows/enrichment-issues.yml
+++ b/.github/workflows/enrichment-issues.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   enrich:
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # issue-buffer top-up against the GitHub API, no chain/network probing
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -58,6 +58,7 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    timeout-minutes: 45 # full production build: chain snapshot + live probes + adapter re-snapshot
     permissions:
       contents: read
     outputs:
@@ -162,6 +163,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: refresh
+    timeout-minutes: 45 # full validate suite plus R2/KV publish and the retried live smoke check
     permissions:
       contents: read
     env:

--- a/.github/workflows/readme-catalog-refresh.yml
+++ b/.github/workflows/readme-catalog-refresh.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # regenerates one README section from committed overlays, no network calls
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,7 @@ concurrency:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # release-please diff + optional publish dispatch, no chain/network probing
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/resync-registry-postgres.yml
+++ b/.github/workflows/resync-registry-postgres.yml
@@ -39,6 +39,7 @@ jobs:
   resync:
     name: Full resync (community + machine-generated)
     runs-on: ubuntu-latest
+    timeout-minutes: 20 # HTTPS upserts to the registry-sync Worker, bounded by registry size
     permissions:
       contents: read
     steps:

--- a/.github/workflows/sync-client-version.yml
+++ b/.github/workflows/sync-client-version.yml
@@ -35,6 +35,7 @@ jobs:
   bump:
     name: Open client version bump PR
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # local diff/version bump + PR open, no external network calls beyond git/GitHub
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/sync-mcp-version.yml
+++ b/.github/workflows/sync-mcp-version.yml
@@ -48,6 +48,7 @@ jobs:
   bump:
     name: Open MCP version bump PR
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # local diff/version bump + PR open, no external network calls beyond git/GitHub
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/sync-operational-surfaces.yml
+++ b/.github/workflows/sync-operational-surfaces.yml
@@ -35,6 +35,7 @@ jobs:
   sync:
     name: Regenerate operational-surfaces.json if stale
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # runs the full registry build (npm run build) hourly
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/sync-registry-to-postgres.yml
+++ b/.github/workflows/sync-registry-to-postgres.yml
@@ -48,6 +48,7 @@ jobs:
   sync:
     name: Upsert changed registry files into Postgres
     runs-on: ubuntu-latest
+    timeout-minutes: 20 # HTTPS upserts to the registry-sync Worker, scoped to one push's changed files
     permissions:
       contents: read
     steps:

--- a/.github/workflows/sync-subnets.yml
+++ b/.github/workflows/sync-subnets.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 45 # full registry pipeline refresh: chain RPC calls plus live surface probes
     permissions:
       contents: read
     outputs:
@@ -140,6 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: sync
     if: needs.sync.outputs.has_changes == 'true'
+    timeout-minutes: 15 # applies an already-generated patch and opens a PR, no network refresh
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/validate-indexer-rs.yml
+++ b/.github/workflows/validate-indexer-rs.yml
@@ -35,6 +35,7 @@ defaults:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # cargo build + test, generous for a cold (uncached) cargo registry/target
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -104,6 +104,7 @@ jobs:
   changes:
     name: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # single inline git diff against the base ref, no build
     outputs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
       run_workflows_validation: ${{ steps.filter.outputs.run_workflows_validation }}
@@ -202,6 +203,7 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # build + full suite with coverage, the main per-PR gate
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -341,6 +343,7 @@ jobs:
     name: checks
     needs: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # build plus the ~20 contract/schema/registry/safety validators
     env:
       # A single guard expression, computed once, that every expensive step
       # below gates on. Deliberately a per-STEP `if:`, not a job-level `if:`
@@ -625,6 +628,7 @@ jobs:
   python:
     name: python
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # hermetic unittest suite (37 cases), no network
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -649,6 +653,7 @@ jobs:
     name: ui
     needs: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # workspace install, drift-check builds, typecheck/test, and the Playwright e2e pass
     env:
       RUN_UI_VALIDATION: ${{ needs.changes.outputs.run_ui_validation }}
     steps:


### PR DESCRIPTION
## Summary

- Adds an explicit `timeout-minutes` to every job in the 13 workflows that had none, each sized to the job's real work and with a short comment explaining the number, mirroring the existing `backfill-economics-history.yml:36` pattern.

## What Changed

- `discover-testnet-surfaces.yml`, `enrichment-issues.yml`, `readme-catalog-refresh.yml`, `resync-registry-postgres.yml`, `sync-client-version.yml`, `sync-mcp-version.yml`, `sync-operational-surfaces.yml`, `sync-registry-to-postgres.yml`, `validate-indexer-rs.yml`, `release-please.yml`: one job each, now bounded.
- `publish-cloudflare.yml` (`refresh`, `publish`) and `sync-subnets.yml` (`sync`, `pull-request`): both jobs in each bounded.
- `validate.yml`: all five jobs (`changes`, `test`, `checks`, `python`, `ui`) bounded.
- No workflow already carrying `timeout-minutes` (the `backfill-*` set, `publish-client.yml`, `publish-python.yml`, `refresh-economics.yml`, `publish-mcp-registry.yml`, `rollup-account-events-daily.yml`, `gittensor-impact.yml`, `smithery-publish.yml`) was touched.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5542`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [ ] Public API/OpenAPI/schema changes are intentional and documented. (n/a — no contract change)

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate`
- [x] `npm run validate:workflows`
- [x] `npm run scan:public-safety`
- [x] `npm run test:ci`
- [x] `git diff --check`

Closes #5542
