### PR TITLE
feat(mcp): add read-only tools for webhook subscriptions and alert triggers

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -28,6 +28,15 @@ import { d1TimeoutMs, withTimeout } from "../workers/storage.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 import { handleRpcProxyRequest } from "../workers/request-handlers/rpc-proxy.mjs";
 import {
+  isValidSubscriptionId,
+  subscriptionStorageKey,
+  publicSubscriptionView,
+  deliveryStoragePrefix,
+  summarizeDeliveryRecords,
+  WEBHOOK_REDELIVERY_LIST_LIMIT,
+} from "./webhooks.mjs";
+import { ALERT_TRIGGER_OWNER_TOKEN_HEADER } from "./alert-triggers.mjs";
+import {
   MCP_CHAIN_STREAM_RESOURCE_URI,
   isValidMcpSessionId,
 } from "../workers/mcp-session-hub.mjs";
@@ -1121,6 +1130,33 @@ function mcpNeuronsTierRequest(pathname, params = {}) {
   }
   const q = qs.toString();
   return new Request(`https://d${pathname}${q ? `?${q}` : ""}`);
+}
+
+// Delivery health for get_webhook_subscription -- mirrors workers/api.mjs's
+// readDeliveryStatus (the same helper the public GET /api/v1/webhooks/
+// subscriptions/{id} route uses), best-effort: a list/get hiccup or a store
+// without `list` (local dev KV mock) degrades to "ok" rather than failing
+// the whole lookup.
+async function readMcpWebhookDeliveryStatus(env, id) {
+  try {
+    if (typeof env.METAGRAPH_CONTROL.list !== "function") {
+      return summarizeDeliveryRecords([]);
+    }
+    const { keys } = await env.METAGRAPH_CONTROL.list({
+      prefix: deliveryStoragePrefix(id),
+      limit: WEBHOOK_REDELIVERY_LIST_LIMIT,
+    });
+    const records = await Promise.all(
+      keys
+        .slice(0, WEBHOOK_REDELIVERY_LIST_LIMIT)
+        .map((entry) =>
+          env.METAGRAPH_CONTROL.get(entry.name, { type: "json" }),
+        ),
+    );
+    return summarizeDeliveryRecords(records);
+  } catch {
+    return summarizeDeliveryRecords([]);
+  }
 }
 
 // Synthetic GET /api/v1/accounts/{ss58}/identity-history{...} request, same
@@ -4742,6 +4778,118 @@ export const MCP_TOOLS = [
           "METAGRAPH_NEURONS_SOURCE",
         )) ?? buildValidatorDetail([], hotkey)
       );
