### PR TITLE
feat(graphql): add Query.incidents mirroring REST /api/v1/incidents

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -23,6 +23,8 @@ import {
 } from "./health-serving.mjs";
 import {
   loadCompareSubnets,
+  loadGlobalIncidents,
+  parseAnalyticsWindow,
   parseCompareDimensionList,
   parseCompareNetuidList,
 } from "./analytics-live.mjs";
@@ -46,7 +48,7 @@ import {
 } from "./accounts-list.mjs";
 import { buildAccountSummary } from "./account-events.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
-import { SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
+import { ANALYTICS_WINDOWS, SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
 import { parseHistoryWindow } from "./neuron-history.mjs";
 import { loadEconomicsTrends } from "./economics-trends.mjs";
 
@@ -78,6 +80,8 @@ export const SDL = `
     endpoints(netuid: Int, limit: Int, cursor: String): EndpointList!
     "Global operational health rollup with per-subnet summaries."
     health: GlobalHealth
+    "Cross-subnet incident ledger: surfaces with consecutive probe failures grouped into downtime incidents over the requested window (7d default, or 30d). Mirrors GET /api/v1/incidents."
+    incidents(window: String): GlobalIncidents!
     "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
     opportunity_boards(limit: Int): OpportunityBoards!
     "Cross-subnet comparison: registry structure, live economics, and live health placed side by side for the requested netuids, in requested order. Mirrors GET /api/v1/compare."
@@ -313,6 +317,37 @@ export const SDL = `
     latency_sample_count: Int
     last_checked: String
     last_ok: String
+  }
+
+  type GlobalIncidents {
+    window: String
+    observed_at: String
+    source: String
+    summary: IncidentsSummary!
+    surfaces: [IncidentSurface!]!
+  }
+
+  type IncidentsSummary {
+    incident_count: Int!
+    affected_surface_count: Int!
+  }
+
+  type IncidentSurface {
+    netuid: Int!
+    surface_id: String
+    incident_count: Int!
+    "Total downtime across this surface's incidents, in milliseconds."
+    downtime_ms: Float!
+    incidents: [Incident!]!
+  }
+
+  type Incident {
+    "Epoch-ms timestamp of the incident's first failed probe."
+    started_at: Float
+    "Epoch-ms timestamp of the incident's last failed probe."
+    ended_at: Float
+    duration_ms: Float
+    failed_samples: Int!
   }
 
   type OpportunityBoards {
@@ -710,6 +745,7 @@ export const FIELD_COMPLEXITY = {
   surfaces: RELATIONSHIP_FIELD_COMPLEXITY,
   endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
+  incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1290,6 +1326,37 @@ const rootValue = {
       health_source: result.health_source,
       scope: result.scope,
       subnets: result.subnets || [],
+    };
+  },
+
+  async incidents({ window }, context) {
+    const parsed = parseAnalyticsWindow(window);
+    if (!parsed) {
+      throw new GraphQLError(
+        `"${window}" is not a valid window. Supported: ${Object.keys(ANALYTICS_WINDOWS).join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const { label, days } = parsed;
+    const params = new URLSearchParams();
+    params.set("window", label);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/incidents", params),
+        "METAGRAPH_HEALTH_SOURCE",
+      )) ??
+      (await loadGlobalIncidents(graphqlD1(context), {
+        windowLabel: label,
+        windowDays: days,
+        observedAt: await loadObservedAt(context),
+      }));
+    return {
+      window: data.window ?? label,
+      observed_at: data.observed_at ?? null,
+      source: data.source ?? null,
+      summary: data.summary ?? { incident_count: 0, affected_surface_count: 0 },
+      surfaces: data.surfaces || [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -2193,6 +2193,181 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
   });
 });
 
+describe("graphql — incidents (#5660, Postgres-tier ledger + D1 fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  function healthDb(rows) {
+    return {
+      prepare: () => ({
+        bind: () => ({ all: async () => ({ results: rows }) }),
+      }),
+    };
+  }
+
+  test("incidents: cold Postgres tier + cold D1 returns a schema-stable empty ledger", async () => {
+    const { status, body } = await gql(
+      "{ incidents { window observed_at summary { incident_count affected_surface_count } surfaces { netuid } } }",
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.incidents, {
+      window: "7d",
+      observed_at: null,
+      summary: { incident_count: 0, affected_surface_count: 0 },
+      surfaces: [],
+    });
+  });
+
+  test("incidents: resolves a Postgres-tier ledger", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          window: "7d",
+          observed_at: "2026-07-14T00:00:00.000Z",
+          source: "live-cron-prober",
+          summary: { incident_count: 1, affected_surface_count: 1 },
+          surfaces: [
+            {
+              netuid: 1,
+              surface_id: "sn-1-website",
+              incident_count: 1,
+              downtime_ms: 4000,
+              incidents: [
+                {
+                  started_at: 1000,
+                  ended_at: 5000,
+                  duration_ms: 4000,
+                  failed_samples: 3,
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      "{ incidents { window summary { incident_count } surfaces { netuid surface_id downtime_ms incidents { started_at ended_at duration_ms failed_samples } } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.incidents.summary.incident_count, 1);
+    const surface = body.data.incidents.surfaces[0];
+    assert.equal(surface.netuid, 1);
+    assert.equal(surface.downtime_ms, 4000);
+    assert.equal(surface.incidents[0].failed_samples, 3);
+  });
+
+  test("incidents: window is forwarded as a query param to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            observed_at: null,
+            source: "live-cron-prober",
+            summary: { incident_count: 0, affected_surface_count: 0 },
+            surfaces: [],
+          });
+        },
+      },
+    };
+    await gql('{ incidents(window: "30d") { window } }', env);
+    assert.equal(capturedUrl.pathname, "/api/v1/incidents");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+  });
+
+  test("incidents: a malformed Postgres-tier body degrades to a schema-stable empty ledger", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      "{ incidents { window observed_at source summary { incident_count affected_surface_count } surfaces { netuid } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.incidents, {
+      window: "7d",
+      observed_at: null,
+      source: null,
+      summary: { incident_count: 0, affected_surface_count: 0 },
+      surfaces: [],
+    });
+  });
+
+  test("incidents: a cold Postgres tier falls back to the live D1 surface_checks aggregate", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: healthDb([
+        {
+          netuid: 2,
+          surface_id: "sn-2-api",
+          surface_key: "sn-2-api",
+          started_at: 1000,
+          ended_at: 9000,
+          failed_samples: 4,
+        },
+      ]),
+    };
+    const { status, body } = await gql(
+      "{ incidents { summary { incident_count affected_surface_count } surfaces { netuid incident_count downtime_ms } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.incidents.summary.incident_count, 1);
+    assert.equal(body.data.incidents.summary.affected_surface_count, 1);
+    assert.equal(body.data.incidents.surfaces[0].netuid, 2);
+    assert.equal(body.data.incidents.surfaces[0].downtime_ms, 8000);
+  });
+
+  test("incidents: a D1 error degrades to an empty ledger (no throw)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          throw new Error("db unavailable");
+        },
+      },
+    };
+    const { status, body } = await gql(
+      "{ incidents { surfaces { netuid } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.incidents.surfaces, []);
+  });
+
+  test("incidents: an unsupported window value is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      '{ incidents(window: "90d") { window } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("incidents is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.incidents, 5);
+  });
+});
+
 describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary
- Adds `Query.incidents(window: String): GlobalIncidents!` to the GraphQL SDL, mirroring `GET /api/v1/incidents` and MCP's `get_global_incidents`.
- Resolves via the same contract REST/MCP already use: `tryPostgresTier(env, request, "METAGRAPH_HEALTH_SOURCE")`, falling back to the live D1 `surface_checks` aggregate (`loadGlobalIncidents` from `src/analytics-live.mjs`, the same pure loader `get_global_incidents`/`get_feed` already share) — never a GraphQL error on a cold tier.
- `window` validates against the same `ANALYTICS_WINDOWS` (`7d`/`30d`) REST/MCP accept, via the already-exported `parseAnalyticsWindow`; an unsupported value returns a `BAD_USER_INPUT` GraphQL error, matching the `validators`/`accounts` sort-validation pattern already in this file.
- Added `incidents` to `FIELD_COMPLEXITY` at the standard relationship weight.
- New `GlobalIncidents`/`IncidentsSummary`/`IncidentSurface`/`Incident` SDL types mirror `formatGlobalIncidents`'s real response shape exactly (read directly from `src/health-serving.mjs`, not guessed). `started_at`/`ended_at`/`duration_ms`/`downtime_ms` use `Float` rather than `Int` since they're raw epoch-ms values that can exceed GraphQL's 32-bit `Int` range.

## Test plan
- [x] `tests/graphql.test.mjs`: successful query on the Postgres-tier path, a malformed Postgres-tier body falling back to a schema-stable empty ledger, the D1 surface_checks fallback path (including a D1-error-degrades-gracefully case), `window` forwarded as a query param, an unsupported `window` value returning `BAD_USER_INPUT` without reaching the Postgres tier, and the `FIELD_COMPLEXITY` weight.
- [x] `npm run lint` / `npm run format:check` clean
- [x] `npm run test:ci` (the coverage-generating pass CI uses) green; new code at 100% line/branch coverage
- [x] `npm run validate:contract-drift` passes

Closes #5660