### PR TITLE
fix(schemas): enforce http(s)-only pattern on the 5 Provider URL fields missing it (#5553)

### DIFF
--- a/schemas/components/03-providers.schema.json
+++ b/schemas/components/03-providers.schema.json
@@ -33,16 +33,19 @@
           "website_url": {
             "type": "string",
             "format": "uri",
+            "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
             "examples": ["https://example.com"]
           },
           "docs_url": {
             "type": "string",
             "format": "uri",
+            "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
             "examples": ["https://docs.example.com"]
           },
           "github_url": {
             "type": "string",
             "format": "uri",
+            "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
             "examples": ["https://github.com/example"]
           },
           "logo_url": {
@@ -86,11 +89,13 @@
           "team_url": {
             "type": "string",
             "format": "uri",
+            "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
             "examples": ["https://example.com/team"]
           },
           "contact_url": {
             "type": "string",
             "format": "uri",
+            "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
             "examples": ["https://example.com/contact"]
           },
           "authority": {

--- a/schemas/provider.schema.json
+++ b/schemas/provider.schema.json
@@ -36,16 +36,19 @@
     "website_url": {
       "type": "string",
       "format": "uri",
+      "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
       "examples": ["https://example.com"]
     },
     "docs_url": {
       "type": "string",
       "format": "uri",
+      "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
       "examples": ["https://docs.example.com"]
     },
     "github_url": {
       "type": "string",
       "format": "uri",
+      "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
       "examples": ["https://github.com/example"]
     },
     "logo_url": {
@@ -89,11 +92,13 @@
     "team_url": {
       "type": "string",
       "format": "uri",
+      "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
       "examples": ["https://example.com/team"]
     },
     "contact_url": {
       "type": "string",
       "format": "uri",
+      "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
       "examples": ["https://example.com/contact"]
     },
     "authority": {

--- a/tests/provider-url-http-pattern.test.mjs
+++ b/tests/provider-url-http-pattern.test.mjs
@@ -1,0 +1,62 @@
+// #5553: logo_url and social.* on the Provider schema carry an explicit
+// http(s)-only `pattern` on top of `format: uri`, but the sibling URL fields
+// website_url / docs_url / github_url / team_url / contact_url only had
+// `format: uri` — which ajv-formats accepts for any RFC-3986 scheme
+// (mailto:, ftp:, javascript:). scripts/validate.mjs's assertPublicHttpUrl
+// already enforces http(s) uniformly across all nine fields at the mandatory
+// gate, so this only closed a gap between the schema's own documented
+// guarantee and that enforced behavior. These tests exercise the schema
+// directly: a known-good provider passes, and a non-http(s) value in each of
+// the five newly-patterned fields fails ajv validation.
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { readJson, repoRoot } from "../scripts/lib.mjs";
+
+const ajv = new Ajv2020({
+  strict: false,
+  validateFormats: true,
+  allErrors: true,
+});
+addFormats(ajv);
+for (const rel of [
+  "schemas/components/01-enums.schema.json",
+  "schemas/provider.schema.json",
+]) {
+  ajv.addSchema(await readJson(path.join(repoRoot, rel)));
+}
+const validate = ajv.getSchema(
+  "https://metagraph.sh/schemas/provider.schema.json",
+);
+const submission = await readJson(
+  path.join(repoRoot, "docs/examples/submissions/direct-provider-profile.json"),
+);
+const GOOD = submission.provider;
+
+const PATTERNED_URL_FIELDS = [
+  "website_url",
+  "docs_url",
+  "github_url",
+  "team_url",
+  "contact_url",
+];
+
+describe("Provider URL fields enforce http(s)-only (#5553)", () => {
+  test("the known-good provider fixture is valid", () => {
+    assert.equal(validate(GOOD), true, JSON.stringify(validate.errors));
+  });
+
+  for (const field of PATTERNED_URL_FIELDS) {
+    test(`rejects a non-http(s) ${field} (mailto:)`, () => {
+      const bad = { ...GOOD, [field]: "mailto:foo@example.com" };
+      assert.equal(validate(bad), false);
+    });
+
+    test(`accepts an https ${field}`, () => {
+      const good = { ...GOOD, [field]: "https://example.com/ok" };
+      assert.equal(validate(good), true, JSON.stringify(validate.errors));
+    });
+  }
+});


### PR DESCRIPTION
## Summary

On the `Provider` schema, `logo_url` and the four `social.*` fields carry an explicit http(s)-only `"pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"` on top of `"format": "uri"`, but the sibling URL fields — `website_url`, `docs_url`, `github_url`, `team_url`, `contact_url` — only had `"format": "uri"`. `ajv-formats`' `uri` accepts any RFC-3986 scheme (`mailto:`, `ftp:`, `javascript:`), so the schema's own documented guarantee for those five fields was weaker than the others.

This was never exploitable at runtime — `scripts/validate.mjs`'s `assertPublicHttpUrl()` already enforces http(s) uniformly across all nine URL fields, and `npm run validate` is a mandatory gate. The gap was purely between the JSON Schema's documented constraint and that enforced behavior, which matters for any consumer that trusts the published schema in isolation (client-side validators, new intake fixtures — the same class of gap #5476 closed for `provider-submission.schema.json`).

## Change

Added `"pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"` — `logo_url`'s exact existing string — to `website_url`, `docs_url`, `github_url`, `team_url`, and `contact_url` in **both** independently-maintained schema copies:

- `schemas/provider.schema.json`
- `schemas/components/03-providers.schema.json`

No runtime code changed (`assertPublicHttpUrl` was already correct).

## Drift check (deliverable)

I compared the two schema copies' URL fields after the change — all six URL fields (`website_url`, `docs_url`, `github_url`, `team_url`, `contact_url`, `logo_url`) now carry identical `format`+`pattern` in both files. No other field-level drift between the two copies was found on the URL-field set.

## Regression test

`tests/provider-url-http-pattern.test.mjs` (mirrors the #5476 provider-submission violation-fixture test): compiles `provider.schema.json` with ajv, asserts a known-good provider passes, and — for each of the five newly-patterned fields — that a `mailto:` value fails and an `https://` value passes. 11 assertions.

## Validation

- `npx vitest run tests/provider-url-http-pattern.test.mjs` — 11 passed.
- `npm run validate:schemas` on the existing registry data — no new failures (every existing provider already uses http(s) URLs; the only reported issue is the pre-existing `registry/native/finney-subnets.json` `total_stake_tao` live-data flake, unrelated to this change).
- `npx prettier --check` — clean.

Closes #5553
