### PR TITLE
fix(ui): make validator x subnet heatmap cells keyboard-focusable

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@jsonbored/ui-kit";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
@@ -65,58 +66,71 @@ export function ValidatorSubnetHeatmap() {
         </div>
       </div>
       <div className="w-full overflow-x-auto [scrollbar-gutter:stable]">
-        <table className="w-full min-w-[640px] text-[11px] font-mono">
-          <thead>
-            <tr>
-              <th className="sticky left-0 z-10 border-b border-border bg-card px-3 py-2 text-left text-[10px] uppercase tracking-widest text-ink-muted">
-                Validator
-              </th>
-              {netuids.map((n) => (
-                <th
-                  key={n}
-                  className="border-b border-border px-1.5 py-2 text-[10px] tabular-nums text-ink-muted"
-                >
-                  {n}
+        <TooltipProvider delayDuration={150}>
+          <table className="w-full min-w-[640px] text-[11px] font-mono">
+            <thead>
+              <tr>
+                <th className="sticky left-0 z-10 border-b border-border bg-card px-3 py-2 text-left text-[10px] uppercase tracking-widest text-ink-muted">
+                  Validator
                 </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((v) => {
-              const byNet = new Map((v.subnets ?? []).map((s) => [s.netuid, s]));
-              return (
-                <tr key={v.hotkey} className="border-b border-border last:border-b-0">
-                  <td className="sticky left-0 z-10 border-r border-border bg-card px-3 py-1.5 text-ink-strong">
-                    <Link
-                      to="/accounts/$ss58"
-                      params={{ ss58: v.hotkey }}
-                      className="block max-w-[12ch] truncate hover:text-accent"
-                      title={v.hotkey}
-                    >
-                      {shortHash(v.hotkey) ?? v.hotkey}
-                    </Link>
-                  </td>
-                  {netuids.map((n) => {
-                    const s = byNet.get(n);
-                    const ratio = s && maxStake > 0 ? s.stake_tao / maxStake : null;
-                    return (
-                      <td key={n} className="p-0.5">
-                        <div
-                          className={classNames("h-6 rounded-sm", stakeTone(ratio))}
-                          title={
-                            s
-                              ? `${shortHash(v.hotkey)} · SN${n}\nstake ${taoCompact(s.stake_tao)} τ · emission ${taoCompact(s.emission_tao)} τ · trust ${s.validator_trust ?? "—"}`
-                              : `SN${n} · not in this validator's top-10 subnets`
-                          }
-                        />
-                      </td>
-                    );
-                  })}
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+                {netuids.map((n) => (
+                  <th
+                    key={n}
+                    className="border-b border-border px-1.5 py-2 text-[10px] tabular-nums text-ink-muted"
+                  >
+                    {n}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((v) => {
+                const byNet = new Map((v.subnets ?? []).map((s) => [s.netuid, s]));
+                return (
+                  <tr key={v.hotkey} className="border-b border-border last:border-b-0">
+                    <td className="sticky left-0 z-10 border-r border-border bg-card px-3 py-1.5 text-ink-strong">
+                      <Link
+                        to="/accounts/$ss58"
+                        params={{ ss58: v.hotkey }}
+                        className="block max-w-[12ch] truncate hover:text-accent"
+                        title={v.hotkey}
+                      >
+                        {shortHash(v.hotkey) ?? v.hotkey}
+                      </Link>
+                    </td>
+                    {netuids.map((n) => {
+                      const s = byNet.get(n);
+                      const ratio = s && maxStake > 0 ? s.stake_tao / maxStake : null;
+                      const summary = s
+                        ? `${shortHash(v.hotkey)} · SN${n} · stake ${taoCompact(s.stake_tao)} τ · emission ${taoCompact(s.emission_tao)} τ · trust ${s.validator_trust ?? "—"}`
+                        : `SN${n} · not in this validator's top-10 subnets`;
+                      return (
+                        <td key={n} className="p-0.5">
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span
+                                tabIndex={0}
+                                role="img"
+                                aria-label={summary}
+                                className={classNames(
+                                  "block h-6 rounded-sm cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+                                  stakeTone(ratio),
+                                )}
+                              />
+                            </TooltipTrigger>
+                            <TooltipContent side="top" className="text-[11px]">
+                              {summary}
+                            </TooltipContent>
+                          </Tooltip>
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </TooltipProvider>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #5577

## What

`validator-subnet-heatmap.tsx` rendered each validator × subnet stake-intensity cell as a plain, non-interactive `<div>` with the actual per-cell data (stake, emission, trust, or "not in top-10 subnets") only in a native `title` attribute. A `title` on a `<div>` only reveals on mouse hover — no `tabIndex`, `role`, or keyboard handler — so a keyboard-only user could never reach any cell, and screen readers get nothing from a bare `title` on a non-interactive element.

Same bug class already fixed once for a sibling heatmap (#3955 → PR #5133, `activity-heatmap.tsx`), but this file was never in scope for that fix. `latency-heatmap.tsx` already has the correct reference pattern: a Radix `Tooltip`/`TooltipTrigger asChild` wrapping a `tabIndex={0}` focusable element with a real `aria-label`.

## Fix

Followed `latency-heatmap.tsx`'s exact pattern:

- Wrapped the table in `<TooltipProvider delayDuration={150}>`.
- Replaced the bare `<div title={...}>` cell with a `<Tooltip>` around a `<span tabIndex={0} role="img" aria-label={summary}>`, with `TooltipContent` rendering the same summary text.
- The summary string (previously only in `title`) is now built once and shared between `aria-label` and `TooltipContent`, so sighted-hover, keyboard-focus, and screen-reader paths all get identical content.
- No change to `stakeTone`, the shading logic, or the underlying data — purely the cell's interactivity/accessibility wrapper.

## Verification

Confirmed on current `main` before making any change: `[role="img"][tabindex="0"]` selector matched 0 elements in the heatmap, and no tooltip reveals via keyboard `Tab`/`focus()`. After the fix: 765 focusable cells (15 validators × up to 51 subnet columns), and focusing a cell reveals its Radix tooltip with the same summary text as `aria-label` — screenshotted and recorded below.

## Screenshots

3 viewports × 2 themes, before/after (at-rest state — the fix's actual effect is only visible on focus/hover, so also see the recordings below):

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/before-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/after-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/after-mobile-dark.png)<br><sub>after</sub> |

## Screen recordings — keyboard focus revealing the tooltip

Per the issue's own acceptance criteria (this behavior can't be shown in a static screenshot), matching the convention from PR #5133:

- **Before**: https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/before-heatmap-keyboard.webm — tabbing finds no focusable cell; nothing reveals.
- **After**: https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-validator-subnet-heatmap-keyboard-5577/after-heatmap-keyboard.webm — focusing a cell reveals its tooltip; tabbing through subsequent cells reveals each one's own data in turn.

## Acceptance criteria

- [x] Cells made keyboard-focusable with an accessible name/description, following `latency-heatmap.tsx`'s pattern
- [x] Before/after screen recording demonstrating keyboard focus revealing a cell's tooltip

## Testing

```
npx tsc --noEmit                          # no new errors in this file
npx eslint validator-subnet-heatmap.tsx   # 0 problems
npx prettier --check validator-subnet-heatmap.tsx   # clean (ran --write before committing)
```

Diff is 65 insertions, 51 deletions (re-indent from adding `TooltipProvider` + the `Tooltip`/`TooltipTrigger`/`TooltipContent` wrapper), in the exact file and line range the issue names.
