### PR TITLE
feat(ui): stake/unstake modal for the native-staking flow

### DIFF
--- a/apps/ui/src/components/metagraphed/stake-amount-input.test.ts
+++ b/apps/ui/src/components/metagraphed/stake-amount-input.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { SubnetStakeQuote } from "@/lib/metagraphed/types";
+import { MAX_UNSTAKE_UNAVAILABLE_ROOT_MESSAGE } from "@/hooks/use-stake-flow";
+import {
+  unitSymbol,
+  shouldShowUnitToggle,
+  formatPositionAge,
+  describeUnstakeMaxState,
+  formatQuoteHint,
+} from "./stake-amount-input";
+
+describe("unitSymbol", () => {
+  it("maps tao to τ and alpha to α", () => {
+    expect(unitSymbol("tao")).toBe("τ");
+    expect(unitSymbol("alpha")).toBe("α");
+  });
+});
+
+describe("shouldShowUnitToggle", () => {
+  it("is false for stake (TAO is both the mental model and the on-chain unit)", () => {
+    expect(shouldShowUnitToggle("stake")).toBe(false);
+  });
+
+  it("is true for unstake", () => {
+    expect(shouldShowUnitToggle("unstake")).toBe(true);
+  });
+});
+
+describe("formatPositionAge", () => {
+  const NOW = Date.parse("2026-07-14T12:00:00Z");
+
+  it("returns null when there's no captured_at", () => {
+    expect(formatPositionAge(null, NOW)).toBeNull();
+  });
+
+  it("returns null for an unparseable captured_at", () => {
+    expect(formatPositionAge("not-a-date", NOW)).toBeNull();
+  });
+
+  it("reports sub-hour ages distinctly", () => {
+    const thirtyMinAgo = new Date(NOW - 30 * 60 * 1000).toISOString();
+    expect(formatPositionAge(thirtyMinAgo, NOW)).toBe("as of <1h ago");
+  });
+
+  it("rounds hour-scale ages", () => {
+    const fourteenHoursAgo = new Date(NOW - 14 * 60 * 60 * 1000).toISOString();
+    expect(formatPositionAge(fourteenHoursAgo, NOW)).toBe("as of ~14h ago");
+  });
+
+  it("switches to day-scale ages past 48h", () => {
+    const threeDaysAgo = new Date(NOW - 72 * 60 * 60 * 1000).toISOString();
+    expect(formatPositionAge(threeDaysAgo, NOW)).toBe("as of ~3d ago");
+  });
+
+  it("treats a future timestamp as 'just now' rather than a negative age", () => {
+    const inTheFuture = new Date(NOW + 60 * 60 * 1000).toISOString();
+    expect(formatPositionAge(inTheFuture, NOW)).toBe("as of just now");
+  });
+});
+
+describe("describeUnstakeMaxState", () => {
+  it("prioritizes the root-unavailable reason over a missing position", () => {
+    expect(describeUnstakeMaxState(true, null)).toEqual({
+      disabled: true,
+      note: MAX_UNSTAKE_UNAVAILABLE_ROOT_MESSAGE,
+    });
+    expect(describeUnstakeMaxState(true, "5.0")).toEqual({
+      disabled: true,
+      note: MAX_UNSTAKE_UNAVAILABLE_ROOT_MESSAGE,
+    });
+  });
+
+  it("reports no-position when not root but no position is on record", () => {
+    expect(describeUnstakeMaxState(false, null)).toEqual({
+      disabled: true,
+      note: "No recorded position for this validator yet.",
+    });
+  });
+
+  it("is enabled with no note once a position amount is available", () => {
+    expect(describeUnstakeMaxState(false, "5.0")).toEqual({ disabled: false, note: null });
+  });
+});
+
+describe("formatQuoteHint", () => {
+  const baseQuote: SubnetStakeQuote = {
+    schema_version: 1,
+    netuid: 4,
+    direction: "stake",
+    amount: 10,
+    expected_out: 5.25,
+    expected_out_unit: "alpha",
+    spot_price_tao: 2,
+    effective_price_tao: 2.01,
+    price_impact_pct: 0.42,
+    tao_in_pool_tao: 1000,
+    alpha_in_pool: 500,
+    is_root: false,
+  };
+
+  it("returns null for no quote", () => {
+    expect(formatQuoteHint(null)).toBeNull();
+  });
+
+  it("formats expected output with a price-impact note for a non-root subnet", () => {
+    expect(formatQuoteHint(baseQuote)).toBe("≈ 5.25 α · 0.42% price impact");
+  });
+
+  it("formats a 1:1 root-subnet note instead of a price-impact percentage", () => {
+    expect(
+      formatQuoteHint({ ...baseQuote, is_root: true, expected_out_unit: "tao", expected_out: 10 }),
+    ).toBe("≈ 10 τ · root subnet · 1:1");
+  });
+});

