### PR TITLE
feat(ui): wire Download CSV into the leaderboards weight-setting and deregistration boards (#5562)

### DIFF
--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -8,12 +8,13 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { PageHero, BrandIcon, TimeAgo, StatTile } from "@jsonbored/ui-kit";
+import { PageHero, BrandIcon, TimeAgo, StatTile, DownloadCsvButton } from "@jsonbored/ui-kit";
 import {
   chainDeregistrationsQuery,
   chainWeightsQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { formatNumber } from "@/lib/metagraphed/format";
 import type { Subnet } from "@/lib/metagraphed/types";
 
@@ -49,6 +50,11 @@ const WINDOW_BTN_ACTIVE =
   "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent";
 const WINDOW_BTN =
   "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30";
+
+// Mirror each board query's own default page size (queries.ts) so the CSV export lines up with
+// the rows rendered on the page rather than drifting from an independently-chosen limit.
+const WEIGHTS_LIMIT = 20;
+const DEREGISTRATIONS_LIMIT = 100;
 
 // Every board on this route ranks the same 7d/30d window, so the window control lives at the page
 // level and governs both sections rather than each board owning a duplicate toggle.
@@ -109,22 +115,26 @@ function useSubnetById(): Map<number, Subnet> {
 }
 
 function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
-  const { data: boardRes } = useSuspenseQuery(chainWeightsQuery(win));
+  const { data: boardRes } = useSuspenseQuery(chainWeightsQuery(win, WEIGHTS_LIMIT));
   const subnetById = useSubnetById();
   const board = boardRes.data;
   const network = board.network;
   const dist = board.intensity_distribution;
+  const weightsCsvUrl = buildUrl("/api/v1/chain/weights", { window: win, limit: WEIGHTS_LIMIT });
 
   return (
     <div className="space-y-8">
-      <div>
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Weight-setting activity
-        </h2>
-        <p className="mt-1 text-sm text-ink-muted">
-          Validator consensus effort ranked by subnet — raw WeightsSet events over the selected
-          window.
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Weight-setting activity
+          </h2>
+          <p className="mt-1 text-sm text-ink-muted">
+            Validator consensus effort ranked by subnet — raw WeightsSet events over the selected
+            window.
+          </p>
+        </div>
+        <DownloadCsvButton url={weightsCsvUrl} />
       </div>
 
       <div className="grid gap-4 sm:grid-cols-3">
@@ -279,21 +289,30 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
 }
 
 function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
-  const { data: boardRes } = useSuspenseQuery(chainDeregistrationsQuery(win));
+  const { data: boardRes } = useSuspenseQuery(
+    chainDeregistrationsQuery(win, DEREGISTRATIONS_LIMIT),
+  );
   const subnetById = useSubnetById();
   const board = boardRes.data;
   const network = board.network;
+  const deregistrationsCsvUrl = buildUrl("/api/v1/chain/deregistrations", {
+    window: win,
+    limit: DEREGISTRATIONS_LIMIT,
+  });
 
   return (
     <div className="space-y-8">
-      <div>
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Deregistrations
-        </h2>
-        <p className="mt-1 text-sm text-ink-muted">
-          Neuron evictions ranked by subnet — raw NeuronDeregistered events over the selected
-          window.
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Deregistrations
+          </h2>
+          <p className="mt-1 text-sm text-ink-muted">
+            Neuron evictions ranked by subnet — raw NeuronDeregistered events over the selected
+            window.
+          </p>
+        </div>
+        <DownloadCsvButton url={deregistrationsCsvUrl} />
       </div>
 
       <div className="grid gap-4 sm:grid-cols-3">


### PR DESCRIPTION
## Summary

Closes #5562

`/leaderboards` was the odd one out among the ranked-list routes: both boards (weight-setting,
deregistrations) already had backend CSV support (`GET /api/v1/chain/weights?format=csv` and
`GET /api/v1/chain/deregistrations?format=csv`), but neither rendered a `DownloadCsvButton` the
way subnets/blocks/endpoints/validators already do. Since the page is two independent boards
rather than one table, each button sits next to its own board's header rather than in the shared
`PageHero` — mirroring the per-board header row each section already owns. Each CSV URL is built
with the same `window`/`limit` the board's own query uses, so the export always matches what's on
screen.

## Verification

Confirmed both endpoints serve CSV live:

```
$ curl -sD - "https://api.metagraph.sh/api/v1/chain/weights?format=csv&window=7d&limit=5"
HTTP/2 200
content-type: text/csv; charset=utf-8
content-disposition: attachment; filename="chain-weights.csv"

$ curl -sD - "https://api.metagraph.sh/api/v1/chain/deregistrations?format=csv&window=7d&limit=5"
HTTP/2 200
content-type: text/csv; charset=utf-8
content-disposition: attachment; filename="chain-deregistrations.csv"
```

Also drove the page with Playwright and intercepted the click: with `?window=30d` selected, the
weight-setting board's button navigates to
`https://api.metagraph.sh/api/v1/chain/weights?window=30d&limit=20&format=csv` — `window` tracks
the active toggle and `limit` matches the on-page query's own default.

## Gates

lint ✓ · typecheck ✓ · unit tests ✓ (936 passed) · build ✓

## Screenshots

Before/after of both boards — the export affordance appears beside each board's own header at
every viewport without crowding the shared `PageHero`.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-after-mobile-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-after-tablet-dark.png)<br><sub>after</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5562-leaderboards-csv-after-desktop-dark.png)<br><sub>after</sub> |

The deregistrations board's own header/button (below the fold on the page top capture above) is
unchanged in shape from the weight-setting board's — same header row, same button, wired to
`/api/v1/chain/deregistrations` instead.
