### PR TITLE
feat(graphql): add Query.accounts / Query.account

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -36,7 +36,16 @@ import {
   buildValidatorDetail,
   overlayFeaturedValidators,
 } from "./metagraph-neurons.mjs";
+import {
+  ACCOUNTS_LIST_LIMIT_DEFAULT,
+  ACCOUNTS_LIST_LIMIT_MAX,
+  ACCOUNTS_LIST_SORTS,
+  DEFAULT_ACCOUNTS_LIST_SORT,
+  buildAccountsList,
+} from "./accounts-list.mjs";
+import { buildAccountSummary } from "./account-events.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
+import { SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
 
 export const GRAPHQL_MAX_DEPTH = 7;
 export const GRAPHQL_MAX_COMPLEXITY = 50;
@@ -78,6 +87,10 @@ export const SDL = `
     validators(sort: String, limit: Int): ValidatorList!
     "One validator's cross-subnet aggregate by hotkey; a hotkey with no validator_permit=1 rows resolves to a schema-stable zeroed aggregate, never null. Mirrors GET /api/v1/validators/{hotkey}."
     validator(hotkey: String!): Validator
+    "Site-wide accounts leaderboard -- every currently-registered hotkey, aggregated cross-subnet from the current neurons snapshot. Mirrors GET /api/v1/accounts."
+    accounts(sort: String, limit: Int): AccountList!
+    "One account's cross-subnet event-history summary by ss58 address; an address with no matching account_events rows resolves to a schema-stable zero summary, never null. Mirrors GET /api/v1/accounts/{ss58}."
+    account(ss58: String!): AccountSummary
   }
 
   type SubnetList {
@@ -421,6 +434,96 @@ export const SDL = `
     captured_at: String
   }
 
+  type AccountList {
+    items: [AccountEntry!]!
+    total: Int!
+    sort: String!
+    captured_at: String
+    block_number: Int
+  }
+
+  type AccountEntry {
+    hotkey: String!
+    coldkey: String
+    coldkey_count: Int
+    subnet_count: Int
+    uid_count: Int
+    validator_count: Int
+    miner_count: Int
+    total_stake_tao: Float
+    total_emission_tao: Float
+    stake_dominance: Float
+    latest_captured_at: String
+    latest_block_number: Int
+    "Per-subnet stake/emission rows for this account, capped at the top 10 by stake."
+    subnets: [AccountSubnet!]!
+  }
+
+  type AccountSubnet {
+    netuid: Int!
+    uid: Int
+    stake_tao: Float
+    emission_tao: Float
+  }
+
+  type AccountSummary {
+    ss58: String!
+    event_count: Int!
+    subnet_count: Int!
+    "True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null."
+    event_scan_capped: Boolean!
+    first_block: Int
+    last_block: Int
+    first_seen_at: String
+    last_seen_at: String
+    event_kinds: [AccountEventKind!]!
+    "Where this hotkey is currently registered + staked (the live cross-subnet footprint)."
+    registrations: [AccountRegistration!]!
+    recent_events: [AccountEvent!]!
+    activity: AccountActivity!
+  }
+
+  type AccountEventKind {
+    kind: String!
+    count: Int!
+  }
+
+  type AccountRegistration {
+    netuid: Int
+    uid: Int
+    stake_tao: Float
+    validator_permit: Boolean!
+    active: Boolean!
+  }
+
+  type AccountEvent {
+    block_number: Int
+    event_index: Int
+    event_kind: String
+    hotkey: String
+    coldkey: String
+    netuid: Int
+    uid: Int
+    amount_tao: Float
+    alpha_amount: Float
+    observed_at: String
+    extrinsic_index: Int
+  }
+
+  "Signing-activity aggregate from the extrinsics tier, matched by signer only -- an account queried by a key that did not sign returns tx_count 0, other fields null/empty."
+  type AccountActivity {
+    tx_count: Int!
+    last_tx_block: Int
+    last_tx_at: String
+    total_fee_tao: Float
+    modules_called: [AccountModuleCall!]!
+  }
+
+  type AccountModuleCall {
+    call_module: String!
+    count: Int!
+  }
+
   # Realtime chain-event firehose (#4983, ADR 0015) -- a thin protocol adapter
   # over the SAME ChainFirehoseHub Durable Object connection #4982's SSE/WS
   # transports use, not a second event pipeline. Reached over WebSocket only
