### PR TITLE
feat(graphql): add Query.blocks / Query.block

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -26,6 +26,7 @@ import {
   parseCompareDimensionList,
   parseCompareNetuidList,
 } from "./analytics-live.mjs";
+import { buildBlock, buildBlockFeed } from "./blocks.mjs";
 import { buildExtrinsic, buildExtrinsicFeed } from "./extrinsics.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
 
@@ -65,6 +66,10 @@ export const SDL = `
     extrinsics(limit: Int, offset: Int, cursor: String, block: Int, signer: String, call_module: String, call_function: String, success: Boolean): ExtrinsicList!
     "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}."
     extrinsic(ref: String!): ExtrinsicDetail
+    "Recent-block feed (newest first). Mirrors GET /api/v1/blocks."
+    blocks(limit: Int, offset: Int, cursor: String): BlockList!
+    "One block by number or 0x block_hash; block is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/{ref}."
+    block(ref: String!): BlockDetail
   }
 
   type SubnetList {
@@ -355,6 +360,34 @@ export const SDL = `
     extrinsic: Extrinsic
   }
 
+  type BlockList {
+    items: [Block!]!
+    "Page count -- this feed has no cheap grand total, matching REST's block_count."
+    total: Int!
+    next_cursor: String
+  }
+
+  "Field names reuse the vocabulary Subscription.chainEvents already established for blocks (block_number, block_hash, extrinsic_count, event_count)."
+  type Block {
+    block_number: Int
+    block_hash: String
+    parent_hash: String
+    author: String
+    extrinsic_count: Int
+    event_count: Int
+    spec_version: Int
+    observed_at: String
+  }
+
+  type BlockDetail {
+    ref: String
+    block: Block
+    "Nearest stored lower block_number (chain-walk nav); null when block is null or at the window edge."
+    prev_block_number: Int
+    "Nearest stored higher block_number (chain-walk nav); null when block is null or at the window edge."
+    next_block_number: Int
+  }
+
   # Realtime chain-event firehose (#4983, ADR 0015) -- a thin protocol adapter
   # over the SAME ChainFirehoseHub Durable Object connection #4982's SSE/WS
   # transports use, not a second event pipeline. Reached over WebSocket only
