### PR TITLE
fix(chain): clamp limit floor to 0 in the 7 remaining chain-* leaderboard loaders (#5579)

### DIFF
--- a/src/chain-axon-removals.mjs
+++ b/src/chain-axon-removals.mjs
@@ -131,7 +131,7 @@ export function buildChainAxonRemovals(
   const list = Array.isArray(subnetRows) ? subnetRows : [];
   const flooredLimit = Math.floor(Number(limit));
   const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(1, Math.min(flooredLimit, CHAIN_AXON_REMOVALS_LIMIT_MAX))
+    ? Math.max(0, Math.min(flooredLimit, CHAIN_AXON_REMOVALS_LIMIT_MAX))
     : CHAIN_AXON_REMOVALS_LIMIT_DEFAULT;
   const observedAt = toIso(networkDistinct?.newest_observed);
 

--- a/src/chain-deregistrations.mjs
+++ b/src/chain-deregistrations.mjs
@@ -133,7 +133,7 @@ export function buildChainDeregistrations(
   const list = Array.isArray(subnetRows) ? subnetRows : [];
   const flooredLimit = Math.floor(Number(limit));
   const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(1, Math.min(flooredLimit, CHAIN_DEREGISTRATIONS_LIMIT_MAX))
+    ? Math.max(0, Math.min(flooredLimit, CHAIN_DEREGISTRATIONS_LIMIT_MAX))
     : CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT;
   const observedAt = toIso(networkDistinct?.newest_observed);
 

--- a/src/chain-prometheus.mjs
+++ b/src/chain-prometheus.mjs
@@ -130,7 +130,7 @@ export function buildChainPrometheus(
   const list = Array.isArray(subnetRows) ? subnetRows : [];
   const flooredLimit = Math.floor(Number(limit));
   const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(1, Math.min(flooredLimit, CHAIN_PROMETHEUS_LIMIT_MAX))
+    ? Math.max(0, Math.min(flooredLimit, CHAIN_PROMETHEUS_LIMIT_MAX))
     : CHAIN_PROMETHEUS_LIMIT_DEFAULT;
   const observedAt = toIso(networkDistinct?.newest_observed);
 

--- a/src/chain-registrations.mjs
+++ b/src/chain-registrations.mjs
@@ -124,7 +124,7 @@ export function buildChainRegistrations(
   const list = Array.isArray(subnetRows) ? subnetRows : [];
   const flooredLimit = Math.floor(Number(limit));
   const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(1, Math.min(flooredLimit, CHAIN_REGISTRATIONS_LIMIT_MAX))
+    ? Math.max(0, Math.min(flooredLimit, CHAIN_REGISTRATIONS_LIMIT_MAX))
     : CHAIN_REGISTRATIONS_LIMIT_DEFAULT;
   const observedAt = toIso(networkDistinct?.newest_observed);
 

--- a/src/chain-serving.mjs
+++ b/src/chain-serving.mjs
@@ -127,7 +127,7 @@ export function buildChainServing(
   const list = Array.isArray(subnetRows) ? subnetRows : [];
   const flooredLimit = Math.floor(Number(limit));
   const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(1, Math.min(flooredLimit, CHAIN_SERVING_LIMIT_MAX))
+    ? Math.max(0, Math.min(flooredLimit, CHAIN_SERVING_LIMIT_MAX))
     : CHAIN_SERVING_LIMIT_DEFAULT;
   const observedAt = toIso(networkDistinct?.newest_observed);
 

--- a/src/chain-stake-moves.mjs
+++ b/src/chain-stake-moves.mjs
@@ -131,7 +131,7 @@ export function buildChainStakeMoves(
   const list = Array.isArray(subnetRows) ? subnetRows : [];
   const flooredLimit = Math.floor(Number(limit));
   const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(1, Math.min(flooredLimit, CHAIN_STAKE_MOVES_LIMIT_MAX))
+    ? Math.max(0, Math.min(flooredLimit, CHAIN_STAKE_MOVES_LIMIT_MAX))
     : CHAIN_STAKE_MOVES_LIMIT_DEFAULT;
   const observedAt = toIso(networkDistinct?.newest_observed);
 

--- a/src/chain-stake-transfers.mjs
+++ b/src/chain-stake-transfers.mjs
@@ -134,7 +134,7 @@ export function buildChainStakeTransfers(
   const list = Array.isArray(subnetRows) ? subnetRows : [];
   const flooredLimit = Math.floor(Number(limit));
   const normalizedLimit = Number.isFinite(flooredLimit)
-    ? Math.max(1, Math.min(flooredLimit, CHAIN_STAKE_TRANSFERS_LIMIT_MAX))
+    ? Math.max(0, Math.min(flooredLimit, CHAIN_STAKE_TRANSFERS_LIMIT_MAX))
     : CHAIN_STAKE_TRANSFERS_LIMIT_DEFAULT;
   const observedAt = toIso(networkDistinct?.newest_observed);
 

--- a/tests/chain-axon-removals.test.mjs
+++ b/tests/chain-axon-removals.test.mjs
@@ -103,6 +103,18 @@ describe("buildChainAxonRemovals", () => {
     assert.equal(data.intensity_distribution.count, 3);
   });
 
+  // #5579: limit floor is 0 (matching #2984's chain-weights fix), so limit: 0
+  // returns an empty leaderboard rather than a single row.
+  test("limit of 0 yields an empty leaderboard, not a single row", () => {
+    const data = buildChainAxonRemovals(SUBNETS, {
+      window: "7d",
+      limit: 0,
+      networkDistinct: NETWORK,
+    });
+    assert.equal(data.subnets.length, 0);
+    assert.equal(data.subnet_count, 3);
+  });
+
   test("limit above the max clamps; a non-numeric limit uses the default", () => {
     const big = buildChainAxonRemovals(SUBNETS, {
       window: "7d",

--- a/tests/chain-deregistrations.test.mjs
+++ b/tests/chain-deregistrations.test.mjs
@@ -92,6 +92,17 @@ describe("buildChainDeregistrations", () => {
     );
   });
 
+  // #5579: limit floor is 0 (matching #2984's chain-weights fix).
+  test("limit of 0 yields an empty leaderboard, not a single row", () => {
+    const data = buildChainDeregistrations(SUBNETS, {
+      window: "7d",
+      limit: 0,
+      networkDistinct: NETWORK,
+    });
+    assert.equal(data.subnets.length, 0);
+    assert.equal(data.subnet_count, 3);
+  });
+
   test("limit caps the leaderboard; distribution and count stay network-wide", () => {
     const data = buildChainDeregistrations(SUBNETS, {
       window: "7d",

--- a/tests/chain-prometheus.test.mjs
+++ b/tests/chain-prometheus.test.mjs
@@ -92,6 +92,17 @@ describe("buildChainPrometheus", () => {
     );
   });
 
+  // #5579: limit floor is 0 (matching #2984's chain-weights fix).
+  test("limit of 0 yields an empty leaderboard, not a single row", () => {
+    const data = buildChainPrometheus(SUBNETS, {
+      window: "7d",
+      limit: 0,
+      networkDistinct: NETWORK,
+    });
+    assert.equal(data.subnets.length, 0);
+    assert.equal(data.subnet_count, 3);
+  });
+
   test("limit caps the leaderboard; distribution and count stay network-wide", () => {
     const data = buildChainPrometheus(SUBNETS, {
       window: "7d",

--- a/tests/chain-registrations.test.mjs
+++ b/tests/chain-registrations.test.mjs
@@ -92,6 +92,17 @@ describe("buildChainRegistrations", () => {
     );
   });
 
+  // #5579: limit floor is 0 (matching #2984's chain-weights fix).
+  test("limit of 0 yields an empty leaderboard, not a single row", () => {
+    const data = buildChainRegistrations(SUBNETS, {
+      window: "7d",
+      limit: 0,
+      networkDistinct: NETWORK,
+    });
+    assert.equal(data.subnets.length, 0);
+    assert.equal(data.subnet_count, 3);
+  });
+
   test("limit caps the leaderboard; distribution and count stay network-wide", () => {
     const data = buildChainRegistrations(SUBNETS, {
       window: "7d",

--- a/tests/chain-serving.test.mjs
+++ b/tests/chain-serving.test.mjs
@@ -92,6 +92,17 @@ describe("buildChainServing", () => {
     );
   });
 
+  // #5579: limit floor is 0 (matching #2984's chain-weights fix).
+  test("limit of 0 yields an empty leaderboard, not a single row", () => {
+    const data = buildChainServing(SUBNETS, {
+      window: "7d",
+      limit: 0,
+      networkDistinct: NETWORK,
+    });
+    assert.equal(data.subnets.length, 0);
+    assert.equal(data.subnet_count, 3);
+  });
+
   test("limit caps the leaderboard; distribution and count stay network-wide", () => {
     const data = buildChainServing(SUBNETS, {
       window: "7d",

--- a/tests/chain-stake-moves.test.mjs
+++ b/tests/chain-stake-moves.test.mjs
@@ -92,6 +92,17 @@ describe("buildChainStakeMoves", () => {
     );
   });
 
+  // #5579: limit floor is 0 (matching #2984's chain-weights fix).
+  test("limit of 0 yields an empty leaderboard, not a single row", () => {
+    const data = buildChainStakeMoves(SUBNETS, {
+      window: "7d",
+      limit: 0,
+      networkDistinct: NETWORK,
+    });
+    assert.equal(data.subnets.length, 0);
+    assert.equal(data.subnet_count, 3);
+  });
+
   test("limit caps the leaderboard; distribution and count stay network-wide", () => {
     const data = buildChainStakeMoves(SUBNETS, {
       window: "7d",

--- a/tests/chain-stake-transfers.test.mjs
+++ b/tests/chain-stake-transfers.test.mjs
@@ -92,6 +92,17 @@ describe("buildChainStakeTransfers", () => {
     );
   });
 
+  // #5579: limit floor is 0 (matching #2984's chain-weights fix).
+  test("limit of 0 yields an empty leaderboard, not a single row", () => {
+    const data = buildChainStakeTransfers(SUBNETS, {
+      window: "7d",
+      limit: 0,
+      networkDistinct: NETWORK,
+    });
+    assert.equal(data.subnets.length, 0);
+    assert.equal(data.subnet_count, 3);
+  });
+
   test("limit caps the leaderboard; distribution and count stay network-wide", () => {
     const data = buildChainStakeTransfers(SUBNETS, {
       window: "7d",


### PR DESCRIPTION
## Summary

#2984 ("fix(chain-weights): clamp limit floor to 0 instead of 1") changed `src/chain-weights.mjs`'s pure builder from `Math.max(1, …)` to `Math.max(0, …)` so that `limit: 0` returns an empty leaderboard rather than a single row, and added a regression test. The same outlier pattern was still live in **7 more** sibling loaders in the `src/chain-*.mjs` leaderboard family, none touched by #2984.

## Change

Changed the `limit` floor from `Math.max(1, …)` to `Math.max(0, …)` — the only change, matching `chain-weights.mjs`'s post-fix shape — in all 7:

- `src/chain-axon-removals.mjs`
- `src/chain-stake-moves.mjs`
- `src/chain-prometheus.mjs`
- `src/chain-deregistrations.mjs`
- `src/chain-registrations.mjs`
- `src/chain-stake-transfers.mjs`
- `src/chain-serving.mjs`

Now all 11 sibling loaders (`chain-turnover`, `chain-stake-flow`, `chain-weights`, `chain-weight-setters` + these 7) agree that `limit: 0` means "return nothing." No other behavioral change.

## Tests

Added a `limit: 0` regression test to each of the 7 corresponding `tests/chain-*.test.mjs` files, mirroring `tests/chain-weights.test.mjs:101` exactly — asserting `data.subnets.length === 0` (empty leaderboard, not one row) while `subnet_count` stays network-wide. Each fails before the fix (would be 1) and passes after.

## Validation

- `npx vitest run` on all 7 affected test files — **204 passed** (7 new `limit: 0` cases + existing suites unchanged).
- `node -c` on all 7 source files + `npx prettier --check` — clean. No schema/contract change (pure `src/**` + `tests/**`), so no generated-artifact regen.

Closes #5579
