### PR TITLE
feat(graphql): add Query.economics_trends mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -47,6 +47,8 @@ import {
 import { buildAccountSummary } from "./account-events.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
 import { SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
+import { parseHistoryWindow } from "./neuron-history.mjs";
+import { loadEconomicsTrends } from "./economics-trends.mjs";
 
 export const GRAPHQL_MAX_DEPTH = 7;
 export const GRAPHQL_MAX_COMPLEXITY = 50;
@@ -96,6 +98,8 @@ export const SDL = `
     accounts(sort: String, limit: Int): AccountList!
     "One account's cross-subnet event-history summary by ss58 address; an address with no matching account_events rows resolves to a schema-stable zero summary, never null. Mirrors GET /api/v1/accounts/{ss58}."
     account(ss58: String!): AccountSummary
+    "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
+    economics_trends(window: String): EconomicsTrends!
   }
 
   type SubnetList {
@@ -191,6 +195,26 @@ export const SDL = `
     alpha_out_pool: Float
     owner_coldkey: String
     owner_hotkey: String
+  }
+
+  type EconomicsTrends {
+    schema_version: Int!
+    window: String
+    day_count: Int!
+    days: [EconomicsTrendsDay!]!
+  }
+
+  "One UTC day of network-wide economics aggregated across every subnet with a snapshot that day. Sums are null only when no subnet reported a value that day."
+  type EconomicsTrendsDay {
+    snapshot_date: String!
+    subnet_count: Int!
+    "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float."
+    total_stake_tao: String
+    alpha_price_tao_weighted: Float
+    alpha_price_tao_median: Float
+    validator_count: Int
+    miner_count: Int
+    mean_emission_share: Float
   }
 
   type SurfaceList {
@@ -696,6 +720,7 @@ export const FIELD_COMPLEXITY = {
   account: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
+  economics_trends: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -1531,6 +1556,42 @@ const rootValue = {
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) ?? buildAccountSummary(ss58, {});
     return accountSummaryNode(data, ss58);
+  },
+
+  async economics_trends({ window }, context) {
+    // Same parseHistoryWindow REST uses, so accepted window labels and the
+    // resulting { label, days } stay identical between REST and GraphQL.
+    const { label, days, error } = parseHistoryWindow(window);
+    if (error) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const params = new URLSearchParams();
+    params.set("window", label);
+    // #4832 gap-closure: reuses METAGRAPH_SUBNET_SNAPSHOTS_SOURCE, same tier
+    // and fallback contract REST's handleEconomicsTrends uses.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/economics/trends", params),
+        "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
+      )) ??
+      (
+        await loadEconomicsTrends(graphqlD1(context), {
+          windowLabel: label,
+          windowDays: days,
+        })
+      ).data;
+    // Normalized the same way blocks/validators/accounts are (schema-stable,
+    // never a GraphQL error), so a malformed/partial Postgres-tier body still
+    // satisfies the non-null EconomicsTrends! contract.
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? label,
+      day_count: data.day_count ?? 0,
+      days: data.days || [],
+    };
   },
 };
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -2801,6 +2801,181 @@ function asPlainJson(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
+describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag / no D1 rows returns a schema-stable empty series", async () => {
+    const { status, body } = await gql(
+      "{ economics_trends { schema_version window day_count days { snapshot_date } } }",
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.economics_trends, {
+      schema_version: 1,
+      window: "30d",
+      day_count: 0,
+      days: [],
+    });
+  });
+
+  test("resolves Postgres-tier days when the tier flag is set", async () => {
+    const env = {
+      METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          window: "90d",
+          day_count: 1,
+          days: [
+            {
+              snapshot_date: "2026-07-01",
+              subnet_count: 3,
+              total_stake_tao: "1000.000000000",
+              alpha_price_tao_weighted: 0.06,
+              alpha_price_tao_median: 0.05,
+              validator_count: 12,
+              miner_count: 200,
+              mean_emission_share: 0.02,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ economics_trends(window: "90d") {
+          window day_count
+          days { snapshot_date subnet_count total_stake_tao alpha_price_tao_weighted alpha_price_tao_median validator_count miner_count mean_emission_share }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.economics_trends.window, "90d");
+    assert.equal(body.data.economics_trends.day_count, 1);
+    const day = body.data.economics_trends.days[0];
+    assert.equal(day.snapshot_date, "2026-07-01");
+    assert.equal(day.subnet_count, 3);
+    assert.equal(day.total_stake_tao, "1000.000000000");
+    assert.equal(day.alpha_price_tao_weighted, 0.06);
+    assert.equal(day.validator_count, 12);
+    assert.equal(day.miner_count, 200);
+    assert.equal(day.mean_emission_share, 0.02);
+  });
+
+  test("window is forwarded as a query param to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            window: "7d",
+            day_count: 0,
+            days: [],
+          });
+        },
+      },
+    };
+    await gql('{ economics_trends(window: "7d") { day_count } }', env);
+    assert.equal(capturedUrl.pathname, "/api/v1/economics/trends");
+    assert.equal(capturedUrl.searchParams.get("window"), "7d");
+  });
+
+  test("a malformed Postgres-tier body falls back to the D1 rollup (schema-stable empty on cold D1)", async () => {
+    const env = {
+      METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      "{ economics_trends { day_count days { snapshot_date } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.economics_trends.day_count, 0);
+    assert.deepEqual(body.data.economics_trends.days, []);
+  });
+
+  test("no Postgres tier flag: rolls up subnet_snapshots rows straight off D1", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  return {
+                    results: [
+                      {
+                        snapshot_date: "2026-06-10",
+                        total_stake_tao: 1000,
+                        alpha_price_tao: 0.06,
+                        validator_count: 12,
+                        miner_count: 200,
+                        emission_share: 0.05,
+                      },
+                    ],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const { status, body } = await gql(
+      `{ economics_trends(window: "7d") {
+          window day_count days { snapshot_date total_stake_tao validator_count }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.economics_trends.window, "7d");
+    assert.equal(body.data.economics_trends.day_count, 1);
+    assert.equal(
+      body.data.economics_trends.days[0].snapshot_date,
+      "2026-06-10",
+    );
+    assert.equal(
+      body.data.economics_trends.days[0].total_stake_tao,
+      "1000.000000000",
+    );
+    assert.equal(body.data.economics_trends.days[0].validator_count, 12);
+  });
+
+  test("a D1 query error degrades to a schema-stable empty series (no throw)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          throw new Error("db unavailable");
+        },
+      },
+    };
+    const { status, body } = await gql(
+      "{ economics_trends { day_count days { snapshot_date } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.economics_trends.day_count, 0);
+    assert.deepEqual(body.data.economics_trends.days, []);
+  });
+
+  test("an unsupported window is a GraphQL error, not a silently substituted default", async () => {
+    const { status, body } = await gql(
+      '{ economics_trends(window: "99d") { day_count } }',
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.match(body.errors[0].message, /99d/);
+  });
+
+  test("economics_trends is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.economics_trends, 5);
+  });
+});
+
 describe("Subscription.chainEvents", () => {
   test("yields a properly-shaped GraphQL execution result for each pushed payload", async () => {
     const hub = fakeChainFirehose((repeater) => {


### PR DESCRIPTION
## Summary

- Adds `Query.economics_trends` to the GraphQL SDL in `src/graphql.mjs`, mirroring `GET /api/v1/economics/trends` and the `get_economics_trends` MCP tool so the same network-wide economics time series is reachable over `POST /api/v1/graphql`.

## What Changed

- `src/graphql.mjs`: new `economics_trends(window: String): EconomicsTrends!` field on `Query`, with `EconomicsTrends` / `EconomicsTrendsDay` types mirroring `loadEconomicsTrends`'s real per-day shape (`total_stake_tao` is a `String` — rao-precision, exceeds the exact-double ceiling as a JSON number — not a `Float`), not the CSV column list.
- Resolver validates `window` with the same `parseHistoryWindow` REST uses (an unsupported window is a GraphQL `BAD_USER_INPUT` error, never a silently substituted default) and resolves via the same `tryPostgresTier(env, request, "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE")` → `loadEconomicsTrends` D1-fallback contract REST's `handleEconomicsTrends` uses, normalized the same schema-stable way `blocks`/`validators`/`accounts` already are.
- Added `economics_trends` to `FIELD_COMPLEXITY` at the `RELATIONSHIP_FIELD_COMPLEXITY` weight (fan-out field, same as every other root query).
- `tests/graphql.test.mjs`: cold-store schema-stable-empty case, a Postgres-tier hit, window forwarded as a query param, a malformed Postgres-tier body normalizing to schema-stable-empty, the D1-fallback rollup path, a D1 query error degrading to schema-stable-empty, an unsupported window returning `BAD_USER_INPUT`, and the complexity-weight assertion.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (GraphQL-only; no `schemas/`/OpenAPI change — the new field mirrors the existing REST/MCP contract, no new REST route.)

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate`
- [x] `npm run validate:contract-drift`
- [x] `npm run validate:types`
- [x] `npm run scan:public-safety`
- [x] `npm run test:coverage` (282 files / 8417 tests passed; `src/graphql.mjs` 100% statements/lines, 100% functions, 98.13% branch — the only uncovered branches are pre-existing, in the untouched `health`/`opportunity_boards` resolvers)
- [x] `git diff --check`

Closes #5663
