### PR TITLE
feat(ui): add Taostats Wallet to the supported-wallets list

### DIFF
--- a/apps/ui/src/components/metagraphed/wallet-connect.tsx
+++ b/apps/ui/src/components/metagraphed/wallet-connect.tsx
@@ -25,10 +25,19 @@ import type { InjectedAccountWithMeta } from "@/lib/metagraphed/wallet-injected"
 const DISCLAIMER =
   "metagraphed never sees your keys. Connecting only shares your public address — signing (a later step) always happens in your wallet, never on our servers.";
 
+// Taostats Wallet added after ADR 0018 was written -- it's a modified
+// Talisman wallet (per Taostats' own announcement), so it implements the
+// same window.injectedWeb3 standard the other three do; no code change to
+// the connect flow itself was needed, only this list. Listed despite
+// Taostats being a competing block explorer -- the wallet is a largely
+// orthogonal product category, and it's purpose-built for exactly this
+// epic's use case (native Bittensor staking), so omitting it would be a
+// disservice to users picking a wallet for this specific reason.
 const SUPPORTED_WALLETS = [
   { label: "Polkadot{.js}", href: "https://polkadot.js.org/extension/" },
   { label: "Talisman", href: "https://talisman.xyz/" },
   { label: "SubWallet", href: "https://subwallet.app/" },
+  { label: "Taostats Wallet", href: "https://taostats.io/bittensor-chrome-wallet" },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Small follow-up to the native-staking epic's wallet-connect flow (#5236). Adds **Taostats Wallet** to the "no wallet extension found" install-link list in `wallet-connect.tsx` (currently Polkadot{.js}, Talisman, SubWallet).

Raised during #5242 prep: Taostats launched a browser-extension wallet after `docs/adr/0018-native-staking-architecture.md` was written, so it wasn't part of the ADR's original three-wallet research pass.

- **Technical compatibility**: verified via web search — Taostats' own announcement describes it as "a modified Talisman wallet, extended by Taostats." Talisman is one of the three wallets the ADR already confirmed implements the standard `window.injectedWeb3` injection protocol. Since metagraphed's `web3Enable`/`web3Accounts` connect flow already works with *any* compliant extension (it doesn't hardcode which wallets are allowed — that list only drives the install-link copy shown when no extension is detected), Taostats Wallet should already connect today with zero change to `wallet.ts`/`wallet-injected.ts`/`use-wallet.ts`. This PR only touches the display list.
- **Product logic**: Taostats markets the wallet as purpose-built for Bittensor staking specifically ("stake or unstake in two clicks," "see APY, emissions, alpha prices inside the wallet") — arguably the most relevant option for exactly this epic's use case. Not listing it would be a disservice to a user picking a wallet for this specific reason.
- **Competitive optics**: Taostats competes with metagraphed as a block explorer, but the wallet is a largely orthogonal product category — recommending it isn't the same as promoting their explorer product.

## Test plan

- [x] `npx vitest run` (apps/ui) — 121 files / 880 tests pass (no test changes needed — this is a static data addition)
- [x] `npm run lint` / `npx tsc --noEmit` / `npm run format:check` (apps/ui) — clean
- [x] `npm run build` (apps/ui, real Nitro/Cloudflare target) — succeeds
- [x] Manual visual QA — confirmed the new entry renders correctly in the empty state, matching the existing three entries' styling exactly (external-link icon, hover state)

## Screenshot

| State | Screenshot |
|---|---|
| "No wallet extension found" — 4 entries | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-taostats-wallet-after.png" width="360">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5236-taostats-wallet-after.png) |

"Before" (the original 3-entry list) is already documented in #5519's own screenshot table — this is purely a one-row addition to an already-reviewed layout, so a full before/after matrix felt like unnecessary duplication for a change this narrow.