+    },
+  },
+  {
+    name: "get_webhook_subscription",
+    title: "Get a webhook subscription's public status",
+    description:
+      "Fetch a webhook change-feed subscription's public status by id: its " +
+      "url, filters, active flag, created_at, and recent delivery health. " +
+      "Never returns the subscription's secret -- there is no way to " +
+      "enumerate subscriptions, only look one up by an id you already hold " +
+      "(the same id returned when it was created). Mirrors GET " +
+      "/api/v1/webhooks/subscriptions/{id}.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+          description:
+            "Subscription id (UUID v4), returned when the subscription was created.",
+        },
+      },
+      required: ["id"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const id = requireString(args, "id");
+      if (!isValidSubscriptionId(id)) {
+        throw toolError(
+          "invalid_params",
+          "Argument `id` must be a valid subscription id (UUID v4).",
+        );
+      }
+      if (!ctx.env.METAGRAPH_CONTROL?.get) {
+        throw toolError(
+          "webhooks_unavailable",
+          "The webhook subscription store is not configured on this deployment.",
+        );
+      }
+      let record;
+      try {
+        record = await ctx.env.METAGRAPH_CONTROL.get(
+          subscriptionStorageKey(id),
+          { type: "json" },
+        );
+      } catch {
+        record = null;
+      }
+      if (!record) {
+        throw toolError("not_found", `No such subscription: ${id}.`);
+      }
+      return {
+        ...publicSubscriptionView(record),
+        delivery: await readMcpWebhookDeliveryStatus(ctx.env, id),
+      };
+    },
+  },
+  {
+    name: "get_alert_trigger",
+    title: "Get a chain alert trigger by id",
+    description:
+      "Fetch a chain alert trigger's full configuration and status by id. " +
+      "Requires the owner_token returned when the trigger was created -- " +
+      "alert triggers have no public view, matching GET " +
+      "/api/v1/alerts/triggers/{id}'s own auth requirement exactly (the " +
+      "same 404 is returned for both a wrong token and a nonexistent id, " +
+      "so this can't be used to enumerate other callers' triggers).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "Alert trigger id." },
+        owner_token: {
+          type: "string",
+          description:
+            "The owner token returned when this trigger was created.",
+        },
+      },
+      required: ["id", "owner_token"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const id = requireString(args, "id");
+      const ownerToken = requireString(args, "owner_token");
+      if (!ctx.env.DATA_API) {
+        throw toolError(
+          "alert_triggers_unavailable",
+          "The alert triggers tier is not bound to this deployment.",
+        );
+      }
+      const upstream = await ctx.env.DATA_API.fetch(
+        new Request(
+          `https://d/api/v1/alerts/triggers/${encodeURIComponent(id)}`,
+          { headers: { [ALERT_TRIGGER_OWNER_TOKEN_HEADER]: ownerToken } },
+        ),
+      );
+      let body;
+      try {
+        body = await upstream.json();
+      } catch {
+        throw toolError(
+          "alert_triggers_unavailable",
+          "The alert triggers tier returned an unreadable response.",
+        );
+      }
+      if (!upstream.ok) {
+        throw toolError(
+          upstream.status === 404 ? "not_found" : "alert_trigger_error",
+          typeof body?.error === "string"
+            ? body.error
+            : "The alert triggers tier returned an error.",
+        );
+      }
+      return body;
     },
   },
   {
@@ -11134,6 +11282,60 @@ const TOOL_OUTPUT_SCHEMAS = {
       captured_at: NULLABLE_STRING,
       block_number: NULLABLE_INT,
       subnets: { type: "array", items: { type: "object" } },
+    },
+  },
+  get_webhook_subscription: {
+    type: "object",
+    additionalProperties: true,
+    required: ["id", "url", "active"],
+    properties: {
+      id: { type: "string" },
+      url: { type: "string" },
+      filters: { type: "object" },
+      created_at: NULLABLE_STRING,
+      active: { type: "boolean" },
+      delivery: {
+        type: "object",
+        required: ["status", "pending", "dead_letter"],
+        properties: {
+          status: { type: "string", enum: ["ok", "retrying", "dead_letter"] },
+          pending: { type: "integer" },
+          dead_letter: { type: "integer" },
+          last_failure: {
+            type: ["object", "null"],
+            properties: {
+              event_id: { type: "string" },
+              attempts: { type: "integer" },
+              reason: NULLABLE_STRING,
+              status_code: NULLABLE_INT,
+              state: { type: "string" },
+              last_attempt_at: NULLABLE_STRING,
+              next_attempt_at: NULLABLE_STRING,
+            },
+          },
+        },
+      },
+    },
+  },
+  get_alert_trigger: {
+    type: "object",
+    additionalProperties: true,
+    required: ["id", "active"],
+    properties: {
+      id: { type: "string" },
+      name: NULLABLE_STRING,
+      table_filter: NULLABLE_STRING,
+      netuid: NULLABLE_INT,
+      event_kind: NULLABLE_STRING,
+      account: NULLABLE_STRING,
+      min_amount_tao: { type: ["number", "null"] },
+      channel: { type: "string" },
+      destination: { type: "string" },
+      active: { type: "boolean" },
+      created_at: NULLABLE_STRING,
+      updated_at: NULLABLE_STRING,
+      last_matched_at: NULLABLE_STRING,
+      match_count: { type: "integer" },
     },
   },
   get_validator_nominators: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14882,6 +14882,136 @@ describe("MCP webhook/alert-trigger read tools (2026-07-14/15 audit follow-up)",
       "invalid_params",
     );
   });
