### PR TITLE
feat(registry): add SN62 Ridges pyproject dependency manifest data-artifact (#4069)

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -91,6 +91,24 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-pyproject-manifest",
+      "kind": "data-artifact",
+      "name": "Ridges project dependency manifest (pyproject.toml)",
+      "notes": "Public no-auth pyproject.toml from the official ridgesai/ridges repository — the SN62 Ridges canonical build/dependency manifest. Declares the project identity (\"Decentralized AI software engineers\"), the required Python range (>=3.12.3,<3.14), the pinned Bittensor stack (bittensor==10.2.1), and the full runtime plus miner/dev dependency graph (FastAPI, SQLAlchemy, asyncpg, docker, openai, harbor, uvicorn, etc.). Machine-readable TOML, no secrets. Pinned to an immutable commit.",
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": [
+        "https://github.com/ridgesai/ridges/blob/06459e91e0e219dec56dfa98109967ec1c739700/pyproject.toml"
+      ],
+      "url": "https://raw.githubusercontent.com/ridgesai/ridges/06459e91e0e219dec56dfa98109967ec1c739700/pyproject.toml"
     }
   ],
   "contact": "hello@ridges.ai"


### PR DESCRIPTION
## Summary

SN62 Ridges' Enrich issue asks for a public **data artifact**, and the subnet
had none registered (its surfaces were `source-repo`, `subnet-api`, and
`openapi`). This adds one: the official `ridgesai/ridges` repository's
`pyproject.toml` — the subnet's canonical build/dependency manifest — as a
community `data-artifact` surface, pinned to an immutable commit.

Closes #4069.

## The surface

- **kind:** `data-artifact` (a new kind for this subnet — no redundancy)
- **url:** `https://raw.githubusercontent.com/ridgesai/ridges/06459e91e0e219dec56dfa98109967ec1c739700/pyproject.toml` (HTTP 200, no auth, machine-readable TOML)
- **source_url (proof of first-party ownership):** the same file in the official
  `ridgesai/ridges` repo — which is already this subnet's registered
  `source_repo`, so provenance is unambiguous.
- **What it contains:** the project identity ("Decentralized AI software
  engineers"), the required Python range (`>=3.12.3,<3.14`), the pinned Bittensor
  stack (`bittensor==10.2.1`), and the full runtime + miner/dev dependency graph
  (FastAPI, SQLAlchemy, asyncpg, docker, openai, harbor, uvicorn, …). Structured,
  machine-queryable, and pinned to an immutable commit SHA.
- No secrets, keys, hotkeys, or wallet material (verified).

## Compliance

- [x] Edits **exactly one** `registry/subnets/ridges.json`, appending one
      community surface with `authority: "community"` and
      `review.state: "community-submitted"`; nothing else touched.
- [x] Links a tracked, currently-open issue (`Closes #4069`, "add public data
      artifact").
- [x] Not a duplicate — the subnet has no existing `data-artifact`, and no other
      open PR targets it.
- [x] `npm run validate:surface -- registry/subnets/ridges.json` passes.
- [x] `npm run scan:public-safety` — ridges.json not flagged.
- [x] `npx prettier --check registry/subnets/ridges.json` clean.
