### PR TITLE
feat(graphql): add Query.blocks_summary mirroring REST blocks/summary

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -28,6 +28,7 @@ import {
 } from "./analytics-live.mjs";
 import { buildExtrinsic, buildExtrinsicFeed } from "./extrinsics.mjs";
 import { buildBlock, buildBlockFeed } from "./blocks.mjs";
+import { buildBlocksSummary } from "./blocks-summary.mjs";
 import {
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
@@ -88,6 +89,8 @@ export const SDL = `
     blocks(limit: Int, offset: Int, cursor: String): BlockList!
     "One block by numeric height or 0x block hash; block is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/{ref}."
     block(ref: String!): BlockDetail
+    "Block-production analytics over the most recent blocks -- inter-block time distribution, extrinsic/event throughput, and block-author decentralization. Mirrors GET /api/v1/blocks/summary."
+    blocks_summary: BlocksSummary!
     "Network-wide validator/operator leaderboard, grouped by hotkey across every subnet it operates in. Mirrors GET /api/v1/validators."
     validators(sort: String, limit: Int): ValidatorList!
     "One validator's cross-subnet aggregate by hotkey; a hotkey with no validator_permit=1 rows resolves to a schema-stable zeroed aggregate, never null. Mirrors GET /api/v1/validators/{hotkey}."
@@ -413,6 +416,56 @@ export const SDL = `
     next_block_number: Int
   }
 
+  type BlocksSummary {
+    schema_version: Int
+    block_count: Int!
+    first_block: Int
+    last_block: Int
+    first_observed_at: String
+    last_observed_at: String
+    "Inter-block time distribution over the window; null when fewer than two consecutive blocks are present."
+    block_time: BlockTimeDistribution
+    throughput: BlockThroughput
+    distinct_authors: Int!
+    "Block-authorship decentralization over the window; null when no block carried an author."
+    author_concentration: BlockAuthorConcentration
+    distinct_spec_versions: Int!
+    "The runtime spec version at the newest block in the window."
+    latest_spec_version: Int
+  }
+
+  type BlockTimeDistribution {
+    count: Int!
+    mean_ms: Int!
+    min_ms: Int!
+    max_ms: Int!
+    p50_ms: Int!
+    p90_ms: Int!
+  }
+
+  type BlockThroughput {
+    total_extrinsics: Int!
+    total_events: Int!
+    mean_extrinsics_per_block: Float!
+    mean_events_per_block: Float!
+    max_extrinsics_in_block: Int!
+  }
+
+  type BlockAuthorConcentration {
+    holders: Int!
+    total: Float!
+    gini: Float!
+    hhi: Float!
+    hhi_normalized: Float!
+    nakamoto_coefficient: Int!
+    top_1pct_share: Float!
+    top_5pct_share: Float!
+    top_10pct_share: Float!
+    top_20pct_share: Float!
+    entropy: Float!
+    entropy_normalized: Float!
+  }
+
   type ValidatorList {
     items: [Validator!]!
     total: Int!
@@ -696,6 +749,7 @@ export const FIELD_COMPLEXITY = {
   account: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
+  blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -1430,6 +1484,32 @@ const rootValue = {
       block: data.block ?? null,
       prev_block_number: data.prev_block_number ?? null,
       next_block_number: data.next_block_number ?? null,
+    };
+  },
+
+  async blocks_summary(_args, context) {
+    // #5664: blocks' D1 write path is retired and the table is dropped in
+    // production, so the Postgres tier being cold is the expected steady state --
+    // fall back to the same pure builder REST uses, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/blocks/summary"),
+        "METAGRAPH_BLOCKS_SOURCE",
+      )) ?? buildBlocksSummary([]);
+    return {
+      schema_version: data.schema_version ?? 1,
+      block_count: data.block_count ?? 0,
+      first_block: data.first_block ?? null,
+      last_block: data.last_block ?? null,
+      first_observed_at: data.first_observed_at ?? null,
+      last_observed_at: data.last_observed_at ?? null,
+      block_time: data.block_time ?? null,
+      throughput: data.throughput ?? null,
+      distinct_authors: data.distinct_authors ?? 0,
+      author_concentration: data.author_concentration ?? null,
+      distinct_spec_versions: data.distinct_spec_versions ?? 0,
+      latest_spec_version: data.latest_spec_version ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -2193,6 +2193,119 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
   });
 });
 
