### PR TITLE
feat(deploy): add box-side runner image for the live economics refresh

### DIFF
--- a/deploy/economics-refresh.Dockerfile
+++ b/deploy/economics-refresh.Dockerfile
@@ -1,0 +1,58 @@
+# Box-side runner for the live economics KV refresh (#1009 follow-up,
+# replaces .github/workflows/refresh-economics.yml). Unlike
+# deploy/metagraph-fetch.Dockerfile's narrow single-purpose containers, this
+# job also needs registry/subnets/*.json -- git-committed curated data that
+# changes via contributor PRs and must stay reasonably fresh -- so the repo
+# checkout is refreshed at CONTAINER RUNTIME (git pull, see
+# scripts/economics-refresh-entrypoint.sh), not frozen at image-build time
+# the way the fetch scripts' bittensor pin is.
+#
+# Same least-privilege split as the other box jobs, preserved across TWO
+# separate `docker run` invocations of this one image instead of one:
+#   STEP=snapshot   -- runs scripts/refresh-native-snapshot.mjs, which shells
+#                       out to `uvx --from bittensor==X.Y` (unpinned PyPI
+#                       resolution at runtime, matching this exact codepath's
+#                       existing GitHub Actions behavior -- not hash-locked
+#                       yet like the other fetch scripts were, tracked as a
+#                       follow-up). Gets ONLY SUBTENSOR_RPC_URL (non-secret).
+#   STEP=economics  -- runs scripts/refresh-economics.mjs --write (pure JS,
+#                       no PyPI/uvx involved). Gets the real
+#                       CLOUDFLARE_API_TOKEN. Runs AFTER the snapshot step,
+#                       reading the file it wrote from the same shared
+#                       volume -- the untrusted-PyPI step and the
+#                       secret-holding step never share a process.
+# Both steps mount the SAME persistent named volume at /repo (a git
+# checkout + node_modules, kept warm across runs) -- see
+# roles/data-refresh-economics/files/refresh-economics.sh in
+# metagraphed-infra for the orchestration.
+#
+# No non-root USER (unlike metagraph-fetch.Dockerfile/chain-firehose-relay.
+# Dockerfile): this container's only inputs are our own git repo, our own
+# fullnode, and the Cloudflare API -- accepts no external network input, so
+# the non-root hardening those long-running/user-facing services need buys
+# little here. Revisit if that changes.
+#
+# Deployed via the data-refresh-economics Ansible role in
+# JSONbored/metagraphed-infra, which copies this Dockerfile +
+# scripts/economics-refresh-entrypoint.sh into
+# roles/data-refresh-economics/files/ and builds directly on the indexer box.
+#
+# Local: docker build -f deploy/economics-refresh.Dockerfile -t metagraphed-data-refresh-economics .
+#
+# Debian (glibc), NOT Alpine (musl) -- matches metagraph-fetch.Dockerfile's
+# own python:3.12-slim base. bittensor's bittensor-drand dependency ships
+# manylinux (glibc) wheels only; on musl, uv falls back to a from-source
+# build that needs a full Rust/cargo toolchain (confirmed by hitting this
+# directly: `error: linker \`cc\` not found` compiling bittensor-drand's
+# pyo3 extension under node:22-alpine). Debian's glibc gets the prebuilt
+# wheel, no compiler needed, matching the already-proven fetch image.
+FROM ghcr.io/astral-sh/uv:0.11.28@sha256:0f36cb9361a3346885ca3677e3767016687b5a170c1a6b88465ec14aefec90aa AS uv
+FROM node:22.23.1-slim
+RUN apt-get update && apt-get install -y --no-install-recommends python3 git ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=uv /uv /uvx /usr/local/bin/
+
+COPY scripts/economics-refresh-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/deploy/economics-refresh.Dockerfile
+++ b/deploy/economics-refresh.Dockerfile
@@ -26,11 +26,19 @@
 # roles/data-refresh-economics/files/refresh-economics.sh in
 # metagraphed-infra for the orchestration.
 #
