### PR TITLE
fix(registry): document 5 subnets' currently-degraded website/dashboard URLs (#5480)

### DIFF
--- a/registry/subnets/8-ball.json
+++ b/registry/subnets/8-ball.json
@@ -14,7 +14,7 @@
   "website_url": "https://8ball125.com/",
   "docs_url": "https://github.com/Barbariandev/8Ball_miner#readme",
   "source_repo": "https://github.com/Barbariandev/8Ball_miner",
-  "notes": "Reviewed overlay for SN125 8 Ball. The public website is live and the public miner/source repository documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
+  "notes": "Reviewed overlay for SN125 8 Ball. The 8ball125.com website currently returns an HTTP 502 response to simple probes and should appear degraded until it recovers; the public miner/source repository documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -22,7 +22,7 @@
     "verified_at": "2026-06-08T15:00:00.000Z",
     "source_count": 7,
     "gap_notes": [
-      "Official website and miner/source repository are verified live.",
+      "Official 8ball125.com website currently returns HTTP 502 to simple probes and should appear degraded until it recovers; the miner/source repository remains the verified public surface.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
@@ -49,7 +49,7 @@
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official 8 Ball website linked from the public SN125 miner repository."
+      "notes": "Official 8 Ball website linked from the public SN125 miner repository. Current probe state is expected to show degraded while 8ball125.com returns HTTP 502 to simple probes."
     },
     {
       "id": "sn-125-eightball-source-repo",

--- a/registry/subnets/ninja.json
+++ b/registry/subnets/ninja.json
@@ -12,6 +12,7 @@
   "contact": "tau@arbos.life",
   "curation": {
     "gap_notes": [
+      "The ninja.arbos.life host currently returns HTTP 404 to simple probes (site root and routes) and should appear degraded until it recovers.",
       "Swagger/OpenAPI routes currently serve HTML UI only; no verified machine-readable schema URL yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
@@ -33,7 +34,7 @@
   ],
   "name": "ninja",
   "netuid": 66,
-  "notes": "Reviewed overlay for SN66 using the official Ninja/Unarbos website, tau workflow repository, miner harness repository, health endpoint, and Swagger UI. The obvious OpenAPI JSON paths currently serve HTML, so schema-backed status remains a gap.",
+  "notes": "Reviewed overlay for SN66 using the official Ninja/Unarbos website, tau workflow repository, miner harness repository, health endpoint, and Swagger UI. The ninja.arbos.life host currently returns HTTP 404 to simple probes (both the site root and its routes) and should appear degraded until it recovers. The obvious OpenAPI JSON paths currently serve HTML, so schema-backed status remains a gap.",
   "schema_version": 1,
   "slug": "sn-66",
   "source_repo": "https://github.com/unarbos/tau",
@@ -45,7 +46,7 @@
       "id": "sn-66-ninja-website",
       "kind": "website",
       "name": "Ninja website",
-      "notes": "Official Ninja SN66 public website.",
+      "notes": "Official Ninja SN66 public website. Current probe state is expected to show degraded while ninja.arbos.life returns HTTP 404 to simple probes.",
       "probe": {
         "enabled": true,
         "expect": "html",
@@ -126,7 +127,7 @@
       "id": "sn-66-ninja-health",
       "kind": "subnet-api",
       "name": "Ninja health endpoint",
-      "notes": "Health path returns HTTP 404 (the host is up; the /health route does not exist) — verified 2026-06-15. Probe disabled pending a valid health URL.",
+      "notes": "Health path returns HTTP 404 — verified 2026-06-15. As of a 2026-07 re-check the ninja.arbos.life host itself also returns HTTP 404 to simple probes and should appear degraded until it recovers. Probe disabled pending a valid health URL.",
       "probe": {
         "enabled": false,
         "expect": "any",

--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -15,7 +15,7 @@
   "website_url": "https://oneoneone.io/",
   "source_repo": "https://github.com/oneoneone-io/subnet-111",
   "dashboard_url": "https://taomarketcap.com/subnets/111",
-  "notes": "Reviewed overlay for SN111 using the official oneoneone website and source repository. No official docs/API/OpenAPI surface is verified yet.",
+  "notes": "Reviewed overlay for SN111 using the official oneoneone website and source repository. The oneoneone.io website currently returns an HTTP 530 (Cloudflare origin unreachable) response to simple probes and should appear degraded until it recovers. No official docs/API/OpenAPI surface is verified yet.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -23,6 +23,7 @@
     "verified_at": "2026-06-08T10:35:00.000Z",
     "source_count": 4,
     "gap_notes": [
+      "The oneoneone.io website currently returns HTTP 530 (Cloudflare origin unreachable) to simple probes and should appear degraded until it recovers.",
       "No verified official docs URL yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified OpenAPI/Swagger schema yet.",
@@ -47,7 +48,7 @@
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official oneoneone website."
+      "notes": "Official oneoneone website. Current probe state is expected to show degraded while oneoneone.io returns HTTP 530 to simple probes."
     },
     {
       "id": "sn-111-oneoneone-source",

--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -26,7 +26,7 @@
     "sn-10-website-common-swagger-json",
     "sn-10-website-subdomain-docs-docs-taofi-com"
   ],
-  "notes": "Reviewed overlay for SN10 Swap using the TaoFi pool page, TaoFi docs, and Swap source repository. Common www.taofi.com API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
+  "notes": "Reviewed overlay for SN10 Swap using the TaoFi pool page, TaoFi docs, and Swap source repository. The www.taofi.com/pool page currently returns an HTTP 402 response to simple probes and should appear degraded until it recovers. Common www.taofi.com API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -34,7 +34,7 @@
     "verified_at": "2026-06-08T20:25:00.000Z",
     "source_count": 5,
     "gap_notes": [
-      "Official TaoFi pool page, docs, and Swap source repository are verified live.",
+      "Official TaoFi pool page (www.taofi.com/pool) currently returns HTTP 402 to simple probes and should appear degraded until it recovers.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
       "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
@@ -62,7 +62,7 @@
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official TaoFi pool page for SN10 Swap."
+      "notes": "Official TaoFi pool page for SN10 Swap. Current probe state is expected to show degraded while the origin returns HTTP 402 to simple probes."
     },
     {
       "id": "sn-10-taofi-docs",

--- a/registry/subnets/tensorclaw.json
+++ b/registry/subnets/tensorclaw.json
@@ -17,7 +17,7 @@
   "dashboard_url": "https://www.tensorclaw.ai/dashboard",
   "website_url": "https://www.tensorclaw.ai/",
   "baseline_excluded_surface_ids": ["sn-92-taomarketcap-website"],
-  "notes": "Reviewed overlay for SN92 using the live Tensorclaw Network website, dashboard, and source repository. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The website links https://github.com/tensorclaw/tensorclaw and the repository README identifies it as Bittensor Tensorclaw Subnet 92.",
+  "notes": "Reviewed overlay for SN92 using the Tensorclaw Network website, dashboard, and source repository. The tensorclaw.ai website and dashboard currently return an HTTP 521 (Cloudflare origin down) response to simple probes and should appear degraded until they recover. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The website links https://github.com/tensorclaw/tensorclaw and the repository README identifies it as Bittensor Tensorclaw Subnet 92.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -26,7 +26,7 @@
     "source_count": 6,
     "gap_notes": [
       "Native chain name currently reports as luis while the public website identifies the project as Tensorclaw Network / Subnet 92.",
-      "Official website, dashboard, and source repository are verified live.",
+      "Official tensorclaw.ai website and dashboard currently return HTTP 521 (Cloudflare origin down) to simple probes and should appear degraded until they recover.",
       "No verified docs site yet beyond directory pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
@@ -89,7 +89,7 @@
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Website identifies Tensorclaw Network as Bittensor Mainnet Subnet 92 and describes a decentralized LLM inference subnet for autonomous agents."
+      "notes": "Website identifies Tensorclaw Network as Bittensor Mainnet Subnet 92 and describes a decentralized LLM inference subnet for autonomous agents. Current probe state is expected to show degraded while the origin returns HTTP 521 to simple probes."
     },
     {
       "id": "sn-92-tensorclaw-source-repo",
@@ -128,7 +128,7 @@
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Public live-demo page for SN92. The page uses Cloudflare Turnstile to unlock trial requests, so it is listed as an auth-gated dashboard surface rather than a public API."
+      "notes": "Public live-demo page for SN92. The page uses Cloudflare Turnstile to unlock trial requests, so it is listed as an auth-gated dashboard surface rather than a public API. Current probe state is expected to show degraded while the origin returns HTTP 521 to simple probes."
     },
     {
       "auth_required": false,


### PR DESCRIPTION
## Summary

Five subnet manifests described a `website_url`/`dashboard_url` as "verified live"
while that URL currently fails a simple probe. I re-checked each URL twice
(browser UA, follow-redirects) — all five are still down with the exact codes the
issue reported — and updated each file's `notes`, `curation.gap_notes`, and the
affected surface's `notes` to document the degraded state instead, following the
precedent already set by `taolend.json` (keep the probe, note "expected to show
degraded") and the merged #5594 for `dogelayer.json`. No URLs were removed (the
outages look like transient origin/server errors, not permanent takedowns), and
no probe-derived health/verification fields were hand-set.

Closes #5480.

## Re-verification (each URL checked twice, ~2s apart)

| Subnet | URL | Result | Action |
| --- | --- | --- | --- |
| SN10 swap | `https://www.taofi.com/pool` | HTTP 402 / 402 | documented degraded |
| SN92 tensorclaw | `https://www.tensorclaw.ai/` + `/dashboard` | HTTP 521 / 521 | documented degraded |
| SN66 ninja | `https://ninja.arbos.life/` | HTTP 404 / 404 | documented degraded |
| SN125 8-ball | `https://8ball125.com/` | HTTP 502 / 502 | documented degraded |
| SN111 oneoneone | `https://oneoneone.io/` | HTTP 530 / 530 | documented degraded |

All five are still down, so all five got the degraded-state treatment.

## What Changed (per file, notes/gap_notes/surface-notes only)

- **`swap.json`** — top `notes` + `gap_notes` now say the `www.taofi.com/pool`
  page returns HTTP 402 to simple probes; the pool website surface note documents
  the expected-degraded probe state.
- **`tensorclaw.json`** — dropped "using the **live** … website, dashboard"; top
  `notes` + `gap_notes` document the tensorclaw.ai website **and** dashboard
  returning HTTP 521 (Cloudflare origin down); both the website and
  dashboard surface notes document the expected-degraded state.
- **`ninja.json`** — the whole `ninja.arbos.life` host now returns HTTP 404 (not
  just `/health`); added a `gap_notes` entry + top-`notes` clause, updated the
  website surface note, and corrected the health surface's now-stale
  "the host is up" claim.
- **`8-ball.json`** — dropped "the public website **is live**"; top `notes` +
  `gap_notes` document `8ball125.com` returning HTTP 502; website surface note
  documents the expected-degraded state.
- **`oneoneone.json`** — added a degraded-state clause to `notes`, a new
  `gap_notes` entry, and a website surface note for `oneoneone.io` returning
  HTTP 530.

No surfaces added/removed; probes left enabled (the taolend model — the probe
correctly reports the outage, so it stays and the note explains it), so the
health prober keeps surfacing these accurately rather than being told to hide them.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5480`).
- [x] No secrets, PATs, wallet data, private URLs, or validator-local state; no
      probe-derived health/verification fields hand-set.
- [x] Only `registry/subnets/*.json` `notes`/`gap_notes` edited; no generated
      artifacts touched.

## Validation

- [x] `npm run validate:surface` on each of the 5 files — all pass.
- [x] `npm run scan:public-safety` — no new findings on any of the 5 files.
- [x] `npx prettier --check` clean on the 5 files; `git diff --check` clean.
