### PR TITLE
feat(api,ui): add CSV export for providers list

### DIFF
--- a/apps/ui/src/lib/metagraphed/providers-csv-params.test.ts
+++ b/apps/ui/src/lib/metagraphed/providers-csv-params.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { providersCsvQueryParams } from "./providers-csv-params";
+
+describe("providersCsvQueryParams", () => {
+  it("forwards API-supported kind and authority filters", () => {
+    expect(
+      providersCsvQueryParams({
+        kind: "subnet-team",
+        authority: "official",
+        sort: "name",
+      }),
+    ).toEqual({
+      kind: "subnet-team",
+      authority: "official",
+      sort: "name",
+    });
+  });
+
+  it("drops the UI-only `high` authority shortcut", () => {
+    expect(providersCsvQueryParams({ authority: "high" })).toEqual({});
+  });
+
+  it("omits client-only sort keys the API cannot honor", () => {
+    expect(providersCsvQueryParams({ sort: "surfaces" })).toEqual({});
+    expect(providersCsvQueryParams({ sort: "endpoints" })).toEqual({});
+  });
+
+  it("returns an empty object when nothing is filterable", () => {
+    expect(providersCsvQueryParams({})).toEqual({});
+  });
+});

--- a/apps/ui/src/lib/metagraphed/providers-csv-params.ts
+++ b/apps/ui/src/lib/metagraphed/providers-csv-params.ts
@@ -1,0 +1,28 @@
+/**
+ * Query params forwarded from the Providers page into the CSV export URL.
+ *
+ * Client-side ranking keys (`surfaces`/`endpoints`/…) are not on the API
+ * sort enum — only backend-supported filters/sorts are passed through so the
+ * download matches what `/api/v1/providers` can actually honor (#5665).
+ */
+export type ProvidersCsvSearch = {
+  kind?: string;
+  authority?: string;
+  sort?: string;
+};
+
+const API_SORT_FIELDS = new Set(["authority", "id", "kind", "name"]);
+
+/** Build `buildUrl` params for GET /api/v1/providers (without format=csv). */
+export function providersCsvQueryParams(search: ProvidersCsvSearch): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (search.kind) params.kind = search.kind;
+  // `high` is a UI nav shortcut (official + provider-claimed), not an API enum.
+  if (search.authority && search.authority !== "high") {
+    params.authority = search.authority;
+  }
+  if (search.sort && API_SORT_FIELDS.has(search.sort)) {
+    params.sort = search.sort;
+  }
+  return params;
+}

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -30,6 +30,7 @@ import {
   PageHero,
   ViewModeToggle,
   ShareButton,
+  DownloadCsvButton,
   TimeAgo,
   ActionBar,
   Donut,
@@ -37,6 +38,8 @@ import {
   Sparkline,
 } from "@jsonbored/ui-kit";
 import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
+import { buildUrl } from "@/lib/metagraphed/client";
+import { providersCsvQueryParams } from "@/lib/metagraphed/providers-csv-params";
 import type { Provider } from "@/lib/metagraphed/types";
 
 const providerSortKeys = ["name", "surfaces", "endpoints", "subnets", "updated"] as const;
@@ -78,6 +81,8 @@ function ProvidersPage() {
     search.q || search.kind || search.authority || (search.sort && search.sort !== "name"),
   );
   const onReset = () => navigate({ search: { view: search.view } as never, replace: true });
+  // DownloadCsvButton appends format=csv; only pass filters the API list honors.
+  const providersCsvUrl = buildUrl("/api/v1/providers", providersCsvQueryParams(search));
   return (
     <AppShell>
       <PageHero
@@ -99,6 +104,7 @@ function ProvidersPage() {
             />
             <ActionBar>
               <ResetFiltersButton active={filtersActive} onReset={onReset} bare />
+              <DownloadCsvButton url={providersCsvUrl} bare />
               <ShareButton bare />
             </ActionBar>
           </>

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -19223,6 +19223,8 @@ export interface operations {
                 sort?: "authority" | "id" | "kind" | "name";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -19230,7 +19232,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19286,6 +19288,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProvidersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2648,6 +2648,17 @@
               "desc"
             ]
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -37946,6 +37946,19 @@
                 "desc"
               ]
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -38009,9 +38022,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -19223,6 +19223,8 @@ export interface operations {
                 sort?: "authority" | "id" | "kind" | "name";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -19230,7 +19232,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19286,6 +19288,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProvidersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1823,7 +1823,8 @@ export const API_ROUTES = [
     "List providers and sources.",
     "standard",
     ["providers"],
-    listQuery("providers"),
+    // CSV export mirrors subnets/candidates (#5665) — generic list serializer.
+    csvListQuery("providers"),
   ),
   route(
     "provider-detail",

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1263,10 +1263,11 @@ describe("subnets CSV export", () => {
   });
 
   test("Accept: text/csv is ignored for collection routes without CSV contracts", async () => {
-    // /api/v1/providers is a list route that intentionally has no CSV contract,
-    // so content negotiation must fall through to the JSON envelope.
+    // /api/v1/source-snapshots is a list route that intentionally has no CSV
+    // contract, so content negotiation must fall through to the JSON envelope.
+    // (Providers gained CSV in #5665 — do not use it as the negative example.)
     const res = await handleRequest(
-      req("/api/v1/providers?limit=1", {
+      req("/api/v1/source-snapshots?limit=1", {
         headers: { accept: "text/csv" },
       }),
       createLocalArtifactEnv(),
@@ -1277,7 +1278,6 @@ describe("subnets CSV export", () => {
 
     const body = await res.json();
     assert.equal(body.ok, true);
-    assert.equal(Array.isArray(body.data.providers), true);
   });
 
   test("empty projected CSV exports retain the requested header row", async () => {
@@ -1430,6 +1430,7 @@ describe("registry list CSV export", () => {
     "endpoints",
     "subnet-endpoints",
     "provider-endpoints",
+    "providers",
     "candidates",
     "subnet-candidates",
     "profiles",
@@ -1450,7 +1451,7 @@ describe("registry list CSV export", () => {
   });
 
   test("list routes without a CSV contract stay JSON-only", () => {
-    for (const id of ["providers", "rpc-endpoints", "source-snapshots"]) {
+    for (const id of ["rpc-endpoints", "source-snapshots"]) {
       const entry = API_ROUTES.find((route) => route.id === id);
       assert.ok(entry, `route ${id} should exist`);
       assert.notEqual(entry.csv_response, true, `${id} must stay JSON-only`);
@@ -1466,6 +1467,7 @@ describe("registry list CSV export", () => {
     ["/api/v1/candidates", "candidates.csv"],
     ["/api/v1/profiles", "profiles.csv"],
     ["/api/v1/coverage-depth", "coverage-depth.csv"],
+    ["/api/v1/providers", "providers.csv"],
   ]) {
     test(`${path}?format=csv returns a named text/csv download`, async () => {
       const res = await handleRequest(

--- a/tests/providers-csv.test.mjs
+++ b/tests/providers-csv.test.mjs
@@ -1,0 +1,79 @@
+/**
+ * Providers list CSV export (#5665).
+ *
+ * Until this issue, GET /api/v1/providers used plain listQuery — format=csv was
+ * ignored. csvListQuery("providers") wires the generic list serializer; this
+ * suite confirms the export is a real text/csv attachment with scalar columns
+ * (no opaque [object Object] cells that would force an exclude option).
+ */
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+function req(path) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+describe("GET /api/v1/providers?format=csv (#5665)", () => {
+  test("returns a named text/csv download with a scalar header row", async () => {
+    const res = await handleRequest(
+      req("/api/v1/providers?format=csv&limit=5"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="providers.csv"',
+    );
+
+    const text = await res.text();
+    const lines = text.split("\r\n").filter(Boolean);
+    assert.ok(lines.length >= 1, "CSV must include a header row");
+    const header = lines[0];
+    assert.ok(header.includes(","), "header should list multiple columns");
+    assert.match(header, /\bid\b/);
+    assert.match(header, /\bname\b/);
+
+    // Projection fields for providers should serialize as scalars — if any
+    // cell were `[object Object]` we'd need csvListQuery(..., { exclude }).
+    for (const line of lines.slice(1)) {
+      assert.doesNotMatch(
+        line,
+        /\[object Object\]/,
+        `row must not leak object cells: ${line.slice(0, 120)}`,
+      );
+    }
+  });
+
+  test("honors Accept: text/csv the same as ?format=csv", async () => {
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/providers", {
+        headers: { accept: "text/csv" },
+      }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="providers.csv"',
+    );
+  });
+
+  test("keeps the JSON envelope when format is omitted", async () => {
+    const res = await handleRequest(
+      req("/api/v1/providers?limit=2"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^application\/json/);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.ok(Array.isArray(body.data) || Array.isArray(body.data?.providers));
+  });
+});


### PR DESCRIPTION
## Summary

- **Backend:** switches `GET /api/v1/providers` from `listQuery` to `csvListQuery("providers")` so `?format=csv` / `Accept: text/csv` return a real `providers.csv` attachment via the generic list serializer (no `exclude` needed — cells stay scalar).
- **Contract:** regenerates OpenAPI / api-index / types so the `format` parameter is advertised.
- **Frontend:** adds `DownloadCsvButton` to the Providers `PageHero` actions (alongside Share), using `providersCsvQueryParams` so only API-supported filters/sorts are forwarded.
- **Tests:** dedicated `tests/providers-csv.test.mjs` plus updates to the registry CSV coverage suite (providers joins the CSV routes; the JSON-only negative example moves off providers).

Closes #5665

## Screenshots

Fixed viewports only (375×812 / 768×1024 / 1280×800). `/providers` PageHero — before has Table/Grid + Share; after adds **Download CSV**.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5665-after-mobile-dark.png)<br><sub>after</sub> |

## Test plan

- [x] `npm run lint --workspace=apps/ui` (0 errors)
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=metagraphed-ui`
- [x] `npm run test --workspace=apps/ui` (1009 tests)
- [x] `npx vitest run tests/providers-csv.test.mjs` + focused `api-coverage` CSV cases
- [x] `npm run validate:contract-drift` / `validate:openapi`
- [ ] Confirm `/providers` Download CSV downloads `providers.csv`
- [ ] Confirm Accept text/csv on `/api/v1/providers` returns CSV after deploy
