### PR TITLE
infra(api): rate-limit the six proxyToDataApi internal-sync write routes

### DIFF
--- a/tests/neurons-sync-proxy.test.mjs
+++ b/tests/neurons-sync-proxy.test.mjs
@@ -106,3 +106,68 @@ test("returns 502 when the upstream response body is unreadable", async () => {
   assert.equal(res.status, 502);
   assert.equal((await res.json()).error.code, "neurons_sync_unavailable");
 });
+
+// #5549: proxyToDataApi (shared by all six internal-sync proxies, exercised
+// here via neurons-sync) is gated by INTERNAL_SYNC_RATE_LIMITER, a no-op when
+// the binding is absent. Mirrors the webhook-subscription/alert-trigger-create
+// suites: within-limit success, over-limit 429 with the standard header
+// family, and unbound-binding no-op (already covered by every test above).
+const baseDataApi = () => ({
+  fetch() {
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  },
+});
+
+test("rate limiting: 429 with the rate-limit header family when the limiter rejects, and DATA_API is never reached", async () => {
+  let calls = 0;
+  const res = await handleRequest(
+    post([{ netuid: 8 }]),
+    {
+      DATA_API: {
+        fetch() {
+          calls += 1;
+          return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        },
+      },
+      INTERNAL_SYNC_RATE_LIMITER: {
+        limit: async () => ({ success: false }),
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 429);
+  assert.equal((await res.json()).error.code, "internal_sync_rate_limited");
+  assert.equal(res.headers.get("retry-after"), "60");
+  assert.equal(res.headers.get("x-ratelimit-limit"), "30");
+  assert.equal(res.headers.get("x-ratelimit-policy"), "30;w=60");
+  assert.equal(res.headers.get("x-ratelimit-remaining"), "0");
+  assert.equal(calls, 0);
+});
+
+test("rate limiting: proceeds normally when the limiter allows the request", async () => {
+  let limiterCalls = 0;
+  const res = await handleRequest(
+    post([{ netuid: 8 }]),
+    {
+      DATA_API: baseDataApi(),
+      INTERNAL_SYNC_RATE_LIMITER: {
+        limit: async () => {
+          limiterCalls += 1;
+          return { success: true };
+        },
+      },
+    },
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.equal(limiterCalls, 1);
+});
+
+test("rate limiting: skips the limiter entirely when the binding is unbound (local dev/CI)", async () => {
+  const res = await handleRequest(
+    post([{ netuid: 8 }]),
+    { DATA_API: baseDataApi() },
+    {},
+  );
+  assert.equal(res.status, 200);
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -856,6 +856,45 @@ async function handleRegistrySyncProxy(request, env) {
   });
 }
 
+// Per-client abuse control for the six internal sync routes proxied through
+// proxyToDataApi below (neurons-sync, backfill-neuron-daily, rollup-account-
+// events-daily, subnet-hyperparams-sync, account-identity-sync, validator-
+// nominator-counts-sync, nominator-positions-sync, #5549). Each authenticates
+// with its OWN shared static secret downstream in data-api.mjs -- this proxy
+// has no auth of its own, so a leaked secret could otherwise script unbounded
+// write volume against the chain-indexer Postgres, the same shape
+// handleAlertTriggerCreate guards against. Looser than that route's 10/60s
+// posture: legitimate callers include chunked historical backfills
+// (scripts/backfill-neuron-history.py, scripts/backfill-stake-monthly.py)
+// that POST many sequential chunks in one run -- 30/60s still firmly bounds
+// abuse while tolerating that pattern. Keyed on a single shared bucket across
+// all six routes (one leaked secret can't just switch routes to dodge the
+// limit). Bound here in wrangler.jsonc (not wrangler.data.jsonc) because
+// ratelimit namespaces are scoped to the Worker script that checks them, and
+// this check runs in api.mjs, not data-api.mjs. Optional-chained so it's a
+// no-op when the binding is absent (local dev/CI).
+const INTERNAL_SYNC_RATE_LIMIT = { limit: 30, windowSeconds: 60 };
+
+async function internalSyncRateLimited(request, env) {
+  if (!env.INTERNAL_SYNC_RATE_LIMITER?.limit) return null;
+  const { success } = await env.INTERNAL_SYNC_RATE_LIMITER.limit({
+    key: `internal-sync:${resolveClientIp(request)}`,
+  });
+  if (success) return null;
+  return errorResponse(
+    "internal_sync_rate_limited",
+    "Too many internal sync requests from this client; slow down.",
+    429,
+    {},
+    {
+      "retry-after": String(INTERNAL_SYNC_RATE_LIMIT.windowSeconds),
+      "x-ratelimit-limit": String(INTERNAL_SYNC_RATE_LIMIT.limit),
+      "x-ratelimit-policy": `${INTERNAL_SYNC_RATE_LIMIT.limit};w=${INTERNAL_SYNC_RATE_LIMIT.windowSeconds}`,
+      "x-ratelimit-remaining": "0",
+    },
+  );
+}
+
 // Generic forwarder to the DATA_API service binding for the internal
 // write/rollup routes that live inside workers/data-api.mjs itself rather
 // than a dedicated Worker (#4771's neurons-sync pattern) -- splitting read
@@ -876,6 +915,8 @@ async function proxyToDataApi(
   if (!env.DATA_API) {
     return errorResponse(code, notBoundMessage, 503);
   }
+  const rateLimited = await internalSyncRateLimited(request, env);
+  if (rateLimited) return rateLimited;
   const upstream = await env.DATA_API.fetch(request);
   let body;
   try {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -504,5 +504,24 @@
         "period": 60,
       },
     },
+    // Per-client abuse control for the six proxyToDataApi internal-sync write
+    // routes (#5549: neurons-sync, backfill-neuron-daily, rollup-account-
+    // events-daily, subnet-hyperparams-sync, account-identity-sync,
+    // validator-nominator-counts-sync, nominator-positions-sync). Each
+    // authenticates with its OWN shared static secret downstream in
+    // data-api.mjs -- this proxy has no auth of its own, so a leaked secret
+    // could otherwise script unbounded write volume. 30 requests / 60s per
+    // client IP -- looser than the 10/60s webhook/alert-trigger posture to
+    // tolerate legitimate chunked historical-backfill scripts (see
+    // proxyToDataApi's own comment in workers/api.mjs). Skipped when the
+    // binding is absent (local dev/CI).
+    {
+      "name": "INTERNAL_SYNC_RATE_LIMITER",
+      "namespace_id": "1007",
+      "simple": {
+        "limit": 30,
+        "period": 60,
+      },
+    },
   ],
 }


### PR DESCRIPTION
## Summary
- Each of the six `proxyToDataApi`-routed internal sync writes (neurons-sync, backfill-neuron-daily, rollup-account-events-daily, subnet-hyperparams-sync, account-identity-sync, validator-nominator-counts-sync, nominator-positions-sync) authenticates with its own shared static secret downstream in `data-api.mjs`, but the proxy itself never bounded request volume — a leaked secret could script unbounded write volume against the chain-indexer Postgres, the same shape `handleAlertTriggerCreate` already guards against (#5549)
- Adds `INTERNAL_SYNC_RATE_LIMITER` (30 req/60s per client IP, one shared bucket across all six routes) to **`wrangler.jsonc`** — note: the linked issue's Requirements section said `wrangler.data.jsonc`, but that's inconsistent with its own requirement to check the limiter inside `proxyToDataApi` (which runs in `workers/api.mjs`, deployed via `wrangler.jsonc` — ratelimit namespaces are scoped to the Worker script that checks them, confirmed by every other limiter in this codebase living in the same config as its check). Went with the technically-correct placement.
- 30/60s rather than the tighter 10/60s used by user-facing shared-secret routes (webhook subscriptions, alert-trigger creation) — `backfill-neuron-history.py`/`backfill-stake-monthly.py` legitimately POST many sequential chunks (default `--days 365`, `--chunk 1000`) in one backfill run, which a tighter limit would break

## Test plan
- [x] New tests on the neurons-sync route (representative of all six, since they share one `proxyToDataApi` call site): over-limit 429 with the standard rate-limit header family + upstream never reached, within-limit success, unbound-binding no-op
- [x] `npx vitest run tests/neurons-sync-proxy.test.mjs tests/account-identity-sync-proxy.test.mjs tests/subnet-hyperparams-sync-proxy.test.mjs tests/rollup-account-events-daily-proxy.test.mjs tests/neuron-daily-backfill-proxy.test.mjs tests/alert-triggers-proxy.test.mjs` — 39/39 passed, no regressions on the sibling routes
- [x] `npm run lint` / `npx prettier --check` clean

Closes #5549