### PR TITLE
feat(graphql): add Query.blocks / Query.block (#5575)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -27,6 +27,7 @@ import {
   parseCompareNetuidList,
 } from "./analytics-live.mjs";
 import { buildExtrinsic, buildExtrinsicFeed } from "./extrinsics.mjs";
+import { buildBlock, buildBlockFeed } from "./blocks.mjs";
 import {
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
@@ -74,6 +75,10 @@ export const SDL = `
     extrinsics(limit: Int, offset: Int, cursor: String, block: Int, signer: String, call_module: String, call_function: String, success: Boolean): ExtrinsicList!
     "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}."
     extrinsic(ref: String!): ExtrinsicDetail
+    "Recent-block feed (newest first). Mirrors GET /api/v1/blocks."
+    blocks(limit: Int, offset: Int, cursor: String): BlockList!
+    "One block by numeric height or 0x block hash; block is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/{ref}."
+    block(ref: String!): BlockDetail
     "Network-wide validator/operator leaderboard, grouped by hotkey across every subnet it operates in. Mirrors GET /api/v1/validators."
     validators(sort: String, limit: Int): ValidatorList!
     "One validator's cross-subnet aggregate by hotkey; a hotkey with no validator_permit=1 rows resolves to a schema-stable zeroed aggregate, never null. Mirrors GET /api/v1/validators/{hotkey}."
@@ -368,6 +373,33 @@ export const SDL = `
     extrinsic: Extrinsic
   }
 
