### PR TITLE
feat(mcp): add get_feed tool mirroring the JSON Feed variant of /api/v1/feeds

### DIFF
--- a/src/feed-mcp.mjs
+++ b/src/feed-mcp.mjs
@@ -1,0 +1,274 @@
+// Changelog-feed loader for MCP parity on GET /api/v1/feeds/* (#5592). Reuses
+// the exact item builders + filters the REST feed route uses (src/feeds.mjs)
+// so `get_feed` never diverges from what an RSS/Atom/JSON Feed reader would
+// see -- it just returns the items as plain JSON instead of a feed document,
+// since JSON is the natural shape for a tool response (RSS/Atom are XML feed-
+// reader formats, not something an agent calls a tool to get).
+//
+// The incidents source is injected as `deps.loadIncidents(ctx)` rather than
+// read here directly -- get_global_incidents already sources the identical
+// cross-subnet incident ledger via the MCP module's own D1 runner +
+// deps-injected observed_at (mcp-server.mjs's mcpD1Runner/mcpObservedAt), and
+// this reuses that exact wiring instead of a second path that would bypass
+// the module's injected-KV convention (see mcp-server.mjs's header comment).
+
+import {
+  FEED_MAX_ITEMS,
+  filterByTag,
+  filterSince,
+  filterUntil,
+  gapsItems,
+  incidentItems,
+  parseSinceParam,
+  registryItems,
+  sortAndCap,
+} from "./feeds.mjs";
+import { loadChangelog } from "./changelog-mcp.mjs";
+
+export const FEED_KINDS = ["registry", "incidents", "gaps", "subnet"];
+const ENRICHMENT_QUEUE_ARTIFACT = "/metagraph/review/enrichment-queue.json";
+
+export function feedMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function requireKind(args) {
+  const value = args?.kind;
+  if (typeof value !== "string" || !FEED_KINDS.includes(value)) {
+    throw feedMcpError(
+      "invalid_params",
+      `Argument \`kind\` is required and must be one of: ${FEED_KINDS.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+// `netuid` is required for kind "subnet" (mirrors /api/v1/feeds/subnets/{netuid})
+// and meaningless for the other three kinds, which have no per-subnet REST
+// variant -- reject it there rather than silently ignoring a param the caller
+// thinks is doing something.
+function resolveNetuid(args, kind) {
+  const value = args?.netuid;
+  if (kind === "subnet") {
+    if (!Number.isInteger(value) || value < 0) {
+      throw feedMcpError(
+        "invalid_params",
+        "Argument `netuid` is required and must be a non-negative integer when kind is `subnet`.",
+      );
+    }
+    return value;
+  }
+  if (value !== undefined && value !== null) {
+    throw feedMcpError(
+      "invalid_params",
+      "Argument `netuid` is only used when kind is `subnet`.",
+    );
+  }
+  return null;
+}
+
+// Same strict ISO-8601 contract as the REST feed's ?since=/?until= (a bare
+// calendar date for `until` is inclusive of the whole UTC day).
+function optionalTimestampMs(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string") {
+    throw feedMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be an ISO-8601 date or date-time string.`,
+    );
+  }
+  const ms = parseSinceParam(value, { endOfDay: key === "until" });
+  if (Number.isNaN(ms)) {
+    throw feedMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be an ISO-8601 date or date-time, e.g. 2026-06-01 or 2026-06-01T00:00:00Z.`,
+    );
+  }
+  return ms;
+}
+
+function optionalTag(args) {
+  const value = args?.tag;
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string") {
+    throw feedMcpError("invalid_params", "Argument `tag` must be a string.");
+  }
+  return value;
+}
+
+function resolveLimit(args) {
+  const value = args?.limit;
+  if (value === undefined || value === null) return FEED_MAX_ITEMS;
+  if (!Number.isInteger(value) || value < 1) {
+    throw feedMcpError(
+      "invalid_params",
+      `Argument \`limit\` must be an integer between 1 and ${FEED_MAX_ITEMS}.`,
+    );
+  }
+  return Math.min(value, FEED_MAX_ITEMS);
+}
+
+// A missing/unreadable changelog degrades to an empty registry feed, same as
+// the REST route's readData -- get_feed's "what changed" framing is about the
+// feed being empty, not the tool erroring out from under an agent.
+async function loadChangelogForFeed(ctx) {
+  return loadChangelog(ctx).catch(() => null);
+}
+
+async function loadGapsQueueForFeed(ctx, { readArtifact } = {}) {
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, ENRICHMENT_QUEUE_ARTIFACT);
+  return result?.ok ? result.data : null;
+}
+
+export async function loadFeedItems(ctx, args, deps = {}) {
+  const kind = requireKind(args);
+  const netuid = resolveNetuid(args, kind);
+  const tag = optionalTag(args);
+  const sinceMs = optionalTimestampMs(args, "since");
+  const untilMs = optionalTimestampMs(args, "until");
+  const limit = resolveLimit(args);
+
+  let items;
+  if (kind === "registry") {
+    items = registryItems(await loadChangelogForFeed(ctx));
+  } else if (kind === "incidents") {
+    items = incidentItems(await deps.loadIncidents(ctx));
+  } else if (kind === "gaps") {
+    items = gapsItems(await loadGapsQueueForFeed(ctx, deps));
+  } else {
+    const [changelog, incidents] = await Promise.all([
+      loadChangelogForFeed(ctx),
+      deps.loadIncidents(ctx),
+    ]);
+    items = [
+      ...registryItems(changelog, netuid),
+      ...incidentItems(incidents, netuid),
+    ];
+  }
+
+  items = filterByTag(items, tag);
+  items = filterSince(items, sinceMs);
+  items = filterUntil(items, untilMs);
+  items = sortAndCap(items, limit);
+
+  return {
+    kind,
+    netuid,
+    filters: {
+      tag,
+      since: args?.since ?? null,
+      until: args?.until ?? null,
+      limit,
+    },
+    returned: items.length,
+    items,
+  };
+}
+
+export const GET_FEED_INSTRUCTIONS =
+  'Use get_feed for "what changed" / changelog discovery -- registry changes, ' +
+  "operational incidents, coverage gaps, or one subnet's combined feed, each as " +
+  "chronological items with an id/url/title/summary/timestamp/tags, filterable " +
+  "by tag/since/until (mirrors the JSON Feed variant of GET /api/v1/feeds/*), ";
+
+export const GET_FEED_MCP_TOOL = {
+  name: "get_feed",
+  title: "Get changelog feed items",
+  description:
+    'Fetch registry "what changed" items as structured JSON: registry changes ' +
+    "(subnets/artifacts/coverage added, removed, renamed, or updated), " +
+    "operational incidents (surface downtime), coverage gaps (ranked " +
+    "enrichment targets), or one subnet's combined registry+incidents feed. " +
+    "Each item has an id, url, title, summary, timestamp, and tags. Filter by " +
+    "tag, and narrow the window with since/until (ISO-8601); page with limit " +
+    '(1-50). Use this for incremental "what\'s new since I last checked" ' +
+    "polling instead of re-fetching and diffing the full registry. Mirrors the " +
+    "JSON Feed variant of GET /api/v1/feeds/registry, /api/v1/feeds/incidents, " +
+    "/api/v1/feeds/gaps, and /api/v1/feeds/subnets/{netuid}.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      kind: {
+        type: "string",
+        enum: FEED_KINDS,
+        description:
+          "Which feed to fetch. `subnet` requires netuid and combines that " +
+          "subnet's registry changes + incidents.",
+      },
+      netuid: {
+        type: "integer",
+        description:
+          "Subnet netuid. Required when kind is `subnet`, unused otherwise.",
+        minimum: 0,
+      },
+      tag: {
+        type: "string",
+        description:
+          "Optional tag filter, e.g. incident, coverage, added, removed, renamed.",
+      },
+      since: {
+        type: "string",
+        description:
+          "Optional ISO-8601 date or date-time lower bound, e.g. 2026-06-01 or 2026-06-01T00:00:00Z.",
+      },
+      until: {
+        type: "string",
+        description:
+          "Optional ISO-8601 date or date-time upper bound (a bare date is inclusive of the whole day).",
+      },
+      limit: {
+        type: "integer",
+        description: `Max items to return (1-${FEED_MAX_ITEMS}, default ${FEED_MAX_ITEMS}).`,
+        minimum: 1,
+        maximum: FEED_MAX_ITEMS,
+      },
+    },
+    required: ["kind"],
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const GET_FEED_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["kind", "returned", "items"],
+  properties: {
+    kind: { type: "string", enum: FEED_KINDS },
+    netuid: NULLABLE_INT,
+    filters: {
+      type: "object",
+      additionalProperties: true,
+      properties: {
+        tag: NULLABLE_STRING,
+        since: NULLABLE_STRING,
+        until: NULLABLE_STRING,
+        limit: { type: "integer" },
+      },
+    },
+    returned: { type: "integer" },
+    items: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: true,
+        required: ["id", "url", "title", "summary", "timestamp", "tags"],
+        properties: {
+          id: { type: "string" },
+          url: { type: "string" },
+          title: { type: "string" },
+          summary: { type: "string" },
+          timestamp: { type: "string" },
+          tags: { type: "array", items: { type: "string" } },
+        },
+      },
+    },
+  },
+};

