### PR TITLE
feat(graphql): add Query.validators / Query.validator

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -27,6 +27,15 @@ import {
   parseCompareNetuidList,
 } from "./analytics-live.mjs";
 import { buildExtrinsic, buildExtrinsicFeed } from "./extrinsics.mjs";
+import {
+  DEFAULT_GLOBAL_VALIDATOR_SORT,
+  GLOBAL_VALIDATOR_LIMIT_DEFAULT,
+  GLOBAL_VALIDATOR_LIMIT_MAX,
+  GLOBAL_VALIDATOR_SORTS,
+  buildGlobalValidators,
+  buildValidatorDetail,
+  overlayFeaturedValidators,
+} from "./metagraph-neurons.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
 
 export const GRAPHQL_MAX_DEPTH = 7;
@@ -65,6 +74,10 @@ export const SDL = `
     extrinsics(limit: Int, offset: Int, cursor: String, block: Int, signer: String, call_module: String, call_function: String, success: Boolean): ExtrinsicList!
     "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}."
     extrinsic(ref: String!): ExtrinsicDetail
+    "Network-wide validator/operator leaderboard, grouped by hotkey across every subnet it operates in. Mirrors GET /api/v1/validators."
+    validators(sort: String, limit: Int): ValidatorList!
+    "One validator's cross-subnet aggregate by hotkey; a hotkey with no validator_permit=1 rows resolves to a schema-stable zeroed aggregate, never null. Mirrors GET /api/v1/validators/{hotkey}."
+    validator(hotkey: String!): Validator
   }
 
   type SubnetList {
@@ -355,6 +368,59 @@ export const SDL = `
     extrinsic: Extrinsic
   }
 
+  type ValidatorList {
+    items: [Validator!]!
+    total: Int!
+    sort: String!
+    captured_at: String
+    block_number: Int
+  }
+
+  type Validator {
+    hotkey: String!
+    featured: Boolean!
+    coldkey: String
+    coldkey_identity: Identity
+    coldkey_count: Int
+    subnet_count: Int
+    uid_count: Int
+    take: Float
+    total_stake_tao: Float
+    root_stake_tao: Float
+    alpha_stake_tao: Float
+    total_emission_tao: Float
+    nominator_count: Int
+    apy_estimate: Float
+    apy_estimate_eligible_subnet_count: Int
+    avg_validator_trust: Float
+    max_validator_trust: Float
+    captured_at: String
+    block_number: Int
+    "Per-subnet membership rows for this validator. The global leaderboard entry caps this at the top 10 by stake; the single-validator lookup carries every subnet."
+    subnets: [ValidatorSubnet!]!
+  }
+
+  type ValidatorSubnet {
+    netuid: Int!
+    uid: Int
+    stake_tao: Float
+    emission_tao: Float
+    validator_trust: Float
+  }
+
+  "Self-reported on-chain identity (SubtensorModule::set_identity) for a coldkey."
+  type Identity {
+    has_identity: Boolean!
+    name: String
+    url: String
+    github: String
+    image: String
+    discord: String
+    description: String
+    additional: String
+    captured_at: String
+  }
+
   # Realtime chain-event firehose (#4983, ADR 0015) -- a thin protocol adapter
   # over the SAME ChainFirehoseHub Durable Object connection #4982's SSE/WS
   # transports use, not a second event pipeline. Reached over WebSocket only
@@ -489,6 +555,8 @@ export const FIELD_COMPLEXITY = {
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
+  validators: RELATIONSHIP_FIELD_COMPLEXITY,
+  validator: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -857,6 +925,27 @@ function extrinsicNode(extrinsic) {
   };
 }
 
