### PR TITLE
feat(ui): validator self-service take (commission) management

### DIFF
--- a/apps/ui/src/components/metagraphed/take-management-modal.tsx
+++ b/apps/ui/src/components/metagraphed/take-management-modal.tsx
@@ -1,0 +1,437 @@
+import { useRef, useState, type ReactNode } from "react";
+import { Link } from "@tanstack/react-router";
+import {
+  AlertCircle,
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  Loader2,
+  ShieldCheck,
+} from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@jsonbored/ui-kit";
+import { WalletConnectPanel } from "@/components/metagraphed/wallet-connect";
+import { SearchInput } from "@/components/metagraphed/table-controls";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { classNames } from "@/lib/metagraphed/format";
+import { broadcastStatusLabel } from "@/components/metagraphed/stake-unstake-modal";
+import type { BroadcastStatus } from "@/lib/metagraphed/broadcast";
+import type { DecodedTxError } from "@/lib/metagraphed/tx-errors";
+import { takePartsToPercent, type TakeDirection } from "@/lib/metagraphed/take-extrinsics";
+import { useTakeFlow, type UseTakeFlowResult } from "@/hooks/use-take-flow";
+
+// #5246: validator self-service take (commission) management -- only ever
+// surfaced when the connected wallet is this hotkey's owning coldkey (see
+// this file's caller in validators.$hotkey.tsx for the gate). Structurally
+// mirrors stake-unstake-modal.tsx (same trigger-render-prop pattern, same
+// hook-mounted-above-<Sheet> lifetime, same close-guard, same reentrancy
+// guard on the confirm button) but the "amount" and "confirm" screens are
+// bespoke to a single network-wide percentage rather than reusing
+// StakeAmountInput/PreSignConfirmation, which are shaped around a two-unit
+// AMM-quoted TAO/alpha amount that doesn't fit a take percentage at all.
+
+const DIRECTIONS: TakeDirection[] = ["increase", "decrease"];
+const DIRECTION_VERB: Record<TakeDirection, string> = {
+  increase: "Increase",
+  decrease: "Decrease",
+};
+
+export interface TakeManagementModalProps {
+  hotkey: string;
+  ownerColdkey: string | null;
+  validatorName?: string;
+  trigger: (open: () => void) => ReactNode;
+}
+
+export function TakeManagementModal({
+  hotkey,
+  ownerColdkey,
+  validatorName,
+  trigger,
+}: TakeManagementModalProps) {
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  // Same rationale as stake-unstake-modal.tsx's confirmInFlightRef: React
+  // batches the state update that disables the confirm button, so a
+  // synchronous ref is what actually closes the double-click window.
+  const confirmInFlightRef = useRef(false);
+  const flow = useTakeFlow(hotkey, ownerColdkey);
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      setOpen(true);
+      return;
+    }
+    if (!flow.canClose) return;
+    flow.close();
+    setOpen(false);
+  };
+
+  const handleConfirm = async () => {
+    if (confirmInFlightRef.current) return;
+    confirmInFlightRef.current = true;
+    setSubmitting(true);
+    try {
+      await flow.submit();
+    } finally {
+      confirmInFlightRef.current = false;
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      {trigger(() => setOpen(true))}
+      <Sheet open={open} onOpenChange={handleOpenChange}>
+        <SheetContent side="right" className="flex w-full flex-col overflow-y-auto sm:max-w-lg">
+          <SheetHeader>
+            <SheetTitle className="font-display text-lg">
+              Manage take · {validatorName ?? shortHash(hotkey, 6)}
+            </SheetTitle>
+            <SheetDescription>
+              {!flow.canClose
+                ? "This can't be closed while a signature is in flight."
+                : "Validator commission, network-wide"}
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="mt-4 flex-1">
+            <TakeFlowBody
+              hotkey={hotkey}
+              flow={flow}
+              submitting={submitting}
+              onConfirm={handleConfirm}
+              onClose={() => handleOpenChange(false)}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}
+
+function TakeFlowBody({
+  hotkey,
+  flow,
+  submitting,
+  onConfirm,
+  onClose,
+}: {
+  hotkey: string;
+  flow: UseTakeFlowResult;
+  submitting: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  switch (flow.phase) {
+    case "connect":
+      return <WalletConnectPanel />;
+
+    case "amount":
+      return <TakeAmountStep flow={flow} />;
+
+    case "confirm":
+      return (
+        <TakeConfirmationStep
+          hotkey={hotkey}
+          flow={flow}
+          confirming={submitting}
+          onConfirm={onConfirm}
+        />
+      );
+
+    case "signing":
+    case "broadcasting":
+      return (
+        <StatusView
+          icon={<Loader2 className="size-6 animate-spin text-ink-muted" aria-hidden />}
+          message={
+            flow.phase === "signing"
+              ? "Awaiting your signature…"
+              : broadcastStatusLabel(flow.txStatus.status as BroadcastStatus)
+          }
+          txHash={flow.txStatus.txHash}
+        />
+      );
+
+    case "failed":
+      return (
+        <div className="flex flex-col items-center gap-4 py-10 text-center">
+          <AlertTriangle className="size-6 text-health-down" aria-hidden />
+          <p className="text-[13px] text-ink-strong">{describeTxError(flow.txStatus.error)}</p>
+          <button
+            type="button"
+            onClick={flow.editAmount}
+            className="rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink/30"
+          >
+            Edit and try again
+          </button>
+        </div>
+      );
+
+    case "done":
+      return (
+        <StatusView
+          icon={<CheckCircle2 className="size-6 text-health-ok" aria-hidden />}
+          message="Finalized."
+          txHash={flow.txStatus.txHash}
+          onClose={onClose}
+        />
+      );
+  }
+}
+
+function TakeAmountStep({ flow }: { flow: UseTakeFlowResult }) {
+  const hasValidPercentInput =
+    flow.percentInput.trim() !== "" &&
+    Number.isFinite(Number(flow.percentInput)) &&
+    Number(flow.percentInput) >= 0;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 space-y-4">
+        <div
+          role="tablist"
+          aria-label="Increase or decrease take"
+          className="inline-flex items-center rounded-md border border-border bg-card p-0.5"
+        >
+          {DIRECTIONS.map((d) => {
+            const active = d === flow.direction;
+            return (
+              <button
+                key={d}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => flow.setDirection(d)}
+                className={classNames(
+                  "min-h-8 rounded px-4 py-1.5 font-mono text-[11px] uppercase tracking-widest transition-colors",
+                  active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong",
+                )}
+              >
+                {d}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <span
+            aria-hidden="true"
+            className="font-mono text-[10px] uppercase tracking-widest text-ink-muted"
+          >
+            New take (%)
+          </span>
+          <SearchInput
+            value={flow.percentInput}
+            onChange={flow.setPercentInput}
+            placeholder="0.00 %"
+            inputMode="decimal"
+            className="w-40 flex-none font-mono tabular-nums"
+          />
+        </div>
+
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-2 rounded border border-border bg-surface/40 p-3 text-[11px]">
+          <dt className="text-ink-muted">Current take</dt>
+          <dd className="text-right font-mono text-ink-strong">
+            {flow.currentTakePct != null ? `${flow.currentTakePct.toFixed(2)}%` : "—"}
+          </dd>
+          <dt className="text-ink-muted">Allowed range</dt>
+          <dd className="text-right font-mono text-ink-strong">
+            {flow.minTakePct != null && flow.maxTakePct != null
+              ? `${flow.minTakePct.toFixed(2)}% – ${flow.maxTakePct.toFixed(2)}%`
+              : "—"}
+          </dd>
+        </dl>
+
+        {flow.direction === "increase" && flow.cooldownDurationLabel ? (
+          <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down">
+            <AlertCircle className="size-3.5 shrink-0" aria-hidden />
+            Take was changed too recently — try again in {flow.cooldownDurationLabel}. (Decreasing
+            take has no cooldown.)
+          </p>
+        ) : null}
+
+        {!hasValidPercentInput ? (
+          <p className="font-mono text-[11px] text-ink-muted">
+            Enter a new take percentage to continue.
+          </p>
+        ) : null}
+
+        {flow.validationMessages.length > 0 ? (
+          <ul className="space-y-1">
+            {flow.validationMessages.map((message) => (
+              <li
+                key={message}
+                className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down"
+              >
+                <AlertCircle className="size-3.5 shrink-0" aria-hidden />
+                {message}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+
+      <SheetFooter className="mt-4">
+        <button
+          type="button"
+          onClick={flow.confirm}
+          disabled={!flow.canConfirm}
+          className="w-full rounded border border-ink-strong/40 bg-surface px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink-strong/60 disabled:opacity-50"
+        >
+          Review {DIRECTION_VERB[flow.direction].toLowerCase()}
+        </button>
+      </SheetFooter>
+    </div>
+  );
+}
+
+function TakeConfirmationStep({
+  hotkey,
+  flow,
+  confirming,
+  onConfirm,
+}: {
+  hotkey: string;
+  flow: UseTakeFlowResult;
+  confirming: boolean;
+  onConfirm: () => void;
+}) {
+  const newTakePct = flow.params != null ? takePartsToPercent(flow.params.take) : null;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <div className="mg-label mb-1">{DIRECTION_VERB[flow.direction]} take</div>
+        <div className="font-display text-lg font-medium text-ink-strong">
+          {newTakePct != null ? `${newTakePct.toFixed(2)}%` : "—"}
+        </div>
+      </div>
+
+      <SummaryRow label="Validator hotkey" value={shortHash(hotkey, 6) ?? hotkey} />
+      <SummaryRow
+        label="Current take"
+        value={flow.currentTakePct != null ? `${flow.currentTakePct.toFixed(2)}%` : "—"}
+      />
+      <SummaryRow
+        label="Network fee"
+        value={flow.feeTao === null ? "Estimating…" : `${flow.feeTao} τ`}
+        loading={flow.feeTao === null}
+      />
+
+      <div className="flex items-start gap-1.5 rounded border border-border bg-surface/40 px-2.5 py-2 text-[11px] text-ink-muted">
+        <ShieldCheck className="mt-0.5 size-3.5 shrink-0 text-ink-muted" aria-hidden="true" />
+        <span>
+          metagraphed builds this transaction for your wallet to sign — we never see your keys and
+          cannot change your take without your extension&rsquo;s approval.
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={flow.editAmount}
+          disabled={confirming}
+          className="flex-1 rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-muted transition-colors hover:border-ink/30 hover:text-ink-strong disabled:opacity-60"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={confirming || flow.feeTao === null}
+          className="flex-1 inline-flex items-center justify-center gap-1.5 rounded border border-ink-strong/40 bg-surface px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink-strong/60 disabled:opacity-60"
+        >
+          {confirming ? (
+            <>
+              <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+              Awaiting signature…
+            </>
+          ) : (
+            <>
+              {DIRECTION_VERB[flow.direction]}
+              <ArrowRight className="size-3.5" aria-hidden="true" />
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SummaryRow({
+  label,
+  value,
+  loading,
+}: {
+  label: string;
+  value: string;
+  loading?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-border/60 py-1.5 last:border-b-0">
+      <span className="text-[11px] text-ink-muted">{label}</span>
+      <span
+        className={classNames(
+          "block text-[12px] font-medium text-ink-strong",
+          loading && "animate-pulse text-ink-muted",
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function StatusView({
+  icon,
+  message,
+  txHash,
+  onClose,
+}: {
+  icon: ReactNode;
+  message: string;
+  txHash: string | null;
+  onClose?: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-4 py-10 text-center">
+      {icon}
+      <p className="text-[13px] text-ink-strong">{message}</p>
+      {txHash ? (
+        <div className="space-y-1">
+          <Link
+            to="/extrinsics/$hash"
+            params={{ hash: txHash }}
+            className="font-mono text-[11px] text-accent hover:underline"
+          >
+            {shortHash(txHash, 8)}
+          </Link>
+          <p className="text-[10px] text-ink-muted">
+            May take a few moments to appear once indexed.
+          </p>
+        </div>
+      ) : null}
+      {onClose ? (
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink/30"
+        >
+          Done
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function describeTxError(error: DecodedTxError | null): string {
+  return error?.message ?? "The transaction failed.";
+}

--- a/apps/ui/src/hooks/use-take-flow.test.ts
+++ b/apps/ui/src/hooks/use-take-flow.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { deriveTakeFlowPhase, canCloseTakeFlow } from "./use-take-flow";
+
+describe("deriveTakeFlowPhase", () => {
+  it("is 'connect' whenever the wallet isn't connected, regardless of confirmed/txStatus", () => {
+    expect(deriveTakeFlowPhase("idle", false, "idle")).toBe("connect");
+    expect(deriveTakeFlowPhase("connecting", true, "finalized")).toBe("connect");
+    expect(deriveTakeFlowPhase("no-extension", true, "signing")).toBe("connect");
+  });
+
+  it("is 'amount' whenever not yet confirmed, once connected", () => {
+    expect(deriveTakeFlowPhase("connected", false, "idle")).toBe("amount");
+    expect(deriveTakeFlowPhase("connected", false, "finalized")).toBe("amount");
+  });
+
+  it("is 'confirm' once confirmed with an idle tx", () => {
+    expect(deriveTakeFlowPhase("connected", true, "idle")).toBe("confirm");
+  });
+
+  it("is 'signing' while the extension is prompting for a signature", () => {
+    expect(deriveTakeFlowPhase("connected", true, "signing")).toBe("signing");
+  });
+
+  it("is 'failed' for a decoded on-chain failure or a rejected/pre-dispatch submission", () => {
+    expect(deriveTakeFlowPhase("connected", true, "failed")).toBe("failed");
+    expect(deriveTakeFlowPhase("connected", true, "submit-error")).toBe("failed");
+  });
+
+  it("is 'done' once finalized", () => {
+    expect(deriveTakeFlowPhase("connected", true, "finalized")).toBe("done");
+  });
+
+  it("is 'broadcasting' for every other in-flight broadcast status", () => {
+    for (const status of [
+      "future",
+      "ready",
+      "broadcast",
+      "in-block",
+      "retracted",
+      "finality-timeout",
+      "usurped",
+      "dropped",
+      "invalid",
+      "error",
+    ] as const) {
+      expect(deriveTakeFlowPhase("connected", true, status)).toBe("broadcasting");
+    }
+  });
+});
+
+describe("canCloseTakeFlow", () => {
+  it("allows closing from idle, failed, submit-error, and finalized", () => {
+    expect(canCloseTakeFlow("idle")).toBe(true);
+    expect(canCloseTakeFlow("failed")).toBe(true);
+    expect(canCloseTakeFlow("submit-error")).toBe(true);
+    expect(canCloseTakeFlow("finalized")).toBe(true);
+  });
+
+  it("blocks closing while signing or mid-broadcast", () => {
+    expect(canCloseTakeFlow("signing")).toBe(false);
+    expect(canCloseTakeFlow("broadcast")).toBe(false);
+    expect(canCloseTakeFlow("in-block")).toBe(false);
+    expect(canCloseTakeFlow("future")).toBe(false);
+  });
+});

--- a/apps/ui/src/hooks/use-take-flow.ts
+++ b/apps/ui/src/hooks/use-take-flow.ts
@@ -1,0 +1,304 @@
+// The composition seam for the take-management modal (#5246, native-staking
+// epic #5229). Mirrors use-stake-flow.ts's structure and conventions closely
+// -- same phase-derivation pattern, same SSR-safe session id, same
+// exported-pure-function testing convention -- but is considerably simpler:
+// take is a single network-wide percentage, not a two-unit AMM-quoted
+// amount, so there's no quote/spot-price/candidate-conversion machinery
+// here at all.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ApiPromise } from "@polkadot/api";
+import { useWallet } from "./use-wallet";
+import { useTxStatus, type TxUiStatus, type UseTxStatusResult } from "./use-tx-status";
+import { raoToTao, type Rao } from "@/lib/metagraphed/units";
+import {
+  percentToTakeParts,
+  takePartsToPercent,
+  delegateTakeCooldownRemainingBlocks,
+  formatCooldownDuration,
+  buildIncreaseTakeParams,
+  buildDecreaseTakeParams,
+  validateTakeInputs,
+  describeTakeValidationIssue,
+  type TakeDirection,
+  type IncreaseTakeParams,
+  type DecreaseTakeParams,
+  type TakeValidationIssue,
+} from "@/lib/metagraphed/take-extrinsics";
+import {
+  getApi,
+  getCurrentBlock,
+  getMaxDelegateTake,
+  getMinDelegateTake,
+  getTxDelegateTakeRateLimit,
+  getCurrentTakeParts,
+  getLastTxBlockDelegateTake,
+  getNextNonce,
+  buildExtrinsic,
+} from "@/lib/metagraphed/chain-connection";
+import { getSigner } from "@/lib/metagraphed/wallet-injected";
+import { computeIdempotencyKey } from "@/lib/metagraphed/broadcast";
+import { estimateFee } from "@/lib/metagraphed/tx-fee";
+
+export type TakeFlowPhase =
+  "connect" | "amount" | "confirm" | "signing" | "broadcasting" | "failed" | "done";
+
+/** Identical shape to deriveStakeFlowPhase (use-stake-flow.ts) -- see that function's doc comment for the phase-transition rationale, unchanged here. */
+export function deriveTakeFlowPhase(
+  walletStatus: string,
+  confirmed: boolean,
+  txStatus: TxUiStatus,
+): TakeFlowPhase {
+  if (walletStatus !== "connected") return "connect";
+  if (!confirmed) return "amount";
+  if (txStatus === "idle") return "confirm";
+  if (txStatus === "signing") return "signing";
+  if (txStatus === "failed" || txStatus === "submit-error") return "failed";
+  if (txStatus === "finalized") return "done";
+  return "broadcasting";
+}
+
+/** Identical to canCloseStakeFlow (use-stake-flow.ts). */
+export function canCloseTakeFlow(txStatus: TxUiStatus): boolean {
+  return (
+    txStatus === "idle" ||
+    txStatus === "failed" ||
+    txStatus === "submit-error" ||
+    txStatus === "finalized"
+  );
+}
+
+interface TakeBounds {
+  maxTakeParts: number;
+  minTakeParts: number;
+  rateLimitBlocks: number;
+  currentTakeParts: number;
+  lastTxBlock: number;
+  currentBlock: number;
+}
+
+export interface UseTakeFlowResult {
+  phase: TakeFlowPhase;
+  wallet: ReturnType<typeof useWallet>;
+  /** Whether the connected wallet is this hotkey's owning coldkey -- the pallet's own NonAssociatedColdKey check, mirrored client-side. */
+  isOwner: boolean;
+
+  direction: TakeDirection;
+  setDirection: (direction: TakeDirection) => void;
+  percentInput: string;
+  setPercentInput: (value: string) => void;
+
+  currentTakePct: number | null;
+  minTakePct: number | null;
+  maxTakePct: number | null;
+  /** Only ever nonzero for "increase" -- decrease_take has no rate limit at all (see take-extrinsics.ts's header comment). */
+  cooldownRemainingBlocks: number;
+  cooldownDurationLabel: string | null;
+
+  params: IncreaseTakeParams | DecreaseTakeParams | null;
+  feeTao: string | null;
+  validationIssues: TakeValidationIssue[];
+  validationMessages: string[];
+  canConfirm: boolean;
+  confirm: () => void;
+  editAmount: () => void;
+
+  txStatus: UseTxStatusResult;
+  submit: () => Promise<void>;
+  canClose: boolean;
+  close: () => void;
+}
+
+/** #5246's composition seam for one hotkey's take-management flow. `ownerColdkey` is the validator-detail API's reported owning coldkey -- re-compared against the LIVE connected wallet address on every render, not frozen at mount, since the user could switch accounts in their extension mid-session. */
+export function useTakeFlow(hotkey: string, ownerColdkey: string | null): UseTakeFlowResult {
+  const wallet = useWallet();
+  const txStatus = useTxStatus();
+
+  const [direction, setDirection] = useState<TakeDirection>("increase");
+  const [percentInput, setPercentInput] = useState("");
+  const [confirmed, setConfirmed] = useState(false);
+
+  const isOwner = !!ownerColdkey && wallet.wallet?.address === ownerColdkey;
+
+  // Generated client-only -- see use-stake-flow.ts's identical pattern for
+  // why (avoids an SSR/CSR hydration mismatch).
+  const [sessionId, setSessionId] = useState("");
+  useEffect(() => {
+    setSessionId(crypto.randomUUID());
+  }, []);
+
+  const [api, setApi] = useState<ApiPromise | null>(null);
+  useEffect(() => {
+    if (wallet.status !== "connected") return;
+    let cancelled = false;
+    getApi()
+      .then((connected) => {
+        if (!cancelled) setApi(connected);
+      })
+      .catch(() => {
+        /* best-effort; bounds/submit simply stay unavailable */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [wallet.status]);
+
+  const [bounds, setBounds] = useState<TakeBounds | null>(null);
+  useEffect(() => {
+    if (!api) return;
+    let cancelled = false;
+    Promise.all([
+      getMaxDelegateTake(api),
+      getMinDelegateTake(api),
+      getTxDelegateTakeRateLimit(api),
+      getCurrentTakeParts(api, hotkey),
+      getLastTxBlockDelegateTake(api, hotkey),
+      getCurrentBlock(api),
+    ])
+      .then(
+        ([
+          maxTakeParts,
+          minTakeParts,
+          rateLimitBlocks,
+          currentTakeParts,
+          lastTxBlock,
+          currentBlock,
+        ]) => {
+          if (!cancelled) {
+            setBounds({
+              maxTakeParts,
+              minTakeParts,
+              rateLimitBlocks,
+              currentTakeParts,
+              lastTxBlock,
+              currentBlock,
+            });
+          }
+        },
+      )
+      .catch(() => {
+        /* best-effort; Max/bounds-derived validation issues just stay unavailable */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api, hotkey]);
+
+  const hasValidPercentInput = percentInput.trim() !== "" && Number.isFinite(Number(percentInput));
+
+  const params = useMemo(() => {
+    if (!hasValidPercentInput) return null;
+    try {
+      const take = percentToTakeParts(Number(percentInput));
+      return direction === "increase"
+        ? buildIncreaseTakeParams({ hotkey, take })
+        : buildDecreaseTakeParams({ hotkey, take });
+    } catch {
+      return null;
+    }
+  }, [hasValidPercentInput, percentInput, direction, hotkey]);
+
+  const cooldownRemainingBlocks = bounds
+    ? delegateTakeCooldownRemainingBlocks(
+        bounds.lastTxBlock,
+        bounds.currentBlock,
+        bounds.rateLimitBlocks,
+      )
+    : 0;
+
+  const validationIssues = useMemo(() => {
+    if (!params || !bounds) return [];
+    return validateTakeInputs({
+      hotkey,
+      isOwner,
+      direction,
+      takeParts: params.take,
+      currentTakeParts: bounds.currentTakeParts,
+      minTakeParts: bounds.minTakeParts,
+      maxTakeParts: bounds.maxTakeParts,
+      cooldownRemainingBlocks,
+    });
+  }, [params, bounds, hotkey, isOwner, direction, cooldownRemainingBlocks]);
+
+  const validationMessages = useMemo(
+    () => validationIssues.map(describeTakeValidationIssue),
+    [validationIssues],
+  );
+
+  const canConfirm = params != null && bounds != null && validationIssues.length === 0;
+
+  // Fee dry-run -- identical posture to use-stake-flow.ts's: only fetched
+  // once the user has reached "confirm" with a resolved, idle tx.
+  const [feeRao, setFeeRao] = useState<Rao | null>(null);
+  useEffect(() => {
+    setFeeRao(null);
+    if (!confirmed || txStatus.status !== "idle") return;
+    if (!api || !wallet.wallet || !params) return;
+    let cancelled = false;
+    const extrinsic = buildExtrinsic(api, params);
+    estimateFee(extrinsic, wallet.wallet.address)
+      .then((fee) => {
+        if (!cancelled) setFeeRao(fee);
+      })
+      .catch(() => {
+        /* best-effort; the confirm screen just keeps showing "Estimating..." */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [confirmed, txStatus.status, api, wallet.wallet, params]);
+
+  const confirm = useCallback(() => setConfirmed(true), []);
+  const editAmount = useCallback(() => {
+    setConfirmed(false);
+    txStatus.reset();
+  }, [txStatus]);
+
+  const close = useCallback(() => {
+    txStatus.reset();
+    setConfirmed(false);
+    setPercentInput("");
+  }, [txStatus]);
+
+  const submit = useCallback(async () => {
+    if (!api || !wallet.wallet || !params) return;
+    const nonce = await getNextNonce(api, wallet.wallet.address);
+    const idempotencyKey = computeIdempotencyKey(params, nonce, sessionId);
+    const extrinsic = buildExtrinsic(api, params);
+    const signer = await getSigner(wallet.wallet.source);
+    await txStatus.submit(api, extrinsic, {
+      signerAddress: wallet.wallet.address,
+      signer,
+      idempotencyKey,
+    });
+  }, [api, wallet.wallet, params, sessionId, txStatus]);
+
+  const phase = deriveTakeFlowPhase(wallet.status, confirmed, txStatus.status);
+
+  return {
+    phase,
+    wallet,
+    isOwner,
+    direction,
+    setDirection,
+    percentInput,
+    setPercentInput,
+    currentTakePct: bounds ? takePartsToPercent(bounds.currentTakeParts) : null,
+    minTakePct: bounds ? takePartsToPercent(bounds.minTakeParts) : null,
+    maxTakePct: bounds ? takePartsToPercent(bounds.maxTakeParts) : null,
+    cooldownRemainingBlocks,
+    cooldownDurationLabel:
+      cooldownRemainingBlocks > 0 ? formatCooldownDuration(cooldownRemainingBlocks) : null,
+    params,
+    feeTao: feeRao != null ? raoToTao(feeRao) : null,
+    validationIssues,
+    validationMessages,
+    canConfirm,
+    confirm,
+    editAmount,
+    txStatus,
+    submit,
+    canClose: canCloseTakeFlow(txStatus.status),
+    close,
+  };
+}

--- a/apps/ui/src/lib/metagraphed/chain-connection.test.ts
+++ b/apps/ui/src/lib/metagraphed/chain-connection.test.ts
@@ -6,7 +6,18 @@ import {
   buildSwapStakeLimitParams,
   buildMoveStakeParams,
 } from "./stake-extrinsics";
-import { getApi, buildExtrinsic, getNextNonce } from "./chain-connection";
+import { buildIncreaseTakeParams, buildDecreaseTakeParams } from "./take-extrinsics";
+import {
+  getApi,
+  buildExtrinsic,
+  getNextNonce,
+  getCurrentBlock,
+  getMaxDelegateTake,
+  getMinDelegateTake,
+  getTxDelegateTakeRateLimit,
+  getCurrentTakeParts,
+  getLastTxBlockDelegateTake,
+} from "./chain-connection";
 import type { ApiPromise } from "@polkadot/api";
 
 const HOTKEY_A = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
@@ -50,6 +61,8 @@ function makeFakeApi() {
         removeStakeLimit: record("removeStakeLimit"),
         swapStakeLimit: record("swapStakeLimit"),
         moveStake: record("moveStake"),
+        increaseTake: record("increaseTake"),
+        decreaseTake: record("decreaseTake"),
       },
     },
   } as unknown as ApiPromise;
@@ -121,6 +134,20 @@ describe("buildExtrinsic", () => {
     buildExtrinsic(api, params);
     expect(calls.moveStake).toEqual([HOTKEY_A, HOTKEY_B, 4, 4, alphaToRawAlpha("3")]);
   });
+
+  it("calls increaseTake with (hotkey, take), in order", () => {
+    const { api, calls } = makeFakeApi();
+    const params = buildIncreaseTakeParams({ hotkey: HOTKEY_A, take: 1000 });
+    buildExtrinsic(api, params);
+    expect(calls.increaseTake).toEqual([HOTKEY_A, 1000]);
+  });
+
+  it("calls decreaseTake with (hotkey, take), in order", () => {
+    const { api, calls } = makeFakeApi();
+    const params = buildDecreaseTakeParams({ hotkey: HOTKEY_A, take: 500 });
+    buildExtrinsic(api, params);
+    expect(calls.decreaseTake).toEqual([HOTKEY_A, 500]);
+  });
 });
 
 describe("getNextNonce", () => {
@@ -129,5 +156,71 @@ describe("getNextNonce", () => {
     const api = { rpc: { system: { accountNextIndex } } } as unknown as ApiPromise;
     await expect(getNextNonce(api, HOTKEY_A)).resolves.toBe(7);
     expect(accountNextIndex).toHaveBeenCalledWith(HOTKEY_A);
+  });
+});
+
+describe("getCurrentBlock", () => {
+  it("returns the chain header's block number as a plain number", async () => {
+    const getHeader = vi.fn(async () => ({ number: { toNumber: () => 8_623_860 } }));
+    const api = { rpc: { chain: { getHeader } } } as unknown as ApiPromise;
+    await expect(getCurrentBlock(api)).resolves.toBe(8_623_860);
+  });
+});
+
+describe("live delegate-take bounds/rate-limit queries", () => {
+  function makeQueryApi(overrides: {
+    maxDelegateTake?: number;
+    minDelegateTake?: number;
+    txDelegateTakeRateLimit?: number;
+    currentTakeParts?: number;
+    lastRateLimitedBlock?: number;
+  }) {
+    const lastRateLimitedBlock = vi.fn(async (_key: unknown) => ({
+      toNumber: () => overrides.lastRateLimitedBlock ?? 0,
+    }));
+    const delegates = vi.fn(async (_hotkey: string) => ({
+      toNumber: () => overrides.currentTakeParts ?? 0,
+    }));
+    const api = {
+      query: {
+        subtensorModule: {
+          maxDelegateTake: vi.fn(async () => ({ toNumber: () => overrides.maxDelegateTake ?? 0 })),
+          minDelegateTake: vi.fn(async () => ({ toNumber: () => overrides.minDelegateTake ?? 0 })),
+          txDelegateTakeRateLimit: vi.fn(async () => ({
+            toNumber: () => overrides.txDelegateTakeRateLimit ?? 0,
+          })),
+          delegates,
+          lastRateLimitedBlock,
+        },
+      },
+    } as unknown as ApiPromise;
+    return { api, delegates, lastRateLimitedBlock };
+  }
+
+  it("getMaxDelegateTake returns the live-confirmed 18% bound (11796 parts)", async () => {
+    const { api } = makeQueryApi({ maxDelegateTake: 11_796 });
+    await expect(getMaxDelegateTake(api)).resolves.toBe(11_796);
+  });
+
+  it("getMinDelegateTake returns the live queried floor", async () => {
+    const { api } = makeQueryApi({ minDelegateTake: 0 });
+    await expect(getMinDelegateTake(api)).resolves.toBe(0);
+  });
+
+  it("getTxDelegateTakeRateLimit returns the live-confirmed 216000-block period", async () => {
+    const { api } = makeQueryApi({ txDelegateTakeRateLimit: 216_000 });
+    await expect(getTxDelegateTakeRateLimit(api)).resolves.toBe(216_000);
+  });
+
+  it("getCurrentTakeParts queries delegates with the hotkey", async () => {
+    const { api, delegates } = makeQueryApi({ currentTakeParts: 655 });
+    await expect(getCurrentTakeParts(api, HOTKEY_A)).resolves.toBe(655);
+    expect(delegates).toHaveBeenCalledWith(HOTKEY_A);
+  });
+
+  it("getLastTxBlockDelegateTake queries lastRateLimitedBlock with the LastTxBlockDelegateTake enum key", async () => {
+    const { api, lastRateLimitedBlock } = makeQueryApi({ lastRateLimitedBlock: 8_600_000 });
+    await expect(getLastTxBlockDelegateTake(api, HOTKEY_A)).resolves.toBe(8_600_000);
+    expect(lastRateLimitedBlock).toHaveBeenCalledWith({ LastTxBlockDelegateTake: HOTKEY_A });
   });
 });

--- a/apps/ui/src/lib/metagraphed/chain-connection.ts
+++ b/apps/ui/src/lib/metagraphed/chain-connection.ts
@@ -22,10 +22,16 @@ import type {
   SwapStakeLimitParams,
   MoveStakeParams,
 } from "./stake-extrinsics";
+import type { IncreaseTakeParams, DecreaseTakeParams } from "./take-extrinsics";
 import { asRao, type Rao } from "./units";
 
 export type StakeCallParams =
-  AddStakeLimitParams | RemoveStakeLimitParams | SwapStakeLimitParams | MoveStakeParams;
+  | AddStakeLimitParams
+  | RemoveStakeLimitParams
+  | SwapStakeLimitParams
+  | MoveStakeParams
+  | IncreaseTakeParams
+  | DecreaseTakeParams;
 
 /**
  * The official Bittensor entrypoint -- matches ADR 0018 §2's "the same shape
@@ -73,6 +79,28 @@ interface BigIntCodec {
 interface AccountInfoCodec {
   data: { free: BigIntCodec };
 }
+interface NumberCodec {
+  toNumber(): number;
+}
+// LastRateLimitedBlock is StorageMap<Identity, RateLimitKey<AccountId>, u64> --
+// a single generic map keyed by an enum whose exact shape subtensor's own
+// on-chain metadata supplies at connection time (RateLimitKey isn't a
+// standard substrate primitive, so there's no static type for it the way
+// there is for e.g. AccountId). Empirically confirmed against live mainnet
+// (2026-07-15) that passing the enum as a plain `{ VariantName: value }`
+// object -- the same shape @polkadot/api accepts for any enum-typed query
+// argument once the runtime metadata describes it -- resolves correctly.
+interface SubtensorQueryApi {
+  query: {
+    subtensorModule: {
+      maxDelegateTake(): Promise<NumberCodec>;
+      minDelegateTake(): Promise<NumberCodec>;
+      txDelegateTakeRateLimit(): Promise<NumberCodec>;
+      delegates(hotkey: string): Promise<NumberCodec>;
+      lastRateLimitedBlock(key: { LastTxBlockDelegateTake: string }): Promise<NumberCodec>;
+    };
+  };
+}
 
 /**
  * The network's live minimum stake floor (rao), read from the pallet's own
@@ -104,6 +132,69 @@ export async function getFreeBalance(api: ApiPromise, coldkeySs58: string): Prom
 export async function getNextNonce(api: ApiPromise, ss58: string): Promise<number> {
   const index = await api.rpc.system.accountNextIndex(ss58);
   return index.toNumber();
+}
+
+/** The live current block height, for computing a delegate-take cooldown remainder against getLastTxBlockDelegateTake. */
+export async function getCurrentBlock(api: ApiPromise): Promise<number> {
+  const header = await api.rpc.chain.getHeader();
+  return header.number.toNumber();
+}
+
+/**
+ * Live take (commission) bounds and rate-limit period -- all three are real
+ * StorageValues (not `#[pallet::constant]`s), confirmed live against mainnet
+ * 2026-07-15 (maxDelegateTake=11796 [18%], minDelegateTake=0,
+ * txDelegateTakeRateLimit=216000 blocks) -- same never-hardcode rule as
+ * getMinStake, since governance could change any of these post-genesis.
+ */
+export async function getMaxDelegateTake(api: ApiPromise): Promise<number> {
+  const raw = await (api as unknown as SubtensorQueryApi).query.subtensorModule.maxDelegateTake();
+  return raw.toNumber();
+}
+
+export async function getMinDelegateTake(api: ApiPromise): Promise<number> {
+  const raw = await (api as unknown as SubtensorQueryApi).query.subtensorModule.minDelegateTake();
+  return raw.toNumber();
+}
+
+export async function getTxDelegateTakeRateLimit(api: ApiPromise): Promise<number> {
+  const raw = await (
+    api as unknown as SubtensorQueryApi
+  ).query.subtensorModule.txDelegateTakeRateLimit();
+  return raw.toNumber();
+}
+
+/**
+ * This hotkey's current take (PerU16 parts). `Delegates` is a `ValueQuery`
+ * map -- a hotkey that has never explicitly set a take still returns a real
+ * number (the pallet's own default), never "not found". do_increase_take/
+ * do_decrease_take use `try_get` internally and only enforce the strictly-
+ * greater/less-than-current check when a value was explicitly written
+ * before -- that Option-vs-default distinction isn't visible through this
+ * convenience query, so validateTakeInputs (take-extrinsics.ts) applies the
+ * strictly-monotonic check unconditionally. That's strictly more
+ * conservative than the chain, never less: the one edge case this can
+ * wrongly block is a hotkey's very first take change landing exactly on the
+ * pallet's default value, which the chain would actually allow -- a rare,
+ * UX-only over-caution, not a fund-safety gap.
+ */
+export async function getCurrentTakeParts(api: ApiPromise, hotkey: string): Promise<number> {
+  const raw = await (api as unknown as SubtensorQueryApi).query.subtensorModule.delegates(hotkey);
+  return raw.toNumber();
+}
+
+/**
+ * The block this hotkey's take was last changed at (increase OR decrease --
+ * decrease_take writes this timestamp too, even though it never itself gates
+ * on it; see take-extrinsics.ts's header comment). 0 means "never changed" --
+ * the ValueQuery default for an unwritten map entry, and also
+ * isDelegateTakeRateLimited's own "never limited" sentinel.
+ */
+export async function getLastTxBlockDelegateTake(api: ApiPromise, hotkey: string): Promise<number> {
+  const raw = await (
+    api as unknown as SubtensorQueryApi
+  ).query.subtensorModule.lastRateLimitedBlock({ LastTxBlockDelegateTake: hotkey });
+  return raw.toNumber();
 }
 
 /**
@@ -153,5 +244,9 @@ export function buildExtrinsic(
         params.netuid,
         params.alphaAmount,
       );
+    case "increase_take":
+      return api.tx.subtensorModule.increaseTake(params.hotkey, params.take);
+    case "decrease_take":
+      return api.tx.subtensorModule.decreaseTake(params.hotkey, params.take);
   }
 }

--- a/apps/ui/src/lib/metagraphed/take-extrinsics.test.ts
+++ b/apps/ui/src/lib/metagraphed/take-extrinsics.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import {
+  TAKE_PARTS_PER_WHOLE,
+  percentToTakeParts,
+  takePartsToPercent,
+  buildIncreaseTakeParams,
+  buildDecreaseTakeParams,
+  isDelegateTakeRateLimited,
+  delegateTakeCooldownRemainingBlocks,
+  formatCooldownDuration,
+  validateTakeInputs,
+  describeTakeValidationIssue,
+} from "./take-extrinsics";
+
+const HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+describe("percentToTakeParts", () => {
+  it("matches the pallet doc comment's own worked example (1% -> 655)", () => {
+    expect(percentToTakeParts(1)).toBe(655);
+  });
+
+  it("matches the live-confirmed 18% max (11796 parts)", () => {
+    expect(percentToTakeParts(18)).toBe(11_796);
+  });
+
+  it("rounds to the nearest representable part", () => {
+    expect(percentToTakeParts(0)).toBe(0);
+    expect(percentToTakeParts(100)).toBe(TAKE_PARTS_PER_WHOLE);
+  });
+
+  it("throws on a non-finite, negative, or out-of-range percentage rather than silently clamping", () => {
+    expect(() => percentToTakeParts(NaN)).toThrow(/invalid/i);
+    expect(() => percentToTakeParts(-1)).toThrow(/invalid/i);
+    expect(() => percentToTakeParts(100.001)).toThrow(/invalid/i);
+  });
+});
+
+describe("takePartsToPercent", () => {
+  it("is the inverse of percentToTakeParts at whole-percent boundaries", () => {
+    expect(takePartsToPercent(655)).toBeCloseTo(1, 1);
+    expect(takePartsToPercent(11_796)).toBeCloseTo(18, 3);
+  });
+});
+
+describe("buildIncreaseTakeParams / buildDecreaseTakeParams", () => {
+  it("packages the call name and inputs untouched", () => {
+    expect(buildIncreaseTakeParams({ hotkey: HOTKEY, take: 1000 })).toEqual({
+      call: "increase_take",
+      hotkey: HOTKEY,
+      take: 1000,
+    });
+    expect(buildDecreaseTakeParams({ hotkey: HOTKEY, take: 500 })).toEqual({
+      call: "decrease_take",
+      hotkey: HOTKEY,
+      take: 500,
+    });
+  });
+});
+
+describe("isDelegateTakeRateLimited", () => {
+  // Mirrors exceeds_tx_delegate_take_rate_limit exactly:
+  // rate_limit == 0 || prev_tx_block == 0 -> never blocked;
+  // otherwise blocked while (current - prev) <= rate_limit.
+  it("is never limited when the rate limit itself is disabled (0)", () => {
+    expect(isDelegateTakeRateLimited(100, 200, 0)).toBe(false);
+  });
+
+  it("is never limited when the hotkey has never changed its take before (lastTxBlock 0)", () => {
+    expect(isDelegateTakeRateLimited(0, 216_000, 216_000)).toBe(false);
+  });
+
+  it("is limited exactly at the boundary (current - prev == rate_limit)", () => {
+    expect(isDelegateTakeRateLimited(1000, 1000 + 216_000, 216_000)).toBe(true);
+  });
+
+  it("is limited just inside the window", () => {
+    expect(isDelegateTakeRateLimited(1000, 1000 + 100, 216_000)).toBe(true);
+  });
+
+  it("is no longer limited just past the window", () => {
+    expect(isDelegateTakeRateLimited(1000, 1000 + 216_001, 216_000)).toBe(false);
+  });
+});
+
+describe("delegateTakeCooldownRemainingBlocks", () => {
+  it("is 0 when not currently limited", () => {
+    expect(delegateTakeCooldownRemainingBlocks(0, 1000, 216_000)).toBe(0);
+    expect(delegateTakeCooldownRemainingBlocks(1000, 1000 + 216_001, 216_000)).toBe(0);
+  });
+
+  it("counts down correctly while limited", () => {
+    expect(delegateTakeCooldownRemainingBlocks(1000, 1000 + 50_000, 216_000)).toBe(166_000);
+  });
+});
+
+describe("formatCooldownDuration", () => {
+  it("formats a no-cooldown state distinctly", () => {
+    expect(formatCooldownDuration(0)).toBe("no cooldown");
+    expect(formatCooldownDuration(-5)).toBe("no cooldown");
+  });
+
+  it("formats the full 216000-block rate limit as about 30 days", () => {
+    expect(formatCooldownDuration(216_000)).toBe("about 30 days");
+  });
+
+  it("tiers down to hours and minutes for shorter remainders", () => {
+    expect(formatCooldownDuration(300)).toBe("about 1 hour"); // 3600s
+    expect(formatCooldownDuration(10)).toBe("about 2 minutes"); // 120s
+    expect(formatCooldownDuration(1)).toBe("less than a minute");
+  });
+});
+
+describe("validateTakeInputs", () => {
+  const base = {
+    hotkey: HOTKEY,
+    isOwner: true,
+    minTakeParts: 0,
+    maxTakeParts: 11_796,
+    cooldownRemainingBlocks: 0,
+  };
+
+  it("passes a valid increase with no issues", () => {
+    expect(
+      validateTakeInputs({
+        ...base,
+        direction: "increase",
+        takeParts: 1000,
+        currentTakeParts: 500,
+      }),
+    ).toEqual([]);
+  });
+
+  it("passes a valid decrease with no issues", () => {
+    expect(
+      validateTakeInputs({
+        ...base,
+        direction: "decrease",
+        takeParts: 200,
+        currentTakeParts: 500,
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags an invalid hotkey and a non-owner wallet together", () => {
+    const issues = validateTakeInputs({
+      ...base,
+      hotkey: "not-a-real-address",
+      isOwner: false,
+      direction: "increase",
+      takeParts: 1000,
+      currentTakeParts: 500,
+    });
+    expect(issues).toContainEqual({ code: "invalid_hotkey" });
+    expect(issues).toContainEqual({ code: "not_owner" });
+  });
+
+  it("flags below-min and above-max take", () => {
+    expect(
+      validateTakeInputs({ ...base, direction: "decrease", takeParts: -1, currentTakeParts: 500 }),
+    ).toContainEqual({ code: "below_min_take", minTakeParts: 0 });
+    expect(
+      validateTakeInputs({
+        ...base,
+        direction: "increase",
+        takeParts: 20_000,
+        currentTakeParts: 500,
+      }),
+    ).toContainEqual({ code: "above_max_take", maxTakeParts: 11_796 });
+  });
+
+  it("flags a non-strictly-increasing increase and a non-strictly-decreasing decrease", () => {
+    expect(
+      validateTakeInputs({ ...base, direction: "increase", takeParts: 500, currentTakeParts: 500 }),
+    ).toContainEqual({ code: "not_strictly_increasing" });
+    expect(
+      validateTakeInputs({ ...base, direction: "decrease", takeParts: 500, currentTakeParts: 500 }),
+    ).toContainEqual({ code: "not_strictly_decreasing" });
+  });
+
+  it("flags rate-limiting only for increase, never for decrease (decrease_take has no rate limit at all)", () => {
+    const increaseIssues = validateTakeInputs({
+      ...base,
+      direction: "increase",
+      takeParts: 1000,
+      currentTakeParts: 500,
+      cooldownRemainingBlocks: 100_000,
+    });
+    expect(increaseIssues).toContainEqual({ code: "rate_limited", remainingBlocks: 100_000 });
+
+    const decreaseIssues = validateTakeInputs({
+      ...base,
+      direction: "decrease",
+      takeParts: 200,
+      currentTakeParts: 500,
+      cooldownRemainingBlocks: 100_000,
+    });
+    expect(decreaseIssues.some((i) => i.code === "rate_limited")).toBe(false);
+  });
+});
+
+describe("describeTakeValidationIssue", () => {
+  it("formats every issue code with human-readable, non-empty copy", () => {
+    const issues: Parameters<typeof describeTakeValidationIssue>[0][] = [
+      { code: "invalid_hotkey" },
+      { code: "not_owner" },
+      { code: "below_min_take", minTakeParts: 0 },
+      { code: "above_max_take", maxTakeParts: 11_796 },
+      { code: "not_strictly_increasing" },
+      { code: "not_strictly_decreasing" },
+      { code: "rate_limited", remainingBlocks: 216_000 },
+    ];
+    for (const issue of issues) {
+      expect(describeTakeValidationIssue(issue).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("formats the max-take message using the live-confirmed 18% bound", () => {
+    expect(describeTakeValidationIssue({ code: "above_max_take", maxTakeParts: 11_796 })).toContain(
+      "18.00%",
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/take-extrinsics.ts
+++ b/apps/ui/src/lib/metagraphed/take-extrinsics.ts
@@ -1,0 +1,209 @@
+// Validator take (commission) self-service (#5246, native-staking epic
+// #5229). Correctness-critical for the same reason stake-extrinsics.ts is:
+// a wrong parameter or a unit mixup here directly affects a validator's
+// revenue, not a cosmetic display value.
+//
+// Every claim below is verified against the live subtensor pallet source
+// (opentensor/subtensor, pallets/subtensor/src/macros/dispatches.rs +
+// staking/increase_take.rs + staking/decrease_take.rs + utils/rate_limiting.rs,
+// read 2026-07-15) AND empirically confirmed against the live mainnet RPC:
+//
+//   - increase_take (call_index 66) / decrease_take (call_index 65) both take
+//     exactly (hotkey: AccountId, take: PerU16) -- no netuid. The dispatch
+//     doc comments both still mention "for subnet ID" / a `netuid` argument
+//     and cite a `NotRegistered` error -- both stale (take is network-wide,
+//     not subnet-scoped, in the actual function signature; `NotRegistered`
+//     isn't a real variant in the error enum at all). Built from the real
+//     `pub fn` signatures, not the doc comments.
+//   - PerU16 is parts-per-65535, per the doc comment's own worked example:
+//     1% = [0.01 * 65535] = [655.35] = 655.
+//   - decrease_take has NO rate-limit check at all (confirmed: no call to
+//     exceeds_tx_delegate_take_rate_limit anywhere in do_decrease_take) --
+//     "decreases instant/unlimited" is accurate. But it DOES still write the
+//     shared last-tx-block-delegate-take timestamp as a side effect, so a
+//     decrease still starts the cooldown clock for a SUBSEQUENT increase.
+//   - do_decrease_take also enforces `take >= MinDelegateTake::<T>::get()` --
+//     a floor bound the issue that spawned this file didn't mention. Both
+//     MaxDelegateTake and MinDelegateTake are live StorageValues (not
+//     `#[pallet::constant]`s), so -- same rule as getMinStake in
+//     chain-connection.ts -- always query live, never hardcode. Confirmed
+//     live against mainnet: maxDelegateTake=11796 (=18.0000%, matching the
+//     doc comment's "18%"), minDelegateTake=0 (currently no floor, but this
+//     is mutable storage, not a guarantee).
+//   - txDelegateTakeRateLimit is also a live StorageValue, confirmed live
+//     against mainnet at 216000 blocks (=30 days at Bittensor's ~12s block
+//     time) -- matches the issue's own "~30 days" claim exactly.
+//   - The remaining-cooldown check itself
+//     (exceeds_tx_delegate_take_rate_limit) is: blocked when
+//     `rate_limit != 0 && prev_tx_block != 0 && (current_block -
+//     prev_tx_block) <= rate_limit` -- mirrored exactly by
+//     isDelegateTakeRateLimited below, including the two "never blocked"
+//     special cases (a disabled rate limit, or a hotkey that has never
+//     changed its take before).
+
+import { isValidSs58 } from "./accounts";
+
+/** PerU16's denominator -- take is expressed as parts-per-this-many. */
+export const TAKE_PARTS_PER_WHOLE = 65_535;
+
+/** Rounds to the nearest representable PerU16 value, clamped to [0, 65535]. Throws on non-finite/negative/>100 input rather than silently clamping a typo into something valid. */
+export function percentToTakeParts(pct: number): number {
+  if (!Number.isFinite(pct) || pct < 0 || pct > 100) {
+    throw new Error(`Invalid take percentage: ${pct}`);
+  }
+  return Math.round((pct / 100) * TAKE_PARTS_PER_WHOLE);
+}
+
+/** The inverse of percentToTakeParts, for display. */
+export function takePartsToPercent(parts: number): number {
+  return (parts / TAKE_PARTS_PER_WHOLE) * 100;
+}
+
+export type TakeDirection = "increase" | "decrease";
+
+export interface IncreaseTakeParams {
+  call: "increase_take";
+  hotkey: string;
+  take: number;
+}
+
+export interface DecreaseTakeParams {
+  call: "decrease_take";
+  hotkey: string;
+  take: number;
+}
+
+/** Params for subtensorModule.increaseTake(hotkey, take). Pure parameter packaging -- pallet-side bounds/direction/rate-limit checks are validateTakeInputs' job, not this function's; the chain re-validates all of this regardless. */
+export function buildIncreaseTakeParams(input: {
+  hotkey: string;
+  take: number;
+}): IncreaseTakeParams {
+  return { call: "increase_take", ...input };
+}
+
+/** Params for subtensorModule.decreaseTake(hotkey, take). */
+export function buildDecreaseTakeParams(input: {
+  hotkey: string;
+  take: number;
+}): DecreaseTakeParams {
+  return { call: "decrease_take", ...input };
+}
+
+/**
+ * Mirrors exceeds_tx_delegate_take_rate_limit exactly, including its two
+ * "never blocked" special cases -- a disabled rate limit (rateLimitBlocks
+ * === 0) or a hotkey whose take has never been changed before
+ * (lastTxBlock === 0, the ValueQuery default for a never-written storage
+ * map entry).
+ */
+export function isDelegateTakeRateLimited(
+  lastTxBlock: number,
+  currentBlock: number,
+  rateLimitBlocks: number,
+): boolean {
+  if (rateLimitBlocks === 0 || lastTxBlock === 0) return false;
+  return Math.max(currentBlock - lastTxBlock, 0) <= rateLimitBlocks;
+}
+
+/** Blocks remaining until an increase_take would clear the cooldown, or 0 if not currently limited. */
+export function delegateTakeCooldownRemainingBlocks(
+  lastTxBlock: number,
+  currentBlock: number,
+  rateLimitBlocks: number,
+): number {
+  if (!isDelegateTakeRateLimited(lastTxBlock, currentBlock, rateLimitBlocks)) return 0;
+  return rateLimitBlocks - Math.max(currentBlock - lastTxBlock, 0);
+}
+
+/** Display-only estimate (Bittensor's well-known ~12s block time) -- never used for the actual rate-limit gating decision, which always compares raw block counts from a live query. */
+const APPROX_SECONDS_PER_BLOCK = 12;
+
+/** A human-readable duration for a remaining-cooldown block count, e.g. "about 30 days". */
+export function formatCooldownDuration(remainingBlocks: number): string {
+  if (remainingBlocks <= 0) return "no cooldown";
+  const seconds = remainingBlocks * APPROX_SECONDS_PER_BLOCK;
+  const minutes = seconds / 60;
+  const hours = minutes / 60;
+  const days = hours / 24;
+  if (days >= 1) return `about ${Math.ceil(days)} day${Math.ceil(days) === 1 ? "" : "s"}`;
+  if (hours >= 1) return `about ${Math.ceil(hours)} hour${Math.ceil(hours) === 1 ? "" : "s"}`;
+  if (minutes >= 1)
+    return `about ${Math.ceil(minutes)} minute${Math.ceil(minutes) === 1 ? "" : "s"}`;
+  return "less than a minute";
+}
+
+export type TakeValidationIssue =
+  | { code: "invalid_hotkey" }
+  | { code: "not_owner" }
+  | { code: "below_min_take"; minTakeParts: number }
+  | { code: "above_max_take"; maxTakeParts: number }
+  | { code: "not_strictly_increasing" }
+  | { code: "not_strictly_decreasing" }
+  | { code: "rate_limited"; remainingBlocks: number };
+
+export interface ValidateTakeInputsParams {
+  hotkey: string;
+  /** Whether the connected wallet is this hotkey's owning coldkey -- the pallet's own NonAssociatedColdKey check, mirrored client-side pre-signature. */
+  isOwner: boolean;
+  direction: TakeDirection;
+  takeParts: number;
+  currentTakeParts: number;
+  minTakeParts: number;
+  maxTakeParts: number;
+  /** Only meaningful for "increase" -- decrease_take has no rate limit at all. */
+  cooldownRemainingBlocks: number;
+}
+
+/**
+ * Client-side pre-flight checks run before any signature prompt fires,
+ * mirroring stake-extrinsics.ts's validateStakeInputs. Returns every issue
+ * found, not just the first. This is a UX convenience, not the safety
+ * boundary -- the chain re-validates all of this itself and remains
+ * authoritative.
+ */
+export function validateTakeInputs({
+  hotkey,
+  isOwner,
+  direction,
+  takeParts,
+  currentTakeParts,
+  minTakeParts,
+  maxTakeParts,
+  cooldownRemainingBlocks,
+}: ValidateTakeInputsParams): TakeValidationIssue[] {
+  const issues: TakeValidationIssue[] = [];
+  if (!isValidSs58(hotkey)) issues.push({ code: "invalid_hotkey" });
+  if (!isOwner) issues.push({ code: "not_owner" });
+  if (takeParts < minTakeParts) issues.push({ code: "below_min_take", minTakeParts });
+  if (takeParts > maxTakeParts) issues.push({ code: "above_max_take", maxTakeParts });
+  if (direction === "increase") {
+    if (takeParts <= currentTakeParts) issues.push({ code: "not_strictly_increasing" });
+    // decrease_take has no rate limit at all -- see this file's header comment.
+    if (cooldownRemainingBlocks > 0) {
+      issues.push({ code: "rate_limited", remainingBlocks: cooldownRemainingBlocks });
+    }
+  } else {
+    if (takeParts >= currentTakeParts) issues.push({ code: "not_strictly_decreasing" });
+  }
+  return issues;
+}
+
+/** Human-readable copy for a validation issue, for the pre-sign confirmation screen. */
+export function describeTakeValidationIssue(issue: TakeValidationIssue): string {
+  switch (issue.code) {
+    case "invalid_hotkey":
+      return "Not a valid hotkey address.";
+    case "not_owner":
+      return "Your connected wallet doesn't own this hotkey.";
+    case "below_min_take":
+      return `Take can't go below ${takePartsToPercent(issue.minTakeParts).toFixed(2)}%.`;
+    case "above_max_take":
+      return `Take can't exceed ${takePartsToPercent(issue.maxTakeParts).toFixed(2)}%.`;
+    case "not_strictly_increasing":
+      return "The new take must be strictly higher than the current take.";
+    case "not_strictly_decreasing":
+      return "The new take must be strictly lower than the current take.";
+    case "rate_limited":
+      return `Take was changed too recently -- try again in ${formatCooldownDuration(issue.remainingBlocks)}.`;
+  }
+}

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { Boxes, Coins, Gauge, Percent, Users, Zap } from "lucide-react";
+import { useWallet } from "@/hooks/use-wallet";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -15,6 +16,7 @@ import { ValidatorApyPanel } from "@/components/metagraphed/validator-apy-panel"
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
 import { WatchValidatorAlert } from "@/components/metagraphed/watch-validator-alert";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
+import { TakeManagementModal } from "@/components/metagraphed/take-management-modal";
 import {
   ValidatorNominatorsTable,
   type ValidatorNominatorsSearch,
@@ -248,6 +250,13 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
     detail.total_stake_tao,
     detail.take,
   );
+  // Take is network-wide, not subnet-scoped, so unlike the per-subnet Stake
+  // action this belongs at the page level, not in SubnetPerformanceTable's
+  // rows. Hidden entirely (not just internally blocked) until the connected
+  // wallet is confirmed to be this validator's owning coldkey -- #5246's own
+  // "only surfaced when..." requirement, not just a submit-time guard.
+  const { wallet } = useWallet();
+  const isOwner = !!wallet && !!detail.coldkey && wallet.address === detail.coldkey;
 
   return (
     <>
@@ -277,7 +286,28 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
             </span>
           </span>
         }
-        actions={<ShareButton />}
+        actions={
+          <div className="flex items-center gap-2">
+            {isOwner ? (
+              <TakeManagementModal
+                hotkey={hotkey}
+                ownerColdkey={detail.coldkey}
+                validatorName={hasIdentity ? displayName : undefined}
+                trigger={(open) => (
+                  <button
+                    type="button"
+                    onClick={open}
+                    className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong transition-colors hover:border-accent/50 hover:text-accent"
+                  >
+                    <Percent className="size-3 text-ink-muted" aria-hidden />
+                    Manage take
+                  </button>
+                )}
+              />
+            ) : null}
+            <ShareButton />
+          </div>
+        }
         caption="explorer / v1"
       />
 


### PR DESCRIPTION
## Summary

Validator self-service take (commission) management (#5246), the next unblocked maintainer-only item in the native-staking epic (#5229) — depends only on already-merged Phase 2 plumbing (#5236–#5241), no other blockers.

- **Entry point**: a "Manage take" button in `validators.$hotkey.tsx`'s `PageHero`, next to Share — only rendered when the connected wallet's address matches the validator's owning coldkey (re-compared live on every render, not frozen at mount, since the user could switch accounts in their extension mid-session). Take is network-wide, not subnet-scoped, so unlike the stake flow this lives at the page level, not per-subnet-row.
- **`use-take-flow.ts`**: mirrors `use-stake-flow.ts`'s composition pattern (same phase derivation, same SSR-safe session id, same close/reentrancy guards) but is considerably simpler — a single percentage value, no AMM quote/unit-conversion machinery.
- **Every bound queried live, never hardcoded**: `maxDelegateTake`/`minDelegateTake`/`txDelegateTakeRateLimit` are real `StorageValue`s (not `#[pallet::constant]`s) — confirmed live against mainnet: `maxDelegateTake=11796` parts (=18.0000%), `minDelegateTake=0`, `txDelegateTakeRateLimit=216000` blocks (=30 days at ~12s/block). All three match the issue's own claims exactly. The cooldown check (`isDelegateTakeRateLimited`) mirrors `exceeds_tx_delegate_take_rate_limit` precisely, including its two "never blocked" special cases (disabled rate limit, or a hotkey that's never changed its take before).

**Two doc-comment/issue drifts found while re-verifying against live pallet source** (same rigor as #5251's review, applied to this issue's own research before building anything):
- `increase_take`/`decrease_take`'s doc comments both still say "for subnet ID" and list a `netuid` argument — the actual `pub fn` signatures take exactly `(hotkey, take: PerU16)`, no `netuid` at all. Take became network-wide at some point and the doc comments never caught up. Built from the real signatures, not the comments.
- Both doc comments also cite a `NotRegistered` error — that name doesn't exist anywhere in the error enum. Confirmed via `subtensorModule.NonAssociatedColdKey`/`DelegateTakeTooLow`/`DelegateTakeTooHigh`, which are real and already correctly mapped in `tx-errors.ts` from #5240.
- **A bound the issue itself didn't mention**: `decrease_take` enforces a live `MinDelegateTake` floor (`take >= min_take`) — the issue's deliverables said "decreases instant/unlimited," which is true for the *rate limit* (confirmed: `do_decrease_take` never calls the rate-limit check at all) but not for the take value itself. Currently `0` on mainnet, so not restrictive today, but it's live-queried like every other bound here, not assumed to stay `0`.

One more interaction worth flagging: `decrease_take` has no rate-limit check of its own, but it *does* still write the shared last-tx-block-delegate-take timestamp as a side effect — so a decrease still starts the cooldown clock for a subsequent increase, even though the decrease itself was never blocked by it.

## Verification

- `npx vitest run` (apps/ui): **977/977 passing**, including 24 new tests in `take-extrinsics.test.ts` (percent↔parts conversion matching the pallet doc comment's own worked example, cooldown math mirroring `exceeds_tx_delegate_take_rate_limit`'s exact boundary conditions, full validation-issue coverage), 9 in `use-take-flow.test.ts` (phase derivation), and new `buildExtrinsic`/live-query coverage in `chain-connection.test.ts`.
- `npx tsc --noEmit`, `npx eslint .` — clean (0 errors; pre-existing route-file fast-refresh warnings only).
- `npm run build` (apps/ui, Cloudflare/Nitro target) — succeeds; confirmed no `@polkadot/*` package leaked into the SSR server bundle.
- **Manual QA against live mainnet RPC + API**, via Playwright with a mocked `window.injectedWeb3` connected as tao.bot's actual owning coldkey (no real extension available in this environment): the "Manage take" button correctly appears only for the owning coldkey, correctly stays hidden otherwise; live bounds display exactly matches the empirically-confirmed chain values (current 0.00%, range 0.00%–18.00%); both direction validations fire correctly (increase-must-exceed-current, decrease-must-be-below-current); reached the real confirm screen with a live fee estimate from a real `paymentInfo()` call against mainnet — further than #5242 got in the same environment, since take-management doesn't require a funded balance the way staking does.

## Screenshots

### Page-level — new "Manage take" action (hidden by default; wallet-gated)

| Viewport | Theme | Before | After |
| --- | --- | --- | --- |
| Desktop (1280px) | Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-after-desktop-dark.png) |
| Desktop (1280px) | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-after-desktop-light.png) |
| Tablet (768px) | Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-after-tablet-dark.png) |
| Tablet (768px) | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-after-tablet-light.png) |
| Mobile (375px) | Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-after-mobile-dark.png) |
| Mobile (375px) | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-after-mobile-light.png) |

The automated "after" captures look identical to "before" since no wallet is connected in that pass — the button is correctly wallet-gated, not a capture failure. See the flow screenshots below for the actual feature.

### Modal flow (live mainnet RPC + API, mocked injected extension connected as the owning coldkey)

| Step | Screenshot |
| --- | --- |
| Owner connected — "Manage take" now visible next to Share | ![owner-connected](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-flow-01-owner-connected.png) |
| Amount step, empty | ![amount-step](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-flow-02-amount-step.png) |
| Increase 5% — live current/range display, Review enabled | ![increase-live-bounds](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-flow-03-increase-live-bounds.png) |
| Decrease tab, 5% (above current) — correctly blocked | ![decrease-validation](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-flow-04-decrease-validation.png) |
| Increase tab, 0% (not above current) — correctly blocked | ![increase-validation](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-flow-05-increase-validation.png) |
| Confirm screen — real fee estimate from a live `paymentInfo()` call | ![confirm-live-fee](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5246-take-management-flow-06-confirm-live-fee.png) |

The signing/broadcasting/done phases aren't screenshotted — no real wallet extension in this environment to actually produce a signature. Their component logic (shared with #5242's `broadcastStatusLabel`, `useTxStatus`) was already verified there.

Closes #5246
