### PR TITLE
fix(ui): give SectionAnchor's copy-link button a 44px touch target (#5567)

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2412,7 +2412,7 @@ function SectionAnchor({
                   type: "button",
                   onClick: onCopy,
                   "aria-label": `Copy link to ${typeof title === "string" ? title : id} section`,
-                  className: "mg-anchor-btn inline-flex items-center text-ink-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5",
+                  className: "mg-anchor-btn inline-flex items-center justify-center text-ink-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded min-h-11 min-w-11 p-0.5",
                   children: copied ? /* @__PURE__ */ jsxRuntime.jsx(lucideReact.Check, { className: "size-3.5 text-accent" }) : /* @__PURE__ */ jsxRuntime.jsx(lucideReact.Link2, { className: "size-3.5" })
                 }
               )

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2383,7 +2383,7 @@ function SectionAnchor({
                   type: "button",
                   onClick: onCopy,
                   "aria-label": `Copy link to ${typeof title === "string" ? title : id} section`,
-                  className: "mg-anchor-btn inline-flex items-center text-ink-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5",
+                  className: "mg-anchor-btn inline-flex items-center justify-center text-ink-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded min-h-11 min-w-11 p-0.5",
                   children: copied ? /* @__PURE__ */ jsx(Check, { className: "size-3.5 text-accent" }) : /* @__PURE__ */ jsx(Link2, { className: "size-3.5" })
                 }
               )

--- a/packages/ui-kit/src/components/metagraphed/section-anchor.tsx
+++ b/packages/ui-kit/src/components/metagraphed/section-anchor.tsx
@@ -77,7 +77,7 @@ export function SectionAnchor({
               type="button"
               onClick={onCopy}
               aria-label={`Copy link to ${typeof title === "string" ? title : id} section`}
-              className="mg-anchor-btn inline-flex items-center text-ink-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
+              className="mg-anchor-btn inline-flex items-center justify-center text-ink-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded min-h-11 min-w-11 p-0.5"
             >
               {copied ? (
                 <Check className="size-3.5 text-accent" />


### PR DESCRIPTION
## Summary

`packages/ui-kit/src/components/metagraphed/section-anchor.tsx`'s "copy link to this section" icon button had no `min-h`/`min-w` — roughly an 18px hit area (a `size-3.5` icon plus `p-0.5`), unlike every other icon-only copy/action button in the shell. `copy-button.tsx:27-31` sets the established convention explicitly, in a comment added when #5333 fixed the same class of bug on that component: `min-h-11 min-w-11` — "the same 44px minimum touch target as every other header icon button in the shell." `SectionAnchor`'s button is icon-only and functionally identical (a copy-to-clipboard toggle) but wasn't covered by #5333–#5338's fixes, none of which name `section-anchor.tsx`.

`SectionAnchor` is used broadly: `panel-shell.tsx`, `subnet-profile-panel.tsx`, `incident-timeline.tsx`, and directly on all six major entity-detail routes (`accounts.$ss58.tsx`, `blocks.$ref.tsx`, `extrinsics.$hash.tsx`, `providers.$slug.tsx`, `subnets.$netuid.tsx`, `validators.$hotkey.tsx`).

## Change

```diff
             <button
               type="button"
               onClick={onCopy}
               aria-label={`Copy link to ${typeof title === "string" ? title : id} section`}
-              className="mg-anchor-btn inline-flex items-center text-ink-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
+              className="mg-anchor-btn inline-flex items-center justify-center text-ink-muted hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded min-h-11 min-w-11 p-0.5"
             >
```

Matches `copy-button.tsx`'s exact treatment — the icon itself stays compact (`size-3.5`, unchanged) and centered within the larger invisible hit area.

## Verification

The button sits inline with an `h2` heading here (unlike `copy-button.tsx`'s standalone placements), so per the issue's own ask I verified on two call sites (`subnets.$netuid.tsx` and `blocks.$ref.tsx`) that the larger hit area doesn't push layout or misalign with the title text — see the hover-state rows below. The button is hover/focus-revealed (`opacity: 0` at rest, per `.mg-anchor-btn` in `styles.css`), so the base at-rest matrix below is visually identical before/after; the actual diff is only visible on hover/focus, captured separately.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop (1280px) · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-desktop-light-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-desktop-light-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-desktop-light-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-desktop-light-after.png) |
| Desktop (1280px) · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-desktop-dark-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-desktop-dark-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-desktop-dark-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-desktop-dark-after.png) |
| Tablet (768px) · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-tablet-light-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-tablet-light-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-tablet-light-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-tablet-light-after.png) |
| Tablet (768px) · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-tablet-dark-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-tablet-dark-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-tablet-dark-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-tablet-dark-after.png) |
| Mobile (375px) · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-mobile-light-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-mobile-light-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-mobile-light-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-mobile-light-after.png) |
| Mobile (375px) · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-mobile-dark-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-mobile-dark-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-mobile-dark-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-mobile-dark-after.png) |

**Hover state on `#economics` (`subnets.$netuid.tsx`) — the actual visible diff (invisible hit-area growth, icon glyph unchanged):**

| Theme | Before | After |
| --- | --- | --- |
| Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-hover-light-before.png" width="300">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-hover-light-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-hover-light-after.png" width="300">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-hover-light-after.png) |
| Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-hover-dark-before.png" width="300">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-hover-dark-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-hover-dark-after.png" width="300">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5567-hover-dark-after.png) |

Closes #5567

## Deliverables (from the issue)

- [x] `section-anchor.tsx`: copy-link button has `min-h-11 min-w-11`
- [x] Verified visually on two call sites (`subnets.$netuid.tsx` and `blocks.$ref.tsx`)
- [x] Before/after screenshots included

## Validation

- [x] `npm run typecheck --workspace=apps/ui` — clean
- [x] `npm run typecheck --workspace=packages/ui-kit` — clean
- [x] `npm run lint --workspace=apps/ui` — 0 errors (pre-existing unrelated warnings only)
- [x] `npm run format:check --workspace=apps/ui` — clean
- [x] `npm test --workspace=apps/ui` — 977/977 tests passing (126/126 files)
- [x] `packages/ui-kit/src` changed → rebuilt and committed `packages/ui-kit/dist`