### PR TITLE
fix(api): rate-limit handleChainFirehoseIngest so a leaked secret can't flood subscribers (#5550)

### DIFF
--- a/tests/chain-firehose-routes.test.mjs
+++ b/tests/chain-firehose-routes.test.mjs
@@ -169,6 +169,96 @@ test("ingest: on valid auth, forwards the body to the hub's /ingest path on the 
   );
 });
 
+// #5550: the ingest write path fans each payload out to every live firehose
+// subscriber, so a leaked secret needs a volume cap, not just auth.
+test("ingest: a within-limit request passes the rate limiter and reaches the hub (#5550)", async () => {
+  let forwarded = false;
+  const env = {
+    CHAIN_FIREHOSE_SYNC_SECRET: "shh",
+    CHAIN_FIREHOSE_INGEST_RATE_LIMITER: {
+      limit: async () => ({ success: true }),
+    },
+    CHAIN_FIREHOSE_HUB: stubHub(() => {
+      forwarded = true;
+      return new Response(JSON.stringify({ ok: true }), { status: 202 });
+    }),
+  };
+  const res = await handleRequest(
+    ingestRequest("{}", { token: "shh" }),
+    env,
+    {},
+  );
+  assert.equal(res.status, 202);
+  assert.ok(forwarded, "a within-limit request must reach the hub");
+});
+
+test("ingest: an over-limit request 429s with the rate-limit header family and never reaches the hub (#5550)", async () => {
+  let forwarded = false;
+  const env = {
+    CHAIN_FIREHOSE_SYNC_SECRET: "shh",
+    CHAIN_FIREHOSE_INGEST_RATE_LIMITER: {
+      limit: async () => ({ success: false }),
+    },
+    CHAIN_FIREHOSE_HUB: stubHub(() => {
+      forwarded = true;
+      return new Response("{}", { status: 202 });
+    }),
+  };
+  const res = await handleRequest(
+    ingestRequest("{}", { token: "shh" }),
+    env,
+    {},
+  );
+  assert.equal(res.status, 429);
+  assert.equal(res.headers.get("retry-after"), "60");
+  assert.equal(res.headers.get("x-ratelimit-limit"), "120");
+  assert.equal(res.headers.get("x-ratelimit-remaining"), "0");
+  assert.ok(res.headers.get("x-ratelimit-policy"));
+  assert.equal(
+    forwarded,
+    false,
+    "an over-limit request must not reach the hub",
+  );
+});
+
+test("ingest: an unbound rate limiter is a no-op (local dev/CI) (#5550)", async () => {
+  let forwarded = false;
+  const env = {
+    CHAIN_FIREHOSE_SYNC_SECRET: "shh",
+    // No CHAIN_FIREHOSE_INGEST_RATE_LIMITER binding at all.
+    CHAIN_FIREHOSE_HUB: stubHub(() => {
+      forwarded = true;
+      return new Response("{}", { status: 202 });
+    }),
+  };
+  const res = await handleRequest(
+    ingestRequest("{}", { token: "shh" }),
+    env,
+    {},
+  );
+  assert.equal(res.status, 202);
+  assert.ok(forwarded);
+});
+
+test("ingest: a wrong token 401s before the limiter is consulted (#5550)", async () => {
+  const env = {
+    CHAIN_FIREHOSE_SYNC_SECRET: "shh",
+    CHAIN_FIREHOSE_INGEST_RATE_LIMITER: {
+      limit: async () => {
+        throw new Error(
+          "limiter must not be consulted for an unauthenticated caller",
+        );
+      },
+    },
+  };
+  const res = await handleRequest(
+    ingestRequest("{}", { token: "nope" }),
+    env,
+    {},
+  );
+  assert.equal(res.status, 401);
+});
+
 test("ingest: relays a non-2xx upstream status (e.g. 400 from an invalid payload) unchanged", async () => {
   const env = {
     CHAIN_FIREHOSE_SYNC_SECRET: "shh",

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -895,6 +895,37 @@ async function internalSyncRateLimited(request, env) {
   );
 }
 
+// #5550: the chain-firehose ingest write path authenticates with a single
+// static shared secret and then fans each accepted payload out to every live
+// SSE/WS/GraphQL-subscription subscriber -- so a leaked CHAIN_FIREHOSE_SYNC_SECRET
+// could flood every connected client with unbounded forged events, a distinct
+// amplification angle from the one-record-per-request internal-sync routes.
+// Generous cap: the #4981 box relay POSTs at most per-block (~5/min at ~12s
+// blocks); 120/60s leaves >20x headroom for multi-event NOTIFY bursts while
+// still firmly bounding abuse. Keyed per client IP; optional-chained so it's a
+// no-op when the binding is absent (local dev/CI).
+const CHAIN_FIREHOSE_INGEST_RATE_LIMIT = { limit: 120, windowSeconds: 60 };
+
+async function chainFirehoseIngestRateLimited(request, env) {
+  if (!env.CHAIN_FIREHOSE_INGEST_RATE_LIMITER?.limit) return null;
+  const { success } = await env.CHAIN_FIREHOSE_INGEST_RATE_LIMITER.limit({
+    key: `chain-firehose-ingest:${resolveClientIp(request)}`,
+  });
+  if (success) return null;
+  return errorResponse(
+    "chain_firehose_ingest_rate_limited",
+    "Too many chain-firehose ingest requests from this client; slow down.",
+    429,
+    {},
+    {
+      "retry-after": String(CHAIN_FIREHOSE_INGEST_RATE_LIMIT.windowSeconds),
+      "x-ratelimit-limit": String(CHAIN_FIREHOSE_INGEST_RATE_LIMIT.limit),
+      "x-ratelimit-policy": `${CHAIN_FIREHOSE_INGEST_RATE_LIMIT.limit};w=${CHAIN_FIREHOSE_INGEST_RATE_LIMIT.windowSeconds}`,
+      "x-ratelimit-remaining": "0",
+    },
+  );
+}
+
 // Generic forwarder to the DATA_API service binding for the internal
 // write/rollup routes that live inside workers/data-api.mjs itself rather
 // than a dedicated Worker (#4771's neurons-sync pattern) -- splitting read
@@ -1072,6 +1103,11 @@ async function handleChainFirehoseIngest(request, env) {
       401,
     );
   }
+  // Rate-limit only authenticated callers (unauth/wrong-method are rejected
+  // above without consuming limiter budget) so a leaked secret can't flood
+  // every live firehose subscriber (#5550).
+  const rateLimited = await chainFirehoseIngestRateLimited(request, env);
+  if (rateLimited) return rateLimited;
   if (!env.CHAIN_FIREHOSE_HUB) {
     return errorResponse(
       "chain_firehose_unavailable",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -530,5 +530,13 @@
         "period": 60,
       },
     },
+    {
+      "name": "CHAIN_FIREHOSE_INGEST_RATE_LIMITER",
+      "namespace_id": "1008",
+      "simple": {
+        "limit": 120,
+        "period": 60,
+      },
+    },
   ],
 }


