### PR TITLE
fix(extrinsics): route every extrinsic through the big-int-safe JSON parse

### DIFF
--- a/src/extrinsics.mjs
+++ b/src/extrinsics.mjs
@@ -13,10 +13,7 @@ import {
 import { decodeCursor, encodeCursor } from "./cursor.mjs";
 import { normalizePostgresValue } from "./scale-normalize.mjs";
 import { decodePostgresCallArgs } from "./postgres-call-args.mjs";
-import {
-  decodeEthereumEvmCallArgs,
-  hasEthereumEvmDecoder,
-} from "./indexer-rs-ethereum-decode.mjs";
+import { decodeEthereumEvmCallArgs } from "./indexer-rs-ethereum-decode.mjs";
 import { parseJsonPreservingBigInts } from "./big-int-safe-json.mjs";
 import { decodeBTreeSetFields } from "./postgres-collection-normalize.mjs";
 
@@ -107,30 +104,28 @@ export function formatExtrinsic(row) {
       // {fieldName: value} object shape that function's own Array.isArray
       // early-return requires it to skip.
       //
-      // u64/u128 precision (SubtensorModule.register's PoW nonce,
-      // set_children's near-u64::MAX sentinel) is DELIBERATELY left as-is
-      // here -- #4693 pins this as an accepted, tested invariant (Postgres's
-      // exact literal converges on the same IEEE-754 double D1 already
-      // serves for the two confirmed fixtures) rather than attempting a fix;
-      // see tests/extrinsics.test.mjs's precision-pinning tests and
-      // wrangler.jsonc's METAGRAPH_EXTRINSICS_SOURCE comment.
-      //
-      // parseJsonPreservingBigInts (#4692 review fix) is gated to ONLY the
-      // call types indexer-rs-ethereum-decode.mjs actually decodes: plain
-      // JSON.parse would ALREADY silently round a U256 limb past
-      // Number.MAX_SAFE_INTEGER before decodeU256Limbs ever saw it (caught by
-      // Gittensory review on the original #4692 PR -- see that module's
-      // header). Scoping to hasEthereumEvmDecoder's 4 call types, rather than
-      // applying it to every extrinsic, avoids ALSO silently changing other
-      // call types' already-known-imprecise large-integer fields (e.g.
-      // SubtensorModule.register's PoW nonce) from a number to a string --
-      // that's #4693's scope, not a side effect to smuggle in here.
-      const parseCallArgs = hasEthereumEvmDecoder(
-        row.call_module,
-        row.call_function,
-      )
-        ? parseJsonPreservingBigInts
-        : JSON.parse;
+      // u64/u128 precision: parseJsonPreservingBigInts now runs for EVERY
+      // extrinsic, not just the call types indexer-rs-ethereum-decode.mjs
+      // decodes -- widening the #4692 review fix that was deliberately
+      // scoped narrow at the time (see wrangler.jsonc's
+      // METAGRAPH_EXTRINSICS_SOURCE comment for the original reasoning). An
+      // exhaustive live audit (2026-07-14/15) found the plain-JSON.parse
+      // rounding bug reaches far more call types than the one "accepted"
+      // fixture (SubtensorModule.register's PoW nonce) previously pinned:
+      // confirmed live on SubtensorModule.set_children's per-child
+      // proportion, SubtensorModule.set_root_weights.version_key,
+      // SubtensorModule.faucet's nonce, and a nested Utility.force_batch ->
+      // SubtensorModule.remove_stake.amount_unstaked reached through
+      // Proxy.proxy -- i.e. any u64-shaped field on any call type can hit
+      // this, not a fixed known set. parseJsonPreservingBigInts is a
+      // documented no-op on any JSON text with no integer literal past
+      // Number.MAX_SAFE_INTEGER (see its own header) -- safe to apply
+      // unconditionally; the only real effect is that a field large enough
+      // to have been silently losing precision now arrives as an exact
+      // decimal STRING instead of a rounded number, matching how
+      // decodeU256Limbs already represents U256 values for exactly this
+      // reason. See tests/extrinsics.test.mjs for the fixtures this fix
+      // resolves.
       call_args = decodeBTreeSetFields(
         row.call_module,
         row.call_function,
@@ -138,7 +133,7 @@ export function formatExtrinsic(row) {
           row.call_module,
           row.call_function,
           normalizePostgresValue(
-            decodePostgresCallArgs(parseCallArgs(row.call_args), {
+            decodePostgresCallArgs(parseJsonPreservingBigInts(row.call_args), {
               call_module: row.call_module,
               call_function: row.call_function,
             }),

--- a/src/indexer-rs-ethereum-decode.mjs
+++ b/src/indexer-rs-ethereum-decode.mjs
@@ -400,15 +400,3 @@ export function decodeEthereumEvmCallArgs(callModule, callFunction, callArgs) {
   const decoder = DECODERS[`${callModule}.${callFunction}`];
   return decoder ? decoder(callArgs) : callArgs;
 }
-
-/** True for exactly the 4 call types this module decodes. Lets
- * formatExtrinsic route ONLY these through the big-int-safe JSON parse
- * (src/big-int-safe-json.mjs) instead of every extrinsic -- deliberately
- * narrow: applying that parse globally would ALSO silently change other
- * call types' already-known-imprecise large-integer fields (e.g.
- * SubtensorModule.register's PoW nonce) from a number to a string, which is
- * #4693's scope to fix, not a side effect to smuggle in here. Reuses this
- * module's own dispatch table so the two lists can't drift apart. */
-export function hasEthereumEvmDecoder(callModule, callFunction) {
-  return `${callModule}.${callFunction}` in DECODERS;
-}

--- a/tests/extrinsics.test.mjs
+++ b/tests/extrinsics.test.mjs
@@ -212,11 +212,15 @@ test("formatExtrinsic preserves a U256 value past Number.MAX_SAFE_INTEGER throug
   assert.equal(out.call_args.transaction.EIP1559.nonce, "69392");
 });
 
-test("formatExtrinsic does NOT extend the big-int-safe parse to call types outside indexer-rs-ethereum-decode.mjs's dispatch table -- preserves existing (already-imprecise) D1-serving behavior for out-of-scope call types", () => {
-  // Scoping the fix to hasEthereumEvmDecoder's 4 call types is deliberate:
-  // SubtensorModule.register's PoW nonce precision loss is an existing,
-  // already-accepted issue (#4693's scope) -- this must not silently change
-  // that field's type from number to string as a side effect of #4692.
+test("formatExtrinsic extends the big-int-safe parse to EVERY call type, not just indexer-rs-ethereum-decode.mjs's dispatch table (fixed 2026-07-15, was previously scoped narrow)", () => {
+  // An exhaustive live audit found the plain-JSON.parse rounding bug reaches
+  // far more call types than the handful indexer-rs-ethereum-decode.mjs
+  // names -- SubtensorModule.register's PoW nonce is exactly one instance of
+  // a general problem, not a special case. parseJsonPreservingBigInts now
+  // runs unconditionally in formatExtrinsic, so this out-of-scope call type
+  // gets exact precision too, matching how U256 fields already work
+  // (a JS number that would lose precision arrives as a decimal string
+  // instead).
   const out = formatExtrinsic({
     block_number: 1,
     extrinsic_index: 0,
@@ -224,8 +228,8 @@ test("formatExtrinsic does NOT extend the big-int-safe parse to call types outsi
     call_function: "register",
     call_args: '{"nonce":[9131459485341369597]}',
   });
-  assert.equal(typeof out.call_args.nonce, "number");
-  assert.equal(out.call_args.nonce, 9131459485341369000);
+  assert.equal(typeof out.call_args.nonce, "string");
+  assert.equal(out.call_args.nonce, "9131459485341369597");
 });
 
 test("formatExtrinsic unwraps a single-element BTreeSet (real SubtensorModule.claim_root, block 8587445/19, #4693)", () => {
@@ -272,13 +276,11 @@ test("formatExtrinsic correctly unwraps a BTreeSet nested inside Utility.batch, 
   assert.deepEqual(nestedCall.call_args.subnets, [1, 2, 3, 4, 5]);
 });
 
-test("formatExtrinsic pins SubtensorModule.register's PoW nonce precision as an accepted, tested invariant (real block 8556317/20, #4693) -- Postgres's exact literal converges on the same value D1 already serves, not a regression to fix here", () => {
+test("formatExtrinsic preserves SubtensorModule.register's PoW nonce precision exactly (real block 8556317/20, fixed 2026-07-15)", () => {
   // nonce is a BARE u64 scalar in the real Postgres row (confirmed via
-  // direct query -- not newtype-wrapped like most other fields), and
-  // formatExtrinsic deliberately does NOT route SubtensorModule.register
-  // through the big-int-safe parse (#4692's hasEthereumEvmDecoder gate) --
-  // per #4693's explicit requirement, this ticket pins the current
-  // convergent-but-lossy behavior rather than fixing it.
+  // direct query -- not newtype-wrapped like most other fields).
+  // parseJsonPreservingBigInts now runs unconditionally in formatExtrinsic,
+  // so this arrives as the exact decimal string instead of a rounded number.
   const out = formatExtrinsic({
     block_number: 8556317,
     extrinsic_index: 20,
@@ -287,14 +289,14 @@ test("formatExtrinsic pins SubtensorModule.register's PoW nonce precision as an 
     call_args:
       '{"work":[16,64,112,106],"nonce":9131459485341369597,"netuid":21}',
   });
-  assert.equal(out.call_args.nonce, 9131459485341369000);
+  assert.equal(out.call_args.nonce, "9131459485341369597");
 });
 
-test("formatExtrinsic pins SubtensorModule.set_children's near-u64::MAX sentinel precision as an accepted, tested invariant (real block 8585337/19, #4693)", () => {
+test("formatExtrinsic preserves SubtensorModule.set_children's near-u64::MAX sentinel precision exactly (real block 8585337/19, fixed 2026-07-15)", () => {
   // children is Vec<(u64, AccountId32)> -- children[0][0] is the proportion
   // (here the true u64::MAX "take-all" sentinel), children[0][1] the child's
   // AccountId32 (untouched here -- top-level AccountId32 decode is a
-  // separate, not-yet-covered gap, out of #4693's scope).
+  // separate gap).
   const out = formatExtrinsic({
     block_number: 8585337,
     extrinsic_index: 19,
@@ -303,7 +305,54 @@ test("formatExtrinsic pins SubtensorModule.set_children's near-u64::MAX sentinel
     call_args:
       '{"netuid":121,"children":[[18446744073709551615,[[100,65,10,124,236,80,140,19,181,73,132,35,107,50,57,120,44,20,174,42,203,246,252,17,211,55,209,239,75,249,82,33]]]]}',
   });
-  assert.equal(out.call_args.children[0][0], 18446744073709552000);
+  assert.equal(out.call_args.children[0][0], "18446744073709551615");
+});
+
+test("formatExtrinsic preserves SubtensorModule.set_root_weights's version_key precision exactly (real block 4633973/7, found by 2026-07-15 exhaustive audit)", () => {
+  const out = formatExtrinsic({
+    block_number: 4633973,
+    extrinsic_index: 7,
+    call_module: "SubtensorModule",
+    call_function: "set_root_weights",
+    call_args:
+      '{"hotkey":"5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y","netuid":0,"dests":[1],"weights":[65535],"version_key":18446744073709551615}',
+  });
+  assert.equal(out.call_args.version_key, "18446744073709551615");
+});
+
+test("formatExtrinsic preserves SubtensorModule.faucet's PoW nonce precision exactly (real block 2351609/48, found by 2026-07-15 exhaustive audit)", () => {
+  const out = formatExtrinsic({
+    block_number: 2351609,
+    extrinsic_index: 48,
+    call_module: "SubtensorModule",
+    call_function: "faucet",
+    call_args:
+      '{"work":[16,64,112,106],"nonce":13306593199926106273,"netuid":1,"block_number":2351600}',
+  });
+  assert.equal(out.call_args.nonce, "13306593199926106273");
+});
+
+test("formatExtrinsic preserves a large u64 nested inside Proxy.proxy -> Utility.force_batch -> SubtensorModule.remove_stake (found by 2026-07-15 exhaustive audit, block 8623242/13)", () => {
+  // Built as a raw JSON TEXT string (not JSON.stringify of a JS object) --
+  // same reason as the U256 test above: a JS number literal this large is
+  // already rounded by V8 before JSON.stringify ever runs, which would test
+  // nothing.
+  const callArgsText =
+    '[{"name":"real","type":"MultiAddress","value":{"name":"Id","values":[[1,2,3]]}},' +
+    '{"name":"force_proxy_type","type":"Option<ProxyType>","value":null},' +
+    '{"name":"call","type":"RuntimeCall","value":{"name":"Utility","values":[' +
+    '{"name":"force_batch","values":[[{"name":"SubtensorModule","values":[' +
+    '{"name":"remove_stake","values":{"hotkey":[[4,5,6]],"netuid":1,' +
+    '"amount_unstaked":18446744073709551615}}]}]]}]}}]';
+  const out = formatExtrinsic({
+    block_number: 8623242,
+    extrinsic_index: 13,
+    call_module: "Proxy",
+    call_function: "proxy",
+    call_args: callArgsText,
+  });
+  const nestedCall = out.call_args[2].value.call_args[0][0];
+  assert.equal(nestedCall.call_args.amount_unstaked, "18446744073709551615");
 });
 
 test("formatExtrinsic normalizes success (0->false, null->null)", () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -144,22 +144,25 @@
     // byte-blob-shaped wrappers with no changes needed (verified against
     // LimitOrders.execute_batched_orders' fee_rate).
     //
-    // u64/u128 precision (SubtensorModule.register's PoW nonce,
-    // set_children's near-u64::MAX sentinel): ACCEPTED, not fixed, per
-    // #4693's explicit requirement. Traced the mechanism during #4692:
-    // fetch-events.py's stored D1 text is itself lossless (Python's
-    // arbitrary-precision int via json.dumps); the rounding happens in the
-    // SHARED formatExtrinsic's plain JSON.parse(row.call_args), applied
-    // identically to both tiers. Verified the two confirmed fixtures
-    // (register nonce, set_children children[0][0]) converge on the exact
-    // same IEEE-754 double D1 already serves -- so flipping the flag would
-    // not change what's served for these two fields today; pinned as tested
-    // invariants in tests/extrinsics.test.mjs rather than "fixed," since a
-    // real fix would need the same big-int-safe parse #4692 built for
-    // Ethereum/EVM, applied more broadly -- deliberately out of scope here
-    // to avoid an uncontrolled type-change blast radius (number -> string)
-    // across every call type; a real investigation into that broader
-    // question is tracked separately.
+    // u64/u128 precision: FIXED 2026-07-15 (was ACCEPTED-not-fixed per
+    // #4693's original requirement, superseded). An exhaustive live audit of
+    // all 90 real on-chain call types found the plain-JSON.parse rounding bug
+    // -- previously pinned as an accepted invariant for just two fixtures
+    // (SubtensorModule.register's PoW nonce, set_children's near-u64::MAX
+    // sentinel) -- reaches far more call types than that: also confirmed on
+    // set_root_weights.version_key, faucet's nonce, and a nested
+    // Utility.force_batch -> remove_stake.amount_unstaked reached through
+    // Proxy.proxy. Fixed exactly the way this comment originally predicted:
+    // src/extrinsics.mjs now routes EVERY extrinsic's call_args through
+    // parseJsonPreservingBigInts (#4692's big-int-safe parse), not just the
+    // narrow Ethereum/EVM dispatch table -- safe because that parse is a
+    // documented no-op on any JSON text with no integer literal past
+    // Number.MAX_SAFE_INTEGER. The previously-accepted "type-change blast
+    // radius" concern is real but intentional: a field large enough to have
+    // been silently losing precision now arrives as an exact decimal STRING
+    // instead of a rounded number, matching how U256 fields already work.
+    // tests/extrinsics.test.mjs's old precision-pinning tests were inverted
+    // to assert the correct value instead of the accepted-lossy one.
     //
     // MCP's extrinsics tools (list_extrinsics/get_extrinsic) are wired
     // through this same flag as of #4694 -- no longer D1-only.


### PR DESCRIPTION
## Summary
- `parseJsonPreservingBigInts` (#4692's review fix) was deliberately scoped to only the 5 call types `indexer-rs-ethereum-decode.mjs` decodes, leaving plain `JSON.parse`'s silent `Number.MAX_SAFE_INTEGER` rounding in place everywhere else — pinned as an "accepted, tested invariant" for two fixtures (`SubtensorModule.register`'s PoW nonce, `set_children`'s near-u64::MAX sentinel)
- An exhaustive live audit of **all 90 real on-chain call types** (2026-07-14/15) found this reaches far more call types than those two fixtures: also confirmed on `set_root_weights.version_key`, `faucet`'s nonce, and a nested `Utility.force_batch -> remove_stake.amount_unstaked` reached through `Proxy.proxy`
- Since `parseJsonPreservingBigInts` is a documented no-op on any JSON text with no integer literal past `Number.MAX_SAFE_INTEGER` (see its own header), it's safe to apply unconditionally rather than allowlist call types one at a time as each gets discovered live
- Removes `hasEthereumEvmDecoder`, now dead code with zero remaining call sites and a docstring describing a mechanism that no longer exists
- Updates `wrangler.jsonc`'s comment (which explicitly predicted this exact fix as the eventual "real fix" when it scoped the original narrow version)

## Test plan
- [x] Inverted the three existing tests that pinned the lossy behavior as an accepted invariant — now assert the exact precise decimal-string value
- [x] Added fixtures for the newly-confirmed cases: `set_root_weights.version_key`, `faucet.nonce`, and the nested `Proxy.proxy -> Utility.force_batch -> remove_stake.amount_unstaked` path (built as raw JSON text, not a JS object literal — a JS number this large would already be rounded by V8 before `JSON.stringify` ever ran, same pitfall the pre-existing U256 test explicitly guards against)
- [x] `npx vitest run tests/extrinsics.test.mjs tests/indexer-rs-ethereum-decode.test.mjs tests/big-int-safe-json.test.mjs` — 102/102 passed
- [x] Full `npm run test:coverage` — passed, coverage floors intact
- [x] `npm run lint` / `npx prettier --check` clean