### PR TITLE
fix(ui): show the Updated value the Providers page already sorts by (#5563)

### DIFF
--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -30,6 +30,7 @@ import {
   PageHero,
   ViewModeToggle,
   ShareButton,
+  TimeAgo,
   Donut,
   DonutLegend,
   Sparkline,
@@ -387,8 +388,14 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                     ) : null}
                   </div>
                   <div className="mt-2 flex items-center justify-between gap-2 font-mono text-[11px] text-ink-muted">
-                    <span>{f.kindLabel}</span>
-                    {host ? <span className="max-w-[20ch] truncate">{host}</span> : null}
+                    <span className="inline-flex min-w-0 items-center gap-2">
+                      <span className="shrink-0">{f.kindLabel}</span>
+                      {host ? <span className="max-w-[20ch] truncate">{host}</span> : null}
+                    </span>
+                    <TimeAgo
+                      at={typeof p.updated_at === "string" ? p.updated_at : undefined}
+                      className="shrink-0"
+                    />
                   </div>
                   <div className="mt-2 grid grid-cols-3 gap-2 border-t border-border/60 pt-2">
                     <ProviderCardStat label="Subnets" value={f.subnetsLabel} />
@@ -410,6 +417,7 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                   <th className="px-3 py-2 text-right">Subnets</th>
                   <th className="px-3 py-2 text-right">Surfaces</th>
                   <th className="px-3 py-2 text-right">Endpoints</th>
+                  <th className="px-3 py-2 text-right">Updated</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
@@ -469,6 +477,9 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                       </td>
                       <td className="px-3 py-2 text-right font-mono text-[11px] tabular-nums">
                         {c?.endpoints ?? 0}
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono text-[11px] text-ink-muted">
+                        <TimeAgo at={typeof p.updated_at === "string" ? p.updated_at : undefined} />
                       </td>
                     </tr>
                   );
@@ -562,6 +573,10 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                     {!webHost && !repoHost && !docsHost ? (
                       <span className="font-mono text-[10px]">no public links yet</span>
                     ) : null}
+                    <TimeAgo
+                      at={typeof p.updated_at === "string" ? p.updated_at : undefined}
+                      className="font-mono"
+                    />
                   </div>
                   <ProviderCountsRow counts={counts[p.slug]} />
                 </Link>


### PR DESCRIPTION
## Summary

`providers.index.tsx` defines `providerSortKeys = [..., "updated"]` and the sort dropdown renders it as a literal, selectable option — selecting it sorts by `updated_at` — but nothing in the file ever displayed `updated_at` to the user, in either the table view (desktop `<table>` + its own mobile stacked-card fallback) or the grid card view. A user who sorts by "updated" sees the list reorder with no visible field explaining why.

Every comparable sortable list page pairs a sortable field with a visible value: `subnets.index.tsx` sorts by `updated_at` and renders it with `<TimeAgo at={s.updated_at ?? s.freshness} />` in both its table row and grid card.

## Change

Adds `<TimeAgo at={...} />` to all three Providers renderings, matching `subnets.index.tsx`'s pattern:

- Desktop `<table>`: new "Updated" column
- Mobile stacked-card (the `<lg` fallback within table view)
- Grid card view

Sort behavior is unchanged — this is a display-only addition, `providerSortKeys`/the sort comparator weren't touched.

## A note on what the screenshots show

The live `/api/v1/providers` response currently has no `updated_at` field for any provider (verified directly against the real API). So every `TimeAgo` renders its `"—"` fallback in production today — this is **pre-existing**: the `"updated"` sort key already silently no-ops against this same absent data before this PR too. This change wires the display up correctly for whenever that field starts arriving; it doesn't fabricate or backfill the data itself (out of scope per the issue).

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop (1280px) · Light — table view | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-desktop-light-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-desktop-light-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-desktop-light-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-desktop-light-after.png)<br><sub>new Updated column</sub> |
| Desktop (1280px) · Dark — table view | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-desktop-dark-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-desktop-dark-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-desktop-dark-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-desktop-dark-after.png) |
| Tablet (768px) · Light — mobile-card fallback | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-tablet-light-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-tablet-light-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-tablet-light-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-tablet-light-after.png) |
| Tablet (768px) · Dark — mobile-card fallback | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-tablet-dark-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-tablet-dark-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-tablet-dark-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-tablet-dark-after.png) |
| Mobile (375px) · Light — mobile-card fallback | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-mobile-light-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-mobile-light-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-mobile-light-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-mobile-light-after.png) |
| Mobile (375px) · Dark — mobile-card fallback | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-mobile-dark-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-mobile-dark-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-mobile-dark-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-mobile-dark-after.png) |

**Grid card view (`?view=grid`) — the second explicitly-requested location:**

| Theme | Before | After |
| --- | --- | --- |
| Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-grid-desktop-light-before.png" width="300">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-grid-desktop-light-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-grid-desktop-light-after.png" width="300">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-grid-desktop-light-after.png) |
| Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-grid-desktop-dark-before.png" width="300">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-grid-desktop-dark-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-grid-desktop-dark-after.png" width="300">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5563-grid-desktop-dark-after.png) |

Closes #5563

## Deliverables (from the issue)

- [x] Providers table view shows an "Updated" column with a `TimeAgo` value
- [x] Providers grid card view shows the same `TimeAgo` value
- [x] Before/after screenshots included

## Validation

- [x] `npm run typecheck --workspace=apps/ui` — clean
- [x] `npm run lint --workspace=apps/ui` — 0 errors (pre-existing unrelated warnings only)
- [x] `npm run format:check --workspace=apps/ui` — clean
- [x] `npm test --workspace=apps/ui` — 983/983 tests passing (127/127 files)