### PR TITLE
fix(ui): add a copy button to AccountCell's valid-address path

### DIFF
--- a/apps/ui/src/components/metagraphed/account-cell.tsx
+++ b/apps/ui/src/components/metagraphed/account-cell.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { type ReactNode } from "react";
+import { CopyButton } from "@jsonbored/ui-kit";
 import { EntityHoverCard } from "./entity-hover-card";
 import { isValidSs58 } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -7,18 +8,22 @@ import { shortHash } from "@/lib/metagraphed/blocks";
 /**
  * Renders an ss58 account value as a truncated `/accounts/$ss58` link wrapped in
  * the account hover-card preview — the treatment ss58 addresses get elsewhere in
- * the app. When the value is missing or not a valid ss58, renders `fallback`
- * (each table keeps its own prior rendering there). Shared by the blocks and
- * extrinsics explorer tables so the cell markup lives in one place.
+ * the app — plus a copy button, matching the block-hash cell's inline idiom
+ * (blocks.index.tsx). When the value is missing or not a valid ss58, renders
+ * `fallback` (each table keeps its own prior rendering there). Shared by the
+ * blocks and extrinsics explorer tables so the cell markup lives in one place.
  */
 export function AccountCell({ ss58, fallback }: { ss58?: string | null; fallback: ReactNode }) {
   if (ss58 && isValidSs58(ss58)) {
     return (
-      <EntityHoverCard kind="account" ss58={ss58}>
-        <Link to="/accounts/$ss58" params={{ ss58 }} className="hover:underline" title={ss58}>
-          {shortHash(ss58)}
-        </Link>
-      </EntityHoverCard>
+      <span className="inline-flex items-center gap-1 min-w-0">
+        <EntityHoverCard kind="account" ss58={ss58}>
+          <Link to="/accounts/$ss58" params={{ ss58 }} className="hover:underline" title={ss58}>
+            {shortHash(ss58)}
+          </Link>
+        </EntityHoverCard>
+        <CopyButton value={ss58} label="account" />
+      </span>
     );
   }
   return <>{fallback}</>;


### PR DESCRIPTION
## Summary

`AccountCell`'s valid-ss58 branch rendered a `Link` wrapped in `EntityHoverCard` with no copy affordance, while the invalid/missing-address `fallback` each caller supplies (`CopyableCode`) already has one — so the common, valid-address case was strictly *less* functional than its own rare edge case.

Adds a `CopyButton` (from `@jsonbored/ui-kit`) alongside the existing `Link`, wrapped in the same `inline-flex items-center gap-1` span the block-hash column already uses in the same tables (`blocks.index.tsx`) — same compact inline idiom, not a new one.

```tsx
<span className="inline-flex items-center gap-1 min-w-0">
  <EntityHoverCard kind="account" ss58={ss58}>
    <Link to="/accounts/$ss58" params={{ ss58 }} className="hover:underline" title={ss58}>
      {shortHash(ss58)}
    </Link>
  </EntityHoverCard>
  <CopyButton value={ss58} label="account" />
</span>
```

The `fallback` prop's contract is untouched — callers still supply their own fallback content for the invalid/missing case.

## Verified on both call sites

- `blocks.index.tsx` — Author column
- `extrinsics.index.tsx` — Signer column (including the unsigned-extrinsic `—` fallback case, unaffected)

## Verification

- [x] `npm run lint` / `npm run format:check` / `npm run typecheck` / `npm run test -- --run` (977 tests) — all green
- [x] `npm run build --workspace=apps/ui`
- [x] Manually confirmed both call sites render the copy button and it actually copies the full ss58 address

## Screenshots

Blocks table (Author column) — before/after, all three viewports, both themes. Mobile renders a separate card list below `md` (`{shortHash(b.author)}` as bare text, no `AccountCell` at all), so those two rows are pixel-identical before/after by construction — included anyway rather than skipped, to avoid relying on an exception the automated screenshot check won't parse.

| Viewport · Theme | Before | After |
| ---------------- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-mobile-dark-after.png)<br><sub>after</sub> |

Extrinsics table (Signer column) — desktop/light, confirming the second call site:

| Before | After |
| --- | --- |
| [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-extrinsics-desktop-light-before.png" width="400">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-extrinsics-desktop-light-before.png) | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-extrinsics-desktop-light-after.png" width="400">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/account-cell-5566-extrinsics-desktop-light-after.png) |

Closes #5566