--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -43,7 +43,7 @@ import {
 
 const SITE_URL = "https://metagraph.sh";
 const API_URL = "https://api.metagraph.sh";
-const FEED_MAX_ITEMS = 50;
+export const FEED_MAX_ITEMS = 50;
 const FEED_CACHE_SECONDS = 600;
 
 const FEED_CONTENT_TYPES = {
@@ -153,7 +153,7 @@ function subnetChangeText(n, change, entry) {
 
 // Registry feed: the latest changelog window's subnet + artifact + coverage
 // changes. `netuid` (optional) filters to one subnet.
-function registryItems(changelog, netuid) {
+export function registryItems(changelog, netuid) {
   const at = toIso(changelog?.generated_at) || new Date().toISOString();
   const items = [];
 
@@ -236,7 +236,7 @@ function registryItems(changelog, netuid) {
 }
 
 // Gaps feed: ranked enrichment targets from the served enrichment queue.
-function gapsItems(enrichmentQueue) {
+export function gapsItems(enrichmentQueue) {
   const at = toIso(enrichmentQueue?.generated_at) || new Date().toISOString();
   const items = [];
   for (const entry of enrichmentQueue?.queue || []) {
@@ -290,7 +290,7 @@ function gapsItems(enrichmentQueue) {
 
 // Incidents feed: each reconstructed incident from the served incidents artifact.
 // `netuid` (optional) filters to one subnet.
-function incidentItems(incidents, netuid) {
+export function incidentItems(incidents, netuid) {
   const items = [];
   for (const surface of incidents?.surfaces || []) {
     if (netuid != null && surface?.netuid !== netuid) continue;
@@ -325,7 +325,7 @@ function incidentItems(incidents, netuid) {
 
 // ── serializers ─────────────────────────────────────────────────────────────
 
-function sortAndCap(items, max = FEED_MAX_ITEMS) {
+export function sortAndCap(items, max = FEED_MAX_ITEMS) {
   return [...items]
     .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
     .slice(0, max);
@@ -346,7 +346,7 @@ function parseFeedLimit(raw) {
 // Optional `?tag=` filter: keep only items whose tags array includes the value.
 // A falsy/absent tag is a no-op (the whole feed). The tag is only ever compared,
 // never rendered into the feed body, so it needs no escaping.
-function filterByTag(items, tag) {
+export function filterByTag(items, tag) {
   if (!tag) return items;
   return items.filter((item) => (item.tags || []).includes(tag));
 }
@@ -354,7 +354,7 @@ function filterByTag(items, tag) {
 // Optional `?since=` filter: keep only items at or after `sinceMs` (epoch ms).
 // A null bound (absent param) is a no-op; items whose timestamp can't be parsed
 // are dropped, so a malformed feed entry never leaks past an explicit `since`.
-function filterSince(items, sinceMs) {
+export function filterSince(items, sinceMs) {
   if (sinceMs == null) return items;
   return items.filter((item) => {
     const t = Date.parse(item.timestamp);
@@ -365,7 +365,7 @@ function filterSince(items, sinceMs) {
 // Optional `?until=` filter: keep only items at or before `untilMs` (epoch ms).
 // A null bound (absent param) is a no-op; items whose timestamp can't be parsed
 // are dropped, so a malformed feed entry never leaks past an explicit `until`.
-function filterUntil(items, untilMs) {
+export function filterUntil(items, untilMs) {
   if (untilMs == null) return items;
   return items.filter((item) => {
     const t = Date.parse(item.timestamp);
@@ -514,7 +514,7 @@ export function parseFeedPath(pathname) {
 // (23:59:59.999Z) so the bound stays inclusive of the named day — `?until=DATE`
 // keeps every item from that day rather than dropping all but the midnight tick.
 // A date-time (with an explicit time) is an exact instant, unaffected by the flag.
-function parseSinceParam(value, { endOfDay = false } = {}) {
+export function parseSinceParam(value, { endOfDay = false } = {}) {
   const raw = String(value);
   const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
   if (dateOnly) {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -165,6 +165,12 @@ import {
   loadChangelog,
 } from "./changelog-mcp.mjs";
 import {
+  GET_FEED_INSTRUCTIONS,
+  GET_FEED_MCP_TOOL,
+  GET_FEED_OUTPUT_SCHEMA,
+  loadFeedItems,
+} from "./feed-mcp.mjs";
+import {
   GET_BUILD_INSTRUCTIONS,
   GET_BUILD_MCP_TOOL,
   GET_BUILD_OUTPUT_SCHEMA,
@@ -688,6 +694,7 @@ export const MCP_INSTRUCTIONS =
   GET_COVERAGE_INSTRUCTIONS +
   GET_CONTRACTS_INSTRUCTIONS +
   GET_CHANGELOG_INSTRUCTIONS +
+  GET_FEED_INSTRUCTIONS +
   GET_BUILD_INSTRUCTIONS +
   GET_ADAPTER_INSTRUCTIONS +
   LIST_CURATION_INSTRUCTIONS +
@@ -8537,6 +8544,23 @@ export const MCP_TOOLS = [
     },
   },
   {
+    ...GET_FEED_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadFeedItems(ctx, args, {
+        // Same cross-subnet incident ledger + wiring get_global_incidents uses
+        // (mcpD1Runner + mcpObservedAt), widest window (30d) -- get_feed's own
+        // since/until narrow further from there.
+        async loadIncidents() {
+          return loadGlobalIncidents(mcpD1Runner(ctx), {
+            windowLabel: "30d",
+            windowDays: 30,
+            observedAt: await mcpObservedAt(ctx),
+          });
+        },
+      });
+    },
+  },
+  {
     ...GET_BUILD_MCP_TOOL,
     async handler(_args, ctx) {
       return loadBuildSummary(ctx);
@@ -12603,6 +12627,7 @@ const TOOL_OUTPUT_SCHEMAS = {
     },
   },
   get_changelog: GET_CHANGELOG_OUTPUT_SCHEMA,
+  get_feed: GET_FEED_OUTPUT_SCHEMA,
   get_build: GET_BUILD_OUTPUT_SCHEMA,
   get_adapter: GET_ADAPTER_OUTPUT_SCHEMA,
   get_agent_catalog: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -11162,6 +11162,279 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.surfaces[0].incidents[0].failed_samples, 3);
   });
 
+  test("get_feed requires kind and rejects an unknown one", async () => {
+    const missing = await callTool("get_feed", {});
+    assert.equal(missing.body.result.isError, true);
+    assert.match(missing.body.result.content[0].text, /kind.*required/);
+
+    const bogus = await callTool("get_feed", { kind: "bogus" });
+    assert.equal(bogus.body.result.isError, true);
+  });
+
+  test("get_feed requires netuid for kind subnet and rejects it otherwise", async () => {
+    const noNetuid = await callTool("get_feed", { kind: "subnet" });
+    assert.equal(noNetuid.body.result.isError, true);
+    assert.match(noNetuid.body.result.content[0].text, /netuid.*required/);
+
+    const strayNetuid = await callTool("get_feed", {
+      kind: "registry",
+      netuid: 7,
+    });
+    assert.equal(strayNetuid.body.result.isError, true);
+    assert.match(
+      strayNetuid.body.result.content[0].text,
+      /netuid.*only used when kind is `subnet`/,
+    );
+  });
+
+  test("get_feed kind=registry returns items from the changelog artifact", async () => {
+    const feedDeps = makeDeps({
+      "/metagraph/changelog.json": {
+        generated_at: "2026-06-15T00:00:00.000Z",
+        summary: {},
+        artifacts: { added: [], modified: [], removed: [] },
+        subnets: {
+          added: [{ netuid: 7, name: "Allways" }],
+          removed: [],
+          renamed: [],
+        },
+      },
+    });
+    const res = await callTool(
+      "get_feed",
+      { kind: "registry" },
+      { deps: feedDeps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.kind, "registry");
+    assert.equal(out.returned, 1);
+    assert.equal(out.items[0].tags.includes("subnet"), true);
+    assert.match(out.items[0].title, /Subnet 7 added/);
+  });
+
+  test("get_feed kind=registry degrades to an empty feed when the changelog artifact is missing", async () => {
+    const res = await callTool(
+      "get_feed",
+      { kind: "registry" },
+      { deps: makeDeps() },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 0);
+    assert.deepEqual(out.items, []);
+  });
+
+  test("get_feed kind=incidents returns items from the live D1 incident ledger", async () => {
+    const now = Date.now();
+    const env = {
+      METAGRAPH_HEALTH_DB: metagraphD1({
+        incidentRows: [
+          {
+            netuid: 7,
+            surface_id: "api-root",
+            surface_key: "api-root",
+            started_at: now - 3_600_000,
+            ended_at: now - 1_800_000,
+            failed_samples: 3,
+          },
+        ],
+      }),
+    };
+    const res = await callTool(
+      "get_feed",
+      { kind: "incidents" },
+      {
+        deps: makeDeps({}, { "health:meta": { last_run_at: FRESH_RUN } }),
+        env,
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.items[0].tags.includes("sn7"), true);
+  });
+
+  test("get_feed kind=gaps returns items from the enrichment-queue artifact", async () => {
+    const feedDeps = makeDeps({
+      "/metagraph/review/enrichment-queue.json": {
+        generated_at: "2026-06-15T00:00:00.000Z",
+        queue: [
+          {
+            netuid: 7,
+            name: "Allways",
+            lane: "direct-submission",
+            priority_score: 42,
+            missing_kinds: ["openapi"],
+            direct_submission_kinds: ["openapi"],
+            recommended_action: "Submit an OpenAPI schema.",
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "get_feed",
+      { kind: "gaps" },
+      { deps: feedDeps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 1);
+    assert.equal(out.items[0].tags.includes("sn7"), true);
+    assert.match(out.items[0].title, /SN7 Allways/);
+  });
+
+  test("get_feed kind=gaps degrades to an empty feed when the enrichment-queue artifact is missing", async () => {
+    const res = await callTool(
+      "get_feed",
+      { kind: "gaps" },
+      { deps: makeDeps() },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.returned, 0);
+    assert.deepEqual(out.items, []);
+  });
+
+  test("get_feed kind=subnet combines that subnet's registry changes and incidents", async () => {
+    const now = Date.now();
+    const feedDeps = makeDeps({
+      "/metagraph/changelog.json": {
+        generated_at: "2026-06-15T00:00:00.000Z",
+        summary: {},
+        artifacts: { added: [], modified: [], removed: [] },
+        subnets: {
+          added: [{ netuid: 7, name: "Allways" }],
+          removed: [],
+          renamed: [],
+        },
+      },
+    });
+    const env = {
+      METAGRAPH_HEALTH_DB: metagraphD1({
+        incidentRows: [
+          {
+            netuid: 7,
+            surface_id: "api-root",
+            surface_key: "api-root",
+            started_at: now - 3_600_000,
+            ended_at: now - 1_800_000,
+            failed_samples: 3,
+          },
+        ],
+      }),
+    };
+    const res = await callTool(
+      "get_feed",
+      { kind: "subnet", netuid: 7 },
+      { deps: feedDeps, env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.returned, 2);
+    const tagSets = out.items.map((item) => item.tags);
+    assert.ok(tagSets.some((tags) => tags.includes("registry")));
+    assert.ok(tagSets.some((tags) => tags.includes("incident")));
+  });
+
+  test("get_feed filters by tag, since/until, and caps with limit", async () => {
+    const feedDeps = makeDeps({
+      "/metagraph/changelog.json": {
+        generated_at: "2026-06-15T00:00:00.000Z",
+        summary: {},
+        artifacts: { added: [], modified: [], removed: [] },
+        subnets: {
+          added: [
+            { netuid: 7, name: "Allways" },
+            { netuid: 8, name: "Second" },
+          ],
+          removed: [],
+          renamed: [],
+        },
+      },
+    });
+    const byTag = await callTool(
+      "get_feed",
+      { kind: "registry", tag: "sn9-does-not-exist" },
+      { deps: feedDeps },
+    );
+    assert.equal(byTag.body.result.structuredContent.returned, 0);
+
+    const limited = await callTool(
+      "get_feed",
+      { kind: "registry", limit: 1 },
+      { deps: feedDeps },
+    );
+    assert.equal(limited.body.result.structuredContent.returned, 1);
+    assert.equal(limited.body.result.structuredContent.filters.limit, 1);
+
+    const windowed = await callTool(
+      "get_feed",
+      {
+        kind: "registry",
+        since: "2026-06-16",
+        until: "2026-06-17",
+      },
+      { deps: feedDeps },
+    );
+    assert.equal(windowed.body.result.structuredContent.returned, 0);
+  });
+
+  test("get_feed rejects a malformed since/until/limit", async () => {
+    const badSince = await callTool("get_feed", {
+      kind: "registry",
+      since: "not-a-date",
+    });
+    assert.equal(badSince.body.result.isError, true);
+
+    const badUntil = await callTool("get_feed", {
+      kind: "registry",
+      until: "not-a-date",
+    });
+    assert.equal(badUntil.body.result.isError, true);
+
+    const badLimit = await callTool("get_feed", {
+      kind: "registry",
+      limit: 0,
+    });
+    assert.equal(badLimit.body.result.isError, true);
+
+    // tools/call does not enforce inputSchema types, so a non-string tag/
+    // since/until must be rejected by the handler itself, not just a bad
+    // string value.
+    const nonStringSince = await callTool("get_feed", {
+      kind: "registry",
+      since: 123,
+    });
+    assert.equal(nonStringSince.body.result.isError, true);
+
+    const nonStringTag = await callTool("get_feed", {
+      kind: "registry",
+      tag: 123,
+    });
+    assert.equal(nonStringTag.body.result.isError, true);
+  });
+
+  test("get_feed payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "get_feed",
+    )?.outputSchema;
+    const feedDeps = makeDeps({
+      "/metagraph/changelog.json": {
+        generated_at: "2026-06-15T00:00:00.000Z",
+        summary: {},
+        artifacts: { added: [], modified: [], removed: [] },
+        subnets: {
+          added: [{ netuid: 7, name: "Allways" }],
+          removed: [],
+          renamed: [],
+        },
+      },
+    });
+    const res = await callTool(
+      "get_feed",
+      { kind: "registry" },
+      { deps: feedDeps },
+    );
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("the D1 runner swallows a query error and a missing result set", async () => {
     // A bound DB whose .all() throws must be caught and yield an empty payload.
     const throwingEnv = {


### PR DESCRIPTION
## Summary

Adds a `get_feed` MCP tool mirroring the JSON Feed variant of `/api/v1/feeds/*` (#741), so an agent can ask "what's new since I last checked" instead of re-fetching and diffing the full registry.

- `kind`: `registry` (subnet/artifact/coverage changes), `incidents` (cross-subnet operational incidents), `gaps` (ranked enrichment targets), or `subnet` (one subnet's combined registry+incidents feed, requires `netuid`)
- Filters: `tag`, `since`/`until` (ISO-8601, same strict parsing as the REST route), `limit` (1-50)
- Returns items as plain JSON (`id`, `url`, `title`, `summary`, `timestamp`, `tags`) rather than an RSS/Atom/JSON-Feed document, since that's the natural shape for a tool response — RSS/Atom are XML formats for feed readers, not tool output

`src/feed-mcp.mjs` reuses the exact item builders + filters the REST feed route already uses (`src/feeds.mjs`, now exported alongside the existing `__test` surface), so the two never diverge on what counts as an item. The incidents source reuses the same D1 wiring `get_global_incidents` already uses (`mcpD1Runner` + `mcpObservedAt`), rather than a second path that would bypass this module's injected-KV convention.

Closes #5592

## Test plan

- [x] `npm run build`
- [x] `npm run validate` / `validate:mcp` / `validate:contract-drift` / `validate:ai`
- [x] `npx vitest run` (full suite, 276 files / 8248 tests)
- [x] `npx vitest run --coverage` scoped to the touched files — every changed line/branch in `src/feed-mcp.mjs`, `src/feeds.mjs`, `src/mcp-server.mjs` is covered
- [x] `npx eslint` / `npx prettier --check` on all touched files
