### PR TITLE
fix(registry): document 5 subnets' degraded website/dashboard URLs

### DIFF
--- a/registry/subnets/8-ball.json
+++ b/registry/subnets/8-ball.json
@@ -14,7 +14,7 @@
   "website_url": "https://8ball125.com/",
   "docs_url": "https://github.com/Barbariandev/8Ball_miner#readme",
   "source_repo": "https://github.com/Barbariandev/8Ball_miner",
-  "notes": "Reviewed overlay for SN125 8 Ball. The public website is live and the public miner/source repository documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
+  "notes": "Reviewed overlay for SN125 8 Ball. The public miner/source repository documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -22,7 +22,7 @@
     "verified_at": "2026-06-08T15:00:00.000Z",
     "source_count": 7,
     "gap_notes": [
-      "Official website and miner/source repository are verified live.",
+      "Miner/source repository is verified live; the official website (8ball125.com) currently returns HTTP 502 and should appear degraded until it recovers.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
@@ -44,12 +44,13 @@
         "https://github.com/Barbariandev/8Ball_miner"
       ],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official 8 Ball website linked from the public SN125 miner repository."
+      "notes": "Official 8 Ball website linked from the public SN125 miner repository.",
+      "rate_limit_notes": "Not probe-enabled: https://8ball125.com/ currently returns HTTP 502 to simple and browser-UA probes (re-verified twice ~2026-07-15) and should appear degraded until it recovers."
     },
     {
       "id": "sn-125-eightball-source-repo",

--- a/registry/subnets/ninja.json
+++ b/registry/subnets/ninja.json
@@ -12,6 +12,7 @@
   "contact": "tau@arbos.life",
   "curation": {
     "gap_notes": [
+      "Official Ninja/Unarbos website (ninja.arbos.life) currently returns HTTP 404 to simple and browser-UA probes and should appear degraded until it recovers.",
       "Swagger/OpenAPI routes currently serve HTML UI only; no verified machine-readable schema URL yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
@@ -47,7 +48,7 @@
       "name": "Ninja website",
       "notes": "Official Ninja SN66 public website.",
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "expect": "html",
         "method": "HEAD",
         "timeout_ms": 10000
@@ -55,7 +56,8 @@
       "provider": "unarbos",
       "public_safe": true,
       "source_urls": ["https://ninja.arbos.life/"],
-      "url": "https://ninja.arbos.life/"
+      "url": "https://ninja.arbos.life/",
+      "rate_limit_notes": "Not probe-enabled: https://ninja.arbos.life/ currently returns HTTP 404 to simple and browser-UA probes (re-verified twice ~2026-07-15) and should appear degraded until it recovers."
     },
     {
       "auth_required": false,

--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -23,6 +23,7 @@
     "verified_at": "2026-06-08T10:35:00.000Z",
     "source_count": 4,
     "gap_notes": [
+      "Official oneoneone website (oneoneone.io) currently returns Cloudflare 530 to simple and browser-UA probes and should appear degraded until it recovers.",
       "No verified official docs URL yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified OpenAPI/Swagger schema yet.",
@@ -42,12 +43,13 @@
       "public_safe": true,
       "source_urls": ["https://oneoneone.io/"],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official oneoneone website."
+      "notes": "Official oneoneone website.",
+      "rate_limit_notes": "Not probe-enabled: https://oneoneone.io/ currently returns Cloudflare 530 to simple and browser-UA probes (re-verified twice ~2026-07-15) and should appear degraded until it recovers."
     },
     {
       "id": "sn-111-oneoneone-source",

--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -34,7 +34,7 @@
     "verified_at": "2026-06-08T20:25:00.000Z",
     "source_count": 5,
     "gap_notes": [
-      "Official TaoFi pool page, docs, and Swap source repository are verified live.",
+      "TaoFi docs and Swap source repository are verified live; the TaoFi pool page (www.taofi.com/pool) currently returns HTTP 402 and should appear degraded until it recovers.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
       "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
@@ -57,12 +57,13 @@
         "https://github.com/Swap-Subnet/swap-subnet"
       ],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official TaoFi pool page for SN10 Swap."
+      "notes": "Official TaoFi pool page for SN10 Swap.",
+      "rate_limit_notes": "Not probe-enabled: https://www.taofi.com/pool currently returns HTTP 402 to simple and browser-UA probes (re-verified twice ~2026-07-15) and should appear degraded until it recovers."
     },
     {
       "id": "sn-10-taofi-docs",

--- a/registry/subnets/tensorclaw.json
+++ b/registry/subnets/tensorclaw.json
@@ -26,7 +26,7 @@
     "source_count": 6,
     "gap_notes": [
       "Native chain name currently reports as luis while the public website identifies the project as Tensorclaw Network / Subnet 92.",
-      "Official website, dashboard, and source repository are verified live.",
+      "Source repository is verified live; the official website and dashboard (tensorclaw.ai) currently return Cloudflare 521 (web server is down) and should appear degraded until they recover.",
       "No verified docs site yet beyond directory pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
@@ -84,12 +84,13 @@
       "public_safe": true,
       "source_urls": ["https://www.tensorclaw.ai/"],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Website identifies Tensorclaw Network as Bittensor Mainnet Subnet 92 and describes a decentralized LLM inference subnet for autonomous agents."
+      "notes": "Website identifies Tensorclaw Network as Bittensor Mainnet Subnet 92 and describes a decentralized LLM inference subnet for autonomous agents.",
+      "rate_limit_notes": "Not probe-enabled: https://www.tensorclaw.ai/ currently returns Cloudflare 521 (web server is down) to simple and browser-UA probes (re-verified twice ~2026-07-15) and should appear degraded until it recovers."
     },
     {
       "id": "sn-92-tensorclaw-source-repo",
@@ -123,12 +124,13 @@
       "public_safe": true,
       "source_urls": ["https://www.tensorclaw.ai/"],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Public live-demo page for SN92. The page uses Cloudflare Turnstile to unlock trial requests, so it is listed as an auth-gated dashboard surface rather than a public API."
+      "notes": "Public live-demo page for SN92. The page uses Cloudflare Turnstile to unlock trial requests, so it is listed as an auth-gated dashboard surface rather than a public API.",
+      "rate_limit_notes": "Not probe-enabled: https://www.tensorclaw.ai/dashboard currently returns Cloudflare 521 (web server is down) to simple and browser-UA probes (re-verified twice ~2026-07-15) and should appear degraded until it recovers."
     },
     {
       "auth_required": false,


### PR DESCRIPTION
## Summary

Re-verified all five URLs flagged in the issue (twice each, ~2026-07-15, browser User-Agent + follow-redirects). **All five are still down**, so each manifest now documents the degraded state instead of claiming "verified live" — following the existing `taolend.json` (`curation.gap_notes`) and `nodexo.json` (`surfaces[].rate_limit_notes`) precedent — and disables the affected surface's `probe` so the health prober no longer misreports it:

| Subnet | URL | Status (checked twice) |
|--------|-----|------------------------|
| `swap.json` (SN10) | `www.taofi.com/pool` | HTTP 402 |
| `tensorclaw.json` (SN92) | `tensorclaw.ai` website + `/dashboard` | Cloudflare 521 (web server down) |
| `ninja.json` (SN66) | `ninja.arbos.life` | HTTP 404 |
| `8-ball.json` (SN125) | `8ball125.com` | HTTP 502 |
| `oneoneone.json` (SN111) | `oneoneone.io` | Cloudflare 530 |

## Per file

For each flagged surface: set `probe.enabled: false` and add a `rate_limit_notes` recording the observed status ("…should appear degraded until it recovers"), and corrected the `curation.gap_notes` / `notes` "verified live" language for that URL.

The **URLs themselves are kept** — per the issue's guidance, the outages may be transient (402/502/521/530 are server-side errors, not DNS/permanent-gone), so they're documented as degraded rather than nulled. The unaffected surfaces on those subnets (e.g. each subnet's `taomarketcap.com` dashboard, and source repositories) are untouched and still probe-enabled.

Closes #5480