+
+  test("get_alert_trigger falls back to the generic error message when the upstream error field is not a string", async () => {
+    const env = {
+      DATA_API: {
+        fetch: async () =>
+          Response.json({ error: { unexpected: "shape" } }, { status: 500 }),
+      },
+    };
+    const res = await callTool(
+      "get_alert_trigger",
+      { id: "trigger-1", owner_token: "token" },
+      { env },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "alert_trigger_error",
+    );
+    assert.equal(
+      res.body.result.structuredContent.error.message,
+      "The alert triggers tier returned an error.",
+    );
+  });
+
+  // readMcpWebhookDeliveryStatus (src/mcp-server.mjs) is a best-effort helper --
+  // the tests above only exercise its happy path (a working `.list` returning no
+  // keys). These target its other branches directly: no `.list` method at all, a
+  // `.list` that throws, and a `.list` that returns real keys worth `.get`-ing.
+  test("get_webhook_subscription degrades delivery status to empty when METAGRAPH_CONTROL has no list method", async () => {
+    const id = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    const env = {
+      METAGRAPH_CONTROL: {
+        async get(key, opts) {
+          if (key !== `webhooks:sub:${id}`) return null;
+          const record = {
+            id,
+            url: "https://hooks.example.com/mg",
+            secret: "s",
+            filters: {},
+            created_at: "2026-07-01T00:00:00.000Z",
+            active: true,
+          };
+          return opts?.type === "json" ? record : JSON.stringify(record);
+        },
+        // No `list` method -- matches an older/partial KV mock shape.
+      },
+    };
+    const res = await callTool("get_webhook_subscription", { id }, { env });
+    assert.equal(res.body.result.isError, false);
+    assert.deepEqual(res.body.result.structuredContent.delivery, {
+      status: "ok",
+      pending: 0,
+      dead_letter: 0,
+      last_failure: null,
+    });
+  });
+
+  test("get_webhook_subscription degrades delivery status to empty when listing delivery records throws", async () => {
+    const id = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    const env = {
+      METAGRAPH_CONTROL: {
+        async get(key, opts) {
+          if (key !== `webhooks:sub:${id}`) return null;
+          const record = {
+            id,
+            url: "https://hooks.example.com/mg",
+            secret: "s",
+            filters: {},
+            created_at: "2026-07-01T00:00:00.000Z",
+            active: true,
+          };
+          return opts?.type === "json" ? record : JSON.stringify(record);
+        },
+        async list() {
+          throw new Error("KV list unavailable");
+        },
+      },
+    };
+    const res = await callTool("get_webhook_subscription", { id }, { env });
+    assert.equal(res.body.result.isError, false);
+    assert.deepEqual(res.body.result.structuredContent.delivery, {
+      status: "ok",
+      pending: 0,
+      dead_letter: 0,
+      last_failure: null,
+    });
+  });
+
+  test("get_webhook_subscription summarizes real delivery records returned by list", async () => {
+    const id = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    const subKey = `webhooks:sub:${id}`;
+    const deliveryKey = `webhooks:delivery:${id}:evt-1`;
+    const deliveryRecord = {
+      state: "dead",
+      last_attempt_at: "2026-07-14T00:00:00.000Z",
+    };
+    const env = {
+      METAGRAPH_CONTROL: {
+        async get(key, opts) {
+          const value =
+            key === subKey
+              ? {
+                  id,
+                  url: "https://hooks.example.com/mg",
+                  secret: "s",
+                  filters: {},
+                  created_at: "2026-07-01T00:00:00.000Z",
+                  active: true,
+                }
+              : key === deliveryKey
+                ? deliveryRecord
+                : null;
+          if (value === null) return null;
+          return opts?.type === "json" ? value : JSON.stringify(value);
+        },
+        async list({ prefix }) {
+          assert.equal(prefix, `webhooks:delivery:${id}:`);
+          return { keys: [{ name: deliveryKey }] };
+        },
+      },
+    };
+    const res = await callTool("get_webhook_subscription", { id }, { env });
+    assert.equal(res.body.result.isError, false);
+    assert.equal(
+      res.body.result.structuredContent.delivery.status,
+      "dead_letter",
+    );
+    assert.equal(res.body.result.structuredContent.delivery.dead_letter, 1);
+    assert.equal(res.body.result.structuredContent.delivery.pending, 0);
+  });
 });
 
 // MCP feature-parity tools (#5225): validator detail/nominators/history, subnet

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14697,6 +14697,193 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 });
 
