### PR TITLE
feat(registry): add SN30 Endure Network litepaper docs surface (#4030)

### DIFF
--- a/registry/subnets/endure-network.json
+++ b/registry/subnets/endure-network.json
@@ -118,6 +118,25 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/30/subnet.json"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/30/candle-chart/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-30-endure-litepaper-docs",
+      "kind": "docs",
+      "name": "Endure Network litepaper",
+      "notes": "Official Endure Network litepaper page on the project's own docs site, linked from the docs nav (Introduction > Architecture > Resources > Litepaper). Distinct from the already-registered docs root (sn-30-endure-docs), which does not itself cover the litepaper content.",
+      "provider": "endure",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
+      "source_urls": [
+        "https://endure.network/",
+        "https://docs.endure.network/"
+      ],
+      "url": "https://docs.endure.network/build/resources/litepaper"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary

Appends one `community` `docs` surface to `registry/subnets/endure-network.json`: the official Endure Network litepaper, published at `https://docs.endure.network/build/resources/litepaper` — found linked from the docs site's own nav (Introduction > Architecture > Resources > Litepaper).

The subnet's already-registered docs surface (`sn-30-endure-docs`) points at the docs root only and does not itself cover the litepaper content, so this is a distinct, real, not-yet-registered surface — not a duplicate. `website_url`/`docs_url` are already set at the top level (auto-promoted from on-chain identity), so this adds only the litepaper sub-page as a new `surfaces[]` entry.

## Surface

- **id:** `sn-30-endure-litepaper-docs`
- **kind:** `docs`
- **url:** `https://docs.endure.network/build/resources/litepaper` — public, no-auth, HTTP 200 `text/html`
- **provider:** `endure` (already registered)
- **source_urls:** `https://endure.network/` (registered `website_url`, links to the docs site) and `https://docs.endure.network/` (registered `docs_url`, whose own nav links to the litepaper)

## Proof of ownership

`docs.endure.network` is the subnet's registered `docs_url`. The docs site's own navigation links directly to the litepaper page from `endure.network`'s docs entry point, and the litepaper's own content ("Endure Network Litepaper — A global market for financial risk intelligence...") matches the subnet's registered identity/notes ("decentralized risk intelligence").

## Precedent

Consistent with the just-merged SN23 Trishool litepaper PR — a subnet can carry more than one `docs` surface (main docs root + litepaper/whitepaper as a distinct entry) when both are genuinely separate, real pages.

Closes #4030

## Validation

- `npx prettier --check registry/subnets/endure-network.json` — clean
- `npm run validate:surface -- registry/subnets/endure-network.json` — passed (5 surfaces)
- `npm run scan:public-safety` — passed
- Re-verified `https://docs.endure.network/build/resources/litepaper` at push time — still HTTP 200

One focused change: one surface appended to one subnet file; nothing else touched.