### PR TITLE
feat(graphql): add Query.extrinsics / Query.extrinsic

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -8,6 +8,12 @@ import {
 } from "graphql";
 import { readArtifact, readHealthKv } from "../workers/storage.mjs";
 import { contractVersion } from "../workers/responses.mjs";
+import { tryPostgresTier } from "../workers/postgres-tier.mjs";
+import {
+  BLOCK_PAGINATION,
+  clampLimit,
+  clampOffset,
+} from "../workers/request-params.mjs";
 import {
   buildGlobalHealth,
   formatLeaderboards,
@@ -20,6 +26,7 @@ import {
   parseCompareDimensionList,
   parseCompareNetuidList,
 } from "./analytics-live.mjs";
+import { buildExtrinsic, buildExtrinsicFeed } from "./extrinsics.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
 
 export const GRAPHQL_MAX_DEPTH = 7;
@@ -54,6 +61,10 @@ export const SDL = `
     opportunity_boards(limit: Int): OpportunityBoards!
     "Cross-subnet comparison: registry structure, live economics, and live health placed side by side for the requested netuids, in requested order. Mirrors GET /api/v1/compare."
     compare(netuids: [Int!]!, dimensions: [String!]): Compare!
+    "Recent-extrinsic feed (newest first), optionally filtered. Mirrors GET /api/v1/extrinsics."
+    extrinsics(limit: Int, offset: Int, cursor: String, block: Int, signer: String, call_module: String, call_function: String, success: Boolean): ExtrinsicList!
+    "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}."
+    extrinsic(ref: String!): ExtrinsicDetail
   }
 
   type SubnetList {
@@ -317,6 +328,33 @@ export const SDL = `
     avg_latency_ms: Int
   }
 
+  type ExtrinsicList {
+    items: [Extrinsic!]!
+    "Page count -- this feed has no cheap grand total, matching REST's extrinsic_count."
+    total: Int!
+    next_cursor: String
+  }
+
+  type Extrinsic {
+    block_number: Int
+    extrinsic_index: Int
+    extrinsic_hash: String
+    signer: String
+    call_module: String
+    call_function: String
+    "JSON-encoded decoded call arguments."
+    call_args: String
+    success: Boolean
+    fee_tao: Float
+    tip_tao: Float
+    observed_at: String
+  }
+
+  type ExtrinsicDetail {
+    ref: String
+    extrinsic: Extrinsic
+  }
+
   # Realtime chain-event firehose (#4983, ADR 0015) -- a thin protocol adapter
   # over the SAME ChainFirehoseHub Durable Object connection #4982's SSE/WS
   # transports use, not a second event pipeline. Reached over WebSocket only
@@ -449,6 +487,8 @@ export const FIELD_COMPLEXITY = {
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
+  extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
+  extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -766,6 +806,20 @@ async function loadEconomicsRows(context) {
   return Array.isArray(data?.subnets) ? data.subnets : [];
 }
 
+// Synthesize the GET request tryPostgresTier forwards to the DATA_API service
+// binding, keyed off the same origin as the inbound GraphQL POST (GraphQL has
+// no REST-shaped request of its own to forward, unlike every REST handler
+// that already owns one matching its own route). Same technique
+// handleCompare's health dimension uses for its own internal compare-health
+// forward (workers/request-handlers/analytics-routes.mjs) rather than
+// forwarding the caller's request unchanged.
+function postgresTierRequest(context, pathname, params) {
+  const pgUrl = new URL(context.request.url);
+  pgUrl.pathname = pathname;
+  pgUrl.search = params ? params.toString() : "";
+  return new Request(pgUrl);
+}
+
 // --- Node builders (attach lazy relationship resolvers to artifact rows) ---
 
 // graphql-js' default field resolver invokes a source property when it is a
@@ -786,6 +840,20 @@ function subnetNode(identity, prefetch = {}) {
     economics: (_args, context) => loadSubnetEconomics(context, netuid),
     surfaces: bundledOr(prefetch.surfaces, loadSubnetSurfaces),
     endpoints: bundledOr(prefetch.endpoints, loadSubnetEndpoints),
+  };
+}
+
+// formatExtrinsic's call_args is a decoded JS value (object/array/null), but
+// the SDL exposes it as an opaque JSON-encoded String (no custom JSON scalar
+// exists in this schema yet) -- stringify it here rather than letting
+// graphql-js' default String serializer coerce the object via `String(...)`
+// (which would silently produce "[object Object]").
+function extrinsicNode(extrinsic) {
+  if (!extrinsic) return null;
+  return {
+    ...extrinsic,
+    call_args:
+      extrinsic.call_args == null ? null : JSON.stringify(extrinsic.call_args),
   };
 }
 
