### PR TITLE
fix(events): recognize 13 real event kinds the JS allowlist never learned

### DIFF
--- a/apps/ui/src/lib/metagraphed/event-kinds.test.ts
+++ b/apps/ui/src/lib/metagraphed/event-kinds.test.ts
@@ -12,7 +12,23 @@ describe("eventKindCategory", () => {
     expect(eventKindCategory("StakeAdded")).toBe("stake");
     expect(eventKindCategory("AxonServed")).toBe("serving");
     expect(eventKindCategory("Transfer")).toBe("transfer");
-    expect(Object.keys(EVENT_KIND_CATEGORIES)).toHaveLength(25);
+    expect(Object.keys(EVENT_KIND_CATEGORIES)).toHaveLength(38);
+  });
+
+  it("maps the kinds found by the 2026-07-14/15 exhaustive decode audit (previously unfiled, dumped into 'other')", () => {
+    expect(eventKindCategory("TimelockedWeightsCommitted")).toBe("consensus");
+    expect(eventKindCategory("TimelockedWeightsRevealed")).toBe("consensus");
+    expect(eventKindCategory("CRV3WeightsCommitted")).toBe("consensus");
+    expect(eventKindCategory("CRV3WeightsRevealed")).toBe("consensus");
+    expect(eventKindCategory("AutoStakeAdded")).toBe("stake");
+    expect(eventKindCategory("StakeSwapped")).toBe("stake");
+    expect(eventKindCategory("Deposit")).toBe("transfer");
+    expect(eventKindCategory("Withdraw")).toBe("transfer");
+    expect(eventKindCategory("Reserved")).toBe("transfer");
+    expect(eventKindCategory("Unreserved")).toBe("transfer");
+    expect(eventKindCategory("Endowed")).toBe("transfer");
+    expect(eventKindCategory("DustLost")).toBe("transfer");
+    expect(eventKindCategory("Issued")).toBe("transfer");
   });
 
   it("returns other for unknown or missing kinds", () => {

--- a/apps/ui/src/lib/metagraphed/event-kinds.ts
+++ b/apps/ui/src/lib/metagraphed/event-kinds.ts
@@ -40,6 +40,19 @@ export const EVENT_KIND_CATEGORIES: Record<string, EventKindCategory> = {
   SubnetOwnerHotkeySet: "governance",
   BurnSet: "governance",
   Transfer: "transfer",
+  CRV3WeightsCommitted: "consensus",
+  CRV3WeightsRevealed: "consensus",
+  TimelockedWeightsCommitted: "consensus",
+  TimelockedWeightsRevealed: "consensus",
+  AutoStakeAdded: "stake",
+  StakeSwapped: "stake",
+  Deposit: "transfer",
+  Withdraw: "transfer",
+  Reserved: "transfer",
+  Unreserved: "transfer",
+  Endowed: "transfer",
+  DustLost: "transfer",
+  Issued: "transfer",
 };
 
 /** Explorer-facing labels for known event kinds. */
@@ -69,6 +82,19 @@ export const EVENT_KIND_LABELS: Record<string, string> = {
   SubnetOwnerHotkeySet: "Subnet owner hotkey set",
   BurnSet: "Burn set",
   Transfer: "Transfer",
+  CRV3WeightsCommitted: "CRV3 weights committed",
+  CRV3WeightsRevealed: "CRV3 weights revealed",
+  TimelockedWeightsCommitted: "Timelocked weights committed",
+  TimelockedWeightsRevealed: "Timelocked weights revealed",
+  AutoStakeAdded: "Auto-stake added",
+  StakeSwapped: "Stake swapped",
+  Deposit: "Deposit",
+  Withdraw: "Withdraw",
+  Reserved: "Reserved",
+  Unreserved: "Unreserved",
+  Endowed: "Endowed",
+  DustLost: "Dust lost",
+  Issued: "Issued",
 };
 
 /** Short category labels for chips / filters. */

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -59,6 +59,30 @@ export const INGESTED_EVENT_KINDS = [
   "AxonInfoRemoved",
   "Faucet",
   "Transfer",
+  // Found by the 2026-07-14/15 exhaustive decode audit: indexer-rs's Rust
+  // extract() (apps/indexer-rs/src/main.rs) has always curated these -- field
+  // values decode correctly (SS58/numbers, never raw) -- but the JS serving
+  // allowlist never learned their names, so ?kind= 400ed on them and they fell
+  // into the "other" event-summary bucket despite being high-frequency
+  // (TimelockedWeightsCommitted alone was ~27% of one subnet's weekly volume).
+  // CRV3WeightsCommitted/Revealed are TimelockedWeights*'s predecessor variant
+  // (superseded on the current runtime, confirmed absent from a live 1000-event
+  // sample) -- included for historical blocks indexer-rs may still have
+  // processed under the older runtime spec.
+  "CRV3WeightsCommitted",
+  "CRV3WeightsRevealed",
+  "TimelockedWeightsCommitted",
+  "TimelockedWeightsRevealed",
+  "AutoStakeAdded",
+  "StakeSwapped",
+  // Native substrate frame/balances Event enum, not SubtensorModule-specific.
+  "Deposit",
+  "Withdraw",
+  "Reserved",
+  "Unreserved",
+  "Endowed",
+  "DustLost",
+  "Issued",
 ];
 
 export const SUBNET_EVENT_SUMMARY_WINDOWS = { "7d": 7, "30d": 30, "90d": 90 };
@@ -92,6 +116,19 @@ const EVENT_KIND_CATEGORIES = {
   SubnetOwnerHotkeySet: "governance",
   BurnSet: "governance",
   Transfer: "transfer",
+  CRV3WeightsCommitted: "consensus",
+  CRV3WeightsRevealed: "consensus",
+  TimelockedWeightsCommitted: "consensus",
+  TimelockedWeightsRevealed: "consensus",
+  AutoStakeAdded: "stake",
+  StakeSwapped: "stake",
+  Deposit: "transfer",
+  Withdraw: "transfer",
+  Reserved: "transfer",
+  Unreserved: "transfer",
+  Endowed: "transfer",
+  DustLost: "transfer",
+  Issued: "transfer",
 };
 
 function toIso(ms) {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -74,6 +74,48 @@ test("INGESTED_EVENT_KINDS accepts StakeTransferred (cross-coldkey stake move) f
   assert.ok(INGESTED_EVENT_KINDS.includes("StakeTransferred"));
 });
 
+test("INGESTED_EVENT_KINDS accepts the kinds found by the 2026-07-14/15 exhaustive decode audit (indexer-rs has always curated these; the JS allowlist never learned their names)", () => {
+  for (const kind of [
+    "CRV3WeightsCommitted",
+    "CRV3WeightsRevealed",
+    "TimelockedWeightsCommitted",
+    "TimelockedWeightsRevealed",
+    "AutoStakeAdded",
+    "StakeSwapped",
+    "Deposit",
+    "Withdraw",
+    "Reserved",
+    "Unreserved",
+    "Endowed",
+    "DustLost",
+    "Issued",
+  ]) {
+    assert.ok(INGESTED_EVENT_KINDS.includes(kind), `missing ${kind}`);
+  }
+});
+
+test("buildSubnetEventSummary categorizes the newly-added kinds instead of dumping them in other (2026-07-14/15 audit fix)", () => {
+  const out = buildSubnetEventSummary(
+    [
+      { event_kind: "TimelockedWeightsCommitted", event_count: 5 },
+      { event_kind: "AutoStakeAdded", event_count: 3 },
+      { event_kind: "Deposit", event_count: 2 },
+    ],
+    [],
+    7,
+  );
+  const byKind = Object.fromEntries(
+    out.event_kinds.map((row) => [row.event_kind, row.category]),
+  );
+  assert.equal(byKind.TimelockedWeightsCommitted, "consensus");
+  assert.equal(byKind.AutoStakeAdded, "stake");
+  assert.equal(byKind.Deposit, "transfer");
+  assert.ok(
+    !out.categories.some((row) => row.category === "other"),
+    "none of these kinds should fall into the other category",
+  );
+});
+
 test("formatAccountEvent maps a D1 row to an API event (ISO time)", () => {
   const out = formatAccountEvent({
     block_number: 1000,


### PR DESCRIPTION
## Summary
- indexer-rs's Rust `extract()` (`apps/indexer-rs/src/main.rs`) has always curated these event kinds — field values decode correctly (SS58/numbers, never raw) — but `INGESTED_EVENT_KINDS` never learned their names, so `?kind=` 400ed on them and they fell into the "other" event-summary bucket despite several being high-frequency (`TimelockedWeightsCommitted` alone was ~27% of one subnet's weekly event volume in a live sample)
- Found by the 2026-07-14/15 exhaustive decode audit:
  - `CRV3WeightsCommitted` / `CRV3WeightsRevealed` (`TimelockedWeights*`'s predecessor variant — superseded on the current runtime, but indexer-rs may still have processed it in older blocks)
  - `TimelockedWeightsCommitted` / `TimelockedWeightsRevealed`
  - `AutoStakeAdded`, `StakeSwapped`
  - `Deposit`, `Withdraw`, `Reserved`, `Unreserved`, `Endowed`, `DustLost`, `Issued` (native substrate frame/balances events, not SubtensorModule-specific)
- Mirrors the fix into `apps/ui/src/lib/metagraphed/event-kinds.ts`, which duplicates the category map for client-side labeling
- The MCP tool's kind validation and the REST route's own error message both import `INGESTED_EVENT_KINDS` directly, so no separate change was needed there

## Test plan
- [x] Live-verified against production before writing the fix (queried real events, confirmed field decode correctness, confirmed `CRV3Weights*` absent from a 1000-event live sample)
- [x] New tests on both the JS and TS sides confirming category mapping (not falling into "other")
- [x] `npx vitest run tests/account-events.test.mjs` — 103/103 passed
- [x] `apps/ui`: `npx vitest run src/lib/metagraphed/event-kinds.test.ts` — 9/9 passed; `npx tsc --noEmit` clean
- [x] `npm run lint` / `npx prettier --check` clean
- [x] No screenshot table — confined to `apps/ui/src/lib/**` + tests, no visual change, per the repo's UI-PR gate rule