### PR TITLE
feat(ui): add Economics docs page

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -366,6 +366,7 @@ function SiteFooter() {
           <FooterLink to="/graphql">GraphQL</FooterLink>
           <FooterLink to="/rpc">RPC</FooterLink>
           <FooterLink to="/feeds">Feeds</FooterLink>
+          <FooterLink to="/economics">Economics</FooterLink>
           <FooterLink to="/gaps">Gaps</FooterLink>
           <FooterLink to="/chain-events">Chain events reference</FooterLink>
           <FooterLink to="/agents">For agents</FooterLink>

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -15,6 +15,7 @@ import {
   ArrowRightLeft,
   Bot,
   Braces,
+  Coins,
   Compass,
   Copy,
   ExternalLink,
@@ -139,6 +140,13 @@ const ROUTE_INDEX: Array<{
     to: "/feeds",
     hint: "RSS, Atom, JSON Feed subscriptions",
     icon: Rss,
+    scope: "route",
+  },
+  {
+    label: "Economics",
+    to: "/economics",
+    hint: "Stake, alpha price, emission share, trends",
+    icon: Coins,
     scope: "route",
   },
   {

--- a/apps/ui/src/lib/metagraphed/economics-docs.test.ts
+++ b/apps/ui/src/lib/metagraphed/economics-docs.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  ECONOMICS_ARTIFACT_PATH,
+  ECONOMICS_MAX_LIMIT,
+  ECONOMICS_PARAMS,
+  ECONOMICS_PATH,
+  ECONOMICS_SEARCH_KEYS,
+  ECONOMICS_SORT_FIELDS,
+  ECONOMICS_SORT_FIELD_COUNT,
+  ECONOMICS_SURFACES,
+  ECONOMICS_SURFACE_COUNT,
+  ECONOMICS_TRENDS_DEFAULT_WINDOW,
+  ECONOMICS_TRENDS_METRICS,
+  ECONOMICS_TRENDS_PATH,
+  ECONOMICS_TRENDS_WINDOWS,
+  buildEconomicsCurlExample,
+  buildEconomicsTrendsCurlExample,
+} from "./economics-docs";
+
+describe("economics docs reference (#3509)", () => {
+  it("keeps Worker-aligned paths and limits", () => {
+    expect(ECONOMICS_PATH).toBe("/api/v1/economics");
+    expect(ECONOMICS_TRENDS_PATH).toBe("/api/v1/economics/trends");
+    expect(ECONOMICS_ARTIFACT_PATH).toBe("/metagraph/economics.json");
+    expect(ECONOMICS_MAX_LIMIT).toBe(1000);
+  });
+
+  it("documents both surfaces exactly once", () => {
+    expect(ECONOMICS_SURFACES).toHaveLength(ECONOMICS_SURFACE_COUNT);
+    const paths = ECONOMICS_SURFACES.map((s) => s.path);
+    expect(paths).toEqual([ECONOMICS_PATH, ECONOMICS_TRENDS_PATH]);
+    expect(new Set(paths).size).toBe(paths.length);
+    for (const s of ECONOMICS_SURFACES) expect(s.method).toBe("GET");
+  });
+
+  it("mirrors the collection's sort fields without duplicates", () => {
+    expect(ECONOMICS_SORT_FIELDS).toHaveLength(ECONOMICS_SORT_FIELD_COUNT);
+    expect(new Set(ECONOMICS_SORT_FIELDS).size).toBe(ECONOMICS_SORT_FIELDS.length);
+    // Sorted, so the rendered list is stable and scannable.
+    expect([...ECONOMICS_SORT_FIELDS]).toEqual([...ECONOMICS_SORT_FIELDS].sort());
+    for (const f of ["emission_share", "alpha_price_tao", "total_stake_tao", "netuid"]) {
+      expect(ECONOMICS_SORT_FIELDS).toContain(f);
+    }
+  });
+
+  it("documents the filter/search/list params", () => {
+    expect(ECONOMICS_PARAMS.map((p) => p.param)).toEqual([
+      "q",
+      "netuid",
+      "registration_allowed",
+      "sort",
+      "order",
+      "limit",
+      "cursor",
+      "fields",
+      "format",
+    ]);
+    expect([...ECONOMICS_SEARCH_KEYS]).toEqual(["name", "slug"]);
+    expect(ECONOMICS_PARAMS.find((p) => p.param === "q")?.detail).toContain("name and slug");
+    expect(ECONOMICS_PARAMS.find((p) => p.param === "limit")?.value).toBe(
+      `1..${ECONOMICS_MAX_LIMIT}`,
+    );
+    // The combined `field:desc` token is explicitly unsupported — say so.
+    expect(ECONOMICS_PARAMS.find((p) => p.param === "sort")?.detail).toContain("NOT supported");
+  });
+
+  it("documents the trends windows and per-day metrics", () => {
+    expect([...ECONOMICS_TRENDS_WINDOWS]).toEqual(["7d", "30d", "90d", "1y", "all"]);
+    expect(ECONOMICS_TRENDS_WINDOWS).toContain(ECONOMICS_TRENDS_DEFAULT_WINDOW);
+    expect(ECONOMICS_TRENDS_DEFAULT_WINDOW).toBe("30d");
+    expect(ECONOMICS_TRENDS_METRICS.length).toBeGreaterThan(0);
+  });
+
+  it("builds curl examples against the real routes", () => {
+    const list = buildEconomicsCurlExample("https://api.metagraph.sh/");
+    expect(list).toContain("https://api.metagraph.sh/api/v1/economics?");
+    expect(list).toContain("order=desc");
+    expect(list).not.toContain("//api/v1");
+
+    const trends = buildEconomicsTrendsCurlExample("https://api.metagraph.sh", "90d");
+    expect(trends).toContain("/api/v1/economics/trends?window=90d");
+    expect(buildEconomicsTrendsCurlExample("https://api.metagraph.sh")).toContain("window=30d");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/economics-docs.ts
+++ b/apps/ui/src/lib/metagraphed/economics-docs.ts
@@ -1,0 +1,143 @@
+/**
+ * Static reference copy for the `/economics` docs page (#3509).
+ *
+ * Paths, filters, sort fields, and windows mirror the `economics` /
+ * `economics-trends` route contracts in `src/contracts.mjs` — keep them in sync
+ * when the Worker contract changes. The UI cannot import Worker `.mjs` modules,
+ * so these are intentional literals.
+ *
+ * @see https://github.com/JSONbored/metagraphed/issues/3509
+ */
+
+export const ECONOMICS_PATH = "/api/v1/economics";
+export const ECONOMICS_TRENDS_PATH = "/api/v1/economics/trends";
+
+/** Static artifact backing the list route (trends is computed live). */
+export const ECONOMICS_ARTIFACT_PATH = "/metagraph/economics.json";
+
+/** Keep aligned with the `limit` schema in listQuery (src/contracts.mjs). */
+export const ECONOMICS_MAX_LIMIT = 1000;
+
+/** Keep aligned with the `window` enum on the economics-trends route. */
+export const ECONOMICS_TRENDS_WINDOWS = ["7d", "30d", "90d", "1y", "all"] as const;
+
+export type EconomicsTrendsWindow = (typeof ECONOMICS_TRENDS_WINDOWS)[number];
+
+export const ECONOMICS_TRENDS_DEFAULT_WINDOW: EconomicsTrendsWindow = "30d";
+
+/** Keep aligned with API_QUERY_COLLECTIONS.economics.search in src/contracts.mjs. */
+export const ECONOMICS_SEARCH_KEYS = ["name", "slug"] as const;
+
+/** Keep aligned with API_QUERY_COLLECTIONS.economics.sort in src/contracts.mjs. */
+export const ECONOMICS_SORT_FIELDS = [
+  "alpha_fdv_tao",
+  "alpha_market_cap_tao",
+  "alpha_price_tao",
+  "block",
+  "emission_share",
+  "max_stake_tao",
+  "max_uids",
+  "max_validators",
+  "miner_count",
+  "miner_readiness",
+  "name",
+  "netuid",
+  "open_slots",
+  "registration_cost_tao",
+  "subnet_volume_tao",
+  "total_stake_tao",
+  "validator_count",
+] as const;
+
+export type EconomicsSurfaceDoc = {
+  method: string;
+  path: string;
+  summary: string;
+  notes: string;
+};
+
+export const ECONOMICS_SURFACES: readonly EconomicsSurfaceDoc[] = [
+  {
+    method: "GET",
+    path: ECONOMICS_PATH,
+    summary: "Per-subnet economic metrics",
+    notes:
+      "Counts, stake, registration cost, alpha price, alpha market-cap and FDV proxies, emission share, and registration block. Served from the economics artifact; ordered by emission share descending by default.",
+  },
+  {
+    method: "GET",
+    path: ECONOMICS_TRENDS_PATH,
+    summary: "Network-wide time series",
+    notes:
+      "One row per UTC day across all subnets, aggregated live from the daily subnet_snapshots rollup — the same source the per-subnet /trajectory reads. No static file; returns day_count 0 and an empty days[] while the rollup is cold.",
+  },
+] as const;
+
+export type EconomicsParamDoc = {
+  param: string;
+  value: string;
+  detail: string;
+};
+
+/** Query params on GET /api/v1/economics (filters + search + list controls). */
+export const ECONOMICS_PARAMS: readonly EconomicsParamDoc[] = [
+  {
+    param: "q",
+    value: "<text>",
+    detail: `Search across ${ECONOMICS_SEARCH_KEYS.join(" and ")}.`,
+  },
+  { param: "netuid", value: "<integer>", detail: "Restrict to a single subnet." },
+  {
+    param: "registration_allowed",
+    value: "true | false",
+    detail: "Only subnets whose registration is currently open (or closed).",
+  },
+  {
+    param: "sort",
+    value: "<field>",
+    detail:
+      "The bare field name only (see the sortable fields below). A combined `field:desc` token is NOT supported — pair it with `order`.",
+  },
+  { param: "order", value: "asc | desc", detail: "Direction for `sort`. Defaults to desc." },
+  {
+    param: "limit",
+    value: `1..${ECONOMICS_MAX_LIMIT}`,
+    detail: "Page size.",
+  },
+  { param: "cursor", value: "<integer>", detail: "Offset cursor for the next page." },
+  { param: "fields", value: "<a,b,c>", detail: "Project a comma-separated subset of fields." },
+  {
+    param: "format",
+    value: "json | csv",
+    detail: "`csv` downloads the transformed list as text/csv; `json` keeps the response envelope.",
+  },
+] as const;
+
+/** Per-day metrics returned by the trends route. */
+export const ECONOMICS_TRENDS_METRICS = [
+  "total stake",
+  "stake-weighted alpha price",
+  "median alpha price",
+  "total validator count",
+  "total miner count",
+  "mean emission share",
+] as const;
+
+export function buildEconomicsCurlExample(apiBase: string): string {
+  const base = apiBase.replace(/\/$/, "");
+  return `curl -s '${base}${ECONOMICS_PATH}?sort=alpha_market_cap_tao&order=desc&limit=5'`;
+}
+
+export function buildEconomicsTrendsCurlExample(
+  apiBase: string,
+  window: EconomicsTrendsWindow = ECONOMICS_TRENDS_DEFAULT_WINDOW,
+): string {
+  const base = apiBase.replace(/\/$/, "");
+  return `curl -s '${base}${ECONOMICS_TRENDS_PATH}?window=${window}'`;
+}
+
+/** Expected surface count — guards accidental drift. */
+export const ECONOMICS_SURFACE_COUNT = 2;
+
+/** Expected sortable-field count — guards drift against the Worker contract. */
+export const ECONOMICS_SORT_FIELD_COUNT = 17;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as GapsRouteImport } from './routes/gaps'
 import { Route as FeedsRouteImport } from './routes/feeds'
 import { Route as ExplorerRouteImport } from './routes/explorer'
 import { Route as EndpointsRouteImport } from './routes/endpoints'
+import { Route as EconomicsRouteImport } from './routes/economics'
 import { Route as ChainEventsRouteImport } from './routes/chain-events'
 import { Route as AgentsRouteImport } from './routes/agents'
 import { Route as AboutRouteImport } from './routes/about'
@@ -99,6 +100,11 @@ const ExplorerRoute = ExplorerRouteImport.update({
 const EndpointsRoute = EndpointsRouteImport.update({
   id: '/endpoints',
   path: '/endpoints',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const EconomicsRoute = EconomicsRouteImport.update({
+  id: '/economics',
+  path: '/economics',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ChainEventsRoute = ChainEventsRouteImport.update({
@@ -202,6 +208,7 @@ export interface FileRoutesByFullPath {
   '/about': typeof AboutRoute
   '/agents': typeof AgentsRoute
   '/chain-events': typeof ChainEventsRoute
+  '/economics': typeof EconomicsRoute
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
   '/feeds': typeof FeedsRoute
@@ -235,6 +242,7 @@ export interface FileRoutesByTo {
   '/about': typeof AboutRoute
   '/agents': typeof AgentsRoute
   '/chain-events': typeof ChainEventsRoute
+  '/economics': typeof EconomicsRoute
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
   '/feeds': typeof FeedsRoute
@@ -269,6 +277,7 @@ export interface FileRoutesById {
   '/about': typeof AboutRoute
   '/agents': typeof AgentsRoute
   '/chain-events': typeof ChainEventsRoute
+  '/economics': typeof EconomicsRoute
   '/endpoints': typeof EndpointsRoute
   '/explorer': typeof ExplorerRoute
   '/feeds': typeof FeedsRoute
@@ -304,6 +313,7 @@ export interface FileRouteTypes {
     | '/about'
     | '/agents'
     | '/chain-events'
+    | '/economics'
     | '/endpoints'
     | '/explorer'
     | '/feeds'
@@ -337,6 +347,7 @@ export interface FileRouteTypes {
     | '/about'
     | '/agents'
     | '/chain-events'
+    | '/economics'
     | '/endpoints'
     | '/explorer'
     | '/feeds'
@@ -370,6 +381,7 @@ export interface FileRouteTypes {
     | '/about'
     | '/agents'
     | '/chain-events'
+    | '/economics'
     | '/endpoints'
     | '/explorer'
     | '/feeds'
@@ -404,6 +416,7 @@ export interface RootRouteChildren {
   AboutRoute: typeof AboutRoute
   AgentsRoute: typeof AgentsRoute
   ChainEventsRoute: typeof ChainEventsRoute
+  EconomicsRoute: typeof EconomicsRoute
   EndpointsRoute: typeof EndpointsRoute
   ExplorerRoute: typeof ExplorerRoute
   FeedsRoute: typeof FeedsRoute
@@ -517,6 +530,13 @@ declare module '@tanstack/react-router' {
       path: '/endpoints'
       fullPath: '/endpoints'
       preLoaderRoute: typeof EndpointsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/economics': {
+      id: '/economics'
+      path: '/economics'
+      fullPath: '/economics'
+      preLoaderRoute: typeof EconomicsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/chain-events': {
@@ -660,6 +680,7 @@ const rootRouteChildren: RootRouteChildren = {
   AboutRoute: AboutRoute,
   AgentsRoute: AgentsRoute,
   ChainEventsRoute: ChainEventsRoute,
+  EconomicsRoute: EconomicsRoute,
   EndpointsRoute: EndpointsRoute,
   ExplorerRoute: ExplorerRoute,
   FeedsRoute: FeedsRoute,

--- a/apps/ui/src/routes/economics.tsx
+++ b/apps/ui/src/routes/economics.tsx
@@ -1,0 +1,216 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { CopyButton, PageHero, SectionHeading } from "@jsonbored/ui-kit";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
+import {
+  ECONOMICS_ARTIFACT_PATH,
+  ECONOMICS_PARAMS,
+  ECONOMICS_PATH,
+  ECONOMICS_SORT_FIELDS,
+  ECONOMICS_SURFACES,
+  ECONOMICS_TRENDS_DEFAULT_WINDOW,
+  ECONOMICS_TRENDS_METRICS,
+  ECONOMICS_TRENDS_PATH,
+  ECONOMICS_TRENDS_WINDOWS,
+  buildEconomicsCurlExample,
+  buildEconomicsTrendsCurlExample,
+} from "@/lib/metagraphed/economics-docs";
+
+export const Route = createFileRoute("/economics")({
+  head: () => ({
+    meta: [
+      { title: "Economics — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Metagraphed economics endpoints — per-subnet stake, alpha price, market-cap and FDV proxies, emission share, and the network-wide daily time series. No API key.",
+      },
+      { property: "og:title", content: "Economics — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "GET /api/v1/economics and /economics/trends — filter, sort, page, or download as CSV.",
+      },
+    ],
+  }),
+  component: EconomicsDocsPage,
+});
+
+const ECONOMICS_URL = `${API_BASE}${ECONOMICS_PATH}`;
+const LIST_CURL = buildEconomicsCurlExample(DEFAULT_API_BASE);
+const TRENDS_CURL = buildEconomicsTrendsCurlExample(DEFAULT_API_BASE);
+
+function EconomicsDocsPage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="API"
+        live
+        title="Economics"
+        description="Per-subnet stake, alpha price, market-cap and FDV proxies, registration cost, and emission share — plus the network-wide daily time series. Read-only, no API key."
+      />
+
+      <div className="mt-6 space-y-section" data-testid="economics-docs">
+        <section>
+          <SectionHeading
+            title="Endpoints"
+            intro="Two GET routes: a per-subnet snapshot list and the network-wide daily rollup."
+          />
+          <div className="space-y-2">
+            <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  GET
+                </div>
+                <code className="mt-0.5 block overflow-x-auto whitespace-nowrap font-mono text-[13px] text-ink-strong">
+                  {ECONOMICS_URL}
+                </code>
+              </div>
+              <CopyButton value={ECONOMICS_URL} label="economics URL" />
+            </div>
+            <div className="overflow-x-auto rounded-lg border border-border">
+              <table className="w-full min-w-[36rem] text-left text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                    <th className="px-3 py-2.5 font-normal">Method</th>
+                    <th className="px-3 py-2.5 font-normal">Path</th>
+                    <th className="px-3 py-2.5 font-normal">Summary</th>
+                    <th className="px-3 py-2.5 font-normal">Notes</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {ECONOMICS_SURFACES.map((row) => (
+                    <tr key={row.path} className="align-top">
+                      <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                        {row.method}
+                      </td>
+                      <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">
+                        {row.path}
+                      </td>
+                      <td className="px-3 py-2.5 text-[12px] text-ink">{row.summary}</td>
+                      <td className="px-3 py-2.5 text-[12px] text-ink-muted">{row.notes}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Filtering & sorting"
+            intro="Params on the list route. `sort` takes a bare field name and pairs with the separate `order` param — a combined `field:desc` token is not supported."
+          />
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-[28rem] text-left text-sm">
+              <thead>
+                <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  <th className="px-3 py-2.5 font-normal">Param</th>
+                  <th className="px-3 py-2.5 font-normal">Value</th>
+                  <th className="px-3 py-2.5 font-normal">Notes</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {ECONOMICS_PARAMS.map((row) => (
+                  <tr key={row.param} className="align-top">
+                    <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                      ?{row.param}=
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2.5 font-mono text-[12px] text-ink">
+                      {row.value}
+                    </td>
+                    <td className="px-3 py-2.5 text-[12px] text-ink-muted">{row.detail}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="mt-3 rounded-lg border border-border bg-card px-4 py-3">
+            <div className="mb-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              Sortable fields
+            </div>
+            <ul className="flex flex-wrap gap-x-3 gap-y-1 font-mono text-[12px] text-ink-strong">
+              {ECONOMICS_SORT_FIELDS.map((field) => (
+                <li key={field}>{field}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="mt-3 rounded-lg border border-border bg-card px-4 py-3">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Example
+              </div>
+              <CopyButton value={LIST_CURL} label="economics curl example" />
+            </div>
+            <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-[12px] leading-relaxed text-ink-strong">
+              {LIST_CURL}
+            </pre>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Trends"
+            intro="One row per UTC day across all subnets, aggregated live from the daily subnet_snapshots rollup. Pass ?format=csv to download the per-day series."
+          />
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="rounded-lg border border-border bg-card px-4 py-3">
+              <div className="mb-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Windows (?window=)
+              </div>
+              <ul className="flex flex-wrap gap-x-3 gap-y-1 font-mono text-[12px] text-ink-strong">
+                {ECONOMICS_TRENDS_WINDOWS.map((w) => (
+                  <li key={w}>
+                    {w}
+                    {w === ECONOMICS_TRENDS_DEFAULT_WINDOW ? (
+                      <span className="ml-1 text-ink-muted">(default)</span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded-lg border border-border bg-card px-4 py-3">
+              <div className="mb-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Per-day metrics
+              </div>
+              <ul className="space-y-1 font-mono text-[12px] text-ink-strong">
+                {ECONOMICS_TRENDS_METRICS.map((m) => (
+                  <li key={m}>{m}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+          <div className="mt-3 rounded-lg border border-border bg-card px-4 py-3">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Example
+              </div>
+              <CopyButton value={TRENDS_CURL} label="economics trends curl example" />
+            </div>
+            <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-[12px] leading-relaxed text-ink-strong">
+              {TRENDS_CURL}
+            </pre>
+          </div>
+          <p className="mt-3 font-mono text-[11px] text-ink-muted">
+            Live charts for this data:{" "}
+            <Link to="/subnets" className="text-accent hover:underline">
+              Subnets
+            </Link>
+            . Machine index:{" "}
+            <Link to="/agents" className="text-accent hover:underline">
+              For agents
+            </Link>
+            .
+          </p>
+        </section>
+      </div>
+
+      <ApiSourceFooter
+        paths={[ECONOMICS_PATH, ECONOMICS_TRENDS_PATH]}
+        artifacts={[ECONOMICS_ARTIFACT_PATH]}
+      />
+    </AppShell>
+  );
+}

--- a/apps/ui/tests/e2e/capture-economics-docs-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-economics-docs-screenshots.mjs
@@ -1,0 +1,80 @@
+/**
+ * Capture /economics docs page screenshots for #3509 (Path C2).
+ *
+ * New page — before captures are the 404/fallback when the route is missing;
+ * after captures show the live docs page.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=before node tests/e2e/capture-economics-docs-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=after  node tests/e2e/capture-economics-docs-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/economics-docs-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8085";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const VIEWPORT_FILTER = process.env.VIEWPORT_FILTER;
+const ALL_VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const VIEWPORTS = VIEWPORT_FILTER
+  ? ALL_VIEWPORTS.filter((v) => v.name === VIEWPORT_FILTER)
+  : ALL_VIEWPORTS;
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function openEconomicsDocs(page) {
+  await page.goto(`${BASE_URL}/economics`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 8000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+  const docs = page.locator('[data-testid="economics-docs"]');
+  const hero = page.getByRole("heading", { name: /^Economics$/i }).first();
+  try {
+    await docs.waitFor({ state: "visible", timeout: 5000 });
+  } catch {
+    await hero.waitFor({ state: "visible", timeout: 30_000 }).catch(() => {});
+  }
+  await page.waitForTimeout(250);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await setTheme(page, theme);
+      await openEconomicsDocs(page);
+      const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+      await context.close();
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Closes #3509

The economics endpoints had no docs page — the only reference was the route contract in `src/contracts.mjs`.

Adds `/economics`, mirroring the `/rpc` (#3515) and `/feeds` (#3512) docs pages:

- **Endpoints** — `GET /api/v1/economics` (per-subnet snapshot: stake, alpha price, market-cap + FDV proxies, registration cost, emission share; emission-share desc by default) and `GET /api/v1/economics/trends` (network-wide daily rollup, computed live from `subnet_snapshots` — `day_count: 0` / empty `days[]` while cold).
- **Filtering & sorting** — the `q` / `netuid` / `registration_allowed` / `sort` / `order` / `limit` / `cursor` / `fields` / `format` params, plus all 17 sortable fields. Calls out the contract's sharp edge explicitly: **`sort` takes a bare field name and pairs with a separate `order`** — a combined `field:desc` token is not supported.
- **Trends** — the `?window=7d|30d|90d|1y|all` enum (default `30d`) and the per-day metrics, with copyable curl examples for both routes.
- Wired into the footer **Operations** column and the command palette (`Coins` icon).

Reference copy lives in a pure `economics-docs` module whose paths, param set, sort fields, and window enum are unit-tested against the Worker contract, so drift fails the suite.

## Gates

typecheck OK - unit tests OK (`economics-docs.test.ts`, 6 new) - eslint `.` OK (0 errors) - prettier OK

## Screenshots

New route — before is the missing-route 404 (verified `HTTP 404` on main); after is the docs page. Captured with Playwright at the three SKILL viewports (375x812 / 768x1024 / 1280x800), each theme forced via `mg-theme`, fixed-viewport (never full-page). Capture script committed at `apps/ui/tests/e2e/capture-economics-docs-screenshots.mjs`.

| Viewport - Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/3509/after-mobile-dark.png)<br><sub>after</sub> |
