### PR TITLE
feat(ui): wire Download CSV into the leaderboards weight-setting and deregistration boards (#5562)

### DIFF
--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -8,12 +8,13 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { PageHero, BrandIcon, TimeAgo, StatTile } from "@jsonbored/ui-kit";
+import { PageHero, BrandIcon, TimeAgo, StatTile, DownloadCsvButton } from "@jsonbored/ui-kit";
 import {
   chainDeregistrationsQuery,
   chainWeightsQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { formatNumber } from "@/lib/metagraphed/format";
 import type { Subnet } from "@/lib/metagraphed/types";
 
@@ -49,6 +50,11 @@ const WINDOW_BTN_ACTIVE =
   "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent";
 const WINDOW_BTN =
   "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30";
+
+// Mirror each board query's own default page size (queries.ts) so the CSV export lines up with
+// the rows rendered on the page rather than drifting from an independently-chosen limit.
+const WEIGHTS_LIMIT = 20;
+const DEREGISTRATIONS_LIMIT = 100;
 
 // Every board on this route ranks the same 7d/30d window, so the window control lives at the page
 // level and governs both sections rather than each board owning a duplicate toggle.
@@ -109,22 +115,26 @@ function useSubnetById(): Map<number, Subnet> {
 }
 
 function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
-  const { data: boardRes } = useSuspenseQuery(chainWeightsQuery(win));
+  const { data: boardRes } = useSuspenseQuery(chainWeightsQuery(win, WEIGHTS_LIMIT));
   const subnetById = useSubnetById();
   const board = boardRes.data;
   const network = board.network;
   const dist = board.intensity_distribution;
+  const weightsCsvUrl = buildUrl("/api/v1/chain/weights", { window: win, limit: WEIGHTS_LIMIT });
 
   return (
     <div className="space-y-8">
-      <div>
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Weight-setting activity
-        </h2>
-        <p className="mt-1 text-sm text-ink-muted">
-          Validator consensus effort ranked by subnet — raw WeightsSet events over the selected
-          window.
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Weight-setting activity
+          </h2>
+          <p className="mt-1 text-sm text-ink-muted">
+            Validator consensus effort ranked by subnet — raw WeightsSet events over the selected
+            window.
+          </p>
+        </div>
+        <DownloadCsvButton url={weightsCsvUrl} />
       </div>
 
       <div className="grid gap-4 sm:grid-cols-3">
@@ -279,21 +289,30 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
 }
 
 function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
-  const { data: boardRes } = useSuspenseQuery(chainDeregistrationsQuery(win));
+  const { data: boardRes } = useSuspenseQuery(
+    chainDeregistrationsQuery(win, DEREGISTRATIONS_LIMIT),
+  );
   const subnetById = useSubnetById();
   const board = boardRes.data;
   const network = board.network;
+  const deregistrationsCsvUrl = buildUrl("/api/v1/chain/deregistrations", {
+    window: win,
+    limit: DEREGISTRATIONS_LIMIT,
+  });
 
   return (
     <div className="space-y-8">
-      <div>
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Deregistrations
-        </h2>
-        <p className="mt-1 text-sm text-ink-muted">
-          Neuron evictions ranked by subnet — raw NeuronDeregistered events over the selected
-          window.
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Deregistrations
+          </h2>
+          <p className="mt-1 text-sm text-ink-muted">
+            Neuron evictions ranked by subnet — raw NeuronDeregistered events over the selected
+            window.
+          </p>
+        </div>
+        <DownloadCsvButton url={deregistrationsCsvUrl} />
       </div>
 
       <div className="grid gap-4 sm:grid-cols-3">


### PR DESCRIPTION
## Summary

`apps/ui/src/routes/leaderboards.tsx` renders two ranked boards — a weight-setting leaderboard (`chainWeightsQuery` → `GET /api/v1/chain/weights`) and a deregistrations board (`chainDeregistrationsQuery` → `GET /api/v1/chain/deregistrations`). Both backend endpoints already support CSV export — verified live:

```
$ curl -sD - "https://api.metagraph.sh/api/v1/chain/weights?format=csv&window=7d&limit=5"
HTTP/2 200
content-type: text/csv; charset=utf-8
content-disposition: attachment; filename="chain-weights.csv"

$ curl -sD - "https://api.metagraph.sh/api/v1/chain/deregistrations?format=csv&window=7d&limit=5"
HTTP/2 200
content-type: text/csv; charset=utf-8
content-disposition: attachment; filename="chain-deregistrations.csv"
```

`leaderboards.tsx` had zero occurrences of `DownloadCsvButton` — the reusable component every other ranked-table page already uses (`endpoints.tsx`, `validators.index.tsx`, `subnets.index.tsx`, `blocks.index.tsx`).

## Change

- Added a `DownloadCsvButton` to each board's own header row, wired to `buildUrl("/api/v1/chain/<weights|deregistrations>", { window, limit })`.
- `WEIGHTS_LIMIT`/`DEREGISTRATIONS_LIMIT` constants mirror each board query's own default page size (20 / 100), so the CSV export lines up with the rows actually rendered on the page rather than an independently-chosen limit.
- Since `leaderboards.tsx` has two independent boards rather than one shared table, each button lives next to its own board's header/controls rather than the shared `PageHero`.
- Both buttons respect the active `window` (7d/30d) search param, since it's threaded through the same `win` value the board's own query already uses.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop (1280px) · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-desktop-light-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-desktop-light-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-desktop-light-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-desktop-light-after.png)<br><sub>Download CSV on both boards</sub> |
| Desktop (1280px) · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-desktop-dark-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-desktop-dark-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-desktop-dark-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-desktop-dark-after.png) |
| Tablet (768px) · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-tablet-light-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-tablet-light-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-tablet-light-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-tablet-light-after.png) |
| Tablet (768px) · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-tablet-dark-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-tablet-dark-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-tablet-dark-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-tablet-dark-after.png) |
| Mobile (375px) · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-mobile-light-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-mobile-light-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-mobile-light-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-mobile-light-after.png)<br><sub>button wraps below the heading, no overflow</sub> |
| Mobile (375px) · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-mobile-dark-before.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-mobile-dark-before.png) | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-mobile-dark-after.png" width="220">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5562-mobile-dark-after.png) |

Closes #5562

## Deliverables (from the issue)

- [x] Weight-setting board has a working `DownloadCsvButton`
- [x] Deregistrations board has a working `DownloadCsvButton`
- [x] Both buttons respect the active `window` (7d/30d) search param
- [x] Before/after screenshots included

## Validation

- [x] `npm run typecheck --workspace=apps/ui` — clean
- [x] `npm run lint --workspace=apps/ui` — 0 errors (pre-existing unrelated warnings only)
- [x] `npm run format:check --workspace=apps/ui` — clean
- [x] `npm test --workspace=apps/ui` — 1005/1005 tests passing (130/130 files)
- [x] `npm run build --workspace=apps/ui` — builds cleanly