### PR TITLE
fix(extrinsics): unwrap the extra array layer on two more BoundedVec fields

### DIFF
--- a/src/postgres-collection-normalize.mjs
+++ b/src/postgres-collection-normalize.mjs
@@ -4,6 +4,16 @@
 // `[[104]]` (confirmed real data, block 8587445/extrinsic_index 19, 162
 // in-window occurrences).
 //
+// Also covers a BoundedVec<T,_> holding a single struct-typed element, the
+// same "extra array layer around a bounded collection" shape as a BTreeSet --
+// found by the 2026-07-14/15 exhaustive decode audit on two call types:
+// LimitOrders.execute_batched_orders's `orders`
+// (BoundedVec<SignedOrder<AccountId32>,_>, block 8617315/extrinsic_index 18:
+// served `[[{"order":{...}}]]` instead of `[{"order":{...}}]`) and
+// Commitments.set_commitment's `info.fields`
+// (BoundedVec<Data,_>, block 8623300/extrinsic_index 12: served
+// `{"fields":[[{"Raw100":"..."}]]}` instead of `{"fields":[{"Raw100":"..."}]}`).
+//
 // Deliberately scoped to named (callModule, callFunction, fieldName)
 // triples, NOT a generic "strip any outer array wrapping another array"
 // rule. That shape is structurally IDENTICAL to an AccountId32/MultiAddress/
@@ -38,7 +48,11 @@
 // header already describes, except walk() runs BEFORE this module ever gets
 // a chance to unwrap the (by-then-already-destroyed) field. walk() checks
 // this same set to skip that heuristic for an allowlisted field instead.
-export const BTREESET_FIELDS = new Set(["SubtensorModule.claim_root.subnets"]);
+export const BTREESET_FIELDS = new Set([
+  "SubtensorModule.claim_root.subnets",
+  "LimitOrders.execute_batched_orders.orders",
+  "Commitments.set_commitment.fields",
+]);
 
 function unwrapBTreeSetLayer(value) {
   return Array.isArray(value) && value.length === 1 && Array.isArray(value[0])

--- a/tests/postgres-collection-normalize.test.mjs
+++ b/tests/postgres-collection-normalize.test.mjs
@@ -140,4 +140,38 @@ describe("decodeBTreeSetFields", () => {
     });
     assert.equal(out.netuid, 9);
   });
+
+  test("unwraps LimitOrders.execute_batched_orders's orders (BoundedVec<SignedOrder,_>, real block 8617315/18, found by 2026-07-14/15 exhaustive audit)", () => {
+    const descriptorShape = [
+      { name: "netuid", type: "u16", value: 74 },
+      {
+        name: "orders",
+        type: "BoundedVec<SignedOrder<AccountId32>, _>",
+        value: [
+          [{ order: { name: "V1", values: [{ amount: 462651842697 }] } }],
+        ],
+      },
+    ];
+    const out = decode(
+      "LimitOrders",
+      "execute_batched_orders",
+      descriptorShape,
+    );
+    assert.deepEqual(out[1].value, [
+      { order: { name: "V1", values: [{ amount: 462651842697 }] } },
+    ]);
+  });
+
+  test("unwraps Commitments.set_commitment's info.fields (BoundedVec<Data,_> nested inside a struct field, real block 8623300/12, found by 2026-07-14/15 exhaustive audit)", () => {
+    const descriptorShape = [
+      { name: "netuid", type: "u16", value: 123 },
+      {
+        name: "info",
+        type: "CommitmentInfo<_>",
+        value: { fields: [[{ Raw100: "https://example.com" }]] },
+      },
+    ];
+    const out = decode("Commitments", "set_commitment", descriptorShape);
+    assert.deepEqual(out[1].value.fields, [{ Raw100: "https://example.com" }]);
+  });
 });


### PR DESCRIPTION
## Summary
- `BTREESET_FIELDS`'s existing allowlist mechanism already handles this exact shape (a `BoundedVec<T,_>` holding a single struct-typed element gets an extra array layer, indistinguishable in JSON from a BTreeSet) — it just didn't have these two fields listed
- Found by the 2026-07-14/15 exhaustive decode audit (all 90 real on-chain call types sampled):
  - `LimitOrders.execute_batched_orders`'s `orders` (`BoundedVec<SignedOrder<AccountId32>,_>`, block 8617315/18: served `[[{"order":{...}}]]` instead of `[{"order":{...}}]`)
  - `Commitments.set_commitment`'s `info.fields` (`BoundedVec<Data,_>`, block 8623300/12: served `{"fields":[[{"Raw100":"..."}]]}` instead of `{"fields":[{"Raw100":"..."}]}`)

## Test plan
- [x] Verified both fixes against live-captured fixture shapes before writing the fix
- [x] Two new tests added matching the existing suite's style
- [x] `npx vitest run tests/postgres-collection-normalize.test.mjs tests/postgres-call-args.test.mjs` — 69/69 passed
- [x] Full `npm run test:coverage` — passed (run together with the sibling #5604 fix, same audit)
- [x] `npm run lint` / `npx prettier --check` clean