### PR TITLE
fix(schemas): enforce http/ws scheme pattern on Surface.url/schema_url and candidate url (#5582)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7627,7 +7627,10 @@ export interface components {
             };
             /** @enum {unknown} */
             schema_status?: "machine-readable" | "ui-only" | "not-captured";
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://example.com/openapi.json
+             */
             schema_url?: string;
             source_urls?: string[];
             /** @description Freshness TTL (#1006): true when last_verified_at is older than the per-kind window (callable surfaces ~30d, identity surfaces ~90-120d), measured against the dataset's native-snapshot captured_at. false when fresh or unverified. */
@@ -7635,7 +7638,10 @@ export interface components {
             status?: components["schemas"]["HealthStatus"];
             subnet_name?: string;
             subnet_slug?: string;
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://example.com
+             */
             url: string;
             verification?: {
                 archived?: boolean;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -20613,7 +20613,11 @@
             ]
           },
           "schema_url": {
+            "examples": [
+              "https://example.com/openapi.json"
+            ],
             "format": "uri",
+            "pattern": "^(?:[Hh][Tt][Tt][Pp][Ss]?|[Ww][Ss][Ss]?)://",
             "type": "string"
           },
           "source_urls": {
@@ -20637,7 +20641,11 @@
             "type": "string"
           },
           "url": {
+            "examples": [
+              "https://example.com"
+            ],
             "format": "uri",
+            "pattern": "^(?:[Hh][Tt][Tt][Pp][Ss]?|[Ww][Ss][Ss]?)://",
             "type": "string"
           },
           "verification": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7627,7 +7627,10 @@ export interface components {
             };
             /** @enum {unknown} */
             schema_status?: "machine-readable" | "ui-only" | "not-captured";
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://example.com/openapi.json
+             */
             schema_url?: string;
             source_urls?: string[];
             /** @description Freshness TTL (#1006): true when last_verified_at is older than the per-kind window (callable surfaces ~30d, identity surfaces ~90-120d), measured against the dataset's native-snapshot captured_at. false when fresh or unverified. */
@@ -7635,7 +7638,10 @@ export interface components {
             status?: components["schemas"]["HealthStatus"];
             subnet_name?: string;
             subnet_slug?: string;
-            /** Format: uri */
+            /**
+             * Format: uri
+             * @example https://example.com
+             */
             url: string;
             verification?: {
                 archived?: boolean;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -20591,7 +20591,11 @@
             ]
           },
           "schema_url": {
+            "examples": [
+              "https://example.com/openapi.json"
+            ],
             "format": "uri",
+            "pattern": "^(?:[Hh][Tt][Tt][Pp][Ss]?|[Ww][Ss][Ss]?)://",
             "type": "string"
           },
           "source_urls": {
@@ -20615,7 +20619,11 @@
             "type": "string"
           },
           "url": {
+            "examples": [
+              "https://example.com"
+            ],
             "format": "uri",
+            "pattern": "^(?:[Hh][Tt][Tt][Pp][Ss]?|[Ww][Ss][Ss]?)://",
             "type": "string"
           },
           "verification": {

--- a/schemas/candidate-surface.schema.json
+++ b/schemas/candidate-surface.schema.json
@@ -63,7 +63,9 @@
     },
     "url": {
       "type": "string",
-      "format": "uri"
+      "format": "uri",
+      "pattern": "^(?:[Hh][Tt][Tt][Pp][Ss]?|[Ww][Ss][Ss]?)://",
+      "examples": ["https://example.com"]
     },
     "source_url": {
       "type": "string",

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -224,7 +224,9 @@
           },
           "url": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "pattern": "^(?:[Hh][Tt][Tt][Pp][Ss]?|[Ww][Ss][Ss]?)://",
+            "examples": ["https://example.com"]
           },
           "provider": {
             "type": "string"
@@ -250,7 +252,9 @@
           },
           "schema_url": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "pattern": "^(?:[Hh][Tt][Tt][Pp][Ss]?|[Ww][Ss][Ss]?)://",
