### PR TITLE
feat(ui): add GraphQL endpoint docs page

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -363,6 +363,7 @@ function SiteFooter() {
           <FooterLink to="/health">Health</FooterLink>
           <FooterLink to="/status">Status</FooterLink>
           <FooterLink to="/schemas">Schemas</FooterLink>
+          <FooterLink to="/graphql">GraphQL</FooterLink>
           <FooterLink to="/gaps">Gaps</FooterLink>
           <FooterLink to="/agents">For agents</FooterLink>
           <FooterLink to="/about">About</FooterLink>

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -14,6 +14,7 @@ import {
   Activity,
   ArrowRightLeft,
   Bot,
+  Braces,
   Compass,
   Copy,
   ExternalLink,
@@ -115,6 +116,13 @@ const ROUTE_INDEX: Array<{
     to: "/schemas",
     hint: "OpenAPI, contracts, drift",
     icon: FileJson,
+    scope: "route",
+  },
+  {
+    label: "GraphQL",
+    to: "/graphql",
+    hint: "Schema, root queries, limits",
+    icon: Braces,
     scope: "route",
   },
   {

--- a/apps/ui/src/lib/metagraphed/graphql-docs.test.ts
+++ b/apps/ui/src/lib/metagraphed/graphql-docs.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  GRAPHQL_DOCS_MAX_BODY_BYTES,
+  GRAPHQL_DOCS_MAX_COMPLEXITY,
+  GRAPHQL_DOCS_MAX_DEPTH,
+  GRAPHQL_DOCS_MAX_PAGE_LIMIT,
+  GRAPHQL_DOCS_MAX_QUERY_BYTES,
+  GRAPHQL_ENDPOINT_PATH,
+  GRAPHQL_ROOT_QUERIES,
+  GRAPHQL_ROOT_QUERY_COUNT,
+  buildGraphqlCurlExample,
+  buildGraphqlLimitRows,
+  formatGraphqlByteBudget,
+} from "./graphql-docs";
+
+describe("graphql docs reference (#3513)", () => {
+  it("keeps Worker-aligned limit constants", () => {
+    expect(GRAPHQL_DOCS_MAX_DEPTH).toBe(7);
+    expect(GRAPHQL_DOCS_MAX_COMPLEXITY).toBe(50);
+    expect(GRAPHQL_DOCS_MAX_BODY_BYTES).toBe(64 * 1024);
+    expect(GRAPHQL_DOCS_MAX_QUERY_BYTES).toBe(16 * 1024);
+    expect(GRAPHQL_DOCS_MAX_PAGE_LIMIT).toBe(100);
+  });
+
+  it("documents all ten root Query fields without duplicates", () => {
+    expect(GRAPHQL_ROOT_QUERIES).toHaveLength(GRAPHQL_ROOT_QUERY_COUNT);
+    const names = GRAPHQL_ROOT_QUERIES.map((q) => q.name);
+    expect(new Set(names).size).toBe(names.length);
+    expect(names).toContain("subnet");
+    expect(names).toContain("compare");
+    expect(names).toContain("opportunity_boards");
+  });
+
+  it("formats byte budgets as KiB when divisible by 1024", () => {
+    expect(formatGraphqlByteBudget(64 * 1024)).toBe("64 KiB");
+    expect(formatGraphqlByteBudget(16 * 1024)).toBe("16 KiB");
+    expect(formatGraphqlByteBudget(100)).toBe("100 B");
+    expect(formatGraphqlByteBudget(Number.NaN)).toBe("—");
+  });
+
+  it("builds a limits table covering depth, complexity, bytes, pages, and rate", () => {
+    const rows = buildGraphqlLimitRows();
+    const labels = rows.map((r) => r.label);
+    expect(labels).toEqual([
+      "Max depth",
+      "Max complexity",
+      "Max POST body",
+      "Max query document",
+      "Page size",
+      "Rate limit",
+    ]);
+    expect(rows[0]?.value).toBe("7");
+    expect(rows[5]?.value).toContain("100");
+  });
+
+  it("builds a curl example against the GraphQL path", () => {
+    const curl = buildGraphqlCurlExample("https://api.metagraph.sh");
+    expect(curl).toContain("POST https://api.metagraph.sh/api/v1/graphql");
+    expect(curl).toContain("content-type: application/json");
+    expect(curl).toContain("subnet(netuid: 7)");
+    expect(GRAPHQL_ENDPOINT_PATH).toBe("/api/v1/graphql");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/graphql-docs.ts
+++ b/apps/ui/src/lib/metagraphed/graphql-docs.ts
@@ -1,0 +1,174 @@
+/**
+ * Static reference copy for the `/graphql` docs page (#3513).
+ *
+ * Numbers and root fields mirror `src/graphql.mjs` — keep them in sync when
+ * the Worker GraphQL contract changes. The UI cannot import Worker `.mjs`
+ * modules, so these are intentional literals.
+ *
+ * @see https://github.com/JSONbored/metagraphed/issues/3513
+ */
+
+/** Keep aligned with GRAPHQL_MAX_DEPTH in src/graphql.mjs */
+export const GRAPHQL_DOCS_MAX_DEPTH = 7;
+
+/** Keep aligned with GRAPHQL_MAX_COMPLEXITY in src/graphql.mjs */
+export const GRAPHQL_DOCS_MAX_COMPLEXITY = 50;
+
+/** Keep aligned with GRAPHQL_MAX_BODY_BYTES in src/graphql.mjs */
+export const GRAPHQL_DOCS_MAX_BODY_BYTES = 64 * 1024;
+
+/** Keep aligned with GRAPHQL_MAX_QUERY_BYTES in src/graphql.mjs */
+export const GRAPHQL_DOCS_MAX_QUERY_BYTES = 16 * 1024;
+
+/** Keep aligned with DEFAULT_PAGE_LIMIT in src/graphql.mjs */
+export const GRAPHQL_DOCS_DEFAULT_PAGE_LIMIT = 20;
+
+/** Keep aligned with MAX_PAGE_LIMIT in src/graphql.mjs */
+export const GRAPHQL_DOCS_MAX_PAGE_LIMIT = 100;
+
+/**
+ * Shared rate limit with the RPC proxy — see workers/request-handlers/rpc-proxy.mjs
+ * (`gql:${ip}` / 100 requests per 60s).
+ */
+export const GRAPHQL_DOCS_RATE_LIMIT_REQUESTS = 100;
+export const GRAPHQL_DOCS_RATE_LIMIT_WINDOW_SECONDS = 60;
+
+/** Relationship roots carry complexity weight 5 in src/graphql.mjs. */
+export const GRAPHQL_DOCS_RELATIONSHIP_FIELD_COST = 5;
+
+export const GRAPHQL_ENDPOINT_PATH = "/api/v1/graphql";
+
+export type GraphQLRootQueryDoc = {
+  name: string;
+  args: string;
+  returns: string;
+  summary: string;
+};
+
+/** Root Query fields from the published SDL (src/graphql.mjs). */
+export const GRAPHQL_ROOT_QUERIES: readonly GraphQLRootQueryDoc[] = [
+  {
+    name: "subnets",
+    args: "limit, cursor",
+    returns: "SubnetList!",
+    summary: "Paginated active-subnet index.",
+  },
+  {
+    name: "subnet",
+    args: "netuid!",
+    returns: "Subnet",
+    summary: "One subnet with health, surfaces, endpoints, and economics.",
+  },
+  {
+    name: "providers",
+    args: "limit, cursor",
+    returns: "ProviderList!",
+    summary: "Paginated provider/source registry.",
+  },
+  {
+    name: "provider",
+    args: "id!",
+    returns: "Provider",
+    summary: "One provider with its subnets.",
+  },
+  {
+    name: "economics",
+    args: "limit, cursor",
+    returns: "EconomicsList!",
+    summary: "Paginated per-subnet economic + validator metrics.",
+  },
+  {
+    name: "surfaces",
+    args: "netuid, limit, cursor",
+    returns: "SurfaceList!",
+    summary: "Curated public surfaces, optionally scoped to one subnet.",
+  },
+  {
+    name: "endpoints",
+    args: "netuid, limit, cursor",
+    returns: "EndpointList!",
+    summary: "Endpoint/resource registry, optionally scoped to one subnet.",
+  },
+  {
+    name: "health",
+    args: "—",
+    returns: "GlobalHealth",
+    summary: "Global operational health rollup with per-subnet summaries.",
+  },
+  {
+    name: "opportunity_boards",
+    args: "limit",
+    returns: "OpportunityBoards!",
+    summary: "Cross-subnet economic opportunity boards.",
+  },
+  {
+    name: "compare",
+    args: "netuids!, dimensions",
+    returns: "Compare!",
+    summary: "Side-by-side registry / economics / health for requested netuids.",
+  },
+] as const;
+
+export type GraphQLLimitRow = {
+  label: string;
+  value: string;
+  detail: string;
+};
+
+/** Format a byte budget for the limits table (e.g. 65536 → "64 KiB"). */
+export function formatGraphqlByteBudget(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "—";
+  if (bytes % 1024 === 0) return `${bytes / 1024} KiB`;
+  return `${bytes} B`;
+}
+
+export function buildGraphqlLimitRows(): GraphQLLimitRow[] {
+  return [
+    {
+      label: "Max depth",
+      value: String(GRAPHQL_DOCS_MAX_DEPTH),
+      detail: "Nested selection sets beyond this fail validation.",
+    },
+    {
+      label: "Max complexity",
+      value: String(GRAPHQL_DOCS_MAX_COMPLEXITY),
+      detail: `Default field cost 1; relationship roots cost ${GRAPHQL_DOCS_RELATIONSHIP_FIELD_COST}.`,
+    },
+    {
+      label: "Max POST body",
+      value: formatGraphqlByteBudget(GRAPHQL_DOCS_MAX_BODY_BYTES),
+      detail: "HTTP request body size cap for POST /api/v1/graphql.",
+    },
+    {
+      label: "Max query document",
+      value: formatGraphqlByteBudget(GRAPHQL_DOCS_MAX_QUERY_BYTES),
+      detail: "Raw query string / document length cap.",
+    },
+    {
+      label: "Page size",
+      value: `${GRAPHQL_DOCS_DEFAULT_PAGE_LIMIT} default · ${GRAPHQL_DOCS_MAX_PAGE_LIMIT} max`,
+      detail: "Cursor pagination on list roots (subnets, providers, …).",
+    },
+    {
+      label: "Rate limit",
+      value: `${GRAPHQL_DOCS_RATE_LIMIT_REQUESTS} / ${GRAPHQL_DOCS_RATE_LIMIT_WINDOW_SECONDS}s`,
+      detail: "Per-client IP, shared policy with the RPC proxy (429 + retry-after).",
+    },
+  ];
+}
+
+/** Example shaped query from README / machine surfaces. */
+export const GRAPHQL_EXAMPLE_QUERY =
+  "{ subnet(netuid: 7) { name health { status } surfaces { kind url } economics { emission_share } } }";
+
+export function buildGraphqlCurlExample(apiBase: string): string {
+  const base = apiBase.replace(/\/$/, "");
+  return [
+    `curl -X POST ${base}${GRAPHQL_ENDPOINT_PATH} \\`,
+    `  -H 'content-type: application/json' \\`,
+    `  -d '{"query":"${GRAPHQL_EXAMPLE_QUERY}"}'`,
+  ].join("\n");
+}
+
+/** Expected root query count — guards accidental drift from the Worker SDL. */
+export const GRAPHQL_ROOT_QUERY_COUNT = 10;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as SchemasRouteImport } from './routes/schemas'
 import { Route as LeaderboardsRouteImport } from './routes/leaderboards'
 import { Route as HealthRouteImport } from './routes/health'
+import { Route as GraphqlRouteImport } from './routes/graphql'
 import { Route as GapsRouteImport } from './routes/gaps'
 import { Route as ExplorerRouteImport } from './routes/explorer'
 import { Route as EndpointsRouteImport } from './routes/endpoints'
@@ -65,6 +66,11 @@ const LeaderboardsRoute = LeaderboardsRouteImport.update({
 const HealthRoute = HealthRouteImport.update({
   id: '/health',
   path: '/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GraphqlRoute = GraphqlRouteImport.update({
+  id: '/graphql',
+  path: '/graphql',
   getParentRoute: () => rootRouteImport,
 } as any)
 const GapsRoute = GapsRouteImport.update({
@@ -180,6 +186,7 @@ export interface FileRoutesByFullPath {
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
+  '/graphql': typeof GraphqlRoute
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
   '/schemas': typeof SchemasRoute
@@ -209,6 +216,7 @@ export interface FileRoutesByTo {
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
+  '/graphql': typeof GraphqlRoute
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
   '/schemas': typeof SchemasRoute
@@ -239,6 +247,7 @@ export interface FileRoutesById {
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
   '/gaps': typeof GapsRoute
+  '/graphql': typeof GraphqlRoute
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
   '/schemas': typeof SchemasRoute
@@ -270,6 +279,7 @@ export interface FileRouteTypes {
     | '/endpoints'
     | '/explorer'
     | '/gaps'
+    | '/graphql'
     | '/health'
     | '/leaderboards'
     | '/schemas'
@@ -299,6 +309,7 @@ export interface FileRouteTypes {
     | '/endpoints'
     | '/explorer'
     | '/gaps'
+    | '/graphql'
     | '/health'
     | '/leaderboards'
     | '/schemas'
@@ -328,6 +339,7 @@ export interface FileRouteTypes {
     | '/endpoints'
     | '/explorer'
     | '/gaps'
+    | '/graphql'
     | '/health'
     | '/leaderboards'
     | '/schemas'
@@ -358,6 +370,7 @@ export interface RootRouteChildren {
   EndpointsRoute: typeof EndpointsRoute
   ExplorerRoute: typeof ExplorerRoute
   GapsRoute: typeof GapsRoute
+  GraphqlRoute: typeof GraphqlRoute
   HealthRoute: typeof HealthRoute
   LeaderboardsRoute: typeof LeaderboardsRoute
   SchemasRoute: typeof SchemasRoute
@@ -423,6 +436,13 @@ declare module '@tanstack/react-router' {
       path: '/health'
       fullPath: '/health'
       preLoaderRoute: typeof HealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/graphql': {
+      id: '/graphql'
+      path: '/graphql'
+      fullPath: '/graphql'
+      preLoaderRoute: typeof GraphqlRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/gaps': {
@@ -582,6 +602,7 @@ const rootRouteChildren: RootRouteChildren = {
   EndpointsRoute: EndpointsRoute,
   ExplorerRoute: ExplorerRoute,
   GapsRoute: GapsRoute,
+  GraphqlRoute: GraphqlRoute,
   HealthRoute: HealthRoute,
   LeaderboardsRoute: LeaderboardsRoute,
   SchemasRoute: SchemasRoute,

--- a/apps/ui/src/routes/graphql.tsx
+++ b/apps/ui/src/routes/graphql.tsx
@@ -1,0 +1,175 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { CopyButton, PageHero, SectionHeading } from "@jsonbored/ui-kit";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
+import {
+  GRAPHQL_ENDPOINT_PATH,
+  GRAPHQL_ROOT_QUERIES,
+  buildGraphqlCurlExample,
+  buildGraphqlLimitRows,
+} from "@/lib/metagraphed/graphql-docs";
+
+export const Route = createFileRoute("/graphql")({
+  head: () => ({
+    meta: [
+      { title: "GraphQL — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Metagraphed GraphQL at /api/v1/graphql — schema discovery, root queries, complexity/depth limits, pagination, and rate limits.",
+      },
+      { property: "og:title", content: "GraphQL — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "Shape one request across the registry: subnets, providers, economics, surfaces, health, compare, and opportunity boards.",
+      },
+    ],
+  }),
+  component: GraphqlDocsPage,
+});
+
+const ENDPOINT_URL = `${API_BASE}${GRAPHQL_ENDPOINT_PATH}`;
+const CURL_EXAMPLE = buildGraphqlCurlExample(DEFAULT_API_BASE);
+const LIMIT_ROWS = buildGraphqlLimitRows();
+
+function GraphqlDocsPage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="API"
+        live
+        title="GraphQL"
+        description="Shape one request across the registry — a subnet with health, surfaces, endpoints, and economics, a provider with its subnets, or the economic opportunity boards. No API key."
+      />
+
+      <div className="mt-6 space-y-section" data-testid="graphql-docs">
+        <section>
+          <SectionHeading
+            title="Endpoint"
+            intro="POST a GraphQL document. GET returns the published SDL. Introspection is enabled. Mainnet-only path."
+          />
+          <div className="space-y-2">
+            <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  POST · GET
+                </div>
+                <code className="mt-0.5 block overflow-x-auto whitespace-nowrap font-mono text-[13px] text-ink-strong">
+                  {ENDPOINT_URL}
+                </code>
+              </div>
+              <CopyButton value={ENDPOINT_URL} label="GraphQL endpoint" />
+            </div>
+            <div className="rounded-lg border border-border bg-card px-4 py-3">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  Example
+                </div>
+                <CopyButton value={CURL_EXAMPLE} label="GraphQL curl example" />
+              </div>
+              <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-[12px] leading-relaxed text-ink-strong">
+                {CURL_EXAMPLE}
+              </pre>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Schema"
+            intro="GET the endpoint for the live SDL. Introspection queries (__schema / __type) are allowed and exempt from the depth and complexity budgets applied to product queries."
+          />
+          <ul className="space-y-1.5 font-mono text-[12px] text-ink-muted">
+            <li>
+              <span className="text-ink-strong">GET</span> {GRAPHQL_ENDPOINT_PATH} → SDL document
+            </li>
+            <li>
+              <span className="text-ink-strong">POST</span> {GRAPHQL_ENDPOINT_PATH} →{" "}
+              <code className="text-ink-strong">
+                {'{ "query", "variables?", "operationName?" }'}
+              </code>
+            </li>
+            <li>
+              Field names mirror artifact JSON keys (snake_case) so resolvers read registry rows
+              directly.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Root queries"
+            intro="Ten Query roots cover the same registry surfaces as REST. List roots take cursor pagination; relationship fields (fresh nested artifacts) cost more against the complexity budget."
+          />
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-[36rem] text-left text-sm">
+              <thead>
+                <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  <th className="px-3 py-2.5 font-normal">Field</th>
+                  <th className="px-3 py-2.5 font-normal">Args</th>
+                  <th className="px-3 py-2.5 font-normal">Returns</th>
+                  <th className="px-3 py-2.5 font-normal">Summary</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {GRAPHQL_ROOT_QUERIES.map((q) => (
+                  <tr key={q.name} className="align-top">
+                    <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">{q.name}</td>
+                    <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">{q.args}</td>
+                    <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">
+                      {q.returns}
+                    </td>
+                    <td className="px-3 py-2.5 text-[12px] text-ink">{q.summary}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-3 font-mono text-[11px] text-ink-muted">
+            Subscriptions: <code className="text-ink-strong">chainEvents</code> over the same path
+            via <code className="text-ink-strong">graphql-transport-ws</code> (WebSocket). See{" "}
+            <Link to="/agents" className="text-accent hover:underline">
+              For agents
+            </Link>{" "}
+            for other machine surfaces.
+          </p>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Limits"
+            intro="Hard caps enforced on every POST. Matching constants live in src/graphql.mjs; rate limiting is keyed per client IP alongside the RPC proxy."
+          />
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-[28rem] text-left text-sm">
+              <thead>
+                <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  <th className="px-3 py-2.5 font-normal">Limit</th>
+                  <th className="px-3 py-2.5 font-normal">Value</th>
+                  <th className="px-3 py-2.5 font-normal">Notes</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {LIMIT_ROWS.map((row) => (
+                  <tr key={row.label} className="align-top">
+                    <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                      {row.label}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2.5 font-mono text-[12px] tabular-nums text-ink">
+                      {row.value}
+                    </td>
+                    <td className="px-3 py-2.5 text-[12px] text-ink-muted">{row.detail}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+
+      <ApiSourceFooter paths={[GRAPHQL_ENDPOINT_PATH]} />
+    </AppShell>
+  );
+}

--- a/apps/ui/tests/e2e/capture-graphql-docs-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-graphql-docs-screenshots.mjs
@@ -1,0 +1,81 @@
+/**
+ * Capture /graphql docs page screenshots for #3513 (Path C2).
+ *
+ * New page — before captures are the 404/fallback when the route is missing;
+ * after captures show the live docs page.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8111 VARIANT=before node tests/e2e/capture-graphql-docs-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8112 VARIANT=after  node tests/e2e/capture-graphql-docs-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/graphql-docs-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8112";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const VIEWPORT_FILTER = process.env.VIEWPORT_FILTER;
+const ALL_VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const VIEWPORTS = VIEWPORT_FILTER
+  ? ALL_VIEWPORTS.filter((v) => v.name === VIEWPORT_FILTER)
+  : ALL_VIEWPORTS;
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function openGraphqlDocs(page) {
+  await page.goto(`${BASE_URL}/graphql`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 8000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+  // Prefer the docs shell; before-state may be a not-found page.
+  const docs = page.locator('[data-testid="graphql-docs"]');
+  const hero = page.getByRole("heading", { name: /GraphQL/i }).first();
+  try {
+    await docs.waitFor({ state: "visible", timeout: 5000 });
+  } catch {
+    await hero.waitFor({ state: "visible", timeout: 30_000 }).catch(() => {});
+  }
+  await page.waitForTimeout(250);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await setTheme(page, theme);
+      await openGraphqlDocs(page);
+      const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+      await context.close();
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add `/graphql` docs page covering `POST`/`GET` `/api/v1/graphql`: schema discovery (live SDL + introspection), all ten root Query fields, and limits (depth 7, complexity 50, body/query byte caps, pagination, rate limit).
- Extract Worker-aligned constants into `graphql-docs.ts` (+ tests) so the UI copy stays checkable against `src/graphql.mjs`.
- Register the page in the site footer (Operations) and command palette.

Closes #3513

## Screenshots

Before = `/graphql` prior to this route (not found / fallback). After = the new docs page.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-before-desktop-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-before-desktop-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-after-desktop-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-before-desktop-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-before-desktop-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-after-desktop-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-before-tablet-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-before-tablet-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-after-tablet-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-before-tablet-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-before-tablet-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-after-tablet-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-before-mobile-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-before-mobile-light.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-after-mobile-light.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-before-mobile-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-before-mobile-dark.png)<br><sub>before</sub> | [<img src=https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-after-mobile-dark.png width=260>](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3513-after-mobile-dark.png)<br><sub>after</sub> |

## Test plan

- [x] `npm test --workspace=apps/ui -- --run graphql-docs` (5 new tests)
- [x] Changed-file prettier + eslint (no errors)
- [ ] CI: `ui` lint/format/typecheck/test/e2e/build, codecov