### PR TITLE
feat(ui): add download button for the OpenAPI spec on the schemas page

### DIFF
--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -3,7 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useCallback, useEffect, useMemo } from "react";
 import { fallback } from "@tanstack/zod-adapter";
 import { z } from "zod";
-import { ChevronLeft, FileCode, Copy, Check } from "lucide-react";
+import { ChevronLeft, FileCode, Copy, Check, Download } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import {
   TimeAgo,
@@ -195,7 +195,19 @@ function SchemasHero() {
       description="JSON Schema is canonical truth. Drift compares the current snapshot to the previous published version."
       caption={<>schemas / v1</>}
       actions={
-        <CopyableCode label="openapi" value={`${API_BASE}/api/v1/openapi.json`} truncate={false} />
+        <>
+          <CopyableCode label="openapi" value={`${API_BASE}/api/v1/openapi.json`} truncate={false} />
+          <a
+            href={`${API_BASE}/metagraph/openapi.json`}
+            download="openapi.json"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors"
+          >
+            <Download className="size-3" aria-hidden />
+            Download spec
+          </a>
+        </>
       }
       kpis={[
         { label: "Schemas", value: <AnimatedNumber value={schemas.length} /> },


### PR DESCRIPTION
## Summary
- Adds a "Download spec" button to the schemas page hero, next to the existing copyable openapi URL, linking to the published `/metagraph/openapi.json` artifact (#3496)

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3496-download-spec-after-mobile-dark.png)<br><sub>after</sub> |

## Test plan
- [x] Verified in-browser: button renders correctly across desktop/tablet/mobile x light/dark, correct href to the published openapi artifact, accessible link role/label
- [x] Caught and fixed a real mobile-wrap bug during verification (nested non-wrapping flex div defeated `PageHero`'s own `flex-wrap` action-row layout, hiding the button off-screen on narrow viewports) — fixed by using a Fragment so both action items are direct flex children
- [x] `npx tsc --noEmit` (apps/ui) clean
- [x] `npm run lint` / `npx prettier --check` clean

Closes #3496