### PR TITLE
feat(ui): add chain analytics endpoint docs page

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -366,6 +366,7 @@ function SiteFooter() {
           <FooterLink to="/graphql">GraphQL</FooterLink>
           <FooterLink to="/rpc">RPC</FooterLink>
           <FooterLink to="/feeds">Feeds</FooterLink>
+          <FooterLink to="/chain">Chain analytics</FooterLink>
           <FooterLink to="/gaps">Gaps</FooterLink>
           <FooterLink to="/chain-events">Chain events reference</FooterLink>
           <FooterLink to="/agents">For agents</FooterLink>

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -15,6 +15,7 @@ import {
   ArrowRightLeft,
   Bot,
   Braces,
+  ChartColumn,
   Compass,
   Copy,
   ExternalLink,
@@ -139,6 +140,13 @@ const ROUTE_INDEX: Array<{
     to: "/feeds",
     hint: "RSS, Atom, JSON Feed subscriptions",
     icon: Rss,
+    scope: "route",
+  },
+  {
+    label: "Chain analytics",
+    to: "/chain",
+    hint: "Activity, calls, signers, fees",
+    icon: ChartColumn,
     scope: "route",
   },
   {

--- a/apps/ui/src/lib/metagraphed/chain-docs.test.ts
+++ b/apps/ui/src/lib/metagraphed/chain-docs.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHAIN_ACTIVITY_PATH,
+  CHAIN_ANALYTICS_ROUTES,
+  CHAIN_ANALYTICS_ROUTE_COUNT,
+  CHAIN_CALLS_PATH,
+  CHAIN_DOCS_CALLS_GROUP_BY,
+  CHAIN_DOCS_CALL_MODULE_MAX_LENGTH,
+  CHAIN_DOCS_DEFAULT_LIMIT,
+  CHAIN_DOCS_DEFAULT_WINDOW,
+  CHAIN_DOCS_FEES_DEFAULT_LIMIT,
+  CHAIN_DOCS_MAX_LIMIT,
+  CHAIN_DOCS_SIGNERS_SORTS,
+  CHAIN_DOCS_WINDOWS,
+  CHAIN_FEES_PATH,
+  CHAIN_SIGNERS_PATH,
+  buildChainBehaviourRows,
+  buildChainCsvCurlExample,
+  buildChainCurlExample,
+  chainAnalyticsUrl,
+  formatChainLimitRange,
+} from "./chain-docs";
+
+describe("chain analytics docs reference", () => {
+  it("keeps Worker-aligned window, enum, and limit constants", () => {
+    expect([...CHAIN_DOCS_WINDOWS]).toEqual(["7d", "30d"]);
+    expect(CHAIN_DOCS_DEFAULT_WINDOW).toBe("7d");
+    expect([...CHAIN_DOCS_SIGNERS_SORTS]).toEqual(["tx_count", "total_fee_tao"]);
+    expect([...CHAIN_DOCS_CALLS_GROUP_BY]).toEqual(["module", "module_function"]);
+    expect(CHAIN_DOCS_MAX_LIMIT).toBe(100);
+    expect(CHAIN_DOCS_DEFAULT_LIMIT).toBe(50);
+    expect(CHAIN_DOCS_FEES_DEFAULT_LIMIT).toBe(25);
+    expect(CHAIN_DOCS_CALL_MODULE_MAX_LENGTH).toBe(100);
+  });
+
+  it("documents the four routed paths without duplicates", () => {
+    expect(CHAIN_ANALYTICS_ROUTES).toHaveLength(CHAIN_ANALYTICS_ROUTE_COUNT);
+    const paths = CHAIN_ANALYTICS_ROUTES.map((r) => r.path);
+    expect(new Set(paths).size).toBe(paths.length);
+    expect(paths).toEqual([
+      CHAIN_ACTIVITY_PATH,
+      CHAIN_CALLS_PATH,
+      CHAIN_SIGNERS_PATH,
+      CHAIN_FEES_PATH,
+    ]);
+    for (const route of CHAIN_ANALYTICS_ROUTES) {
+      expect(route.method).toBe("GET");
+      expect(route.path.startsWith("/api/v1/chain/")).toBe(true);
+      expect(route.params.length).toBeGreaterThan(0);
+      expect(route.responseFields).toContain("observed_at");
+      expect(route.csvColumns.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("gives every route a window param and only the routes that page a limit param", () => {
+    const named = (path: string) => {
+      const route = CHAIN_ANALYTICS_ROUTES.find((r) => r.path === path);
+      return route ? route.params.map((p) => p.name) : [];
+    };
+    for (const route of CHAIN_ANALYTICS_ROUTES) {
+      expect(route.params.map((p) => p.name)).toContain("window");
+    }
+    // activity aggregates a fixed per-day series -- it takes no limit/call_module scope.
+    expect(named(CHAIN_ACTIVITY_PATH)).toEqual(["window", "format"]);
+    expect(named(CHAIN_CALLS_PATH)).toContain("group_by");
+    expect(named(CHAIN_SIGNERS_PATH)).toContain("sort");
+    expect(named(CHAIN_FEES_PATH)).not.toContain("sort");
+    for (const path of [CHAIN_CALLS_PATH, CHAIN_SIGNERS_PATH, CHAIN_FEES_PATH]) {
+      expect(named(path)).toContain("limit");
+      expect(named(path)).toContain("call_module");
+    }
+  });
+
+  it("formats a limit range and guards non-finite input", () => {
+    expect(formatChainLimitRange(50, 100)).toBe("50 default · 100 max");
+    expect(formatChainLimitRange(25, 100)).toBe("25 default · 100 max");
+    expect(formatChainLimitRange(Number.NaN, 100)).toBe("—");
+  });
+
+  it("builds a behaviour table covering window, limits, validation, and caching", () => {
+    const rows = buildChainBehaviourRows();
+    expect(rows.map((r) => r.label)).toEqual([
+      "Window",
+      "Result limit",
+      "Unknown params",
+      "Cold store",
+      "Caching",
+      "Source tier",
+    ]);
+    expect(rows[0]?.value).toContain("7d");
+    expect(rows[1]?.value).toBe("50 default · 100 max");
+  });
+
+  it("builds request URLs and curl examples against the resolved window", () => {
+    expect(chainAnalyticsUrl("https://api.metagraph.sh", CHAIN_ACTIVITY_PATH)).toBe(
+      "https://api.metagraph.sh/api/v1/chain/activity",
+    );
+    expect(
+      chainAnalyticsUrl("https://api.metagraph.sh/", CHAIN_CALLS_PATH, { window: "30d" }),
+    ).toBe("https://api.metagraph.sh/api/v1/chain/calls?window=30d");
+
+    const curl = buildChainCurlExample("https://api.metagraph.sh");
+    expect(curl).toContain("https://api.metagraph.sh/api/v1/chain/activity?window=7d");
+
+    const csvCurl = buildChainCsvCurlExample("https://api.metagraph.sh");
+    expect(csvCurl).toContain("/api/v1/chain/fees?window=30d&format=csv");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/chain-docs.ts
+++ b/apps/ui/src/lib/metagraphed/chain-docs.ts
@@ -1,0 +1,275 @@
+/**
+ * Static reference copy for the `/chain` docs page.
+ *
+ * Paths, windows, enums, and limits mirror `workers/api.mjs` +
+ * `workers/request-handlers/analytics.mjs` + `workers/config.mjs` — keep them in
+ * sync when the Worker chain-analytics contract changes. The UI cannot import
+ * Worker `.mjs` modules, so these are intentional literals.
+ */
+
+/** Keep aligned with ANALYTICS_WINDOWS in workers/config.mjs */
+export const CHAIN_DOCS_WINDOWS = ["7d", "30d"] as const;
+
+export type ChainDocsWindow = (typeof CHAIN_DOCS_WINDOWS)[number];
+
+/** Keep aligned with DEFAULT_ANALYTICS_WINDOW in workers/config.mjs */
+export const CHAIN_DOCS_DEFAULT_WINDOW: ChainDocsWindow = "7d";
+
+/** Keep aligned with ANALYTICS_WINDOW_PARAM in workers/config.mjs */
+export const CHAIN_DOCS_WINDOW_PARAM = "window";
+
+/** Keep aligned with CHAIN_SIGNERS_SORTS in src/chain-query-loaders.mjs */
+export const CHAIN_DOCS_SIGNERS_SORTS = ["tx_count", "total_fee_tao"] as const;
+
+/** Keep aligned with the group_by enum on handleChainCalls */
+export const CHAIN_DOCS_CALLS_GROUP_BY = ["module", "module_function"] as const;
+
+/** Keep aligned with validateFormatParam in workers/request-handlers/analytics.mjs */
+export const CHAIN_DOCS_FORMATS = ["json", "csv"] as const;
+
+/** Keep aligned with the parseLimitParam maxLimit shared by calls/signers/fees */
+export const CHAIN_DOCS_MAX_LIMIT = 100;
+
+/** Keep aligned with parseLimitParam defaultLimit on handleChainCalls / handleChainSigners */
+export const CHAIN_DOCS_DEFAULT_LIMIT = 50;
+
+/** Keep aligned with parseLimitParam defaultLimit on handleChainFees */
+export const CHAIN_DOCS_FEES_DEFAULT_LIMIT = 25;
+
+/** Keep aligned with the validateMaxLength(url, "call_module", 100) guard */
+export const CHAIN_DOCS_CALL_MODULE_MAX_LENGTH = 100;
+
+export const CHAIN_ACTIVITY_PATH = "/api/v1/chain/activity";
+export const CHAIN_CALLS_PATH = "/api/v1/chain/calls";
+export const CHAIN_SIGNERS_PATH = "/api/v1/chain/signers";
+export const CHAIN_FEES_PATH = "/api/v1/chain/fees";
+
+export type ChainAnalyticsParamDoc = {
+  name: string;
+  values: string;
+  detail: string;
+};
+
+export type ChainAnalyticsRouteDoc = {
+  path: string;
+  method: "GET";
+  title: string;
+  summary: string;
+  params: readonly ChainAnalyticsParamDoc[];
+  responseFields: readonly string[];
+  csvColumns: readonly string[];
+};
+
+const WINDOW_PARAM: ChainAnalyticsParamDoc = {
+  name: "window",
+  values: CHAIN_DOCS_WINDOWS.join(" | "),
+  detail: `Rolling UTC window. Defaults to ${CHAIN_DOCS_DEFAULT_WINDOW}; any other value is rejected.`,
+};
+
+const FORMAT_PARAM: ChainAnalyticsParamDoc = {
+  name: "format",
+  values: CHAIN_DOCS_FORMATS.join(" | "),
+  detail: "csv returns the row-shaped table below; json returns the full envelope.",
+};
+
+const CALL_MODULE_PARAM: ChainAnalyticsParamDoc = {
+  name: "call_module",
+  values: `string ≤ ${CHAIN_DOCS_CALL_MODULE_MAX_LENGTH}`,
+  detail: "Optional pallet scope, backed by idx_extrinsics_module_block.",
+};
+
+/** The four chain-analytics routes, as routed in workers/api.mjs. */
+export const CHAIN_ANALYTICS_ROUTES: readonly ChainAnalyticsRouteDoc[] = [
+  {
+    path: CHAIN_ACTIVITY_PATH,
+    method: "GET",
+    title: "Activity",
+    summary:
+      "Daily network aggregates — block/extrinsic/event counts, success rate, and unique signers, newest day first.",
+    params: [WINDOW_PARAM, FORMAT_PARAM],
+    responseFields: ["schema_version", "window", "day_count", "days[]", "observed_at"],
+    csvColumns: [
+      "day",
+      "block_count",
+      "extrinsic_count",
+      "event_count",
+      "successful_extrinsics",
+      "success_rate",
+      "unique_signers",
+    ],
+  },
+  {
+    path: CHAIN_CALLS_PATH,
+    method: "GET",
+    title: "Calls",
+    summary:
+      "Extrinsic call-mix breakdown — count and share per pallet, or per pallet/function with group_by=module_function.",
+    params: [
+      WINDOW_PARAM,
+      {
+        name: "group_by",
+        values: CHAIN_DOCS_CALLS_GROUP_BY.join(" | "),
+        detail: "Defaults to module. module_function adds call_function to every row.",
+      },
+      {
+        name: "limit",
+        values: `1–${CHAIN_DOCS_MAX_LIMIT}`,
+        detail: `Defaults to ${CHAIN_DOCS_DEFAULT_LIMIT}. Shares use the full-window denominator, so a truncated tail never skews them.`,
+      },
+      CALL_MODULE_PARAM,
+      FORMAT_PARAM,
+    ],
+    responseFields: [
+      "schema_version",
+      "window",
+      "group_by",
+      "total_extrinsics",
+      "call_count",
+      "calls[]",
+      "observed_at",
+    ],
+    csvColumns: ["call_module", "count", "share"],
+  },
+  {
+    path: CHAIN_SIGNERS_PATH,
+    method: "GET",
+    title: "Signers",
+    summary:
+      "Most-active-account leaderboard — signers ranked by extrinsic count or total fees paid, with the newest signed block.",
+    params: [
+      WINDOW_PARAM,
+      {
+        name: "sort",
+        values: CHAIN_DOCS_SIGNERS_SORTS.join(" | "),
+        detail: "Defaults to tx_count.",
+      },
+      {
+        name: "limit",
+        values: `1–${CHAIN_DOCS_MAX_LIMIT}`,
+        detail: `Defaults to ${CHAIN_DOCS_DEFAULT_LIMIT}.`,
+      },
+      CALL_MODULE_PARAM,
+      FORMAT_PARAM,
+    ],
+    responseFields: [
+      "schema_version",
+      "window",
+      "sort",
+      "signer_count",
+      "signers[]",
+      "observed_at",
+    ],
+    csvColumns: ["signer", "tx_count", "total_fee_tao", "total_tip_tao", "last_tx_block"],
+  },
+  {
+    path: CHAIN_FEES_PATH,
+    method: "GET",
+    title: "Fees",
+    summary:
+      "Fee/tip market — a per-UTC-day series with totals, averages, and exact medians, plus a windowed top-fee-payer list.",
+    params: [
+      WINDOW_PARAM,
+      {
+        name: "limit",
+        values: `1–${CHAIN_DOCS_MAX_LIMIT}`,
+        detail: `Defaults to ${CHAIN_DOCS_FEES_DEFAULT_LIMIT}. Bounds top_fee_payers only — the daily series always covers the window.`,
+      },
+      CALL_MODULE_PARAM,
+      FORMAT_PARAM,
+    ],
+    responseFields: [
+      "schema_version",
+      "window",
+      "day_count",
+      "daily[]",
+      "top_fee_payers[]",
+      "observed_at",
+    ],
+    csvColumns: [
+      "day",
+      "extrinsic_count",
+      "total_fee_tao",
+      "avg_fee_tao",
+      "median_fee_tao",
+      "total_tip_tao",
+      "avg_tip_tao",
+      "median_tip_tao",
+    ],
+  },
+] as const;
+
+export type ChainBehaviourRow = {
+  label: string;
+  value: string;
+  detail: string;
+};
+
+/** Render a default/max pair for the behaviour table (e.g. "50 default · 100 max"). */
+export function formatChainLimitRange(defaultLimit: number, maxLimit: number): string {
+  if (!Number.isFinite(defaultLimit) || !Number.isFinite(maxLimit)) return "—";
+  return `${defaultLimit} default · ${maxLimit} max`;
+}
+
+export function buildChainBehaviourRows(): ChainBehaviourRow[] {
+  return [
+    {
+      label: "Window",
+      value: CHAIN_DOCS_WINDOWS.join(" | "),
+      detail: `Defaults to ${CHAIN_DOCS_DEFAULT_WINDOW}. An unsupported window is a 400, not a clamp.`,
+    },
+    {
+      label: "Result limit",
+      value: formatChainLimitRange(CHAIN_DOCS_DEFAULT_LIMIT, CHAIN_DOCS_MAX_LIMIT),
+      detail: `calls and signers. fees defaults to ${CHAIN_DOCS_FEES_DEFAULT_LIMIT} payers.`,
+    },
+    {
+      label: "Unknown params",
+      value: "400",
+      detail: "Every route allowlists its params, and each may be supplied only once.",
+    },
+    {
+      label: "Cold store",
+      value: "schema-stable",
+      detail: "Empty lists with zeroed counts rather than an error before the first snapshot.",
+    },
+    {
+      label: "Caching",
+      value: "edge, short",
+      detail:
+        "Keyed on the resolved window, so a bare request and an explicit default share one entry.",
+    },
+    {
+      label: "Source tier",
+      value: "Postgres → D1",
+      detail: "Falls back to the first-party D1 chain tiers when the Postgres tier is unavailable.",
+    },
+  ];
+}
+
+export function chainAnalyticsUrl(
+  apiBase: string,
+  path: string,
+  params: Record<string, string> = {},
+): string {
+  const base = apiBase.replace(/\/$/, "");
+  const search = new URLSearchParams(params).toString();
+  return `${base}${path}${search ? `?${search}` : ""}`;
+}
+
+export function buildChainCurlExample(apiBase: string): string {
+  const url = chainAnalyticsUrl(apiBase, CHAIN_ACTIVITY_PATH, {
+    [CHAIN_DOCS_WINDOW_PARAM]: CHAIN_DOCS_DEFAULT_WINDOW,
+  });
+  return `curl -s '${url}'`;
+}
+
+export function buildChainCsvCurlExample(apiBase: string): string {
+  const url = chainAnalyticsUrl(apiBase, CHAIN_FEES_PATH, {
+    [CHAIN_DOCS_WINDOW_PARAM]: "30d",
+    format: "csv",
+  });
+  return `curl -s '${url}'`;
+}
+
+/** Expected route count — guards accidental drift from the Worker router. */
+export const CHAIN_ANALYTICS_ROUTE_COUNT = 4;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as FeedsRouteImport } from './routes/feeds'
 import { Route as ExplorerRouteImport } from './routes/explorer'
 import { Route as EndpointsRouteImport } from './routes/endpoints'
 import { Route as ChainEventsRouteImport } from './routes/chain-events'
+import { Route as ChainRouteImport } from './routes/chain'
 import { Route as AgentsRouteImport } from './routes/agents'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
@@ -104,6 +105,11 @@ const EndpointsRoute = EndpointsRouteImport.update({
 const ChainEventsRoute = ChainEventsRouteImport.update({
   id: '/chain-events',
   path: '/chain-events',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ChainRoute = ChainRouteImport.update({
+  id: '/chain',
+  path: '/chain',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AgentsRoute = AgentsRouteImport.update({
@@ -201,6 +207,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/agents': typeof AgentsRoute
+  '/chain': typeof ChainRoute
   '/chain-events': typeof ChainEventsRoute
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
@@ -234,6 +241,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/agents': typeof AgentsRoute
+  '/chain': typeof ChainRoute
   '/chain-events': typeof ChainEventsRoute
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
@@ -268,6 +276,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/agents': typeof AgentsRoute
+  '/chain': typeof ChainRoute
   '/chain-events': typeof ChainEventsRoute
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
@@ -303,6 +312,7 @@ export interface FileRouteTypes {
     | '/'
     | '/about'
     | '/agents'
+    | '/chain'
     | '/chain-events'
     | '/endpoints'
     | '/explorer'
@@ -336,6 +346,7 @@ export interface FileRouteTypes {
     | '/'
     | '/about'
     | '/agents'
+    | '/chain'
     | '/chain-events'
     | '/endpoints'
     | '/explorer'
@@ -369,6 +380,7 @@ export interface FileRouteTypes {
     | '/'
     | '/about'
     | '/agents'
+    | '/chain'
     | '/chain-events'
     | '/endpoints'
     | '/explorer'
@@ -403,6 +415,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
   AgentsRoute: typeof AgentsRoute
+  ChainRoute: typeof ChainRoute
   ChainEventsRoute: typeof ChainEventsRoute
   EndpointsRoute: typeof EndpointsRoute
   ExplorerRoute: typeof ExplorerRoute
@@ -524,6 +537,13 @@ declare module '@tanstack/react-router' {
       path: '/chain-events'
       fullPath: '/chain-events'
       preLoaderRoute: typeof ChainEventsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/chain': {
+      id: '/chain'
+      path: '/chain'
+      fullPath: '/chain'
+      preLoaderRoute: typeof ChainRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/agents': {
@@ -659,6 +679,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
   AgentsRoute: AgentsRoute,
+  ChainRoute: ChainRoute,
   ChainEventsRoute: ChainEventsRoute,
   EndpointsRoute: EndpointsRoute,
   ExplorerRoute: ExplorerRoute,

--- a/apps/ui/src/routes/chain.tsx
+++ b/apps/ui/src/routes/chain.tsx
@@ -1,0 +1,227 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { CopyButton, PageHero, SectionHeading } from "@jsonbored/ui-kit";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
+import {
+  CHAIN_ACTIVITY_PATH,
+  CHAIN_ANALYTICS_ROUTES,
+  CHAIN_CALLS_PATH,
+  CHAIN_FEES_PATH,
+  CHAIN_SIGNERS_PATH,
+  buildChainBehaviourRows,
+  buildChainCsvCurlExample,
+  buildChainCurlExample,
+  chainAnalyticsUrl,
+} from "@/lib/metagraphed/chain-docs";
+
+export const Route = createFileRoute("/chain")({
+  head: () => ({
+    meta: [
+      { title: "Chain analytics — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Metagraphed chain analytics — GET /api/v1/chain/activity, /calls, /signers, /fees: windowed network aggregates, call mix, signer leaderboards, and the fee market.",
+      },
+      { property: "og:title", content: "Chain analytics — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "Four windowed read endpoints over the first-party chain tiers — daily activity, call mix, most-active signers, and fee/tip market analytics. JSON or CSV.",
+      },
+    ],
+  }),
+  component: ChainDocsPage,
+});
+
+const ACTIVITY_URL = chainAnalyticsUrl(API_BASE, CHAIN_ACTIVITY_PATH);
+const CURL_EXAMPLE = buildChainCurlExample(DEFAULT_API_BASE);
+const CSV_CURL_EXAMPLE = buildChainCsvCurlExample(DEFAULT_API_BASE);
+const BEHAVIOUR_ROWS = buildChainBehaviourRows();
+
+function ChainDocsPage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="API"
+        live
+        title="Chain analytics"
+        description="Four windowed read endpoints over the first-party chain tiers — what the network did each day, which pallets it spent its blockspace on, who signed the most, and what it paid in fees. No API key."
+      />
+
+      <div className="mt-6 space-y-section" data-testid="chain-docs">
+        <section>
+          <SectionHeading
+            title="Endpoints"
+            intro="All four are GET, unauthenticated, and share one rolling window contract. Every response carries the standard envelope (ok, data, meta) with the snapshot's observed_at."
+          />
+          <div className="space-y-2">
+            <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  GET
+                </div>
+                <code className="mt-0.5 block overflow-x-auto whitespace-nowrap font-mono text-[13px] text-ink-strong">
+                  {ACTIVITY_URL}
+                </code>
+              </div>
+              <CopyButton value={ACTIVITY_URL} label="Chain activity URL" />
+            </div>
+            <div className="overflow-x-auto rounded-lg border border-border">
+              <table className="w-full min-w-[36rem] text-left text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                    <th className="px-3 py-2.5 font-normal">Method</th>
+                    <th className="px-3 py-2.5 font-normal">Path</th>
+                    <th className="px-3 py-2.5 font-normal">Summary</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {CHAIN_ANALYTICS_ROUTES.map((route) => (
+                    <tr key={route.path} className="align-top">
+                      <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                        {route.method}
+                      </td>
+                      <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">
+                        {route.path}
+                      </td>
+                      <td className="px-3 py-2.5 text-[12px] text-ink">{route.summary}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="rounded-lg border border-border bg-card px-4 py-3">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  Example
+                </div>
+                <CopyButton value={CURL_EXAMPLE} label="Chain analytics curl example" />
+              </div>
+              <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-[12px] leading-relaxed text-ink-strong">
+                {CURL_EXAMPLE}
+              </pre>
+            </div>
+          </div>
+          <p className="mt-3 font-mono text-[11px] text-ink-muted">
+            Live block + extrinsic UI:{" "}
+            <Link to="/explorer" className="text-accent hover:underline">
+              Explorer
+            </Link>
+            . Machine index:{" "}
+            <Link to="/agents" className="text-accent hover:underline">
+              For agents
+            </Link>
+            .
+          </p>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Parameters"
+            intro="Each route allowlists its own query params — anything else is a 400 rather than a silently ignored filter. Response fields are the keys of the data object."
+          />
+          <div className="space-y-4">
+            {CHAIN_ANALYTICS_ROUTES.map((route) => (
+              <div key={route.path} className="rounded-lg border border-border bg-card px-4 py-3">
+                <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                  <span className="font-mono text-[13px] text-ink-strong">{route.title}</span>
+                  <code className="font-mono text-[11px] text-ink-muted">{route.path}</code>
+                </div>
+                <dl className="mt-3 space-y-1.5">
+                  {route.params.map((param) => (
+                    <div key={param.name} className="flex flex-wrap gap-x-2 text-[12px]">
+                      <dt className="font-mono text-ink-strong">{param.name}</dt>
+                      <dd className="font-mono text-ink-muted">{param.values}</dd>
+                      <dd className="w-full text-ink-muted sm:w-auto">{param.detail}</dd>
+                    </div>
+                  ))}
+                </dl>
+                <div className="mt-3 border-t border-border pt-2">
+                  <div className="mb-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                    Response
+                  </div>
+                  <ul className="flex flex-wrap gap-x-3 gap-y-1 font-mono text-[12px] text-ink-strong">
+                    {route.responseFields.map((field) => (
+                      <li key={field}>{field}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="CSV export"
+            intro="Add ?format=csv to any of the four. Each route exports its primary row-shaped table — the fee-payer leaderboard stays JSON-only in the envelope."
+          />
+          <div className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              {CHAIN_ANALYTICS_ROUTES.map((route) => (
+                <div key={route.path} className="rounded-lg border border-border bg-card px-4 py-3">
+                  <div className="mb-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                    {route.title}
+                  </div>
+                  <ul className="space-y-1 font-mono text-[12px] text-ink-strong">
+                    {route.csvColumns.map((column) => (
+                      <li key={column}>{column}</li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+            <div className="rounded-lg border border-border bg-card px-4 py-3">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  Example
+                </div>
+                <CopyButton value={CSV_CURL_EXAMPLE} label="Chain analytics CSV curl example" />
+              </div>
+              <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-[12px] leading-relaxed text-ink-strong">
+                {CSV_CURL_EXAMPLE}
+              </pre>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Behaviour"
+            intro="Shared contract across the four routes. Matching constants live in workers/config.mjs and workers/request-handlers/analytics.mjs."
+          />
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-[28rem] text-left text-sm">
+              <thead>
+                <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  <th className="px-3 py-2.5 font-normal">Aspect</th>
+                  <th className="px-3 py-2.5 font-normal">Value</th>
+                  <th className="px-3 py-2.5 font-normal">Notes</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {BEHAVIOUR_ROWS.map((row) => (
+                  <tr key={row.label} className="align-top">
+                    <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                      {row.label}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2.5 font-mono text-[12px] tabular-nums text-ink">
+                      {row.value}
+                    </td>
+                    <td className="px-3 py-2.5 text-[12px] text-ink-muted">{row.detail}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+
+      <ApiSourceFooter
+        paths={[CHAIN_ACTIVITY_PATH, CHAIN_CALLS_PATH, CHAIN_SIGNERS_PATH, CHAIN_FEES_PATH]}
+      />
+    </AppShell>
+  );
+}

--- a/apps/ui/tests/e2e/capture-chain-docs-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-chain-docs-screenshots.mjs
@@ -1,0 +1,80 @@
+/**
+ * Capture /chain docs page screenshots (Path C2).
+ *
+ * New page — before captures are the 404/fallback when the route is missing;
+ * after captures show the live docs page.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8113 VARIANT=before node tests/e2e/capture-chain-docs-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8114 VARIANT=after  node tests/e2e/capture-chain-docs-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/chain-docs-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8114";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const VIEWPORT_FILTER = process.env.VIEWPORT_FILTER;
+const ALL_VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const VIEWPORTS = VIEWPORT_FILTER
+  ? ALL_VIEWPORTS.filter((v) => v.name === VIEWPORT_FILTER)
+  : ALL_VIEWPORTS;
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function openChainDocs(page) {
+  await page.goto(`${BASE_URL}/chain`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 8000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+  const docs = page.locator('[data-testid="chain-docs"]');
+  const hero = page.getByRole("heading", { name: /^Chain analytics$/i }).first();
+  try {
+    await docs.waitFor({ state: "visible", timeout: 5000 });
+  } catch {
+    await hero.waitFor({ state: "visible", timeout: 30_000 }).catch(() => {});
+  }
+  await page.waitForTimeout(250);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await setTheme(page, theme);
+      await openChainDocs(page);
+      const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+      await context.close();
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add `/chain` docs page covering the four chain-analytics endpoints: `GET /api/v1/chain/activity`, `/calls`, `/signers`, `/fees` — per-route query params, response fields, CSV columns, and the shared window/limit/validation/caching contract.
- Extract Worker-aligned constants into `chain-docs.ts` (+ tests) so the UI copy stays checkable against `workers/config.mjs` and `workers/request-handlers/analytics.mjs` (windows `7d|30d` default `7d`, limit defaults 50/50/25 with max 100, `call_module` ≤ 100, sort/group_by enums).
- Register the page in the site footer (Operations) and command palette.

Closes #3511

## Screenshots

New route — before is the missing-route 404; after is the docs page.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/3511-after-mobile-dark.png)<br><sub>after</sub> |

## Test plan

- [x] `npx vitest run src/lib/metagraphed/chain-docs.test.ts` (6 new tests)
- [x] `npm test --workspace=apps/ui` (131 files / 1011 tests)
- [x] `lint` (0 errors) · `format:check` · `typecheck` · `build` (`--workspace=apps/ui`)
- [x] `test:e2e --workspace=apps/ui` responsive-overflow (24/24)
- [x] `routeTree.gen.ts` regenerated and committed
- [ ] CI `ui` job
