### PR TITLE
feat(ui): network-wide validator-dominance chart

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
@@ -1,0 +1,80 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { BarMini, TreemapMini, type TreemapMiniDatum } from "@jsonbored/ui-kit";
+import { validatorsQuery } from "@/lib/metagraphed/queries";
+import { EmptyState } from "@/components/metagraphed/states";
+import {
+  VALIDATOR_DOMINANCE_TOP_N,
+  buildValidatorDominanceChartData,
+} from "./validator-dominance-ranking";
+
+const DOMINANCE_COLOR = "var(--accent)";
+
+/**
+ * Network-wide validator-dominance chart (#2565) — the network-wide
+ * counterpart to `ValidatorsTableLoader`'s per-subnet stake-dominance block
+ * (src/components/metagraphed/validators-panel.tsx): a ranked BarMini paired
+ * with an area-proportional TreemapMini, both fed by the same top-N rows so
+ * the two views never drift. Reads GET /api/v1/validators?sort=stake_dominance
+ * directly (self-contained fetch, independent of the leaderboard table's own
+ * sort selector above it) so this block always shows the dominance ranking
+ * regardless of how the table is currently sorted.
+ */
+export function ValidatorDominanceChart() {
+  const res = useSuspenseQuery(
+    validatorsQuery({ sort: "stake_dominance", limit: VALIDATOR_DOMINANCE_TOP_N }),
+  ).data;
+  const rows = buildValidatorDominanceChartData(res.data.validators);
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        title="No dominance data yet"
+        description="Stake-dominance shares haven't been computed for any validator in the current snapshot."
+      />
+    );
+  }
+
+  const barData = rows.map((r) => ({ label: r.label, value: r.value, color: DOMINANCE_COLOR }));
+  const tiles: TreemapMiniDatum[] = rows.map((r) => ({
+    label: r.label,
+    value: r.value,
+    color: DOMINANCE_COLOR,
+  }));
+  // Sum of the top-N shares only — not full network coverage (the API caps
+  // this fetch to VALIDATOR_DOMINANCE_TOP_N rows), so the label says "top N"
+  // rather than implying it accounts for every validator.
+  const coveredPct = rows.reduce((sum, r) => sum + r.share, 0) * 100;
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          Stake dominance · top {rows.length}
+        </span>
+        <span className="font-mono text-[10px] text-ink-muted">
+          {coveredPct.toFixed(1)}% of network stake
+        </span>
+      </div>
+      <BarMini
+        data={barData}
+        formatValue={(v) => `${v.toFixed(2)}%`}
+        ariaLabel={`Validator stake dominance, top ${rows.length} operators ranked by network stake share`}
+      />
+      {tiles.length > 1 ? (
+        <div className="mt-4 border-t border-border pt-3">
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            Concentration
+            <span className="ml-2 normal-case tracking-normal text-ink-subtle">
+              share within the top {tiles.length}
+            </span>
+          </div>
+          <TreemapMini
+            data={tiles}
+            formatValue={(v) => `${v.toFixed(2)}%`}
+            ariaLabel={`Validator stake dominance treemap across the top ${tiles.length} operators, sized by network stake share`}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/charts/validator-dominance-ranking.test.ts
+++ b/apps/ui/src/components/metagraphed/charts/validator-dominance-ranking.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  VALIDATOR_DOMINANCE_TOP_N,
+  buildValidatorDominanceChartData,
+  type ValidatorDominanceSource,
+} from "./validator-dominance-ranking";
+
+function validator(overrides: Partial<ValidatorDominanceSource>): ValidatorDominanceSource {
+  return {
+    hotkey: "5AAAA1",
+    coldkey_identity: null,
+    total_stake_tao: 0,
+    stake_dominance: null,
+    subnet_count: 0,
+    ...overrides,
+  };
+}
+
+describe("buildValidatorDominanceChartData", () => {
+  it("returns an empty list for an empty leaderboard", () => {
+    expect(buildValidatorDominanceChartData([])).toEqual([]);
+  });
+
+  it("returns an empty list when no row has a known positive stake share", () => {
+    const out = buildValidatorDominanceChartData([
+      validator({ hotkey: "5Null", stake_dominance: null }),
+      validator({ hotkey: "5Zero", stake_dominance: 0 }),
+      validator({ hotkey: "5Neg", stake_dominance: -0.01 }),
+    ]);
+    expect(out).toEqual([]);
+  });
+
+  it("shapes a single row, using shortHash as the label when no identity name is set", () => {
+    const out = buildValidatorDominanceChartData([
+      validator({
+        hotkey: "5F1prathntNaN1Xtu9nRe1TwSBYQaBhVQPdpF4Xj9",
+        total_stake_tao: 1234.5,
+        stake_dominance: 0.1234,
+        subnet_count: 7,
+      }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      hotkey: "5F1prathntNaN1Xtu9nRe1TwSBYQaBhVQPdpF4Xj9",
+      share: 0.1234,
+      value: 12.34,
+      stakeTao: 1234.5,
+      subnetCount: 7,
+    });
+    // shortHash keeps 6 chars on each side, joined with an ellipsis.
+    expect(out[0].label).toBe("5F1pra…pF4Xj9");
+  });
+
+  it("prefers the coldkey identity name over shortHash when present", () => {
+    const out = buildValidatorDominanceChartData([
+      validator({
+        hotkey: "5Hotkey",
+        coldkey_identity: { name: "  TensorOps  " },
+        stake_dominance: 0.05,
+      }),
+    ]);
+    expect(out[0].label).toBe("TensorOps");
+  });
+
+  it("falls back to shortHash when the identity name is blank", () => {
+    const out = buildValidatorDominanceChartData([
+      validator({
+        hotkey: "5Short",
+        coldkey_identity: { name: "   " },
+        stake_dominance: 0.05,
+      }),
+    ]);
+    expect(out[0].label).toBe("5Short");
+  });
+
+  it("sorts multiple rows by stake_dominance descending", () => {
+    const out = buildValidatorDominanceChartData([
+      validator({ hotkey: "5Low", stake_dominance: 0.01 }),
+      validator({ hotkey: "5High", stake_dominance: 0.4 }),
+      validator({ hotkey: "5Mid", stake_dominance: 0.1 }),
+    ]);
+    expect(out.map((r) => r.hotkey)).toEqual(["5High", "5Mid", "5Low"]);
+  });
+
+  it("breaks a stake_dominance tie by total_stake_tao descending", () => {
+    const out = buildValidatorDominanceChartData([
+      validator({ hotkey: "5Small", stake_dominance: 0.1, total_stake_tao: 100 }),
+      validator({ hotkey: "5Big", stake_dominance: 0.1, total_stake_tao: 500 }),
+    ]);
+    expect(out.map((r) => r.hotkey)).toEqual(["5Big", "5Small"]);
+  });
+
+  it("breaks a full stake_dominance + total_stake_tao tie by hotkey ascending", () => {
+    const out = buildValidatorDominanceChartData([
+      validator({ hotkey: "5Zzz", stake_dominance: 0.1, total_stake_tao: 100 }),
+      validator({ hotkey: "5Aaa", stake_dominance: 0.1, total_stake_tao: 100 }),
+    ]);
+    expect(out.map((r) => r.hotkey)).toEqual(["5Aaa", "5Zzz"]);
+  });
+
+  it("exposes the default top-N limit and applies it when no limit is passed", () => {
+    expect(VALIDATOR_DOMINANCE_TOP_N).toBe(10);
+    const many = Array.from({ length: VALIDATOR_DOMINANCE_TOP_N + 5 }, (_, i) =>
+      validator({ hotkey: `5Row${i}`, stake_dominance: 1 - i * 0.01 }),
+    );
+    expect(buildValidatorDominanceChartData(many)).toHaveLength(VALIDATOR_DOMINANCE_TOP_N);
+  });
+
+  it("respects a custom limit", () => {
+    const rows = [
+      validator({ hotkey: "5A", stake_dominance: 0.3 }),
+      validator({ hotkey: "5B", stake_dominance: 0.2 }),
+      validator({ hotkey: "5C", stake_dominance: 0.1 }),
+    ];
+    expect(buildValidatorDominanceChartData(rows, 2)).toHaveLength(2);
+  });
+
+  it("clamps a zero or negative limit to an empty list", () => {
+    const rows = [validator({ hotkey: "5A", stake_dominance: 0.3 })];
+    expect(buildValidatorDominanceChartData(rows, 0)).toEqual([]);
+    expect(buildValidatorDominanceChartData(rows, -5)).toEqual([]);
+  });
+});

--- a/apps/ui/src/components/metagraphed/charts/validator-dominance-ranking.ts
+++ b/apps/ui/src/components/metagraphed/charts/validator-dominance-ranking.ts
@@ -1,0 +1,77 @@
+import { shortHash } from "@/lib/metagraphed/blocks";
+
+/**
+ * Pure "shape the network-wide validator leaderboard into chart-ready rows"
+ * logic for the validator-dominance chart (#2565). Kept separate from the
+ * rendering component so the ranking + tie-break rules get direct unit
+ * coverage without a React render.
+ */
+
+/** Default number of validators the dominance chart surfaces. */
+export const VALIDATOR_DOMINANCE_TOP_N = 10;
+
+/** Minimal shape this module needs from a `GlobalValidator` row. */
+export interface ValidatorDominanceSource {
+  hotkey: string;
+  coldkey_identity?: { name: string | null } | null;
+  total_stake_tao: number;
+  stake_dominance: number | null;
+  subnet_count: number;
+}
+
+/** One chart-ready row — BarMini and TreemapMini both accept `{ label, value, color? }`. */
+export interface ValidatorDominanceDatum {
+  hotkey: string;
+  label: string;
+  /** Stake share of the network total, as a percentage (0–100) rounded for display. */
+  value: number;
+  /** Same share as the raw 0–1 fraction, for callers that want the unrounded number. */
+  share: number;
+  stakeTao: number;
+  subnetCount: number;
+}
+
+/**
+ * Rank validators by network-wide stake share (`stake_dominance`) and take
+ * the top `limit`. `stake_dominance` is precomputed server-side against the
+ * FULL network total — it is NOT derivable client-side from this payload
+ * alone, since the payload itself is already truncated to `limit` rows (the
+ * same reason `ValidatorsTableLoader`'s per-subnet treemap derives shares
+ * from a local top-N sum instead: no network-wide total travels with a
+ * truncated set). Rows with no known share (null, zero, or negative) are
+ * excluded rather than sorted to the bottom — a dominance chart has nothing
+ * meaningful to plot for an unknown share.
+ *
+ * Deterministic tie-break: stake_dominance desc -> total_stake_tao desc ->
+ * hotkey asc, so equal-share rows always render in the same order.
+ */
+export function buildValidatorDominanceChartData(
+  validators: readonly ValidatorDominanceSource[],
+  limit: number = VALIDATOR_DOMINANCE_TOP_N,
+): ValidatorDominanceDatum[] {
+  const ranked = validators
+    .filter(
+      (v): v is ValidatorDominanceSource & { stake_dominance: number } =>
+        typeof v.stake_dominance === "number" && v.stake_dominance > 0,
+    )
+    .sort((a, b) => {
+      const shareDiff = b.stake_dominance - a.stake_dominance;
+      if (shareDiff !== 0) return shareDiff;
+      const stakeDiff = b.total_stake_tao - a.total_stake_tao;
+      if (stakeDiff !== 0) return stakeDiff;
+      return a.hotkey.localeCompare(b.hotkey);
+    });
+
+  return ranked.slice(0, Math.max(0, limit)).map((v) => {
+    const identityName = v.coldkey_identity?.name?.trim();
+    return {
+      hotkey: v.hotkey,
+      label:
+        identityName && identityName.length > 0 ? identityName : (shortHash(v.hotkey) ?? v.hotkey),
+      share: v.stake_dominance,
+      value: Number((v.stake_dominance * 100).toFixed(2)),
+      stakeTao: v.total_stake_tao,
+      subnetCount: v.subnet_count,
+    };
+  });
+}

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -13,6 +13,7 @@ import { buildUrl } from "@/lib/metagraphed/client";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
+import { ValidatorDominanceChart } from "@/components/metagraphed/charts/validator-dominance-chart";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { ValidatorCardList } from "@/components/metagraphed/validator-card-list";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
@@ -103,6 +104,13 @@ function ValidatorsPage() {
           />
         </Suspense>
       </QueryErrorBoundary>
+      <div className="mt-6" id="validator-dominance">
+        <QueryErrorBoundary>
+          <Suspense fallback={<Skeleton className="h-48 w-full" />}>
+            <ValidatorDominanceChart />
+          </Suspense>
+        </QueryErrorBoundary>
+      </div>
       <div className="mt-6" id="validator-subnet-heatmap">
         <QueryErrorBoundary>
           <Suspense fallback={<Skeleton className="h-64 w-full" />}>


### PR DESCRIPTION
## Summary

Network-wide validator-dominance chart (#2565) on `/validators`, between the
leaderboard table and the existing per-subnet stake-intensity heatmap — the
network-wide counterpart to `ValidatorsTableLoader`'s per-subnet stake-dominance
block.

- `buildValidatorDominanceChartData` (pure, unit-tested): ranks validators by
  `stake_dominance` (server-computed against the full network total — not
  re-derivable client-side from a truncated payload), excludes rows with no known
  positive share, and applies a deterministic tie-break
  (`stake_dominance` desc → `total_stake_tao` desc → `hotkey` asc).
- `ValidatorDominanceChart`: a ranked `BarMini` paired with an area-proportional
  `TreemapMini`, both fed by the same top-N rows so the two views never drift.
  Self-contained fetch (`GET /api/v1/validators?sort=stake_dominance`),
  independent of the leaderboard table's own sort selector above it, so this
  block always shows the dominance ranking regardless of how the table is
  currently sorted. `EmptyState` when no validator has a known share.
- Wired into `validators.index.tsx` with the same `QueryErrorBoundary` +
  `Suspense` pattern already used for the heatmap directly below it.

## Verification

- `npx vitest run` (apps/ui) — 988/988 passing, including 11 new tests in
  `validator-dominance-ranking.test.ts` (empty/all-excluded leaderboards, identity
  vs. shortHash label fallback, sort + full three-level tie-break, default and
  custom limits, zero/negative limit clamping).
- `npx tsc --noEmit`, `npx eslint .` — clean (0 errors; pre-existing route-file
  fast-refresh warnings only, unrelated to this change).
- `npm run format:check`, `npm run build` (Cloudflare/Nitro target) — clean.
- Manual visual QA via a live dev server against the real API — confirmed the
  chart renders real data (`tao.bot` 16.65% down to `Ventura Labs` 0.93%, 28.4%
  of network stake covered) and the concentration treemap renders correctly.

## Screenshots

| Viewport | Theme | Before | After |
| --- | --- | --- | --- |
| Desktop (1280px) | Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2565-validator-dominance-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2565-validator-dominance-after-desktop-dark.png) |
| Desktop (1280px) | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2565-validator-dominance-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2565-validator-dominance-after-desktop-light.png) |
| Tablet (768px) | Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2565-validator-dominance-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2565-validator-dominance-after-tablet-dark.png) |
| Tablet (768px) | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2565-validator-dominance-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2565-validator-dominance-after-tablet-light.png) |
| Mobile (375px) | Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2565-validator-dominance-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2565-validator-dominance-after-mobile-dark.png) |
| Mobile (375px) | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2565-validator-dominance-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2565-validator-dominance-after-mobile-light.png) |

"Before" was captured against production (metagraph.sh); "after" against a local
dev server on the same real API, so the underlying data differs slightly between
the two (live snapshots taken minutes apart) — the structural change (the new
section) is what these are meant to show.

Closes #2565