### PR TITLE
fix(registry): document 5 subnets' degraded website/dashboard URLs (#5480)

### DIFF
--- a/registry/subnets/8-ball.json
+++ b/registry/subnets/8-ball.json
@@ -14,7 +14,7 @@
   "website_url": "https://8ball125.com/",
   "docs_url": "https://github.com/Barbariandev/8Ball_miner#readme",
   "source_repo": "https://github.com/Barbariandev/8Ball_miner",
-  "notes": "Reviewed overlay for SN125 8 Ball. The public website is live and the public miner/source repository documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
+  "notes": "Reviewed overlay for SN125 8 Ball. The 8ball125.com website currently returns HTTP 502 to simple probes and should appear degraded until it recovers. The public miner/source repository documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -22,7 +22,7 @@
     "verified_at": "2026-06-08T15:00:00.000Z",
     "source_count": 7,
     "gap_notes": [
-      "Official website and miner/source repository are verified live.",
+      "Official website (8ball125.com) currently returns HTTP 502 to simple probes and should appear degraded until it recovers; the miner/source repository is verified live.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",

--- a/registry/subnets/ninja.json
+++ b/registry/subnets/ninja.json
@@ -12,7 +12,8 @@
   "contact": "tau@arbos.life",
   "curation": {
     "gap_notes": [
-      "Swagger/OpenAPI routes currently serve HTML UI only; no verified machine-readable schema URL yet.",
+      "The ninja.arbos.life host (website, dashboard, /health, and /swagger) currently returns HTTP 404 to simple probes and should appear degraded until it recovers.",
+      "Swagger/OpenAPI routes previously served HTML UI only; no verified machine-readable schema URL yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
     ],
@@ -33,7 +34,7 @@
   ],
   "name": "ninja",
   "netuid": 66,
-  "notes": "Reviewed overlay for SN66 using the official Ninja/Unarbos website, tau workflow repository, miner harness repository, health endpoint, and Swagger UI. The obvious OpenAPI JSON paths currently serve HTML, so schema-backed status remains a gap.",
+  "notes": "Reviewed overlay for SN66 using the official Ninja/Unarbos tau workflow repository and miner harness repository. The ninja.arbos.life host (website, dashboard, /health endpoint, and Swagger UI) currently returns HTTP 404 to simple probes and should appear degraded until it recovers.",
   "schema_version": 1,
   "slug": "sn-66",
   "source_repo": "https://github.com/unarbos/tau",

--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -15,7 +15,7 @@
   "website_url": "https://oneoneone.io/",
   "source_repo": "https://github.com/oneoneone-io/subnet-111",
   "dashboard_url": "https://taomarketcap.com/subnets/111",
-  "notes": "Reviewed overlay for SN111 using the official oneoneone website and source repository. No official docs/API/OpenAPI surface is verified yet.",
+  "notes": "Reviewed overlay for SN111 using the official oneoneone website and source repository. The oneoneone.io website currently returns a Cloudflare 530 origin error to simple probes and should appear degraded until it recovers. No official docs/API/OpenAPI surface is verified yet.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -23,6 +23,7 @@
     "verified_at": "2026-06-08T10:35:00.000Z",
     "source_count": 4,
     "gap_notes": [
+      "Official website (oneoneone.io) currently returns a Cloudflare 530 origin error to simple probes and should appear degraded until it recovers.",
       "No verified official docs URL yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified OpenAPI/Swagger schema yet.",

--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -26,7 +26,7 @@
     "sn-10-website-common-swagger-json",
     "sn-10-website-subdomain-docs-docs-taofi-com"
   ],
-  "notes": "Reviewed overlay for SN10 Swap using the TaoFi pool page, TaoFi docs, and Swap source repository. Common www.taofi.com API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
+  "notes": "Reviewed overlay for SN10 Swap using the TaoFi pool page, TaoFi docs, and Swap source repository. The www.taofi.com/pool page currently returns HTTP 402 to simple probes and should appear degraded until it recovers. Common www.taofi.com API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -34,7 +34,7 @@
     "verified_at": "2026-06-08T20:25:00.000Z",
     "source_count": 5,
     "gap_notes": [
-      "Official TaoFi pool page, docs, and Swap source repository are verified live.",
+      "Official TaoFi pool page (www.taofi.com/pool) currently returns HTTP 402 to simple probes and should appear degraded until it recovers; TaoFi docs and the Swap source repository are verified live.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
       "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",

--- a/registry/subnets/tensorclaw.json
+++ b/registry/subnets/tensorclaw.json
@@ -17,7 +17,7 @@
   "dashboard_url": "https://www.tensorclaw.ai/dashboard",
   "website_url": "https://www.tensorclaw.ai/",
   "baseline_excluded_surface_ids": ["sn-92-taomarketcap-website"],
-  "notes": "Reviewed overlay for SN92 using the live Tensorclaw Network website, dashboard, and source repository. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The website links https://github.com/tensorclaw/tensorclaw and the repository README identifies it as Bittensor Tensorclaw Subnet 92.",
+  "notes": "Reviewed overlay for SN92 using the Tensorclaw Network website, dashboard, and source repository. The www.tensorclaw.ai website and its /dashboard currently return a Cloudflare 521 (web server is down) to simple probes and should appear degraded until they recover. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The repository README identifies https://github.com/tensorclaw/tensorclaw as Bittensor Tensorclaw Subnet 92.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -26,7 +26,7 @@
     "source_count": 6,
     "gap_notes": [
       "Native chain name currently reports as luis while the public website identifies the project as Tensorclaw Network / Subnet 92.",
-      "Official website, dashboard, and source repository are verified live.",
+      "Official website and dashboard (www.tensorclaw.ai, /dashboard) currently return a Cloudflare 521 (web server is down) to simple probes and should appear degraded until they recover; the source repository is verified live.",
       "No verified docs site yet beyond directory pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",


### PR DESCRIPTION
## Summary

Five subnet manifests asserted (in `notes` / `curation.gap_notes`) that a `website_url` / `dashboard_url` was "verified live," but the URL currently returns a hard error. I re-checked each one **twice with a browser User-Agent, ~seconds apart, following redirects** (per the issue's instruction to distinguish a genuine outage from bot-blocking) — all five are still down, consistently:

| Subnet | URL | Status (both checks) |
| --- | --- | --- |
| SN10 Swap | `https://www.taofi.com/pool` | **402** |
| SN92 Tensorclaw | `https://www.tensorclaw.ai/` + `/dashboard` | **521** (Cloudflare "web server is down") |
| SN66 ninja | `https://ninja.arbos.life/` | **404** |
| SN125 8 Ball | `https://8ball125.com/` | **502** |
| SN111 oneoneone | `https://oneoneone.io/` | **530** (Cloudflare origin error) |

None is a bot-block (those return 403/429/challenge HTML); these are genuine origin errors (521/530 = Cloudflare origin down; 402/404/502 = hard failures).

## What changed

For each of the 5 `registry/subnets/*.json` files, updated `notes` and the relevant `curation.gap_notes` entry to document the degraded state plainly and stop calling the failing URL "verified live" — following the precedent already set by `taolend.json` (`gap_notes`: "Official website currently returns 500/server-error responses to simple probes and should appear degraded until it recovers") and `nodexo.json`. The recently-merged `#5594` (dogelayer website-outage documentation) uses the same treatment.

The URLs themselves are **left in place** — the issue notes these outages could be transient, so per its guidance I documented the degraded state rather than removing/nulling the URLs (no evidence of permanent removal like a DNS lame-delegation).

## Validation

- `npm run validate:surface -- <5 files>` → passed (34 surfaces across 5 files)
- `npm run scan:public-safety` → passed
- `npm run validate` (full suite, after `npm run build`) → passed
- `npx prettier --check <5 files>` → clean
- `npm run build` produces **no** generated-artifact drift — `notes`/`gap_notes` are curation-review metadata, not projected into `public/`; the diff is confined to the 5 source files.

Five registry files, no generated artifacts. Closes #5480