+// buildGlobalValidators' per-hotkey entries carry featured/uid_count/
+// latest_captured_at/latest_block_number; buildValidatorDetail's single-hotkey
+// aggregate has no featured/uid_count and names the same timestamps
+// captured_at/block_number -- normalized here so both resolvers return the
+// same Validator shape. Both builders always return an object (rows=[]
+// degrades to a zeroed aggregate, never null/undefined), so there is no null
+// case to guard. `subnets` entries are passed through as-is: the leaderboard's
+// compact 5-field rows and the detail's full formatNeuron rows share the
+// fields ValidatorSubnet declares, and graphql-js' default field resolver
+// reads them straight off each row, the same technique this file's other node
+// builders use for rows with more columns than any one GraphQL type exposes.
+function validatorNode(validator) {
+  return {
+    ...validator,
+    featured: validator.featured === true,
+    captured_at: validator.latest_captured_at ?? validator.captured_at ?? null,
+    block_number:
+      validator.latest_block_number ?? validator.block_number ?? null,
+  };
+}
+
 function providerNode(provider) {
   const netuids = provider?.netuids || [];
   return {
@@ -1133,6 +1222,54 @@ const rootValue = {
       ref: data.ref ?? ref,
       extrinsic: extrinsicNode(data.extrinsic),
     };
+  },
+
+  async validators({ sort, limit }, context) {
+    const requestedSort = sort ?? DEFAULT_GLOBAL_VALIDATOR_SORT;
+    if (!GLOBAL_VALIDATOR_SORTS.includes(requestedSort)) {
+      throw new GraphQLError(
+        `"${requestedSort}" is not a supported sort. Supported: ${GLOBAL_VALIDATOR_SORTS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: GLOBAL_VALIDATOR_LIMIT_DEFAULT,
+      maxLimit: GLOBAL_VALIDATOR_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("sort", requestedSort);
+    params.set("limit", String(safeLimit));
+    const data = overlayFeaturedValidators(
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/validators", params),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ??
+        buildGlobalValidators([], {
+          sort: requestedSort,
+          limit: safeLimit,
+        }),
+    );
+    return {
+      items: (data.validators || []).map(validatorNode),
+      total: data.validator_count ?? 0,
+      sort: data.sort ?? requestedSort,
+      captured_at: data.captured_at ?? null,
+      block_number: data.block_number ?? null,
+    };
+  },
+
+  async validator({ hotkey }, context) {
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/validators/${encodeURIComponent(hotkey)}`,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildValidatorDetail([], hotkey);
+    return validatorNode(data);
   },
 };
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1987,6 +1987,246 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
   });
 });
 
+describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("validators: cold/no-tier store returns a schema-stable empty page (fallback builder)", async () => {
+    const { status, body } = await gql(
+      "{ validators { items { hotkey } total sort captured_at block_number } }",
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.validators, {
+      items: [],
+      total: 0,
+      sort: "subnet_count",
+      captured_at: null,
+      block_number: null,
+    });
+  });
+
+  test("validators: resolves Postgres-tier rows, normalizing latest_* into captured_at/block_number", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          sort: "total_stake",
+          limit: 20,
+          captured_at: "2026-07-14T00:00:00.000Z",
+          block_number: 100,
+          validator_count: 1,
+          validators: [
+            {
+              hotkey: "5Validator",
+              featured: true,
+              coldkey: "5Coldkey",
+              coldkey_identity: { has_identity: false },
+              coldkey_count: 1,
+              subnet_count: 1,
+              uid_count: 1,
+              take: 0.1,
+              total_stake_tao: 1000,
+              root_stake_tao: 0,
+              alpha_stake_tao: 1000,
+              total_emission_tao: 5,
+              nominator_count: 3,
+              apy_estimate: 0.12,
+              apy_estimate_eligible_subnet_count: 1,
+              avg_validator_trust: 0.9,
+              max_validator_trust: 0.9,
+              latest_captured_at: "2026-07-14T00:00:00.000Z",
+              latest_block_number: 100,
+              subnets: [
+                {
+                  netuid: 1,
+                  uid: 5,
+                  stake_tao: 1000,
+                  emission_tao: 5,
+                  validator_trust: 0.9,
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      '{ validators(sort: "total_stake", limit: 5) { items { hotkey featured coldkey nominator_count captured_at block_number subnets { netuid uid stake_tao } } total sort captured_at block_number } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.validators.total, 1);
+    assert.equal(body.data.validators.sort, "total_stake");
+    assert.equal(body.data.validators.captured_at, "2026-07-14T00:00:00.000Z");
+    assert.equal(body.data.validators.block_number, 100);
+    const item = body.data.validators.items[0];
+    assert.equal(item.hotkey, "5Validator");
+    assert.equal(item.featured, true);
+    assert.equal(item.nominator_count, 3);
+    assert.equal(item.captured_at, "2026-07-14T00:00:00.000Z");
+    assert.equal(item.block_number, 100);
+    assert.deepEqual(item.subnets, [{ netuid: 1, uid: 5, stake_tao: 1000 }]);
+  });
+
+  test("validators: sort and limit args are forwarded as query params to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            sort: "uid_count",
+            limit: 5,
+            captured_at: null,
+            block_number: null,
+            validator_count: 0,
+            validators: [],
+          });
+        },
+      },
+    };
+    await gql('{ validators(sort: "uid_count", limit: 5) { total } }', env);
+    assert.equal(capturedUrl.pathname, "/api/v1/validators");
+    assert.equal(capturedUrl.searchParams.get("sort"), "uid_count");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+  });
+
+  test("validators: an omitted limit forwards the default limit to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            sort: "subnet_count",
+            limit: 20,
+            captured_at: null,
+            block_number: null,
+            validator_count: 0,
+            validators: [],
+          });
+        },
+      },
+    };
+    await gql("{ validators { total } }", env);
+    assert.equal(capturedUrl.searchParams.get("sort"), "subnet_count");
+    assert.equal(capturedUrl.searchParams.get("limit"), "20");
+  });
+
+  test("validators: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      "{ validators { items { hotkey } total sort captured_at block_number } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.validators, {
+      items: [],
+      total: 0,
+      sort: "subnet_count",
+      captured_at: null,
+      block_number: null,
+    });
+  });
+
+  test("validators: an unsupported sort value is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      '{ validators(sort: "not_a_real_sort") { total } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("validator: a hotkey with no validator_permit=1 rows resolves to a schema-stable zeroed aggregate, never null", async () => {
+    const { status, body } = await gql(
+      '{ validator(hotkey: "5NoRows") { hotkey featured subnet_count total_stake_tao captured_at block_number subnets { netuid } } }',
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.validator, {
+      hotkey: "5NoRows",
+      featured: false,
+      subnet_count: 0,
+      total_stake_tao: 0,
+      captured_at: null,
+      block_number: null,
+      subnets: [],
+    });
+  });
+
+  test("validator: resolves Postgres-tier detail data, normalizing captured_at/block_number", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          hotkey: "5Validator",
+          coldkey: "5Coldkey",
+          coldkey_identity: { has_identity: false },
+          coldkey_count: 1,
+          subnet_count: 2,
+          take: 0.1,
+          total_stake_tao: 2000,
+          root_stake_tao: 500,
+          alpha_stake_tao: 1500,
+          total_emission_tao: 8,
+          nominator_count: null,
+          apy_estimate: null,
+          apy_estimate_eligible_subnet_count: 0,
+          avg_validator_trust: 0.8,
+          max_validator_trust: 0.85,
+          captured_at: "2026-07-14T01:00:00.000Z",
+          block_number: 200,
+          subnets: [
+            { netuid: 1, uid: 5, stake_tao: 500, emission_tao: 2 },
+            { netuid: 3, uid: 9, stake_tao: 1500, emission_tao: 6 },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      '{ validator(hotkey: "5Validator") { hotkey subnet_count captured_at block_number subnets { netuid stake_tao } } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.validator.hotkey, "5Validator");
+    assert.equal(body.data.validator.subnet_count, 2);
+    assert.equal(body.data.validator.captured_at, "2026-07-14T01:00:00.000Z");
+    assert.equal(body.data.validator.block_number, 200);
+    assert.deepEqual(body.data.validator.subnets, [
+      { netuid: 1, stake_tao: 500 },
+      { netuid: 3, stake_tao: 1500 },
+    ]);
+  });
+
+  test("validators / validator are weighted as fan-out fields", () => {
+    assert.equal(FIELD_COMPLEXITY.validators, 5);
+    assert.equal(FIELD_COMPLEXITY.validator, 5);
+  });
+});
+
 // --- Subscription.chainEvents (#4983, ADR 0015) ---------------------------------
 //
 // The DO-runtime side of this wiring (ChainFirehoseHub.subscribeChainEvents,


### PR DESCRIPTION
## Pick The Right Template

