### PR TITLE
fix(analytics): reuse parseLimitParam for leaderboards limit validation

### DIFF
--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -735,6 +735,13 @@ describe("handleLeaderboards", () => {
     assert.match(body.error.message, /limit must be an integer/);
   });
 
+  test("rejects a leading-zero limit, matching parseLimitParam elsewhere", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleLeaderboards(req("/"), env, url("/?limit=007"));
+    const body = await errorJson(res);
+    assert.match(body.error.message, /limit must be an integer/);
+  });
+
   test("filters to a single board when requested", async () => {
     const env = createLocalArtifactEnv();
     const body = await json(
@@ -1232,6 +1239,11 @@ describe("canonicalLeaderboardsCachePath", () => {
 
   test("falls back to raw search on invalid limit", () => {
     const raw = "/api/v1/registry/leaderboards?limit=0";
+    assert.equal(canonicalLeaderboardsCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on a leading-zero limit", () => {
+    const raw = "/api/v1/registry/leaderboards?limit=007";
     assert.equal(canonicalLeaderboardsCachePath(url(raw)), raw);
   });
 

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -26,7 +26,10 @@ import {
   dailyLatencyColumns,
   surfaceStatusAvgLatencySql,
 } from "../../src/health-sql.mjs";
-import { parseNonNegativeIntParam } from "../request-params.mjs";
+import {
+  parseLimitParam,
+  parseNonNegativeIntParam,
+} from "../request-params.mjs";
 import {
   parseHistoryWindow,
   unsupportedWindowMessage,
@@ -374,19 +377,16 @@ export function canonicalTrajectoryCachePath(url, request = null) {
 export function canonicalLeaderboardsCachePath(url) {
   const validationError = validateQueryParams(url, ["board", "limit"]);
   if (validationError) return `${url.pathname}${url.search}`;
-  const limit = url.searchParams.get("limit");
-  if (
-    limit !== null &&
-    (!/^\d+$/.test(limit) || Number(limit) < 1 || Number(limit) > 100)
-  ) {
-    return `${url.pathname}${url.search}`;
-  }
+  const { limit, error: limitError } = parseLimitParam(url, {
+    defaultLimit: 20,
+    maxLimit: 100,
+  });
+  if (limitError) return `${url.pathname}${url.search}`;
   const board = url.searchParams.get("board");
   if (board && !LEADERBOARD_BOARDS.includes(board)) {
     return `${url.pathname}${url.search}`;
   }
-  const cap = Math.max(1, Math.min(100, Number(limit) || 20));
-  const params = [`limit=${cap}`];
+  const params = [`limit=${limit}`];
   if (board) params.unshift(`board=${encodeURIComponent(board)}`);
   return `${url.pathname}?${params.join("&")}`;
 }
@@ -448,17 +448,11 @@ export async function handleLeaderboards(request, env, url) {
       400,
     );
   }
-  const limit = url.searchParams.get("limit");
-  if (
-    limit !== null &&
-    (!/^\d+$/.test(limit) || Number(limit) < 1 || Number(limit) > 100)
-  ) {
-    return errorResponse(
-      "invalid_query",
-      "limit must be an integer between 1 and 100.",
-      400,
-    );
-  }
+  const { limit, error: limitError } = parseLimitParam(url, {
+    defaultLimit: 20,
+    maxLimit: 100,
+  });
+  if (limitError) return analyticsQueryError(limitError);
 
   const { subnetMeta, mostComplete } = await leaderboardProfilesProjection(env);
 


### PR DESCRIPTION
## Summary

- `canonicalLeaderboardsCachePath` and `handleLeaderboards` in
  `workers/request-handlers/analytics-routes.mjs` each hand-rolled the same
  `limit` check with `/^\d+$/`, which accepts a leading zero (`limit=007`).
  Every `chain/*` route validates `limit` through the shared
  `parseLimitParam` in `workers/request-params.mjs`, which requires
  `/^[1-9]\d*$/` and rejects the leading-zero case with a 400.

## What Changed

- Both call sites now validate `limit` via `parseLimitParam(url, {
defaultLimit: 20, maxLimit: 100 })` instead of the duplicated inline regex,
  removing the second hand-rolled copy of the check in the same file.
- Existing behavior is unchanged for every currently-valid input (absent
  limit still defaults to 20, out-of-range/non-numeric still 400s with the
  same message); only `limit=007`-style leading-zero values now 400
  consistently with the rest of the analytics API.
- Added regression tests: `handleLeaderboards` rejects `limit=007`, and
  `canonicalLeaderboardsCachePath` falls back to the raw search string on
  `limit=007`.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5555`).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited
      (no artifacts touched — logic-only change in `workers/`).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented
      (no schema/OpenAPI shape change — `limit` was already documented as
      `{ type: "integer", minimum: 1, maximum: 100 }`; this only fixes the
      one route not enforcing it).

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run scan:public-safety`
- [x] `npm run test:ci` (8164 passed)
- [x] `npm run test:coverage` — changed lines fully covered, no
      uncovered lines/branches in the diff
- [x] `git diff --check`

Closes #5555