+            "examples": ["https://example.com/openapi.json"]
           },
           "schema_status": {
             "enum": ["machine-readable", "ui-only", "not-captured"]

--- a/src/openapi-sample.mjs
+++ b/src/openapi-sample.mjs
@@ -56,6 +56,10 @@ function valueForPattern(pattern, name = "") {
       // http(s)-only guard (e.g. provider logo_url) — keep the sample a valid
       // absolute URL so it satisfies both the pattern and format: uri.
       return "https://api.metagraph.sh/example";
+    case "^(?:[Hh][Tt][Tt][Pp][Ss]?|[Ww][Ss][Ss]?)://":
+      // http(s)/ws(s) guard (Surface.url/schema_url — a surface may point at a
+      // WebSocket RPC endpoint) — keep the sample a valid absolute URL.
+      return "https://api.metagraph.sh/example";
     default:
       return "example";
   }

--- a/tests/surface-url-scheme-pattern.test.mjs
+++ b/tests/surface-url-scheme-pattern.test.mjs
@@ -1,0 +1,92 @@
+// #5582: Surface.url / Surface.schema_url (and the candidate-surface url) were
+// declared with `format: uri` only, which ajv-formats accepts for any RFC-3986
+// scheme (javascript:, ftp:, mailto:, data:). scripts/validate.mjs's isValidUrl
+// already restricts these to http/https/ws/wss at runtime, so this closed the
+// gap between the schema's documented contract and that enforcement. Unlike the
+// Provider fix (#5553, http(s)-only), a Surface may legitimately point at a
+// WebSocket RPC endpoint, so the pattern must also allow ws(s)://.
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { readJson, repoRoot } from "../scripts/lib.mjs";
+
+const SCHEME_PATTERN = "^(?:[Hh][Tt][Tt][Pp][Ss]?|[Ww][Ss][Ss]?)://";
+
+// candidate-surface.schema.json is self-contained (no $refs), so it validates
+// standalone with ajv — the same shape as tests/provider-url-http-pattern.test.mjs.
+const ajv = new Ajv2020({
+  strict: false,
+  validateFormats: true,
+  allErrors: true,
+});
+addFormats(ajv);
+const candidateSchema = await readJson(
+  path.join(repoRoot, "schemas/candidate-surface.schema.json"),
+);
+const validateCandidate = ajv.compile(candidateSchema);
+
+const GOOD_CANDIDATE = {
+  schema_version: 1,
+  id: "sn-1-example-api",
+  netuid: 1,
+  state: "verified",
+  name: "Example API",
+  kind: "subnet-api",
+  url: "https://api.example.com",
+  source_url: "https://github.com/example/repo",
+  provider: "example",
+  auth_required: false,
+  public_safe: true,
+};
+
+describe("candidate-surface url scheme pattern (#5582)", () => {
+  test("the known-good candidate fixture is valid", () => {
+    assert.equal(
+      validateCandidate(GOOD_CANDIDATE),
+      true,
+      JSON.stringify(validateCandidate.errors),
+    );
+  });
+
+  for (const scheme of [
+    "https://api.example.com",
+    "http://api.example.com",
+    "wss://rpc.example.com",
+    "ws://rpc.example.com",
+  ]) {
+    test(`accepts a ${scheme.split(":")[0]}:// url`, () => {
+      const good = { ...GOOD_CANDIDATE, url: scheme };
+      assert.equal(
+        validateCandidate(good),
+        true,
+        JSON.stringify(validateCandidate.errors),
+      );
+    });
+  }
+
+  for (const bad of [
+    "mailto:ops@example.com",
+    "ftp://files.example.com",
+    "javascript:alert(1)",
+    "data:text/plain,hi",
+  ]) {
+    test(`rejects a non-http/ws url (${bad.split(":")[0]}:)`, () => {
+      const doc = { ...GOOD_CANDIDATE, url: bad };
+      assert.equal(validateCandidate(doc), false);
+    });
+  }
+});
+
+describe("Surface component url/schema_url carry the http/ws scheme pattern (#5582)", () => {
+  test("Surface.url and Surface.schema_url declare the http/ws pattern", async () => {
+    const surfaces = await readJson(
+      path.join(repoRoot, "schemas/components/04-surfaces.schema.json"),
+    );
+    const surface = surfaces.components?.schemas?.Surface?.properties;
+    assert.ok(surface, "04-surfaces must define a Surface schema");
+    assert.equal(surface.url?.pattern, SCHEME_PATTERN);
+    assert.equal(surface.schema_url?.pattern, SCHEME_PATTERN);
+  });
+});


### PR DESCRIPTION
## Summary

`schemas/components/04-surfaces.schema.json`'s `Surface.url` and `Surface.schema_url` were declared with `"format": "uri"` only — no scheme-restricting `pattern` — so ajv-formats accepted any RFC-3986 scheme (`javascript:`, `ftp:`, `mailto:`, `data:`). The runtime validator `scripts/validate.mjs`'s `isValidUrl` is stricter (restricts to `http/https/ws/wss`), so the schema's documented contract was weaker than what's enforced — the same class of gap #5553 fixed for the `Provider` schema, on `Surface`. (`Surface.auth.token_url` on the same object already carries a scheme pattern.)

Unlike #5553's http(s)-only pattern, a `Surface.url` may legitimately point at a **WebSocket RPC endpoint** (`isValidUrl` allows `ws:`/`wss:` for exactly this reason), so the added pattern must allow `ws(s)://` too.

## Change

- Added `"pattern": "^(?:[Hh][Tt][Tt][Pp][Ss]?|[Ww][Ss][Ss]?)://"` (http/https/ws/wss, case-insensitive scheme) to `Surface.url` and `Surface.schema_url` in `schemas/components/04-surfaces.schema.json`, and to `url` in `schemas/candidate-surface.schema.json` (the pre-promotion candidate shape had the identical gap). Added matching `examples` to each field.
- `src/openapi-sample.mjs`: added a `valueForPattern` case for the new scheme pattern so the deterministically-generated OpenAPI response examples emit a valid absolute URL (`https://api.metagraph.sh/example`) instead of the bare `"example"` placeholder, which the pattern (correctly) rejects.
- Ran `npm run build`; committed the regenerated `schemas/api-components.schema.json`, `public/metagraph/openapi.json`, `public/metagraph/types.d.ts`, and `packages/contract/index.d.ts` (the pattern flows into the OpenAPI contract + the generated types' JSDoc), so `validate:contract-drift` stays green.

## Regression test

`tests/surface-url-scheme-pattern.test.mjs`: compiles the self-contained `candidate-surface.schema.json` with ajv and asserts a known-good candidate passes; `https`/`http`/`ws`/`wss` urls all pass (proving the ws allowance that distinguishes this from #5553); and `mailto:`/`ftp:`/`javascript:`/`data:` urls all fail. A second check asserts `Surface.url`/`Surface.schema_url` in the component schema carry the pattern (guards against removal). 10 assertions.

## Validation (full "checks" gate, run locally)

- `validate:contract-drift`, `validate:schema-enums`, `validate:openapi-examples`, `validate:generated-client`, `validate:committed-seed`, `validate:surface` — all pass.
- `npx vitest run tests/surface-url-scheme-pattern.test.mjs` — 10 passed.
- `npm run validate:schemas` on existing registry data — passes (every existing surface already uses http/ws schemes).

Closes #5582
