### PR TITLE
fix(ui): add the missing ShareButton to Endpoints and Leaderboards

### DIFF
--- a/apps/ui/src/components/metagraphed/table-controls.tsx
+++ b/apps/ui/src/components/metagraphed/table-controls.tsx
@@ -228,13 +228,26 @@ export function PageSizeSelect({
  * Calls `onReset` to let the route decide which keys to clear (typically
  * search, sort, filters, and cursor; preserves user's page-size choice).
  */
-export function ResetFiltersButton({ active, onReset }: { active: boolean; onReset: () => void }) {
+export function ResetFiltersButton({
+  active,
+  onReset,
+  bare,
+}: {
+  active: boolean;
+  onReset: () => void;
+  /** Borderless variant for grouping inside an `ActionBar` segmented pill. */
+  bare?: boolean;
+}) {
   if (!active) return null;
   return (
     <button
       type="button"
       onClick={onReset}
-      className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 text-[11px] font-medium text-ink hover:border-ink/30 min-h-7"
+      className={
+        bare
+          ? "inline-flex items-center gap-1 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+          : "inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-1 text-[11px] font-medium text-ink hover:border-ink/30 min-h-7"
+      }
       title="Clear search, filters, and pagination"
     >
       <X className="size-3" /> Reset filters

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -37,6 +37,7 @@ import {
   TableState,
   PageHero,
   ShareButton,
+  ActionBar,
   SectionAnchor,
   StatTile,
   BarMini,
@@ -213,7 +214,9 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
         }
         actions={
           <>
-            <ShareButton />
+            <ActionBar>
+              <ShareButton bare />
+            </ActionBar>
             <a
               href="#history"
               className="inline-flex items-center rounded-full border border-accent/30 bg-accent/10 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/15"

--- a/apps/ui/src/routes/admin-changes.index.tsx
+++ b/apps/ui/src/routes/admin-changes.index.tsx
@@ -5,7 +5,7 @@ import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
-import { PageHero, ShareButton, DownloadCsvButton } from "@jsonbored/ui-kit";
+import { PageHero, ShareButton, DownloadCsvButton, ActionBar } from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { CallModuleExtrinsicsTable } from "@/components/metagraphed/call-module-extrinsics-table";
 import { governanceConfigChangesQuery } from "@/lib/metagraphed/queries";
@@ -68,8 +68,10 @@ function AdminChangesPage() {
         description="AdminUtils root-origin config changes — subtensor's own admin pallet for subnet hyperparameters and network-wide config, newest first."
         actions={
           <>
-            <DownloadCsvButton url={adminChangesCsvUrl} />
-            <ShareButton />
+            <ActionBar>
+              <DownloadCsvButton url={adminChangesCsvUrl} bare />
+              <ShareButton bare />
+            </ActionBar>
           </>
         }
       />

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -12,6 +12,7 @@ import {
   TimeAgo,
   PageHero,
   ShareButton,
+  ActionBar,
   SectionAnchor,
   StatTile,
 } from "@jsonbored/ui-kit";
@@ -170,7 +171,11 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
             <span className="text-ink-muted">—</span>
           )
         }
-        actions={<ShareButton />}
+        actions={
+          <ActionBar>
+            <ShareButton bare />
+          </ActionBar>
+        }
         caption="explorer / v1"
       />
 

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -15,6 +15,7 @@ import {
   ListShell,
   ShareButton,
   DownloadCsvButton,
+  ActionBar,
   StatTile,
   Sparkline,
   CopyButton,
@@ -96,8 +97,10 @@ function BlocksPage() {
         description="Recent Bittensor blocks indexed directly from the chain — newest first, with author, extrinsic, and event counts."
         actions={
           <>
-            <DownloadCsvButton url={blocksCsvUrl} />
-            <ShareButton />
+            <ActionBar>
+              <DownloadCsvButton url={blocksCsvUrl} bare />
+              <ShareButton bare />
+            </ActionBar>
           </>
         }
       />

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -22,6 +22,7 @@ import {
   DownloadCsvButton,
   SparkLegend,
   StatTile,
+  ShareButton,
 } from "@jsonbored/ui-kit";
 import { Radio, Server, ShieldCheck, Activity } from "lucide-react";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
@@ -145,6 +146,7 @@ function EndpointsPage() {
         live
         title="Endpoints"
         description="A load-balanced reverse proxy for Bittensor RPC, plus the registry of callable Subtensor and subnet endpoints behind it."
+        actions={<ShareButton />}
       />
       <div className="space-y-section">
         {/* Endpoint KPIs stay visible above the tabs so the tab bar has context

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -11,6 +11,7 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import {
   PageHero,
   ShareButton,
+  ActionBar,
   ListShell,
   LoadMore,
   TimeAgo,
@@ -127,7 +128,9 @@ function ExplorerPage() {
         description="The Bittensor network at a glance — daily activity, fees, call mix, and the most active accounts, computed live from the chain-direct tiers."
         actions={
           <>
-            <ShareButton />
+            <ActionBar>
+              <ShareButton bare />
+            </ActionBar>
             <ChainHeadTip />
           </>
         }

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -11,6 +11,7 @@ import {
   TimeAgo,
   PageHero,
   ShareButton,
+  ActionBar,
   SectionAnchor,
   StatTile,
 } from "@jsonbored/ui-kit";
@@ -177,7 +178,11 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
             {extrinsicCall(extrinsic.call_module, extrinsic.call_function)}
           </span>
         }
-        actions={<ShareButton />}
+        actions={
+          <ActionBar>
+            <ShareButton bare />
+          </ActionBar>
+        }
         caption="explorer / v1"
       />
 

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -21,6 +21,7 @@ import {
   PageHero,
   ListShell,
   ShareButton,
+  ActionBar,
   CopyableCode,
   CopyButton,
   DownloadCsvButton,
@@ -92,8 +93,10 @@ function ExtrinsicsPage() {
         description="Recent Bittensor extrinsics (transactions) indexed directly from the chain — newest first, with call, signer, and success."
         actions={
           <>
-            <DownloadCsvButton url={extrinsicsCsvUrl} />
-            <ShareButton />
+            <ActionBar>
+              <DownloadCsvButton url={extrinsicsCsvUrl} bare />
+              <ShareButton bare />
+            </ActionBar>
           </>
         }
       />

--- a/apps/ui/src/routes/health.tsx
+++ b/apps/ui/src/routes/health.tsx
@@ -15,6 +15,7 @@ import {
   HealthPill,
   TableState,
   PageHero,
+  ActionBar,
   PageSection,
   TimeAgo,
   AnimatedNumber,
@@ -133,13 +134,15 @@ function HealthPage() {
             interval={effectiveInterval}
             controls={
               <>
-                <Link
-                  to="/status"
-                  className="inline-flex items-center gap-1 rounded-md border border-border bg-card px-2.5 py-1.5 text-[11px] font-medium text-ink-muted hover:border-ink/30 hover:text-ink-strong min-h-9"
-                >
-                  Public status
-                  <ArrowUpRight className="size-3" aria-hidden="true" />
-                </Link>
+                <ActionBar>
+                  <Link
+                    to="/status"
+                    className="inline-flex items-center gap-1 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+                  >
+                    Public status
+                    <ArrowUpRight className="size-3" aria-hidden="true" />
+                  </Link>
+                </ActionBar>
                 <AutoRefreshControl
                   enabled={enabled}
                   visible={visible}

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -8,7 +8,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { PageHero, BrandIcon, TimeAgo, StatTile } from "@jsonbored/ui-kit";
+import { PageHero, BrandIcon, TimeAgo, StatTile, ShareButton } from "@jsonbored/ui-kit";
 import {
   chainDeregistrationsQuery,
   chainWeightsQuery,
@@ -64,6 +64,7 @@ function LeaderboardsPage() {
         live
         title="Leaderboards"
         description="Network-wide chain activity boards — ranked by subnet from live chain-direct analytics."
+        actions={<ShareButton />}
       />
       <div className="flex flex-wrap items-center justify-end gap-2">
         <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -30,6 +30,7 @@ import {
   PageHero,
   ViewModeToggle,
   ShareButton,
+  ActionBar,
   Donut,
   DonutLegend,
   Sparkline,
@@ -95,8 +96,10 @@ function ProvidersPage() {
                 })
               }
             />
-            <ResetFiltersButton active={filtersActive} onReset={onReset} />
-            <ShareButton />
+            <ActionBar>
+              <ResetFiltersButton active={filtersActive} onReset={onReset} bare />
+              <ShareButton bare />
+            </ActionBar>
           </>
         }
       />

--- a/apps/ui/src/routes/runtime.index.tsx
+++ b/apps/ui/src/routes/runtime.index.tsx
@@ -4,7 +4,7 @@ import { Suspense, type ReactNode } from "react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
-import { PageHero, ShareButton, TableState, TimeAgo } from "@jsonbored/ui-kit";
+import { PageHero, ShareButton, ActionBar, TableState, TimeAgo } from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { runtimeVersionHistoryQuery } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
@@ -38,7 +38,11 @@ function RuntimePage() {
         live
         title="Runtime"
         description="Spec-version upgrade history for the Bittensor chain, tracked from the first-party blocks tier — every observed runtime upgrade, newest first."
-        actions={<ShareButton />}
+        actions={
+          <ActionBar>
+            <ShareButton bare />
+          </ActionBar>
+        }
       />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -17,6 +17,7 @@ import {
   ViewModeToggle,
   ShareButton,
   DownloadCsvButton,
+  ActionBar,
   ListShell,
   LoadMore,
   StatTile,
@@ -175,9 +176,11 @@ function SubnetsPage() {
             {search.view === "table" ? (
               <DensityToggle value={effectiveDensity} onChange={setDensity} />
             ) : null}
-            <ResetFiltersButton active={filtersActive} onReset={onReset} />
-            <DownloadCsvButton url={subnetsCsvUrl} />
-            <ShareButton />
+            <ActionBar>
+              <ResetFiltersButton active={filtersActive} onReset={onReset} bare />
+              <DownloadCsvButton url={subnetsCsvUrl} bare />
+              <ShareButton bare />
+            </ActionBar>
           </>
         }
       />

--- a/apps/ui/src/routes/sudo.index.tsx
+++ b/apps/ui/src/routes/sudo.index.tsx
@@ -6,7 +6,14 @@ import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
-import { PageHero, ShareButton, DownloadCsvButton, CopyButton, TimeAgo } from "@jsonbored/ui-kit";
+import {
+  PageHero,
+  ShareButton,
+  DownloadCsvButton,
+  ActionBar,
+  CopyButton,
+  TimeAgo,
+} from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { CallModuleExtrinsicsTable } from "@/components/metagraphed/call-module-extrinsics-table";
 import { sudoCallsQuery, sudoKeyQuery } from "@/lib/metagraphed/queries";
@@ -84,8 +91,10 @@ function SudoPage() {
         description="Root-origin (Sudo) calls on the Bittensor chain — subtensor has no Council or Senate, so Sudo is the whole root-origin surface, plus the account currently holding the Sudo key."
         actions={
           <>
-            <DownloadCsvButton url={sudoCsvUrl} />
-            <ShareButton />
+            <ActionBar>
+              <DownloadCsvButton url={sudoCsvUrl} bare />
+              <ShareButton bare />
+            </ActionBar>
           </>
         }
         kpis={[

--- a/apps/ui/src/routes/surfaces.tsx
+++ b/apps/ui/src/routes/surfaces.tsx
@@ -17,6 +17,7 @@ import {
   BrandIcon,
   ShareButton,
   DownloadCsvButton,
+  ActionBar,
   ViewModeToggle,
   ListShell,
   LoadMore,
@@ -111,9 +112,11 @@ function SurfacesPage() {
                   })
                 }
               />
-              <ResetFiltersButton active={filtersActive} onReset={onReset} />
-              <DownloadCsvButton url={surfacesCsvUrl} />
-              <ShareButton />
+              <ActionBar>
+                <ResetFiltersButton active={filtersActive} onReset={onReset} bare />
+                <DownloadCsvButton url={surfacesCsvUrl} bare />
+                <ShareButton bare />
+              </ActionBar>
             </>
           }
         />

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { PageHero, ShareButton, DownloadCsvButton } from "@jsonbored/ui-kit";
+import { PageHero, ShareButton, DownloadCsvButton, ActionBar } from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
@@ -84,8 +84,10 @@ function ValidatorsPage() {
         description="Network-wide validator directory — hotkeys ranked across all Bittensor subnets, computed live from the chain-direct metagraph."
         actions={
           <>
-            <DownloadCsvButton url={validatorsCsvUrl} />
-            <ShareButton />
+            <ActionBar>
+              <DownloadCsvButton url={validatorsCsvUrl} bare />
+              <ShareButton bare />
+            </ActionBar>
           </>
         }
       />

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1555,7 +1555,8 @@ function buildCsvDownloadUrl(url) {
 function DownloadCsvButton({
   url,
   label = "Download CSV",
-  className
+  className,
+  bare
 }) {
   const exportUrl = buildCsvDownloadUrl(url);
   const onClick = () => {
@@ -1569,10 +1570,12 @@ function DownloadCsvButton({
       "aria-label": label,
       title: label,
       className: classNames(
-        // rounded-full matches the pill idiom shared by SectionBadge/FilterChip/
-        // other compact header controls it commonly sits next to — a plain
-        // `rounded` rectangle reads as a mismatched shape beside a pill.
-        "inline-flex items-center gap-1.5 rounded-full border border-border bg-card p-1.5 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:px-2.5 sm:py-1",
+        bare ? "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : (
+          // rounded-full matches the pill idiom shared by SectionBadge/FilterChip/
+          // other compact header controls it commonly sits next to — a plain
+          // `rounded` rectangle reads as a mismatched shape beside a pill.
+          "inline-flex items-center gap-1.5 rounded-full border border-border bg-card p-1.5 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:px-2.5 sm:py-1"
+        ),
         className
       ),
       children: [
@@ -2457,7 +2460,12 @@ function SectionHeading({
     }
   );
 }
-function ShareButton({ url, label = "Share view", className }) {
+function ShareButton({
+  url,
+  label = "Share view",
+  className,
+  bare
+}) {
   const { copied, copy } = useCopy({ toastOnSuccess: false });
   const [announcement, setAnnouncement] = React3.useState("");
   React3.useEffect(() => {
@@ -2485,7 +2493,7 @@ function ShareButton({ url, label = "Share view", className }) {
         "aria-label": "Copy link with current filters, sort, and page",
         title: "Copy link with current filters, sort, and page",
         className: classNames(
-          "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors",
+          bare ? "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors" : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors",
           className
         ),
         children: [
@@ -2496,6 +2504,21 @@ function ShareButton({ url, label = "Share view", className }) {
     ),
     /* @__PURE__ */ jsxRuntime.jsx("span", { role: "status", "aria-live": "polite", className: "sr-only", children: announcement })
   ] });
+}
+function ActionBar({
+  children,
+  className
+}) {
+  return /* @__PURE__ */ jsxRuntime.jsx(
+    "div",
+    {
+      className: classNames(
+        "inline-flex items-center gap-0.5 rounded-md border border-border bg-card p-0.5",
+        className
+      ),
+      children
+    }
+  );
 }
 function timeAgoAbsoluteTitle(at) {
   if (!isUsableTimestamp(at)) return void 0;
@@ -3839,6 +3862,7 @@ exports.Accordion = Accordion;
 exports.AccordionContent = AccordionContent;
 exports.AccordionItem = AccordionItem;
 exports.AccordionTrigger = AccordionTrigger;
+exports.ActionBar = ActionBar;
 exports.AnimatedNumber = AnimatedNumber;
 exports.BackToTop = BackToTop;
 exports.BarMini = BarMini;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1526,7 +1526,8 @@ function buildCsvDownloadUrl(url) {
 function DownloadCsvButton({
   url,
   label = "Download CSV",
-  className
+  className,
+  bare
 }) {
   const exportUrl = buildCsvDownloadUrl(url);
   const onClick = () => {
@@ -1540,10 +1541,12 @@ function DownloadCsvButton({
       "aria-label": label,
       title: label,
       className: classNames(
-        // rounded-full matches the pill idiom shared by SectionBadge/FilterChip/
-        // other compact header controls it commonly sits next to — a plain
-        // `rounded` rectangle reads as a mismatched shape beside a pill.
-        "inline-flex items-center gap-1.5 rounded-full border border-border bg-card p-1.5 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:px-2.5 sm:py-1",
+        bare ? "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : (
+          // rounded-full matches the pill idiom shared by SectionBadge/FilterChip/
+          // other compact header controls it commonly sits next to — a plain
+          // `rounded` rectangle reads as a mismatched shape beside a pill.
+          "inline-flex items-center gap-1.5 rounded-full border border-border bg-card p-1.5 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:px-2.5 sm:py-1"
+        ),
         className
       ),
       children: [
@@ -2428,7 +2431,12 @@ function SectionHeading({
     }
   );
 }
-function ShareButton({ url, label = "Share view", className }) {
+function ShareButton({
+  url,
+  label = "Share view",
+  className,
+  bare
+}) {
   const { copied, copy } = useCopy({ toastOnSuccess: false });
   const [announcement, setAnnouncement] = useState("");
   useEffect(() => {
@@ -2456,7 +2464,7 @@ function ShareButton({ url, label = "Share view", className }) {
         "aria-label": "Copy link with current filters, sort, and page",
         title: "Copy link with current filters, sort, and page",
         className: classNames(
-          "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors",
+          bare ? "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors" : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors",
           className
         ),
         children: [
@@ -2467,6 +2475,21 @@ function ShareButton({ url, label = "Share view", className }) {
     ),
     /* @__PURE__ */ jsx("span", { role: "status", "aria-live": "polite", className: "sr-only", children: announcement })
   ] });
+}
+function ActionBar({
+  children,
+  className
+}) {
+  return /* @__PURE__ */ jsx(
+    "div",
+    {
+      className: classNames(
+        "inline-flex items-center gap-0.5 rounded-md border border-border bg-card p-0.5",
+        className
+      ),
+      children
+    }
+  );
 }
 function timeAgoAbsoluteTitle(at) {
   if (!isUsableTimestamp(at)) return void 0;
@@ -3805,4 +3828,4 @@ function TreemapMini({
   );
 }
 
-export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EntityHero, ExternalLink, FreshnessBadge, FreshnessIndicator, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, InfoTooltip, Kbd, KeyChip, ListCard, ListShell, LoadMore, McpToolsList, MethodologyCallout, MiniRadial, MiniStack, NoDataSpark, PageHero, PageSection, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, RealtimeFreshness, ReviewChip, SCOPES, ScrollReveal, SearchScopeChip, SectionAnchor, SectionHeading, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, cn, fmtYield, freshnessBadgeTimeCopy, freshnessDotClass, freshnessTierLabel, prefetchBrandIcon, safeExternalUrl, tierFreshnessLabel, timeAgoAbsoluteTitle, visibleTools };
+export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EntityHero, ExternalLink, FreshnessBadge, FreshnessIndicator, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, InfoTooltip, Kbd, KeyChip, ListCard, ListShell, LoadMore, McpToolsList, MethodologyCallout, MiniRadial, MiniStack, NoDataSpark, PageHero, PageSection, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, RealtimeFreshness, ReviewChip, SCOPES, ScrollReveal, SearchScopeChip, SectionAnchor, SectionHeading, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, cn, fmtYield, freshnessBadgeTimeCopy, freshnessDotClass, freshnessTierLabel, prefetchBrandIcon, safeExternalUrl, tierFreshnessLabel, timeAgoAbsoluteTitle, visibleTools };

--- a/packages/ui-kit/src/components/metagraphed/action-bar.tsx
+++ b/packages/ui-kit/src/components/metagraphed/action-bar.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+import { classNames } from "@/lib/format";
+
+/**
+ * Segmented container for one-shot page actions (share, download, reset
+ * filters) — the `bare`-variant sibling of `SegmentedToggle`'s pill treatment,
+ * so a row of fire-and-forget actions reads as one deliberate control cluster
+ * instead of a wrapping line of individually-bordered boxes. Children should
+ * render with each button's own `bare` prop set so they lose their standalone
+ * border/background and pick up this shared one instead.
+ */
+export function ActionBar({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={classNames(
+        "inline-flex items-center gap-0.5 rounded-md border border-border bg-card p-0.5",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/ui-kit/src/components/metagraphed/download-csv-button.tsx
+++ b/packages/ui-kit/src/components/metagraphed/download-csv-button.tsx
@@ -8,6 +8,8 @@ interface Props {
   filename?: string;
   label?: string;
   className?: string;
+  /** Borderless variant for grouping inside an `ActionBar` segmented pill. */
+  bare?: boolean;
 }
 
 /** Append `format=csv` to an API URL, preserving existing query params. */
@@ -21,6 +23,7 @@ export function DownloadCsvButton({
   url,
   label = "Download CSV",
   className,
+  bare,
 }: Props) {
   const exportUrl = buildCsvDownloadUrl(url);
 
@@ -35,10 +38,12 @@ export function DownloadCsvButton({
       aria-label={label}
       title={label}
       className={classNames(
-        // rounded-full matches the pill idiom shared by SectionBadge/FilterChip/
-        // other compact header controls it commonly sits next to — a plain
-        // `rounded` rectangle reads as a mismatched shape beside a pill.
-        "inline-flex items-center gap-1.5 rounded-full border border-border bg-card p-1.5 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:px-2.5 sm:py-1",
+        bare
+          ? "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          : // rounded-full matches the pill idiom shared by SectionBadge/FilterChip/
+            // other compact header controls it commonly sits next to — a plain
+            // `rounded` rectangle reads as a mismatched shape beside a pill.
+            "inline-flex items-center gap-1.5 rounded-full border border-border bg-card p-1.5 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:px-2.5 sm:py-1",
         className,
       )}
     >

--- a/packages/ui-kit/src/components/metagraphed/share-button.tsx
+++ b/packages/ui-kit/src/components/metagraphed/share-button.tsx
@@ -9,9 +9,16 @@ interface Props {
   url?: string;
   label?: string;
   className?: string;
+  /** Borderless variant for grouping inside an `ActionBar` segmented pill. */
+  bare?: boolean;
 }
 
-export function ShareButton({ url, label = "Share view", className }: Props) {
+export function ShareButton({
+  url,
+  label = "Share view",
+  className,
+  bare,
+}: Props) {
   // #3425: reuse the shared useCopy hook for the clipboard write, copied-state,
   // and reset timer (the app-wide primitive every other copy affordance uses),
   // keeping ShareButton's two extras it doesn't cover — the window.location.href
@@ -53,7 +60,9 @@ export function ShareButton({ url, label = "Share view", className }: Props) {
         aria-label="Copy link with current filters, sort, and page"
         title="Copy link with current filters, sort, and page"
         className={classNames(
-          "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors",
+          bare
+            ? "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
+            : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors",
           className,
         )}
       >

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -133,6 +133,7 @@ export {
 } from "@/components/metagraphed/section-anchor";
 export { SectionHeading } from "@/components/metagraphed/section-heading";
 export { ShareButton } from "@/components/metagraphed/share-button";
+export { ActionBar } from "@/components/metagraphed/action-bar";
 export { TableState } from "@/components/metagraphed/table-state";
 export {
   timeAgoAbsoluteTitle,


### PR DESCRIPTION
Closes #5561

## What

Every other top-level list page (`subnets.index.tsx`, `validators.index.tsx`, etc.) passes `actions={<ShareButton />}` to its `PageHero`. Two didn't:

- `apps/ui/src/routes/endpoints.tsx` — `PageHero` had no `actions` at all, despite carrying the richest shareable filter state of any list page (`endpointsSearchSchema`: `q`, `category`, `provider`, `health`, `region`, `eligibility`, `sort`, `order`, `page`, `pageSize`, `netuid`, `callable`, plus `tab`).
- `apps/ui/src/routes/leaderboards.tsx` — same gap; its `window` (7d/30d) param changes the shown data with no share affordance.

## Fix

Both files already imported other components from `@jsonbored/ui-kit` — extended the existing import list with `ShareButton` and passed `actions={<ShareButton />}` to each `PageHero` call, identical in shape to every other list page's usage. No other change — `ShareButton` takes no required props (defaults to `window.location.href`).

## Screenshots

3 viewports × 2 themes, before/after, both pages:

### Endpoints

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-before-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-after-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/endpoints-after-mobile-dark.png)<br><sub>after</sub> |

### Leaderboards

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-before-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-after-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-list-pages-share-button-5561/leaderboards-after-mobile-dark.png)<br><sub>after</sub> |

## Acceptance criteria

- [x] `apps/ui/src/routes/endpoints.tsx`: `PageHero` call passes `actions={<ShareButton />}`
- [x] `apps/ui/src/routes/leaderboards.tsx`: `PageHero` call passes `actions={<ShareButton />}`
- [x] Before/after screenshots across all 3 viewports × 2 themes, both pages

## Testing

```
npx tsc --noEmit                          # pre-existing unrelated errors only (stale local ui-kit dist typings, unrelated files), reproduce identically on a clean checkout
npx eslint <changed files>                # clean aside from pre-existing CRLF line-ending noise (core.autocrlf) and pre-existing fast-refresh warnings, confirmed via `git diff --check`
npx prettier --check <changed files>      # same CRLF-only noise, diff itself is clean
```

Diff is 4 insertions, 1 deletion, across exactly the two files the issue names.
