### PR TITLE
fix(analytics): use shared parseLimitParam for leaderboards limit validation (#5555)

### DIFF
--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -735,6 +735,17 @@ describe("handleLeaderboards", () => {
     assert.match(body.error.message, /limit must be an integer/);
   });
 
+  // #5555: a leading-zero limit like 007 must be rejected the same way every
+  // other analytics route rejects it (shared parseLimitParam, /^[1-9]\d*$/),
+  // not silently accepted because Number("007") === 7 is in range.
+  test("rejects a leading-zero limit like 007", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleLeaderboards(req("/"), env, url("/?limit=007"));
+    assert.equal(res.status, 400);
+    const body = await errorJson(res);
+    assert.match(body.error.message, /limit must be an integer/);
+  });
+
   test("filters to a single board when requested", async () => {
     const env = createLocalArtifactEnv();
     const body = await json(
@@ -1232,6 +1243,13 @@ describe("canonicalLeaderboardsCachePath", () => {
 
   test("falls back to raw search on invalid limit", () => {
     const raw = "/api/v1/registry/leaderboards?limit=0";
+    assert.equal(canonicalLeaderboardsCachePath(url(raw)), raw);
+  });
+
+  // #5555: a leading-zero limit is invalid under the shared parseLimitParam,
+  // so it must not be canonicalized into the shared default cache key.
+  test("falls back to raw search on a leading-zero limit like 007", () => {
+    const raw = "/api/v1/registry/leaderboards?limit=007";
     assert.equal(canonicalLeaderboardsCachePath(url(raw)), raw);
   });
 

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -26,7 +26,10 @@ import {
   dailyLatencyColumns,
   surfaceStatusAvgLatencySql,
 } from "../../src/health-sql.mjs";
-import { parseNonNegativeIntParam } from "../request-params.mjs";
+import {
+  parseLimitParam,
+  parseNonNegativeIntParam,
+} from "../request-params.mjs";
 import {
   parseHistoryWindow,
   unsupportedWindowMessage,
@@ -374,18 +377,15 @@ export function canonicalTrajectoryCachePath(url, request = null) {
 export function canonicalLeaderboardsCachePath(url) {
   const validationError = validateQueryParams(url, ["board", "limit"]);
   if (validationError) return `${url.pathname}${url.search}`;
-  const limit = url.searchParams.get("limit");
-  if (
-    limit !== null &&
-    (!/^\d+$/.test(limit) || Number(limit) < 1 || Number(limit) > 100)
-  ) {
+  const parsedLimit = parseLimitParam(url, { defaultLimit: 20, maxLimit: 100 });
+  if (parsedLimit.error) {
     return `${url.pathname}${url.search}`;
   }
   const board = url.searchParams.get("board");
   if (board && !LEADERBOARD_BOARDS.includes(board)) {
     return `${url.pathname}${url.search}`;
   }
-  const cap = Math.max(1, Math.min(100, Number(limit) || 20));
+  const cap = parsedLimit.limit;
   const params = [`limit=${cap}`];
   if (board) params.unshift(`board=${encodeURIComponent(board)}`);
   return `${url.pathname}?${params.join("&")}`;
@@ -448,17 +448,11 @@ export async function handleLeaderboards(request, env, url) {
       400,
     );
   }
-  const limit = url.searchParams.get("limit");
-  if (
-    limit !== null &&
-    (!/^\d+$/.test(limit) || Number(limit) < 1 || Number(limit) > 100)
-  ) {
-    return errorResponse(
-      "invalid_query",
-      "limit must be an integer between 1 and 100.",
-      400,
-    );
+  const parsedLimit = parseLimitParam(url, { defaultLimit: 20, maxLimit: 100 });
+  if (parsedLimit.error) {
+    return errorResponse("invalid_query", parsedLimit.error.message, 400);
   }
+  const limit = parsedLimit.limit;
 
   const { subnetMeta, mostComplete } = await leaderboardProfilesProjection(env);
 


### PR DESCRIPTION
## Summary

`workers/request-params.mjs`'s `parseLimitParam` is the shared, canonical `limit` validator for the analytics routes that reject an out-of-range value with a 400 (it requires `/^[1-9]\d*$/` — no leading zero — and is what every `chain/*` route calls). The leaderboards code path in `workers/request-handlers/analytics-routes.mjs` did not reuse it — it hand-rolled the same check twice with a looser regex `/^\d+$/` (which permits a leading zero):

- `canonicalLeaderboardsCachePath` (was lines 373-388)
- `handleLeaderboards` (was lines 451-461) — the identical inline check, duplicated

The practical divergence: `GET /api/v1/registry/leaderboards?limit=007` was accepted (`Number("007") === 7`, in range), while the same value on any `chain/*` route is rejected with a 400 — two implementations of the same documented `{ integer, min 1, max 100 }` contract disagreeing on a leading-zero edge case.

## Change

Both leaderboards call sites now validate `limit` via the shared `parseLimitParam(url, { defaultLimit: 20, maxLimit: 100 })`:

- `handleLeaderboards` — on `parsedLimit.error`, returns the existing `invalid_query` 400 with the same `"limit must be an integer between 1 and 100."` message; otherwise uses `parsedLimit.limit`.
- `canonicalLeaderboardsCachePath` — on `parsedLimit.error`, bails to the raw path (as before for an invalid limit); otherwise uses `parsedLimit.limit` as the cap.

`defaultLimit: 20, maxLimit: 100` preserve the route's existing default/max. `formatLeaderboards` computes `Math.max(1, Math.min(100, Number(limit) || 20))`, so passing it the parsed number is behaviorally identical to the previous string for every in-range input. The redundant inline `Math.max/Math.min` clamp and the duplicated regex are both removed. Only the leading-zero edge case changes: `limit=007` now 400s (and is no longer canonicalized into the shared cache key), matching every other analytics route.

## Regression tests

Added to `tests/request-handlers-analytics-routes.test.mjs`:
- `handleLeaderboards` — `?limit=007` returns 400 with `/limit must be an integer/`.
- `canonicalLeaderboardsCachePath` — `?limit=007` falls back to the raw search rather than canonicalizing.

## Validation

- `npx vitest run tests/request-handlers-analytics-routes.test.mjs` — **77 passed** (75 pre-existing unchanged + 2 new), confirming default/valid/out-of-range/non-numeric behavior is preserved.
- `node -c` + `npx prettier --check` — clean.

Closes #5555
