### PR TITLE
fix(ui): distinct notice + no-retry when the chain-events deep-history tier is unbound

### DIFF
--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -4,6 +4,7 @@ import {
   Inbox,
   Clock,
   CheckCircle2,
+  Database,
   ExternalLink as ExternalLinkIcon,
 } from "lucide-react";
 import { useState } from "react";
@@ -13,6 +14,32 @@ import { ApiError } from "@/lib/metagraphed/client";
 import { getNetworkPrefix } from "@/lib/metagraphed/config";
 import { isUsableTimestamp } from "@/lib/metagraphed/format";
 import { NativeOnlyNotice } from "./native-only-notice";
+
+/**
+ * Shown when a `/chain-events*` request 503s with `data_tier_unavailable` —
+ * the deep-history Postgres tier's `DATA_API` service binding isn't wired
+ * into this deployment. Expected on a preview/fork/from-scratch environment,
+ * not a fault in the feed itself, so an informational notice reads better
+ * than a red error card (mirrors `NativeOnlyNotice`'s same reasoning).
+ */
+function DataTierUnavailableNotice({ context }: { context?: string }) {
+  return (
+    <div role="status" className="rounded border border-border bg-surface p-4">
+      <div className="flex items-start gap-3">
+        <Database className="size-4 shrink-0 text-ink-muted" />
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 font-display text-sm font-medium text-ink-strong">
+            Deep-history tier not enabled
+          </div>
+          <p className="text-xs leading-relaxed text-ink-muted">
+            {context ? `The ${context} view` : "This view"} reads the Postgres all-events tier,
+            which isn't bound in this deployment. It's unrelated to the rest of this page.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 // Re-exported so existing `import { Skeleton, ... } from "@/components/metagraphed/states"`
 // call sites keep working -- Skeleton's canonical home is now packages/ui-kit (needed by
@@ -47,6 +74,14 @@ export function ErrorState({
   // Degrade to an informational notice instead of a red error card.
   if (isApi && error.code === "artifact_not_found" && getNetworkPrefix() !== "") {
     return <NativeOnlyNotice context={context} />;
+  }
+  // #2564: the chain-events deep-history tier (workers/api.mjs's handleChainEventsProxy)
+  // 503s with this exact code whenever the DATA_API service binding isn't wired into a
+  // deployment (e.g. a preview/fork environment). That's an expected, documented
+  // condition, not a fault in this feed — an informational notice reads better than a
+  // red error card for every call site that reads /chain-events*.
+  if (isApi && error.code === "data_tier_unavailable") {
+    return <DataTierUnavailableNotice context={context} />;
   }
   const message = (error as Error)?.message ?? "Unknown error";
   const url = isApi ? error.url : undefined;

--- a/apps/ui/src/router.tsx
+++ b/apps/ui/src/router.tsx
@@ -53,6 +53,13 @@ export const getRouter = () => {
           if (error instanceof ApiError && error.code === "artifact_not_found") {
             return false;
           }
+          // #2564: `data_tier_unavailable` means the DATA_API service binding
+          // isn't wired into this deployment — retrying won't change that
+          // within a session, so don't burn 3 retries with backoff before the
+          // DataTierUnavailableNotice degradation renders.
+          if (error instanceof ApiError && error.code === "data_tier_unavailable") {
+            return false;
+          }
           return failureCount < 3;
         },
       },


### PR DESCRIPTION
## Summary

While scoping #2564 ("standalone global chain-events feed page"), found that
the actual functional deliverables — a global, newest-first, filterable,
paginated raw-events feed with block links — already ship as
`ChainEventsFeedSection` on `/explorer` (`chainEventsInfiniteQuery`, `ListShell`,
`LoadMore`). Building a separate `/events` route now would duplicate that
component rather than fill a real gap. The one genuine gap against this
issue's deliverables was the missing **distinct 503 handling** ("not a generic
error") — every call site reading `/chain-events*` (`explorer.tsx`,
`blocks.$ref.tsx`, `accounts.$ss58.tsx`) fell through to a red `ErrorState` card
on `data_tier_unavailable`, even though that's an expected, documented
deployment condition (the `DATA_API` service binding not being wired in), not
a fault in the feed.

- **`states.tsx`**: added a `data_tier_unavailable` branch to `ErrorState`,
  mirroring the existing `artifact_not_found` → `NativeOnlyNotice` carve-out
  (#370) — new `DataTierUnavailableNotice` renders an informational `role="status"`
  card ("Deep-history tier not enabled") instead of a red error card. Fixing it
  in the shared `ErrorState` component benefits every call site at once, not
  just one page.
- **`router.tsx`**: found during visual verification — the global `QueryClient`
  retries any non-`artifact_not_found` `ApiError` up to 3 times with exponential
  backoff before a query settles into its error state, so the new notice sat
  behind ~7s of spinner. Added `data_tier_unavailable` to the same no-retry
  carve-out, since a missing service binding won't resolve by retrying within a
  session.

## Verification

- `npx tsc --noEmit`, `npx eslint .` — clean (0 errors; pre-existing route-file
  fast-refresh warnings only).
- `npx vitest run` — 999/999 passing (no new test file — this is a shared
  presentational component with no extracted pure logic to unit test, same
  convention as `NativeOnlyNotice`).
- `npm run format:check`, `npm run build` (Cloudflare/Nitro target) — clean.
- Manual regression check against the live dev server + real production API:
  confirmed the happy path (50 real event rows, no error/notice card) is
  unaffected.
- Manual QA of the new notice: monkey-patched `window.fetch` to force a real
  `503 data_tier_unavailable` envelope and triggered a genuine client-side
  refetch (via the pallet filter) — confirmed the notice renders immediately
  (no retry delay) with the correct copy and icon.

## Screenshots

| State | Theme | Screenshot |
| --- | --- | --- |
| Before (happy path, real data — unaffected by this PR) | Dark | ![before-dark](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2564-chain-events-before-desktop-dark.png) |
| After (forced `data_tier_unavailable`) | Dark | ![after-dark](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2564-chain-events-after-desktop-dark.png) |
| After (forced `data_tier_unavailable`) | Light | ![after-light](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/2564-chain-events-after-desktop-light.png) |

The "after" screenshots were captured by intercepting `/api/v1/chain-events*`
to return a real `data_tier_unavailable` envelope (production's tier is
actually live, so this state can't be reached against real data in this
environment) — the response body matches `workers/api.mjs`'s real
`handleChainEventsProxy` error shape exactly.

Closes #2564