### PR TITLE
feat(ci): scheduled check for Worker deploy drift vs origin/main

### DIFF
--- a/.github/workflows/check-worker-deploy-drift.yml
+++ b/.github/workflows/check-worker-deploy-drift.yml
@@ -1,0 +1,62 @@
+name: Check Worker Deploy Drift
+
+# Detects a stuck/failed Cloudflare Workers Builds deploy (issue #5538, parent epic
+# #4651). The Worker CODE deploys via Cloudflare Workers Builds on push to main -- a
+# Cloudflare-side git integration, not a GitHub Actions step (see
+# publish-cloudflare.yml's header) -- so nothing here previously checked that a
+# Builds deploy actually landed the commit it should have. This scheduled job reads
+# back the commit Workers Builds tied to the currently-live deployment (via the
+# Cloudflare API, using the same read-only CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID
+# secrets publish-cloudflare.yml already uses) and compares it against a fresh
+# origin/main HEAD checkout, failing the job once the drift has persisted across a
+# prior scheduled run (see scripts/check-worker-deploy-drift.mjs for the exact
+# grace-window rule -- this only needs to catch a genuinely stuck build, not race a
+# normal in-flight deploy).
+on:
+  schedule:
+    - cron: "53 8 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: check-worker-deploy-drift-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    env:
+      WORKER_SCRIPT_NAME: metagraphed
+      WORKFLOW_FILENAME: check-worker-deploy-drift.yml
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Resolve origin/main HEAD
+        id: main-head
+        run: |
+          set -euo pipefail
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "committed_at=$(git log -1 --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.23.1
+
+      - name: Check live Worker deployment against origin/main HEAD
+        run: node scripts/check-worker-deploy-drift.mjs
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          MAIN_HEAD_SHA: ${{ steps.main-head.outputs.sha }}
+          MAIN_HEAD_COMMITTED_AT: ${{ steps.main-head.outputs.committed_at }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "worker:test": "node scripts/worker-test.mjs",
     "worker:deploy:dry-run": "node scripts/worker-deploy-dry-run.mjs",
     "worker:bundle:budget": "node scripts/worker-bundle-budget.mjs",
+    "worker:check-deploy-drift": "node scripts/check-worker-deploy-drift.mjs",
     "smoke:live": "node scripts/smoke-live-api.mjs",
     "lint": "eslint .",
     "format:check": "prettier --check .",

--- a/scripts/check-worker-deploy-drift.mjs
+++ b/scripts/check-worker-deploy-drift.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// Scheduled drift guard (issue #5538, parent epic #4651): the Worker CODE deploys
+// via Cloudflare Workers Builds on push to main (a Cloudflare-side git integration,
+// not a GitHub Actions step -- see publish-cloudflare.yml's header), so nothing in
+// this repo previously verified that a Builds deploy actually landed. A stuck build
+// leaves the live Worker silently drifting stale vs. main with no signal here. This
+// compares the live deployment's Workers-Builds-linked commit against origin/main
+// HEAD and fails the scheduled job once the drift has persisted across a prior
+// scheduled run (see evaluateDeployDrift below for the grace-window rule).
+import { fileURLToPath } from "node:url";
+
+const DEPLOYMENTS_PATH_TEMPLATE =
+  "https://api.cloudflare.com/client/v4/accounts/{accountId}/workers/scripts/{scriptName}/deployments";
+
+export function extractDeployedCommitSha(deploymentsJson) {
+  const deployments = deploymentsJson?.result?.deployments;
+  if (!Array.isArray(deployments) || deployments.length === 0) {
+    throw new Error(
+      "Cloudflare deployments response contained no deployments for this Worker script",
+    );
+  }
+  const active = deployments[0];
+  const commitSha = active?.annotations?.["workers/commit_hash"];
+  if (!commitSha) {
+    throw new Error(
+      `Active deployment ${active?.id ?? "(unknown id)"} has no workers/commit_hash annotation -- Workers Builds may not be linked to git for this script`,
+    );
+  }
+  return commitSha;
+}
+
+export function findPreviousScheduledRunAt(runsJson, currentRunId) {
+  const runs = Array.isArray(runsJson?.workflow_runs)
+    ? runsJson.workflow_runs
+    : [];
+  const previous = runs
+    .filter((run) => String(run.id) !== String(currentRunId))
+    .sort(
+      (a, b) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    )[0];
+  return previous?.created_at ?? null;
+}
+
+// Grace window, per issue #5538: skip the very first scheduled run that observes a
+// drift (a normal in-flight Builds deploy), only alert once the drift already
+// existed as of the PREVIOUS scheduled run -- i.e. it has persisted across a full
+// scheduled interval, not just "since the last push". Deliberately time-boundary-
+// free (no arbitrary hour threshold): it reuses the scheduled run history GitHub
+// Actions already retains instead of inventing separate persisted state.
+export function evaluateDeployDrift({
+  deployedCommitSha,
+  mainHeadSha,
+  mainHeadCommittedAt,
+  previousScheduledRunAt,
+}) {
+  if (deployedCommitSha === mainHeadSha) {
+    return {
+      drifted: false,
+      shouldAlert: false,
+      reason: `deployed commit ${deployedCommitSha} matches origin/main HEAD`,
+    };
+  }
+  if (!previousScheduledRunAt) {
+    return {
+      drifted: true,
+      shouldAlert: false,
+      reason: `origin/main HEAD ${mainHeadSha} (pushed ${mainHeadCommittedAt}) is not yet deployed (live: ${deployedCommitSha}), but there is no prior scheduled run to compare against -- within the grace window`,
+    };
+  }
+  const pushedBeforePreviousRun =
+    new Date(mainHeadCommittedAt).getTime() <
+    new Date(previousScheduledRunAt).getTime();
+  if (!pushedBeforePreviousRun) {
+    return {
+      drifted: true,
+      shouldAlert: false,
+      reason: `origin/main HEAD ${mainHeadSha} was pushed after the previous scheduled run (${previousScheduledRunAt}) -- this is the first scheduled run to observe the drift, within the grace window`,
+    };
+  }
+  return {
+    drifted: true,
+    shouldAlert: true,
+    reason: `origin/main HEAD ${mainHeadSha} (pushed ${mainHeadCommittedAt}) is still undeployed (live: ${deployedCommitSha}) as of the previous scheduled run (${previousScheduledRunAt}) -- drift has persisted across more than one scheduled run`,
+  };
+}
+
+async function main() {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+  const scriptName = process.env.WORKER_SCRIPT_NAME || "metagraphed";
+  const mainHeadSha = process.env.MAIN_HEAD_SHA;
+  const mainHeadCommittedAt = process.env.MAIN_HEAD_COMMITTED_AT;
+  const githubToken = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const runId = process.env.GITHUB_RUN_ID;
+  const workflowFilename = process.env.WORKFLOW_FILENAME;
+
+  if (!accountId || !apiToken) {
+    console.error(
+      "::error::CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are required to check the live Worker deployment -- a contributor PR cannot supply these, a maintainer must configure the repo secrets.",
+    );
+    return 1;
+  }
+  if (!mainHeadSha || !mainHeadCommittedAt) {
+    console.error(
+      "::error::MAIN_HEAD_SHA and MAIN_HEAD_COMMITTED_AT must be set from a fresh checkout before running this check.",
+    );
+    return 1;
+  }
+
+  const deploymentsUrl = DEPLOYMENTS_PATH_TEMPLATE.replace(
+    "{accountId}",
+    accountId,
+  ).replace("{scriptName}", scriptName);
+  const deploymentsRes = await fetch(deploymentsUrl, {
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+  if (deploymentsRes.status === 401 || deploymentsRes.status === 403) {
+    console.error(
+      `::error::CLOUDFLARE_API_TOKEN lacks permission to read Worker deployments for '${scriptName}' (HTTP ${deploymentsRes.status}). Grant the token Workers Scripts read access -- a contributor PR cannot change token scope, this needs a maintainer.`,
+    );
+    return 1;
+  }
+  if (!deploymentsRes.ok) {
+    console.error(
+      `::error::Cloudflare deployments API returned HTTP ${deploymentsRes.status}: ${await deploymentsRes.text()}`,
+    );
+    return 1;
+  }
+
+  let deployedCommitSha;
+  try {
+    deployedCommitSha = extractDeployedCommitSha(await deploymentsRes.json());
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    return 1;
+  }
+
+  let previousScheduledRunAt = null;
+  if (githubToken && repository && workflowFilename) {
+    const runsUrl = `https://api.github.com/repos/${repository}/actions/workflows/${workflowFilename}/runs?event=schedule&status=completed&per_page=5`;
+    const runsRes = await fetch(runsUrl, {
+      headers: {
+        Authorization: `Bearer ${githubToken}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!runsRes.ok) {
+      console.error(
+        `::error::GitHub Actions API returned HTTP ${runsRes.status} while listing previous scheduled runs: ${await runsRes.text()}`,
+      );
+      return 1;
+    }
+    previousScheduledRunAt = findPreviousScheduledRunAt(
+      await runsRes.json(),
+      runId,
+    );
+  }
+
+  const result = evaluateDeployDrift({
+    deployedCommitSha,
+    mainHeadSha,
+    mainHeadCommittedAt,
+    previousScheduledRunAt,
+  });
+  console.log(JSON.stringify(result, null, 2));
+  if (result.shouldAlert) {
+    console.error(`::error::${result.reason}`);
+    return 1;
+  }
+  return 0;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error(`::error::${error.stack || error.message}`);
+      process.exit(1);
+    });
+}

--- a/tests/check-worker-deploy-drift.test.mjs
+++ b/tests/check-worker-deploy-drift.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  evaluateDeployDrift,
+  extractDeployedCommitSha,
+  findPreviousScheduledRunAt,
+} from "../scripts/check-worker-deploy-drift.mjs";
+
+describe("extractDeployedCommitSha", () => {
+  test("reads the commit hash annotation off the active (first) deployment", () => {
+    const sha = extractDeployedCommitSha({
+      result: {
+        deployments: [
+          { id: "dep-2", annotations: { "workers/commit_hash": "abc123" } },
+          { id: "dep-1", annotations: { "workers/commit_hash": "old999" } },
+        ],
+      },
+    });
+    assert.equal(sha, "abc123");
+  });
+
+  test("throws when there are no deployments", () => {
+    assert.throws(
+      () => extractDeployedCommitSha({ result: { deployments: [] } }),
+      /no deployments/,
+    );
+  });
+
+  test("throws when the active deployment has no commit_hash annotation", () => {
+    assert.throws(
+      () =>
+        extractDeployedCommitSha({
+          result: { deployments: [{ id: "dep-1", annotations: {} }] },
+        }),
+      /no workers\/commit_hash annotation/,
+    );
+  });
+});
+
+describe("findPreviousScheduledRunAt", () => {
+  test("returns the most recent completed run excluding the current run", () => {
+    const at = findPreviousScheduledRunAt(
+      {
+        workflow_runs: [
+          { id: 3, created_at: "2026-07-14T09:00:00Z" },
+          { id: 2, created_at: "2026-07-13T09:00:00Z" },
+          { id: 1, created_at: "2026-07-12T09:00:00Z" },
+        ],
+      },
+      3,
+    );
+    assert.equal(at, "2026-07-13T09:00:00Z");
+  });
+
+  test("returns null when there is no prior run", () => {
+    const at = findPreviousScheduledRunAt(
+      { workflow_runs: [{ id: 1, created_at: "2026-07-14T09:00:00Z" }] },
+      1,
+    );
+    assert.equal(at, null);
+  });
+
+  test("tolerates a missing workflow_runs array", () => {
+    assert.equal(findPreviousScheduledRunAt({}, 1), null);
+  });
+});
+
+describe("evaluateDeployDrift", () => {
+  test("no alert when the deployed commit matches origin/main HEAD", () => {
+    const r = evaluateDeployDrift({
+      deployedCommitSha: "abc123",
+      mainHeadSha: "abc123",
+      mainHeadCommittedAt: "2026-07-14T09:00:00Z",
+      previousScheduledRunAt: "2026-07-13T09:00:00Z",
+    });
+    assert.equal(r.drifted, false);
+    assert.equal(r.shouldAlert, false);
+  });
+
+  test("no alert on the very first scheduled run ever (no prior run to compare)", () => {
+    const r = evaluateDeployDrift({
+      deployedCommitSha: "old999",
+      mainHeadSha: "abc123",
+      mainHeadCommittedAt: "2026-07-14T09:00:00Z",
+      previousScheduledRunAt: null,
+    });
+    assert.equal(r.drifted, true);
+    assert.equal(r.shouldAlert, false);
+    assert.match(r.reason, /no prior scheduled run/);
+  });
+
+  test("no alert when main HEAD was pushed after the previous scheduled run (first run to see it)", () => {
+    const r = evaluateDeployDrift({
+      deployedCommitSha: "old999",
+      mainHeadSha: "abc123",
+      mainHeadCommittedAt: "2026-07-14T10:00:00Z",
+      previousScheduledRunAt: "2026-07-14T09:00:00Z",
+    });
+    assert.equal(r.drifted, true);
+    assert.equal(r.shouldAlert, false);
+    assert.match(r.reason, /first scheduled run to observe/);
+  });
+
+  test("alerts once the drift already existed as of the previous scheduled run", () => {
+    const r = evaluateDeployDrift({
+      deployedCommitSha: "old999",
+      mainHeadSha: "abc123",
+      mainHeadCommittedAt: "2026-07-12T09:00:00Z",
+      previousScheduledRunAt: "2026-07-13T09:00:00Z",
+    });
+    assert.equal(r.drifted, true);
+    assert.equal(r.shouldAlert, true);
+    assert.match(r.reason, /persisted across more than one scheduled run/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a scheduled GitHub Actions workflow that catches a stuck/failed Cloudflare Workers Builds deploy — the class of bug the parent epic (#4651) named directly ("a deployed streamer/cron silently drifting stale vs. `main` — no diff-detection today").

- `.github/workflows/check-worker-deploy-drift.yml`: runs daily (`workflow_dispatch` also enabled for manual runs), checks out a fresh `main` HEAD, and runs the drift check with the existing read-only `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` secrets.
- `scripts/check-worker-deploy-drift.mjs`: reads the commit Workers Builds tied to the currently-live `metagraphed` deployment (`workers/commit_hash` deployment annotation from the Cloudflare deployments API) and compares it to `origin/main` HEAD.
  - Fails loudly with a clear message if the token lacks permission to read deployments (HTTP 401/403) instead of silently no-oping — token scope changes need a maintainer, not a contributor PR.
  - Grace window: skips the very first scheduled run that observes a drift, and only alerts once the drift already existed as of the *previous* scheduled run (looked up via the GitHub Actions API's own run history — no separate persisted state needed).
- `tests/check-worker-deploy-drift.test.mjs`: unit tests for the three pure functions (`extractDeployedCommitSha`, `findPreviousScheduledRunAt`, `evaluateDeployDrift`), covering the annotation-parsing failure modes and every branch of the grace-window rule.

## Validation

- `npm run validate:workflows` — pinned-action-SHA + permissions/concurrency conventions pass
- `npm test` — full suite green (8212 tests), including the new test file
- `npm run validate` / `npm run build` — clean, no diff churn
- `npm run lint` / `npm run format:check` on the changed files — clean

Closes #5538