@@ -489,6 +522,8 @@ export const FIELD_COMPLEXITY = {
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
+  blocks: RELATIONSHIP_FIELD_COMPLEXITY,
+  block: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -1132,6 +1167,49 @@ const rootValue = {
     return {
       ref: data.ref ?? ref,
       extrinsic: extrinsicNode(data.extrinsic),
+    };
+  },
+
+  async blocks({ limit, offset, cursor }, context) {
+    const safeLimit = clampLimit(limit, BLOCK_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    if (cursor) params.set("cursor", cursor);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/blocks", params),
+        "METAGRAPH_BLOCKS_SOURCE",
+      )) ??
+      buildBlockFeed([], {
+        limit: safeLimit,
+        offset: safeOffset,
+        nextCursor: null,
+      });
+    return {
+      items: data.blocks || [],
+      total: data.block_count ?? 0,
+      next_cursor: data.next_cursor ?? null,
+    };
+  },
+
+  async block({ ref }, context) {
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/blocks/${encodeURIComponent(ref)}`,
+        ),
+        "METAGRAPH_BLOCKS_SOURCE",
+      )) ?? buildBlock(undefined, ref);
+    return {
+      ref: data.ref ?? ref,
+      block: data.block ?? null,
+      prev_block_number: data.prev_block_number ?? null,
+      next_block_number: data.next_block_number ?? null,
     };
   },
 };

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1987,6 +1987,188 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
   });
 });
 
+describe("graphql — blocks / block (#5575, Postgres-tier block explorer)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("blocks: cold/no-tier store returns a schema-stable empty page (fallback builder)", async () => {
+    const { status, body } = await gql(
+      "{ blocks { items { block_number } total next_cursor } }",
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.blocks, {
+      items: [],
+      total: 0,
+      next_cursor: null,
+    });
+  });
+
+  test("blocks: resolves Postgres-tier rows, reusing the ChainEvent field vocabulary", async () => {
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          block_count: 1,
+          limit: 20,
+          offset: 0,
+          next_cursor: "cursor-1",
+          blocks: [
+            {
+              block_number: 5,
+              block_hash: `0x${"a".repeat(64)}`,
+              parent_hash: `0x${"b".repeat(64)}`,
+              author: "5Author",
+              extrinsic_count: 3,
+              event_count: 7,
+              spec_version: 260,
+              observed_at: "2026-07-14T00:00:00.000Z",
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      "{ blocks { items { block_number author extrinsic_count event_count } total next_cursor } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.blocks.total, 1);
+    assert.equal(body.data.blocks.next_cursor, "cursor-1");
+    const item = body.data.blocks.items[0];
+    assert.equal(item.block_number, 5);
+    assert.equal(item.author, "5Author");
+    assert.equal(item.extrinsic_count, 3);
+    assert.equal(item.event_count, 7);
+  });
+
+  test("blocks: limit/offset/cursor args are forwarded as query params to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            block_count: 0,
+            limit: 5,
+            offset: 0,
+            next_cursor: null,
+            blocks: [],
+          });
+        },
+      },
+    };
+    await gql(`{ blocks(limit: 5, cursor: "abc123") { total } }`, env);
+    assert.equal(capturedUrl.pathname, "/api/v1/blocks");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl.searchParams.get("cursor"), "abc123");
+  });
+
+  test("blocks: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      "{ blocks { items { block_number } total next_cursor } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.blocks, {
+      items: [],
+      total: 0,
+      next_cursor: null,
+    });
+  });
+
+  test("block: resolves a Postgres-tier row by numeric ref, including chain-walk nav", async () => {
+    const ref = "123";
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ref,
+          block: {
+            block_number: 123,
+            block_hash: `0x${"c".repeat(64)}`,
+            parent_hash: `0x${"d".repeat(64)}`,
+            author: "5Author",
+            extrinsic_count: 2,
+            event_count: 4,
+            spec_version: 260,
+            observed_at: "2026-07-14T00:00:00.000Z",
+          },
+          prev_block_number: 122,
+          next_block_number: 124,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ block(ref: "${ref}") { ref block { block_number block_hash } prev_block_number next_block_number } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.block.ref, ref);
+    assert.equal(body.data.block.block.block_number, 123);
+    assert.equal(body.data.block.prev_block_number, 122);
+    assert.equal(body.data.block.next_block_number, 124);
+  });
+
+  test("block: resolves a Postgres-tier row by 0x block_hash ref", async () => {
+    const ref = `0x${"e".repeat(64)}`;
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ref,
+          block: {
+            block_number: 9,
+            block_hash: ref,
+            parent_hash: `0x${"f".repeat(64)}`,
+            author: "5Author",
+            extrinsic_count: 0,
+            event_count: 1,
+            spec_version: 260,
+            observed_at: "2026-07-14T00:00:00.000Z",
+          },
+          prev_block_number: 8,
+          next_block_number: null,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ block(ref: "${ref}") { ref block { block_number block_hash } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.block.ref, ref);
+    assert.equal(body.data.block.block.block_hash, ref);
+  });
+
+  test("block: unresolved ref returns block:null, never a GraphQL error", async () => {
+    const ref = "999999999";
+    const { status, body } = await gql(
+      `{ block(ref: "${ref}") { ref block { block_number } prev_block_number next_block_number } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.block.ref, ref);
+    assert.equal(body.data.block.block, null);
+    assert.equal(body.data.block.prev_block_number, null);
+    assert.equal(body.data.block.next_block_number, null);
+  });
+
+  test("blocks / block are weighted as fan-out fields", () => {
+    assert.equal(FIELD_COMPLEXITY.blocks, 5);
+    assert.equal(FIELD_COMPLEXITY.block, 5);
+  });
+});
+
 // --- Subscription.chainEvents (#4983, ADR 0015) ---------------------------------
 //
 // The DO-runtime side of this wiring (ChainFirehoseHub.subscribeChainEvents,


### PR DESCRIPTION
## Summary

Adds `Query.blocks` / `Query.block` to the GraphQL SDL, mirroring `GET /api/v1/blocks` and
`GET /api/v1/blocks/{ref}` (and the MCP `list_blocks`/`get_block` tools) so the block explorer
is reachable over GraphQL. Reuses the field vocabulary `Subscription.chainEvents` already
established for blocks (`block_number`, `block_hash`, `extrinsic_count`, `event_count`), plus
the detail-only `parent_hash`/`author`/`spec_version`/`observed_at`/`prev_block_number`/
`next_block_number` fields from `formatBlock`/`buildBlock`.

- `Query.blocks(limit, offset, cursor): BlockList!` / `Query.block(ref: String!): BlockDetail`
  added to the SDL, with doc comments.
- Resolvers go through the same `tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE")` +
  pure-fallback (`buildBlockFeed`/`buildBlock`) contract REST uses, so a cold/retired D1 tier
  degrades to a schema-stable empty page / `block: null` instead of a GraphQL error.
- `blocks` and `block` added to `FIELD_COMPLEXITY` as fan-out fields.

## Test plan

- [x] `npx vitest run tests/graphql.test.mjs` — 123 passed, including the 10 new
      `blocks`/`block` tests (cold-tier fallback, resolved Postgres-tier rows, limit/offset/
      cursor forwarding, malformed-body fallback, lookup by block number, lookup by `0x` hash,
      unresolved-ref `block: null`, and the `FIELD_COMPLEXITY` weight check).
- [x] `npx eslint src/graphql.mjs tests/graphql.test.mjs` — clean.
- [x] `npx prettier --check src/graphql.mjs tests/graphql.test.mjs` — clean.

Closes #5575
