### PR TITLE
feat(ui): add Feeds docs page

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -365,6 +365,7 @@ function SiteFooter() {
           <FooterLink to="/schemas">Schemas</FooterLink>
           <FooterLink to="/graphql">GraphQL</FooterLink>
           <FooterLink to="/rpc">RPC</FooterLink>
+          <FooterLink to="/feeds">Feeds</FooterLink>
           <FooterLink to="/gaps">Gaps</FooterLink>
           <FooterLink to="/agents">For agents</FooterLink>
           <FooterLink to="/about">About</FooterLink>

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -25,6 +25,7 @@ import {
   KeyRound,
   Layers,
   Network,
+  Rss,
   Search,
   SlidersHorizontal,
   Sparkles,
@@ -131,6 +132,13 @@ const ROUTE_INDEX: Array<{
     to: "/rpc",
     hint: "Proxy, pools, endpoints, usage",
     icon: Zap,
+    scope: "route",
+  },
+  {
+    label: "Feeds",
+    to: "/feeds",
+    hint: "RSS, Atom, JSON Feed subscriptions",
+    icon: Rss,
     scope: "route",
   },
   {

--- a/apps/ui/src/lib/metagraphed/feeds-docs.test.ts
+++ b/apps/ui/src/lib/metagraphed/feeds-docs.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  FEEDS_BASE_PATH,
+  FEEDS_DOCS_CACHE_SECONDS,
+  FEEDS_DOCS_CONTENT_TYPES,
+  FEEDS_DOCS_FORMATS,
+  FEEDS_DOCS_MAX_ITEMS,
+  FEED_KINDS,
+  FEED_KIND_COUNT,
+  FEED_PARAMS,
+  buildFeedCurlExample,
+  feedPath,
+} from "./feeds-docs";
+
+describe("feeds docs reference (#3512)", () => {
+  it("keeps Worker-aligned limit constants", () => {
+    expect(FEEDS_DOCS_MAX_ITEMS).toBe(50);
+    expect(FEEDS_DOCS_CACHE_SECONDS).toBe(600);
+  });
+
+  it("documents every feed kind exactly once", () => {
+    expect(FEED_KINDS).toHaveLength(FEED_KIND_COUNT);
+    const slugs = FEED_KINDS.map((k) => k.slug);
+    expect(slugs).toEqual(["registry", "incidents", "gaps", "subnets/{netuid}"]);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("maps each serializer to its Worker content-type", () => {
+    expect([...FEEDS_DOCS_FORMATS]).toEqual(["json", "rss", "atom"]);
+    expect(FEEDS_DOCS_CONTENT_TYPES.json).toBe("application/feed+json; charset=utf-8");
+    expect(FEEDS_DOCS_CONTENT_TYPES.rss).toBe("application/rss+xml; charset=utf-8");
+    expect(FEEDS_DOCS_CONTENT_TYPES.atom).toBe("application/atom+xml; charset=utf-8");
+    for (const f of FEEDS_DOCS_FORMATS)
+      expect(FEEDS_DOCS_CONTENT_TYPES[f]).toContain("charset=utf-8");
+  });
+
+  it("documents the tag/since/until/limit params", () => {
+    expect(FEED_PARAMS.map((p) => p.param)).toEqual(["tag", "since", "until", "limit"]);
+    const limit = FEED_PARAMS.find((p) => p.param === "limit");
+    expect(limit?.value).toBe(`1..${FEEDS_DOCS_MAX_ITEMS}`);
+    expect(limit?.detail).toContain(String(FEEDS_DOCS_MAX_ITEMS));
+  });
+
+  it("builds feed paths with and without an explicit serializer suffix", () => {
+    expect(FEEDS_BASE_PATH).toBe("/api/v1/feeds");
+    expect(feedPath("registry")).toBe("/api/v1/feeds/registry");
+    expect(feedPath("registry", "rss")).toBe("/api/v1/feeds/registry.rss");
+    expect(feedPath("incidents", "atom")).toBe("/api/v1/feeds/incidents.atom");
+    expect(feedPath("subnets/{netuid}", "json")).toBe("/api/v1/feeds/subnets/{netuid}.json");
+  });
+
+  it("builds a curl example against a real feed path", () => {
+    const curl = buildFeedCurlExample("https://api.metagraph.sh/", "registry", "json");
+    expect(curl).toContain("https://api.metagraph.sh/api/v1/feeds/registry.json");
+    expect(curl).toContain("limit=10");
+    expect(curl).not.toContain("//api/v1");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/feeds-docs.ts
+++ b/apps/ui/src/lib/metagraphed/feeds-docs.ts
@@ -1,0 +1,114 @@
+/**
+ * Static reference copy for the `/feeds` docs page (#3512).
+ *
+ * Kinds, formats, params, and limits mirror `src/feeds.mjs` — keep them in sync
+ * when the Worker feed contract changes. The UI cannot import Worker `.mjs`
+ * modules, so these are intentional literals.
+ *
+ * @see https://github.com/JSONbored/metagraphed/issues/3512
+ */
+
+/** Keep aligned with FEED_MAX_ITEMS in src/feeds.mjs */
+export const FEEDS_DOCS_MAX_ITEMS = 50;
+
+/** Keep aligned with FEED_CACHE_SECONDS in src/feeds.mjs */
+export const FEEDS_DOCS_CACHE_SECONDS = 600;
+
+export const FEEDS_BASE_PATH = "/api/v1/feeds";
+
+/** Serializer suffixes, in the order the docs table lists them. */
+export const FEEDS_DOCS_FORMATS = ["json", "rss", "atom"] as const;
+
+export type FeedsDocsFormat = (typeof FEEDS_DOCS_FORMATS)[number];
+
+/** Keep aligned with FEED_CONTENT_TYPES in src/feeds.mjs */
+export const FEEDS_DOCS_CONTENT_TYPES: Record<FeedsDocsFormat, string> = {
+  json: "application/feed+json; charset=utf-8",
+  rss: "application/rss+xml; charset=utf-8",
+  atom: "application/atom+xml; charset=utf-8",
+};
+
+export type FeedKindDoc = {
+  /** Path segment under /api/v1/feeds (may carry a `{netuid}` template). */
+  slug: string;
+  summary: string;
+  /** Tags each item in this feed carries, for `?tag=` narrowing. */
+  tags: string;
+};
+
+/** Keep aligned with the route list in src/feeds.mjs. */
+export const FEED_KINDS: readonly FeedKindDoc[] = [
+  {
+    slug: "registry",
+    summary: "Registry changes from the 6h changelog deltas — subnets, artifacts, and coverage.",
+    tags: "registry + one of subnet/artifact/coverage + the change verb (added/removed/renamed/modified)",
+  },
+  {
+    slug: "incidents",
+    summary: "Reconstructed incident history — one item per incident, opened and resolved.",
+    tags: "incident, sn<netuid>, and ongoing or resolved",
+  },
+  {
+    slug: "gaps",
+    summary: "Open coverage gaps — what each subnet is still missing, by queue lane.",
+    tags: "gaps, the queue lane, sn<netuid>, and each missing/direct-submission kind",
+  },
+  {
+    slug: "subnets/{netuid}",
+    summary: "Everything above, narrowed to a single subnet.",
+    tags: "the same tags as the feed each item came from",
+  },
+] as const;
+
+export type FeedParamDoc = {
+  param: string;
+  value: string;
+  detail: string;
+};
+
+/** Keep aligned with the query-param handling in src/feeds.mjs. */
+export const FEED_PARAMS: readonly FeedParamDoc[] = [
+  {
+    param: "tag",
+    value: "<tag>",
+    detail:
+      "Narrow a feed to items carrying that tag, so one URL serves a focused subscription. An unknown tag yields an empty (but valid) feed.",
+  },
+  {
+    param: "since",
+    value: "<ISO-8601>",
+    detail:
+      "Only items at or after that instant, for incremental polling. A bare calendar date resolves to the inclusive start of that UTC day. Malformed input is a 400.",
+  },
+  {
+    param: "until",
+    value: "<ISO-8601>",
+    detail:
+      "Only items at or before that instant. A bare calendar date is inclusive of the whole UTC day (end-of-day), symmetric with `since`. Malformed input is a 400.",
+  },
+  {
+    param: "limit",
+    value: `1..${FEEDS_DOCS_MAX_ITEMS}`,
+    detail: `Cap the number of returned items (default and hard cap ${FEEDS_DOCS_MAX_ITEMS}). A larger value clamps; a non-integer or < 1 is a 400.`,
+  },
+] as const;
+
+/**
+ * Path for a feed kind, optionally with an explicit serializer suffix.
+ * `feedPath("registry", "rss")` → `/api/v1/feeds/registry.rss`.
+ */
+export function feedPath(slug: string, format?: FeedsDocsFormat): string {
+  return `${FEEDS_BASE_PATH}/${slug}${format ? `.${format}` : ""}`;
+}
+
+export function buildFeedCurlExample(
+  apiBase: string,
+  slug = "registry",
+  format: FeedsDocsFormat = "json",
+): string {
+  const base = apiBase.replace(/\/$/, "");
+  return `curl -s '${base}${feedPath(slug, format)}?limit=10'`;
+}
+
+/** Expected feed-kind count — guards accidental drift. */
+export const FEED_KIND_COUNT = 4;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as LeaderboardsRouteImport } from './routes/leaderboards'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as GraphqlRouteImport } from './routes/graphql'
 import { Route as GapsRouteImport } from './routes/gaps'
+import { Route as FeedsRouteImport } from './routes/feeds'
 import { Route as ExplorerRouteImport } from './routes/explorer'
 import { Route as EndpointsRouteImport } from './routes/endpoints'
 import { Route as AgentsRouteImport } from './routes/agents'
@@ -82,6 +83,11 @@ const GraphqlRoute = GraphqlRouteImport.update({
 const GapsRoute = GapsRouteImport.update({
   id: '/gaps',
   path: '/gaps',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FeedsRoute = FeedsRouteImport.update({
+  id: '/feeds',
+  path: '/feeds',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ExplorerRoute = ExplorerRouteImport.update({
@@ -191,6 +197,7 @@ export interface FileRoutesByFullPath {
   '/agents': typeof AgentsRoute
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
+  '/feeds': typeof FeedsRoute
   '/gaps': typeof GapsRoute
   '/graphql': typeof GraphqlRoute
   '/health': typeof HealthRoute
@@ -222,6 +229,7 @@ export interface FileRoutesByTo {
   '/agents': typeof AgentsRoute
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
+  '/feeds': typeof FeedsRoute
   '/gaps': typeof GapsRoute
   '/graphql': typeof GraphqlRoute
   '/health': typeof HealthRoute
@@ -254,6 +262,7 @@ export interface FileRoutesById {
   '/agents': typeof AgentsRoute
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
+  '/feeds': typeof FeedsRoute
   '/gaps': typeof GapsRoute
   '/graphql': typeof GraphqlRoute
   '/health': typeof HealthRoute
@@ -287,6 +296,7 @@ export interface FileRouteTypes {
     | '/agents'
     | '/endpoints'
     | '/explorer'
+    | '/feeds'
     | '/gaps'
     | '/graphql'
     | '/health'
@@ -318,6 +328,7 @@ export interface FileRouteTypes {
     | '/agents'
     | '/endpoints'
     | '/explorer'
+    | '/feeds'
     | '/gaps'
     | '/graphql'
     | '/health'
@@ -349,6 +360,7 @@ export interface FileRouteTypes {
     | '/agents'
     | '/endpoints'
     | '/explorer'
+    | '/feeds'
     | '/gaps'
     | '/graphql'
     | '/health'
@@ -381,6 +393,7 @@ export interface RootRouteChildren {
   AgentsRoute: typeof AgentsRoute
   EndpointsRoute: typeof EndpointsRoute
   ExplorerRoute: typeof ExplorerRoute
+  FeedsRoute: typeof FeedsRoute
   GapsRoute: typeof GapsRoute
   GraphqlRoute: typeof GraphqlRoute
   HealthRoute: typeof HealthRoute
@@ -470,6 +483,13 @@ declare module '@tanstack/react-router' {
       path: '/gaps'
       fullPath: '/gaps'
       preLoaderRoute: typeof GapsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/feeds': {
+      id: '/feeds'
+      path: '/feeds'
+      fullPath: '/feeds'
+      preLoaderRoute: typeof FeedsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/explorer': {
@@ -621,6 +641,7 @@ const rootRouteChildren: RootRouteChildren = {
   AgentsRoute: AgentsRoute,
   EndpointsRoute: EndpointsRoute,
   ExplorerRoute: ExplorerRoute,
+  FeedsRoute: FeedsRoute,
   GapsRoute: GapsRoute,
   GraphqlRoute: GraphqlRoute,
   HealthRoute: HealthRoute,

--- a/apps/ui/src/routes/feeds.tsx
+++ b/apps/ui/src/routes/feeds.tsx
@@ -1,0 +1,184 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { CopyButton, PageHero, SectionHeading } from "@jsonbored/ui-kit";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
+import {
+  FEEDS_DOCS_CACHE_SECONDS,
+  FEEDS_DOCS_CONTENT_TYPES,
+  FEEDS_DOCS_FORMATS,
+  FEEDS_DOCS_MAX_ITEMS,
+  FEED_KINDS,
+  FEED_PARAMS,
+  buildFeedCurlExample,
+  feedPath,
+} from "@/lib/metagraphed/feeds-docs";
+
+export const Route = createFileRoute("/feeds")({
+  head: () => ({
+    meta: [
+      { title: "Feeds — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Metagraphed content feeds — subscribe to registry changes, incidents, and coverage gaps as RSS 2.0, Atom 1.0, or JSON Feed. No API key.",
+      },
+      { property: "og:title", content: "Feeds — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "RSS / Atom / JSON Feed over registry changes, incidents, and gaps — filter by tag, page by since/until.",
+      },
+    ],
+  }),
+  component: FeedsDocsPage,
+});
+
+const REGISTRY_FEED_URL = `${API_BASE}${feedPath("registry")}`;
+const CURL_EXAMPLE = buildFeedCurlExample(DEFAULT_API_BASE, "registry", "json");
+
+function FeedsDocsPage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="API"
+        live
+        title="Feeds"
+        description="Subscribe to registry changes, incidents, and coverage gaps as RSS 2.0, Atom 1.0, or JSON Feed — computed at request time from artifacts already served. Read-only, no API key."
+      />
+
+      <div className="mt-6 space-y-section" data-testid="feeds-docs">
+        <section>
+          <SectionHeading
+            title="Feeds"
+            intro="Four GET feeds, all content-negotiated. Point any reader, crawler, or agent at a URL below."
+          />
+          <div className="space-y-2">
+            <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  GET
+                </div>
+                <code className="mt-0.5 block overflow-x-auto whitespace-nowrap font-mono text-[13px] text-ink-strong">
+                  {REGISTRY_FEED_URL}
+                </code>
+              </div>
+              <CopyButton value={REGISTRY_FEED_URL} label="registry feed URL" />
+            </div>
+            <div className="overflow-x-auto rounded-lg border border-border">
+              <table className="w-full min-w-[36rem] text-left text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                    <th className="px-3 py-2.5 font-normal">Path</th>
+                    <th className="px-3 py-2.5 font-normal">Summary</th>
+                    <th className="px-3 py-2.5 font-normal">Item tags</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {FEED_KINDS.map((kind) => (
+                    <tr key={kind.slug} className="align-top">
+                      <td className="px-3 py-2.5 font-mono text-[11px] text-ink-strong">
+                        {feedPath(kind.slug)}
+                      </td>
+                      <td className="px-3 py-2.5 text-[12px] text-ink">{kind.summary}</td>
+                      <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">
+                        {kind.tags}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Formats"
+            intro="Format precedence: an explicit .rss / .atom / .json suffix wins, then the Accept header, then JSON Feed as the default."
+          />
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-[28rem] text-left text-sm">
+              <thead>
+                <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  <th className="px-3 py-2.5 font-normal">Suffix</th>
+                  <th className="px-3 py-2.5 font-normal">Example</th>
+                  <th className="px-3 py-2.5 font-normal">Content-Type</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {FEEDS_DOCS_FORMATS.map((format) => (
+                  <tr key={format} className="align-top">
+                    <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">.{format}</td>
+                    <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">
+                      {feedPath("registry", format)}
+                    </td>
+                    <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">
+                      {FEEDS_DOCS_CONTENT_TYPES[format]}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Filtering & paging"
+            intro="Every param composes. Use ?since= for incremental polling and ?tag= to turn one feed URL into a focused subscription."
+          />
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-[28rem] text-left text-sm">
+              <thead>
+                <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  <th className="px-3 py-2.5 font-normal">Param</th>
+                  <th className="px-3 py-2.5 font-normal">Value</th>
+                  <th className="px-3 py-2.5 font-normal">Notes</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {FEED_PARAMS.map((row) => (
+                  <tr key={row.param} className="align-top">
+                    <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                      ?{row.param}=
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2.5 font-mono text-[12px] text-ink">
+                      {row.value}
+                    </td>
+                    <td className="px-3 py-2.5 text-[12px] text-ink-muted">{row.detail}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="mt-3 rounded-lg border border-border bg-card px-4 py-3">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Example
+              </div>
+              <CopyButton value={CURL_EXAMPLE} label="feeds curl example" />
+            </div>
+            <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-[12px] leading-relaxed text-ink-strong">
+              {CURL_EXAMPLE}
+            </pre>
+          </div>
+          <p className="mt-3 font-mono text-[11px] text-ink-muted">
+            Responses are cached for {FEEDS_DOCS_CACHE_SECONDS}s and capped at{" "}
+            {FEEDS_DOCS_MAX_ITEMS} items. Browse the same data:{" "}
+            <Link to="/gaps" className="text-accent hover:underline">
+              Gaps
+            </Link>
+            . Machine index:{" "}
+            <Link to="/agents" className="text-accent hover:underline">
+              For agents
+            </Link>
+            .
+          </p>
+        </section>
+      </div>
+
+      <ApiSourceFooter paths={FEED_KINDS.map((kind) => feedPath(kind.slug))} />
+    </AppShell>
+  );
+}

--- a/apps/ui/tests/e2e/capture-feeds-docs-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-feeds-docs-screenshots.mjs
@@ -1,0 +1,80 @@
+/**
+ * Capture /feeds docs page screenshots for #3512 (Path C2).
+ *
+ * New page — before captures are the 404/fallback when the route is missing;
+ * after captures show the live docs page.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=before node tests/e2e/capture-feeds-docs-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=after  node tests/e2e/capture-feeds-docs-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/feeds-docs-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8085";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const VIEWPORT_FILTER = process.env.VIEWPORT_FILTER;
+const ALL_VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const VIEWPORTS = VIEWPORT_FILTER
+  ? ALL_VIEWPORTS.filter((v) => v.name === VIEWPORT_FILTER)
+  : ALL_VIEWPORTS;
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function openFeedsDocs(page) {
+  await page.goto(`${BASE_URL}/feeds`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 8000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+  const docs = page.locator('[data-testid="feeds-docs"]');
+  const hero = page.getByRole("heading", { name: /^Feeds$/i }).first();
+  try {
+    await docs.waitFor({ state: "visible", timeout: 5000 });
+  } catch {
+    await hero.waitFor({ state: "visible", timeout: 30_000 }).catch(() => {});
+  }
+  await page.waitForTimeout(250);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await setTheme(page, theme);
+      await openFeedsDocs(page);
+      const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+      await context.close();
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Closes #3512

The public content feeds (RSS 2.0 / Atom 1.0 / JSON Feed over registry changes, incidents, and coverage gaps) had no docs page — the only reference was the module header in `src/feeds.mjs`.

Adds `/feeds`, mirroring the `/rpc` docs page (#3515 / #5642):

- **Feeds** — the four content-negotiated kinds (`registry`, `incidents`, `gaps`, `subnets/{netuid}`), each with its summary and the item tags it carries for `?tag=` narrowing.
- **Formats** — the `.rss` / `.atom` / `.json` suffixes, the suffix > Accept > JSON Feed precedence, and each serializer's exact content-type.
- **Filtering & paging** — the composable `?tag` / `?since` / `?until` / `?limit` params (bare-date inclusivity, 400s, the 50-item clamp), plus a copyable curl example.
- Wired into the footer **Operations** column and the command palette (`Rss` icon).

Reference copy lives in a pure `feeds-docs` module whose constants are unit-tested against the Worker's own values (`FEED_MAX_ITEMS` 50, `FEED_CACHE_SECONDS` 600, `FEED_CONTENT_TYPES`), so drift fails the suite.

## Gates

typecheck OK - unit tests OK (`feeds-docs.test.ts`, 6 new) - eslint `.` OK (0 errors) - prettier OK

## Screenshots

New route — before is the missing-route 404; after is the docs page. Captured with Playwright at the three SKILL viewports (375x812 / 768x1024 / 1280x800), each theme forced via `mg-theme`, fixed-viewport (never full-page). Capture script committed at `apps/ui/tests/e2e/capture-feeds-docs-screenshots.mjs`.

| Viewport - Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3512/after-mobile-dark.png)<br><sub>after</sub> |