### PR DESCRIPTION
## Summary

`workers/api.mjs`'s `handleChainFirehoseIngest` is the write path the box-side relay POSTs each chain-event `NOTIFY` payload to. It authenticates with a single static shared secret (`CHAIN_FIREHOSE_SYNC_SECRET`) and then forwards the body into the `CHAIN_FIREHOSE_HUB` Durable Object's `/ingest`, which **fans it out to every live SSE/WebSocket/GraphQL-subscription subscriber** of `/api/v1/chain/stream`. There was no rate limiter anywhere on this path, so a leaked secret let a caller flood every connected real-time subscriber with unbounded forged events — a distinct amplification angle from the one-record-per-request internal-sync routes (#5473) that already carry limiters.

## Change

Mirrors the existing `internalSyncRateLimited` helper:

- New `ratelimits` binding `CHAIN_FIREHOSE_INGEST_RATE_LIMITER` in `wrangler.jsonc` (namespace 1008), following the block at the end of the `ratelimits` array.
- New `chainFirehoseIngestRateLimited(request, env)` helper returning a 429 with the standard header family (`retry-after`, `x-ratelimit-limit`, `x-ratelimit-policy`, `x-ratelimit-remaining`), keyed per client IP, optional-chained so it's a **no-op when the binding is absent** (local dev/CI).
- The check is applied in `handleChainFirehoseIngest` **after** the `request.method !== "POST"` guard and the `timingSafeEqual` auth check, so unauthenticated/wrong-method callers are rejected first without consuming limiter budget.

**Limit: 120 / 60s.** The box relay POSTs at most per-block (~5/min at ~12s blocks), so 120/min leaves >20× headroom for multi-event NOTIFY bursts while firmly bounding a forged-flood.

## Tests (`tests/chain-firehose-routes.test.mjs`)

Four new cases: within-limit request reaches the hub; over-limit request returns 429 with the full header family and **never** reaches the hub; an unbound limiter is a no-op; and a wrong-token request 401s **before** the limiter is consulted (the limiter throws if called, proving auth precedence).

## Validation

- `npx vitest run tests/chain-firehose-routes.test.mjs` — 14 passed (10 pre-existing + 4 new).
- `npx vitest run tests/api-coverage.test.mjs tests/batch-ratelimit.test.mjs` — 257 passed (no regression).
- `node -c workers/api.mjs` clean; `wrangler.jsonc` parses; `npx prettier --check` clean. No schema/contract change.

Closes #5550
