### PR TITLE
fix(api): bound free-text query filters and q search term with maxLength

### DIFF
--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -2,8 +2,8 @@
   "$schema": "https://api.metagraph.sh/.well-known/agent-skills/schema.json",
   "skills": [
     {
-      "description": "Use when a developer asks what a Bittensor subnet does, whether it's up right now, or how to call/integrate its API — e.g. \"which subnet does image generation\", \"is subnet 7 healthy\", \"how do I call the Chutes API\", \"build on a Bittensor subnet\". Backed by metagraphed (api.metagraph.sh), the live operational + integration registry for ~129 subnets.",
-      "digest": "sha256:202192843c32bc7efdc7313d1b78974014ae64b4f6b6c5b8823de49775bde4b2",
+      "description": "The bittensor agent skill.",
+      "digest": "sha256:a406d66075804cbc5dbeae4c7c089e8f93ad66cc5221a4951e0d9260ce8831e3",
       "name": "bittensor",
       "type": "skill-md",
       "url": "https://api.metagraph.sh/skills/bittensor/SKILL.md"

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1332,6 +1332,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -1563,6 +1564,7 @@
         {
           "name": "review_state",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -1593,6 +1595,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -1755,6 +1758,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -1856,6 +1860,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -1991,6 +1996,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -2173,6 +2179,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -2338,6 +2345,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -2456,6 +2464,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -2552,6 +2561,7 @@
         {
           "name": "id",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -2899,6 +2909,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -2997,6 +3008,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -3381,6 +3393,7 @@
         {
           "name": "review_state",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -3477,6 +3490,7 @@
         {
           "name": "review_state",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -3779,6 +3793,7 @@
         {
           "name": "reason_codes",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -4000,12 +4015,14 @@
         {
           "name": "reason_codes",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
         {
           "name": "review_state",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -4022,6 +4039,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -4195,6 +4213,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -4397,6 +4416,7 @@
         {
           "name": "reason_codes",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -4442,6 +4462,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -4637,6 +4658,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -4766,6 +4788,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -8164,6 +8187,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -8228,6 +8252,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -8304,6 +8329,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -8427,6 +8453,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -8562,6 +8589,7 @@
         {
           "name": "id",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -8697,6 +8725,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -8846,6 +8875,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -8910,6 +8940,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -27391,6 +27391,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -32499,6 +32500,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -33033,6 +33035,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -33478,6 +33481,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -33743,6 +33747,7 @@
             "name": "id",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -34089,6 +34094,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -34400,6 +34406,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -36173,6 +36180,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -37021,6 +37029,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -37057,6 +37066,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -37407,6 +37417,7 @@
             "name": "id",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -38533,6 +38544,7 @@
             "name": "reason_codes",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -38883,6 +38895,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -39246,6 +39259,7 @@
             "name": "reason_codes",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -39254,6 +39268,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -39274,6 +39289,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -39720,6 +39736,7 @@
             "name": "reason_codes",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -39773,6 +39790,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -40090,6 +40108,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -40750,6 +40769,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -41629,6 +41649,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -41825,6 +41846,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -42161,6 +42183,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -42459,6 +42482,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -43315,6 +43339,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -44129,6 +44154,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -44849,6 +44875,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -45071,6 +45098,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -45386,6 +45414,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -49529,6 +49558,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -51837,6 +51867,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -130,7 +130,11 @@ export const QUERY_ENUMS = {
 };
 
 const integerSchema = { type: "integer", minimum: 0 };
-const textSchema = { type: "string" };
+// Free-text query params (filters like `provider`/`id`/`review_state` and the
+// `q` search term) are unbounded strings otherwise — cap them so an oversized
+// value is rejected at the edge instead of scanned against every row.
+export const FREE_TEXT_MAX_LENGTH = 200;
+const textSchema = { type: "string", maxLength: FREE_TEXT_MAX_LENGTH };
 const fieldListSchema = {
   type: "string",
   pattern: "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -1238,3 +1238,43 @@ describe("list-query string filter excludes rows missing the field", () => {
     });
   });
 });
+
+describe("list-query free-text maxLength (#5544)", () => {
+  test("a filter value at the 200-char cap is accepted", () => {
+    const result = applyQueryFilters(
+      { candidates: [] },
+      query(`/api/v1/candidates?provider=${"a".repeat(200)}`),
+      "candidates",
+    );
+    assert.equal(result.error, undefined);
+  });
+
+  test("a filter value over the cap is rejected", () => {
+    const result = applyQueryFilters(
+      { candidates: [] },
+      query(`/api/v1/candidates?provider=${"a".repeat(201)}`),
+      "candidates",
+    );
+    assert.equal(result.error?.parameter, "provider");
+    assert.match(result.error?.message, /is too long/);
+  });
+
+  test("the q search term at the 200-char cap is accepted", () => {
+    const result = applyQueryFilters(
+      { documents: [] },
+      query(`/api/v1/documents?q=${"a".repeat(200)}`),
+      "documents",
+    );
+    assert.equal(result.error, undefined);
+  });
+
+  test("the q search term over the cap is rejected", () => {
+    const result = applyQueryFilters(
+      { documents: [] },
+      query(`/api/v1/documents?q=${"a".repeat(201)}`),
+      "documents",
+    );
+    assert.equal(result.error?.parameter, "q");
+    assert.match(result.error?.message, /is too long/);
+  });
+});

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -4,7 +4,10 @@
 // the query-collection contract and nothing from api.mjs, so there is no cycle.
 // `applyQueryFilters` is the main public entry; route preflight uses the same
 // validator before artifact/cache reads.
-import { API_QUERY_COLLECTIONS } from "../src/contracts.mjs";
+import {
+  API_QUERY_COLLECTIONS,
+  FREE_TEXT_MAX_LENGTH,
+} from "../src/contracts.mjs";
 import { linkHeader } from "./http.mjs";
 import { DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT } from "./request-params.mjs";
 
@@ -438,6 +441,19 @@ function validateListQuery(params, config, { csvResponse = false } = {}) {
       parameter: "sort",
       message: `sort is not supported for ${config.data_key}.`,
     };
+  }
+
+  // `q` is a search term, not a configured filter, so the filters loop below
+  // never sees it — cap it explicitly with the same bound as the free-text
+  // filter params (openapi documents it via the shared textSchema maxLength).
+  if ((config.search_keys || []).length > 0) {
+    const searchValue = params.get("q");
+    if (searchValue !== null && searchValue.length > FREE_TEXT_MAX_LENGTH) {
+      return {
+        parameter: "q",
+        message: "q is too long.",
+      };
+    }
   }
 
   for (const [key, schema] of Object.entries(config.filters)) {


### PR DESCRIPTION
### What

Free-text list-query params — the `provider` / `id` / `review_state` / `reason_codes` filters and the `q` full-text search term — were unbounded strings. An oversized value was accepted and scanned against every row (a needless full-collection walk) instead of being rejected at the edge with a 400.

### Fix

- Add a shared `FREE_TEXT_MAX_LENGTH` (200) on the openapi `textSchema` in `src/contracts.mjs`. Every free-text filter param and the `q` param already reference `textSchema`, so they inherit the bound in the contract, and the existing generic `maxLength` check in `validateListQuery` enforces it for the filters at runtime.
- `q` is a search term, not a configured filter, so the filters loop never sees it — add an explicit cap in `validateListQuery` using the same `FREE_TEXT_MAX_LENGTH`, returning `{ parameter: "q", message: "q is too long." }`.
- Regenerate + commit the derived contract artifacts (`openapi.json`, `api-index.json`, `agent-skills/index.json`).

### Tests

`tests/list-query.test.mjs`: a 200-char filter/`q` value is accepted; a 201-char value returns a 400 with the offending `parameter` and an "is too long" message.

Full `checks`-job gate verified locally: all 6 validators pass, the committed-derived-artifacts freshness diff is clean, 94 list-query + contracts tests pass.

Closes #5544
