### PR TITLE
infra(registry-sync): rate-limit the registry-sync Worker

### DIFF
--- a/tests/registry-sync-api.test.mjs
+++ b/tests/registry-sync-api.test.mjs
@@ -135,6 +135,55 @@ test("rejects a missing or wrong token (401)", async () => {
   expect(missing.status).toBe(401);
 });
 
+// #5548: gated by REGISTRY_SYNC_RATE_LIMITER (a no-op when the binding is
+// absent). Mirrors the webhook-subscription/alert-trigger-create suites:
+// within-limit success, over-limit 429 with the standard header family, and
+// unbound-binding no-op (already covered implicitly by every test above,
+// which uses baseEnv() with no limiter bound).
+const allowLimiter = () => ({ limit: vi.fn(async () => ({ success: true })) });
+const rejectLimiter = () => ({
+  limit: vi.fn(async () => ({ success: false })),
+});
+
+test("rate limiting: 429 with the rate-limit header family when the limiter rejects", async () => {
+  const limiter = rejectLimiter();
+  const res = await worker.fetch(
+    post({ providers: [provider()] }, { secret: SECRET }),
+    baseEnv({ REGISTRY_SYNC_RATE_LIMITER: limiter }),
+    {},
+  );
+  expect(res.status).toBe(429);
+  expect((await res.json()).error).toMatch(/too many registry sync requests/);
+  expect(res.headers.get("retry-after")).toBe("60");
+  expect(res.headers.get("x-ratelimit-limit")).toBe("30");
+  expect(res.headers.get("x-ratelimit-policy")).toBe("30;w=60");
+  expect(res.headers.get("x-ratelimit-remaining")).toBe("0");
+  expect(limiter.limit.mock.calls.length).toBe(1);
+  expect(sqlCalls.length).toBe(0);
+});
+
+test("rate limiting: proceeds normally when the limiter allows the request", async () => {
+  const limiter = allowLimiter();
+  const res = await worker.fetch(
+    post({ providers: [provider()] }, { secret: SECRET }),
+    baseEnv({ REGISTRY_SYNC_RATE_LIMITER: limiter }),
+    {},
+  );
+  expect(res.status).toBe(200);
+  expect(limiter.limit.mock.calls.length).toBe(1);
+});
+
+test("rate limiting: rejects an invalid token before consulting the limiter", async () => {
+  const limiter = rejectLimiter();
+  const res = await worker.fetch(
+    post({ providers: [provider()] }, { secret: "wrong" }),
+    baseEnv({ REGISTRY_SYNC_RATE_LIMITER: limiter }),
+    {},
+  );
+  expect(res.status).toBe(401);
+  expect(limiter.limit.mock.calls.length).toBe(0);
+});
+
 test("returns 503 when the HYPERDRIVE binding is unavailable", async () => {
   const res = await worker.fetch(
     post({ providers: [provider()] }, { secret: SECRET }),

--- a/workers/registry-sync-api.mjs
+++ b/workers/registry-sync-api.mjs
@@ -21,15 +21,23 @@
 // + Workers VPC Service + Hyperdrive path already proven for reads).
 import postgres from "postgres";
 import { timingSafeEqual } from "../src/webhooks.mjs";
+import { resolveClientIp } from "./config.mjs";
 
 const TOKEN_HEADER = "x-registry-sync-token";
 const MAX_BODY_BYTES = 4_194_304; // 4 MiB -- the full registry is ~1.5k surfaces, comfortably under this
 const MAX_ROWS_PER_KIND = 5_000;
+// Per-caller abuse control (#5548) -- see wrangler.registry.jsonc's
+// REGISTRY_SYNC_RATE_LIMITER comment for why 30/60s rather than the tighter
+// 10/60s used by other shared-secret write routes.
+const RATE_LIMIT = { limit: 30, windowSeconds: 60 };
 
-function json(data, status = 200) {
+function json(data, status = 200, extraHeaders = {}) {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { "content-type": "application/json; charset=utf-8" },
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...extraHeaders,
+    },
   });
 }
 
@@ -51,6 +59,26 @@ export default {
     const provided = request.headers.get(TOKEN_HEADER) || "";
     if (!provided || !timingSafeEqual(provided, env.REGISTRY_SYNC_SECRET)) {
       return json({ error: `provide a valid ${TOKEN_HEADER} header` }, 401);
+    }
+    // Rate-limit AFTER auth so an unauthenticated caller is rejected without
+    // consuming limiter budget. Optional-chained so it's a no-op when the
+    // binding is absent (local dev/CI).
+    if (env.REGISTRY_SYNC_RATE_LIMITER?.limit) {
+      const { success } = await env.REGISTRY_SYNC_RATE_LIMITER.limit({
+        key: resolveClientIp(request),
+      });
+      if (!success) {
+        return json(
+          { error: "too many registry sync requests; slow down" },
+          429,
+          {
+            "retry-after": String(RATE_LIMIT.windowSeconds),
+            "x-ratelimit-limit": String(RATE_LIMIT.limit),
+            "x-ratelimit-policy": `${RATE_LIMIT.limit};w=${RATE_LIMIT.windowSeconds}`,
+            "x-ratelimit-remaining": "0",
+          },
+        );
+      }
     }
     if (!env.HYPERDRIVE?.connectionString) {
       return json({ error: "hyperdrive binding unavailable" }, 503);

--- a/wrangler.registry.jsonc
+++ b/wrangler.registry.jsonc
@@ -49,4 +49,27 @@
       "localConnectionString": "postgresql://metagraphed_registry:postgres@localhost:5433/metagraphed_registry",
     },
   ],
+  // Per-caller abuse control for this Worker's only route (#5548) -- the
+  // shared-secret check above authenticates the CALLER, not the REQUEST
+  // VOLUME, so anyone holding REGISTRY_SYNC_SECRET could otherwise script
+  // unbounded write/delete cycles (including full-table DELETEs, see
+  // MAX_ROWS_PER_KIND in workers/registry-sync-api.mjs) against the live
+  // registry. Mirrors ALERT_TRIGGER_CREATE_RATE_LIMITER's posture
+  // (wrangler.data.jsonc) for the same shared-secret-write shape, but looser
+  // than its 10/60s to tolerate scripts/backfill-registry-postgres.mjs's
+  // legitimate chunked full-resync POSTs. Namespace id is local to THIS
+  // Worker's own bindings -- reusing an id already used elsewhere doesn't
+  // collide (ratelimit namespaces are scoped per Worker script). Skipped
+  // when unbound (local dev/CI), matching every other optional rate-limiter
+  // binding's convention in this codebase.
+  "ratelimits": [
+    {
+      "name": "REGISTRY_SYNC_RATE_LIMITER",
+      "namespace_id": "1001",
+      "simple": {
+        "limit": 30,
+        "period": 60,
+      },
+    },
+  ],
 }


