### PR TITLE
fix(api): bound free-text query filters and q search with a maxLength (#5544)

### DIFF
--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -27391,6 +27391,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -32499,6 +32500,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -33033,6 +33035,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -33478,6 +33481,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -33743,6 +33747,7 @@
             "name": "id",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -34089,6 +34094,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -34400,6 +34406,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -36173,6 +36180,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -37021,6 +37029,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -37057,6 +37066,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -37407,6 +37417,7 @@
             "name": "id",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -38533,6 +38544,7 @@
             "name": "reason_codes",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -38883,6 +38895,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -39246,6 +39259,7 @@
             "name": "reason_codes",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -39254,6 +39268,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -39274,6 +39289,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -39720,6 +39736,7 @@
             "name": "reason_codes",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -39773,6 +39790,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -40090,6 +40108,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -40750,6 +40769,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -41629,6 +41649,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -41825,6 +41846,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -42161,6 +42183,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -42459,6 +42482,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -43315,6 +43339,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -44129,6 +44154,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -44849,6 +44875,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -45071,6 +45098,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -45386,6 +45414,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -49529,6 +49558,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -51837,6 +51867,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -130,7 +130,14 @@ export const QUERY_ENUMS = {
 };
 
 const integerSchema = { type: "integer", minimum: 0 };
-const textSchema = { type: "string" };
+// Free-text filter/search values (provider, id, review_state, reason_codes, and
+// the `q` search param). Bounded (#5544): generous for free-typed search prose
+// yet well above the structured-token fields' 64-100 char caps, so no filter or
+// `q` can drive unbounded per-request scan work from an unbounded input.
+// validateListQuery (workers/list-query.mjs) enforces this on the filter params
+// generically and on `q` explicitly via this same exported cap.
+export const FREE_TEXT_MAX_LENGTH = 200;
+const textSchema = { type: "string", maxLength: FREE_TEXT_MAX_LENGTH };
 const fieldListSchema = {
   type: "string",
   pattern: "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -353,6 +353,43 @@ describe("list-query case-insensitive enum/string filters (#2073)", () => {
   });
 });
 
+describe("list-query free-text maxLength (#5544)", () => {
+  const atCap = "a".repeat(200);
+  const overCap = "a".repeat(201);
+
+  test("a provider filter at the 200-char cap passes; one char over 400s", () => {
+    const ok = applyQueryFilters(
+      { candidates: [] },
+      query(`/api/v1/candidates?provider=${atCap}`),
+      "candidates",
+    );
+    assert.equal(ok.error, undefined);
+    const bad = applyQueryFilters(
+      { candidates: [] },
+      query(`/api/v1/candidates?provider=${overCap}`),
+      "candidates",
+    );
+    assert.equal(bad.error?.parameter, "provider");
+    assert.match(bad.error.message, /is too long/);
+  });
+
+  test("a q search value at the 200-char cap passes; one char over 400s", () => {
+    const ok = applyQueryFilters(
+      { documents: [] },
+      query(`/api/v1/documents?q=${atCap}`),
+      "documents",
+    );
+    assert.equal(ok.error, undefined);
+    const bad = applyQueryFilters(
+      { documents: [] },
+      query(`/api/v1/documents?q=${overCap}`),
+      "documents",
+    );
+    assert.equal(bad.error?.parameter, "q");
+    assert.match(bad.error.message, /is too long/);
+  });
+});
+
 describe("list-query numeric range filters", () => {
   const data = {
     subnets: [

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -4,7 +4,10 @@
 // the query-collection contract and nothing from api.mjs, so there is no cycle.
 // `applyQueryFilters` is the main public entry; route preflight uses the same
 // validator before artifact/cache reads.
-import { API_QUERY_COLLECTIONS } from "../src/contracts.mjs";
+import {
+  API_QUERY_COLLECTIONS,
+  FREE_TEXT_MAX_LENGTH,
+} from "../src/contracts.mjs";
 import { linkHeader } from "./http.mjs";
 import { DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT } from "./request-params.mjs";
 
@@ -438,6 +441,20 @@ function validateListQuery(params, config, { csvResponse = false } = {}) {
       parameter: "sort",
       message: `sort is not supported for ${config.data_key}.`,
     };
+  }
+
+  // #5544: the free-text `q` search param is a search param, not one of
+  // config.filters, so the generic maxLength check below never covers it. Bound
+  // it explicitly to the same cap the filter textSchema carries, so an unbounded
+  // `q` can't drive unbounded per-term scan work in searchRows.
+  if ((config.search_keys || []).length > 0) {
+    const searchValue = params.get("q");
+    if (searchValue !== null && searchValue.length > FREE_TEXT_MAX_LENGTH) {
+      return {
+        parameter: "q",
+        message: "q is too long.",
+      };
+    }
   }
 
   for (const [key, schema] of Object.entries(config.filters)) {


### PR DESCRIPTION
## Summary

`src/contracts.mjs`'s shared `textSchema = { type: "string" }` (reused for the free-text query filters `provider` / `id` / `review_state` / `reason_codes` across 16 collection definitions, **and** as the schema for the `q` search param on every searchable collection) carried no `maxLength`. Structured-token filters like `pallet`/`method`/`call_module`/`netuids` already cap at 64–100/767, but these free-text values were unbounded — an arbitrarily long value passed validation and reached `searchRows`, which tokenizes it and does an `.includes()` scan of every row per term, i.e. per-request work proportional to an unbounded input.

## Change

- `src/contracts.mjs`: added an exported `FREE_TEXT_MAX_LENGTH = 200` and set `textSchema = { type: "string", maxLength: FREE_TEXT_MAX_LENGTH }`. 200 is generous for free-typed search prose yet well above the 64–100-char structured-token caps. This propagates to all 16 `textSchema` usages automatically; `validateListQuery` already enforces `schema.maxLength` generically on filter params.
- `workers/list-query.mjs`: the `q` search param is **not** one of `config.filters`, so the generic filter loop never covered it (verified: a 201-char `q` was accepted pre-fix). Added an explicit `q`-length check in `validateListQuery`, bounded to the same exported `FREE_TEXT_MAX_LENGTH`, returning the standard `"q is too long."` 400 — so `q` and the filter fields share one cap.
- Ran `npm run build`; committed the regenerated `public/metagraph/openapi.json` (the filter params now document `maxLength: 200`) so `validate:contract-drift` stays green. (No `maxLength`-driven change to the component types / `.d.ts`.)

## Tests (`tests/list-query.test.mjs`)

Two cases, both branches each: a `provider` filter (collection `candidates`) and the `q` search (collection `documents`) at exactly 200 chars pass; one char over (201) returns a 400 with `parameter` set to the field and message `… is too long.`

## Validation (full "checks" gate, run locally)

- All 6 checks-job validators pass: `validate:contract-drift`, `validate:schema-enums`, `validate:openapi-examples`, `validate:generated-client`, `validate:committed-seed`, `validate:surface`.
- `npx vitest run tests/list-query.test.mjs tests/contracts.test.mjs` — 92 passed.
- `node -c` + `npx prettier --check` — clean.

Closes #5544