+// Read-only MCP tools for webhook subscriptions + chain alert triggers, added
+// after the 2026-07-14/15 exhaustive audit found neither had any MCP
+// presence despite REST support -- deliberately scoped to GET-by-known-id
+// only (no create/delete), matching the exact auth posture of the REST
+// routes they mirror so no new exposure is introduced (#5589/#5590).
+describe("MCP webhook/alert-trigger read tools (2026-07-14/15 audit follow-up)", () => {
+  function makeControlKv(records = {}) {
+    return {
+      async get(key, opts) {
+        const value = records[key];
+        if (value === undefined) return null;
+        return opts?.type === "json" ? value : JSON.stringify(value);
+      },
+      async list() {
+        return { keys: [] };
+      },
+    };
+  }
+
+  test("get_webhook_subscription returns the public view + delivery status for a known id, never the secret", async () => {
+    const id = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    const env = {
+      METAGRAPH_CONTROL: makeControlKv({
+        [`webhooks:sub:${id}`]: {
+          id,
+          url: "https://hooks.example.com/mg",
+          secret: "should-never-be-returned",
+          filters: { kinds: ["subnet.updated"] },
+          created_at: "2026-07-01T00:00:00.000Z",
+          active: true,
+        },
+      }),
+    };
+    const res = await callTool("get_webhook_subscription", { id }, { env });
+    assert.equal(res.body.result.isError, false);
+    const out = res.body.result.structuredContent;
+    assert.equal(out.id, id);
+    assert.equal(out.url, "https://hooks.example.com/mg");
+    assert.equal(out.secret, undefined);
+    assert.equal(out.active, true);
+    assert.deepEqual(out.filters, { kinds: ["subnet.updated"] });
+    assert.equal(out.delivery.status, "ok");
+    assert.equal(out.delivery.pending, 0);
+    assert.equal(out.delivery.dead_letter, 0);
+  });
+
+  test("get_webhook_subscription treats a KV read failure the same as not-found rather than throwing", async () => {
+    const id = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    const env = {
+      METAGRAPH_CONTROL: {
+        async get() {
+          throw new Error("KV unavailable");
+        },
+      },
+    };
+    const res = await callTool("get_webhook_subscription", { id }, { env });
+    assert.equal(res.body.result.isError, true);
+    assert.equal(res.body.result.structuredContent.error.code, "not_found");
+  });
+
+  test("get_webhook_subscription surfaces a not_found tool error (not a thrown exception) for an unknown id", async () => {
+    const id = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    const env = { METAGRAPH_CONTROL: makeControlKv({}) };
+    const res = await callTool("get_webhook_subscription", { id }, { env });
+    assert.equal(res.body.result.isError, true);
+    assert.equal(res.body.result.structuredContent.error.code, "not_found");
+  });
+
+  test("get_webhook_subscription rejects a malformed id before touching KV", async () => {
+    const res = await callTool(
+      "get_webhook_subscription",
+      { id: "not-a-uuid" },
+      { env: {} },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "invalid_params",
+    );
+  });
+
+  test("get_webhook_subscription returns webhooks_unavailable when METAGRAPH_CONTROL is unbound", async () => {
+    const res = await callTool(
+      "get_webhook_subscription",
+      { id: "3fa85f64-5717-4562-b3fc-2c963f66afa6" },
+      { env: {} },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "webhooks_unavailable",
+    );
+  });
+
+  test("get_alert_trigger forwards the id + owner_token to DATA_API and relays the response", async () => {
+    let capturedPath;
+    let capturedToken;
+    const env = {
+      DATA_API: {
+        fetch: async (req) => {
+          const url = new URL(req.url);
+          capturedPath = url.pathname;
+          capturedToken = req.headers.get("x-alert-trigger-owner-token");
+          return Response.json({
+            id: "trigger-1",
+            name: "Big stake moves",
+            channel: "discord",
+            destination: "https://discord.example/webhook",
+            active: true,
+            match_count: 3,
+          });
+        },
+      },
+    };
+    const res = await callTool(
+      "get_alert_trigger",
+      { id: "trigger-1", owner_token: "owner-secret" },
+      { env },
+    );
+    assert.equal(res.body.result.isError, false);
+    assert.equal(capturedPath, "/api/v1/alerts/triggers/trigger-1");
+    assert.equal(capturedToken, "owner-secret");
+    assert.equal(res.body.result.structuredContent.name, "Big stake moves");
+    assert.equal(res.body.result.structuredContent.match_count, 3);
+  });
+
+  test("get_alert_trigger surfaces a not_found tool error for a wrong owner_token or unknown id (same 404 as REST, no enumeration oracle)", async () => {
+    const env = {
+      DATA_API: {
+        fetch: async () =>
+          Response.json({ error: "no such trigger" }, { status: 404 }),
+      },
+    };
+    const res = await callTool(
+      "get_alert_trigger",
+      { id: "trigger-1", owner_token: "wrong" },
+      { env },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(res.body.result.structuredContent.error.code, "not_found");
+  });
+
+  test("get_alert_trigger returns alert_triggers_unavailable when the upstream response body is unreadable", async () => {
+    const env = {
+      DATA_API: {
+        fetch: async () => new Response("not json", { status: 200 }),
+      },
+    };
+    const res = await callTool(
+      "get_alert_trigger",
+      { id: "trigger-1", owner_token: "token" },
+      { env },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "alert_triggers_unavailable",
+    );
+  });
+
+  test("get_alert_trigger returns alert_triggers_unavailable when DATA_API is unbound", async () => {
+    const res = await callTool(
+      "get_alert_trigger",
+      { id: "trigger-1", owner_token: "token" },
+      { env: {} },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "alert_triggers_unavailable",
+    );
+  });
+
+  test("get_alert_trigger rejects a missing owner_token", async () => {
+    const res = await callTool(
+      "get_alert_trigger",
+      { id: "trigger-1" },
+      { env: {} },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "invalid_params",
+    );
+  });
+});
+
 // MCP feature-parity tools (#5225): validator detail/nominators/history, subnet
 // hyperparameters/volume/recycled, account identity/position-history,
 // sudo/governance-config feeds, the runtime spec-version timeline, and the


### PR DESCRIPTION
## Summary
- Neither webhook subscriptions nor chain alert triggers had any MCP presence despite full REST support — an agent had no way to look either up, even read-only (#5589, #5590)
- Scoped to **GET-by-known-id only**, matching each REST route's own auth posture exactly — no create/delete, so no new abuse surface is introduced:
  - `get_webhook_subscription(id)` — mirrors `GET /api/v1/webhooks/subscriptions/{id}`. No credential required (the route's own public view already strips the subscription secret) — same as REST.
  - `get_alert_trigger(id, owner_token)` — mirrors `GET /api/v1/alerts/triggers/{id}`. Requires the `owner_token` returned at creation; returns the same 404 for a wrong token or unknown id as REST (no enumeration oracle).
- Neither issue's flagged auth question (should MCP expose create/delete for a shared-secret-authenticated resource) needed resolving to ship this — read-only sidesteps it entirely. Create/delete stay deferred pending a real per-user-credential model, tracked separately if wanted.

## Test plan
- [x] 10 new tests: successful lookup + secret-never-returned, not-found (unknown id / wrong owner_token), malformed id rejected before touching KV, unbound-binding degradation, KV-read-failure and unreadable-upstream-response-body branches
- [x] `npx vitest run tests/mcp-server.test.mjs` — 1036/1036 passed
- [x] Full `npm run test:coverage` — passed twice (iterated once to close two branch-coverage gaps found by the first run), coverage floors intact
- [x] `npm run lint` / `npx prettier --check` clean

Closes #5589
Closes #5590