+describe("graphql — blocks_summary (#5664, Postgres-tier feed)", () => {
+  test("blocks_summary: cold/no-tier store returns the schema-stable zeroed card (fallback builder, production steady state)", async () => {
+    const { status, body } = await gql(
+      "{ blocks_summary { schema_version block_count first_block last_block block_time { count } throughput { total_extrinsics } distinct_authors author_concentration { holders } distinct_spec_versions latest_spec_version } }",
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.blocks_summary, {
+      schema_version: 1,
+      block_count: 0,
+      first_block: null,
+      last_block: null,
+      block_time: null,
+      throughput: null,
+      distinct_authors: 0,
+      author_concentration: null,
+      distinct_spec_versions: 0,
+      latest_spec_version: null,
+    });
+  });
+
+  test("blocks_summary: resolves Postgres-tier rows into the production summary", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            block_count: 2,
+            first_block: 100,
+            last_block: 101,
+            first_observed_at: "2026-07-14T00:00:00.000Z",
+            last_observed_at: "2026-07-14T00:00:12.000Z",
+            block_time: {
+              count: 1,
+              mean_ms: 12000,
+              min_ms: 12000,
+              max_ms: 12000,
+              p50_ms: 12000,
+              p90_ms: 12000,
+            },
+            throughput: {
+              total_extrinsics: 5,
+              total_events: 9,
+              mean_extrinsics_per_block: 2.5,
+              mean_events_per_block: 4.5,
+              max_extrinsics_in_block: 3,
+            },
+            distinct_authors: 2,
+            author_concentration: {
+              holders: 2,
+              total: 2,
+              gini: 0,
+              hhi: 0.5,
+              hhi_normalized: 0,
+              nakamoto_coefficient: 1,
+              top_1pct_share: 0.5,
+              top_5pct_share: 0.5,
+              top_10pct_share: 0.5,
+              top_20pct_share: 0.5,
+              entropy: 1,
+              entropy_normalized: 1,
+            },
+            distinct_spec_versions: 1,
+            latest_spec_version: 200,
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      "{ blocks_summary { block_count first_block last_block block_time { count mean_ms p50_ms p90_ms } throughput { total_extrinsics mean_extrinsics_per_block } distinct_authors author_concentration { holders gini nakamoto_coefficient } distinct_spec_versions latest_spec_version } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.pathname, "/api/v1/blocks/summary");
+    assert.equal(body.data.blocks_summary.block_count, 2);
+    assert.equal(body.data.blocks_summary.first_block, 100);
+    assert.equal(body.data.blocks_summary.last_block, 101);
+    assert.equal(body.data.blocks_summary.block_time.count, 1);
+    assert.equal(body.data.blocks_summary.throughput.total_extrinsics, 5);
+    assert.equal(body.data.blocks_summary.distinct_authors, 2);
+    assert.equal(
+      body.data.blocks_summary.author_concentration.nakamoto_coefficient,
+      1,
+    );
+    assert.equal(body.data.blocks_summary.distinct_spec_versions, 1);
+    assert.equal(body.data.blocks_summary.latest_spec_version, 200);
+  });
+
+  test("blocks_summary: a malformed Postgres-tier body degrades to the schema-stable zeroed card", async () => {
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      "{ blocks_summary { block_count block_time { count } throughput { total_extrinsics } author_concentration { holders } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.blocks_summary, {
+      block_count: 0,
+      block_time: null,
+      throughput: null,
+      author_concentration: null,
+    });
+  });
+
+  test("blocks_summary is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.blocks_summary, 5);
+  });
+});
+
 describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## What

Adds `Query.blocks_summary` to the GraphQL SDL in `src/graphql.mjs`, mirroring `GET /api/v1/blocks/summary` (REST) and `get_blocks_summary` (MCP) — the last gap in the `Query.blocks`/`Query.block` sibling family (#5573/#5574/#5575/#5580).

- `Query.blocks_summary: BlocksSummary!` (no args, matching REST's `validateQueryParams(url, [])`), placed next to `blocks`/`block` with an SDL doc-comment.
- `BlocksSummary` type plus nested `BlockTimeDistribution`, `BlockThroughput`, `BlockAuthorConcentration` types, shaped directly off `buildBlocksSummary`'s real return object (`src/blocks-summary.mjs`).
- Resolver added to `rootValue`, using the same `tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE")` → `buildBlocksSummary([])` fallback contract REST/MCP use, so a cold/retired-D1 store returns the schema-stable zeroed card instead of a GraphQL error. Each field is extracted with an explicit `??` default (matching the `blocks`/`block` resolvers' pattern) so a malformed upstream body can't violate the schema's non-null fields.
- `blocks_summary` added to `FIELD_COMPLEXITY` at the `RELATIONSHIP_FIELD_COMPLEXITY` weight, same as `blocks`/`block`.

## Tests

`tests/graphql.test.mjs`: cold/no-tier fallback (zeroed card), a successful Postgres-tier resolve (including nested `block_time`/`throughput`/`author_concentration` fields and the forwarded request path), a malformed Postgres-tier body degrading to the zeroed card, and the fan-out complexity weight.

## Validation run

- `npm run lint`
- `npm run format:check`
- `npm run validate`
- `npm run validate:contract-drift`
- `npm run build`
- `npm run test:coverage` (full suite, unsharded) — 8413 passed; `src/graphql.mjs` at 100% line coverage

Closes #5664
