### PR TITLE
fix(ui): add a copy affordance for hotkeys in the subnet neuron table

### DIFF
--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { Download } from "lucide-react";
+import { CopyButton } from "@jsonbored/ui-kit";
 import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
 import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -210,25 +211,28 @@ export function NeuronTable({
                     <div className="flex items-center gap-1.5">
                       {n.featured ? <FeaturedBadge /> : null}
                       {n.hotkey ? (
-                        isValidator ? (
-                          <Link
-                            to="/validators/$hotkey"
-                            params={{ hotkey: n.hotkey }}
-                            className="text-ink-muted hover:text-ink hover:underline"
-                            title={n.hotkey}
-                          >
-                            {shortHash(n.hotkey) ?? n.hotkey}
-                          </Link>
-                        ) : (
-                          <Link
-                            to="/accounts/$ss58"
-                            params={{ ss58: n.hotkey }}
-                            className="text-ink-muted hover:text-ink hover:underline"
-                            title={n.hotkey}
-                          >
-                            {shortHash(n.hotkey) ?? n.hotkey}
-                          </Link>
-                        )
+                        <>
+                          {isValidator ? (
+                            <Link
+                              to="/validators/$hotkey"
+                              params={{ hotkey: n.hotkey }}
+                              className="text-ink-muted hover:text-ink hover:underline"
+                              title={n.hotkey}
+                            >
+                              {shortHash(n.hotkey) ?? n.hotkey}
+                            </Link>
+                          ) : (
+                            <Link
+                              to="/accounts/$ss58"
+                              params={{ ss58: n.hotkey }}
+                              className="text-ink-muted hover:text-ink hover:underline"
+                              title={n.hotkey}
+                            >
+                              {shortHash(n.hotkey) ?? n.hotkey}
+                            </Link>
+                          )}
+                          <CopyButton value={n.hotkey} label="hotkey" />
+                        </>
                       ) : (
                         "—"
                       )}


### PR DESCRIPTION
Closes #5565

## What

`apps/ui/src/components/metagraphed/neuron-table.tsx` renders each neuron's hotkey as a plain link with only a `title` tooltip — no copy affordance — in both the validator (`/validators/$hotkey`) and non-validator (`/accounts/$ss58`) branches. A user who wants the full hotkey has to read the truncated `shortHash` display or click through to the detail page. `NeuronTable` is rendered on the subnet-detail page via both `metagraph-panel.tsx` and `validators-panel.tsx`.

Every comparable identifier table elsewhere in the app pairs the truncated value with a copy affordance (`validator-nominators-table.tsx` uses `CopyableCode`; the block/extrinsic explorer tables use `CopyButton`). This is the same gap class as #5339, but that issue is scoped to the separate `validators.index.tsx` table — this is the distinct `NeuronTable` component on the subnet-detail page.

## Fix

Added `CopyButton` (imported from `@jsonbored/ui-kit`, matching the precedent in `blocks.index.tsx`) next to the hotkey link in both rendering branches:

```diff
 {n.hotkey ? (
-  isValidator ? (
-    <Link to="/validators/$hotkey" ...>{shortHash(n.hotkey) ?? n.hotkey}</Link>
-  ) : (
-    <Link to="/accounts/$ss58" ...>{shortHash(n.hotkey) ?? n.hotkey}</Link>
-  )
+  <>
+    {isValidator ? (
+      <Link to="/validators/$hotkey" ...>{shortHash(n.hotkey) ?? n.hotkey}</Link>
+    ) : (
+      <Link to="/accounts/$ss58" ...>{shortHash(n.hotkey) ?? n.hotkey}</Link>
+    )}
+    <CopyButton value={n.hotkey} label="hotkey" />
+  </>
 ) : "—"}
```

Both branches get identical treatment, so the fix is consistent regardless of validator/miner role. No change to the links themselves or the column layout.

## Verification

Verified on both call sites this component is rendered from — `metagraph-panel.tsx`'s Metagraph tab table and `validators-panel.tsx`'s Validators tab table both show the copy icon next to every hotkey.

## Screenshots

3 viewports × 2 themes, before/after (Validators tab table):

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/before-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/after-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-neuron-table-hotkey-copy-5565/after-mobile-dark.png)<br><sub>after</sub> |

## Acceptance criteria

- [x] `neuron-table.tsx`: hotkey cell has a working copy button in both rendering branches
- [x] Verified on both call sites (`metagraph-panel.tsx`, `validators-panel.tsx`)
- [x] Before/after screenshots included

## Testing

```
npx tsc --noEmit                    # no new errors in this file
npx eslint neuron-table.tsx         # clean aside from pre-existing CRLF line-ending noise (core.autocrlf), confirmed via `git diff --check`
npx prettier --check neuron-table.tsx   # same CRLF-only noise, diff itself is clean
```

Diff is 23 insertions, 19 deletions (re-wrapping the existing ternary in a fragment plus the new `CopyButton`), in the exact file the issue names.
