### PR TITLE
fix(api): bound free-text q (200) and filter params (100) with a maxLength (#5544)

### DIFF
--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1332,6 +1332,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -1563,6 +1564,7 @@
         {
           "name": "review_state",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -1593,6 +1595,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -1755,6 +1758,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -1856,6 +1860,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -1991,6 +1996,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -2173,6 +2179,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -2338,6 +2345,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -2456,6 +2464,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -2552,6 +2561,7 @@
         {
           "name": "id",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -2899,6 +2909,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -2997,6 +3008,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -3381,6 +3393,7 @@
         {
           "name": "review_state",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -3477,6 +3490,7 @@
         {
           "name": "review_state",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -3779,6 +3793,7 @@
         {
           "name": "reason_codes",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -4000,12 +4015,14 @@
         {
           "name": "reason_codes",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
         {
           "name": "review_state",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -4022,6 +4039,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -4195,6 +4213,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -4397,6 +4416,7 @@
         {
           "name": "reason_codes",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -4442,6 +4462,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -4637,6 +4658,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -4766,6 +4788,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -8164,6 +8187,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -8228,6 +8252,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -8304,6 +8329,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -8427,6 +8453,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -8562,6 +8589,7 @@
         {
           "name": "id",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -8697,6 +8725,7 @@
         {
           "name": "provider",
           "schema": {
+            "maxLength": 100,
             "type": "string"
           }
         },
@@ -8846,6 +8875,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },
@@ -8910,6 +8940,7 @@
         {
           "name": "q",
           "schema": {
+            "maxLength": 200,
             "type": "string"
           }
         },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -27383,6 +27383,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -32491,6 +32492,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -33025,6 +33027,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -33470,6 +33473,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -33735,6 +33739,7 @@
             "name": "id",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -34081,6 +34086,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -34392,6 +34398,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -36165,6 +36172,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -37013,6 +37021,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -37049,6 +37058,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -37399,6 +37409,7 @@
             "name": "id",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -38525,6 +38536,7 @@
             "name": "reason_codes",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -38875,6 +38887,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -39238,6 +39251,7 @@
             "name": "reason_codes",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -39246,6 +39260,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -39266,6 +39281,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -39712,6 +39728,7 @@
             "name": "reason_codes",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -39765,6 +39782,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -40082,6 +40100,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -40742,6 +40761,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -41621,6 +41641,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -41817,6 +41838,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -42153,6 +42175,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -42451,6 +42474,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -43307,6 +43331,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -44121,6 +44146,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -44841,6 +44867,7 @@
             "name": "q",
             "required": false,
             "schema": {
+              "maxLength": 200,
               "type": "string"
             }
           },
@@ -45063,6 +45090,7 @@
             "name": "review_state",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -45378,6 +45406,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -49521,6 +49550,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },
@@ -51829,6 +51859,7 @@
             "name": "provider",
             "required": false,
             "schema": {
+              "maxLength": 100,
               "type": "string"
             }
           },

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -130,7 +130,19 @@ export const QUERY_ENUMS = {
 };
 
 const integerSchema = { type: "integer", minimum: 0 };
-const textSchema = { type: "string" };
+// Free-text query params carry an explicit maxLength so an arbitrarily long
+// value can't drive unbounded per-row scan work in searchRows / filter matching
+// (#5544) — every other validated param already bounds its input. `q` is
+// free-typed search prose (a generous 200-char ceiling); the exact-ish filters
+// (provider, id, review_state, reason_codes) are structured tokens, bounded
+// tighter at 100, in line with the existing pallet/method/call_module limits.
+// SEARCH_TEXT_MAX_LENGTH is exported because the generic maxLength check in
+// validateListQuery only iterates config.filters — `q` is a search param, not a
+// filter, so workers/list-query.mjs enforces its bound from this single source.
+export const SEARCH_TEXT_MAX_LENGTH = 200;
+const FILTER_TEXT_MAX_LENGTH = 100;
+const searchTextSchema = { type: "string", maxLength: SEARCH_TEXT_MAX_LENGTH };
+const filterTextSchema = { type: "string", maxLength: FILTER_TEXT_MAX_LENGTH };
 const fieldListSchema = {
   type: "string",
   pattern: "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
@@ -141,7 +153,7 @@ export const API_QUERY_COLLECTIONS = {
     filters: {
       netuid: integerSchema,
       kind: enumSchema(QUERY_ENUMS.surfaceKind),
-      provider: textSchema,
+      provider: filterTextSchema,
       state: enumSchema(QUERY_ENUMS.candidateState),
     },
     sort: ["confidence", "id", "kind", "name", "netuid", "provider", "state"],
@@ -179,7 +191,7 @@ export const API_QUERY_COLLECTIONS = {
     filters: {
       netuid: integerSchema,
       kind: enumSchema(QUERY_ENUMS.surfaceKind),
-      provider: textSchema,
+      provider: filterTextSchema,
     },
     sort: ["id", "kind", "name", "netuid", "provider"],
   }),
@@ -219,7 +231,7 @@ export const API_QUERY_COLLECTIONS = {
       layer: enumSchema(QUERY_ENUMS.endpointLayer),
       netuid: integerSchema,
       pool_eligible: enumSchema(["true", "false"]),
-      provider: textSchema,
+      provider: filterTextSchema,
       publication_state: enumSchema(QUERY_ENUMS.endpointPublicationState),
       status: enumSchema(QUERY_ENUMS.healthStatus),
     },
@@ -239,7 +251,7 @@ export const API_QUERY_COLLECTIONS = {
   }),
   "endpoint-pools": queryCollection("pools", {
     filters: {
-      id: textSchema,
+      id: filterTextSchema,
       kind: enumSchema(["subtensor-rpc", "subtensor-wss", "archive"]),
     },
     sort: ["eligible_count", "endpoint_count", "id", "kind"],
@@ -249,7 +261,7 @@ export const API_QUERY_COLLECTIONS = {
     filters: {
       netuid: integerSchema,
       kind: enumSchema(QUERY_ENUMS.surfaceKind),
-      provider: textSchema,
+      provider: filterTextSchema,
       status: enumSchema(QUERY_ENUMS.healthStatus),
       severity: enumSchema(QUERY_ENUMS.endpointIncidentSeverity),
       state: enumSchema(QUERY_ENUMS.endpointIncidentState),
@@ -279,7 +291,7 @@ export const API_QUERY_COLLECTIONS = {
       netuid: integerSchema,
       subnet_type: enumSchema(QUERY_ENUMS.subnetType),
       curation_level: enumSchema(QUERY_ENUMS.curationLevel),
-      review_state: textSchema,
+      review_state: filterTextSchema,
       confidence: enumSchema(["low", "medium", "high"]),
       profile_level: enumSchema(QUERY_ENUMS.profileLevel),
     },
@@ -327,7 +339,7 @@ export const API_QUERY_COLLECTIONS = {
     filters: {
       netuid: integerSchema,
       curation_level: enumSchema(QUERY_ENUMS.curationLevel),
-      review_state: textSchema,
+      review_state: filterTextSchema,
     },
     sort: [
       "candidate_count",
@@ -346,7 +358,7 @@ export const API_QUERY_COLLECTIONS = {
       curation_level: enumSchema(QUERY_ENUMS.curationLevel),
       candidate_api_kinds: enumSchema(QUERY_ENUMS.surfaceKind),
       operational_kinds: enumSchema(QUERY_ENUMS.surfaceKind),
-      reason_codes: textSchema,
+      reason_codes: filterTextSchema,
       recommended_adapter_kind: enumSchema(QUERY_ENUMS.recommendedAdapterKind),
     },
     sort: [
@@ -384,8 +396,8 @@ export const API_QUERY_COLLECTIONS = {
       missing_kinds: enumSchema(QUERY_ENUMS.surfaceKind),
       netuid: integerSchema,
       profile_level: enumSchema(QUERY_ENUMS.profileLevel),
-      reason_codes: textSchema,
-      review_state: textSchema,
+      reason_codes: filterTextSchema,
+      review_state: filterTextSchema,
       manual_review_required: enumSchema(["true", "false"]),
     },
     search: ["name", "slug", "recommended_action", "reason_codes"],
@@ -458,7 +470,7 @@ export const API_QUERY_COLLECTIONS = {
       missing_kinds: enumSchema(QUERY_ENUMS.surfaceKind),
       netuid: integerSchema,
       profile_level: enumSchema(QUERY_ENUMS.profileLevel),
-      reason_codes: textSchema,
+      reason_codes: filterTextSchema,
       submission_route: enumSchema([
         "direct-candidate-pr",
         "adapter-request",
@@ -527,7 +539,7 @@ export const API_QUERY_COLLECTIONS = {
     filters: {
       netuid: integerSchema,
       kind: enumSchema(QUERY_ENUMS.surfaceKind),
-      provider: textSchema,
+      provider: filterTextSchema,
       status: enumSchema(QUERY_ENUMS.healthStatus),
       classification: enumSchema(QUERY_ENUMS.healthClassification),
     },
@@ -547,7 +559,7 @@ export const API_QUERY_COLLECTIONS = {
   }),
   pools: queryCollection("pools", {
     filters: {
-      id: textSchema,
+      id: filterTextSchema,
       kind: enumSchema(["subtensor-rpc", "subtensor-wss", "archive"]),
     },
     sort: ["eligible_count", "endpoint_count", "id", "kind"],
@@ -555,7 +567,7 @@ export const API_QUERY_COLLECTIONS = {
   }),
   providers: queryCollection("providers", {
     filters: {
-      id: textSchema,
+      id: filterTextSchema,
       kind: enumSchema(QUERY_ENUMS.providerKind),
       authority: enumSchema(QUERY_ENUMS.providerAuthority),
     },
@@ -4245,7 +4257,9 @@ function listQuery(collection, options = {}) {
     .map(([name, schema]) => ({ name, schema }))
     .filter((parameter) => !excluded.has(parameter.name));
   const searchParameters =
-    config.search_keys.length > 0 ? [{ name: "q", schema: textSchema }] : [];
+    config.search_keys.length > 0
+      ? [{ name: "q", schema: searchTextSchema }]
+      : [];
   // Each numeric range field F → a `min_F` + `max_F` inclusive-bound parameter.
   const rangeParameters = config.range_filters.flatMap((field) => [
     { name: `min_${field}`, schema: { type: "number" } },

--- a/tests/free-text-filter-maxlength.test.mjs
+++ b/tests/free-text-filter-maxlength.test.mjs
@@ -1,0 +1,78 @@
+// #5544: free-text query filters (`q`, `provider`, `id`, `review_state`,
+// `reason_codes`) were all built from a shared `textSchema = { type: "string" }`
+// with no maxLength, unlike every other validated param (pallet/method 64,
+// call_module 100, netuids 767). An arbitrarily long value passed
+// validateListQuery untouched and reached searchRows, which tokenizes it and
+// scans every row's haystack per term — unbounded per-request work driven by an
+// unbounded input. `q` is now searchTextSchema (200, generous for search prose)
+// and the exact-ish filters are filterTextSchema (100, matching the structured
+// -token precedent). validateListQuery already reads schema.maxLength
+// generically, so this is a schema-data fix; these tests are the regression.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { validateListQueryParams } from "../workers/list-query.mjs";
+
+function query(path) {
+  return new URL(`https://api.metagraph.sh${path}`);
+}
+
+describe("free-text query filters enforce a maxLength (#5544)", () => {
+  // `economics` is a searchable collection (search_keys > 0), so it exposes `q`.
+  test("rejects a q longer than 200 chars", () => {
+    const error = validateListQueryParams(
+      query(`/api/v1/economics?q=${"a".repeat(201)}`),
+      "economics",
+    );
+    assert.equal(error.parameter, "q");
+    assert.equal(error.message, "q is too long.");
+  });
+
+  test("accepts a q of exactly 200 chars", () => {
+    assert.equal(
+      validateListQueryParams(
+        query(`/api/v1/economics?q=${"a".repeat(200)}`),
+        "economics",
+      ),
+      null,
+    );
+  });
+
+  // `endpoints` carries the exact-ish `provider` filter (filterTextSchema, 100).
+  test("rejects a provider filter longer than 100 chars", () => {
+    const error = validateListQueryParams(
+      query(`/api/v1/endpoints?provider=${"a".repeat(101)}`),
+      "endpoints",
+    );
+    assert.equal(error.parameter, "provider");
+    assert.equal(error.message, "provider is too long.");
+  });
+
+  test("accepts a provider filter of exactly 100 chars", () => {
+    assert.equal(
+      validateListQueryParams(
+        query(`/api/v1/endpoints?provider=${"a".repeat(100)}`),
+        "endpoints",
+      ),
+      null,
+    );
+  });
+
+  // A searchable collection with no q param at all is still valid — the bound
+  // only applies when q is present.
+  test("accepts a searchable route with no q param", () => {
+    assert.equal(
+      validateListQueryParams(query("/api/v1/economics"), "economics"),
+      null,
+    );
+  });
+
+  // `providers` carries the exact-ish `id` filter — same filterTextSchema bound.
+  test("rejects an id filter longer than 100 chars", () => {
+    const error = validateListQueryParams(
+      query(`/api/v1/providers?id=${"a".repeat(101)}`),
+      "providers",
+    );
+    assert.equal(error.parameter, "id");
+    assert.equal(error.message, "id is too long.");
+  });
+});

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -4,7 +4,10 @@
 // the query-collection contract and nothing from api.mjs, so there is no cycle.
 // `applyQueryFilters` is the main public entry; route preflight uses the same
 // validator before artifact/cache reads.
-import { API_QUERY_COLLECTIONS } from "../src/contracts.mjs";
+import {
+  API_QUERY_COLLECTIONS,
+  SEARCH_TEXT_MAX_LENGTH,
+} from "../src/contracts.mjs";
 import { linkHeader } from "./http.mjs";
 import { DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT } from "./request-params.mjs";
 
@@ -471,6 +474,20 @@ function validateListQuery(params, config, { csvResponse = false } = {}) {
       return {
         parameter: key,
         message: `${key} is not in the expected format.`,
+      };
+    }
+  }
+
+  // The `q` free-text search param isn't in config.filters, so the generic
+  // maxLength check above never sees it (#5544). Bound it explicitly from the
+  // same searchTextSchema ceiling so an oversized query can't drive unbounded
+  // per-term, per-row scan work in searchRows.
+  if ((config.search_keys?.length || 0) > 0 && params.has("q")) {
+    const value = params.get("q");
+    if (value.length > SEARCH_TEXT_MAX_LENGTH) {
+      return {
+        parameter: "q",
+        message: "q is too long.",
       };
     }
   }


### PR DESCRIPTION
## Summary

`workers/list-query.mjs`'s `validateListQuery` enforces `schema.maxLength` on any
query-filter param whose schema declares one, but the shared
`textSchema = { type: "string" }` in `src/contracts.mjs` carried **no**
`maxLength` — so `provider`, `id`, `review_state`, `reason_codes`, and the `q`
free-text search param reused it unbounded, unlike every other validated param
(`pallet`/`method` 64, `call_module` 100, `netuids` 767). An arbitrarily long
value passed validation untouched; for `q` it then reaches `searchRows`, which
tokenizes it and `.includes()`-scans every row's haystack per term — unbounded
per-request work driven by an unbounded input.

Closes #5544.

## What Changed

- **`src/contracts.mjs`** — split the unbounded shared `textSchema` into two
  purpose-specific schemas, per the issue's suggestion:
  - `searchTextSchema` (`maxLength: 200`) for `q` — generous for free-typed
    search prose.
  - `filterTextSchema` (`maxLength: 100`) for the exact-ish filters
    (`provider`/`id`/`review_state`/`reason_codes`) — a structured-token bound in
    line with the existing `call_module` (100) / `pallet`·`method` (64) precedent.
  - Exported `SEARCH_TEXT_MAX_LENGTH` as the single source of truth for `q`.
- **`workers/list-query.mjs`** — the generic `maxLength` check only iterates
  `config.filters`, so `q` (a *search* param, not a filter) was never bounded at
  runtime even with the schema in place. Added an explicit `q`-length check from
  the same `SEARCH_TEXT_MAX_LENGTH` ceiling, closing the actual unbounded
  -`searchRows` path the issue describes.
- **`public/metagraph/openapi.json`, `public/metagraph/api-index.json`** —
  regenerated via `npm run build` so both derived artifacts carry the new
  `maxLength` on every affected query param (31 params each).
- **`tests/free-text-filter-maxlength.test.mjs`** — regression tests: `q` and
  `provider`/`id` reject over-limit values (with the exact 400 message), accept
  boundary-length values, and a searchable route with no `q` stays valid.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5544`).
- [x] No secrets, PATs, wallet data, private URLs, or validator-local state.
- [x] Generated artifacts (`openapi.json`, `api-index.json`) were produced by
      `npm run build`, not hand-edited; deploy-owned `r2-manifest.json` /
      `schemas/index.json` are untouched.
- [x] Public OpenAPI change is intentional and documented above.

## Validation

- [x] `npm run validate:schemas` · `npm run validate:openapi` ·
      `npm run validate:api` — all green.
- [x] `npm run lint` + `npm run format:check` clean on changed files.
- [x] `npx vitest run` on the affected suites (contracts, list-query,
      free-text-filter-maxlength, api-coverage, economics-query) — 352 passed.
- [x] Patch coverage: the new `list-query.mjs` branch has 0 uncovered
      statements/branches (both the reject and accept paths, plus the no-`q`
      path, are exercised).
- [x] `git diff --check` clean.