@@ -1003,6 +1071,69 @@ const rootValue = {
       observedAt: await loadObservedAt(context),
     });
   },
+
+  async extrinsics(
+    {
+      limit,
+      offset,
+      cursor,
+      block,
+      signer,
+      call_module: callModule,
+      call_function: callFunction,
+      success,
+    },
+    context,
+  ) {
+    if (block != null && (!Number.isInteger(block) || block < 0)) {
+      throw new GraphQLError("block must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const safeLimit = clampLimit(limit, BLOCK_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    if (cursor) params.set("cursor", cursor);
+    if (block != null) params.set("block", String(block));
+    if (signer) params.set("signer", signer);
+    if (callModule) params.set("call_module", callModule);
+    if (callFunction) params.set("call_function", callFunction);
+    if (success != null) params.set("success", String(success));
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/extrinsics", params),
+        "METAGRAPH_EXTRINSICS_SOURCE",
+      )) ??
+      buildExtrinsicFeed([], {
+        limit: safeLimit,
+        offset: safeOffset,
+        nextCursor: null,
+      });
+    return {
+      items: (data.extrinsics || []).map(extrinsicNode),
+      total: data.extrinsic_count ?? 0,
+      next_cursor: data.next_cursor ?? null,
+    };
+  },
+
+  async extrinsic({ ref }, context) {
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/extrinsics/${encodeURIComponent(ref)}`,
+        ),
+        "METAGRAPH_EXTRINSICS_SOURCE",
+      )) ?? buildExtrinsic(undefined, ref);
+    return {
+      ref: data.ref ?? ref,
+      extrinsic: extrinsicNode(data.extrinsic),
+    };
+  },
 };
 
 // --- Response helpers ---
@@ -1165,7 +1296,7 @@ export async function handleGraphQLRequest(request, env) {
     schema,
     document,
     rootValue,
-    contextValue: { env, cache: new Map() },
+    contextValue: { env, cache: new Map(), request },
     variableValues: variables ?? undefined,
     operationName: operationName ?? undefined,
   });

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1765,6 +1765,228 @@ describe("graphql — compare (reuse the shared compare loader)", () => {
   });
 });
 
+describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("extrinsics: cold/no-tier store returns a schema-stable empty page (fallback builder)", async () => {
+    const { status, body } = await gql(
+      "{ extrinsics { items { call_module } total next_cursor } }",
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.extrinsics, {
+      items: [],
+      total: 0,
+      next_cursor: null,
+    });
+  });
+
+  test("extrinsics: resolves Postgres-tier rows, JSON-encoding call_args", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          extrinsic_count: 1,
+          limit: 20,
+          offset: 0,
+          next_cursor: "cursor-1",
+          extrinsics: [
+            {
+              block_number: 5,
+              extrinsic_index: 0,
+              extrinsic_hash: `0x${"a".repeat(64)}`,
+              signer: "5Signer",
+              call_module: "SubtensorModule",
+              call_function: "register",
+              call_args: [{ name: "netuid", value: 1 }],
+              success: true,
+              fee_tao: 0.001,
+              tip_tao: 0,
+              observed_at: "2026-07-14T00:00:00.000Z",
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      "{ extrinsics { items { block_number call_module call_args success } total next_cursor } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.extrinsics.total, 1);
+    assert.equal(body.data.extrinsics.next_cursor, "cursor-1");
+    const item = body.data.extrinsics.items[0];
+    assert.equal(item.call_module, "SubtensorModule");
+    assert.equal(item.success, true);
+    assert.equal(
+      item.call_args,
+      JSON.stringify([{ name: "netuid", value: 1 }]),
+    );
+  });
+
+  test("extrinsics: filter args are forwarded as query params to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            extrinsic_count: 0,
+            limit: 5,
+            offset: 0,
+            next_cursor: null,
+            extrinsics: [],
+          });
+        },
+      },
+    };
+    await gql(
+      `{ extrinsics(limit: 5, block: 42, signer: "5Signer", call_module: "SubtensorModule", call_function: "register", success: true) { total } }`,
+      env,
+    );
+    assert.equal(capturedUrl.pathname, "/api/v1/extrinsics");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl.searchParams.get("block"), "42");
+    assert.equal(capturedUrl.searchParams.get("signer"), "5Signer");
+    assert.equal(
+      capturedUrl.searchParams.get("call_module"),
+      "SubtensorModule",
+    );
+    assert.equal(capturedUrl.searchParams.get("call_function"), "register");
+    assert.equal(capturedUrl.searchParams.get("success"), "true");
+  });
+
+  test("extrinsics: a cursor arg is forwarded as a query param to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            extrinsic_count: 0,
+            limit: 20,
+            offset: 0,
+            next_cursor: null,
+            extrinsics: [],
+          });
+        },
+      },
+    };
+    await gql(`{ extrinsics(cursor: "abc123") { total } }`, env);
+    assert.equal(capturedUrl.searchParams.get("cursor"), "abc123");
+  });
+
+  test("extrinsics: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      "{ extrinsics { items { call_module } total next_cursor } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.extrinsics, {
+      items: [],
+      total: 0,
+      next_cursor: null,
+    });
+  });
+
+  test("extrinsic: a malformed Postgres-tier body falls back to the requested ref", async () => {
+    const ref = "5-2";
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      `{ extrinsic(ref: "${ref}") { ref extrinsic { call_module } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.extrinsic.ref, ref);
+    assert.equal(body.data.extrinsic.extrinsic, null);
+  });
+
+  test("extrinsics: a negative block filter is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      "{ extrinsics(block: -1) { total } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("extrinsic: unresolved ref returns extrinsic:null, never a GraphQL error", async () => {
+    const ref = `0x${"a".repeat(64)}`;
+    const { status, body } = await gql(
+      `{ extrinsic(ref: "${ref}") { ref extrinsic { call_module } } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.extrinsic.ref, ref);
+    assert.equal(body.data.extrinsic.extrinsic, null);
+  });
+
+  test("extrinsic: resolves a Postgres-tier row by composite ref", async () => {
+    const ref = "5-2";
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ref,
+          extrinsic: {
+            block_number: 5,
+            extrinsic_index: 2,
+            extrinsic_hash: null,
+            signer: "5Signer",
+            call_module: "SubtensorModule",
+            call_function: "set_weights",
+            call_args: null,
+            success: true,
+            fee_tao: 0,
+            tip_tao: 0,
+            observed_at: "2026-07-14T00:00:00.000Z",
+          },
+          events: [],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ extrinsic(ref: "${ref}") { ref extrinsic { call_module call_function } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.extrinsic.ref, ref);
+    assert.equal(body.data.extrinsic.extrinsic.call_module, "SubtensorModule");
+    assert.equal(body.data.extrinsic.extrinsic.call_function, "set_weights");
+  });
+
+  test("extrinsics / extrinsic are weighted as fan-out fields", () => {
+    assert.equal(FIELD_COMPLEXITY.extrinsics, 5);
+    assert.equal(FIELD_COMPLEXITY.extrinsic, 5);
+  });
+});
+
 // --- Subscription.chainEvents (#4983, ADR 0015) ---------------------------------
 //
 // The DO-runtime side of this wiring (ChainFirehoseHub.subscribeChainEvents,


### PR DESCRIPTION
## Pick The Right Template

Use the matching PR template so the submission gate can classify your PR
correctly:

- [Subnet surface](?template=surface.md): one `registry/subnets/<slug>.json`
  file — a community surface added with `npm run surface:add`; for a missing
  subnet manifest, scaffold it first with `npm run subnet:new` in the same file
  (optionally plus one `registry/providers/*.json` for a debut provider).
- [Provider/operator profile](?template=provider-profile.md): one
  `registry/providers/*.json` file only.
- [Backend/code change](?template=backend-code.md): scripts, schemas,
  contracts, workflows, or registry generator logic.
- [Docs-only change](?template=docs-only.md): README or docs edits only.

For data submissions, do not edit generated `public/metagraph/**` artifacts,
native snapshots, scripts, workflows, or package files.

## Summary

- Add `Query.extrinsics` / `Query.extrinsic` to the GraphQL SDL, mirroring
  `GET /api/v1/extrinsics` and `GET /api/v1/extrinsics/{ref}` (and the MCP
  `list_extrinsics`/`get_extrinsic` tools), which previously had no GraphQL
  presence.

## What Changed

- `src/graphql.mjs`:
  - New SDL: `Query.extrinsics(limit, offset, cursor, block, signer,
    call_module, call_function, success): ExtrinsicList!` and
    `Query.extrinsic(ref: String!): ExtrinsicDetail`, plus the
    `ExtrinsicList`/`Extrinsic`/`ExtrinsicDetail` types mirroring
    `formatExtrinsic`'s output shape (`EXTRINSIC_READ_COLUMNS`), reusing the
    same field names `ChainEvent`'s "extrinsics only" fields already
    established (`extrinsic_index`, `call_module`, `call_function`, `signer`,
    `success`).
  - Both resolvers go through the same `tryPostgresTier(env, request,
    "METAGRAPH_EXTRINSICS_SOURCE")` + pure-fallback contract REST uses, so a
    cold/retired D1 tier degrades to a schema-stable empty page /
    `extrinsic: null` instead of a GraphQL error — never a 4xx/5xx on a cold
    store. Since GraphQL's own inbound request is a POST to `/api/v1/graphql`
    (not a REST-shaped GET), the resolvers synthesize the GET request
    `tryPostgresTier` expects, the same technique `handleCompare`'s health
    dimension already uses for its own internal forward.
  - `block` is validated the same way `handleExtrinsics` does
    (non-negative-integer check, `BAD_USER_INPUT` GraphQLError on a negative
    value — GraphQL's own `Int` type already rejects non-integers at the
    validation layer).
  - `extrinsics`/`extrinsic` added to `FIELD_COMPLEXITY` at the standard
    relationship weight.
  - `call_args` (a decoded JS object/array) is exposed as a JSON-encoded
    `String` field — this schema has no custom JSON scalar yet, so it's
    stringified explicitly rather than letting the default `String`
    serializer coerce it.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5580`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none
      touched — GraphQL SDL is not part of the OpenAPI/REST contract).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (none —
      this only extends the GraphQL SDL, `validate:contract-drift` confirms no
      REST/OpenAPI drift).

## Validation

- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage` (`tests/graphql.test.mjs`: 115/115 passing;
      `src/graphql.mjs` at 100% statement/line coverage — the only uncovered
      branches, 1015/1035-1038, are pre-existing `health`/`opportunity_boards`
      code untouched by this diff)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

New tests added to `tests/graphql.test.mjs` cover: a cold/no-tier store
returning a schema-stable empty page, resolving Postgres-tier rows (including
JSON-encoding `call_args`), filter/cursor args forwarded as query params to
the Postgres tier, a negative `block` filter rejected as `BAD_USER_INPUT`
before ever reaching the tier, an unresolved `extrinsic(ref)` returning
`extrinsic: null` (never a GraphQL error), resolving a Postgres-tier row by
composite ref, a malformed Postgres-tier body degrading to the schema-stable
fallback for both fields, and the `FIELD_COMPLEXITY` weights.

Closes #5580
