### PR TITLE
fix(indexer-rs): install curl in the runtime image for the stuck-block alert

### DIFF
--- a/apps/indexer-rs/Dockerfile
+++ b/apps/indexer-rs/Dockerfile
@@ -8,8 +8,13 @@ COPY src ./src
 RUN cargo build --release --locked
 
 FROM debian:bookworm-slim
+# curl: run_live's stuck-block alert (metagraphed-indexer-rs#4) shells out to
+# it via tokio::process::Command rather than adding an HTTP client crate --
+# without it here, alert_stuck_block would silently fail at runtime (a
+# missing binary is a caught, logged error, not a crash, but the whole
+# point of that fix is the alert actually firing).
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build /app/target/release/backfill-rs /app/backfill-rs


### PR DESCRIPTION
## Summary
- #5667 added a Discord webhook alert (\`run_live\`'s stuck-block escalation path) that shells out to \`curl\` via \`tokio::process::Command\` rather than adding an HTTP client crate -- but the runtime image (\`debian:bookworm-slim\`) only installed \`ca-certificates\`, not \`curl\`. A missing binary is a caught, logged error (not a crash), but the whole point of that fix is the alert actually firing.
- Caught building the image locally to deploy #5667, before it ever reached production.

## Test plan
- [x] \`node scripts/scan-public-safety.mjs\`
- [ ] Docker image build in progress (will confirm \`curl\` present before deploying)