### PR TITLE
fix(registry): document dogelayer's persistent website outage (#5568)

### DIFF
--- a/registry/providers/dogelayer.json
+++ b/registry/providers/dogelayer.json
@@ -4,6 +4,7 @@
   "id": "dogelayer",
   "kind": "subnet-team",
   "name": "dogelayer",
+  "notes": "The dogelayer.ai marketing domain currently returns a Cloudflare 530 origin error to simple probes, so the GitHub repository is the verified public source surface.",
   "public_notes": "Subnet 80 (dogelayer) team profile — decentralized mining pool infrastructure. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
   "schema_version": 1,
   "social": {


### PR DESCRIPTION
## Summary

`registry/providers/dogelayer.json` (the community-authority provider profile for SN80 dogelayer) sets `website_url: "https://dogelayer.ai/"`. Verified independently just now — 3 checks over several seconds all return a Cloudflare 530 ("origin is unreachable"):

```
$ curl -sL -o /dev/null -w "%{http_code}" https://dogelayer.ai/
530
```

`website_url` is a **required** field on `schemas/provider.schema.json`, so it can't simply be removed. Adds a `notes` field documenting the known-degraded state, following the exact precedent already set by the same directory's `registry/providers/alphacore.json` (same situation: a dead marketing domain, GitHub repo as the verified public source surface).

## Change

One field added to one file — `registry/providers/dogelayer.json`:

```diff
   "name": "dogelayer",
+  "notes": "The dogelayer.ai marketing domain currently returns a Cloudflare 530 origin error to simple probes, so the GitHub repository is the verified public source surface.",
   "public_notes": "...",
```

Closes #5568

## Validation

- [x] `npx prettier --check registry/providers/dogelayer.json` — clean
- [x] `npm run validate` — passed (129 native subnets, 129 curated overlays, 1613 surfaces, 133 providers, 2037 candidates)
- [x] `npm run scan:public-safety` — passed
- [x] Re-verified `https://dogelayer.ai/` at fix time — still 530 (Cloudflare origin error), 3/3 checks