### PR DESCRIPTION
## Summary
- `REGISTRY_SYNC_SECRET` authenticates the caller but never bounded request volume — a leaked secret could script unbounded write/delete cycles (including full-table `DELETE FROM surfaces`/`DELETE FROM subnets`, `MAX_ROWS_PER_KIND = 5,000` per kind) against the live registry Postgres (#5548)
- Adds `REGISTRY_SYNC_RATE_LIMITER` (30 req/60s per client IP) to `wrangler.registry.jsonc`, checked in `workers/registry-sync-api.mjs` immediately after the existing shared-secret auth check (so unauthenticated callers are rejected without consuming limiter budget)
- 30/60s rather than the tighter 10/60s used by user-facing shared-secret routes (webhook subscriptions, alert-trigger creation) — this route's legitimate callers include `scripts/backfill-registry-postgres.mjs`'s chunked full-resync POSTs, which would trip a tighter limit
- Optional-chained (`env.REGISTRY_SYNC_RATE_LIMITER?.limit`) so it's a no-op when unbound, matching every other rate limiter in this codebase

## Test plan
- [x] New tests: over-limit 429 with the standard rate-limit header family, within-limit success, auth-before-rate-limit ordering (invalid token rejected without consuming limiter budget)
- [x] `npx vitest run tests/registry-sync-api.test.mjs` — 27/27 passed
- [x] `npm run lint` / `npx prettier --check` clean

Closes #5548