-# No non-root USER (unlike metagraph-fetch.Dockerfile/chain-firehose-relay.
-# Dockerfile): this container's only inputs are our own git repo, our own
-# fullnode, and the Cloudflare API -- accepts no external network input, so
-# the non-root hardening those long-running/user-facing services need buys
-# little here. Revisit if that changes.
+# Non-root (uid 10001, matching metagraph-fetch.Dockerfile/chain-firehose-
+# relay.Dockerfile's own convention). Originally shipped without one on the
+# theory that this container accepts no external network input -- a security
+# review correctly called that out as reasoning about the wrong risk: the
+# real exposure isn't inbound network requests, it's SUPPLY CHAIN (npm ci's
+# postinstall scripts across ~600 packages, the unpinned-at-runtime bittensor
+# PyPI resolution noted above, in principle a compromised git ref) running
+# arbitrary code -- and root privilege inside the container widens the blast
+# radius of a container escape regardless of whether the process itself
+# listens on a socket. /repo is pre-created + chowned here (not left for
+# Docker to auto-create on first volume mount) so the entrypoint's runtime
+# git clone/npm ci -- which must run as this same non-root user -- can
+# actually write to it.
 #
 # Deployed via the data-refresh-economics Ansible role in
 # JSONbored/metagraphed-infra, which copies this Dockerfile +
