### PR TITLE
fix(api): cap shared free-text query filter schema with a maxLength

### DIFF
--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -27378,6 +27378,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -32486,6 +32487,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -33020,6 +33022,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -33465,6 +33468,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -33730,6 +33734,7 @@
             "name": "id",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -34076,6 +34081,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -34387,6 +34393,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -36160,6 +36167,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -37008,6 +37016,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -37044,6 +37053,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -37394,6 +37404,7 @@
             "name": "id",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -38520,6 +38531,7 @@
             "name": "reason_codes",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -38870,6 +38882,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -39233,6 +39246,7 @@
             "name": "reason_codes",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -39241,6 +39255,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -39261,6 +39276,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -39707,6 +39723,7 @@
             "name": "reason_codes",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -39760,6 +39777,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -40077,6 +40095,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -40737,6 +40756,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -41616,6 +41636,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -41812,6 +41833,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -42148,6 +42170,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -42446,6 +42469,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -43302,6 +43326,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -44116,6 +44141,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -44836,6 +44862,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -45058,6 +45085,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -45373,6 +45401,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -49516,6 +49545,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },
@@ -51824,6 +51854,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 256,
               "type": "string"
             }
           },

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -130,7 +130,11 @@ export const QUERY_ENUMS = {
 };
 
 const integerSchema = { type: "integer", minimum: 0 };
-const textSchema = { type: "string" };
+// Shared schema for free-text filters (provider, id, review_state, reason_codes, q). A maxLength cap
+// mirrors every other validated string param (pallet/method 64, call_module 100, netuids 767) so these
+// filters can't be sent an unbounded value; validateListQuery enforces it. 256 is well above any real
+// provider slug, id, review-state, reason-code list, or search term.
+const textSchema = { type: "string", maxLength: 256 };
 const fieldListSchema = {
   type: "string",
   pattern: "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -452,6 +452,29 @@ describe("list-query numeric range filters", () => {
     assert.match(bad.error.message, /must be a number/);
   });
 
+  test("rejects a free-text filter value over the shared textSchema maxLength", () => {
+    const tooLong = "x".repeat(257);
+    const bad = applyQueryFilters(
+      { candidates: [] },
+      query(`/api/v1/candidates?provider=${tooLong}`),
+      "candidates",
+    );
+
+    assert.equal(bad.error.parameter, "provider");
+    assert.equal(bad.error.message, "provider is too long.");
+  });
+
+  test("accepts a free-text filter value at the textSchema maxLength boundary", () => {
+    const atLimit = "x".repeat(256);
+    const ok = applyQueryFilters(
+      { candidates: [] },
+      query(`/api/v1/candidates?provider=${atLimit}`),
+      "candidates",
+    );
+
+    assert.equal(ok.error, undefined);
+  });
+
   test("contradictory min_ > max_ on the same field is a query error", () => {
     const bad = applyQueryFilters(
       data,


### PR DESCRIPTION
## Summary

`textSchema` (`src/contracts.mjs:133`) is the shared schema reused for every free-text list filter across `API_QUERY_COLLECTIONS` — `provider`, `id`, `review_state`, `reason_codes`, and the search `q` param — but it was `{ type: "string" }` with **no `maxLength`**. Every other validated string param already declares one (`pallet`/`method` `maxLength: 64`, `call_module` `100`, `netuids` `767`), and `validateListQuery` (`workers/list-query.mjs`) enforces `schema.maxLength` whenever present. So these free-text filters were the one class of param that accepted an unbounded value.

## Fix

Add `maxLength: 256` to the shared `textSchema`. 256 is comfortably above any real provider slug, id, review-state, reason-code list, or search term, so no legitimate query is rejected — it just closes the unbounded-input gap, consistently with the rest of the contract.

Scoped to the shared `textSchema` per the issue; the separate inline `{ type: "string" }` schemas for `hotkey`/`coldkey`/`cursor`/`kind` (SS58 addresses, pagination tokens) are different concerns and left untouched (one focused change).

## Regenerated / verified

- `public/metagraph/openapi.json` regenerated — the 31 documented free-text query params now carry `maxLength: 256` (diff is exactly those 31 additions, nothing else).
- `validate:contract-drift`, `validate:types`, `validate:generated-client`, `validate:openapi`, `validate:openapi-examples` all pass locally.

## Tests

`tests/list-query.test.mjs`: a free-text filter value of 257 chars is rejected (`provider is too long.`), and a value at the 256 boundary is accepted. All 85 tests pass.

Closes #5544