### PR TITLE
fix(webhooks): rotate dispatch selection so subscriptions past the cap aren't permanently starved (#5546)

### DIFF
--- a/scripts/dispatch-webhooks.mjs
+++ b/scripts/dispatch-webhooks.mjs
@@ -20,6 +20,7 @@ import {
   repoRoot,
   stableStringify,
 } from "./lib.mjs";
+import { selectDispatchKeys } from "./lib/webhook-dispatch-selection.mjs";
 import {
   buildChangeEvent,
   dispatchWithRedelivery,
@@ -81,7 +82,14 @@ if (allKeys.length > MAX_DISPATCH_SUBSCRIPTIONS) {
     `::warning::webhook dispatch capped at ${MAX_DISPATCH_SUBSCRIPTIONS} of ${allKeys.length} registered subscriptions`,
   );
 }
-const keys = allKeys.slice(0, MAX_DISPATCH_SUBSCRIPTIONS);
+// Fair rotation across runs (#5546): once the total exceeds the cap, a fixed
+// lexicographic slice would starve every subscription sorting after the cap
+// forever. Seed the selection with the wall-clock so each run rotates the
+// window; every subscription is dispatched within a bounded number of runs.
+const keys = selectDispatchKeys(allKeys, {
+  max: MAX_DISPATCH_SUBSCRIPTIONS,
+  seed: Date.now(),
+});
 if (keys.length === 0) {
   console.log("No webhook subscriptions registered; nothing to dispatch.");
   process.exit(0);

--- a/scripts/lib/webhook-dispatch-selection.mjs
+++ b/scripts/lib/webhook-dispatch-selection.mjs
@@ -1,0 +1,59 @@
+// #5546: fair per-run selection of which webhook subscriptions to dispatch to
+// when the total exceeds the per-run fan-out cap (MAX_DISPATCH_SUBSCRIPTIONS).
+//
+// The dispatcher lists subscription keys from KV (returned in lexicographic
+// order) and may only fan out to `max` of them per run. A plain
+// `keys.slice(0, max)` deterministically picks the same lexicographically-first
+// `max` keys every run, so once the total exceeds the cap every subscription
+// whose id sorts after the cap receives ZERO dispatches forever.
+//
+// This selects a fair rotating window instead: keys are ordered by a
+// run-varying hash (a per-run `seed`, e.g. the publish timestamp), so across a
+// bounded number of runs every subscription is eventually included. The cap
+// itself is preserved. When the total is within the cap, the input is returned
+// unchanged (no reordering) so the common case is byte-for-byte identical to the
+// previous behavior.
+
+// FNV-1a 32-bit — a small, dependency-free, well-distributed string hash.
+function fnv1a32(str) {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < str.length; i += 1) {
+    hash ^= str.charCodeAt(i);
+    // hash *= 16777619, kept in 32-bit unsigned range.
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Choose up to `max` subscription keys to dispatch to this run.
+ *
+ * @param {string[]} allKeys - every registered subscription key (any order).
+ * @param {{ max: number, seed?: number|string }} options
+ * @returns {string[]} at most `max` keys; the full input (unchanged order) when
+ *   `allKeys.length <= max`.
+ */
+export function selectDispatchKeys(allKeys, { max, seed = 0 }) {
+  if (!Array.isArray(allKeys)) {
+    throw new TypeError("selectDispatchKeys: allKeys must be an array");
+  }
+  if (!Number.isInteger(max) || max < 0) {
+    throw new RangeError(
+      "selectDispatchKeys: max must be a non-negative integer",
+    );
+  }
+  if (allKeys.length <= max) {
+    // Within the cap: no rotation needed, preserve the input exactly.
+    return [...allKeys];
+  }
+  const seedStr = String(seed);
+  return allKeys
+    .map((key) => ({ key, rank: fnv1a32(`${seedStr}:${key}`) }))
+    .sort((a, b) => {
+      if (a.rank !== b.rank) return a.rank - b.rank;
+      // Stable tiebreak on the key so equal-hash pairs are deterministic.
+      return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+    })
+    .slice(0, max)
+    .map((entry) => entry.key);
+}

--- a/tests/webhook-dispatch-selection.test.mjs
+++ b/tests/webhook-dispatch-selection.test.mjs
@@ -1,0 +1,80 @@
+// #5546: the webhook dispatcher capped its per-run fan-out with a fixed
+// `keys.slice(0, max)`, so once registered subscriptions exceeded the cap every
+// subscription whose id sorted after the cap received zero dispatches forever.
+// selectDispatchKeys rotates the selected window by a per-run seed so every
+// subscription is eventually dispatched, while preserving the cap and the
+// within-cap behavior exactly.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { selectDispatchKeys } from "../scripts/lib/webhook-dispatch-selection.mjs";
+
+// Realistic subscription keys: WEBHOOK_KV_PREFIX + a v4-uuid-ish id.
+function makeKeys(n) {
+  return Array.from(
+    { length: n },
+    (_, i) =>
+      `webhooks:sub:${String(i).padStart(6, "0")}-${(i * 2654435761) >>> 0}`,
+  );
+}
+
+describe("selectDispatchKeys (#5546)", () => {
+  test("returns the input unchanged when the total is within the cap", () => {
+    const keys = makeKeys(100);
+    const out = selectDispatchKeys(keys, { max: 128, seed: 12345 });
+    assert.deepEqual(out, keys); // same keys, same order — no rotation
+  });
+
+  test("selects exactly `max` keys when the total exceeds the cap", () => {
+    const keys = makeKeys(200);
+    const out = selectDispatchKeys(keys, { max: 128, seed: 1 });
+    assert.equal(out.length, 128);
+    // Every selected key is a real registered key, with no duplicates.
+    assert.equal(new Set(out).size, 128);
+    for (const k of out) assert.ok(keys.includes(k));
+  });
+
+  test("is deterministic for a given seed", () => {
+    const keys = makeKeys(200);
+    assert.deepEqual(
+      selectDispatchKeys(keys, { max: 128, seed: 42 }),
+      selectDispatchKeys(keys, { max: 128, seed: 42 }),
+    );
+  });
+
+  test("a different seed rotates the window (not always the same 128)", () => {
+    const keys = makeKeys(200);
+    const a = selectDispatchKeys(keys, { max: 128, seed: 1 });
+    const b = selectDispatchKeys(keys, { max: 128, seed: 2 });
+    assert.notDeepEqual(a, b);
+  });
+
+  test("every subscription past the cap is eventually dispatched across runs (no permanent starvation)", () => {
+    const keys = makeKeys(200);
+    const max = 128;
+    // The lexicographically-last key is exactly what the old slice(0, 128)
+    // could never reach; it must appear for at least one seed.
+    const lastKey = [...keys].sort().at(-1);
+
+    const everSelected = new Set();
+    let lastKeySeen = false;
+    for (let seed = 0; seed < 60; seed += 1) {
+      const selected = selectDispatchKeys(keys, { max, seed });
+      for (const k of selected) everSelected.add(k);
+      if (selected.includes(lastKey)) lastKeySeen = true;
+    }
+    assert.ok(
+      lastKeySeen,
+      "the lexicographically-last subscription must be dispatched within a bounded number of runs",
+    );
+    assert.equal(
+      everSelected.size,
+      keys.length,
+      "every registered subscription must be dispatched at least once across runs",
+    );
+  });
+
+  test("rejects invalid arguments", () => {
+    assert.throws(() => selectDispatchKeys("nope", { max: 1 }), TypeError);
+    assert.throws(() => selectDispatchKeys([], { max: -1 }), RangeError);
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/dispatch-webhooks.mjs` hard-caps its per-run fan-out to `MAX_DISPATCH_SUBSCRIPTIONS = 128` with `allKeys.slice(0, 128)`. `listKvKeys` returns subscription keys (`webhooks:sub:<uuid>`) in Cloudflare KV's lexicographic order, so that slice deterministically selects the **same** first 128 keys every run. Once the total exceeds 128, every subscription whose id sorts after the 128th receives **zero** dispatches forever — never delayed, never retried, since an excluded subscription never enters the delivery pipeline at all. There's no cap on how many subscriptions can register (creation is only IP-rate-limited), so this is reachable in normal operation.

## Change

Extracted the selection into a small, pure, unit-testable module `scripts/lib/webhook-dispatch-selection.mjs` (the dispatcher itself is a top-level script that `process.exit()`s on import, so the logic had to live in an importable module to be tested):

- `selectDispatchKeys(allKeys, { max, seed })` orders keys by a per-run FNV-1a hash of `seed:key` and takes the first `max`. With a run-varying `seed` (the dispatcher passes `Date.now()`), the selected window rotates each run, so **every** subscription is dispatched within a bounded number of runs instead of a fixed lexicographic prefix.
- The `MAX_DISPATCH_SUBSCRIPTIONS` cap and the existing `::warning::` log are unchanged — only the *selection within* the cap becomes fair.
- When the total is **within** the cap the input is returned unchanged (same keys, same order), so the common case is byte-for-byte identical to before.

The dispatcher (`scripts/dispatch-webhooks.mjs`) now calls `selectDispatchKeys(allKeys, { max: MAX_DISPATCH_SUBSCRIPTIONS, seed: Date.now() })`.

## Tests

`tests/webhook-dispatch-selection.test.mjs` (6 cases): within-cap returns the input unchanged; over-cap selects exactly `max` unique real keys; deterministic per seed; different seeds rotate the window; and — the regression that matters — across 60 seeds over a 200-key set **every** subscription (including the lexicographically-last one the old slice could never reach) is selected at least once. Plus argument-validation guards.

## Validation

- `npx vitest run tests/webhook-dispatch-selection.test.mjs` — 6 passed.
- `npx vitest run tests/webhooks.test.mjs tests/webhooks-core.test.mjs` — 103 passed (no regression in the existing webhook suites).
- `node -c` + `npx prettier --check` — clean. No schema/contract change.

Closes #5546