Use the matching PR template so the submission gate can classify your PR
correctly:

- [Subnet surface](?template=surface.md): one `registry/subnets/<slug>.json`
  file — a community surface added with `npm run surface:add`; for a missing
  subnet manifest, scaffold it first with `npm run subnet:new` in the same file
  (optionally plus one `registry/providers/*.json` for a debut provider).
- [Provider/operator profile](?template=provider-profile.md): one
  `registry/providers/*.json` file only.
- [Backend/code change](?template=backend-code.md): scripts, schemas,
  contracts, workflows, or registry generator logic.
- [Docs-only change](?template=docs-only.md): README or docs edits only.

For data submissions, do not edit generated `public/metagraph/**` artifacts,
native snapshots, scripts, workflows, or package files.

## Summary

- Add `Query.validators` / `Query.validator` to the GraphQL SDL, mirroring
  `GET /api/v1/validators` and `GET /api/v1/validators/{hotkey}` (and the
  MCP `list_global_validators`/`get_validator_detail` tools), which
  previously had no GraphQL presence.

## What Changed

- `src/graphql.mjs`:
  - New SDL: `Query.validators(sort: String, limit: Int): ValidatorList!`
    and `Query.validator(hotkey: String!): Validator`, plus
    `ValidatorList`/`Validator`/`Identity` types mirroring
    `buildGlobalValidators`'/`buildValidatorDetail`'s actual output shape
    (`src/metagraph-neurons.mjs`).
  - Both resolvers go through the same `tryPostgresTier(env, request,
    "METAGRAPH_NEURONS_SOURCE")` + pure-fallback contract REST uses, so a
    cold/retired D1 tier degrades to a schema-stable empty leaderboard /
    zeroed single-validator aggregate instead of a GraphQL error. Since
    GraphQL's own inbound request is a POST to `/api/v1/graphql`, the
    resolvers synthesize the GET request `tryPostgresTier` expects, the
    same technique the `extrinsics`/`extrinsic` resolvers already use.
  - `sort` is validated against the same `GLOBAL_VALIDATOR_SORTS` allow-list
    `handleGlobalValidators` uses, rejecting an unsupported value as a
    `BAD_USER_INPUT` `GraphQLError` before the tier is ever reached (matching
    `compare`'s existing error shape); `limit` is clamped, matching how
    `extrinsics`/`blocks` already handle their own limit args in this file.
  - `buildGlobalValidators`' per-hotkey leaderboard entries and
    `buildValidatorDetail`'s single-hotkey aggregate share most field names
    but diverge on a few (`featured`/`uid_count` only exist on the former;
    `captured_at`/`block_number` vs `latest_captured_at`/`latest_block_number`)
    -- `validatorNode` normalizes both into one `Validator` shape so
    `validators.items` and `validator()` return the same GraphQL type.
  - `validators`/`validator` added to `FIELD_COMPLEXITY` at the standard
    relationship weight.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5573`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none
      touched — GraphQL SDL is not part of the OpenAPI/REST contract).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (none —
      this only extends the GraphQL SDL, `validate:contract-drift` confirms no
      REST/OpenAPI drift).

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:contract-drift`
- [x] `npx vitest run` (278 files, 8296 tests passing)
- [x] `npx vitest run tests/graphql.test.mjs --coverage --coverage.include='src/graphql.mjs'`
      (124/124 passing; every line/branch this diff added is covered — the
      only uncovered branches, in the pre-existing `health`/`opportunity_boards`
      resolvers, are untouched by this diff)

New tests added to `tests/graphql.test.mjs` cover: a cold/no-tier store
falling back to a schema-stable empty page, resolving Postgres-tier
leaderboard rows (including the `latest_*` → `captured_at`/`block_number`
normalization), `sort`/`limit` args forwarded as query params to the
Postgres tier, an unsupported `sort` rejected as `BAD_USER_INPUT` before ever
reaching the tier, a malformed Postgres-tier body degrading to a
schema-stable empty page, a hotkey with no `validator_permit=1` rows
resolving to a zeroed aggregate (never `null`), and resolving Postgres-tier
detail data, and the `FIELD_COMPLEXITY` weights.

Closes #5573
