### PR TITLE
feat(ui): subnet OHLC candlestick chart

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
@@ -1,0 +1,107 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { subnetOhlcQuery } from "@/lib/metagraphed/queries";
+import { CandlestickMini, type CandlestickDatum } from "@jsonbored/ui-kit";
+import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { classNames, formatTao } from "@/lib/metagraphed/format";
+
+const INTERVALS = ["1h", "1d"] as const;
+type Interval = (typeof INTERVALS)[number];
+
+// Same precision rule as accounts.$ss58.tsx's fmtAlphaPrice / subnets.$netuid.tsx's
+// fmtQuotePrice -- the alpha_price_tao scale is small enough (typically well under
+// 1 TAO/alpha) that a fixed decimal count reads as either all-zeros or unreadably
+// long; scientific notation only kicks in once fixed notation would round to 0.
+function fmtOhlcPrice(v: number): string {
+  if (!Number.isFinite(v)) return "—";
+  if (v < 0.001) return v.toExponential(2);
+  return v < 1 ? v.toFixed(4) : v.toFixed(3);
+}
+
+/**
+ * OHLC price/volume candlestick chart for one subnet (#5656, Phase 2 of the
+ * OHLC epic #5304 -- follows #5655's backend). An interval toggle mirrors
+ * subnet-history-chart.tsx's window-selector pattern; root (netuid 0) and a
+ * cold/empty series both render an EmptyState rather than an empty chart
+ * area, matching the backend's own root_excluded / empty-candles contract.
+ */
+export function SubnetOhlcChart({ netuid }: { netuid: number }) {
+  const [interval, setIntervalState] = useState<Interval>("1h");
+  const { data: res, isLoading } = useQuery(subnetOhlcQuery(netuid, { interval }));
+  const data = res?.data;
+
+  const candles = useMemo<CandlestickDatum[]>(() => {
+    if (!data?.candles.length) return [];
+    return data.candles.map((c) => ({
+      label: c.bucket_start_iso,
+      open: c.open,
+      high: c.high,
+      low: c.low,
+      close: c.close,
+    }));
+  }, [data?.candles]);
+
+  const intervalSelector = (
+    <div
+      role="tablist"
+      aria-label="Candle interval"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
+      {INTERVALS.map((i) => (
+        <button
+          key={i}
+          type="button"
+          role="tab"
+          aria-selected={i === interval}
+          onClick={() => setIntervalState(i)}
+          className={classNames(
+            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            i === interval ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {i}
+        </button>
+      ))}
+    </div>
+  );
+
+  if (data?.root_excluded) {
+    return (
+      <EmptyState
+        title="No market for root"
+        description="Root (netuid 0) has no AMM pool -- stake there is 1:1 TAO, with no price to chart."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-end">{intervalSelector}</div>
+      {isLoading ? (
+        <Skeleton className="h-40 w-full" />
+      ) : candles.length === 0 ? (
+        <EmptyState
+          title="No trades yet"
+          description="OHLC candles are built from executed stake/unstake trades -- once this subnet has trading activity in the selected interval, candles will appear here."
+        />
+      ) : (
+        <div className="rounded-xl border border-border bg-card p-4">
+          <CandlestickMini
+            data={candles}
+            width={640}
+            height={180}
+            formatValue={fmtOhlcPrice}
+            ariaLabel={`Subnet ${netuid} alpha price, ${candles.length} ${interval} candles`}
+          />
+          <div className="mt-2 flex items-center justify-between font-mono text-[10px] text-ink-muted">
+            <span>{candles.length} candles</span>
+            <span>
+              latest close {fmtOhlcPrice(candles[candles.length - 1]!.close)} τ/α · vol{" "}
+              {formatTao(data!.candles[data!.candles.length - 1]!.volume_tao)}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.subnet-ohlc.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-ohlc.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeSubnetOhlc, normalizeSubnetOhlcCandle, subnetOhlcQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/ohlc",
+  });
+}
+
+// Invoke a queryOptions' queryFn directly (the factory returns a fully-typed
+// options object; each call site keeps its own precise data type), mirroring
+// queries.subnet-registrations.test.ts's own runQuery helper.
+function runQuery<
+  O extends {
+    queryKey: readonly unknown[];
+    queryFn?: (context: never) => unknown;
+  },
+>(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
+}
+
+const RAW_CANDLE = {
+  bucket_start: 1_700_000_000_000,
+  bucket_start_iso: "2023-11-14T22:13:20.000Z",
+  open: 1.5,
+  high: 2,
+  low: 1,
+  close: 1.8,
+  volume_alpha: 100,
+  volume_tao: 180,
+  event_count: 5,
+};
+
+describe("normalizeSubnetOhlcCandle", () => {
+  it("passes a well-formed candle through", () => {
+    expect(normalizeSubnetOhlcCandle(RAW_CANDLE)).toEqual(RAW_CANDLE);
+  });
+
+  it("returns null for a non-object row", () => {
+    for (const raw of [null, undefined, 42, "x", []]) {
+      expect(normalizeSubnetOhlcCandle(raw)).toBeNull();
+    }
+  });
+
+  it("returns null when bucket_start is missing or non-finite", () => {
+    expect(normalizeSubnetOhlcCandle({ ...RAW_CANDLE, bucket_start: undefined })).toBeNull();
+    expect(normalizeSubnetOhlcCandle({ ...RAW_CANDLE, bucket_start: "not-a-number" })).toBeNull();
+    expect(normalizeSubnetOhlcCandle({ ...RAW_CANDLE, bucket_start: NaN })).toBeNull();
+  });
+
+  it("derives bucket_start_iso from bucket_start when the server omits it", () => {
+    const candle = normalizeSubnetOhlcCandle({ bucket_start: 1_700_000_000_000 });
+    expect(candle?.bucket_start_iso).toBe(new Date(1_700_000_000_000).toISOString());
+  });
+
+  it("coerces junk numeric fields to 0 rather than NaN", () => {
+    const candle = normalizeSubnetOhlcCandle({
+      bucket_start: 1_700_000_000_000,
+      open: "not-a-number",
+      high: undefined,
+      low: null,
+      close: {},
+      volume_alpha: "nope",
+      volume_tao: NaN,
+      event_count: "nope",
+    });
+    expect(candle).toEqual({
+      bucket_start: 1_700_000_000_000,
+      bucket_start_iso: new Date(1_700_000_000_000).toISOString(),
+      open: 0,
+      high: 0,
+      low: 0,
+      close: 0,
+      volume_alpha: 0,
+      volume_tao: 0,
+      event_count: 0,
+    });
+  });
+});
+
+describe("normalizeSubnetOhlc", () => {
+  it("passes a well-formed response through", () => {
+    const raw = {
+      schema_version: 1,
+      netuid: 7,
+      interval: "1h",
+      candles: [RAW_CANDLE],
+      root_excluded: false,
+    };
+    expect(normalizeSubnetOhlc(7, "1h", raw)).toEqual(raw);
+  });
+
+  it("degrades cold / junk input to a schema-stable empty series", () => {
+    for (const raw of [{}, null, undefined, "not-an-object"]) {
+      const data = normalizeSubnetOhlc(7, "1h", raw);
+      expect(data.netuid).toBe(7);
+      expect(data.schema_version).toBe(1);
+      expect(data.interval).toBe("1h");
+      expect(data.candles).toEqual([]);
+      expect(data.root_excluded).toBe(false);
+    }
+  });
+
+  it("drops a malformed candle without dropping the rest of the batch", () => {
+    const data = normalizeSubnetOhlc(7, "1h", {
+      candles: [RAW_CANDLE, { bucket_start: "junk" }, { ...RAW_CANDLE, bucket_start: 2 }],
+    });
+    expect(data.candles).toHaveLength(2);
+  });
+
+  it("normalizes interval to '1h' or '1d', never anything else", () => {
+    expect(normalizeSubnetOhlc(7, "1h", { interval: "1d" }).interval).toBe("1d");
+    expect(normalizeSubnetOhlc(7, "1h", { interval: "5m" }).interval).toBe("1h");
+    expect(normalizeSubnetOhlc(7, "1h", { interval: undefined }).interval).toBe("1h");
+  });
+
+  it("always forces root_excluded:true for netuid 0, even if the server omits it", () => {
+    const data = normalizeSubnetOhlc(0, "1h", { candles: [RAW_CANDLE] });
+    expect(data.root_excluded).toBe(true);
+  });
+
+  it("respects an explicit root_excluded:true from the server for a non-root netuid too", () => {
+    const data = normalizeSubnetOhlc(7, "1h", { root_excluded: true });
+    expect(data.root_excluded).toBe(true);
+  });
+
+  it("falls back to the requested netuid/interval when the server omits them", () => {
+    const data = normalizeSubnetOhlc(12, "1d", {});
+    expect(data.netuid).toBe(12);
+  });
+});
+
+describe("subnetOhlcQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits its route with the interval and days params", async () => {
+    resolveWith({ netuid: 7, interval: "1d", candles: [] });
+    const res = await runQuery(subnetOhlcQuery(7, { interval: "1d", days: 30 }));
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/ohlc",
+      expect.objectContaining({ params: { interval: "1d", days: 30 } }),
+    );
+    expect(res.data.interval).toBe("1d");
+  });
+
+  it("defaults to a 1h interval and no days param when omitted", async () => {
+    resolveWith({});
+    await runQuery(subnetOhlcQuery(7));
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/ohlc",
+      expect.objectContaining({ params: { interval: "1h", days: undefined } }),
+    );
+  });
+
+  it("normalizes the response through normalizeSubnetOhlc", async () => {
+    resolveWith({ candles: [RAW_CANDLE] });
+    const res = await runQuery(subnetOhlcQuery(7));
+    expect(res.data.candles).toEqual([RAW_CANDLE]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -197,6 +197,8 @@ import type {
   SubnetRegistrations,
   SubnetStakeFlow,
   SubnetAlphaVolume,
+  SubnetOhlc,
+  SubnetOhlcCandle,
   SubnetMovers,
   SubnetMover,
   MetagraphNeuron,
@@ -4629,6 +4631,74 @@ export const subnetAlphaVolumeQuery = (netuid: number) =>
     },
     staleTime: STALE_MED,
   });
+
+// A finite candle field, or 0 -- matches normalizeSubnetAlphaVolume's own
+// "0 is a real value" convention for volume/count fields (unlike
+// sentiment_ratio/vol_mcap_ratio, which stay null to distinguish "no data"
+// from "genuinely zero").
+export function normalizeSubnetOhlcCandle(raw: unknown): SubnetOhlcCandle | null {
+  if (!isRecord(raw)) return null;
+  const bucketStart = firstFiniteNumber(raw.bucket_start);
+  if (bucketStart == null) return null;
+  return {
+    bucket_start: bucketStart,
+    bucket_start_iso: firstString(raw.bucket_start_iso) ?? new Date(bucketStart).toISOString(),
+    open: coerceFiniteNumber(raw.open) ?? 0,
+    high: coerceFiniteNumber(raw.high) ?? 0,
+    low: coerceFiniteNumber(raw.low) ?? 0,
+    close: coerceFiniteNumber(raw.close) ?? 0,
+    volume_alpha: coerceFiniteNumber(raw.volume_alpha) ?? 0,
+    volume_tao: coerceFiniteNumber(raw.volume_tao) ?? 0,
+    event_count: firstFiniteNumber(raw.event_count) ?? 0,
+  };
+}
+
+// Cold/absent store, an empty window, or root (netuid 0) all yield a
+// schema-stable empty candles array -- never throws. A malformed individual
+// candle row is dropped rather than poisoning the whole series.
+export function normalizeSubnetOhlc(netuid: number, interval: string, raw: unknown): SubnetOhlc {
+  const d = isRecord(raw) ? raw : {};
+  const candles = Array.isArray(d.candles)
+    ? d.candles.map(normalizeSubnetOhlcCandle).filter((c): c is SubnetOhlcCandle => c != null)
+    : [];
+  const normalizedInterval = d.interval === "1d" ? "1d" : "1h";
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    netuid: firstFiniteNumber(d.netuid) ?? netuid,
+    interval: normalizedInterval,
+    candles,
+    root_excluded: d.root_excluded === true || netuid === 0,
+  };
+}
+
+export interface SubnetOhlcParams {
+  interval?: "1h" | "1d";
+  /** Lookback window in days (server clamps to [1, 365], default 90). */
+  days?: number;
+}
+
+// GET /api/v1/subnets/{netuid}/ohlc (#5655): open/high/low/close/volume
+// candles from the same account_events stream /volume reads, bucketed by
+// ?interval=. Root (netuid 0) always normalizes to root_excluded:true with
+// an empty series, matching the server's own short-circuit.
+export const subnetOhlcQuery = (netuid: number, params: SubnetOhlcParams = {}) => {
+  const interval = params.interval ?? "1h";
+  return queryOptions({
+    queryKey: k("subnet-ohlc", netuid, interval, params.days ?? null),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetOhlc>>(`/api/v1/subnets/${netuid}/ohlc`, {
+        params: { interval, days: params.days },
+        signal,
+      });
+      return {
+        data: normalizeSubnetOhlc(netuid, interval, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+};
 
 export interface SubnetEventsParams {
   /** Filter to one event_kind (e.g. "StakeAdded"). */

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1904,6 +1904,31 @@ export interface SubnetAlphaVolume {
   vol_mcap_ratio: number | null;
 }
 
+/** One open/high/low/close/volume candle from /api/v1/subnets/{netuid}/ohlc. */
+export interface SubnetOhlcCandle {
+  bucket_start: number;
+  bucket_start_iso: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume_alpha: number;
+  volume_tao: number;
+  event_count: number;
+}
+
+/** OHLC price/volume candlesticks for one subnet (#5655), bucketed by
+ * ?interval=1h|1d from the account_events StakeAdded/StakeRemoved stream.
+ * Root (netuid 0) has no AMM pool and always carries root_excluded:true with
+ * an empty candles array rather than a meaningless flat-line series. */
+export interface SubnetOhlc {
+  schema_version: number;
+  netuid: number;
+  interval: "1h" | "1d";
+  candles: SubnetOhlcCandle[];
+  root_excluded: boolean;
+}
+
 /** One subnet's movement over the comparison window on the /subnets/movers board. */
 export interface SubnetMover {
   netuid: number;

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -52,6 +52,7 @@ import { ReliabilityPanel } from "@/components/metagraphed/reliability-panel";
 import { EconomicsPanel } from "@/components/metagraphed/economics-panel";
 import { EndpointSnippet, apiSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { SubnetHistoryChart } from "@/components/metagraphed/subnet-history-chart";
+import { SubnetOhlcChart } from "@/components/metagraphed/subnet-ohlc-chart";
 import { MetagraphTableLoader } from "@/components/metagraphed/metagraph-panel";
 import { ValidatorsTableLoader } from "@/components/metagraphed/validators-panel";
 import { DistributionPanel } from "@/components/metagraphed/concentration-panel";
@@ -421,6 +422,21 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
       >
         <QueryErrorBoundary>
           <AlphaVolumeScorecard netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      {/* 5a2b — OHLC price/volume candlesticks (#5656, Phase 2 of the OHLC
+          epic #5304): open/high/low/close candles from the same trade stream
+          the 24h volume scorecard above reads, just bucketed by time instead
+          of summed into a rolling total. */}
+      <SectionAnchor
+        id="ohlc"
+        title="Price history"
+        subtitle="Open/high/low/close candles built from executed stake/unstake trades."
+        info="GET /api/v1/subnets/{netuid}/ohlc — OHLCV candles bucketed by ?interval=1h|1d from the same account_events StakeAdded/StakeRemoved stream as 24h Volume above. Each trade's price is amount_tao / alpha_amount; empty buckets are gaps, never synthesized flat candles."
+      >
+        <QueryErrorBoundary>
+          <SubnetOhlcChart netuid={netuid} />
         </QueryErrorBoundary>
       </SectionAnchor>
 

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3127,6 +3127,188 @@ function BarMini({
     }
   );
 }
+var BODY_WIDTH_RATIO = 0.6;
+function CandlestickMini({
+  data,
+  width = 480,
+  height = 160,
+  upColor = "var(--health-ok)",
+  downColor = "var(--health-down)",
+  className,
+  ariaLabel,
+  formatValue,
+  interactive = true
+}) {
+  const wrapRef = React3.useRef(null);
+  const [hover, setHover] = React3.useState(null);
+  const candles = data.slice(-500).filter(
+    (c) => Number.isFinite(c.open) && Number.isFinite(c.high) && Number.isFinite(c.low) && Number.isFinite(c.close)
+  );
+  if (candles.length === 0) {
+    return /* @__PURE__ */ jsxRuntime.jsx(
+      "svg",
+      {
+        width: "100%",
+        height,
+        viewBox: `0 0 ${width} ${height}`,
+        preserveAspectRatio: "none",
+        className: `block max-w-full ${className ?? ""}`,
+        style: { maxWidth: width },
+        "aria-label": ariaLabel,
+        children: /* @__PURE__ */ jsxRuntime.jsx(
+          "line",
+          {
+            x1: 0,
+            y1: height / 2,
+            x2: width,
+            y2: height / 2,
+            stroke: "var(--border)",
+            strokeDasharray: "2 3"
+          }
+        )
+      }
+    );
+  }
+  let min = candles[0].low;
+  let max = candles[0].high;
+  for (const c of candles) {
+    if (c.low < min) min = c.low;
+    if (c.high > max) max = c.high;
+  }
+  const span = max - min || 1;
+  const padY = height * 0.06;
+  const plotHeight = height - padY * 2;
+  const y = (v) => padY + plotHeight - (v - min) / span * plotHeight;
+  const slotWidth = width / candles.length;
+  const bodyWidth = Math.max(1, slotWidth * BODY_WIDTH_RATIO);
+  const bars = candles.map((c, i) => {
+    const cx = slotWidth * (i + 0.5);
+    const up = c.close >= c.open;
+    const color = up ? upColor : downColor;
+    const bodyTop = y(Math.max(c.open, c.close));
+    const bodyBottom = y(Math.min(c.open, c.close));
+    const bodyHeight = Math.max(1, bodyBottom - bodyTop);
+    return {
+      cx,
+      up,
+      color,
+      wickTop: y(c.high),
+      wickBottom: y(c.low),
+      bodyTop,
+      bodyHeight
+    };
+  });
+  const canTooltip = interactive && candles.length > 0;
+  function onMove(e) {
+    if (!canTooltip) return;
+    const rect = wrapRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
+    const idx = Math.min(
+      candles.length - 1,
+      Math.floor(x / rect.width * candles.length)
+    );
+    setHover(idx);
+  }
+  function onKeyDown(e) {
+    if (!canTooltip) return;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setHover((prev) => Math.min(candles.length - 1, (prev ?? -1) + 1));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setHover((prev) => Math.max(0, (prev ?? candles.length) - 1));
+    }
+  }
+  function onFocus() {
+    if (!canTooltip) return;
+    setHover((prev) => prev ?? 0);
+  }
+  const hoverCandle = hover != null ? candles[hover] : null;
+  const hoverBar = hover != null ? bars[hover] : null;
+  const fmt = formatValue ?? ((v) => v.toString());
+  const tooltipText = hoverCandle ? `${hoverCandle.label} \xB7 O ${fmt(hoverCandle.open)} H ${fmt(hoverCandle.high)} L ${fmt(hoverCandle.low)} C ${fmt(hoverCandle.close)}` : "";
+  return /* @__PURE__ */ jsxRuntime.jsxs(
+    "div",
+    {
+      ref: wrapRef,
+      className: `relative block w-full ${className ?? ""}`,
+      style: { width: "100%", maxWidth: width, height },
+      onPointerMove: onMove,
+      onPointerLeave: () => setHover(null),
+      onKeyDown,
+      onFocus,
+      onBlur: () => setHover(null),
+      tabIndex: canTooltip ? 0 : void 0,
+      "aria-label": canTooltip ? `${ariaLabel ?? "Candlestick chart"}, use arrow keys to step through candles` : void 0,
+      children: [
+        /* @__PURE__ */ jsxRuntime.jsxs(
+          "svg",
+          {
+            width: "100%",
+            height,
+            viewBox: `0 0 ${width} ${height}`,
+            preserveAspectRatio: "none",
+            role: "img",
+            "aria-label": ariaLabel,
+            className: "block w-full",
+            children: [
+              bars.map((b, i) => /* @__PURE__ */ jsxRuntime.jsxs("g", { children: [
+                /* @__PURE__ */ jsxRuntime.jsx(
+                  "line",
+                  {
+                    x1: b.cx,
+                    x2: b.cx,
+                    y1: b.wickTop,
+                    y2: b.wickBottom,
+                    stroke: b.color,
+                    strokeWidth: 1
+                  }
+                ),
+                /* @__PURE__ */ jsxRuntime.jsx(
+                  "rect",
+                  {
+                    x: b.cx - bodyWidth / 2,
+                    y: b.bodyTop,
+                    width: bodyWidth,
+                    height: b.bodyHeight,
+                    fill: b.color,
+                    opacity: b.up ? 0.85 : 0.7
+                  }
+                )
+              ] }, i)),
+              hoverBar ? /* @__PURE__ */ jsxRuntime.jsx(
+                "line",
+                {
+                  x1: hoverBar.cx,
+                  x2: hoverBar.cx,
+                  y1: 0,
+                  y2: height,
+                  stroke: "var(--ink-muted)",
+                  strokeOpacity: 0.35,
+                  strokeWidth: 1
+                }
+              ) : null
+            ]
+          }
+        ),
+        hoverBar && tooltipText ? /* @__PURE__ */ jsxRuntime.jsx(
+          "div",
+          {
+            className: "pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
+            style: {
+              left: Math.max(60, Math.min(width - 60, hoverBar.cx)),
+              top: Math.max(0, hoverBar.wickTop - 4)
+            },
+            role: "tooltip",
+            children: tooltipText
+          }
+        ) : null,
+        /* @__PURE__ */ jsxRuntime.jsx("span", { "aria-live": "polite", className: "sr-only", children: tooltipText })
+      ]
+    }
+  );
+}
 function Donut({
   segments,
   size = 96,
@@ -3868,6 +4050,7 @@ exports.BackToTop = BackToTop;
 exports.BarMini = BarMini;
 exports.BrandIcon = BrandIcon;
 exports.CandidateChip = CandidateChip;
+exports.CandlestickMini = CandlestickMini;
 exports.Command = Command;
 exports.CommandDialog = CommandDialog;
 exports.CommandEmpty = CommandEmpty;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3098,6 +3098,188 @@ function BarMini({
     }
   );
 }
+var BODY_WIDTH_RATIO = 0.6;
+function CandlestickMini({
+  data,
+  width = 480,
+  height = 160,
+  upColor = "var(--health-ok)",
+  downColor = "var(--health-down)",
+  className,
+  ariaLabel,
+  formatValue,
+  interactive = true
+}) {
+  const wrapRef = useRef(null);
+  const [hover, setHover] = useState(null);
+  const candles = data.slice(-500).filter(
+    (c) => Number.isFinite(c.open) && Number.isFinite(c.high) && Number.isFinite(c.low) && Number.isFinite(c.close)
+  );
+  if (candles.length === 0) {
+    return /* @__PURE__ */ jsx(
+      "svg",
+      {
+        width: "100%",
+        height,
+        viewBox: `0 0 ${width} ${height}`,
+        preserveAspectRatio: "none",
+        className: `block max-w-full ${className ?? ""}`,
+        style: { maxWidth: width },
+        "aria-label": ariaLabel,
+        children: /* @__PURE__ */ jsx(
+          "line",
+          {
+            x1: 0,
+            y1: height / 2,
+            x2: width,
+            y2: height / 2,
+            stroke: "var(--border)",
+            strokeDasharray: "2 3"
+          }
+        )
+      }
+    );
+  }
+  let min = candles[0].low;
+  let max = candles[0].high;
+  for (const c of candles) {
+    if (c.low < min) min = c.low;
+    if (c.high > max) max = c.high;
+  }
+  const span = max - min || 1;
+  const padY = height * 0.06;
+  const plotHeight = height - padY * 2;
+  const y = (v) => padY + plotHeight - (v - min) / span * plotHeight;
+  const slotWidth = width / candles.length;
+  const bodyWidth = Math.max(1, slotWidth * BODY_WIDTH_RATIO);
+  const bars = candles.map((c, i) => {
+    const cx = slotWidth * (i + 0.5);
+    const up = c.close >= c.open;
+    const color = up ? upColor : downColor;
+    const bodyTop = y(Math.max(c.open, c.close));
+    const bodyBottom = y(Math.min(c.open, c.close));
+    const bodyHeight = Math.max(1, bodyBottom - bodyTop);
+    return {
+      cx,
+      up,
+      color,
+      wickTop: y(c.high),
+      wickBottom: y(c.low),
+      bodyTop,
+      bodyHeight
+    };
+  });
+  const canTooltip = interactive && candles.length > 0;
+  function onMove(e) {
+    if (!canTooltip) return;
+    const rect = wrapRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
+    const idx = Math.min(
+      candles.length - 1,
+      Math.floor(x / rect.width * candles.length)
+    );
+    setHover(idx);
+  }
+  function onKeyDown(e) {
+    if (!canTooltip) return;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setHover((prev) => Math.min(candles.length - 1, (prev ?? -1) + 1));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setHover((prev) => Math.max(0, (prev ?? candles.length) - 1));
+    }
+  }
+  function onFocus() {
+    if (!canTooltip) return;
+    setHover((prev) => prev ?? 0);
+  }
+  const hoverCandle = hover != null ? candles[hover] : null;
+  const hoverBar = hover != null ? bars[hover] : null;
+  const fmt = formatValue ?? ((v) => v.toString());
+  const tooltipText = hoverCandle ? `${hoverCandle.label} \xB7 O ${fmt(hoverCandle.open)} H ${fmt(hoverCandle.high)} L ${fmt(hoverCandle.low)} C ${fmt(hoverCandle.close)}` : "";
+  return /* @__PURE__ */ jsxs(
+    "div",
+    {
+      ref: wrapRef,
+      className: `relative block w-full ${className ?? ""}`,
+      style: { width: "100%", maxWidth: width, height },
+      onPointerMove: onMove,
+      onPointerLeave: () => setHover(null),
+      onKeyDown,
+      onFocus,
+      onBlur: () => setHover(null),
+      tabIndex: canTooltip ? 0 : void 0,
+      "aria-label": canTooltip ? `${ariaLabel ?? "Candlestick chart"}, use arrow keys to step through candles` : void 0,
+      children: [
+        /* @__PURE__ */ jsxs(
+          "svg",
+          {
+            width: "100%",
+            height,
+            viewBox: `0 0 ${width} ${height}`,
+            preserveAspectRatio: "none",
+            role: "img",
+            "aria-label": ariaLabel,
+            className: "block w-full",
+            children: [
+              bars.map((b, i) => /* @__PURE__ */ jsxs("g", { children: [
+                /* @__PURE__ */ jsx(
+                  "line",
+                  {
+                    x1: b.cx,
+                    x2: b.cx,
+                    y1: b.wickTop,
+                    y2: b.wickBottom,
+                    stroke: b.color,
+                    strokeWidth: 1
+                  }
+                ),
+                /* @__PURE__ */ jsx(
+                  "rect",
+                  {
+                    x: b.cx - bodyWidth / 2,
+                    y: b.bodyTop,
+                    width: bodyWidth,
+                    height: b.bodyHeight,
+                    fill: b.color,
+                    opacity: b.up ? 0.85 : 0.7
+                  }
+                )
+              ] }, i)),
+              hoverBar ? /* @__PURE__ */ jsx(
+                "line",
+                {
+                  x1: hoverBar.cx,
+                  x2: hoverBar.cx,
+                  y1: 0,
+                  y2: height,
+                  stroke: "var(--ink-muted)",
+                  strokeOpacity: 0.35,
+                  strokeWidth: 1
+                }
+              ) : null
+            ]
+          }
+        ),
+        hoverBar && tooltipText ? /* @__PURE__ */ jsx(
+          "div",
+          {
+            className: "pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap",
+            style: {
+              left: Math.max(60, Math.min(width - 60, hoverBar.cx)),
+              top: Math.max(0, hoverBar.wickTop - 4)
+            },
+            role: "tooltip",
+            children: tooltipText
+          }
+        ) : null,
+        /* @__PURE__ */ jsx("span", { "aria-live": "polite", className: "sr-only", children: tooltipText })
+      ]
+    }
+  );
+}
 function Donut({
   segments,
   size = 96,
@@ -3828,4 +4010,4 @@ function TreemapMini({
   );
 }
 
-export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EntityHero, ExternalLink, FreshnessBadge, FreshnessIndicator, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, InfoTooltip, Kbd, KeyChip, ListCard, ListShell, LoadMore, McpToolsList, MethodologyCallout, MiniRadial, MiniStack, NoDataSpark, PageHero, PageSection, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, RealtimeFreshness, ReviewChip, SCOPES, ScrollReveal, SearchScopeChip, SectionAnchor, SectionHeading, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, cn, fmtYield, freshnessBadgeTimeCopy, freshnessDotClass, freshnessTierLabel, prefetchBrandIcon, safeExternalUrl, tierFreshnessLabel, timeAgoAbsoluteTitle, visibleTools };
+export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EntityHero, ExternalLink, FreshnessBadge, FreshnessIndicator, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, InfoTooltip, Kbd, KeyChip, ListCard, ListShell, LoadMore, McpToolsList, MethodologyCallout, MiniRadial, MiniStack, NoDataSpark, PageHero, PageSection, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, RealtimeFreshness, ReviewChip, SCOPES, ScrollReveal, SearchScopeChip, SectionAnchor, SectionHeading, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, buildCsvDownloadUrl, cn, fmtYield, freshnessBadgeTimeCopy, freshnessDotClass, freshnessTierLabel, prefetchBrandIcon, safeExternalUrl, tierFreshnessLabel, timeAgoAbsoluteTitle, visibleTools };

--- a/packages/ui-kit/src/components/metagraphed/charts/candlestick-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/candlestick-mini.tsx
@@ -1,0 +1,239 @@
+import {
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+
+export interface CandlestickDatum {
+  /** Timestamp label, e.g. an ISO string or a formatted "12:00 UTC". */
+  label: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+const MAX_CANDLES = 500;
+// Fraction of each candle's slot width the body rect occupies -- the
+// remainder is inter-candle gap, mirroring a typical OHLC chart's spacing.
+const BODY_WIDTH_RATIO = 0.6;
+
+interface Props {
+  data: CandlestickDatum[];
+  width?: number;
+  height?: number;
+  /** Body/wick color for a close >= open candle. */
+  upColor?: string;
+  /** Body/wick color for a close < open candle. */
+  downColor?: string;
+  className?: string;
+  ariaLabel?: string;
+  /** Format a price for the tooltip (e.g. (v) => `${v.toFixed(4)} TAO`). */
+  formatValue?: (v: number) => string;
+  /** Disable interactive tooltip when false. */
+  interactive?: boolean;
+}
+
+/**
+ * Tiny inline-SVG OHLC candlestick chart. Mirrors Sparkline's rendering and
+ * interaction conventions (viewBox-based responsive sizing, CSS-variable
+ * theming, pointer/keyboard-navigable hover tooltip, aria-live announcement)
+ * so both read as the same visual language, just plotting four values per
+ * point instead of one. Empty input renders the same dashed baseline
+ * Sparkline uses for a flat/empty series, rather than an empty chart area.
+ */
+export function CandlestickMini({
+  data,
+  width = 480,
+  height = 160,
+  upColor = "var(--health-ok)",
+  downColor = "var(--health-down)",
+  className,
+  ariaLabel,
+  formatValue,
+  interactive = true,
+}: Props) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [hover, setHover] = useState<number | null>(null);
+
+  const candles = data
+    .slice(-MAX_CANDLES)
+    .filter(
+      (c) =>
+        Number.isFinite(c.open) &&
+        Number.isFinite(c.high) &&
+        Number.isFinite(c.low) &&
+        Number.isFinite(c.close),
+    );
+
+  if (candles.length === 0) {
+    return (
+      <svg
+        width="100%"
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        className={`block max-w-full ${className ?? ""}`}
+        style={{ maxWidth: width }}
+        aria-label={ariaLabel}
+      >
+        <line
+          x1={0}
+          y1={height / 2}
+          x2={width}
+          y2={height / 2}
+          stroke="var(--border)"
+          strokeDasharray="2 3"
+        />
+      </svg>
+    );
+  }
+
+  let min = candles[0]!.low;
+  let max = candles[0]!.high;
+  for (const c of candles) {
+    if (c.low < min) min = c.low;
+    if (c.high > max) max = c.high;
+  }
+  const span = max - min || 1;
+  const padY = height * 0.06;
+  const plotHeight = height - padY * 2;
+  const y = (v: number) => padY + plotHeight - ((v - min) / span) * plotHeight;
+
+  const slotWidth = width / candles.length;
+  const bodyWidth = Math.max(1, slotWidth * BODY_WIDTH_RATIO);
+  const bars = candles.map((c, i) => {
+    const cx = slotWidth * (i + 0.5);
+    const up = c.close >= c.open;
+    const color = up ? upColor : downColor;
+    const bodyTop = y(Math.max(c.open, c.close));
+    const bodyBottom = y(Math.min(c.open, c.close));
+    // A flat candle (open === close) would collapse to a zero-height rect --
+    // give it a hairline so it's still visible, matching how a real
+    // candlestick chart renders a doji.
+    const bodyHeight = Math.max(1, bodyBottom - bodyTop);
+    return {
+      cx,
+      up,
+      color,
+      wickTop: y(c.high),
+      wickBottom: y(c.low),
+      bodyTop,
+      bodyHeight,
+    };
+  });
+
+  const canTooltip = interactive && candles.length > 0;
+
+  function onMove(e: ReactPointerEvent<HTMLDivElement>) {
+    if (!canTooltip) return;
+    const rect = wrapRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
+    const idx = Math.min(
+      candles.length - 1,
+      Math.floor((x / rect.width) * candles.length),
+    );
+    setHover(idx);
+  }
+
+  function onKeyDown(e: ReactKeyboardEvent<HTMLDivElement>) {
+    if (!canTooltip) return;
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setHover((prev) => Math.min(candles.length - 1, (prev ?? -1) + 1));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setHover((prev) => Math.max(0, (prev ?? candles.length) - 1));
+    }
+  }
+
+  function onFocus() {
+    if (!canTooltip) return;
+    setHover((prev) => prev ?? 0);
+  }
+
+  const hoverCandle = hover != null ? candles[hover] : null;
+  const hoverBar = hover != null ? bars[hover] : null;
+  const fmt = formatValue ?? ((v: number) => v.toString());
+  const tooltipText = hoverCandle
+    ? `${hoverCandle.label} · O ${fmt(hoverCandle.open)} H ${fmt(hoverCandle.high)} L ${fmt(hoverCandle.low)} C ${fmt(hoverCandle.close)}`
+    : "";
+
+  return (
+    <div
+      ref={wrapRef}
+      className={`relative block w-full ${className ?? ""}`}
+      style={{ width: "100%", maxWidth: width, height }}
+      onPointerMove={onMove}
+      onPointerLeave={() => setHover(null)}
+      onKeyDown={onKeyDown}
+      onFocus={onFocus}
+      onBlur={() => setHover(null)}
+      tabIndex={canTooltip ? 0 : undefined}
+      aria-label={
+        canTooltip
+          ? `${ariaLabel ?? "Candlestick chart"}, use arrow keys to step through candles`
+          : undefined
+      }
+    >
+      <svg
+        width="100%"
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label={ariaLabel}
+        className="block w-full"
+      >
+        {bars.map((b, i) => (
+          <g key={i}>
+            <line
+              x1={b.cx}
+              x2={b.cx}
+              y1={b.wickTop}
+              y2={b.wickBottom}
+              stroke={b.color}
+              strokeWidth={1}
+            />
+            <rect
+              x={b.cx - bodyWidth / 2}
+              y={b.bodyTop}
+              width={bodyWidth}
+              height={b.bodyHeight}
+              fill={b.color}
+              opacity={b.up ? 0.85 : 0.7}
+            />
+          </g>
+        ))}
+        {hoverBar ? (
+          <line
+            x1={hoverBar.cx}
+            x2={hoverBar.cx}
+            y1={0}
+            y2={height}
+            stroke="var(--ink-muted)"
+            strokeOpacity={0.35}
+            strokeWidth={1}
+          />
+        ) : null}
+      </svg>
+      {hoverBar && tooltipText ? (
+        <div
+          className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full rounded border border-border bg-paper px-1.5 py-0.5 font-mono text-[10px] leading-tight text-ink-strong shadow-sm whitespace-nowrap"
+          style={{
+            left: Math.max(60, Math.min(width - 60, hoverBar.cx)),
+            top: Math.max(0, hoverBar.wickTop - 4),
+          }}
+          role="tooltip"
+        >
+          {tooltipText}
+        </div>
+      ) : null}
+      <span aria-live="polite" className="sr-only">
+        {tooltipText}
+      </span>
+    </div>
+  );
+}

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -169,6 +169,10 @@ export {
   BarMini,
 } from "@/components/metagraphed/charts/bar-mini";
 export {
+  type CandlestickDatum,
+  CandlestickMini,
+} from "@/components/metagraphed/charts/candlestick-mini";
+export {
   type DonutSegment,
   Donut,
   DonutLegend,


### PR DESCRIPTION
## Summary

Phase 2 (frontend) of the OHLC epic #5304 — a candlestick chart on the subnet detail page,
right after the existing "24h Volume" scorecard (same trade stream, bucketed by time instead
of summed into a rolling total). Backend (#5655) already merged via #5668.

- **New `CandlestickMini` chart primitive** in `packages/ui-kit` — mirrors `Sparkline`'s exact
  conventions (viewBox-based responsive SVG, CSS-variable theming, pointer/keyboard-navigable
  hover tooltip with `aria-live` announcement) so it reads as the same visual language, just
  plotting four values per point instead of one. Up/down candles use the existing
  `--health-ok`/`--health-down` semantic tones already used elsewhere in this design system
  (e.g. the sentiment tone on the 24h Volume scorecard right above it) — no new color tokens.
- **`SubnetOhlcChart`** wires it to the new `subnetOhlcQuery`, with a 1h/1d interval toggle
  mirroring `subnet-history-chart.tsx`'s own window-selector pattern (`role="tablist"`, same
  pill-button styling).
- **Root (netuid 0)** and a **cold/empty series** both render an `EmptyState` rather than an
  empty chart area, matching the backend's own `root_excluded`/empty-candles contract exactly.
- New `normalizeSubnetOhlc`/`normalizeSubnetOhlcCandle` (exported, matching this codebase's
  convention of exporting normalizers for direct unit testing — see
  `queries.subnet-registrations.test.ts`'s precedent).

## Verification

- `npx vitest run` (apps/ui) — 1020/1020 passing, including 15 new tests in
  `queries.subnet-ohlc.test.ts` (normalizer well-formed/degraded/malformed-row/root-forcing
  coverage, plus query-param wiring tests).
- `npx tsc --noEmit`, `npx eslint .` — clean (0 errors; pre-existing route-file fast-refresh
  warnings only).
- `npx prettier --check .`, `npm run build` (Cloudflare/Nitro target) — clean, re-verified
  after rebasing onto `main` (which now includes the merged backend).
- Manual visual QA: mocked a realistic multi-candle response and triggered a genuine
  client-side refetch via the interval toggle (SSR embeds real data server-side on first
  paint, so a client interaction is needed to exercise the mock) — confirmed correct
  open/high/low/close wick+body rendering, up/down coloring, and the footer stats line.
- Confirmed the empty-state fallback renders correctly against production today (the backend
  route only just merged and hasn't deployed yet at time of writing) — degrades to the same
  "No trades yet" `EmptyState` a genuinely-cold subnet would show, not a broken/error state.

## Screenshots

| State | Theme | Screenshot |
| --- | --- | --- |
| Before (no Price History section) | Dark | ![before-dark](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5656-ohlc-chart-before-desktop-dark.png) |
| After (populated chart, mocked realistic data) | Dark | ![after-dark](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5656-ohlc-chart-after-desktop-dark.png) |
| After (populated chart, mocked realistic data) | Light | ![after-light](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/5656-ohlc-chart-after-desktop-light.png) |

Note on the light screenshot: I verified `document.documentElement.classList.contains("dark")`
is correctly `false` in that capture (the theme mechanism itself is working), but the
resulting render is visually indistinguishable from dark — this appears to be a pre-existing,
site-wide characteristic (not something this PR introduces or could fix in scope), flagging it
here for visibility rather than silently passing off a mislabeled screenshot.

The "before" screenshot was captured locally (temporarily commenting out the new
`SectionAnchor` in `subnets.$netuid.tsx`, screenshotting, then restoring it — confirmed via
`git diff` that the restored file exactly matches the intended final diff).

Closes #5656