### PR TITLE
fix(ui): use --chart-1 theme token for the Yield series

### DIFF
--- a/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
@@ -103,7 +103,12 @@ export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; ne
             />
           ) : null}
           {series.yield.length > 0 ? (
-            <HistoryRow label="Yield" series={series.yield} color="#38bdf8" format={yieldStr} />
+            <HistoryRow
+              label="Yield"
+              series={series.yield}
+              color="var(--chart-1)"
+              format={yieldStr}
+            />
           ) : null}
         </div>
       )}


### PR DESCRIPTION
Closes #5564

## What

`apps/ui/src/components/metagraphed/account-position-history-chart.tsx` renders three `HistoryRow` series in the account position-history chart. `Staked` uses `healthColorVar("warn")` and `Emission` uses `var(--accent, #00c899)` — both theme tokens — but `Yield` hardcoded a raw hex value: `color="#38bdf8"`. A literal hex color doesn't participate in the app's light/dark theme system, unlike its two siblings.

Every comparable history chart in the app uses the dedicated `--chart-1`…`--chart-6` custom properties for exactly this case — `neuron-history-chart.tsx` uses `var(--chart-1)`, `var(--chart-3)`, `var(--chart-6)` alongside `var(--accent)`/`var(--health-warn)`/`var(--health-ok)`.

## Fix

```diff
-<HistoryRow label="Yield" series={series.yield} color="#38bdf8" format={yieldStr} />
+<HistoryRow
+  label="Yield"
+  series={series.yield}
+  color="var(--chart-1)"
+  format={yieldStr}
+/>
```

`--chart-1` is defined for both themes in `packages/ui-kit/src/styles.css` (`oklch(0.64 0.13 250)` light / `oklch(0.76 0.12 250)` dark) — the same blue hue family as the original hardcoded value, so the visual result is effectively unchanged while now correctly theme-aware.

## Verification

Rendered against a live account with a real 3-series position history (SN1 validator, `stake`/`emission`/`yield` all populated over the trailing 90d window) in both light and dark theme. The Yield line remains a clearly distinct blue from Staked (warn/orange) and Emission (accent/teal) in both themes — confirmed via the before/after screenshot matrix below, captured from the same live data in both states to isolate just the color-source change.

## Screenshots

3 viewports × 2 themes, before/after, chart region:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/before-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/after-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-yield-chart-theme-color-5564/after-mobile-dark.png)<br><sub>after</sub> |

## Acceptance criteria

- [x] `account-position-history-chart.tsx`: Yield series uses a `--chart-N` CSS custom property instead of a hardcoded hex value
- [x] Before/after screenshots in both light and dark theme included

## Testing

```
npx tsc --noEmit                          # no new errors in this file (2 pre-existing unrelated errors elsewhere reproduce identically on a clean checkout)
npx eslint account-position-history-chart.tsx     # clean aside from pre-existing CRLF line-ending noise (core.autocrlf), confirmed via `git diff --check`
npx prettier --check account-position-history-chart.tsx   # same CRLF-only noise, diff itself is clean
```

Diff is 6 insertions, 1 deletion, in the exact line the issue names.
