### PR TITLE
fix(api): set x-content-type-options nosniff on the three SSE responses missing it (#5545)

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -13608,6 +13608,7 @@ async function handleMcpStreamRequest(request, env) {
       "content-type": "text/event-stream",
       "cache-control": "no-store",
       "access-control-allow-origin": "*",
+      "x-content-type-options": "nosniff",
       connection: "keep-alive",
     },
   });

--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -543,6 +543,8 @@ test("ChainFirehoseHub /subscribe (SSE): responds with a text/event-stream and a
   assert.equal(res.status, 200);
   assert.equal(res.headers.get("content-type"), "text/event-stream");
   assert.equal(res.headers.get("cache-control"), "no-store");
+  // #5545: SSE responses must carry nosniff like every other response builder.
+  assert.equal(res.headers.get("x-content-type-options"), "nosniff");
   const reader = res.body.getReader();
   const { value } = await reader.read();
   assert.equal(new TextDecoder().decode(value), ": connected\n\n");

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1170,6 +1170,8 @@ describe("MCP transport handling", () => {
       });
       assert.equal(response.status, 200);
       assert.equal(response.headers.get("content-type"), "text/event-stream");
+      // #5545: SSE responses must carry nosniff like every other builder.
+      assert.equal(response.headers.get("x-content-type-options"), "nosniff");
       assert.equal(hub.calls.length, 1);
       assert.match(hub.calls[0].url, /\/stream\?sessionId=/);
       assert.match(

--- a/tests/mcp-session-hub.test.mjs
+++ b/tests/mcp-session-hub.test.mjs
@@ -331,6 +331,9 @@ test("handleStream: opens an SSE stream, flushing any pending notification immed
   );
   assert.equal(res.status, 200);
   assert.equal(res.headers.get("content-type"), "text/event-stream");
+  // #5545: every text/event-stream response must carry nosniff, matching the
+  // workers/api.mjs SSE precedent and every other response-header builder.
+  assert.equal(res.headers.get("x-content-type-options"), "nosniff");
   const reader = res.body.getReader();
   const { value } = await reader.read();
   const text = new TextDecoder().decode(value);

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -755,6 +755,7 @@ export class ChainFirehoseHub {
         "content-type": "text/event-stream",
         "cache-control": "no-store",
         "access-control-allow-origin": "*",
+        "x-content-type-options": "nosniff",
         connection: "keep-alive",
       },
     });

--- a/workers/mcp-session-hub.mjs
+++ b/workers/mcp-session-hub.mjs
@@ -378,6 +378,7 @@ export class McpSessionHub {
         "content-type": "text/event-stream",
         "cache-control": "no-store",
         "access-control-allow-origin": "*",
+        "x-content-type-options": "nosniff",
         connection: "keep-alive",
       },
     });


### PR DESCRIPTION
## Summary

Every JSON/SVG/GraphQL response builder in this codebase sets `x-content-type-options: nosniff`, and the Worker's own SSE change-feed handler (`workers/api.mjs` `handleEventsRequest`, line 4136) sets it on its `text/event-stream` response. Three other `text/event-stream` response sites did not, emitting only `content-type` / `cache-control` / `access-control-allow-origin` / `connection`.

## Change

Added `"x-content-type-options": "nosniff"` — matching the `workers/api.mjs` SSE precedent exactly (same header, same value) — to the three SSE responses that were missing it:

- `workers/mcp-session-hub.mjs` — `McpSessionHub.handleStream()`
- `workers/chain-firehose-hub.mjs` — `ChainFirehoseHub.fetch()` SSE-upgrade branch
- `src/mcp-server.mjs` — `handleMcpStreamRequest()`

Pure consistency fix: one header added per site, no other header or behavior change.

## Regression tests

Extended each site's existing SSE test to assert the header is present:

- `tests/mcp-session-hub.test.mjs` — `handleStream` opens-an-SSE-stream test
- `tests/chain-firehose-hub.test.mjs` — `/subscribe (SSE)` test
- `tests/mcp-server.test.mjs` — MCP stream proxy test

## Validation

- `node -c` on all three source files — clean; `npx prettier --check` — clean.
- `npx vitest run tests/mcp-session-hub.test.mjs tests/chain-firehose-hub.test.mjs tests/mcp-server.test.mjs` — all pass (1133 tests across the three files with the new `nosniff` assertions).

Closes #5545
