### PR TITLE
feat(deploy): add box-side runner image for registry-sync + testnet-discovery

### DIFF
--- a/deploy/data-refresh-node.Dockerfile
+++ b/deploy/data-refresh-node.Dockerfile
@@ -1,0 +1,35 @@
+# Box-side runner for the Node-only, no-chain-RPC data-refresh jobs:
+# registry-sync (replaces .github/workflows/resync-registry-postgres.yml)
+# and testnet-discovery (replaces
+# .github/workflows/discover-testnet-surfaces.yml). Neither job needs
+# Python/uv/bittensor -- unlike deploy/economics-refresh.Dockerfile, this is
+# pure Node + git, so a single container per run is enough (no untrusted-
+# PyPI-resolution step to isolate from a secret-holding step): npm ci
+# --ignore-scripts + a tracked-file integrity check (see
+# scripts/data-refresh-node-entrypoint.sh) is the supply-chain guard,
+# applied from the start rather than as a follow-up fix.
+#
+# Non-root (uid 10001, matching metagraph-fetch.Dockerfile/chain-firehose-
+# relay.Dockerfile/economics-refresh.Dockerfile's own convention). /repo is
+# pre-created + chowned here so the entrypoint's runtime git clone/npm ci
+# (which runs as this same non-root user) can write to it.
+#
+# Deployed via the data-refresh-node Ansible role in
+# JSONbored/metagraphed-infra, which copies this Dockerfile +
+# scripts/data-refresh-node-entrypoint.sh into
+# roles/data-refresh-node/files/ and builds directly on the indexer box.
+#
+# Local: docker build -f deploy/data-refresh-node.Dockerfile -t metagraphed-data-refresh-node .
+FROM node:22.23.1-slim
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -u 10001 -m runner \
+  && mkdir -p /repo \
+  && chown runner:runner /repo
+
+COPY scripts/data-refresh-node-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+USER runner
+ENTRYPOINT ["/entrypoint.sh"]