@@ -557,6 +660,8 @@ export const FIELD_COMPLEXITY = {
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
   validators: RELATIONSHIP_FIELD_COMPLEXITY,
   validator: RELATIONSHIP_FIELD_COMPLEXITY,
+  accounts: RELATIONSHIP_FIELD_COMPLEXITY,
+  account: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -946,6 +1051,30 @@ function validatorNode(validator) {
   };
 }
 
+// buildAccountSummary always returns a full-shaped object (a cold/absent store
+// still yields a zeroed summary, never a partial one), but a malformed
+// Postgres-tier response body degrades to `{}` -- normalized here the same way
+// extrinsicNode/ExtrinsicDetail's `data.ref ?? ref` fallback degrades a
+// malformed extrinsic-detail body, so a bad upstream body still resolves to
+// the same schema-stable zero shape as a genuinely cold store, not a
+// Non-Null-field error.
+function accountSummaryNode(data, ss58) {
+  return {
+    ss58: data.ss58 ?? ss58,
+    event_count: data.event_count ?? 0,
+    subnet_count: data.subnet_count ?? 0,
+    event_scan_capped: data.event_scan_capped === true,
+    first_block: data.first_block ?? null,
+    last_block: data.last_block ?? null,
+    first_seen_at: data.first_seen_at ?? null,
+    last_seen_at: data.last_seen_at ?? null,
+    event_kinds: data.event_kinds || [],
+    registrations: data.registrations || [],
+    recent_events: data.recent_events || [],
+    activity: data.activity || { tx_count: 0, modules_called: [] },
+  };
+}
+
 function providerNode(provider) {
   const netuids = provider?.netuids || [];
   return {
@@ -1270,6 +1399,58 @@ const rootValue = {
         "METAGRAPH_NEURONS_SOURCE",
       )) ?? buildValidatorDetail([], hotkey);
     return validatorNode(data);
+  },
+
+  async accounts({ sort, limit }, context) {
+    const requestedSort = sort ?? DEFAULT_ACCOUNTS_LIST_SORT;
+    if (!ACCOUNTS_LIST_SORTS.includes(requestedSort)) {
+      throw new GraphQLError(
+        `"${requestedSort}" is not a supported sort. Supported: ${ACCOUNTS_LIST_SORTS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: ACCOUNTS_LIST_LIMIT_DEFAULT,
+      maxLimit: ACCOUNTS_LIST_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("sort", requestedSort);
+    params.set("limit", String(safeLimit));
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/accounts", params),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ??
+      buildAccountsList([], {
+        sort: requestedSort,
+        limit: safeLimit,
+      });
+    return {
+      items: data.accounts || [],
+      total: data.account_count ?? 0,
+      sort: data.sort ?? requestedSort,
+      captured_at: data.captured_at ?? null,
+      block_number: data.block_number ?? null,
+    };
+  },
+
+  async account({ ss58 }, context) {
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}`,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildAccountSummary(ss58, {});
+    return accountSummaryNode(data, ss58);
   },
 };
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -2227,6 +2227,306 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
   });
 });
 
+describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderboard)", () => {
+  const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  test("accounts: cold/no-tier store returns a schema-stable empty page (fallback builder)", async () => {
+    const { status, body } = await gql(
+      "{ accounts { items { hotkey } total sort captured_at block_number } }",
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.accounts, {
+      items: [],
+      total: 0,
+      sort: "total_stake",
+      captured_at: null,
+      block_number: null,
+    });
+  });
+
+  test("accounts: resolves Postgres-tier rows", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            sort: "total_stake",
+            limit: 5,
+            captured_at: "2026-07-15T00:00:00.000Z",
+            block_number: 300,
+            account_count: 1,
+            accounts: [
+              {
+                hotkey: "5Account",
+                coldkey: "5Coldkey",
+                coldkey_count: 1,
+                subnet_count: 2,
+                uid_count: 2,
+                validator_count: 1,
+                miner_count: 1,
+                total_stake_tao: 1500,
+                total_emission_tao: 7,
+                stake_dominance: 0.42,
+                latest_captured_at: "2026-07-15T00:00:00.000Z",
+                latest_block_number: 300,
+                subnets: [
+                  { netuid: 1, uid: 5, stake_tao: 1000, emission_tao: 5 },
+                  { netuid: 3, uid: 9, stake_tao: 500, emission_tao: 2 },
+                ],
+              },
+            ],
+          }),
+      },
+    };
+    const { status, body } = await gql(
+      '{ accounts(sort: "total_stake", limit: 5) { items { hotkey coldkey subnet_count total_stake_tao stake_dominance latest_captured_at latest_block_number subnets { netuid uid stake_tao emission_tao } } total sort captured_at block_number } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.accounts.total, 1);
+    assert.equal(body.data.accounts.sort, "total_stake");
+    assert.equal(body.data.accounts.captured_at, "2026-07-15T00:00:00.000Z");
+    assert.equal(body.data.accounts.block_number, 300);
+    const item = body.data.accounts.items[0];
+    assert.equal(item.hotkey, "5Account");
+    assert.equal(item.coldkey, "5Coldkey");
+    assert.equal(item.subnet_count, 2);
+    assert.equal(item.total_stake_tao, 1500);
+    assert.equal(item.stake_dominance, 0.42);
+    assert.deepEqual(item.subnets, [
+      { netuid: 1, uid: 5, stake_tao: 1000, emission_tao: 5 },
+      { netuid: 3, uid: 9, stake_tao: 500, emission_tao: 2 },
+    ]);
+  });
+
+  test("accounts: sort and limit args are forwarded as query params to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            sort: "uid_count",
+            limit: 5,
+            captured_at: null,
+            block_number: null,
+            account_count: 0,
+            accounts: [],
+          });
+        },
+      },
+    };
+    await gql('{ accounts(sort: "uid_count", limit: 5) { total } }', env);
+    assert.equal(capturedUrl.pathname, "/api/v1/accounts");
+    assert.equal(capturedUrl.searchParams.get("sort"), "uid_count");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+  });
+
+  test("accounts: an omitted sort/limit forwards the defaults to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            sort: "total_stake",
+            limit: 20,
+            captured_at: null,
+            block_number: null,
+            account_count: 0,
+            accounts: [],
+          });
+        },
+      },
+    };
+    await gql("{ accounts { total } }", env);
+    assert.equal(capturedUrl.searchParams.get("sort"), "total_stake");
+    assert.equal(capturedUrl.searchParams.get("limit"), "20");
+  });
+
+  test("accounts: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      "{ accounts { items { hotkey } total sort captured_at block_number } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.accounts, {
+      items: [],
+      total: 0,
+      sort: "total_stake",
+      captured_at: null,
+      block_number: null,
+    });
+  });
+
+  test("accounts: an unsupported sort value is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      '{ accounts(sort: "not_a_real_sort") { total } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("account: an invalid ss58 is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      '{ account(ss58: "not-a-valid-address") { ss58 } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    // `account` is a nullable field (unlike `validators`/`accounts`), so the
+    // thrown error nulls out just this field, not the whole `data` object.
+    assert.equal(body.data.account, null);
+    assert.equal(called, false);
+  });
+
+  test("account: a never-seen address (cold store) resolves to a schema-stable zero summary, never null", async () => {
+    const { status, body } = await gql(
+      `{ account(ss58: "${SS58}") { ss58 event_count subnet_count event_scan_capped first_block last_block event_kinds { kind } registrations { netuid } recent_events { block_number } activity { tx_count modules_called { call_module } } } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account, {
+      ss58: SS58,
+      event_count: 0,
+      subnet_count: 0,
+      event_scan_capped: false,
+      first_block: null,
+      last_block: null,
+      event_kinds: [],
+      registrations: [],
+      recent_events: [],
+      activity: { tx_count: 0, modules_called: [] },
+    });
+  });
+
+  test("account: resolves Postgres-tier detail data", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            ss58: SS58,
+            event_count: 12,
+            subnet_count: 2,
+            event_scan_capped: false,
+            first_block: 100,
+            last_block: 500,
+            first_seen_at: "2026-06-01T00:00:00.000Z",
+            last_seen_at: "2026-07-14T00:00:00.000Z",
+            event_kinds: [{ kind: "Transfer", count: 5 }],
+            registrations: [
+              {
+                netuid: 1,
+                uid: 5,
+                stake_tao: 10,
+                validator_permit: true,
+                active: true,
+              },
+            ],
+            recent_events: [
+              { block_number: 500, event_index: 0, event_kind: "Transfer" },
+            ],
+            activity: {
+              tx_count: 3,
+              last_tx_block: 490,
+              last_tx_at: "2026-07-13T00:00:00.000Z",
+              total_fee_tao: 0.01,
+              modules_called: [{ call_module: "SubtensorModule", count: 3 }],
+            },
+          }),
+      },
+    };
+    const { status, body } = await gql(
+      `{ account(ss58: "${SS58}") { ss58 event_count subnet_count first_block last_block event_kinds { kind count } registrations { netuid stake_tao validator_permit active } recent_events { block_number event_kind } activity { tx_count last_tx_block total_fee_tao modules_called { call_module count } } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.account.ss58, SS58);
+    assert.equal(body.data.account.event_count, 12);
+    assert.equal(body.data.account.subnet_count, 2);
+    assert.equal(body.data.account.first_block, 100);
+    assert.equal(body.data.account.last_block, 500);
+    assert.deepEqual(body.data.account.event_kinds, [
+      { kind: "Transfer", count: 5 },
+    ]);
+    assert.deepEqual(body.data.account.registrations, [
+      { netuid: 1, stake_tao: 10, validator_permit: true, active: true },
+    ]);
+    assert.deepEqual(body.data.account.recent_events, [
+      { block_number: 500, event_kind: "Transfer" },
+    ]);
+    assert.deepEqual(body.data.account.activity, {
+      tx_count: 3,
+      last_tx_block: 490,
+      total_fee_tao: 0.01,
+      modules_called: [{ call_module: "SubtensorModule", count: 3 }],
+    });
+  });
+
+  test("account: a malformed Postgres-tier body degrades to a schema-stable zero summary", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      `{ account(ss58: "${SS58}") { ss58 event_count subnet_count event_scan_capped first_block last_block event_kinds { kind } registrations { netuid } recent_events { block_number } activity { tx_count modules_called { call_module } } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account, {
+      ss58: SS58,
+      event_count: 0,
+      subnet_count: 0,
+      event_scan_capped: false,
+      first_block: null,
+      last_block: null,
+      event_kinds: [],
+      registrations: [],
+      recent_events: [],
+      activity: { tx_count: 0, modules_called: [] },
+    });
+  });
+
+  test("accounts / account are weighted as fan-out fields", () => {
+    assert.equal(FIELD_COMPLEXITY.accounts, 5);
+    assert.equal(FIELD_COMPLEXITY.account, 5);
+  });
+});
+
 // --- Subscription.chainEvents (#4983, ADR 0015) ---------------------------------
 //
 // The DO-runtime side of this wiring (ChainFirehoseHub.subscribeChainEvents,


### PR DESCRIPTION
## Summary

- Adds `Query.accounts` / `Query.account` to the GraphQL schema, mirroring `GET /api/v1/accounts` and `GET /api/v1/accounts/{ss58}` (and the `list_accounts`/`get_account` MCP tools) — closing the same gap `Query.validators`/`Query.validator` (#5616) closed for the validators leaderboard.

## What Changed

- `src/graphql.mjs`:
  - New SDL: `Query.accounts(sort, limit): AccountList!`, `Query.account(ss58): AccountSummary`, plus `AccountList`, `AccountEntry`, `AccountSubnet`, `AccountSummary`, `AccountEventKind`, `AccountRegistration`, `AccountEvent`, `AccountActivity`, `AccountModuleCall` types whose fields mirror `buildAccountsList`'s (`src/accounts-list.mjs`) and `buildAccountSummary`'s (`src/account-events.mjs`) actual output shapes.
  - `accounts` resolves via `tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")` — the same flag the REST accounts-list route uses — falling back to `buildAccountsList([], { sort, limit })` on a cold tier.
  - `account` resolves via the distinct `tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")` flag, matching the REST split exactly (never collapsed onto one flag), falling back to `buildAccountSummary(ss58, {})`.
  - `ss58` is validated against the shared `SS58_ADDRESS_PATTERN` (`workers/config.mjs`) before any Postgres-tier call — an invalid address raises a `GraphQLError` (`BAD_USER_INPUT`) instead of reaching the tier with a malformed path.
  - `sort` on `accounts` is validated against the same `ACCOUNTS_LIST_SORTS` allow-list `workers/request-handlers/entities.mjs` uses.
  - `accounts`/`account` added to `FIELD_COMPLEXITY` at the relationship weight, matching every other collection/detail root field.
- `tests/graphql.test.mjs`: cold-store fallback, Postgres-tier resolution, sort/limit query-param forwarding, malformed-body degradation, unsupported-sort rejection, invalid-ss58 rejection, and the never-seen-address schema-stable zero summary (never `null`), for both fields.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5574`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (no schema change in this PR — no artifacts regenerated)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (GraphQL SDL-only; no `schemas/` change)

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate`
- [x] `npm test` (full suite, 278 files / 8307 tests)
- [x] `npm run test:coverage -- tests/graphql.test.mjs` (100% statements/lines/functions, 97.93% branches on `graphql.mjs`; the two uncovered branch groups are pre-existing `health`/`opportunity_boards` resolver code untouched by this diff — every branch this PR adds is covered)
- [x] `git diff --check`

Closes #5574