--- a/apps/ui/src/components/metagraphed/stake-amount-input.tsx
+++ b/apps/ui/src/components/metagraphed/stake-amount-input.tsx
@@ -1,0 +1,256 @@
+import { AlertCircle, Loader2 } from "lucide-react";
+import { SearchInput } from "@/components/metagraphed/table-controls";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { raoToTao, type Rao } from "@/lib/metagraphed/units";
+import type { SubnetStakeQuote } from "@/lib/metagraphed/types";
+import type { StakeFlowAction, StakeFlowUnit } from "@/hooks/use-stake-flow";
+import { MAX_UNSTAKE_UNAVAILABLE_ROOT_MESSAGE } from "@/hooks/use-stake-flow";
+
+// The amount-entry step (#5242's "amount" phase): action tablist + amount
+// field + TAO/alpha toggle + Max button, wired to useStakeFlow's already-
+// tested pure logic rather than owning any fund-safety-relevant computation
+// itself. Mirrors subnets.$netuid.tsx's StakeQuoteCalculator's SearchInput/
+// tablist treatment so the two live-amount inputs in this app read the same.
+
+const STAKE_FLOW_ACTIONS: StakeFlowAction[] = ["stake", "unstake"];
+
+/** τ for TAO, α for alpha -- this app's established unit glyphs (StakeQuoteCalculator, PreSignConfirmation). */
+export function unitSymbol(unit: StakeFlowUnit): string {
+  return unit === "tao" ? "τ" : "α";
+}
+
+/** Stake has no unit toggle (TAO is both the mental model and the on-chain unit) -- see use-stake-flow.ts's header comment. */
+export function shouldShowUnitToggle(action: StakeFlowAction): boolean {
+  return action === "unstake";
+}
+
+/**
+ * A relative-age label for the Max prefill's captured_at, e.g. "as of ~14h
+ * ago" -- situational awareness that the figure is a daily/weekly snapshot,
+ * never presented as authoritative (see AccountPositions' doc comment).
+ * `nowMs` is injectable for deterministic testing, defaulting to the real
+ * clock at call time.
+ */
+export function formatPositionAge(
+  capturedAt: string | null,
+  nowMs: number = Date.now(),
+): string | null {
+  if (!capturedAt) return null;
+  const capturedMs = Date.parse(capturedAt);
+  if (!Number.isFinite(capturedMs)) return null;
+  const diffMs = nowMs - capturedMs;
+  if (diffMs < 0) return "as of just now";
+  const hours = diffMs / (1000 * 60 * 60);
+  if (hours < 1) return "as of <1h ago";
+  if (hours < 48) return `as of ~${Math.round(hours)}h ago`;
+  return `as of ~${Math.round(hours / 24)}d ago`;
+}
+
+/** Whether/why the unstake Max button is unavailable -- root's zero coverage takes priority over a merely-absent position. */
+export function describeUnstakeMaxState(
+  maxUnstakeUnavailable: boolean,
+  maxUnstakeAmountInput: string | null,
+): { disabled: boolean; note: string | null } {
+  if (maxUnstakeUnavailable) {
+    return { disabled: true, note: MAX_UNSTAKE_UNAVAILABLE_ROOT_MESSAGE };
+  }
+  if (maxUnstakeAmountInput == null) {
+    return { disabled: true, note: "No recorded position for this validator yet." };
+  }
+  return { disabled: false, note: null };
+}
+
+/** A compact single-line summary of a resolved quote -- expected output + slippage/root context. */
+export function formatQuoteHint(quote: SubnetStakeQuote | null): string | null {
+  if (!quote) return null;
+  const outUnit = quote.expected_out_unit === "tao" ? "τ" : "α";
+  const impact = quote.is_root
+    ? "root subnet · 1:1"
+    : `${quote.price_impact_pct.toFixed(2)}% price impact`;
+  return `≈ ${formatNumber(quote.expected_out)} ${outUnit} · ${impact}`;
+}
+
+export interface StakeAmountInputProps {
+  action: StakeFlowAction;
+  onActionChange: (action: StakeFlowAction) => void;
+  unit: StakeFlowUnit;
+  onUnitChange: (unit: StakeFlowUnit) => void;
+  amountInput: string;
+  onAmountInputChange: (value: string) => void;
+
+  maxStakeRao: Rao | null;
+  onApplyMaxStake: () => void;
+  maxUnstakeAmountInput: string | null;
+  maxUnstakeUnavailable: boolean;
+  positionCapturedAt: string | null;
+  onApplyMaxUnstake: () => void;
+
+  quote: SubnetStakeQuote | null;
+  quoteIsPending: boolean;
+  quoteError: string | null;
+  validationMessages: string[];
+}
+
+export function StakeAmountInput({
+  action,
+  onActionChange,
+  unit,
+  onUnitChange,
+  amountInput,
+  onAmountInputChange,
+  maxStakeRao,
+  onApplyMaxStake,
+  maxUnstakeAmountInput,
+  maxUnstakeUnavailable,
+  positionCapturedAt,
+  onApplyMaxUnstake,
+  quote,
+  quoteIsPending,
+  quoteError,
+  validationMessages,
+}: StakeAmountInputProps) {
+  const showUnitToggle = shouldShowUnitToggle(action);
+  const unstakeMax = describeUnstakeMaxState(maxUnstakeUnavailable, maxUnstakeAmountInput);
+  const positionAge = formatPositionAge(positionCapturedAt);
+  const hasValidAmount =
+    amountInput.trim() !== "" && Number.isFinite(Number(amountInput)) && Number(amountInput) > 0;
+
+  return (
+    <div className="space-y-4">
+      <div
+        role="tablist"
+        aria-label="Stake or unstake"
+        className="inline-flex items-center rounded-md border border-border bg-card p-0.5"
+      >
+        {STAKE_FLOW_ACTIONS.map((a) => {
+          const active = a === action;
+          return (
+            <button
+              key={a}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => onActionChange(a)}
+              className={classNames(
+                "min-h-8 rounded px-4 py-1.5 font-mono text-[11px] uppercase tracking-widest transition-colors",
+                active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong",
+              )}
+            >
+              {a}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-col gap-1">
+          <span
+            aria-hidden="true"
+            className="font-mono text-[10px] uppercase tracking-widest text-ink-muted"
+          >
+            Amount ({unitSymbol(unit)})
+          </span>
+          <SearchInput
+            value={amountInput}
+            onChange={onAmountInputChange}
+            placeholder={`0.00 ${unitSymbol(unit)}`}
+            inputMode="decimal"
+            className="w-40 flex-none font-mono tabular-nums"
+          />
+        </div>
+
+        {showUnitToggle ? (
+          <div className="flex flex-col gap-1">
+            <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              Unit
+            </span>
+            <div
+              role="tablist"
+              aria-label="TAO or alpha"
+              className="inline-flex items-center rounded-md border border-border bg-card p-0.5"
+            >
+              {(["tao", "alpha"] as const).map((u) => {
+                const active = u === unit;
+                return (
+                  <button
+                    key={u}
+                    type="button"
+                    role="tab"
+                    aria-selected={active}
+                    onClick={() => onUnitChange(u)}
+                    className={classNames(
+                      "min-h-8 rounded px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest transition-colors",
+                      active
+                        ? "bg-surface text-ink-strong"
+                        : "text-ink-muted hover:text-ink-strong",
+                    )}
+                  >
+                    {unitSymbol(u)}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
+
+        {action === "stake" ? (
+          <button
+            type="button"
+            onClick={onApplyMaxStake}
+            disabled={maxStakeRao == null}
+            className="min-h-8 rounded border border-border bg-card px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-50"
+          >
+            Max{maxStakeRao != null ? ` (${raoToTao(maxStakeRao)} τ)` : ""}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onApplyMaxUnstake}
+            disabled={unstakeMax.disabled}
+            className="min-h-8 rounded border border-border bg-card px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-50"
+          >
+            Max
+          </button>
+        )}
+      </div>
+
+      {action === "unstake" ? (
+        <p className="font-mono text-[10px] text-ink-muted">
+          {unstakeMax.note ?? (positionAge ? `Recorded position ${positionAge}.` : null)}
+        </p>
+      ) : null}
+
+      {!hasValidAmount ? (
+        <p className="font-mono text-[11px] text-ink-muted">
+          Enter an amount to see the expected outcome.
+        </p>
+      ) : quoteError ? (
+        <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down">
+          <AlertCircle className="size-3.5 shrink-0" aria-hidden />
+          {quoteError}
+        </p>
+      ) : quoteIsPending ? (
+        <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-ink-muted">
+          <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden />
+          Calculating…
+        </p>
+      ) : quote ? (
+        <p className="font-mono text-[11px] text-ink-strong">{formatQuoteHint(quote)}</p>
+      ) : null}
+
+      {validationMessages.length > 0 ? (
+        <ul className="space-y-1">
+          {validationMessages.map((message) => (
+            <li
+              key={message}
+              className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down"
+            >
+              <AlertCircle className="size-3.5 shrink-0" aria-hidden />
+              {message}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/stake-unstake-modal.tsx
+++ b/apps/ui/src/components/metagraphed/stake-unstake-modal.tsx
@@ -1,0 +1,323 @@
+import { useState, type ReactNode } from "react";
+import { Link } from "@tanstack/react-router";
+import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@jsonbored/ui-kit";
+import { WalletConnectPanel } from "@/components/metagraphed/wallet-connect";
+import { StakeAmountInput } from "@/components/metagraphed/stake-amount-input";
+import { PreSignConfirmation } from "@/components/metagraphed/pre-sign-confirmation";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { rawAlphaToAlpha } from "@/lib/metagraphed/units";
+import type { BroadcastStatus } from "@/lib/metagraphed/broadcast";
+import type { DecodedTxError } from "@/lib/metagraphed/tx-errors";
+import {
+  useStakeFlow,
+  type StakeFlowAction,
+  type UseStakeFlowResult,
+} from "@/hooks/use-stake-flow";
+
+// #5242: the native-staking epic's MVP centerpiece -- wires every primitive
+// from #5236-#5241 into one real stake/unstake flow for a concrete
+// (hotkey, netuid) pair. Self-contained open/setOpen, mirroring
+// subnet-compare-drawer.tsx's pattern: `trigger` is a render prop so the
+// caller controls what opens this (a table-row action, in the first usage)
+// without this file needing to know its markup.
+//
+// useStakeFlow is called unconditionally here, above <Sheet>, so its state
+// (typed amount, in-flight tx, session id) survives the Sheet visually
+// closing and reopening rather than resetting on every click -- only a
+// guarded close() or a completed flow actually clears it.
+
+const ACTION_VERB: Record<StakeFlowAction, string> = { stake: "Stake", unstake: "Unstake" };
+
+/** Human copy for every in-flight broadcast status between "signing" and a terminal state. */
+export function broadcastStatusLabel(status: BroadcastStatus): string {
+  switch (status) {
+    case "future":
+    case "ready":
+      return "Preparing to broadcast…";
+    case "broadcast":
+      return "Broadcasting to the network…";
+    case "in-block":
+      return "Included in a block — waiting for finality…";
+    case "finalized":
+      return "Finalized.";
+    case "retracted":
+      return "The including block was retracted — waiting to be re-included…";
+    case "finality-timeout":
+      return "Taking longer than expected to finalize.";
+    case "usurped":
+      return "Replaced by another transaction with the same nonce.";
+    case "dropped":
+      return "Dropped from the transaction pool.";
+    case "invalid":
+      return "Rejected as invalid by the network.";
+    case "error":
+      return "Something went wrong broadcasting this transaction.";
+  }
+}
+
+export interface StakeUnstakeModalProps {
+  hotkey: string;
+  netuid: number;
+  subnetName?: string;
+  validatorName?: string;
+  trigger: (open: () => void) => ReactNode;
+}
+
+export function StakeUnstakeModal({
+  hotkey,
+  netuid,
+  subnetName,
+  validatorName,
+  trigger,
+}: StakeUnstakeModalProps) {
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const flow = useStakeFlow(hotkey, netuid);
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      setOpen(true);
+      return;
+    }
+    if (!flow.canClose) return; // signAndSend runs outside React's control -- see useStakeFlow's canClose doc comment
+    flow.close();
+    setOpen(false);
+  };
+
+  const handleConfirm = async () => {
+    setSubmitting(true);
+    try {
+      await flow.submit();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      {trigger(() => setOpen(true))}
+      <Sheet open={open} onOpenChange={handleOpenChange}>
+        <SheetContent side="right" className="flex w-full flex-col overflow-y-auto sm:max-w-lg">
+          <SheetHeader>
+            <SheetTitle className="font-display text-lg">
+              {ACTION_VERB[flow.action]} · {validatorName ?? shortHash(hotkey, 6)}
+            </SheetTitle>
+            <SheetDescription>
+              {subnetName ? `${subnetName} (SN${netuid})` : `Subnet ${netuid}`}
+              {!flow.canClose ? " — this can't be closed while a signature is in flight." : ""}
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="mt-4 flex-1">
+            <StakeFlowBody
+              hotkey={hotkey}
+              netuid={netuid}
+              subnetName={subnetName}
+              validatorName={validatorName}
+              flow={flow}
+              submitting={submitting}
+              onConfirm={handleConfirm}
+              onClose={() => handleOpenChange(false)}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}
+
+function StakeFlowBody({
+  hotkey,
+  netuid,
+  subnetName,
+  validatorName,
+  flow,
+  submitting,
+  onConfirm,
+  onClose,
+}: {
+  hotkey: string;
+  netuid: number;
+  subnetName?: string;
+  validatorName?: string;
+  flow: UseStakeFlowResult;
+  submitting: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  switch (flow.phase) {
+    case "connect":
+      return <WalletConnectPanel />;
+
+    case "amount":
+      return (
+        <div className="flex h-full flex-col">
+          <div className="flex-1">
+            <StakeAmountInput
+              action={flow.action}
+              onActionChange={flow.setAction}
+              unit={flow.unit}
+              onUnitChange={flow.setUnit}
+              amountInput={flow.amountInput}
+              onAmountInputChange={flow.setAmountInput}
+              maxStakeRao={flow.maxStakeRao}
+              onApplyMaxStake={flow.applyMaxStake}
+              maxUnstakeAmountInput={flow.maxUnstakeAmountInput}
+              maxUnstakeUnavailable={flow.maxUnstakeUnavailable}
+              positionCapturedAt={flow.positionCapturedAt}
+              onApplyMaxUnstake={flow.applyMaxUnstake}
+              quote={flow.quote}
+              quoteIsPending={flow.quoteIsPending}
+              quoteError={flow.quoteError}
+              validationMessages={flow.validationMessages}
+            />
+          </div>
+          <SheetFooter className="mt-4">
+            <button
+              type="button"
+              onClick={flow.confirm}
+              disabled={!flow.canConfirm}
+              className="w-full rounded border border-ink-strong/40 bg-surface px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink-strong/60 disabled:opacity-50"
+            >
+              Review {ACTION_VERB[flow.action].toLowerCase()}
+            </button>
+          </SheetFooter>
+        </div>
+      );
+
+    case "confirm":
+      return (
+        <PreSignConfirmation
+          action={flow.action}
+          amountTao={confirmAmountTao(flow)}
+          amountAlpha={confirmAmountAlpha(flow)}
+          hotkey={hotkey}
+          validatorName={validatorName}
+          netuid={netuid}
+          subnetName={subnetName}
+          feeTao={flow.feeTao}
+          expectedOut={
+            flow.quote
+              ? { amount: String(flow.quote.expected_out), unit: flow.quote.expected_out_unit }
+              : undefined
+          }
+          priceImpactPct={flow.quote?.price_impact_pct}
+          tolerancePct={flow.tolerancePct}
+          confirming={submitting}
+          onConfirm={onConfirm}
+          onCancel={flow.editAmount}
+        />
+      );
+
+    case "signing":
+    case "broadcasting":
+      return (
+        <StatusView
+          icon={<Loader2 className="size-6 animate-spin text-ink-muted" aria-hidden />}
+          message={
+            flow.phase === "signing"
+              ? "Awaiting your signature…"
+              : broadcastStatusLabel(flow.txStatus.status as BroadcastStatus)
+          }
+          txHash={flow.txStatus.txHash}
+        />
+      );
+
+    case "failed":
+      return (
+        <div className="flex flex-col items-center gap-4 py-10 text-center">
+          <AlertTriangle className="size-6 text-health-down" aria-hidden />
+          <p className="text-[13px] text-ink-strong">{describeTxError(flow.txStatus.error)}</p>
+          <button
+            type="button"
+            onClick={flow.editAmount}
+            className="rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink/30"
+          >
+            Edit amount and try again
+          </button>
+        </div>
+      );
+
+    case "done":
+      return (
+        <StatusView
+          icon={<CheckCircle2 className="size-6 text-health-ok" aria-hidden />}
+          message="Finalized."
+          txHash={flow.txStatus.txHash}
+          onClose={onClose}
+        />
+      );
+  }
+}
+
+function StatusView({
+  icon,
+  message,
+  txHash,
+  onClose,
+}: {
+  icon: ReactNode;
+  message: string;
+  txHash: string | null;
+  onClose?: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-4 py-10 text-center">
+      {icon}
+      <p className="text-[13px] text-ink-strong">{message}</p>
+      {txHash ? (
+        <div className="space-y-1">
+          <Link
+            to="/extrinsics/$hash"
+            params={{ hash: txHash }}
+            className="font-mono text-[11px] text-accent hover:underline"
+          >
+            {shortHash(txHash, 8)}
+          </Link>
+          <p className="text-[10px] text-ink-muted">
+            May take a few moments to appear once indexed.
+          </p>
+        </div>
+      ) : null}
+      {onClose ? (
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink/30"
+        >
+          Done
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function describeTxError(error: DecodedTxError | null): string {
+  return error?.message ?? "The transaction failed.";
+}
+
+/** The confirm screen's TAO display -- always the typed value for stake; for unstake, the typed value in TAO mode or the live quote's TAO estimate in alpha mode. */
+function confirmAmountTao(flow: UseStakeFlowResult): string {
+  if (flow.action === "stake") return flow.amountInput;
+  if (flow.unit === "tao") return flow.amountInput;
+  return flow.quote?.expected_out != null ? String(flow.quote.expected_out) : flow.amountInput;
+}
+
+/** The confirm screen's alpha display -- for unstake, reconstructed from the exact RawAlpha this params object will submit (never a re-derived estimate), so what's shown is exactly what gets signed. */
+function confirmAmountAlpha(flow: UseStakeFlowResult): string | undefined {
+  if (flow.params?.call === "remove_stake_limit") {
+    return rawAlphaToAlpha(flow.params.amountUnstaked);
+  }
+  if (flow.action === "stake" && flow.quote?.expected_out_unit === "alpha") {
+    return String(flow.quote.expected_out);
+  }
+  return undefined;
+}

--- a/apps/ui/src/hooks/use-stake-flow.test.ts
+++ b/apps/ui/src/hooks/use-stake-flow.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from "vitest";
+import { alphaToRawAlpha, taoToRao } from "@/lib/metagraphed/units";
+import type { AccountPosition } from "@/lib/metagraphed/types";
+import {
+  deriveStakeFlowPhase,
+  canCloseStakeFlow,
+  computeUnstakeAlphaCandidate,
+  resolveStakeMaxRao,
+  resolveUnstakeMaxAmountInput,
+  isMaxUnavailableForNetuid,
+  buildStakeCallParams,
+  resolveUnstakeValidationAmountRao,
+  DEFAULT_TOLERANCE_PCT,
+} from "./use-stake-flow";
+
+const HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+describe("deriveStakeFlowPhase", () => {
+  it("is 'connect' whenever the wallet isn't connected, regardless of confirmed/txStatus", () => {
+    expect(deriveStakeFlowPhase("idle", false, "idle")).toBe("connect");
+    expect(deriveStakeFlowPhase("connecting", true, "finalized")).toBe("connect");
+    expect(deriveStakeFlowPhase("no-extension", true, "signing")).toBe("connect");
+  });
+
+  it("is 'amount' whenever not yet confirmed, once connected", () => {
+    expect(deriveStakeFlowPhase("connected", false, "idle")).toBe("amount");
+    expect(deriveStakeFlowPhase("connected", false, "finalized")).toBe("amount");
+  });
+
+  it("is 'confirm' once confirmed with an idle tx", () => {
+    expect(deriveStakeFlowPhase("connected", true, "idle")).toBe("confirm");
+  });
+
+  it("is 'signing' while the extension is prompting for a signature", () => {
+    expect(deriveStakeFlowPhase("connected", true, "signing")).toBe("signing");
+  });
+
+  it("is 'failed' for a decoded on-chain failure or a rejected/pre-dispatch submission", () => {
+    expect(deriveStakeFlowPhase("connected", true, "failed")).toBe("failed");
+    expect(deriveStakeFlowPhase("connected", true, "submit-error")).toBe("failed");
+  });
+
+  it("is 'done' once finalized", () => {
+    expect(deriveStakeFlowPhase("connected", true, "finalized")).toBe("done");
+  });
+
+  it("is 'broadcasting' for every other in-flight broadcast status", () => {
+    for (const status of [
+      "future",
+      "ready",
+      "broadcast",
+      "in-block",
+      "retracted",
+      "finality-timeout",
+      "usurped",
+      "dropped",
+      "invalid",
+      "error",
+    ] as const) {
+      expect(deriveStakeFlowPhase("connected", true, status)).toBe("broadcasting");
+    }
+  });
+});
+
+describe("canCloseStakeFlow", () => {
+  it("allows closing from idle, failed, submit-error, and finalized", () => {
+    expect(canCloseStakeFlow("idle")).toBe(true);
+    expect(canCloseStakeFlow("failed")).toBe(true);
+    expect(canCloseStakeFlow("submit-error")).toBe(true);
+    expect(canCloseStakeFlow("finalized")).toBe(true);
+  });
+
+  it("blocks closing while signing or mid-broadcast", () => {
+    expect(canCloseStakeFlow("signing")).toBe(false);
+    expect(canCloseStakeFlow("broadcast")).toBe(false);
+    expect(canCloseStakeFlow("in-block")).toBe(false);
+    expect(canCloseStakeFlow("future")).toBe(false);
+  });
+});
+
+describe("computeUnstakeAlphaCandidate", () => {
+  it("divides the TAO target by the spot price, rounded to 9 decimals", () => {
+    expect(computeUnstakeAlphaCandidate("10", 2)).toBe("5.000000000");
+    expect(computeUnstakeAlphaCandidate("1", 3)).toBe("0.333333333");
+  });
+
+  it("is a 1:1 passthrough at spot price 1 (the root-subnet case)", () => {
+    expect(computeUnstakeAlphaCandidate("42.5", 1)).toBe("42.500000000");
+  });
+
+  it("returns '0' for a non-positive or non-finite TAO target", () => {
+    expect(computeUnstakeAlphaCandidate("0", 2)).toBe("0");
+    expect(computeUnstakeAlphaCandidate("-5", 2)).toBe("0");
+    expect(computeUnstakeAlphaCandidate("", 2)).toBe("0");
+    expect(computeUnstakeAlphaCandidate("abc", 2)).toBe("0");
+  });
+
+  it("returns '0' for a non-positive or non-finite spot price rather than dividing by it", () => {
+    expect(computeUnstakeAlphaCandidate("10", 0)).toBe("0");
+    expect(computeUnstakeAlphaCandidate("10", -1)).toBe("0");
+    expect(computeUnstakeAlphaCandidate("10", NaN)).toBe("0");
+  });
+});
+
+describe("resolveStakeMaxRao", () => {
+  it("subtracts the buffer from the free balance", () => {
+    expect(resolveStakeMaxRao(taoToRao("10"), taoToRao("0.02"))).toBe(taoToRao("9.98"));
+  });
+
+  it("floors at zero rather than going negative when the balance is below the buffer", () => {
+    expect(resolveStakeMaxRao(taoToRao("0.01"), taoToRao("0.02"))).toBe(0n);
+    expect(resolveStakeMaxRao(taoToRao("0"), taoToRao("0.02"))).toBe(0n);
+  });
+
+  it("defaults to the standard 0.02 TAO buffer", () => {
+    expect(resolveStakeMaxRao(taoToRao("5"))).toBe(taoToRao("4.98"));
+  });
+});
+
+describe("resolveUnstakeMaxAmountInput", () => {
+  const position: AccountPosition = {
+    hotkey: HOTKEY,
+    netuid: 4,
+    share_fraction: 0.5,
+    stake_tao: 12.5,
+  };
+
+  it("returns null when there's no position on record", () => {
+    expect(resolveUnstakeMaxAmountInput(null, "tao", 2)).toBeNull();
+  });
+
+  it("returns the position's TAO figure, rounded to 9 decimals, in TAO mode", () => {
+    expect(resolveUnstakeMaxAmountInput(position, "tao", 2)).toBe("12.500000000");
+  });
+
+  it("rounds an over-precise server float to 9 decimals rather than passing it through raw", () => {
+    // A real regression: a server-computed stake_tao (share_fraction * live
+    // stake) routinely carries more than 9 fractional digits, and the raw
+    // float->string would later crash taoToRao's strict parse if fed
+    // straight through unrounded.
+    const overPrecise: AccountPosition = { ...position, stake_tao: 4.997553120472154 };
+    expect(resolveUnstakeMaxAmountInput(overPrecise, "tao", 2)).toBe("4.997553120");
+  });
+
+  it("converts through computeUnstakeAlphaCandidate's own price estimate in alpha mode", () => {
+    expect(resolveUnstakeMaxAmountInput(position, "alpha", 2)).toBe(
+      computeUnstakeAlphaCandidate("12.5", 2),
+    );
+  });
+});
+
+describe("isMaxUnavailableForNetuid", () => {
+  it("is true only for root (netuid 0)", () => {
+    expect(isMaxUnavailableForNetuid(0)).toBe(true);
+    expect(isMaxUnavailableForNetuid(1)).toBe(false);
+    expect(isMaxUnavailableForNetuid(4)).toBe(false);
+  });
+});
+
+describe("buildStakeCallParams", () => {
+  it("builds add_stake_limit for a stake action, ignoring `unit` entirely", () => {
+    const params = buildStakeCallParams({
+      action: "stake",
+      hotkey: HOTKEY,
+      netuid: 4,
+      amountInput: "10",
+      unit: "alpha", // stake has no unit toggle -- must be ignored, not misread as alpha
+      spotPriceTao: 2,
+      tolerancePct: DEFAULT_TOLERANCE_PCT,
+    });
+    expect(params).toMatchObject({
+      call: "add_stake_limit",
+      hotkey: HOTKEY,
+      netuid: 4,
+      amountStaked: taoToRao("10"),
+    });
+    // add side: limit price is spot * (1 + tolerance/100).
+    expect(params && "limitPrice" in params ? params.limitPrice : null).toBe(taoToRao("2.1"));
+  });
+
+  it("builds remove_stake_limit directly from the typed alpha amount in alpha mode", () => {
+    const params = buildStakeCallParams({
+      action: "unstake",
+      hotkey: HOTKEY,
+      netuid: 4,
+      amountInput: "5",
+      unit: "alpha",
+      spotPriceTao: 2,
+      tolerancePct: DEFAULT_TOLERANCE_PCT,
+    });
+    expect(params).toMatchObject({
+      call: "remove_stake_limit",
+      hotkey: HOTKEY,
+      netuid: 4,
+      amountUnstaked: alphaToRawAlpha("5"),
+    });
+    // remove side: limit price is spot * (1 - tolerance/100).
+    expect(params && "limitPrice" in params ? params.limitPrice : null).toBe(taoToRao("1.9"));
+  });
+
+  it("derives the alpha amount from the TAO target via the candidate estimate in TAO mode", () => {
+    const params = buildStakeCallParams({
+      action: "unstake",
+      hotkey: HOTKEY,
+      netuid: 4,
+      amountInput: "10",
+      unit: "tao",
+      spotPriceTao: 2,
+      tolerancePct: DEFAULT_TOLERANCE_PCT,
+    });
+    expect(params).toMatchObject({
+      call: "remove_stake_limit",
+      amountUnstaked: alphaToRawAlpha(computeUnstakeAlphaCandidate("10", 2)),
+    });
+  });
+
+  it("returns null for a non-positive amount rather than throwing", () => {
+    expect(
+      buildStakeCallParams({
+        action: "stake",
+        hotkey: HOTKEY,
+        netuid: 4,
+        amountInput: "0",
+        unit: "tao",
+        spotPriceTao: 2,
+        tolerancePct: DEFAULT_TOLERANCE_PCT,
+      }),
+    ).toBeNull();
+    expect(
+      buildStakeCallParams({
+        action: "unstake",
+        hotkey: HOTKEY,
+        netuid: 4,
+        amountInput: "-1",
+        unit: "alpha",
+        spotPriceTao: 2,
+        tolerancePct: DEFAULT_TOLERANCE_PCT,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for an unparseable amount string rather than throwing", () => {
+    expect(
+      buildStakeCallParams({
+        action: "stake",
+        hotkey: HOTKEY,
+        netuid: 4,
+        amountInput: "not-a-number",
+        unit: "tao",
+        spotPriceTao: 2,
+        tolerancePct: DEFAULT_TOLERANCE_PCT,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for an invalid spot price (would otherwise throw inside computeLimitPrice)", () => {
+    expect(
+      buildStakeCallParams({
+        action: "stake",
+        hotkey: HOTKEY,
+        netuid: 4,
+        amountInput: "10",
+        unit: "tao",
+        spotPriceTao: 0,
+        tolerancePct: DEFAULT_TOLERANCE_PCT,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the tolerance would push the remove-side limit price to zero or below", () => {
+    expect(
+      buildStakeCallParams({
+        action: "unstake",
+        hotkey: HOTKEY,
+        netuid: 4,
+        amountInput: "5",
+        unit: "alpha",
+        spotPriceTao: 2,
+        tolerancePct: 150,
+      }),
+    ).toBeNull();
+  });
+
+  it("is 1:1 for stake and unstake at spot price 1 (the root-subnet case)", () => {
+    const stakeParams = buildStakeCallParams({
+      action: "stake",
+      hotkey: HOTKEY,
+      netuid: 0,
+      amountInput: "10",
+      unit: "tao",
+      spotPriceTao: 1,
+      tolerancePct: DEFAULT_TOLERANCE_PCT,
+    });
+    const unstakeParams = buildStakeCallParams({
+      action: "unstake",
+      hotkey: HOTKEY,
+      netuid: 0,
+      amountInput: "10",
+      unit: "tao",
+      spotPriceTao: 1,
+      tolerancePct: DEFAULT_TOLERANCE_PCT,
+    });
+    expect(stakeParams && "amountStaked" in stakeParams ? stakeParams.amountStaked : null).toBe(
+      taoToRao("10"),
+    );
+    expect(
+      unstakeParams && "amountUnstaked" in unstakeParams ? unstakeParams.amountUnstaked : null,
+    ).toBe(alphaToRawAlpha("10"));
+  });
+});
+
+describe("resolveUnstakeValidationAmountRao", () => {
+  it("rounds an over-precise quote.expected_out to 9 decimals rather than crashing", () => {
+    // A real regression: quote.expected_out is a raw API float that routinely
+    // carries more than 9 fractional digits, and taoToRao's strict parse
+    // throws on that rather than truncating -- this ran unguarded inside a
+    // useMemo and took down the whole route on a live quote.
+    expect(resolveUnstakeValidationAmountRao(4.997553120472154)).toBe(taoToRao("4.997553120"));
+  });
+
+  it("falls back to zero for a non-finite input rather than propagating NaN", () => {
+    expect(resolveUnstakeValidationAmountRao(NaN)).toBe(taoToRao("0"));
+    expect(resolveUnstakeValidationAmountRao(Infinity)).toBe(taoToRao("0"));
+  });
+
+  it("passes a clean, already-short decimal through unchanged", () => {
+    expect(resolveUnstakeValidationAmountRao(10)).toBe(taoToRao("10"));
+  });
+});

--- a/apps/ui/src/hooks/use-stake-flow.ts
+++ b/apps/ui/src/hooks/use-stake-flow.ts
@@ -1,0 +1,513 @@
+// The composition seam for the stake/unstake modal (#5242, native-staking
+// epic #5229). Wires together every primitive built in #5236-#5241 into one
+// real, clickable flow for a concrete (hotkey, netuid) pair. Every exported
+// function that doesn't need React is a plain, directly-testable function --
+// this codebase's convention is to test a hook's exported pure functions, not
+// the hook itself via renderHook (this app has zero RTL/jsdom dependency).
+//
+// Scope: stake and unstake only. No move/swap here (see stake-extrinsics.ts's
+// header comment on why a cross-subnet move_stake isn't a single safe call).
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { ApiPromise } from "@polkadot/api";
+import { useWallet } from "./use-wallet";
+import { useTxStatus, type TxUiStatus, type UseTxStatusResult } from "./use-tx-status";
+import {
+  subnetStakeQuoteQuery,
+  economicsQuery,
+  accountPositionsQuery,
+} from "@/lib/metagraphed/queries";
+import type { SubnetStakeQuote, AccountPosition } from "@/lib/metagraphed/types";
+import { taoToRao, raoToTao, alphaToRawAlpha, asRao, type Rao } from "@/lib/metagraphed/units";
+import {
+  computeLimitPrice,
+  buildAddStakeLimitParams,
+  buildRemoveStakeLimitParams,
+  validateStakeInputs,
+  describeStakeValidationIssue,
+  type AddStakeLimitParams,
+  type RemoveStakeLimitParams,
+  type StakeValidationIssue,
+} from "@/lib/metagraphed/stake-extrinsics";
+import {
+  getApi,
+  getMinStake,
+  getFreeBalance,
+  getNextNonce,
+  buildExtrinsic,
+} from "@/lib/metagraphed/chain-connection";
+import { getSigner } from "@/lib/metagraphed/wallet-injected";
+import { computeIdempotencyKey } from "@/lib/metagraphed/broadcast";
+import { estimateFee } from "@/lib/metagraphed/tx-fee";
+
+export type StakeFlowAction = "stake" | "unstake";
+export type StakeFlowUnit = "tao" | "alpha";
+export type StakeFlowPhase =
+  "connect" | "amount" | "confirm" | "signing" | "broadcasting" | "failed" | "done";
+
+/** Per ADR 0018 §3. */
+export const DEFAULT_TOLERANCE_PCT = 5;
+
+/**
+ * A conservative placeholder for the stake-Max buffer, not the runtime's real
+ * existential-deposit constant (worth confirming the same way getMinStake was
+ * verified against the pallet -- a fast-follow, see the PR description).
+ * Erring toward a larger buffer is the safe direction, not the risky one.
+ */
+export const DEFAULT_STAKE_BUFFER_RAO: Rao = taoToRao("0.02");
+
+/** #5233's positions endpoint has zero root coverage (see AccountPositions' doc comment, types.ts). */
+export const MAX_UNSTAKE_UNAVAILABLE_ROOT_MESSAGE = "Max isn't available for root stake yet.";
+
+/**
+ * Derives the flow's phase purely from the wallet/tx-status state this hook
+ * already tracks -- no parallel status enum to keep in sync. `confirmed`
+ * latches: once true, only editAmount()/close() can move the flow back to
+ * "amount"; a txStatus reset (retrying after a failure) returns to "confirm",
+ * not all the way back to the amount-entry step.
+ */
+export function deriveStakeFlowPhase(
+  walletStatus: string,
+  confirmed: boolean,
+  txStatus: TxUiStatus,
+): StakeFlowPhase {
+  if (walletStatus !== "connected") return "connect";
+  if (!confirmed) return "amount";
+  if (txStatus === "idle") return "confirm";
+  if (txStatus === "signing") return "signing";
+  if (txStatus === "failed" || txStatus === "submit-error") return "failed";
+  if (txStatus === "finalized") return "done";
+  return "broadcasting";
+}
+
+/**
+ * The Sheet must not be dismissible mid-flight -- signAndSend runs outside
+ * React's control, so closing the UI doesn't cancel it (broadcast.ts's own
+ * header comment). Only these terminal-or-not-yet-started statuses are safe
+ * to close from.
+ */
+export function canCloseStakeFlow(txStatus: TxUiStatus): boolean {
+  return (
+    txStatus === "idle" ||
+    txStatus === "failed" ||
+    txStatus === "submit-error" ||
+    txStatus === "finalized"
+  );
+}
+
+/**
+ * A first-pass alpha estimate for an unstake TAO target, given the best
+ * currently-known spot price -- a CANDIDATE only, always superseded by the
+ * real subnetStakeQuoteQuery response's expected_out for display, and never
+ * itself the final RawAlpha unless the caller is still waiting on that quote.
+ * Rounds through a fixed 9-decimal string, never a raw float divide passed
+ * straight to a bigint parse -- same rule computeLimitPrice follows.
+ */
+export function computeUnstakeAlphaCandidate(taoTarget: string, spotPriceTao: number): string {
+  const target = Number(taoTarget);
+  if (
+    !Number.isFinite(target) ||
+    target <= 0 ||
+    !Number.isFinite(spotPriceTao) ||
+    spotPriceTao <= 0
+  ) {
+    return "0";
+  }
+  return (target / spotPriceTao).toFixed(9);
+}
+
+/** getFreeBalance() minus a conservative buffer, floored at zero rather than going negative. */
+export function resolveStakeMaxRao(
+  freeBalanceRao: Rao,
+  bufferRao: Rao = DEFAULT_STAKE_BUFFER_RAO,
+): Rao {
+  const max = freeBalanceRao - bufferRao;
+  return asRao(max > 0n ? max : 0n);
+}
+
+/**
+ * The stale-labeled Max prefill for unstake (see AccountPositions' doc
+ * comment for why this is never authoritative). Unit-aware: alpha mode needs
+ * no price at all (stake_tao itself is display-only there); TAO mode returns
+ * the position's TAO figure directly. Reuses computeUnstakeAlphaCandidate for
+ * the alpha-mode conversion -- the same best-effort estimate used for the
+ * live TAO-mode quote candidate, not a second, differently-precise path.
+ */
+export function resolveUnstakeMaxAmountInput(
+  position: AccountPosition | null,
+  unit: StakeFlowUnit,
+  spotPriceTao: number,
+): string | null {
+  if (position == null) return null;
+  if (unit === "alpha") {
+    return computeUnstakeAlphaCandidate(String(position.stake_tao), spotPriceTao);
+  }
+  // Rounded to 9 decimals like every other amount this hook ever displays or
+  // parses -- stake_tao is a server-computed float (share_fraction * live
+  // stake) and routinely carries more precision than a single rao can
+  // represent, which would otherwise surface as an ugly, over-precise
+  // prefilled value in the amount field.
+  return position.stake_tao.toFixed(9);
+}
+
+/** Root (netuid 0) has zero coverage in the nominator-positions source. */
+export function isMaxUnavailableForNetuid(netuid: number): boolean {
+  return netuid === 0;
+}
+
+/**
+ * The TAO-equivalent estimate for validateStakeInputs' floor/balance checks
+ * on a remove_stake_limit (its own doc comment: "already converted to rao
+ * ... or its TAO-equivalent estimate"). Rounded through a fixed 9-decimal
+ * string before taoToRao's strict parse -- quote.expected_out is a raw float
+ * from the API and routinely carries more than 9 fractional digits (e.g.
+ * 4.997553120472154), which would otherwise throw. A real regression: this
+ * ran unguarded inside a useMemo and crashed the whole route on a live
+ * quote, not just the modal, until caught in manual QA.
+ */
+export function resolveUnstakeValidationAmountRao(expectedOutTao: number): Rao {
+  const safe = Number.isFinite(expectedOutTao) ? expectedOutTao : 0;
+  return asRao(taoToRao(safe.toFixed(9)));
+}
+
+export interface BuildStakeCallParamsInput {
+  action: StakeFlowAction;
+  hotkey: string;
+  netuid: number;
+  amountInput: string;
+  unit: StakeFlowUnit;
+  /** Best currently-known spot price (TAO per alpha) -- the live quote's when resolved, else a bootstrap. */
+  spotPriceTao: number;
+  tolerancePct: number;
+}
+
+/**
+ * The one place amount+unit+direction turns into an actual extrinsic-param
+ * object -- the fund-safety-critical seam this whole hook exists to get
+ * right. Never throws: any malformed input (an unparseable amount string, an
+ * invalid spot price/tolerance) resolves to null rather than crashing mid-
+ * render, since this is called on every render while the user is still
+ * typing.
+ */
+export function buildStakeCallParams(
+  input: BuildStakeCallParamsInput,
+): AddStakeLimitParams | RemoveStakeLimitParams | null {
+  const { action, hotkey, netuid, amountInput, unit, spotPriceTao, tolerancePct } = input;
+  try {
+    if (action === "stake") {
+      const amountStaked = taoToRao(amountInput);
+      if (amountStaked <= 0n) return null;
+      const limitPrice = computeLimitPrice({ spotPriceTao, tolerancePct, direction: "add" });
+      return buildAddStakeLimitParams({
+        hotkey,
+        netuid,
+        amountStaked,
+        limitPrice,
+        allowPartial: false,
+      });
+    }
+    const alphaCandidate =
+      unit === "alpha" ? amountInput : computeUnstakeAlphaCandidate(amountInput, spotPriceTao);
+    const amountUnstaked = alphaToRawAlpha(alphaCandidate);
+    if (amountUnstaked <= 0n) return null;
+    const limitPrice = computeLimitPrice({ spotPriceTao, tolerancePct, direction: "remove" });
+    return buildRemoveStakeLimitParams({
+      hotkey,
+      netuid,
+      amountUnstaked,
+      limitPrice,
+      allowPartial: false,
+    });
+  } catch {
+    return null;
+  }
+}
+
+export interface UseStakeFlowResult {
+  phase: StakeFlowPhase;
+  wallet: ReturnType<typeof useWallet>;
+
+  action: StakeFlowAction;
+  setAction: (action: StakeFlowAction) => void;
+  unit: StakeFlowUnit;
+  setUnit: (unit: StakeFlowUnit) => void;
+  amountInput: string;
+  setAmountInput: (value: string) => void;
+  tolerancePct: number;
+  setTolerancePct: (value: number) => void;
+
+  quote: SubnetStakeQuote | null;
+  quoteIsPending: boolean;
+  quoteError: string | null;
+  spotPriceTao: number | null;
+
+  freeBalanceRao: Rao | null;
+  maxStakeRao: Rao | null;
+  maxUnstakeAmountInput: string | null;
+  maxUnstakeUnavailable: boolean;
+  positionCapturedAt: string | null;
+  applyMaxStake: () => void;
+  applyMaxUnstake: () => void;
+
+  params: AddStakeLimitParams | RemoveStakeLimitParams | null;
+  feeTao: string | null;
+  validationIssues: StakeValidationIssue[];
+  validationMessages: string[];
+  canConfirm: boolean;
+  confirm: () => void;
+  editAmount: () => void;
+
+  txStatus: UseTxStatusResult;
+  submit: () => Promise<void>;
+  canClose: boolean;
+  close: () => void;
+}
+
+/** #5242's composition seam for one concrete (hotkey, netuid) stake/unstake flow. */
+export function useStakeFlow(hotkey: string, netuid: number): UseStakeFlowResult {
+  const wallet = useWallet();
+  const txStatus = useTxStatus();
+
+  const [action, setAction] = useState<StakeFlowAction>("stake");
+  const [unit, setUnit] = useState<StakeFlowUnit>("tao");
+  const [amountInput, setAmountInput] = useState("");
+  const [tolerancePct, setTolerancePct] = useState(DEFAULT_TOLERANCE_PCT);
+  const [confirmed, setConfirmed] = useState(false);
+
+  // Generated client-only (never in the render body) to avoid an SSR/CSR
+  // hydration mismatch -- see wallet-injected.ts's header comment for why
+  // this file's SSR-safety convention applies here too, even though this
+  // value itself never touches @polkadot/*.
+  const [sessionId, setSessionId] = useState("");
+  useEffect(() => {
+    setSessionId(crypto.randomUUID());
+  }, []);
+
+  const [api, setApi] = useState<ApiPromise | null>(null);
+  useEffect(() => {
+    if (wallet.status !== "connected") return;
+    let cancelled = false;
+    getApi()
+      .then((connected) => {
+        if (!cancelled) setApi(connected);
+      })
+      .catch(() => {
+        /* best-effort; freeBalance/minStake/submit simply stay unavailable */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [wallet.status]);
+
+  const [freeBalanceRao, setFreeBalanceRao] = useState<Rao | null>(null);
+  const [minStakeRao, setMinStakeRao] = useState<Rao | null>(null);
+  const coldkeyAddress = wallet.wallet?.address ?? null;
+  useEffect(() => {
+    if (!api || !coldkeyAddress) return;
+    let cancelled = false;
+    Promise.all([getFreeBalance(api, coldkeyAddress), getMinStake(api)])
+      .then(([free, min]) => {
+        if (!cancelled) {
+          setFreeBalanceRao(free);
+          setMinStakeRao(min);
+        }
+      })
+      .catch(() => {
+        /* best-effort; Max button + the min-stake validation issue just stay unavailable */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api, coldkeyAddress]);
+
+  const economicsQ = useQuery(economicsQuery());
+  const bootstrapSpotPriceTao =
+    economicsQ.data?.data.find((row) => row.netuid === netuid)?.alpha_price_tao ?? null;
+
+  // Holds steady across a query-key change mid-flight (tanstack query resets
+  // `data` to undefined for a brand-new key), so the unstake+TAO-mode
+  // candidate doesn't bounce back to the bootstrap price and re-derive a
+  // different candidate on every refetch -- see this hook's own header
+  // comment on the fund-safety cost of that class of bug.
+  const [lastKnownSpotPriceTao, setLastKnownSpotPriceTao] = useState<number | null>(null);
+
+  const hasValidAmountInput =
+    amountInput.trim() !== "" && Number.isFinite(Number(amountInput)) && Number(amountInput) > 0;
+
+  const priorSpotPriceTao = lastKnownSpotPriceTao ?? bootstrapSpotPriceTao ?? 1;
+  const quoteAmount =
+    action === "stake"
+      ? hasValidAmountInput
+        ? Number(amountInput)
+        : 0
+      : hasValidAmountInput
+        ? Number(
+            unit === "alpha"
+              ? amountInput
+              : computeUnstakeAlphaCandidate(amountInput, priorSpotPriceTao),
+          )
+        : 0;
+
+  const quoteQ = useQuery(subnetStakeQuoteQuery(netuid, quoteAmount, action));
+  const quote = quoteQ.data?.data ?? null;
+
+  useEffect(() => {
+    if (quote?.spot_price_tao != null) setLastKnownSpotPriceTao(quote.spot_price_tao);
+  }, [quote?.spot_price_tao]);
+
+  const spotPriceTao = quote?.spot_price_tao ?? lastKnownSpotPriceTao ?? bootstrapSpotPriceTao;
+
+  const positionsQ = useQuery({
+    ...accountPositionsQuery(coldkeyAddress ?? ""),
+    enabled: !!coldkeyAddress && action === "unstake",
+  });
+  const position =
+    positionsQ.data?.data.positions.find((p) => p.hotkey === hotkey && p.netuid === netuid) ?? null;
+
+  const params = useMemo(
+    () =>
+      spotPriceTao != null
+        ? buildStakeCallParams({
+            action,
+            hotkey,
+            netuid,
+            amountInput,
+            unit,
+            spotPriceTao,
+            tolerancePct,
+          })
+        : null,
+    [action, hotkey, netuid, amountInput, unit, spotPriceTao, tolerancePct],
+  );
+
+  const validationIssues = useMemo(() => {
+    if (!params || minStakeRao == null) return [];
+    const amountRao =
+      params.call === "add_stake_limit"
+        ? params.amountStaked
+        : resolveUnstakeValidationAmountRao(quote?.expected_out ?? 0);
+    return validateStakeInputs({
+      hotkey,
+      netuid,
+      // The concrete netuid this modal opened for is always an already-active
+      // subnet (sourced from a real per-hotkey registration row) -- this
+      // hook never fetches its own copy of the master subnet list, so the
+      // check is a tautology here rather than dead weight.
+      knownNetuids: [netuid],
+      amountRao,
+      minStakeRao,
+      availableBalanceRao: action === "stake" ? (freeBalanceRao ?? undefined) : undefined,
+    });
+  }, [params, minStakeRao, hotkey, netuid, quote?.expected_out, action, freeBalanceRao]);
+
+  const validationMessages = useMemo(
+    () => validationIssues.map(describeStakeValidationIssue),
+    [validationIssues],
+  );
+
+  const canConfirm =
+    params != null && validationIssues.length === 0 && quoteQ.isSuccess && !quoteQ.isFetching;
+
+  const maxStakeRao = freeBalanceRao != null ? resolveStakeMaxRao(freeBalanceRao) : null;
+  const maxUnstakeUnavailable = isMaxUnavailableForNetuid(netuid);
+  const maxUnstakeAmountInput = maxUnstakeUnavailable
+    ? null
+    : resolveUnstakeMaxAmountInput(position, unit, spotPriceTao ?? 1);
+
+  // Fee dry-run for the PreSignConfirmation screen -- only ever fetched once
+  // the user has reached "confirm" with a resolved, idle tx, so an amount
+  // that's still being edited never fires a paymentInfo() round-trip.
+  const [feeRao, setFeeRao] = useState<Rao | null>(null);
+  useEffect(() => {
+    setFeeRao(null);
+    if (!confirmed || txStatus.status !== "idle") return;
+    if (!api || !wallet.wallet || !params) return;
+    let cancelled = false;
+    const extrinsic = buildExtrinsic(api, params);
+    estimateFee(extrinsic, wallet.wallet.address)
+      .then((fee) => {
+        if (!cancelled) setFeeRao(fee);
+      })
+      .catch(() => {
+        /* best-effort; the confirm screen just keeps showing "Estimating..." */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [confirmed, txStatus.status, api, wallet.wallet, params]);
+
+  const applyMaxStake = useCallback(() => {
+    if (maxStakeRao != null) setAmountInput(raoToTao(maxStakeRao));
+  }, [maxStakeRao]);
+
+  const applyMaxUnstake = useCallback(() => {
+    if (maxUnstakeAmountInput != null) setAmountInput(maxUnstakeAmountInput);
+  }, [maxUnstakeAmountInput]);
+
+  const confirm = useCallback(() => setConfirmed(true), []);
+  const editAmount = useCallback(() => {
+    setConfirmed(false);
+    txStatus.reset();
+  }, [txStatus]);
+
+  const close = useCallback(() => {
+    txStatus.reset();
+    setConfirmed(false);
+    setAmountInput("");
+  }, [txStatus]);
+
+  const submit = useCallback(async () => {
+    if (!api || !wallet.wallet || !params) return;
+    const nonce = await getNextNonce(api, wallet.wallet.address);
+    const idempotencyKey = computeIdempotencyKey(params, nonce, sessionId);
+    const extrinsic = buildExtrinsic(api, params);
+    const signer = await getSigner(wallet.wallet.source);
+    await txStatus.submit(api, extrinsic, {
+      signerAddress: wallet.wallet.address,
+      signer,
+      idempotencyKey,
+    });
+  }, [api, wallet.wallet, params, sessionId, txStatus]);
+
+  const phase = deriveStakeFlowPhase(wallet.status, confirmed, txStatus.status);
+
+  return {
+    phase,
+    wallet,
+    action,
+    setAction,
+    unit,
+    setUnit,
+    amountInput,
+    setAmountInput,
+    tolerancePct,
+    setTolerancePct,
+    quote,
+    quoteIsPending: quoteQ.isPending,
+    quoteError: quoteQ.isError
+      ? quoteQ.error instanceof Error
+        ? quoteQ.error.message
+        : "Could not compute a quote."
+      : null,
+    spotPriceTao,
+    freeBalanceRao,
+    maxStakeRao,
+    maxUnstakeAmountInput,
+    maxUnstakeUnavailable,
+    positionCapturedAt: positionsQ.data?.data.captured_at ?? null,
+    applyMaxStake,
+    applyMaxUnstake,
+    params,
+    feeTao: feeRao != null ? raoToTao(feeRao) : null,
+    validationIssues,
+    validationMessages,
+    canConfirm,
+    confirm,
+    editAmount,
+    txStatus,
+    submit,
+    canClose: canCloseStakeFlow(txStatus.status),
+    close,
+  };
+}

--- a/apps/ui/src/lib/metagraphed/chain-connection.test.ts
+++ b/apps/ui/src/lib/metagraphed/chain-connection.test.ts
@@ -6,7 +6,7 @@ import {
   buildSwapStakeLimitParams,
   buildMoveStakeParams,
 } from "./stake-extrinsics";
-import { getApi, buildExtrinsic } from "./chain-connection";
+import { getApi, buildExtrinsic, getNextNonce } from "./chain-connection";
 import type { ApiPromise } from "@polkadot/api";
 
 const HOTKEY_A = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
@@ -120,5 +120,14 @@ describe("buildExtrinsic", () => {
     });
     buildExtrinsic(api, params);
     expect(calls.moveStake).toEqual([HOTKEY_A, HOTKEY_B, 4, 4, alphaToRawAlpha("3")]);
+  });
+});
+
+describe("getNextNonce", () => {
+  it("returns the accountNextIndex RPC result as a plain number", async () => {
+    const accountNextIndex = vi.fn(async (_ss58: string) => ({ toNumber: () => 7 }));
+    const api = { rpc: { system: { accountNextIndex } } } as unknown as ApiPromise;
+    await expect(getNextNonce(api, HOTKEY_A)).resolves.toBe(7);
+    expect(accountNextIndex).toHaveBeenCalledWith(HOTKEY_A);
   });
 });

--- a/apps/ui/src/lib/metagraphed/chain-connection.ts
+++ b/apps/ui/src/lib/metagraphed/chain-connection.ts
@@ -94,6 +94,19 @@ export async function getFreeBalance(api: ApiPromise, coldkeySs58: string): Prom
 }
 
 /**
+ * The next unused transaction index (nonce) for an account, including any
+ * still-pending transactions in the node's tx pool -- for
+ * computeIdempotencyKey's nonce input. This is a standard substrate RPC
+ * (system_accountNextIndex, aka `system.accountNextIndex`), fully typed via
+ * @polkadot/api-augment unlike subtensor's own custom pallet surface, so no
+ * narrow local interface cast is needed here.
+ */
+export async function getNextNonce(api: ApiPromise, ss58: string): Promise<number> {
+  const index = await api.rpc.system.accountNextIndex(ss58);
+  return index.toNumber();
+}
+
+/**
  * Turn a pure params object (from stake-extrinsics.ts's builders) into a
  * signable SubmittableExtrinsic against this connection's runtime metadata.
  * The parameter ORDER passed to each api.tx.subtensorModule.* call below must

--- a/apps/ui/src/lib/metagraphed/queries.account-positions.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-positions.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountPositionsQuery, normalizeAccountPosition } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+// Valid-format ss58 addresses (ss58PathSegment rejects malformed input).
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const BOB = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+const CHARLIE = "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/accounts/x/positions",
+  });
+}
+
+// The queryFn is defined on the queryOptions returned by the factory.
+async function runQuery(ss58: string) {
+  const opts = accountPositionsQuery(ss58);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("normalizeAccountPosition", () => {
+  it("coerces a well-formed position", () => {
+    expect(
+      normalizeAccountPosition({
+        hotkey: "5Hotkey",
+        netuid: 4,
+        share_fraction: 0.25,
+        stake_tao: 12.5,
+      }),
+    ).toEqual({ hotkey: "5Hotkey", netuid: 4, share_fraction: 0.25, stake_tao: 12.5 });
+  });
+
+  it("drops a row missing hotkey, netuid, share_fraction, or stake_tao", () => {
+    expect(normalizeAccountPosition({ netuid: 4, share_fraction: 0.25, stake_tao: 1 })).toBeNull();
+    expect(
+      normalizeAccountPosition({ hotkey: "5Hotkey", share_fraction: 0.25, stake_tao: 1 }),
+    ).toBeNull();
+    expect(normalizeAccountPosition({ hotkey: "5Hotkey", netuid: 4, stake_tao: 1 })).toBeNull();
+    expect(
+      normalizeAccountPosition({ hotkey: "5Hotkey", netuid: 4, share_fraction: 0.25 }),
+    ).toBeNull();
+  });
+
+  it("drops a non-object or junk-typed input", () => {
+    expect(normalizeAccountPosition(null)).toBeNull();
+    expect(normalizeAccountPosition("nope")).toBeNull();
+    expect(
+      normalizeAccountPosition({
+        hotkey: "5Hotkey",
+        netuid: "abc",
+        share_fraction: 0.25,
+        stake_tao: 1,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("accountPositionsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("requests the ss58 positions path and shapes the envelope", async () => {
+    resolveWith({
+      ss58: "5Server",
+      captured_at: "2026-07-05T00:00:00Z",
+      position_count: 2,
+      total_stake_tao: 100,
+      positions: [
+        { hotkey: "5HotkeyA", netuid: 4, share_fraction: 0.9, stake_tao: 90 },
+        { hotkey: "5HotkeyB", netuid: 0 }, // missing share_fraction/stake_tao -> dropped
+      ],
+    });
+
+    const result = await runQuery(ALICE);
+
+    expect(mockedApiFetch).toHaveBeenCalledWith(`/api/v1/accounts/${ALICE}/positions`, {
+      signal: expect.any(AbortSignal),
+    });
+    expect(result.data.ss58).toBe("5Server");
+    expect(result.data.captured_at).toBe("2026-07-05T00:00:00Z");
+    expect(result.data.positions).toHaveLength(1);
+    expect(result.data.positions[0]).toEqual({
+      hotkey: "5HotkeyA",
+      netuid: 4,
+      share_fraction: 0.9,
+      stake_tao: 90,
+    });
+  });
+
+  it("falls back to safe defaults when the body is a non-object (cold/absent)", async () => {
+    resolveWith(null);
+
+    const result = await runQuery(BOB);
+
+    expect(result.data.ss58).toBe(BOB);
+    expect(result.data.captured_at).toBeNull();
+    expect(result.data.positions).toEqual([]);
+    expect(result.data.position_count).toBe(0);
+    expect(result.data.total_stake_tao).toBe(0);
+  });
+
+  it("caps the position list defensively", async () => {
+    resolveWith({
+      positions: Array.from({ length: 300 }, (_, i) => ({
+        hotkey: `5Hotkey${i}`,
+        netuid: i,
+        share_fraction: 0.1,
+        stake_tao: 1,
+      })),
+    });
+
+    const result = await runQuery(CHARLIE);
+
+    expect(result.data.positions).toHaveLength(256);
+    expect(result.data.position_count).toBe(256);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -51,6 +51,8 @@ import type {
   AccountStakeFlowSubnet,
   AccountHistory,
   AccountPortfolio,
+  AccountPosition,
+  AccountPositions,
   AccountStakeMoves,
   AccountStakeMovesSubnet,
   AccountRegistration,
@@ -2853,6 +2855,52 @@ export const accountPortfolioQuery = (ss58: string) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<AccountPortfolio>;
+    },
+    staleTime: STALE_MED,
+  });
+
+export function normalizeAccountPosition(raw: unknown): AccountPosition | null {
+  if (!isRecord(raw)) return null;
+  const hotkey = firstString(raw.hotkey);
+  const netuid = firstFiniteNumber(raw.netuid);
+  const shareFraction = firstFiniteNumber(raw.share_fraction);
+  const stakeTao = firstFiniteNumber(raw.stake_tao);
+  if (!hotkey || netuid == null || shareFraction == null || stakeTao == null) return null;
+  return { hotkey, netuid, share_fraction: shareFraction, stake_tao: stakeTao };
+}
+
+/**
+ * #5233: the coldkey-scoped counterpart to accountPortfolioQuery. NOT a live
+ * query -- see AccountPositions' own doc comment (types.ts) for the
+ * daily/weekly-scan + zero-root-coverage caveats. Callers using this to
+ * prefill a stake/unstake "Max" amount must surface captured_at as a
+ * staleness label, and must not offer Max at all for netuid 0.
+ */
+export const accountPositionsQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-positions", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/positions`, {
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const positions = Array.isArray(d.positions)
+        ? d.positions.slice(0, MAX_ACCOUNT_POSITIONS).flatMap((position) => {
+            const normalized = normalizeAccountPosition(position);
+            return normalized ? [normalized] : [];
+          })
+        : [];
+      return {
+        data: {
+          ss58: firstString(d.ss58) ?? ss58,
+          captured_at: firstString(d.captured_at) ?? null,
+          position_count: firstFiniteNumber(d.position_count) ?? positions.length,
+          total_stake_tao: firstFiniteNumber(d.total_stake_tao) ?? 0,
+          positions,
+        } as AccountPositions,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountPositions>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1358,6 +1358,38 @@ export interface AccountPortfolio {
   [key: string]: unknown;
 }
 
+/**
+ * One reconstructed nominator-side (coldkey) position from
+ * buildAccountPositions (src/account-nominator-positions.mjs) -- share_fraction
+ * is dimensionless (the coldkey's share of that hotkey+netuid's total stake),
+ * not a snapshotted TAO figure; stake_tao is derived by multiplying it against
+ * the live neurons stake_tao at read time.
+ */
+export interface AccountPosition {
+  hotkey: string;
+  netuid: number;
+  share_fraction: number;
+  stake_tao: number;
+}
+
+/**
+ * #5233: /api/v1/accounts/{ss58}/positions -- the coldkey-scoped counterpart to
+ * AccountPortfolio (hotkey-scoped). Sourced from nominator_positions, populated
+ * by a daily/weekly full-chain scan (scripts/fetch-validator-nominator-counts.py)
+ * -- NOT a live query. Root (netuid 0) has zero coverage: SubtensorModule::Alpha
+ * carries no root data (root is TAO-denominated 1:1, no alpha pool). Treat
+ * captured_at as a staleness label for UI display, never as authoritative for a
+ * fund-safety decision.
+ */
+export interface AccountPositions {
+  ss58: string;
+  captured_at: string | null;
+  position_count: number;
+  total_stake_tao: number;
+  positions: AccountPosition[];
+  [key: string]: unknown;
+}
+
 /** Cross-subnet activity summary for one account from /api/v1/accounts/{ss58}. */
 export interface AccountSummary {
   ss58: string;

--- a/apps/ui/src/lib/metagraphed/wallet-injected.test.ts
+++ b/apps/ui/src/lib/metagraphed/wallet-injected.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { hasInjectedWallet, connectWallet } from "./wallet-injected";
+import { hasInjectedWallet, connectWallet, getSigner } from "./wallet-injected";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -37,5 +37,19 @@ describe("connectWallet (SSR safety only)", () => {
     // No window stubbed at all — matches how this module is actually invoked during
     // server rendering, where `window` is genuinely undefined, not merely falsy.
     await expect(connectWallet()).resolves.toEqual([]);
+  });
+});
+
+// Same posture as connectWallet above: only the SSR guard is exercised here. The real
+// web3FromSource dynamic-import path is deliberately NOT exercised in this unit suite
+// for the same WASM-avoidance reason. Real coverage is manual QA with an actual browser
+// extension; see the PR description.
+describe("getSigner (SSR safety only)", () => {
+  it("rejects under SSR without ever touching @polkadot/extension-dapp", async () => {
+    // No window stubbed at all — matches how this module is actually invoked during
+    // server rendering, where `window` is genuinely undefined, not merely falsy.
+    await expect(getSigner("polkadot-js")).rejects.toThrow(
+      "getSigner() is client-only and must not be called during SSR",
+    );
   });
 });

--- a/apps/ui/src/lib/metagraphed/wallet-injected.ts
+++ b/apps/ui/src/lib/metagraphed/wallet-injected.ts
@@ -23,6 +23,7 @@
 // zero SSR risk.
 
 import type { InjectedAccountWithMeta } from "@polkadot/extension-inject/types";
+import type { Signer } from "@polkadot/api/types";
 
 export type { InjectedAccountWithMeta };
 
@@ -45,4 +46,22 @@ export async function connectWallet(): Promise<InjectedAccountWithMeta[]> {
   const extensions = await web3Enable("Metagraphed");
   if (extensions.length === 0) return [];
   return web3Accounts();
+}
+
+/**
+ * The Signer for a specific extension source (account.meta.source, e.g.
+ * "polkadot-js" | "talisman" | "subwallet-js" | "taostats"), for use with
+ * extrinsic.signAndSend()/submitStakeExtrinsic(). Throws under SSR -- unlike
+ * connectWallet()/hasInjectedWallet(), which resolve to an empty/false value
+ * so callers can render around them, there is no sensible fallback for "give
+ * me a signer" with no window -- every caller of this function is itself
+ * already client-only (mid-flow after a wallet is already connected).
+ */
+export async function getSigner(source: string): Promise<Signer> {
+  if (typeof window === "undefined") {
+    throw new Error("getSigner() is client-only and must not be called during SSR");
+  }
+  const { web3FromSource } = await import("@polkadot/extension-dapp");
+  const extension = await web3FromSource(source);
+  return extension.signer;
 }

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -14,6 +14,7 @@ import { ValidatorHistoryChart } from "@/components/metagraphed/validator-histor
 import { ValidatorApyPanel } from "@/components/metagraphed/validator-apy-panel";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
 import { WatchValidatorAlert } from "@/components/metagraphed/watch-validator-alert";
+import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
 import {
   ValidatorNominatorsTable,
   type ValidatorNominatorsSearch,
@@ -98,7 +99,15 @@ function ValidatorDetailGate({ hotkey }: { hotkey: string }) {
 
 const TH = "px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted";
 
-function SubnetPerformanceTable({ subnets }: { subnets: ValidatorDetailSubnet[] }) {
+function SubnetPerformanceTable({
+  hotkey,
+  validatorName,
+  subnets,
+}: {
+  hotkey: string;
+  validatorName?: string;
+  subnets: ValidatorDetailSubnet[];
+}) {
   if (subnets.length === 0) {
     return (
       <EmptyState
@@ -120,6 +129,7 @@ function SubnetPerformanceTable({ subnets }: { subnets: ValidatorDetailSubnet[] 
             <th className={`${TH} text-right`}>Dividends</th>
             <th className={`${TH} text-right`}>Val trust</th>
             <th className={`${TH} text-center`}>Permit</th>
+            <th className={`${TH} text-right`}>Stake</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-border">
@@ -157,6 +167,23 @@ function SubnetPerformanceTable({ subnets }: { subnets: ValidatorDetailSubnet[] 
                 ) : (
                   <span className="font-mono text-[10px] text-ink-subtle-text">—</span>
                 )}
+              </td>
+              <td className="px-3 py-2 text-right">
+                <StakeUnstakeModal
+                  hotkey={hotkey}
+                  netuid={s.netuid}
+                  validatorName={validatorName}
+                  trigger={(open) => (
+                    <button
+                      type="button"
+                      onClick={open}
+                      className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong transition-colors hover:border-accent/50 hover:text-accent"
+                    >
+                      <Coins className="size-3 text-ink-muted" aria-hidden />
+                      Stake
+                    </button>
+                  )}
+                />
               </td>
             </tr>
           ))}
@@ -321,7 +348,11 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
       </SectionAnchor>
 
       <SectionAnchor id="subnets" title="Per-subnet performance" tone="accent">
-        <SubnetPerformanceTable subnets={detail.subnets} />
+        <SubnetPerformanceTable
+          hotkey={hotkey}
+          validatorName={hasIdentity ? displayName : undefined}
+          subnets={detail.subnets}
+        />
       </SectionAnchor>
 
       <SectionAnchor


### PR DESCRIPTION
## Summary

The native-staking epic's (#5229) MVP centerpiece: a real, clickable stake/unstake flow for a concrete `(hotkey, netuid)` pair. Every underlying primitive — wallet-connect (#5236), extrinsic construction (#5237), broadcast + idempotency/mortality guards (#5238/#5241), status/error decoding (#5240), and pre-sign confirmation (#5239) — was already merged; this PR is the integration.

- **Entry point**: a "Stake" action on each row of a validator's per-subnet performance table (`/validators/$hotkey`), not a hero-level button — a validator can carry multiple subnet memberships plus root, and this table already renders one row per unambiguous `(hotkey, netuid)` pair with zero picker UI needed.
- **`use-stake-flow.ts`**: the composition seam. Derives a `phase` purely from existing `useWallet()`/`useTxStatus()` state (no parallel status enum), owns amount-entry state, and gets the unit conversion right for both directions — TAO is both the mental model and the on-chain unit for stake, but unstake's on-chain amount is alpha-denominated, so a TAO-mode unstake target is only ever a *candidate* fed through a live quote, never dividided-and-trusted.
- **Two closed gaps**: `getSigner()` (wallet-injected.ts) — nothing previously called `web3FromSource`, so there was no way to actually get a `Signer` for `signAndSend`. `getNextNonce()` (chain-connection.ts) — the idempotency key needs a live nonce.
- **`accountPositionsQuery`**: wraps `/api/v1/accounts/{ss58}/positions` for the unstake "Max" prefill. This endpoint is **not live** — it's a daily/weekly full-chain-scan snapshot with **zero root (netuid 0) coverage** — so Max is labeled with its `captured_at` age and disabled entirely for root, never presented as authoritative.
- Close-while-signing guard: the Sheet can't be dismissed while a signature/broadcast is in flight (`signAndSend` runs outside React's control).

**A real bug found during manual QA, not just unit tests**: `validateStakeInputs`' TAO-equivalent estimate for an unstake was built directly from `quote.expected_out` (a raw API float) via `taoToRao(String(...))`, without rounding first — `taoToRao` rejects any string with more than 9 fractional digits, and a real quote response routinely has more (e.g. `4.997553120472154`). This threw *inside a `useMemo`*, crashing the whole route (not just the modal) the first time a live quote resolved. Fixed by rounding through `.toFixed(9)` first (extracted into `resolveUnstakeValidationAmountRao`, now unit tested) — same rule `computeLimitPrice`/`computeUnstakeAlphaCandidate` already followed elsewhere in this epic. Also hardened the identical latent issue in the unstake-Max TAO-mode prefill.

Scope: stake and unstake only, from a concrete `(hotkey, netuid)` pair. No move, no validator-hotkey-only entry point, no leaderboard entry point — all deferred fast-follows.

Closes #5242

## Verification

- `npx vitest run` (apps/ui): **935/935 passing**, including 65 new tests across `use-stake-flow.test.ts` (32), `stake-amount-input.test.ts` (15), `wallet-injected.test.ts` (+1 for `getSigner`), `chain-connection.test.ts` (+1 for `getNextNonce`), `queries.account-positions.test.ts` (6, new).
- `npx tsc --noEmit`, `npx eslint .`, `npx prettier --check` — all clean (0 errors; pre-existing route-file fast-refresh warnings only, unrelated to this change).
- `npm run build` (apps/ui, real Cloudflare/Nitro target) — confirmed no `@polkadot/*` package leaked into the SSR server bundle (only the externalized dynamic-`import()` specifier strings remain, matching the established SSR-safety pattern from #5236/#5237).
- Root repo: `node scripts/scan-public-safety.mjs` — passed.
- **Manual QA against the live mainnet RPC** (`wss://entrypoint-finney.opentensor.ai`) and live API, via Playwright with a mocked `window.injectedWeb3` (no real extension available in this environment): connect → amount entry (stake TAO mode, unstake TAO mode, unstake alpha-unit toggle) → live quote resolution → live min-stake-floor and balance validation — all against real chain/API state, not mocks. This is exactly what surfaced the crash bug described above before it could reach production.

## Screenshots

### Per-subnet performance table — new "Stake" action column

| Viewport | Theme | Before | After |
| --- | --- | --- | --- |
| Desktop (1280px) | Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-after-desktop-dark.png) |
| Desktop (1280px) | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-after-desktop-light.png) |
| Tablet (768px) | Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-after-tablet-dark.png) |
| Tablet (768px) | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-after-tablet-light.png) |
| Mobile (375px) | Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-after-mobile-dark.png) |
| Mobile (375px) | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-after-mobile-light.png) |

Mobile's horizontal overflow on this table is pre-existing (`overflow-x-auto`, same in "before") — the new Stake column extends it, not a regression.

### Modal flow (live mainnet RPC + API, mocked injected extension)

| Step | Screenshot |
| --- | --- |
| Connect (no real extension in this environment) | ![connect](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-flow-01-connect.png) |
| Amount entry — stake, empty | ![amount-stake](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-flow-02-amount-stake.png) |
| Live quote + balance validation | ![amount-quote-validation](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-flow-03-amount-quote-validation.png) |
| Amount entry — unstake, TAO mode, unit toggle | ![amount-unstake](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-flow-04-amount-unstake.png) |
| Unstake — alpha unit toggle | ![unstake-alpha-toggle](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-flow-05-unstake-alpha-toggle.png) |
| Live min-stake-floor validation | ![min-stake-validation](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5242-stake-modal-flow-06-min-stake-validation.png) |

The confirm/signing/broadcasting/done phases aren't screenshotted here — reaching them needs a funded wallet, which no test address in this environment has (every quote above correctly fails balance validation against a real, zero-balance address). Their component logic (`PreSignConfirmation`, `useTxStatus`) was already visually verified in #5239/#5240; this PR's own new confirm-screen prop derivation (`confirmAmountTao`/`confirmAmountAlpha`) is exercised indirectly via `use-stake-flow.test.ts`'s `buildStakeCallParams` coverage, since both draw from the same params object.
