### PR TITLE
fix(schemas): validate generated public artifacts against public-artifacts.schema.json (#5551)

### DIFF
--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -154,6 +154,16 @@ const candidateSchema = await readJson(
 const providerSubmissionSchema = await readJson(
   path.join(repoRoot, "schemas/provider-submission.schema.json"),
 );
+// #5551: public-artifacts.schema.json documents the top-level shape of every
+// generated artifact served from metagraph.sh/metagraph (schema_version: 1,
+// network: "finney", the required per-kind properties). Registered explicitly
+// so it's addSchema'd under its $id here — rather than only ajv.compile()'d for
+// syntax by the generic loop below — and its `$defs` can be $ref'd to validate
+// real artifact data against it (see the public-artifact loop after the
+// per-component validation).
+const publicArtifactsSchema = await readJson(
+  path.join(repoRoot, "schemas/public-artifacts.schema.json"),
+);
 const openapi = await readJson(
   path.join(repoRoot, "public/metagraph/openapi.json"),
 );
@@ -163,6 +173,7 @@ for (const schema of [
   subnetSchema,
   candidateSchema,
   providerSubmissionSchema,
+  publicArtifactsSchema,
 ]) {
   ajv.addSchema(schema, schema.$id);
 }
@@ -171,6 +182,7 @@ const explicitlyRegisteredSchemaIds = new Set([
   subnetSchema.$id,
   candidateSchema.$id,
   providerSubmissionSchema.$id,
+  publicArtifactsSchema.$id,
 ]);
 for (const schemaPath of await listJsonFiles(path.join(repoRoot, "schemas"))) {
   const schema = await readJson(schemaPath);
@@ -222,12 +234,44 @@ validate(
   "direct-provider-profile example",
 );
 
-for (const artifact of await artifactValidationTargets()) {
+const artifactTargets = await artifactValidationTargets();
+for (const artifact of artifactTargets) {
   const validator = compileComponentValidator(artifact.schema_ref);
   validate(
     validator,
     await readJson(artifact.file_path),
     `artifact:${artifact.label}`,
+  );
+}
+
+// #5551: additionally validate each real artifact against
+// public-artifacts.schema.json's own top-level contract, keyed by the artifact
+// id (hyphens -> underscores) to the schema property of the same name — e.g.
+// `api-index` -> `api_index` -> `$defs.genericArtifact`, `contracts` ->
+// `$defs.contractsArtifact`. This enforces the constraints that schema promises
+// (schema_version: 1, network: "finney", required per-kind fields), which were
+// previously only ajv.compile()-syntax-checked and fs.access()-existence-checked
+// (scripts/validate.mjs), never validated against real data. Artifacts the
+// schema does not document (e.g. openapi) carry no matching property and are
+// skipped; the per-component schema_ref check above still covers every artifact.
+const publicArtifactProperties = publicArtifactsSchema.properties || {};
+const publicArtifactValidators = new Map();
+for (const artifact of artifactTargets) {
+  const propertyKey = artifact.label.split(":")[0].replace(/-/g, "_");
+  const propertyRef = publicArtifactProperties[propertyKey]?.$ref;
+  if (!propertyRef) {
+    continue;
+  }
+  if (!publicArtifactValidators.has(propertyRef)) {
+    publicArtifactValidators.set(
+      propertyRef,
+      ajv.compile({ $ref: publicArtifactsSchema.$id + propertyRef }),
+    );
+  }
+  validate(
+    publicArtifactValidators.get(propertyRef),
+    await readJson(artifact.file_path),
+    `public-artifact:${artifact.label}`,
   );
 }
 

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1379,6 +1379,13 @@ async function validateGeneratedArtifacts(
     }
   }
 
+  // Presence guard only — that each canonical schema contract is on disk. It is
+  // NOT the enforcement of these schemas: their real data-validation lives in
+  // scripts/validate-schemas.mjs, which ajv-compiles each and validates real
+  // provider/subnet/candidate records and (since #5551) the generated public
+  // artifacts against public-artifacts.schema.json's own `$defs`. Previously the
+  // existence check below was the SOLE signal that public-artifacts.schema.json
+  // was "enforced", which it never was against real data (#5551).
   for (const schemaPath of [
     "schemas/provider.schema.json",
     "schemas/subnet-manifest.schema.json",

--- a/tests/public-artifacts-schema-validation.test.mjs
+++ b/tests/public-artifacts-schema-validation.test.mjs
@@ -1,0 +1,78 @@
+// #5551: schemas/public-artifacts.schema.json documents the top-level shape of
+// every generated public artifact (schema_version: 1, network: "finney", the
+// required per-kind fields), but nothing ever validated a real artifact's data
+// against it — it was only ajv.compile()-syntax-checked and fs.access()
+// -existence-checked. scripts/validate-schemas.mjs now validates each real
+// artifact against the matching top-level $def. These tests lock that contract:
+// a real committed artifact passes, and deliberate constraint violations fail.
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { readJson, repoRoot } from "../scripts/lib.mjs";
+
+const schema = await readJson(
+  path.join(repoRoot, "schemas/public-artifacts.schema.json"),
+);
+const ajv = new Ajv2020({ strict: false, allErrors: true });
+addFormats(ajv);
+ajv.addSchema(schema, schema.$id);
+
+function validatorFor(defName) {
+  return ajv.compile({ $ref: `${schema.$id}#/$defs/${defName}` });
+}
+
+const genericArtifact = validatorFor("genericArtifact");
+const subnetsArtifact = validatorFor("subnetsArtifact");
+
+// A real, committed artifact this schema's genericArtifact def directly covers.
+const apiIndex = await readJson(
+  path.join(repoRoot, "public/metagraph/api-index.json"),
+);
+
+describe("public-artifacts.schema.json validates real artifacts (#5551)", () => {
+  test("the committed api-index.json artifact is valid", () => {
+    assert.equal(
+      genericArtifact(apiIndex),
+      true,
+      ajv.errorsText(genericArtifact.errors),
+    );
+  });
+
+  test("rejects an artifact whose schema_version is not the const 1", () => {
+    assert.equal(genericArtifact({ ...apiIndex, schema_version: 2 }), false);
+  });
+
+  test("rejects an artifact missing the required generated_at", () => {
+    const { generated_at: _omitted, ...withoutGeneratedAt } = apiIndex;
+    assert.equal(genericArtifact(withoutGeneratedAt), false);
+  });
+
+  test("rejects a subnets artifact whose network is not the const finney", () => {
+    const bad = {
+      schema_version: 1,
+      generated_at: "1970-01-01T00:00:00.000Z",
+      network: "test",
+      source: {},
+      subnets: [],
+    };
+    assert.equal(subnetsArtifact(bad), false);
+    assert.match(ajv.errorsText(subnetsArtifact.errors), /network|finney/i);
+  });
+
+  test("accepts a minimally-valid subnets artifact (network: finney)", () => {
+    const good = {
+      schema_version: 1,
+      generated_at: "1970-01-01T00:00:00.000Z",
+      network: "finney",
+      source: {},
+      subnets: [],
+    };
+    assert.equal(
+      subnetsArtifact(good),
+      true,
+      ajv.errorsText(subnetsArtifact.errors),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`schemas/public-artifacts.schema.json` documents the top-level shape of every
generated public artifact served from `metagraph.sh/metagraph` — `schema_version:
const 1` + `generated_at` on every artifact (`$defs.artifactBase`), `network:
const "finney"` on the subnets artifact, and dedicated `$defs` for the coverage,
curation, gaps, verification, health-history, rpc-endpoints, contracts,
schema-drift, and review artifacts. But nothing ever validated a real artifact's
**data** against it: `validate-schemas.mjs` only `ajv.compile()`-syntax-checked
it (via the generic "compile every schema" loop), and `validate.mjs` only
`fs.access()`-existence-checked it. Its per-component validation path is keyed on
each `PUBLIC_ARTIFACTS` entry's `schema_ref` (an OpenAPI component like
`ContractsArtifact`) — a separate namespace from this schema's own lowercase
`$defs`. So every constraint it promises was unenforced against real data.

Closes #5551.

Direction chosen: **(a) wire it into real validation** (the schema accurately
describes the artifacts — I verified all covered artifacts validate cleanly — so
it's a live contract worth enforcing, not a superseded file to retire).

## What Changed

- **`scripts/validate-schemas.mjs`** — register `public-artifacts.schema.json`
  under its `$id` (moved into the explicit-registration list so it's addSchema'd
  once, not just syntax-compiled by the generic loop), then, alongside the
  existing per-component `schema_ref` check, validate each real artifact against
  the matching top-level `$def`. Artifacts are mapped by id → schema property of
  the same name (hyphens → underscores): `api-index` → `api_index` →
  `$defs.genericArtifact`, `contracts` → `$defs.contractsArtifact`, `subnets` →
  `$defs.subnetsArtifact`, etc. This covers **25** of the schema's top-level
  artifact kinds — every artifact whose id maps to a documented property,
  including all four committed artifacts the issue named. Artifacts the schema
  doesn't document (e.g. `openapi`) carry no matching property and are skipped;
  the two aggregate `$defs` (`health`, `review`) have no single 1:1 artifact file
  (they fan out into many `health-*`/`review-*` sub-artifacts with their own
  component schemas), so they're intentionally left out rather than guess a
  mapping. It reuses the exact `artifactValidationTargets()` set the per-component
  loop already reads, so no new file-existence surface is introduced.
- **`scripts/validate.mjs`** — the existence-only schema-presence check no longer
  reads as the *enforcement* of `public-artifacts.schema.json`; added a comment
  making explicit that real data-validation now lives in `validate-schemas.mjs`
  (per the issue's requirement that the existence check "must not remain the sole
  signal that this schema is enforced").
- **`tests/public-artifacts-schema-validation.test.mjs`** — the required
  failing-fixture test: the committed `api-index.json` validates; `schema_version:
  2`, a missing `generated_at`, and a subnets artifact with `network: "test"` all
  fail; a minimally-valid `network: "finney"` subnets artifact passes.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5551`).
- [x] No secrets, PATs, wallet data, private URLs, or validator-local state.
- [x] No generated artifacts touched — only two build scripts + one test.

## Validation

- [x] `npm run validate:schemas` — passes (all 25 mapped artifacts validate
      against `public-artifacts.schema.json` post-build).
- [x] `npx vitest run tests/public-artifacts-schema-validation.test.mjs` — 5/5.
- [x] `npx eslint` + `npx prettier --check` clean on all three changed files.
- [x] `git diff --check` clean.
