### PR TITLE
fix(ci): pass the required amount param in the stake-quote smoke check

### DIFF
--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -498,6 +498,10 @@ export function apiRouteUrl(routePath, date, options = {}) {
   } else if (routePath === "/api/v1/compare") {
     // compare requires `netuids` — a bare GET is a 400 (#1682).
     url.searchParams.set("netuids", "7,8");
+  } else if (routePath === "/api/v1/subnets/{netuid}/stake-quote") {
+    // stake-quote requires `amount` — a bare GET is a correct 400
+    // invalid_amount, not a route failure (same #1682 class as compare above).
+    url.searchParams.set("amount", "1");
   } else if (
     [
       "/api/v1/surfaces",


### PR DESCRIPTION
## Summary
- `Publish Cloudflare Backend`'s live smoke test failed twice today because `scripts/smoke-live-api.mjs` hit `/api/v1/subnets/{netuid}/stake-quote` without the required `?amount=` query param, correctly getting a `400 invalid_amount` back
- This is not an API regression — `r2:upload`/`kv:publish` (the actual data publish) already succeed before this smoke step runs, so no data went stale, only the smoke gate itself was red
- Fixes the check by adding `amount=1` for this route, mirroring the existing `/api/v1/compare` required-param pattern (same file, same class of fix, #1682)

## Test plan
- [x] `node -e` verification that `apiRouteUrl` now produces a URL with `amount=1` for the stake-quote route
- [x] `curl` confirms `?amount=1` alone (no `direction`) returns 200 against the live route
- [x] `npx vitest run tests/smoke-route-substitution.test.mjs` — 160/160 passed
- [x] `npm run lint` / `npx prettier --check` clean