### PR TITLE
infra(ci): cache npm deps in discover-testnet, enrichment-issues, publish-client

### DIFF
--- a/.github/workflows/discover-testnet-surfaces.yml
+++ b/.github/workflows/discover-testnet-surfaces.yml
@@ -38,6 +38,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.23.1
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install
         run: npm ci

--- a/.github/workflows/enrichment-issues.yml
+++ b/.github/workflows/enrichment-issues.yml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.23.1
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install
         run: npm ci

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           node-version: 24.18.0
           registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Validate release version
         env:


### PR DESCRIPTION
Adds `cache: npm` (with `cache-dependency-path: package-lock.json`) to the `actions/setup-node` step in the three workflows that run a full `npm ci` without it, matching the pattern already used by `validate.yml` and the `sync-*`/`refresh-economics`/`readme-catalog-refresh` workflows:

- `discover-testnet-surfaces.yml`
- `enrichment-issues.yml`
- `publish-client.yml` (validate job; the publish job's Setup Node.js step never runs `npm ci`, so it's untouched)

`publish-cloudflare.yml` is deliberately **not** touched. It was in scope per the issue, but `scripts/validate-workflows.mjs` hard-fails on any `cache: npm` in that file:

```
publish-cloudflare.yml: publish workflow must not restore shared npm caches on the Cloudflare release path
```

That check was added in #2295, which explicitly stripped `cache: npm` from this workflow's two Setup Node steps ("disable npm cache in Cloudflare publish") — this is the production release path (writes to R2/KV), and the check exists to keep it from restoring a shared cache. Adding it back would fail `npm run validate:workflows`, which is itself one of this issue's own deliverables, so leaving this file alone is what makes both requirements satisfiable at once.

Verified locally:
- `npm run validate:workflows` passes (24 workflows validated)
- `npm run lint` passes

Closes #5541
