### PR TITLE
feat(mcp): add a query_graphql bridge tool for /api/v1/graphql

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -31,6 +31,11 @@ import {
   MCP_CHAIN_STREAM_RESOURCE_URI,
   isValidMcpSessionId,
 } from "../workers/mcp-session-hub.mjs";
+import {
+  GRAPHQL_MAX_COMPLEXITY,
+  GRAPHQL_MAX_DEPTH,
+  handleGraphQLRequest,
+} from "./graphql.mjs";
 import { CONTRACT_VERSION, PRIMARY_DOMAIN, QUERY_ENUMS } from "./contracts.mjs";
 import {
   GET_ECONOMICS_INSTRUCTIONS,
@@ -1643,6 +1648,21 @@ function requireString(args, key) {
     );
   }
   return value.trim();
+}
+
+// A plain object (not an array) for GraphQL `variables`, or undefined when
+// absent — matches the shape handleGraphQLRequest destructures from the POST
+// body.
+function optionalVariables(args) {
+  const value = args?.variables;
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw toolError(
+      "invalid_params",
+      "Argument `variables` must be an object when provided.",
+    );
+  }
+  return value;
 }
 
 // A trimmed optional string, or null when absent/blank — for free-form filters
@@ -9385,6 +9405,62 @@ export const MCP_TOOLS = [
       });
     },
   },
+  {
+    name: "query_graphql",
+    title: "Run a GraphQL query against /api/v1/graphql",
+    description:
+      "Forward an arbitrary read-only query (+ optional variables) to the " +
+      "metagraphed GraphQL endpoint and return its JSON-RPC-style result " +
+      `({ data, errors }). Prefer this over the individual REST-mirrored ` +
+      "tools (get_subnet, list_subnets, ...) when you need arbitrary field " +
+      "selection or several nested relations in one round-trip; prefer a " +
+      "dedicated tool instead when the lookup is a single well-known shape, " +
+      "since it needs no query string. Mutations are not supported — the " +
+      `schema is query-only. Subject to the same limits as the REST ` +
+      `endpoint: max depth ${GRAPHQL_MAX_DEPTH}, max complexity ` +
+      `${GRAPHQL_MAX_COMPLEXITY}; a query over either limit returns an ` +
+      "error instead of executing.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "GraphQL query document, e.g. '{ health { status } }'.",
+        },
+        variables: {
+          type: "object",
+          description: "Optional variables object for the query.",
+        },
+        operationName: {
+          type: "string",
+          description:
+            "Optional operation name, required only when `query` defines more than one operation.",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const query = requireString(args, "query");
+      const variables = optionalVariables(args);
+      const operationName = optionalString(args, "operationName");
+      const request = new Request("https://internal/api/v1/graphql", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          query,
+          variables,
+          operationName: operationName ?? undefined,
+        }),
+      });
+      const response = await handleGraphQLRequest(request, ctx.env);
+      const result = await response.json();
+      if (response.status >= 400) {
+        throw toolError("invalid_params", result.errors[0].message);
+      }
+      return result;
+    },
+  },
 ];
 
 const TOOLS_BY_NAME = new Map(MCP_TOOLS.map((tool) => [tool.name, tool]));
@@ -12852,6 +12928,14 @@ const TOOL_OUTPUT_SCHEMAS = {
       error: NULLABLE_STRING,
       probed_at: NULLABLE_STRING,
       from_cache: { type: "boolean" },
+    },
+  },
+  query_graphql: {
+    type: "object",
+    additionalProperties: true,
+    properties: {
+      data: { type: ["object", "null"] },
+      errors: { type: "array", items: { type: "object" } },
     },
   },
 };

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -1471,3 +1471,56 @@ describe("get_build — branch coverage", () => {
     assert.match(res.body.result.content[0].text, /build-summary\.json/);
   });
 });
+
+// ── query_graphql — GraphQL bridge branches ───────────────────────────────
+describe("query_graphql — branch coverage", () => {
+  test("forwards query + variables + operationName and returns the endpoint's data", async () => {
+    const res = await callTool("query_graphql", {
+      query:
+        "query GetSubnet($n: Int!) { subnet(netuid: $n) { netuid } }",
+      variables: { n: 1 },
+      operationName: "GetSubnet",
+    });
+    assert.equal(res.body.result.isError, false);
+    assert.deepEqual(res.body.result.structuredContent, {
+      data: { subnet: null },
+    });
+  });
+
+  test("runs without optional variables/operationName", async () => {
+    const res = await callTool("query_graphql", {
+      query: "{ health { status } }",
+    });
+    assert.equal(res.body.result.isError, false);
+    assert.deepEqual(res.body.result.structuredContent, {
+      data: { health: null },
+    });
+  });
+
+  test("rejects a missing query", async () => {
+    const res = await callTool("query_graphql", {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Argument `query` must be a non-empty string/,
+    );
+  });
+
+  test("rejects a non-object `variables`", async () => {
+    const res = await callTool("query_graphql", {
+      query: "{ health { status } }",
+      variables: [1, 2],
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Argument `variables` must be an object/,
+    );
+  });
+
+  test("surfaces the endpoint's parse error as invalid_params", async () => {
+    const res = await callTool("query_graphql", { query: "{ subnet(" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /^invalid_params:/);
+  });
+});


### PR DESCRIPTION
## What

Adds a `query_graphql` MCP tool that bridges `/api/v1/graphql` into MCP: it accepts a query string, optional `variables`/`operationName`, forwards them straight through `handleGraphQLRequest`, and returns the `{ data, errors }` result.

## Why

The individual REST-mirrored MCP tools (`get_subnet`, `list_subnets`, ...) don't cover everything the GraphQL schema can express — arbitrary field selection or several nested relations in one round-trip. There was no MCP passthrough for `/api/v1/graphql` at all.

## Notes

- Forwards to `handleGraphQLRequest(request, ctx.env)` directly, so it inherits the endpoint's existing `maxDepthRule`/`maxComplexityRule` validation (`GRAPHQL_MAX_DEPTH` / `GRAPHQL_MAX_COMPLEXITY`) instead of re-implementing a cap — a query over either limit gets rejected the same way REST rejects it.
- Read-only: the SDL exposes no mutations, so there's no write/abuse surface beyond what `/api/v1/graphql` already guards.
- Tool description explains when to prefer this over a dedicated REST-mirrored tool vs. when a single well-known lookup is simpler.
- Declares an `outputSchema` (`TOOL_OUTPUT_SCHEMAS.query_graphql`) consistent with the rest of the registry.

Closes #5591
