### PR TITLE
fix(analytics): clamp limit in chain-transfers/chain-query-loaders loaders (#5578)

### DIFF
--- a/src/chain-query-loaders.mjs
+++ b/src/chain-query-loaders.mjs
@@ -6,6 +6,8 @@ import { DAY_MS } from "../workers/config.mjs";
 import { buildChainSigners } from "./chain-analytics.mjs";
 
 export const CHAIN_SIGNERS_SORTS = ["tx_count", "total_fee_tao"];
+export const CHAIN_SIGNERS_LIMIT_DEFAULT = 50;
+export const CHAIN_SIGNERS_LIMIT_MAX = 100;
 
 function normalizeChainSignersSort(sort) {
   return CHAIN_SIGNERS_SORTS.includes(sort) ? sort : "tx_count";
@@ -20,14 +22,23 @@ export async function loadChainSigners(
     windowLabel,
     windowDays,
     observedAt = null,
-    limit = 50,
+    limit = CHAIN_SIGNERS_LIMIT_DEFAULT,
     callModule = null,
     sort = "tx_count",
   },
 ) {
   const cutoff = Date.now() - windowDays * DAY_MS;
+  // Clamp limit to a whole number in [1, MAX] so a direct caller cannot make a
+  // negative/oversized value reach the LIMIT ? below (the HTTP layer already
+  // validates 1..MAX; this keeps the pure loader safe independent of that).
+  const flooredLimit = Math.floor(Number(limit));
+  const boundedLimit = Number.isFinite(flooredLimit)
+    ? Math.max(1, Math.min(flooredLimit, CHAIN_SIGNERS_LIMIT_MAX))
+    : CHAIN_SIGNERS_LIMIT_DEFAULT;
   const moduleClause = callModule ? " AND call_module = ?" : "";
-  const params = callModule ? [cutoff, callModule, limit] : [cutoff, limit];
+  const params = callModule
+    ? [cutoff, callModule, boundedLimit]
+    : [cutoff, boundedLimit];
   const sortBy = normalizeChainSignersSort(sort);
   const rows = await d1Runner(
     `SELECT signer,

--- a/src/chain-transfers.mjs
+++ b/src/chain-transfers.mjs
@@ -114,6 +114,13 @@ export async function loadChainTransfers(
     CHAIN_TRANSFER_WINDOWS[windowLabel] ??
     CHAIN_TRANSFER_WINDOWS[DEFAULT_CHAIN_TRANSFER_WINDOW];
   const cutoff = Date.now() - days * DAY_MS;
+  // Clamp limit to a whole number in [1, MAX] so a direct caller cannot make a
+  // negative/oversized value reach the LIMIT ? below (the HTTP layer already
+  // validates 1..MAX; this keeps the pure loader safe independent of that).
+  const flooredLimit = Math.floor(Number(limit));
+  const boundedLimit = Number.isFinite(flooredLimit)
+    ? Math.max(1, Math.min(flooredLimit, CHAIN_TRANSFER_LIMIT_MAX))
+    : CHAIN_TRANSFER_LIMIT_DEFAULT;
 
   const totalsRows = await d1(
     "SELECT COUNT(*) AS transfer_count, " +
@@ -128,14 +135,14 @@ export async function loadChainTransfers(
       "COUNT(*) AS transfer_count FROM account_events " +
       "WHERE event_kind = ? AND observed_at >= ? AND hotkey IS NOT NULL " +
       "GROUP BY hotkey ORDER BY volume_tao DESC, hotkey ASC LIMIT ?",
-    [TRANSFER_KIND, cutoff, limit],
+    [TRANSFER_KIND, cutoff, boundedLimit],
   );
   const receivers = await d1(
     "SELECT coldkey AS address, SUM(amount_tao) AS volume_tao, " +
       "COUNT(*) AS transfer_count FROM account_events " +
       "WHERE event_kind = ? AND observed_at >= ? AND coldkey IS NOT NULL " +
       "GROUP BY coldkey ORDER BY volume_tao DESC, coldkey ASC LIMIT ?",
-    [TRANSFER_KIND, cutoff, limit],
+    [TRANSFER_KIND, cutoff, boundedLimit],
   );
 
   return buildChainTransfers({

--- a/tests/chain-query-loaders.test.mjs
+++ b/tests/chain-query-loaders.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { loadChainSigners } from "../src/chain-query-loaders.mjs";
+import {
+  loadChainSigners,
+  CHAIN_SIGNERS_LIMIT_DEFAULT,
+  CHAIN_SIGNERS_LIMIT_MAX,
+} from "../src/chain-query-loaders.mjs";
 
 describe("loadChainSigners", () => {
   test("builds a ranked leaderboard from extrinsic rows", async () => {
@@ -92,5 +96,42 @@ describe("loadChainSigners", () => {
     );
     assert.equal(data.sort, "tx_count");
     assert.match(sql, /ORDER BY tx_count DESC, signer ASC/);
+  });
+
+  test("a negative limit clamps to 1, not D1's 'no limit at all' behavior", async () => {
+    let params;
+    await loadChainSigners(
+      async (_query, bound) => {
+        params = bound;
+        return [];
+      },
+      { windowLabel: "7d", windowDays: 7, limit: -1 },
+    );
+    assert.equal(params.at(-1), 1);
+  });
+
+  test("a limit above the max clamps; a non-numeric limit uses the default", async () => {
+    let params;
+    await loadChainSigners(
+      async (_query, bound) => {
+        params = bound;
+        return [];
+      },
+      {
+        windowLabel: "7d",
+        windowDays: 7,
+        limit: CHAIN_SIGNERS_LIMIT_MAX + 500,
+      },
+    );
+    assert.equal(params.at(-1), CHAIN_SIGNERS_LIMIT_MAX);
+
+    await loadChainSigners(
+      async (_query, bound) => {
+        params = bound;
+        return [];
+      },
+      { windowLabel: "7d", windowDays: 7, limit: "bogus" },
+    );
+    assert.equal(params.at(-1), CHAIN_SIGNERS_LIMIT_DEFAULT);
   });
 });

--- a/tests/chain-transfers.test.mjs
+++ b/tests/chain-transfers.test.mjs
@@ -5,6 +5,8 @@ import {
   loadChainTransfers,
   CHAIN_TRANSFER_WINDOWS,
   DEFAULT_CHAIN_TRANSFER_WINDOW,
+  CHAIN_TRANSFER_LIMIT_DEFAULT,
+  CHAIN_TRANSFER_LIMIT_MAX,
 } from "../src/chain-transfers.mjs";
 
 const party = (address, volume, count = 1) => ({
@@ -216,5 +218,41 @@ describe("loadChainTransfers", () => {
     assert.equal(d.transfer_count, 0);
     assert.deepEqual(d.top_senders, []);
     assert.deepEqual(d.top_receivers, []);
+  });
+
+  test("a negative limit clamps to 1, not D1's 'no limit at all' behavior", async () => {
+    const calls = [];
+    const d1 = async (sql, params) => {
+      calls.push({ sql, params });
+      return [];
+    };
+    await loadChainTransfers(d1, { windowLabel: "7d", limit: -1 });
+    const senderCall = calls.find((c) => /GROUP BY hotkey/.test(c.sql));
+    const receiverCall = calls.find((c) => /GROUP BY coldkey/.test(c.sql));
+    assert.equal(senderCall.params.at(-1), 1);
+    assert.equal(receiverCall.params.at(-1), 1);
+  });
+
+  test("a limit above the max clamps; a non-numeric limit uses the default", async () => {
+    const calls = [];
+    const d1 = async (sql, params) => {
+      calls.push({ sql, params });
+      return [];
+    };
+    await loadChainTransfers(d1, {
+      windowLabel: "7d",
+      limit: CHAIN_TRANSFER_LIMIT_MAX + 500,
+    });
+    assert.equal(
+      calls.find((c) => /GROUP BY hotkey/.test(c.sql)).params.at(-1),
+      CHAIN_TRANSFER_LIMIT_MAX,
+    );
+
+    calls.length = 0;
+    await loadChainTransfers(d1, { windowLabel: "7d", limit: "bogus" });
+    assert.equal(
+      calls.find((c) => /GROUP BY hotkey/.test(c.sql)).params.at(-1),
+      CHAIN_TRANSFER_LIMIT_DEFAULT,
+    );
   });
 });


### PR DESCRIPTION
## Summary

`loadChainTransfers` (`src/chain-transfers.mjs`) and `loadChainSigners` (`src/chain-query-loaders.mjs`) passed their `limit` parameter straight into a D1 `LIMIT ?` query with zero clamping. `chain-transfers.mjs` even exports `CHAIN_TRANSFER_LIMIT_MAX` specifically to bound this, but the constant was never referenced again in the file — dead as a safety bound.

Every sibling module in the `src/chain-*.mjs` windowed-loader family self-clamps `limit` inside the pure loader before it reaches a query, independent of what the HTTP/MCP layer happens to validate upstream — `chain-transfer-pairs.mjs:158-161` is the clearest example; `chain-turnover.mjs` carries the same guard with a comment explaining why ("a direct caller cannot make slice() behave oddly, the HTTP layer already validates 1..MAX, this keeps the pure builder aligned"). Both current REST/MCP callers already pre-validate `limit` to `1..MAX`, so this isn't reachable through the live API today — but D1/SQLite treats a **negative** `LIMIT` as "no limit at all," so any future direct caller passing `limit: -1` would silently return the entire table instead of the advertised cap, the opposite failure mode of every sibling loader.

## Change

- `loadChainTransfers` now clamps to `[1, CHAIN_TRANSFER_LIMIT_MAX]` before both `LIMIT ?` queries (senders, receivers), falling back to `CHAIN_TRANSFER_LIMIT_DEFAULT` on a non-finite value.
- `loadChainSigners` gains a new `CHAIN_SIGNERS_LIMIT_MAX` constant (this module had none) and the same clamp before its query.
- Neither function's public parameter contract nor the REST/MCP call sites changed — this is purely an internal invariant fix in the pure loaders, matching every sibling module's existing behavior.

## Tests

Regression tests in `tests/chain-transfers.test.mjs` and `tests/chain-query-loaders.test.mjs` assert a negative/oversized/non-numeric `limit` passed directly to each loader still produces a bounded `LIMIT ?` parameter, mirroring the existing `limit: 0` / limit-above-max standard already used in `tests/chain-weights.test.mjs` for the sibling fix this follows (#2984).

Closes #5578

## Validation

- [x] `git diff --check` — clean
- [x] `npm run lint` && `npm run format:check` — clean
- [x] `npm run validate` — passed (129 native subnets, 129 curated overlays, 1613 surfaces, 133 providers, 2037 candidates)
- [x] `npm run validate:contract-drift` — passed (no schema/route change)
- [x] `npm run test:coverage` — 8241/8241 tests passing (276/276 files); `chain-transfers.mjs` and `chain-query-loaders.mjs` both at 100% statement/branch/function coverage