--- a/scripts/data-refresh-node-entrypoint.sh
+++ b/scripts/data-refresh-node-entrypoint.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Runs one step of the box-side Node-only data-refresh jobs (registry-sync,
+# testnet-discovery) -- see deploy/data-refresh-node.Dockerfile's header.
+# Unlike deploy/economics-refresh.Dockerfile's two-container split, neither
+# job here needs a separate untrusted-fetch step: both are pure JS with no
+# PyPI/uvx involved, so npm ci's own --ignore-scripts + integrity check
+# (below) is the only supply-chain guard needed, in ONE container.
+set -euo pipefail
+
+: "${STEP:?STEP env var required (registry-sync|testnet-discovery)}"
+
+REPO_DIR=/repo
+GIT_REPO_URL="https://github.com/JSONbored/metagraphed.git"
+# Floating branch, not a pinned commit SHA -- same rationale as
+# economics-refresh-entrypoint.sh: both jobs need to stay current with
+# registry data and code fixes, and main already requires review + CI +
+# the Gittensory Gate before anything lands.
+GIT_REF="main"
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+  # Clone into a temp dir, THEN copy its contents into $REPO_DIR -- see
+  # economics-refresh-entrypoint.sh's identical comment for why (an
+  # interrupted clone straight into $REPO_DIR would leave a partial .git
+  # that the next run's "already cloned?" check would treat as success;
+  # $REPO_DIR is the volume's own mount point, not a plain directory, so
+  # it can't be removed/replaced wholesale).
+  CLONE_TMP="$(mktemp -d /tmp/metagraphed-clone.XXXXXX)"
+  echo "entrypoint: cloning ${GIT_REPO_URL}@${GIT_REF} (first run on this volume)"
+  git clone --depth 1 --branch "$GIT_REF" "$GIT_REPO_URL" "$CLONE_TMP"
+  find "$REPO_DIR" -mindepth 1 -delete
+  cp -a "$CLONE_TMP"/. "$REPO_DIR"/
+  rm -rf "$CLONE_TMP"
+else
+  echo "entrypoint: refreshing existing checkout"
+  git -C "$REPO_DIR" fetch --depth 1 origin "$GIT_REF"
+  git -C "$REPO_DIR" reset --hard "origin/${GIT_REF}"
+  git -C "$REPO_DIR" clean -fdx
+fi
+
+cd "$REPO_DIR"
+echo "entrypoint: npm ci --ignore-scripts"
+npm ci --ignore-scripts --no-audit --no-fund
+# --ignore-scripts closes the install-time-arbitrary-code vector (lifecycle
+# scripts from any of ~600 npm packages); this check catches anything that
+# still wrote to the tracked source tree some other way. Same defense as
+# economics-refresh-entrypoint.sh's install_deps -- found necessary there via
+# a security review, applied here from the start.
+if ! git diff --quiet -- . ':(exclude)node_modules'; then
+  echo "entrypoint: npm ci modified tracked source files -- aborting" >&2
+  git diff --stat -- . ':(exclude)node_modules' >&2
+  exit 1
+fi
+
+case "$STEP" in
+  registry-sync)
+    : "${REGISTRY_SYNC_SECRET:?REGISTRY_SYNC_SECRET env var required for the registry-sync step}"
+    echo "entrypoint: full registry resync to Postgres"
+    exec node scripts/backfill-registry-postgres.mjs
+    ;;
+  testnet-discovery)
+    echo "entrypoint: probing testnet subnet surfaces"
+    node scripts/discover-testnet-surfaces.mjs --out /tmp/testnet-discovery.json
+    callable_count="$(node -e "process.stdout.write(String(require('/tmp/testnet-discovery.json').summary.callable_count))")"
+    if [ "$callable_count" != "0" ]; then
+      echo "entrypoint: $callable_count testnet subnet(s) now expose a callable API -- promote them to curated testnet surfaces"
+      if [ -n "${LIVE_ALERT_WEBHOOK_URL:-}" ]; then
+        payload="$(node -e "process.stdout.write(JSON.stringify({content:\`ℹ️ metagraphed testnet-discovery: \${process.argv[1]} subnet(s) now expose a callable API — promote to curated testnet surfaces.\`}))" "$callable_count")"
+        curl -fsS -m 15 -X POST "$LIVE_ALERT_WEBHOOK_URL" -H "content-type: application/json" -d "$payload" || echo "entrypoint: testnet-discovery alert webhook failed" >&2
+      fi
+    fi
+    ;;
+  *)
+    echo "entrypoint: unknown STEP '$STEP' (want registry-sync|testnet-discovery)" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Adds \`deploy/data-refresh-node.Dockerfile\` + \`scripts/data-refresh-node-entrypoint.sh\`, the box-side runner for moving \`resync-registry-postgres.yml\` (6h) and \`discover-testnet-surfaces.yml\` (weekly) off GitHub Actions -- consolidating recurring data jobs onto our own infra instead of fragmenting across GitHub Actions and box-side systemd timers.
- Node-only (no Python/uv/bittensor): neither job touches chain RPC, so this is a single container per run -- \`npm ci --ignore-scripts\` + a tracked-file integrity check is the supply-chain guard, applied from the start (found necessary as a follow-up fix on the economics-refresh image; applied proactively here).

## Test plan
- [x] \`docker build\` succeeds
- [x] \`STEP=testnet-discovery\`: real run against the live registry, probed 32 \`subnet_urls\`, correct classification breakdown
- [x] \`STEP=registry-sync\`: confirmed the full round-trip (clone, \`npm ci --ignore-scripts\`, script execution, HTTPS POST) against the real production \`registry-sync-api\` Worker -- a deliberately wrong secret got a real 401 back, confirming mechanics work without risking a bad write
- [x] \`shellcheck\` clean, \`node scripts/scan-public-safety.mjs\` clean, \`npm run build && npm run validate\` clean