@@ -52,7 +60,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3 git ca-
   && rm -rf /var/lib/apt/lists/*
 COPY --from=uv /uv /uvx /usr/local/bin/
 
+RUN useradd -u 10001 -m runner \
+  && mkdir -p /repo \
+  && chown runner:runner /repo
+
 COPY scripts/economics-refresh-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+USER runner
 ENTRYPOINT ["/entrypoint.sh"]

--- a/scripts/economics-refresh-entrypoint.sh
+++ b/scripts/economics-refresh-entrypoint.sh
@@ -22,6 +22,29 @@ GIT_REPO_URL="https://github.com/JSONbored/metagraphed.git"
 # worth fixing from that same review.)
 GIT_REF="main"
 
+# npm ci runs in the SAME shared /repo volume the economics step later reads
+# scripts/refresh-economics.mjs (and node_modules/.bin/wrangler, the exact
+# binary that makes the authenticated Cloudflare API call) from -- a
+# security review correctly pointed out that this breaks the stated trust
+# boundary between the snapshot step (untrusted, no secrets) and the
+# economics step (holds CLOUDFLARE_API_TOKEN): a malicious postinstall/
+# preinstall/prepare script from any of ~600 npm packages, running during
+# the SNAPSHOT step's npm ci, could plant or modify a file the ECONOMICS
+# step later executes with the real token in scope. --ignore-scripts closes
+# the install-time-arbitrary-code vector (this repo's own package.json has
+# no lifecycle scripts of its own, confirmed); the git diff check below is
+# defense in depth against anything that still wrote to the tracked source
+# tree some other way.
+install_deps() {
+  echo "entrypoint: npm ci --ignore-scripts"
+  npm ci --ignore-scripts --no-audit --no-fund
+  if ! git diff --quiet -- . ':(exclude)node_modules'; then
+    echo "entrypoint: npm ci modified tracked source files -- aborting" >&2
+    git diff --stat -- . ':(exclude)node_modules' >&2
+    exit 1
+  fi
+}
+
 if [ ! -d "$REPO_DIR/.git" ]; then
   # Clone into a temp dir, THEN copy its contents into $REPO_DIR -- an
   # interrupted clone straight into $REPO_DIR would leave a partial .git
@@ -39,8 +62,7 @@ if [ ! -d "$REPO_DIR/.git" ]; then
   cp -a "$CLONE_TMP"/. "$REPO_DIR"/
   rm -rf "$CLONE_TMP"
   cd "$REPO_DIR"
-  echo "entrypoint: npm ci"
-  npm ci --no-audit --no-fund
+  install_deps
 elif [ "$STEP" = "snapshot" ]; then
   # Only the snapshot step re-syncs the checkout -- it always runs FIRST (see
   # roles/data-refresh-economics/files/refresh-economics.sh in
@@ -56,8 +78,7 @@ elif [ "$STEP" = "snapshot" ]; then
   git -C "$REPO_DIR" reset --hard "origin/${GIT_REF}"
   git -C "$REPO_DIR" clean -fdx
   cd "$REPO_DIR"
-  echo "entrypoint: npm ci"
-  npm ci --no-audit --no-fund
+  install_deps
 else
   echo "entrypoint: reusing existing checkout as-is (economics step runs right after snapshot, same volume)"
   cd "$REPO_DIR"

--- a/scripts/economics-refresh-entrypoint.sh
+++ b/scripts/economics-refresh-entrypoint.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Runs one step of the box-side live-economics refresh (replaces
+# .github/workflows/refresh-economics.yml) -- see
+# deploy/economics-refresh.Dockerfile's header for the two-container trust
+# boundary this preserves (this same entrypoint drives both containers, the
+# STEP env var picks which).
+set -euo pipefail
+
+: "${STEP:?STEP env var required (snapshot|economics)}"
+
+REPO_DIR=/repo
+GIT_REPO_URL="https://github.com/JSONbored/metagraphed.git"
+GIT_REF="main"
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+  echo "entrypoint: cloning ${GIT_REPO_URL}@${GIT_REF} (first run on this volume)"
+  git clone --depth 1 --branch "$GIT_REF" "$GIT_REPO_URL" "$REPO_DIR"
+  cd "$REPO_DIR"
+  echo "entrypoint: npm ci"
+  npm ci --no-audit --no-fund
+elif [ "$STEP" = "snapshot" ]; then
+  # Only the snapshot step re-syncs the checkout -- it always runs FIRST (see
+  # roles/data-refresh-economics/files/refresh-economics.sh in
+  # metagraphed-infra) and writes registry/native/finney-subnets.json as a
+  # local, UNCOMMITTED change for the economics step to read right after.
+  # The economics step must NOT also reset/clean here, or it would wipe that
+  # freshly-written file back to whatever's committed on origin/main before
+  # ever reading it (hit this for real in local testing: the economics
+  # artifact came back with a month-stale captured_at because git clean -fdx
+  # deleted the snapshot the prior container had just written).
+  echo "entrypoint: refreshing existing checkout"
+  git -C "$REPO_DIR" fetch --depth 1 origin "$GIT_REF"
+  git -C "$REPO_DIR" reset --hard "origin/${GIT_REF}"
+  git -C "$REPO_DIR" clean -fdx
+  cd "$REPO_DIR"
+  echo "entrypoint: npm ci"
+  npm ci --no-audit --no-fund
+else
+  echo "entrypoint: reusing existing checkout as-is (economics step runs right after snapshot, same volume)"
+  cd "$REPO_DIR"
+fi
+
+case "$STEP" in
+  snapshot)
+    : "${SUBTENSOR_RPC_URL:?SUBTENSOR_RPC_URL env var required for the snapshot step}"
+    echo "entrypoint: refreshing native chain snapshot"
+    exec node scripts/refresh-native-snapshot.mjs
+    ;;
+  economics)
+    echo "entrypoint: publishing live economics"
+    exec node scripts/refresh-economics.mjs --write
+    ;;
+  *)
+    echo "entrypoint: unknown STEP '$STEP' (want snapshot|economics)" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/economics-refresh-entrypoint.sh
+++ b/scripts/economics-refresh-entrypoint.sh
@@ -10,11 +10,34 @@ set -euo pipefail
 
 REPO_DIR=/repo
 GIT_REPO_URL="https://github.com/JSONbored/metagraphed.git"
+# Floating branch, not a pinned commit SHA -- deliberate: this job's whole
+# purpose is staying current with registry/subnets/*.json (contributor PRs
+# land on main continuously) as well as any code fixes, so pinning would
+# defeat that and require manual re-pinning on every deploy. main already
+# requires review + CI + the Gittensory Gate before anything lands, the
+# same trust level every other box job implicitly extends to this repo.
+# (A security review flagged the unpinned clone given this same container
+# later holds CLOUDFLARE_API_TOKEN in the economics step -- considered, not
+# overlooked; see the atomic-clone fix just below for the finding that WAS
+# worth fixing from that same review.)
 GIT_REF="main"
 
 if [ ! -d "$REPO_DIR/.git" ]; then
+  # Clone into a temp dir, THEN copy its contents into $REPO_DIR -- an
+  # interrupted clone straight into $REPO_DIR would leave a partial .git
+  # directory that this same "already cloned?" check would treat as success
+  # on the NEXT run, silently proceeding against a broken checkout (flagged
+  # by a security review on the PR that added this script; real, cheap to
+  # fix). Copy, not `mv $CLONE_TMP $REPO_DIR` -- $REPO_DIR is the volume's
+  # own mount point, not a plain directory, so it can't be removed/replaced
+  # wholesale (`rm -rf $REPO_DIR` fails with "Device or resource busy",
+  # hit this for real testing the first version of this fix).
+  CLONE_TMP="$(mktemp -d /tmp/metagraphed-clone.XXXXXX)"
   echo "entrypoint: cloning ${GIT_REPO_URL}@${GIT_REF} (first run on this volume)"
-  git clone --depth 1 --branch "$GIT_REF" "$GIT_REPO_URL" "$REPO_DIR"
+  git clone --depth 1 --branch "$GIT_REF" "$GIT_REPO_URL" "$CLONE_TMP"
+  find "$REPO_DIR" -mindepth 1 -delete
+  cp -a "$CLONE_TMP"/. "$REPO_DIR"/
+  rm -rf "$CLONE_TMP"
   cd "$REPO_DIR"
   echo "entrypoint: npm ci"
   npm ci --no-audit --no-fund


### PR DESCRIPTION
## Summary
- Adds `deploy/economics-refresh.Dockerfile` + `scripts/economics-refresh-entrypoint.sh`, the box-side runner for moving `refresh-economics.yml` off GitHub Actions onto the indexer box (companion `metagraphed-infra` Ansible role incoming) -- matching the `refresh-metagraph`/`refresh-account-identity`/`refresh-subnet-hyperparams` migration already live there.
- Debian-based (`node:22.23.1-slim`), not Alpine: `bittensor`'s `bittensor-drand` dependency has no musl wheel, so `uv` falls back to a from-source Rust build with no toolchain present under Alpine. Matches `metagraph-fetch.Dockerfile`'s already-proven `python:3.12-slim` base.
- One image, `STEP`-selected entrypoint, two containers sharing a persistent checkout volume -- preserves the same fetch/secret trust-boundary split the other box jobs use: `STEP=snapshot` (no secrets, the existing unpinned-PyPI bittensor fetch) writes the native snapshot; `STEP=economics` (holds `CLOUDFLARE_API_TOKEN`, pure JS, no PyPI involved) reads it and publishes to KV.

## Test plan
- [x] `docker build` succeeds
- [x] `STEP=snapshot` against the public `finney` RPC end-to-end locally: clones, `npm ci`, fetches, writes a fresh native snapshot
- [x] `STEP=economics` against the same volume: correctly reuses the snapshot step's checkout, builds a full economics artifact (129/129 subnets), dry-run mode (`kv: "skipped"`) confirmed safe with no write credentials
- [x] Caught and fixed a real bug in testing: the economics step's own git sync was wiping the snapshot step's just-written, uncommitted file before ever reading it (stale `captured_at`) -- fixed by only resyncing the checkout on the snapshot step
- [x] `shellcheck` clean, `node scripts/scan-public-safety.mjs` clean, `npm run build && npm run validate` clean