+  type BlockList {
+    items: [Block!]!
+    "Page count -- this feed has no cheap grand total, matching REST's block_count."
+    total: Int!
+    next_cursor: String
+  }
+
+  type Block {
+    block_number: Int
+    block_hash: String
+    parent_hash: String
+    author: String
+    extrinsic_count: Int
+    event_count: Int
+    spec_version: Int
+    observed_at: String
+  }
+
+  type BlockDetail {
+    ref: String
+    block: Block
+    "Nearest STORED lower block height for chain-walk nav (detail only); null at the start of the retained window or when the ref didn't resolve."
+    prev_block_number: Int
+    "Nearest STORED higher block height for chain-walk nav (detail only); null at the head of the retained window or when the ref didn't resolve."
+    next_block_number: Int
+  }
+
   type ValidatorList {
     items: [Validator!]!
     total: Int!
@@ -557,6 +589,8 @@ export const FIELD_COMPLEXITY = {
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
   validators: RELATIONSHIP_FIELD_COMPLEXITY,
   validator: RELATIONSHIP_FIELD_COMPLEXITY,
+  blocks: RELATIONSHIP_FIELD_COMPLEXITY,
+  block: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -1221,6 +1255,52 @@ const rootValue = {
     return {
       ref: data.ref ?? ref,
       extrinsic: extrinsicNode(data.extrinsic),
+    };
+  },
+
+  async blocks({ limit, offset, cursor }, context) {
+    const safeLimit = clampLimit(limit, BLOCK_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    if (cursor) params.set("cursor", cursor);
+    // #4909: blocks' D1 write path is retired and the table is dropped in
+    // production, so the Postgres tier being cold is the expected steady state —
+    // fall back to the same pure builder REST uses, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/blocks", params),
+        "METAGRAPH_BLOCKS_SOURCE",
+      )) ??
+      buildBlockFeed([], {
+        limit: safeLimit,
+        offset: safeOffset,
+        nextCursor: null,
+      });
+    return {
+      items: data.blocks || [],
+      total: data.block_count ?? 0,
+      next_cursor: data.next_cursor ?? null,
+    };
+  },
+
+  async block({ ref }, context) {
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/blocks/${encodeURIComponent(ref)}`,
+        ),
+        "METAGRAPH_BLOCKS_SOURCE",
+      )) ?? buildBlock(undefined, ref);
+    return {
+      ref: data.ref ?? ref,
+      block: data.block ?? null,
+      prev_block_number: data.prev_block_number ?? null,
+      next_block_number: data.next_block_number ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1987,6 +1987,212 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
   });
 });
 
+describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("blocks: cold/no-tier store returns a schema-stable empty page (fallback builder, production steady state)", async () => {
+    const { status, body } = await gql(
+      "{ blocks { items { block_number } total next_cursor } }",
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.blocks, {
+      items: [],
+      total: 0,
+      next_cursor: null,
+    });
+  });
+
+  test("blocks: resolves Postgres-tier rows into the block feed", async () => {
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          block_count: 1,
+          limit: 20,
+          offset: 0,
+          next_cursor: "cursor-1",
+          blocks: [
+            {
+              block_number: 123,
+              block_hash: `0x${"b".repeat(64)}`,
+              parent_hash: `0x${"a".repeat(64)}`,
+              author: "5Author",
+              extrinsic_count: 3,
+              event_count: 7,
+              spec_version: 200,
+              observed_at: "2026-07-14T00:00:00.000Z",
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      "{ blocks { items { block_number block_hash extrinsic_count event_count } total next_cursor } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.blocks.total, 1);
+    assert.equal(body.data.blocks.next_cursor, "cursor-1");
+    const item = body.data.blocks.items[0];
+    assert.equal(item.block_number, 123);
+    assert.equal(item.extrinsic_count, 3);
+    assert.equal(item.event_count, 7);
+  });
+
+  test("blocks: limit/offset/cursor are forwarded as query params to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            block_count: 0,
+            limit: 5,
+            offset: 10,
+            next_cursor: null,
+            blocks: [],
+          });
+        },
+      },
+    };
+    await gql(
+      `{ blocks(limit: 5, offset: 10, cursor: "abc123") { total } }`,
+      env,
+    );
+    assert.equal(capturedUrl.pathname, "/api/v1/blocks");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl.searchParams.get("offset"), "10");
+    assert.equal(capturedUrl.searchParams.get("cursor"), "abc123");
+  });
+
+  test("blocks: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      "{ blocks { items { block_number } total next_cursor } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.blocks, {
+      items: [],
+      total: 0,
+      next_cursor: null,
+    });
+  });
+
+  test("block: resolves a Postgres-tier row by numeric height, with chain-walk nav", async () => {
+    const ref = "123";
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ref,
+          block: {
+            block_number: 123,
+            block_hash: `0x${"b".repeat(64)}`,
+            parent_hash: `0x${"a".repeat(64)}`,
+            author: "5Author",
+            extrinsic_count: 3,
+            event_count: 7,
+            spec_version: 200,
+            observed_at: "2026-07-14T00:00:00.000Z",
+          },
+          prev_block_number: 122,
+          next_block_number: 124,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ block(ref: "${ref}") { ref block { block_number spec_version } prev_block_number next_block_number } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.block.ref, ref);
+    assert.equal(body.data.block.block.block_number, 123);
+    assert.equal(body.data.block.block.spec_version, 200);
+    assert.equal(body.data.block.prev_block_number, 122);
+    assert.equal(body.data.block.next_block_number, 124);
+  });
+
+  test("block: resolves a Postgres-tier row by 0x block hash", async () => {
+    const ref = `0x${"b".repeat(64)}`;
+    let capturedUrl;
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            ref,
+            block: {
+              block_number: 123,
+              block_hash: ref,
+              parent_hash: null,
+              author: null,
+              extrinsic_count: 0,
+              event_count: 0,
+              spec_version: 200,
+              observed_at: "2026-07-14T00:00:00.000Z",
+            },
+            prev_block_number: null,
+            next_block_number: null,
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      `{ block(ref: "${ref}") { ref block { block_number block_hash } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.pathname, `/api/v1/blocks/${ref}`);
+    assert.equal(body.data.block.block.block_number, 123);
+    assert.equal(body.data.block.block.block_hash, ref);
+  });
+
+  test("block: unresolved ref returns block:null, never a GraphQL error", async () => {
+    const ref = `0x${"c".repeat(64)}`;
+    const { status, body } = await gql(
+      `{ block(ref: "${ref}") { ref block { block_number } prev_block_number next_block_number } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.block.ref, ref);
+    assert.equal(body.data.block.block, null);
+    assert.equal(body.data.block.prev_block_number, null);
+    assert.equal(body.data.block.next_block_number, null);
+  });
+
+  test("block: a malformed Postgres-tier body falls back to the requested ref", async () => {
+    const ref = "123";
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      `{ block(ref: "${ref}") { ref block { block_number } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.block.ref, ref);
+    assert.equal(body.data.block.block, null);
+  });
+
+  test("blocks / block are weighted as fan-out fields", () => {
+    assert.equal(FIELD_COMPLEXITY.blocks, 5);
+    assert.equal(FIELD_COMPLEXITY.block, 5);
+  });
+});
+
 describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Adds `Query.blocks` / `Query.block` to the GraphQL API, closing the last read-side gap in the block-explorer surface. The block explorer is already a first-party REST (`GET /api/v1/blocks`, `/api/v1/blocks/{ref}`) and MCP (`list_blocks` / `get_block`) surface, and the realtime `Subscription.chainEvents` firehose already models the block shape inline — but there was no `Query`-side way to page through block history or look one up by hash/number.

This mirrors the just-landed `Query.extrinsics` (#5595) and `Query.validators` (#5616) pattern exactly.

## What changed (`src/graphql.mjs`)

- **SDL** — `Query.blocks(limit: Int, offset: Int, cursor: String): BlockList!` and `Query.block(ref: String!): BlockDetail`, plus `BlockList` / `Block` / `BlockDetail` types. `Block` reuses the `block_number` / `block_hash` / `extrinsic_count` / `event_count` vocabulary `ChainEvent` already established, so a client sees one consistent shape across the `Query` and `Subscription` roots; `BlockDetail` adds the detail-only chain-walk nav fields `prev_block_number` / `next_block_number`.
- **Resolvers** — both resolve via `tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE")` with the same pure `buildBlockFeed` / `buildBlock` fallbacks the REST handlers use. Per the #4909 D1 retirement, the blocks table is dropped in production, so a cold Postgres tier is the *expected steady state* — the fallback returns a schema-stable page, never a GraphQL error. `ref` accepts a numeric height or a `0x` block hash; an unresolved `ref` returns `block: null` (matching REST's schema-stable `block:null` contract).
- **`FIELD_COMPLEXITY`** — `blocks` / `block` added at `RELATIONSHIP_FIELD_COMPLEXITY` (5), like the sibling read/fan-out roots.

## Tests (`tests/graphql.test.mjs`)

New `blocks / block` describe block, mirroring the extrinsics/validators suites:
- `blocks`: cold-tier fallback (production steady state) → schema-stable empty page; resolves Postgres-tier rows; `limit`/`offset`/`cursor` forwarded as query params; malformed body degrades to an empty page.
- `block`: resolves by numeric height (with `prev`/`next` nav); resolves by `0x` hash (asserts the `/api/v1/blocks/{ref}` path); unresolved `ref` → `block: null` with no GraphQL error; malformed body falls back to the requested `ref`.
- complexity-weight assertion for both fields.

## Validation

- `npx vitest run tests/graphql.test.mjs` → **133 passed** (9 new)
- `npm run lint` → clean · `npx prettier --check src/graphql.mjs tests/graphql.test.mjs` → clean
- `npm run validate:contract-drift` → pass (GraphQL SDL is a separate read-only graph; no `npm run build` regen / no generated-artifact changes)
- Coverage on `src/graphql.mjs`: 100% statements / functions / lines; all new lines and branches covered.

Two files, no generated artifacts. Closes #5575
