### PR TITLE
fix(validate): add missing 'unknown' to verificationClassifications to match Classification enum (#5552)

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -109,6 +109,7 @@ const verificationClassifications = new Set([
   "timeout",
   "content-mismatch",
   "wrong-chain",
+  "unknown",
 ]);
 const reviewDecisions = new Set([
   "maintainer-reviewed",

--- a/tests/validate-classification-enum-parity.test.mjs
+++ b/tests/validate-classification-enum-parity.test.mjs
@@ -1,0 +1,69 @@
+// Regression coverage for #5552: scripts/validate.mjs hand-rolls a
+// `verificationClassifications` allow-list that must stay in lock-step with
+// schemas/components/01-enums.schema.json's `Classification` enum (the schema
+// that backs the required `classification` property of every surface's and
+// candidate's `verification`). The hand-rolled set had drifted — it was
+// missing "unknown" — so a schema-legal `classification: "unknown"` would be
+// hard-rejected by `npm run validate` as an "invalid classification".
+//
+// validate.mjs is a top-level script (it runs and process.exit()s on import,
+// and in isolation fails on unrelated stale generated-artifact checks), so it
+// cannot be imported or run in a unit test to exercise the set directly.
+// Instead this asserts source-level parity: the set literal in validate.mjs
+// must equal the schema enum exactly, which both proves "unknown" is now
+// accepted and guards against either list silently re-diverging in future.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, test } from "vitest";
+import { repoRoot } from "../scripts/lib.mjs";
+
+function classificationEnumFromSchema() {
+  const schema = JSON.parse(
+    readFileSync(
+      path.join(repoRoot, "schemas/components/01-enums.schema.json"),
+      "utf8",
+    ),
+  );
+  const enumValues = schema.components?.schemas?.Classification?.enum;
+  assert.ok(
+    Array.isArray(enumValues) && enumValues.length > 0,
+    "schema must declare a Classification enum",
+  );
+  return enumValues;
+}
+
+function verificationClassificationsFromValidate() {
+  const source = readFileSync(
+    path.join(repoRoot, "scripts/validate.mjs"),
+    "utf8",
+  );
+  const match = source.match(
+    /const verificationClassifications = new Set\(\[([\s\S]*?)\]\)/,
+  );
+  assert.ok(
+    match,
+    "validate.mjs must define verificationClassifications as a Set literal",
+  );
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+}
+
+describe("validate.mjs classification allow-list parity (#5552)", () => {
+  test("verificationClassifications matches the schema Classification enum exactly", () => {
+    const schemaEnum = classificationEnumFromSchema();
+    const validateSet = verificationClassificationsFromValidate();
+
+    // "unknown" is a real classification produced elsewhere in the codebase;
+    // it must be present so a schema-legal verification result passes validate.
+    assert.ok(
+      validateSet.includes("unknown"),
+      'verificationClassifications must include "unknown"',
+    );
+
+    assert.deepEqual(
+      [...validateSet].sort(),
+      [...schemaEnum].sort(),
+      "validate.mjs verificationClassifications must equal the schema Classification enum",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/validate.mjs` hand-rolls a `verificationClassifications` allow-list (lines 100-112) that is supposed to mirror `schemas/components/01-enums.schema.json`'s `Classification` enum — the schema that backs the required `classification` property of every surface's and candidate's `verification`. The hand-rolled set had drifted: it carried only **11** values, missing **`"unknown"`**, which the schema enum declares (12 values total).

`unknown` is a real classification value produced elsewhere in this codebase (`scripts/build-artifacts.mjs`, `scripts/lib/endpoint-artifacts.mjs`, `scripts/probes-smoke.mjs`, `src/health-serving.mjs`). It just isn't emitted on the `surface.verification`/`candidate.verification` write path *today*, which is why the divergence has been dormant — but the moment any script or fixture legitimately writes `classification: "unknown"` (schema-legal), the mandatory `npm run validate` gate would hard-reject it as an "invalid classification".

## Change

- `scripts/validate.mjs`: add `"unknown"` to `verificationClassifications` so it matches the `Classification` enum exactly. This only *loosens* the allow-list (accepts one additional, schema-legal value), so it cannot reject any input that previously validated.

## Sibling-enum drift check (deliverable 3)

I checked the other hand-rolled `new Set([...])` allow-lists near `verificationClassifications` in `scripts/validate.mjs`:

- `reviewStates` (lines 93-99) — exactly matches the schema `ReviewState` enum (`unreviewed`, `machine-generated`, `maintainer-reviewed`, `needs-review`, `stale`). **No drift.**
- `reviewDecisions` (lines 113-117) — a purpose-specific subset (`maintainer-reviewed`, `needs-review`, `stale`) used for promotion-evidence decisions; it is not a copy of any single `01-enums.schema.json` enum, so there is nothing to keep in parity. **No drift.**

Only `verificationClassifications` had diverged.

## Regression test

`tests/validate-classification-enum-parity.test.mjs` asserts source-level parity: `validate.mjs`'s `verificationClassifications` set must equal the schema's `Classification` enum exactly (and explicitly includes `"unknown"`). This fails before the fix (11 ≠ 12) and passes after, and guards against **either** list silently re-diverging in future.

> Why a source-parity test rather than a running-fixture test: `validate.mjs` is a top-level script that `process.exit()`s on import and, run in isolation, fails on unrelated stale generated-artifact checks — so it can't be imported or cleanly run in a unit test to exercise the set directly. Asserting the set literal equals the schema enum is the robust, deterministic regression guard for exactly this "two copies of one enum drift apart" bug.

## Validation

- `npx vitest run tests/validate-classification-enum-parity.test.mjs` — passes
- `node -c scripts/validate.mjs` — syntax OK
- `npx prettier --check` — clean

Closes #5552
