### PR TITLE
fix(schemas): enforce public-artifacts.schema.json against committed artifacts

### DIFF
--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -231,6 +231,32 @@ for (const artifact of await artifactValidationTargets()) {
   );
 }
 
+// #5551: enforce schemas/public-artifacts.schema.json against the real committed
+// artifacts it documents. The generic loop above only ajv.compile()s it for
+// syntax; nothing validated actual artifact data against its `$defs` (the
+// `schema_version: 1` const, per-kind required properties, etc.), and
+// validate.mjs merely existence-checked the file. The other artifacts this
+// schema describes (providers, subnets, health, ...) are R2-only / gitignored
+// (built and served on deploy), so only the git-committed ones are checkable
+// here; each is validated against the `$def` its top-level property `$ref`s.
+const PUBLIC_ARTIFACTS_SCHEMA_ID =
+  "https://metagraph.sh/schemas/public-artifacts.schema.json";
+const publicArtifactTargets = [
+  { property: "api_index", file_path: "public/metagraph/api-index.json" },
+  { property: "contracts", file_path: "public/metagraph/contracts.json" },
+  { property: "r2_manifest", file_path: "public/metagraph/r2-manifest.json" },
+];
+for (const { property, file_path } of publicArtifactTargets) {
+  const validator = ajv.getSchema(
+    `${PUBLIC_ARTIFACTS_SCHEMA_ID}#/properties/${property}`,
+  );
+  validate(
+    validator,
+    await readJson(path.join(repoRoot, file_path)),
+    `public-artifact:${property}`,
+  );
+}
+
 if (errors.length > 0) {
   console.error(`Schema validation failed with ${errors.length} issue(s):`);
   for (const error of errors.slice(0, 80)) {

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1383,7 +1383,10 @@ async function validateGeneratedArtifacts(
     "schemas/provider.schema.json",
     "schemas/subnet-manifest.schema.json",
     "schemas/candidate-surface.schema.json",
-    "schemas/public-artifacts.schema.json",
+    // public-artifacts.schema.json is no longer existence-checked here: #5551
+    // wired it into real ajv validation in validate-schemas.mjs (its committed
+    // artifacts are validated against its `$defs`), so a bare fs.access is no
+    // longer the sole signal that the schema is enforced.
   ]) {
     try {
       await fs.access(path.join(repoRoot, schemaPath));

--- a/tests/public-artifacts-schema.test.mjs
+++ b/tests/public-artifacts-schema.test.mjs
@@ -1,0 +1,83 @@
+// #5551: schemas/public-artifacts.schema.json documents the top-level shape of
+// every generated public artifact (the `schema_version: 1` const from
+// artifactBase, per-kind required properties, `base_path: "/metagraph"`, etc.)
+// but was only ever ajv-compiled for syntax — nothing validated real artifact
+// data against it, and validate.mjs merely existence-checked the file. These
+// tests exercise the schema directly: the real committed artifacts must pass
+// against the `$def` their top-level property `$ref`s, and each documented
+// constraint must reject a fixture that violates it.
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { readJson, repoRoot } from "../scripts/lib.mjs";
+
+const SCHEMA_ID = "https://metagraph.sh/schemas/public-artifacts.schema.json";
+
+const ajv = new Ajv2020({
+  strict: false,
+  validateFormats: true,
+  allErrors: true,
+});
+addFormats(ajv);
+ajv.addSchema(
+  await readJson(path.join(repoRoot, "schemas/public-artifacts.schema.json")),
+);
+
+const validatorFor = (property) =>
+  ajv.getSchema(`${SCHEMA_ID}#/properties/${property}`);
+
+// The committed artifacts this schema covers (the rest — providers, subnets,
+// health, ... — are R2-only / gitignored, built and served on deploy).
+const COMMITTED = {
+  api_index: "public/metagraph/api-index.json",
+  contracts: "public/metagraph/contracts.json",
+  r2_manifest: "public/metagraph/r2-manifest.json",
+};
+
+describe("public-artifacts.schema.json enforcement (#5551)", () => {
+  for (const [property, file] of Object.entries(COMMITTED)) {
+    test(`the committed ${property} artifact validates against its $def`, async () => {
+      const validate = validatorFor(property);
+      const data = await readJson(path.join(repoRoot, file));
+      assert.equal(validate(data), true, JSON.stringify(validate.errors));
+    });
+  }
+
+  test("rejects an artifact whose schema_version is not the const 1", async () => {
+    const validate = validatorFor("api_index");
+    const bad = structuredClone(
+      await readJson(path.join(repoRoot, COMMITTED.api_index)),
+    );
+    bad.schema_version = 2;
+    assert.equal(validate(bad), false);
+  });
+
+  test("rejects an artifact missing the required generated_at", async () => {
+    const validate = validatorFor("api_index");
+    const bad = structuredClone(
+      await readJson(path.join(repoRoot, COMMITTED.api_index)),
+    );
+    delete bad.generated_at;
+    assert.equal(validate(bad), false);
+  });
+
+  test("rejects a contracts artifact whose base_path isn't /metagraph", async () => {
+    const validate = validatorFor("contracts");
+    const bad = structuredClone(
+      await readJson(path.join(repoRoot, COMMITTED.contracts)),
+    );
+    bad.base_path = "/not-metagraph";
+    assert.equal(validate(bad), false);
+  });
+
+  test("rejects a contracts artifact missing a required property", async () => {
+    const validate = validatorFor("contracts");
+    const bad = structuredClone(
+      await readJson(path.join(repoRoot, COMMITTED.contracts)),
+    );
+    delete bad.artifacts;
+    assert.equal(validate(bad), false);
+  });
+});


### PR DESCRIPTION
### What

`schemas/public-artifacts.schema.json` documents the top-level shape of every generated public artifact — `schema_version` const `1` and required `generated_at` (via `artifactBase`), per-kind required properties, `base_path` const `/metagraph` for the contracts artifact, etc. But nothing ever validated real artifact data against it:

- `validate-schemas.mjs`'s generic loop only `ajv.compile()`s it for **syntax** — never validates any data.
- No `PUBLIC_ARTIFACTS` entry references it; those validate against the separate `schemas/components/*` OpenAPI-component namespace.
- `validate.mjs` merely `fs.access()`d the file (existence only).

So every constraint it documented was silently unenforced.

### Fix — direction (a): wire it into real validation

Following the #5476 precedent (which wired `provider-submission.schema.json` in the same way), validate each **committed** public artifact against the `$def` its top-level property `$ref`s. The other artifacts this schema describes (`providers`, `subnets`, `health`, …) are R2-only / gitignored — built and served on deploy — so only the git-committed ones are checkable here: `api_index` → `api-index.json`, `contracts` → `contracts.json`, `r2_manifest` → `r2-manifest.json`.

Also drop the now-redundant existence-only check in `validate.mjs`, so a bare `fs.access` is no longer the sole "enforced" signal (per the issue's second deliverable).

### Tests

`tests/public-artifacts-schema.test.mjs`: the three committed artifacts validate against their `$def`; and violating a documented constraint fails — `schema_version: 2` (const), a missing `generated_at`, a contracts `base_path` that isn't `/metagraph`, and a contracts artifact missing a required property.

Verified locally: `validate:schemas` passes (the real artifacts satisfy the schema), the full registry `validate` passes, all 6 `checks`-job validators pass, and the 7 new tests pass. Code-only (`scripts/**` + `tests/**`), no artifact regeneration.

Closes #5551
