### PR TITLE
infra(ci): add a report-only root-workspace dependency-CVE (SCA) scan (#5543)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -402,6 +402,23 @@ jobs:
       - name: Install
         run: npm ci
 
+      # Report-only SCA for the ROOT workspace — workers/** (the Worker API, MCP
+      # server, webhook dispatcher), src/**, and scripts/** — the repo's larger,
+      # more security-sensitive dependency surface, which until now had strictly
+      # less CI coverage than apps/ui (#5543). Same posture as the apps/ui CVE
+      # scan in the `ui` job below and the gate #1772 established: surface
+      # high/critical runtime advisories at PR time without failing the job
+      # (Renovate is async/non-blocking, so a feature PR can still merge a
+      # vulnerable transitive dep between Renovate runs). No `--workspace` flag,
+      # so this audits the whole lockfile — a superset that necessarily covers
+      # the root deps this gap is about; the minor overlap with the apps/ui-
+      # scoped scan is harmless since both are report-only. Never `--force`.
+      # Tighten to blocking once it stays clean.
+      - name: Dependency CVE scan (SCA, report-only)
+        run: |
+          npm audit --audit-level=high --omit=dev \
+            || echo "::warning::npm audit found high/critical advisories in the root workspace's runtime dependencies — review above (report-only; not failing CI yet)"
+
       # Lint + format + the documentation/intake/safety/security scans below
       # run UNCONDITIONALLY, docs fast lane or not — they're cheap (no build,
       # no network), and directly relevant to a docs-only diff (a stray secret,


### PR DESCRIPTION
## Summary

`validate.yml`'s `ui` job already runs a report-only dependency-CVE (SCA) scan
scoped to `apps/ui` (`Dependency CVE scan (SCA, report-only)`), but the **root
workspace** — `workers/**` (the Worker API, MCP server, webhook dispatcher, the
code that handles secrets, signs webhooks, and talks to Postgres/R2/KV),
`src/**`, and `scripts/**` — had **no** `npm audit` (or any SCA) step in any
workflow. That is the repo's larger, more security-sensitive dependency surface,
and it had strictly less CI coverage than the frontend.

Closes #5543.

## What Changed

- Added a report-only `Dependency CVE scan (SCA, report-only)` step to the
  `checks` job in `.github/workflows/validate.yml`, right after `npm ci`.
- It runs `npm audit --audit-level=high --omit=dev` (no `--workspace` flag, so it
  audits the whole installed lockfile — a superset that necessarily covers the
  root `workers`/`src`/`scripts` runtime deps this gap is about) and pipes a
  non-failing `::warning::` on advisories, exactly mirroring the existing
  `apps/ui` step and the posture #1772 established.
- **Report-only** — it never fails the build (`|| echo "::warning::…"`), and
  never invokes `npm audit fix --force`. The comment documents the posture, the
  whole-lockfile choice (minor, harmless overlap with the `apps/ui`-scoped scan
  since both are report-only), and points at this issue and #1772.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5543`).
- [x] No secrets, PATs, wallet data, private URLs, or validator-local state.
- [x] No generated artifacts touched; single-file workflow change.

## Validation

- [x] `npx prettier --check .github/workflows/validate.yml` — clean.
- [x] `npm audit --audit-level=high --omit=dev` runs locally and exits cleanly
      (root tree currently has no high/critical advisories; the step is
      report-only regardless).
- [x] `git diff --check` clean; the diff is only the new step + its comment.
