### PR TITLE
fix(ci): authenticate release-please with a PAT instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,13 +44,18 @@ jobs:
         with:
           persist-credentials: false
 
+      # Authenticates as a real account (via RELEASE_PLEASE_TOKEN, a fine-grained PAT) rather than the
+      # default GITHUB_TOKEN. GitHub Apps like github-actions[bot] aren't tracked as repo collaborators,
+      # so PRs/commits it authors were repeatedly re-flagged as needing manual workflow-run approval on
+      # every push, even with the least-restrictive fork-PR-approval setting -- a real collaborator
+      # identity doesn't hit that gate.
       - name: Run release-please
         id: release
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       # release-please creates the component tag + GitHub Release with GITHUB_TOKEN,
       # which (by GitHub's recursion-prevention rule) does NOT fire push/tag-based


### PR DESCRIPTION
## Summary

- `release-please.yml`'s "Run release-please" step authenticated with the default `GITHUB_TOKEN`, so its Release PRs were authored as `github-actions[bot]` -- not tracked as a repo collaborator, which repeatedly re-flagged the resulting workflow runs as needing manual approval on every push, even with the least-restrictive fork-PR-approval setting.
- Switches that step's `token` input to `secrets.RELEASE_PLEASE_TOKEN` (a fine-grained PAT tied to a real account, already added as a repo secret) so future Release PRs stop hitting that gate.
- The `Dispatch npm publish` / `Dispatch PyPI publish` steps stay on `GITHUB_TOKEN` -- they only call `gh workflow run` (workflow_dispatch), which isn't subject to the same collaborator-approval check.
- Mirrors the equivalent fix already applied in `JSONbored/loopover`'s `.github/workflows/mcp-release-please.yml`.

## Test plan

- [x] `actionlint` locally clean on the changed workflow file
- [ ] Next scheduled/dispatched `release-please` run authenticates as a real account and its Release PR(s) do not require manual workflow approval