### PR TITLE
feat(ui): add RPC surface docs page

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -364,6 +364,7 @@ function SiteFooter() {
           <FooterLink to="/status">Status</FooterLink>
           <FooterLink to="/schemas">Schemas</FooterLink>
           <FooterLink to="/graphql">GraphQL</FooterLink>
+          <FooterLink to="/rpc">RPC</FooterLink>
           <FooterLink to="/gaps">Gaps</FooterLink>
           <FooterLink to="/agents">For agents</FooterLink>
           <FooterLink to="/about">About</FooterLink>

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -32,6 +32,7 @@ import {
   User,
   Wifi,
   Workflow,
+  Zap,
 } from "lucide-react";
 import { searchQuery, semanticSearchQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
@@ -123,6 +124,13 @@ const ROUTE_INDEX: Array<{
     to: "/graphql",
     hint: "Schema, root queries, limits",
     icon: Braces,
+    scope: "route",
+  },
+  {
+    label: "RPC",
+    to: "/rpc",
+    hint: "Proxy, pools, endpoints, usage",
+    icon: Zap,
     scope: "route",
   },
   {

--- a/apps/ui/src/lib/metagraphed/rpc-docs.test.ts
+++ b/apps/ui/src/lib/metagraphed/rpc-docs.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  RPC_API_SURFACES,
+  RPC_API_SURFACE_COUNT,
+  RPC_DOCS_DENIED_PREFIXES,
+  RPC_DOCS_MAX_ATTEMPTS,
+  RPC_DOCS_MAX_BODY_BYTES,
+  RPC_DOCS_MAX_STATE_QUERY_KEYS_PAGE_SIZE,
+  RPC_DOCS_MAX_STATE_QUERY_RESPONSE_BYTES,
+  RPC_DOCS_NETWORKS,
+  RPC_DOCS_SAFE_METHODS,
+  RPC_DOCS_SAFE_METHOD_COUNT,
+  RPC_DOCS_STATE_QUERY_METHODS,
+  RPC_ENDPOINTS_PATH,
+  RPC_POOLS_PATH,
+  RPC_USAGE_PATH,
+  buildRpcCurlExample,
+  buildRpcLimitRows,
+  formatRpcByteBudget,
+  rpcProxyPath,
+} from "./rpc-docs";
+
+describe("rpc docs reference (#3515)", () => {
+  it("keeps Worker-aligned limit constants", () => {
+    expect(RPC_DOCS_MAX_BODY_BYTES).toBe(64 * 1024);
+    expect(RPC_DOCS_MAX_STATE_QUERY_RESPONSE_BYTES).toBe(256 * 1024);
+    expect(RPC_DOCS_MAX_STATE_QUERY_KEYS_PAGE_SIZE).toBe(250);
+    expect(RPC_DOCS_MAX_ATTEMPTS).toBe(3);
+  });
+
+  it("documents networks, catalog surfaces, and method allowlists without duplicates", () => {
+    expect([...RPC_DOCS_NETWORKS]).toEqual(["finney", "test"]);
+    expect(RPC_API_SURFACES).toHaveLength(RPC_API_SURFACE_COUNT);
+    expect(RPC_DOCS_SAFE_METHODS).toHaveLength(RPC_DOCS_SAFE_METHOD_COUNT);
+    expect(RPC_DOCS_STATE_QUERY_METHODS).toContain("state_getStorage");
+    expect(RPC_DOCS_DENIED_PREFIXES).toContain("author_");
+    const paths = RPC_API_SURFACES.map((s) => s.path);
+    expect(new Set(paths).size).toBe(paths.length);
+    expect(paths).toContain(RPC_POOLS_PATH);
+    expect(paths).toContain(RPC_ENDPOINTS_PATH);
+    expect(paths).toContain(RPC_USAGE_PATH);
+  });
+
+  it("formats byte budgets as KiB when divisible by 1024", () => {
+    expect(formatRpcByteBudget(64 * 1024)).toBe("64 KiB");
+    expect(formatRpcByteBudget(256 * 1024)).toBe("256 KiB");
+    expect(formatRpcByteBudget(100)).toBe("100 B");
+    expect(formatRpcByteBudget(Number.NaN)).toBe("—");
+  });
+
+  it("builds a limits table covering rate, body, state-query, and failover", () => {
+    const rows = buildRpcLimitRows();
+    const labels = rows.map((r) => r.label);
+    expect(labels).toEqual([
+      "Rate limit",
+      "State-query rate",
+      "Max POST body",
+      "Max state-query response",
+      "state_getKeysPaged page",
+      "Failover attempts",
+    ]);
+    expect(rows[0]?.value).toContain("100");
+    expect(rows[1]?.value).toContain("20");
+  });
+
+  it("builds a curl example against the network proxy path", () => {
+    expect(rpcProxyPath("finney")).toBe("/rpc/v1/finney");
+    expect(rpcProxyPath("test")).toBe("/rpc/v1/test");
+    const curl = buildRpcCurlExample("https://api.metagraph.sh", "finney");
+    expect(curl).toContain("POST");
+    expect(curl).toContain("https://api.metagraph.sh/rpc/v1/finney");
+    expect(curl).toContain("chain_getHeader");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/rpc-docs.ts
+++ b/apps/ui/src/lib/metagraphed/rpc-docs.ts
@@ -1,0 +1,177 @@
+/**
+ * Static reference copy for the `/rpc` docs page (#3515).
+ *
+ * Paths, networks, allowlists, and limits mirror
+ * `workers/request-handlers/rpc-proxy.mjs` + `workers/config.mjs` — keep them
+ * in sync when the Worker RPC contract changes. The UI cannot import Worker
+ * `.mjs` modules, so these are intentional literals.
+ *
+ * @see https://github.com/JSONbored/metagraphed/issues/3515
+ */
+
+/** Keep aligned with MAX_RPC_BODY_BYTES in workers/config.mjs */
+export const RPC_DOCS_MAX_BODY_BYTES = 64 * 1024;
+
+/** Keep aligned with MAX_STATE_QUERY_RESPONSE_BYTES in workers/config.mjs */
+export const RPC_DOCS_MAX_STATE_QUERY_RESPONSE_BYTES = 256 * 1024;
+
+/** Keep aligned with MAX_STATE_QUERY_KEYS_PAGE_SIZE in workers/config.mjs */
+export const RPC_DOCS_MAX_STATE_QUERY_KEYS_PAGE_SIZE = 250;
+
+/** Keep aligned with RPC_RATE_LIMIT in workers/request-handlers/rpc-proxy.mjs */
+export const RPC_DOCS_RATE_LIMIT_REQUESTS = 100;
+export const RPC_DOCS_RATE_LIMIT_WINDOW_SECONDS = 60;
+
+/** Keep aligned with STATE_QUERY_RATE_LIMIT in workers/request-handlers/rpc-proxy.mjs */
+export const RPC_DOCS_STATE_QUERY_RATE_LIMIT_REQUESTS = 20;
+export const RPC_DOCS_STATE_QUERY_RATE_LIMIT_WINDOW_SECONDS = 60;
+
+/** Keep aligned with RPC_MAX_ATTEMPTS in workers/request-handlers/rpc-proxy.mjs */
+export const RPC_DOCS_MAX_ATTEMPTS = 3;
+
+/** Keep aligned with RPC_PROXY_POOLS keys in workers/request-handlers/rpc-proxy.mjs */
+export const RPC_DOCS_NETWORKS = ["finney", "test"] as const;
+
+export type RpcDocsNetwork = (typeof RPC_DOCS_NETWORKS)[number];
+
+export const RPC_PROXY_PATH_TEMPLATE = "/rpc/v1/{network}";
+
+export const RPC_POOLS_PATH = "/api/v1/rpc/pools";
+export const RPC_ENDPOINTS_PATH = "/api/v1/rpc/endpoints";
+export const RPC_USAGE_PATH = "/api/v1/rpc/usage";
+
+/** Keep aligned with SAFE_RPC_METHODS in workers/config.mjs */
+export const RPC_DOCS_SAFE_METHODS = [
+  "chain_getBlock",
+  "chain_getBlockHash",
+  "chain_getFinalizedHead",
+  "chain_getHeader",
+  "rpc_methods",
+  "state_getRuntimeVersion",
+  "system_chain",
+  "system_health",
+  "system_name",
+  "system_properties",
+  "system_version",
+] as const;
+
+/** Keep aligned with SAFE_RPC_STATE_QUERY_METHODS in workers/config.mjs */
+export const RPC_DOCS_STATE_QUERY_METHODS = ["state_getStorage", "state_getKeysPaged"] as const;
+
+/** Keep aligned with DENIED_RPC_PREFIXES in workers/config.mjs */
+export const RPC_DOCS_DENIED_PREFIXES = [
+  "author_",
+  "state_call",
+  "sudo_",
+  "payment_",
+  "contracts_",
+] as const;
+
+export type RpcApiSurfaceDoc = {
+  method: string;
+  path: string;
+  summary: string;
+  notes: string;
+};
+
+/** Catalog surfaces that pair with the live HTTP proxy. */
+export const RPC_API_SURFACES: readonly RpcApiSurfaceDoc[] = [
+  {
+    method: "POST",
+    path: RPC_PROXY_PATH_TEMPLATE,
+    summary: "Read-only JSON-RPC reverse proxy",
+    notes:
+      "Network segment is finney (mainnet) or test (testnet). Single JSON-RPC object only — no batches, no HTTP WebSocket upgrade.",
+  },
+  {
+    method: "GET",
+    path: RPC_POOLS_PATH,
+    summary: "Proxy pool roster + live eligibility",
+    notes:
+      "Serves rpc/pools.json with probe-derived health overlaid from KV so dead upstreams show as ineligible.",
+  },
+  {
+    method: "GET",
+    path: RPC_ENDPOINTS_PATH,
+    summary: "Base-layer Subtensor RPC/WSS registry",
+    notes:
+      "Filterable catalog (kind, layer, status, provider, pool_eligible, latency). Pair with the live table on /endpoints.",
+  },
+  {
+    method: "GET",
+    path: RPC_USAGE_PATH,
+    summary: "Proxy usage analytics",
+    notes:
+      "Request volume, latency p50/p95, failover/error/cache rates, per-endpoint and per-network distribution. ?window=7d|30d.",
+  },
+] as const;
+
+export type RpcLimitRow = {
+  label: string;
+  value: string;
+  detail: string;
+};
+
+/** Format a byte budget for the limits table (e.g. 65536 → "64 KiB"). */
+export function formatRpcByteBudget(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "—";
+  if (bytes % 1024 === 0) return `${bytes / 1024} KiB`;
+  return `${bytes} B`;
+}
+
+export function buildRpcLimitRows(): RpcLimitRow[] {
+  return [
+    {
+      label: "Rate limit",
+      value: `${RPC_DOCS_RATE_LIMIT_REQUESTS} / ${RPC_DOCS_RATE_LIMIT_WINDOW_SECONDS}s`,
+      detail:
+        "Per-client IP on POST /rpc/v1/* (429 + retry-after). Shared binding policy with GraphQL.",
+    },
+    {
+      label: "State-query rate",
+      value: `${RPC_DOCS_STATE_QUERY_RATE_LIMIT_REQUESTS} / ${RPC_DOCS_STATE_QUERY_RATE_LIMIT_WINDOW_SECONDS}s`,
+      detail:
+        "Additional budget for state_getStorage / state_getKeysPaged — does not starve ordinary chain/system reads.",
+    },
+    {
+      label: "Max POST body",
+      value: formatRpcByteBudget(RPC_DOCS_MAX_BODY_BYTES),
+      detail: "HTTP request body size cap for the read-only proxy.",
+    },
+    {
+      label: "Max state-query response",
+      value: formatRpcByteBudget(RPC_DOCS_MAX_STATE_QUERY_RESPONSE_BYTES),
+      detail: "Decoded upstream body cap for state-query methods after fetch.",
+    },
+    {
+      label: "state_getKeysPaged page",
+      value: String(RPC_DOCS_MAX_STATE_QUERY_KEYS_PAGE_SIZE),
+      detail: "Caller-supplied count is clamped server-side (not rejected).",
+    },
+    {
+      label: "Failover attempts",
+      value: String(RPC_DOCS_MAX_ATTEMPTS),
+      detail: "Per request across the health-ordered pool before surfacing upstream failure.",
+    },
+  ];
+}
+
+export function rpcProxyPath(network: RpcDocsNetwork): string {
+  return `/rpc/v1/${network}`;
+}
+
+export function buildRpcCurlExample(apiBase: string, network: RpcDocsNetwork = "finney"): string {
+  const base = apiBase.replace(/\/$/, "");
+  const url = `${base}${rpcProxyPath(network)}`;
+  return [
+    `curl -s '${url}' \\`,
+    `  -X POST -H 'content-type: application/json' \\`,
+    `  -d '{"jsonrpc":"2.0","id":1,"method":"chain_getHeader","params":[]}'`,
+  ].join("\n");
+}
+
+/** Expected catalog surface count — guards accidental drift. */
+export const RPC_API_SURFACE_COUNT = 4;
+
+/** Expected safe method count (excluding state-query allowlist). */
+export const RPC_DOCS_SAFE_METHOD_COUNT = 11;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SurfacesRouteImport } from './routes/surfaces'
 import { Route as StatusRouteImport } from './routes/status'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as SchemasRouteImport } from './routes/schemas'
+import { Route as RpcRouteImport } from './routes/rpc'
 import { Route as LeaderboardsRouteImport } from './routes/leaderboards'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as GraphqlRouteImport } from './routes/graphql'
@@ -56,6 +57,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const SchemasRoute = SchemasRouteImport.update({
   id: '/schemas',
   path: '/schemas',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RpcRoute = RpcRouteImport.update({
+  id: '/rpc',
+  path: '/rpc',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LeaderboardsRoute = LeaderboardsRouteImport.update({
@@ -189,6 +195,7 @@ export interface FileRoutesByFullPath {
   '/graphql': typeof GraphqlRoute
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
+  '/rpc': typeof RpcRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -219,6 +226,7 @@ export interface FileRoutesByTo {
   '/graphql': typeof GraphqlRoute
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
+  '/rpc': typeof RpcRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -250,6 +258,7 @@ export interface FileRoutesById {
   '/graphql': typeof GraphqlRoute
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
+  '/rpc': typeof RpcRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -282,6 +291,7 @@ export interface FileRouteTypes {
     | '/graphql'
     | '/health'
     | '/leaderboards'
+    | '/rpc'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -312,6 +322,7 @@ export interface FileRouteTypes {
     | '/graphql'
     | '/health'
     | '/leaderboards'
+    | '/rpc'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -342,6 +353,7 @@ export interface FileRouteTypes {
     | '/graphql'
     | '/health'
     | '/leaderboards'
+    | '/rpc'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -373,6 +385,7 @@ export interface RootRouteChildren {
   GraphqlRoute: typeof GraphqlRoute
   HealthRoute: typeof HealthRoute
   LeaderboardsRoute: typeof LeaderboardsRoute
+  RpcRoute: typeof RpcRoute
   SchemasRoute: typeof SchemasRoute
   SettingsRoute: typeof SettingsRoute
   StatusRoute: typeof StatusRoute
@@ -422,6 +435,13 @@ declare module '@tanstack/react-router' {
       path: '/schemas'
       fullPath: '/schemas'
       preLoaderRoute: typeof SchemasRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/rpc': {
+      id: '/rpc'
+      path: '/rpc'
+      fullPath: '/rpc'
+      preLoaderRoute: typeof RpcRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/leaderboards': {
@@ -605,6 +625,7 @@ const rootRouteChildren: RootRouteChildren = {
   GraphqlRoute: GraphqlRoute,
   HealthRoute: HealthRoute,
   LeaderboardsRoute: LeaderboardsRoute,
+  RpcRoute: RpcRoute,
   SchemasRoute: SchemasRoute,
   SettingsRoute: SettingsRoute,
   StatusRoute: StatusRoute,

--- a/apps/ui/src/routes/rpc.tsx
+++ b/apps/ui/src/routes/rpc.tsx
@@ -1,0 +1,218 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { CopyButton, PageHero, SectionHeading } from "@jsonbored/ui-kit";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
+import {
+  RPC_API_SURFACES,
+  RPC_DOCS_DENIED_PREFIXES,
+  RPC_DOCS_NETWORKS,
+  RPC_DOCS_SAFE_METHODS,
+  RPC_DOCS_STATE_QUERY_METHODS,
+  RPC_ENDPOINTS_PATH,
+  RPC_POOLS_PATH,
+  RPC_PROXY_PATH_TEMPLATE,
+  RPC_USAGE_PATH,
+  buildRpcCurlExample,
+  buildRpcLimitRows,
+  rpcProxyPath,
+} from "@/lib/metagraphed/rpc-docs";
+
+export const Route = createFileRoute("/rpc")({
+  head: () => ({
+    meta: [
+      { title: "RPC — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Metagraphed RPC surface — POST /rpc/v1/{network} proxy, GET /api/v1/rpc/pools, /endpoints, /usage, allowlisted methods, and rate limits.",
+      },
+      { property: "og:title", content: "RPC — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "One read-only JSON-RPC URL for finney and test, plus the pool, endpoint catalog, and usage analytics APIs.",
+      },
+    ],
+  }),
+  component: RpcDocsPage,
+});
+
+const FINNEY_PROXY_URL = `${API_BASE}${rpcProxyPath("finney")}`;
+const CURL_EXAMPLE = buildRpcCurlExample(DEFAULT_API_BASE, "finney");
+const LIMIT_ROWS = buildRpcLimitRows();
+
+function RpcDocsPage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="API"
+        live
+        title="RPC"
+        description="One read-only JSON-RPC URL for Bittensor — health-aware load balancing, failover, and abuse controls. Plus the pool roster, endpoint catalog, and proxy usage analytics. No API key."
+      />
+
+      <div className="mt-6 space-y-section" data-testid="rpc-docs">
+        <section>
+          <SectionHeading
+            title="Proxy"
+            intro="POST a single JSON-RPC object to /rpc/v1/{network}. Supported networks: finney (mainnet) and test (testnet). WebSocket upgrade is not available on this HTTP path — use wss.metagraph.sh or a public WSS endpoint."
+          />
+          <div className="space-y-2">
+            <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  POST
+                </div>
+                <code className="mt-0.5 block overflow-x-auto whitespace-nowrap font-mono text-[13px] text-ink-strong">
+                  {`${API_BASE}${RPC_PROXY_PATH_TEMPLATE}`}
+                </code>
+              </div>
+              <CopyButton value={FINNEY_PROXY_URL} label="RPC proxy URL (finney)" />
+            </div>
+            <ul className="space-y-1.5 font-mono text-[12px] text-ink-muted">
+              {RPC_DOCS_NETWORKS.map((network) => (
+                <li key={network}>
+                  <span className="text-ink-strong">{network}</span> →{" "}
+                  <code className="text-ink-strong">
+                    {API_BASE}
+                    {rpcProxyPath(network)}
+                  </code>
+                </li>
+              ))}
+            </ul>
+            <div className="rounded-lg border border-border bg-card px-4 py-3">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  Example
+                </div>
+                <CopyButton value={CURL_EXAMPLE} label="RPC curl example" />
+              </div>
+              <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-[12px] leading-relaxed text-ink-strong">
+                {CURL_EXAMPLE}
+              </pre>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Catalog & analytics"
+            intro="Static registry projections and live proxy telemetry. Live explorer UI for pools and traffic lives on Endpoints."
+          />
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-[36rem] text-left text-sm">
+              <thead>
+                <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  <th className="px-3 py-2.5 font-normal">Method</th>
+                  <th className="px-3 py-2.5 font-normal">Path</th>
+                  <th className="px-3 py-2.5 font-normal">Summary</th>
+                  <th className="px-3 py-2.5 font-normal">Notes</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {RPC_API_SURFACES.map((row) => (
+                  <tr key={row.path} className="align-top">
+                    <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                      {row.method}
+                    </td>
+                    <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">{row.path}</td>
+                    <td className="px-3 py-2.5 text-[12px] text-ink">{row.summary}</td>
+                    <td className="px-3 py-2.5 text-[12px] text-ink-muted">{row.notes}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-3 font-mono text-[11px] text-ink-muted">
+            Live pool + usage panels:{" "}
+            <Link to="/endpoints" className="text-accent hover:underline">
+              Endpoints
+            </Link>
+            . Machine index:{" "}
+            <Link to="/agents" className="text-accent hover:underline">
+              For agents
+            </Link>
+            .
+          </p>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Allowlisted methods"
+            intro="Only safe read methods pass. Mutating and heavy prefixes are denied. State-query methods need param validation and a separate rate budget."
+          />
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="rounded-lg border border-border bg-card px-4 py-3">
+              <div className="mb-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Safe methods
+              </div>
+              <ul className="space-y-1 font-mono text-[12px] text-ink-strong">
+                {RPC_DOCS_SAFE_METHODS.map((method) => (
+                  <li key={method}>{method}</li>
+                ))}
+              </ul>
+            </div>
+            <div className="space-y-3">
+              <div className="rounded-lg border border-border bg-card px-4 py-3">
+                <div className="mb-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  State-query (extra budget)
+                </div>
+                <ul className="space-y-1 font-mono text-[12px] text-ink-strong">
+                  {RPC_DOCS_STATE_QUERY_METHODS.map((method) => (
+                    <li key={method}>{method}</li>
+                  ))}
+                </ul>
+              </div>
+              <div className="rounded-lg border border-border bg-card px-4 py-3">
+                <div className="mb-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  Denied prefixes
+                </div>
+                <ul className="space-y-1 font-mono text-[12px] text-ink-muted">
+                  {RPC_DOCS_DENIED_PREFIXES.map((prefix) => (
+                    <li key={prefix}>
+                      <code className="text-ink-strong">{prefix}</code>*
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Limits"
+            intro="Hard caps on every proxied POST. Matching constants live in workers/config.mjs and workers/request-handlers/rpc-proxy.mjs."
+          />
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-[28rem] text-left text-sm">
+              <thead>
+                <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  <th className="px-3 py-2.5 font-normal">Limit</th>
+                  <th className="px-3 py-2.5 font-normal">Value</th>
+                  <th className="px-3 py-2.5 font-normal">Notes</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {LIMIT_ROWS.map((row) => (
+                  <tr key={row.label} className="align-top">
+                    <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                      {row.label}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2.5 font-mono text-[12px] tabular-nums text-ink">
+                      {row.value}
+                    </td>
+                    <td className="px-3 py-2.5 text-[12px] text-ink-muted">{row.detail}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+
+      <ApiSourceFooter paths={[RPC_POOLS_PATH, RPC_ENDPOINTS_PATH, RPC_USAGE_PATH]} />
+    </AppShell>
+  );
+}

--- a/apps/ui/tests/e2e/capture-rpc-docs-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-rpc-docs-screenshots.mjs
@@ -1,0 +1,80 @@
+/**
+ * Capture /rpc docs page screenshots for #3515 (Path C2).
+ *
+ * New page — before captures are the 404/fallback when the route is missing;
+ * after captures show the live docs page.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8113 VARIANT=before node tests/e2e/capture-rpc-docs-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8114 VARIANT=after  node tests/e2e/capture-rpc-docs-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/rpc-docs-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8114";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const VIEWPORT_FILTER = process.env.VIEWPORT_FILTER;
+const ALL_VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const VIEWPORTS = VIEWPORT_FILTER
+  ? ALL_VIEWPORTS.filter((v) => v.name === VIEWPORT_FILTER)
+  : ALL_VIEWPORTS;
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function openRpcDocs(page) {
+  await page.goto(`${BASE_URL}/rpc`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 8000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+  const docs = page.locator('[data-testid="rpc-docs"]');
+  const hero = page.getByRole("heading", { name: /^RPC$/i }).first();
+  try {
+    await docs.waitFor({ state: "visible", timeout: 5000 });
+  } catch {
+    await hero.waitFor({ state: "visible", timeout: 30_000 }).catch(() => {});
+  }
+  await page.waitForTimeout(250);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await setTheme(page, theme);
+      await openRpcDocs(page);
+      const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+      await context.close();
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
﻿## Summary
- Add `/rpc` docs page covering the read-only JSON-RPC proxy (`POST /rpc/v1/{network}`), catalog routes (`GET /api/v1/rpc/pools`, `/endpoints`, `/usage`), allowlisted methods, and Worker-aligned limits.
- Wire footer Operations + command palette; unit-test the reference constants against Worker numbers.
- Screenshot capture script for Path C2 (12 viewport × theme captures).

Closes #3515

## Screenshots

New route — before is the missing-route 404; after is the docs page.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/3515-after-mobile-dark.png)<br><sub>after</sub> |

## Test plan
- [x] `npx vitest run src/lib/metagraphed/rpc-docs.test.ts` (apps/ui)
- [ ] CI `ui` job (lint, format, typecheck, test, e2e, build)
- [ ] Spot-check `/rpc` proxy URL, method tables, and links to `/endpoints`
