### PR TITLE
fix(ui): pre-launch security review fixes for native staking (#5251)

### DIFF
--- a/apps/ui/src/components/metagraphed/stake-unstake-modal.tsx
+++ b/apps/ui/src/components/metagraphed/stake-unstake-modal.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
 import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react";
 import {
@@ -80,6 +80,17 @@ export function StakeUnstakeModal({
 }: StakeUnstakeModalProps) {
   const [open, setOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  // A ref, not just the `submitting` state: React batches the state update
+  // from a click handler, so the DOM button's `disabled` attribute doesn't
+  // actually flip until the next render -- a genuine double-click can fire a
+  // second handler invocation before that happens. A ref mutates immediately,
+  // synchronously, closing that window at the earliest possible point.
+  // broadcast.ts's idempotency-key check is still the real, provable
+  // fund-safety guard underneath this (see submitStakeExtrinsic's own
+  // concurrent-race test) -- this ref only prevents the confusing UX of a
+  // benign duplicate click surfacing as a transient "submit-error" flash
+  // while the real submission is still awaiting a signature.
+  const confirmInFlightRef = useRef(false);
   const flow = useStakeFlow(hotkey, netuid);
 
   const handleOpenChange = (next: boolean) => {
@@ -93,10 +104,13 @@ export function StakeUnstakeModal({
   };
 
   const handleConfirm = async () => {
+    if (confirmInFlightRef.current) return;
+    confirmInFlightRef.current = true;
     setSubmitting(true);
     try {
       await flow.submit();
     } finally {
+      confirmInFlightRef.current = false;
       setSubmitting(false);
     }
   };

--- a/apps/ui/src/lib/metagraphed/broadcast.test.ts
+++ b/apps/ui/src/lib/metagraphed/broadcast.test.ts
@@ -152,6 +152,38 @@ describe("submitStakeExtrinsic", () => {
     ).rejects.toThrow(/already submitted/i);
   });
 
+  it("holds under a genuine concurrent race, not just sequential awaited calls -- a real double-click fires both before either resolves", async () => {
+    // hasAlreadySubmitted's check-then-add runs synchronously, before the
+    // first `await` inside submitStakeExtrinsic -- JS never interleaves two
+    // async function bodies at a non-await point, so this is safe by
+    // construction, but that's a claim about the runtime, not a test. Fire
+    // both calls with the SAME idempotency key and don't await the first
+    // before starting the second, mirroring what a real double-click on an
+    // as-yet-not-visually-disabled button produces.
+    const { extrinsic: first } = makeFakeExtrinsic();
+    const { extrinsic: second } = makeFakeExtrinsic();
+    const key = computeIdempotencyKey(sampleParams, 7, "concurrent-race-test");
+
+    const results = await Promise.allSettled([
+      submitStakeExtrinsic(fakeApi, first, {
+        signerAddress: HOTKEY,
+        signer: fakeSigner,
+        idempotencyKey: key,
+      }),
+      submitStakeExtrinsic(fakeApi, second, {
+        signerAddress: HOTKEY,
+        signer: fakeSigner,
+        idempotencyKey: key,
+      }),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason.message).toMatch(/already submitted/i);
+  });
+
   it("maps every ExtrinsicStatus variant to the corresponding BroadcastStatus", async () => {
     const { extrinsic, emit } = makeFakeExtrinsic();
     const key = computeIdempotencyKey(sampleParams, 4, "status-map-test");

--- a/apps/ui/src/lib/metagraphed/stake-extrinsics.ts
+++ b/apps/ui/src/lib/metagraphed/stake-extrinsics.ts
@@ -3,10 +3,12 @@
 // here is a real fund-safety bug, not a cosmetic one.
 //
 // Every call shape below is verified against the live subtensor pallet source
-// (opentensor/subtensor, pallets/subtensor/src/macros/dispatches.rs, read
-// 2026-07-14) -- call name, parameter order, and parameter type for each of
-// add_stake_limit (call_index 88), remove_stake_limit (89), swap_stake_limit
-// (90), and move_stake (85).
+// (opentensor/subtensor, pallets/subtensor/src/macros/dispatches.rs) --
+// call name, parameter order, and parameter type for each of add_stake_limit
+// (call_index 88), remove_stake_limit (89), swap_stake_limit (90), and
+// move_stake (85). Re-checked twice: read 2026-07-14 when this module was
+// built, re-verified 2026-07-15 for #5251's pre-launch security review --
+// unchanged both times, call indices included.
 //
 // Per docs/adr/0018-native-staking-architecture.md §3, this module only ever
 // builds the `_limit` variants -- add_stake_limit/remove_stake_limit/
@@ -17,14 +19,22 @@
 // NO `_limit` counterpart anywhere in the pallet, and its cross-subnet case
 // runs through the same unprotected AMM-swap path as swap_stake (confirmed by
 // reading staking/move_stake.rs's `do_move_stake`, which calls the same
-// `transition_stake_internal` swap_stake uses, with the price-limit argument
-// hardcoded to `None`). A same-subnet move_stake (origin_netuid ==
-// destination_netuid) is genuinely riskless -- no AMM swap occurs, it's a
-// pure hotkey reassignment -- and is supported directly. A cross-subnet move
-// is NOT exposed as a single call here; buildMoveStakeParams throws with a
-// pointer to compose it from buildRemoveStakeLimitParams (origin) +
-// buildAddStakeLimitParams (destination) instead -- two slippage-protected
-// legs achieving the same end state, rather than one unprotected atomic call.
+// `transition_stake_internal` swap_stake uses -- but note the exact mechanism
+// on re-read: it passes `T::SwapInterface::min_price()`/`max_price()`, the
+// widest possible bounds, not a literal `None` sentinel; `transition_stake_
+// internal` treats `maybe_limit_price: Option<TaoBalance>` as slippage-
+// protected only when `Some`, so passing the extreme bound is functionally
+// identical to no protection at all -- any real price will fall inside it).
+// A same-subnet move_stake (origin_netuid == destination_netuid) is
+// genuinely riskless -- confirmed by re-reading transition_stake_internal's
+// own branch: same-netuid calls transfer_stake_within_subnet, a pure
+// hotkey/coldkey reassignment that never touches unstake_from_subnet/
+// stake_into_subnet (the two calls that actually invoke the AMM) -- and is
+// supported directly. A cross-subnet move is NOT exposed as a single call
+// here; buildMoveStakeParams throws with a pointer to compose it from
+// buildRemoveStakeLimitParams (origin) + buildAddStakeLimitParams
+// (destination) instead -- two slippage-protected legs achieving the same
+// end state, rather than one unprotected atomic call.
 
 import { taoToRao, raoToTao, type Rao, type RawAlpha } from "./units";
 import { isValidSs58 } from "./accounts";

--- a/apps/ui/src/lib/metagraphed/tx-errors.test.ts
+++ b/apps/ui/src/lib/metagraphed/tx-errors.test.ts
@@ -29,7 +29,6 @@ const EXPECTED_MODULE_ERRORS: Array<[section: string, name: string, category: Tx
   ["subtensorModule", "InvalidChildkeyTake", "invalid_argument"],
   ["subtensorModule", "TransferDisallowed", "disabled"],
   ["swap", "InsufficientLiquidity", "insufficient_liquidity"],
-  ["swap", "SlippageTooHigh", "insufficient_liquidity"],
   ["swap", "PriceLimitExceeded", "insufficient_liquidity"],
   ["swap", "ReservesTooLow", "insufficient_liquidity"],
   ["swap", "InsufficientBalance", "insufficient_balance"],
@@ -57,6 +56,15 @@ describe("decodeModuleError", () => {
     expect(decoded.category).toBe("unknown");
     expect(decoded.source).toBe("someOtherPallet.SomeWeirdError");
     expect(decoded.message).toContain("someOtherPallet.SomeWeirdError");
+  });
+
+  it("falls through to unknown for swap.SlippageTooHigh -- it isn't a real swap-pallet Error<T> variant", () => {
+    // Regression: #5251's re-verification pass found this key was never a
+    // real variant (pallets/swap/src/pallet/mod.rs has no such name at all)
+    // -- swap.PriceLimitExceeded already covers the identical failure mode
+    // ("the operation would exceed the price limit"), so removing the dead
+    // entry loses no real coverage.
+    expect(decodeModuleError("swap", "SlippageTooHigh").category).toBe("unknown");
   });
 });
 

--- a/apps/ui/src/lib/metagraphed/tx-errors.ts
+++ b/apps/ui/src/lib/metagraphed/tx-errors.ts
@@ -17,6 +17,15 @@
 //     message.
 //   - `BalanceLow` does not exist anywhere in either pallet's error enum --
 //     dropped, not carried forward as a guess.
+//   - Re-verified again against live source for #5251's pre-launch security
+//     review (2026-07-15): all four extrinsics' call indices/parameter order,
+//     every subtensorModule error name below, and all twelve
+//     CustomTransactionError codes are unchanged. One real drift found and
+//     fixed: `swap.SlippageTooHigh` was never a real swap-pallet Error<T>
+//     variant (pallets/swap/src/pallet/mod.rs has no such name at all) --
+//     removed as dead/unreachable. `swap.PriceLimitExceeded` already covers
+//     the identical failure mode ("the operation would exceed the price
+//     limit", the pallet's own doc comment), so no coverage is lost.
 //   - The five numeric tx-pool codes the issue cited (1, 6, 7, 8, 25) were
 //     independently verified against common/src/transaction_error.rs's own
 //     `CustomTransactionError -> u8` mapping and are all correct; the rest of
@@ -160,13 +169,9 @@ const MODULE_ERRORS: Record<string, ErrorEntry> = {
     category: "insufficient_liquidity",
     message: "Not enough liquidity in this subnet's pool for this trade size.",
   },
-  "swap.SlippageTooHigh": {
-    category: "insufficient_liquidity",
-    message: "Price moved beyond your slippage tolerance -- try again or widen the tolerance.",
-  },
   "swap.PriceLimitExceeded": {
     category: "insufficient_liquidity",
-    message: "The trade would cross your price limit.",
+    message: "Price moved beyond your slippage tolerance -- try again or widen the tolerance.",
   },
   "swap.ReservesTooLow": {
     category: "insufficient_liquidity",


### PR DESCRIPTION
## Summary

Partial work on #5251, the native-staking epic's pre-launch security review. That issue's own "Depends on" line lists all of Phase 2+3 (#5236–#5248), and Phase 3 isn't fully shipped yet (#5243/#5244/#5246 still open) — so this PR doesn't close #5251. It covers the parts of the review that don't depend on unshipped UI: dependency audit, re-verifying extrinsic construction against live pallet source, and adversarial-testing the mortality/nonce/idempotency guards against everything already merged.

**No visual change.** Two of the three fixes are backend logic (a dead error-mapping key, a `useRef` reentrancy guard); the third is an error-message string only reachable via a live on-chain `PriceLimitExceeded` rejection. Skipping the before/after screenshot table since there's nothing to diff — happy to add one if that's the wrong call here.

## What was reviewed

**Dependency audit** (`@polkadot/api`, `@polkadot/extension-dapp`, and transitive deps):
- Exact-pinned in `package-lock.json` with sha512 integrity hashes; CI uses `npm ci` throughout (not `npm install`), so a compromised in-range release can't get silently pulled in.
- Zero install-time lifecycle scripts (`preinstall`/`install`/`postinstall`) across all 32 `@polkadot/*` packages — the only three packages in the entire tree that have one (`esbuild`, `sharp`, `workerd`) are pre-existing, unrelated build tooling.
- No known advisories at the installed versions — cross-checked both `npm audit` and a direct GitHub Advisory Database GraphQL query for `@polkadot/api`, `@polkadot/extension-dapp`, `@polkadot/util-crypto`.
- Canonical provenance confirmed (repo URLs match `polkadot-js/api` / `polkadot-js/extension` / `polkadot-js/common`, consistent maintainer set), and pinned to the latest published version, not a stale one.

**Extrinsic construction re-verified against live `opentensor/subtensor` source** (last touched today, so genuinely current): all 4 call indices (85/88/89/90) and every parameter's name/order/type for `move_stake`/`add_stake_limit`/`remove_stake_limit`/`swap_stake_limit` are unchanged since the library was built. Also re-confirmed the fund-safety claim behind why cross-subnet `move_stake` isn't exposed directly — traced `do_move_stake` → `transition_stake_internal`'s actual branch logic: same-subnet calls `transfer_stake_within_subnet` (pure reassignment, never touches the AMM) while cross-subnet calls `unstake_from_subnet`/`stake_into_subnet` with `SwapInterface::min_price()`/`max_price()` (the widest possible bounds — functionally unprotected). The comment describing this said "hardcoded to `None`", which was imprecise; corrected.

**Adversarial testing**: added a test that races two `submitStakeExtrinsic()` calls with the same idempotency key via `Promise.allSettled` *without* awaiting between them (the existing tests only covered sequential awaited calls) — confirms the guard holds under a genuine concurrent double-click, not just reasoning about it. Also found and closed a real (if narrow) gap: the confirm button's disabled state depends on a React state update that's batched, so a fast-enough double-click could fire `handleConfirm` twice before the DOM reflects the first click. The chain-level guard already prevents any actual double-broadcast, but the losing call would've shown a confusing "submit-error" flash while the real submission was still awaiting a signature — added a synchronous `useRef`-backed guard to close that window at the UI layer.

**One real drift found and fixed**: `tx-errors.ts` mapped `swap.SlippageTooHigh` as a decodable `DispatchError`, but that name was never a real variant in the swap pallet's `Error<T>` enum (confirmed: zero occurrences in `pallets/swap/src/pallet/mod.rs`, not even in a comment). `swap.PriceLimitExceeded` already covers the identical failure mode ("the operation would exceed the price limit"), so removing the dead entry loses no real coverage — folded its clearer message text into the entry that actually exists.

Everything else — all 22 `subtensorModule` error names, all 12 `CustomTransactionError` codes, and the `InitialMinStake` pallet constant — re-verified unchanged.

## Staged-rollout recommendation

Given the guards check out and no fund-safety-critical drift was found, I'd recommend a soft launch behind a feature flag (gate the "Stake" entry point on `validators.$hotkey.tsx`) over a separate testnet deployment — this is a mainnet-only feature (subtensor doesn't have a meaningfully-populated public testnet for this kind of user testing), and a flag gets you the same "limited blast radius" property without a second environment to maintain. Full recommendation posted as a comment on #5251.

## Verification

- `npx vitest run` (apps/ui): 937/937 passing, including the new concurrent-race test and a regression test for the removed dead error-mapping key.
- `npx tsc --noEmit`, `npx eslint .` — clean.
- `npm run build` (apps/ui, Cloudflare/Nitro target) — succeeds.

Part of #5251.
