### PR TITLE
fix(data-api): dedup uptime rollup on stable (surface_key, day), not surface_id

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -5334,7 +5334,32 @@ test("health-uptime-rollup-sync rolls up each valid day via PERCENTILE_CONT", as
   expect(body).toEqual({ ok: true, days_rolled: ["2026-07-11", "2026-07-10"] });
   expect(queryText()).toMatch(/INSERT INTO surface_uptime_daily\b/);
   expect(queryText()).toMatch(/PERCENTILE_CONT\(0\.5\)/);
-  expect(queryText()).toMatch(/ON CONFLICT \(surface_id, day\) DO UPDATE/);
+  expect(queryText()).toMatch(
+    /ON CONFLICT \(surface_key, day\) WHERE surface_key IS NOT NULL DO UPDATE/,
+  );
+});
+
+test("health-uptime-rollup-sync upserts on the stable (surface_key, day) key and refreshes surface_id", async () => {
+  // surface_id churns across re-registrations; the unique index that actually
+  // guards this table is idx_surface_uptime_daily_key_day_unique on
+  // (surface_key, day). Conflicting on (surface_id, day) instead would let a
+  // same-day re-roll under a new surface_id fall through to a plain INSERT and
+  // hit a unique violation, aborting the whole sync with a 502. Assert the
+  // arbiter is the stable key and that surface_id is refreshed on update.
+  const res = await postHealthUptimeRollup(
+    {
+      days: [dayBounds("2026-07-11", 1780000000000, 1780086400000)],
+      updated_at: 1780086400000,
+    },
+    { secret: HEALTH_CHECKS_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const sql = queryText();
+  expect(sql).toMatch(
+    /ON CONFLICT \(surface_key, day\) WHERE surface_key IS NOT NULL DO UPDATE/,
+  );
+  expect(sql).not.toMatch(/ON CONFLICT \(surface_id, day\)/);
+  expect(sql).toMatch(/surface_id = excluded\.surface_id/);
 });
 
 test("health-uptime-rollup-sync maps a DB failure to a clean 502 instead of throwing", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2285,6 +2285,14 @@ async function handleHealthUptimeRollupSync(request, env) {
     return await sql.begin(async (sql) => {
       await sql`SET statement_timeout = '20000ms'`;
       for (const { date, start, end } of validDays) {
+        // Dedup on (surface_key, day), not (surface_id, day): surface_id churns
+        // across re-registrations while surface_key is stable, so a same-day
+        // re-roll with a new surface_id must UPDATE the existing key's row
+        // (refreshing surface_id) rather than INSERT a second one that would
+        // violate idx_surface_uptime_daily_key_day_unique and abort the sync.
+        // Mirrors the D1 prober's primary ON CONFLICT arbiter (health-prober.mjs);
+        // Postgres allows a single arbiter, and the CTE's COALESCE guarantees
+        // surface_key is never null, so the partial index always applies.
         await sql`
         WITH ranked AS (
           SELECT
@@ -2325,7 +2333,8 @@ async function handleHealthUptimeRollupSync(request, env) {
           ${updatedAt} AS updated_at
         FROM ranked
         GROUP BY surface_key, netuid
-        ON CONFLICT (surface_id, day) DO UPDATE SET
+        ON CONFLICT (surface_key, day) WHERE surface_key IS NOT NULL DO UPDATE SET
+          surface_id = excluded.surface_id,
           surface_key = excluded.surface_key,
           netuid = excluded.netuid,
           samples = excluded.samples,


### PR DESCRIPTION
### The bug

`handleHealthUptimeRollupSync` (`workers/data-api.mjs`) upserts into `surface_uptime_daily` with:

```sql
ON CONFLICT (surface_id, day) DO UPDATE SET ...
```

But the unique index that actually guards that table is on **`(surface_key, day)`**:

```sql
CREATE UNIQUE INDEX idx_surface_uptime_daily_key_day_unique
  ON surface_uptime_daily (surface_key, day) WHERE surface_key IS NOT NULL;
```
(`deploy/postgres/schema.sql`)

`surface_id` **churns** across surface re-registrations while `surface_key` is stable — which is exactly why this query `GROUP BY surface_key, netuid` and emits `MAX(surface_id)` (surface_id is aggregated *away*) and a `COALESCE(surface_key, surface_id)` that is **guaranteed non-null**. The row identity here is `(surface_key, day)`; `surface_id` is a display alias.

### Failure scenario

1. Day D, run 1: `surface_key='sfk-A'`, `surface_id='id-1'` → inserts `(id-1, sfk-A, D)`.
2. Day D, run 2 (hourly cron re-rolls today): the surface re-registered as `surface_id='id-2'` (same `sfk-A`). `MAX(surface_id)='id-2'`.
3. The upsert tries to insert `(id-2, sfk-A, D)`. It does **not** collide on `(surface_id, day)`, so Postgres proceeds to a plain INSERT → which violates the `(surface_key, day)` unique index → `23505 unique_violation`.
4. That error isn't caught by the single `ON CONFLICT` clause, so it aborts the transaction and the handler returns **HTTP 502 "write failed"** — the entire Postgres uptime rollup for that run is dropped.

### Fix

Conflict on the stable `(surface_key, day)` key (the CTE's `COALESCE` guarantees `surface_key` is non-null, so the partial index always applies) and refresh `surface_id` in the `DO UPDATE SET`. This matches the D1 prober's **primary** arbiter (`src/health-prober.mjs` lists `ON CONFLICT(surface_key, day) …` first, then `(surface_id, day)`); SQLite permits multiple arbiters, Postgres permits one, and the port had collapsed to the wrong one.

### Why this is *not* the documented `surface_status` "acceptable degrade"

`surface_status` (`handleHealthChecksSync`, ~L2042) deliberately uses `ON CONFLICT (surface_id)` with a documented comment accepting a brief surface_key-churn failure. That choice is correct **there** because `surface_status` binds `surface_key` **raw** from the probe payload — it can be `NULL`, so `surface_id` (the always-present PK) is the only arbiter that covers *every* row; conflicting on a nullable `surface_key` would miss null-key rows.

`surface_uptime_daily` is different: its CTE `COALESCE(surface_key, surface_id)`s the key to **never-null** and `GROUP BY surface_key`, so `(surface_key, day)` is a *complete* arbiter with no null-key gap — and it is the query's own grouping key. Here `(surface_id, day)` isn't an accepted degrade; it's a crash with no upside (it neither dedups on the real key nor avoids the unique-index violation). The comment's framing ("surface_id-only rather than silently duplicate a row") doesn't apply, because conflicting on `surface_key` here duplicates nothing.

### Tests

`tests/data-api.test.mjs`: updated the existing rollup assertion to the correct arbiter, and added a regression test asserting the `(surface_key, day) WHERE surface_key IS NOT NULL` arbiter, the absence of the old `(surface_id, day)` arbiter, and that `surface_id = excluded.surface_id` is refreshed. Full `data-api` suite (454 tests) passes; changed lines are covered.

Worker-only change — no schema/contract regeneration.
