### PR TITLE
feat(graphql): add Query.subnet_movers mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -47,8 +47,20 @@ import {
 import { buildAccountSummary } from "./account-events.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
 import { SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
-import { parseHistoryWindow } from "./neuron-history.mjs";
+import {
+  parseHistoryWindow,
+  unsupportedWindowMessage,
+} from "./neuron-history.mjs";
 import { loadEconomicsTrends } from "./economics-trends.mjs";
+import {
+  DEFAULT_MOVERS_SORT,
+  DEFAULT_MOVERS_WINDOW,
+  MOVERS_LIMIT_DEFAULT,
+  MOVERS_LIMIT_MAX,
+  MOVERS_SORTS,
+  MOVERS_WINDOWS,
+  buildMovers,
+} from "./movers.mjs";
 
 export const GRAPHQL_MAX_DEPTH = 7;
 export const GRAPHQL_MAX_COMPLEXITY = 50;
@@ -100,6 +112,8 @@ export const SDL = `
     account(ss58: String!): AccountSummary
     "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
     economics_trends(window: String): EconomicsTrends!
+    "Cross-subnet momentum leaderboard: every subnet ranked by its stake/emission/validator change between a window's start and end snapshots; movers is empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/subnets/movers."
+    subnet_movers(window: String, sort: String, limit: Int): SubnetMovers!
   }
 
   type SubnetList {
@@ -215,6 +229,57 @@ export const SDL = `
     validator_count: Int
     miner_count: Int
     mean_emission_share: Float
+  }
+
+  type SubnetMovers {
+    schema_version: Int!
+    window: String
+    start_date: String
+    end_date: String
+    sort: String!
+    subnet_count: Int!
+    network: SubnetMoversNetwork!
+    movers: [SubnetMover!]!
+  }
+
+  "Network-wide boundary totals for the movers window, summed across every ranked subnet (not just the returned page)."
+  type SubnetMoversNetwork {
+    "Lossless fixed 9-decimal (rao-precision) TAO string -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float."
+    total_stake_start_tao: String!
+    total_stake_end_tao: String!
+    total_stake_delta_tao: String!
+    total_emission_start_tao: String!
+    total_emission_end_tao: String!
+    total_emission_delta_tao: String!
+    total_validators_start: Int!
+    total_validators_end: Int!
+    total_validators_delta: Int!
+    gainers: Int!
+    losers: Int!
+    unchanged: Int!
+  }
+
+  "One subnet's stake/emission/validator/neuron movement between the window's start and end snapshots."
+  type SubnetMover {
+    netuid: Int!
+    stake_start_tao: Float!
+    stake_end_tao: Float!
+    stake_delta_tao: Float!
+    "Null when the start snapshot's stake was 0 (growth from nothing is undefined)."
+    stake_pct_change: Float
+    "This subnet's share of network stake at the end snapshot; null when the network total is 0."
+    stake_share_pct: Float
+    emission_start_tao: Float!
+    emission_end_tao: Float!
+    emission_delta_tao: Float!
+    emission_pct_change: Float
+    emission_share_pct: Float
+    validators_start: Int!
+    validators_end: Int!
+    validators_delta: Int!
+    neurons_start: Int!
+    neurons_end: Int!
+    neurons_delta: Int!
   }
 
   type SurfaceList {
@@ -721,6 +786,7 @@ export const FIELD_COMPLEXITY = {
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
   economics_trends: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_movers: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -1591,6 +1657,80 @@ const rootValue = {
       window: data.window ?? label,
       day_count: data.day_count ?? 0,
       days: data.days || [],
+    };
+  },
+
+  async subnet_movers({ window, sort, limit }, context) {
+    const requestedWindow = window ?? DEFAULT_MOVERS_WINDOW;
+    if (!Object.hasOwn(MOVERS_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(requestedWindow, MOVERS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const requestedSort = sort ?? DEFAULT_MOVERS_SORT;
+    if (!MOVERS_SORTS.includes(requestedSort)) {
+      throw new GraphQLError(
+        `"${requestedSort}" is not a supported sort. Supported: ${MOVERS_SORTS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const requestedLimit = limit ?? MOVERS_LIMIT_DEFAULT;
+    if (
+      !Number.isInteger(requestedLimit) ||
+      requestedLimit < 1 ||
+      requestedLimit > MOVERS_LIMIT_MAX
+    ) {
+      throw new GraphQLError(
+        `limit must be an integer from 1 to ${MOVERS_LIMIT_MAX}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    params.set("sort", requestedSort);
+    params.set("limit", String(requestedLimit));
+    // Same tryPostgresTier + buildMovers([], [], ...) fallback contract REST's
+    // handleSubnetMovers uses -- a cold/absent tier yields a schema-stable
+    // empty leaderboard, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/subnets/movers", params),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ??
+      buildMovers([], [], {
+        window: requestedWindow,
+        startDate: null,
+        endDate: null,
+        sort: requestedSort,
+        limit: requestedLimit,
+      });
+    const network = data.network ?? {};
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? requestedWindow,
+      start_date: data.start_date ?? null,
+      end_date: data.end_date ?? null,
+      sort: data.sort ?? requestedSort,
+      subnet_count: data.subnet_count ?? 0,
+      network: {
+        total_stake_start_tao: network.total_stake_start_tao ?? "0.000000000",
+        total_stake_end_tao: network.total_stake_end_tao ?? "0.000000000",
+        total_stake_delta_tao: network.total_stake_delta_tao ?? "0.000000000",
+        total_emission_start_tao:
+          network.total_emission_start_tao ?? "0.000000000",
+        total_emission_end_tao: network.total_emission_end_tao ?? "0.000000000",
+        total_emission_delta_tao:
+          network.total_emission_delta_tao ?? "0.000000000",
+        total_validators_start: network.total_validators_start ?? 0,
+        total_validators_end: network.total_validators_end ?? 0,
+        total_validators_delta: network.total_validators_delta ?? 0,
+        gainers: network.gainers ?? 0,
+        losers: network.losers ?? 0,
+        unchanged: network.unchanged ?? 0,
+      },
+      movers: data.movers || [],
     };
   },
 };

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -2976,6 +2976,201 @@ describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time 
   });
 });
 
+describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback leaderboard)", () => {
+  function moversQuery(argsClause) {
+    return `{ subnet_movers${argsClause} {
+      schema_version window start_date end_date sort subnet_count
+      network {
+        total_stake_start_tao total_stake_end_tao total_stake_delta_tao
+        total_emission_start_tao total_emission_end_tao total_emission_delta_tao
+        total_validators_start total_validators_end total_validators_delta
+        gainers losers unchanged
+      }
+      movers { netuid stake_delta_tao emission_delta_tao validators_delta }
+    } }`;
+  }
+
+  test("cold store, default args: schema-stable empty leaderboard", async () => {
+    const { status, body } = await gql(moversQuery(""));
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_movers, {
+      schema_version: 1,
+      window: "30d",
+      start_date: null,
+      end_date: null,
+      sort: "stake",
+      subnet_count: 0,
+      network: {
+        total_stake_start_tao: "0.000000000",
+        total_stake_end_tao: "0.000000000",
+        total_stake_delta_tao: "0.000000000",
+        total_emission_start_tao: "0.000000000",
+        total_emission_end_tao: "0.000000000",
+        total_emission_delta_tao: "0.000000000",
+        total_validators_start: 0,
+        total_validators_end: 0,
+        total_validators_delta: 0,
+        gainers: 0,
+        losers: 0,
+        unchanged: 0,
+      },
+      movers: [],
+    });
+  });
+
+  test("resolves Postgres-tier movers for a valid non-default window/sort combination", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            window: "7d",
+            start_date: "2026-07-08",
+            end_date: "2026-07-15",
+            sort: "emission",
+            subnet_count: 1,
+            network: {
+              total_stake_start_tao: "1000.000000000",
+              total_stake_end_tao: "1200.000000000",
+              total_stake_delta_tao: "200.000000000",
+              total_emission_start_tao: "10.000000000",
+              total_emission_end_tao: "12.000000000",
+              total_emission_delta_tao: "2.000000000",
+              total_validators_start: 5,
+              total_validators_end: 6,
+              total_validators_delta: 1,
+              gainers: 1,
+              losers: 0,
+              unchanged: 0,
+            },
+            movers: [
+              {
+                netuid: 3,
+                stake_start_tao: 1000,
+                stake_end_tao: 1200,
+                stake_delta_tao: 200,
+                stake_pct_change: 20,
+                stake_share_pct: 100,
+                emission_start_tao: 10,
+                emission_end_tao: 12,
+                emission_delta_tao: 2,
+                emission_pct_change: 20,
+                emission_share_pct: 100,
+                validators_start: 5,
+                validators_end: 6,
+                validators_delta: 1,
+                neurons_start: 20,
+                neurons_end: 21,
+                neurons_delta: 1,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      moversQuery('(window: "7d", sort: "emission")'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.pathname, "/api/v1/subnets/movers");
+    assert.equal(capturedUrl.searchParams.get("window"), "7d");
+    assert.equal(capturedUrl.searchParams.get("sort"), "emission");
+    assert.equal(capturedUrl.searchParams.get("limit"), "20");
+    assert.equal(body.data.subnet_movers.window, "7d");
+    assert.equal(body.data.subnet_movers.sort, "emission");
+    assert.equal(body.data.subnet_movers.subnet_count, 1);
+    assert.equal(
+      body.data.subnet_movers.network.total_stake_delta_tao,
+      "200.000000000",
+    );
+    assert.equal(body.data.subnet_movers.movers.length, 1);
+    assert.equal(body.data.subnet_movers.movers[0].netuid, 3);
+    assert.equal(body.data.subnet_movers.movers[0].emission_delta_tao, 2);
+  });
+
+  test("a limit argument is forwarded as a query param to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({ schema_version: 1, movers: [] });
+        },
+      },
+    };
+    await gql(moversQuery("(limit: 5)"), env);
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+  });
+
+  test("a malformed Postgres-tier body degrades to schema-stable defaults (no throw)", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(moversQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.subnet_movers.subnet_count, 0);
+    assert.deepEqual(body.data.subnet_movers.movers, []);
+    assert.equal(
+      body.data.subnet_movers.network.total_stake_start_tao,
+      "0.000000000",
+    );
+    assert.equal(body.data.subnet_movers.network.gainers, 0);
+  });
+
+  test("an unsupported window is a GraphQL error, not a silently substituted default", async () => {
+    const { status, body } = await gql(moversQuery('(window: "1y")'));
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    const err = body.errors.find(
+      (e) => e.extensions?.code === "BAD_USER_INPUT",
+    );
+    assert.ok(err);
+    assert.match(err.message, /1y/);
+  });
+
+  test("an unsupported sort is a GraphQL error, not a silently substituted default", async () => {
+    const { status, body } = await gql(moversQuery('(sort: "bogus")'));
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    const err = body.errors.find(
+      (e) => e.extensions?.code === "BAD_USER_INPUT",
+    );
+    assert.ok(err);
+    assert.match(err.message, /bogus/);
+  });
+
+  test("a limit above MOVERS_LIMIT_MAX is a GraphQL error, matching REST's exact rejection", async () => {
+    const { status, body } = await gql(moversQuery("(limit: 101)"));
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    const err = body.errors.find(
+      (e) => e.extensions?.code === "BAD_USER_INPUT",
+    );
+    assert.ok(err);
+    assert.match(err.message, /1 to 100/);
+  });
+
+  test("a limit below 1 is a GraphQL error", async () => {
+    const { status, body } = await gql(moversQuery("(limit: 0)"));
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    const err = body.errors.find(
+      (e) => e.extensions?.code === "BAD_USER_INPUT",
+    );
+    assert.ok(err);
+  });
+
+  test("subnet_movers is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_movers, 5);
+  });
+});
+
 describe("Subscription.chainEvents", () => {
   test("yields a properly-shaped GraphQL execution result for each pushed payload", async () => {
     const hub = fakeChainFirehose((repeater) => {


### PR DESCRIPTION
## What

Adds `Query.subnet_movers` to the GraphQL SDL in `src/graphql.mjs`, mirroring `GET /api/v1/subnets/movers` (REST) and `get_subnet_movers` (MCP) — the cross-subnet momentum leaderboard (every subnet ranked by stake/emission/validator change over a window) is now reachable over `POST /api/v1/graphql`.

- `Query.subnet_movers(window: String, sort: String, limit: Int): SubnetMovers!`, with an SDL doc-comment, placed next to `economics_trends`.
- `SubnetMovers` type plus nested `SubnetMoversNetwork` (network-wide boundary totals) and `SubnetMover` (per-subnet scorecard) types, shaped directly off `buildMovers`'s real return object (`src/movers.mjs`) — `total_*_tao` network fields are lossless rao-precision `String`s (same `total_stake_tao`-exceeds-double-precision reasoning `economics_trends` already applies), per-subnet `*_pct_change`/`*_share_pct` fields are nullable `Float` (null when undefined, matching `pctChange`/`pctShare`'s contract).
- Resolver validates `window` against `MOVERS_WINDOWS` and `sort` against `MOVERS_SORTS` (unsupported value → `BAD_USER_INPUT` GraphQL error carrying REST's exact "supported: ..." message, never a silent fallback), and `limit` against `MOVERS_LIMIT_MAX`/min 1 (out-of-range → `BAD_USER_INPUT`, matching REST's `parseBoundedIntParam` rejection rather than clamping).
- Resolves via the same `tryPostgresTier(env, request, "METAGRAPH_NEURONS_SOURCE")` → `buildMovers([], [], ...)` fallback contract REST's `handleSubnetMovers` uses, so a cold/absent tier returns the schema-stable empty leaderboard instead of a GraphQL error. `network` fields are extracted with explicit `??` defaults so a malformed upstream body can't violate the schema's non-null fields.
- `subnet_movers` added to `FIELD_COMPLEXITY` at the `RELATIONSHIP_FIELD_COMPLEXITY` weight, same as the other fan-out fields.

## Tests

`tests/graphql.test.mjs`: cold-tier default-args fallback (schema-stable empty leaderboard), a successful Postgres-tier resolve with a valid non-default `window`/`sort` combination (including the forwarded query params), a limit argument forwarded to the Postgres tier, a malformed Postgres-tier body degrading to schema-stable defaults, an unsupported `window` (GraphQL error), an unsupported `sort` (GraphQL error), a `limit` above `MOVERS_LIMIT_MAX` (GraphQL error, not clamped) and below 1, and the fan-out complexity weight.

## Validation run

- `npm run lint`
- `npm run format:check`
- `npm run validate`
- `npm run validate:contract-drift`
- `npm run build`
- `npm run test:coverage` (full suite, unsharded) — 8434 passed; `src/graphql.mjs` at 100% line coverage (the diff's added lines/branches are fully covered; the file's pre-existing 98.41% branch figure is unrelated code outside this diff)

Closes #5662
