### PR TITLE
fix(ui): add ShareButton + ApiSourceFooter to subnet and provider detail pages

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -27,6 +27,8 @@ import {
   DotRow,
   NoDataSpark,
   Sparkline,
+  ShareButton,
+  ActionBar,
 } from "@jsonbored/ui-kit";
 import {
   subnetEndpointsQuery,
@@ -445,6 +447,11 @@ export function SubnetMasthead({
               })}
             </div>
           ) : null}
+          <div className="mt-3">
+            <ActionBar>
+              <ShareButton bare />
+            </ActionBar>
+          </div>
         </div>
         {/* Desktop/tablet: health + curation beside the identity block. Mobile
             counterpart lives in the status row above so the body column stays wide. */}

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useMemo } from "react";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import {
   EmptyState,
   PageHeading,
@@ -16,6 +17,8 @@ import {
   PrimaryLinksRail,
   CopyableCode,
   SectionAnchor,
+  ShareButton,
+  ActionBar,
 } from "@jsonbored/ui-kit";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { EndpointsGlance } from "@/components/metagraphed/endpoints-glance";
@@ -131,6 +134,11 @@ function ProviderShell({ slug }: { slug: string }) {
         subtitle={shouldShowProviderSlugSubtitle(p?.name, slug) ? <>· {slug}</> : null}
         description={p?.notes}
         links={<PrimaryLinksRail website={p?.website ?? p?.homepage} docs={p?.docs} />}
+        actions={
+          <ActionBar>
+            <ShareButton bare />
+          </ActionBar>
+        }
         stats={[
           { label: "Endpoints", value: formatNumber(summary?.endpoint_count) },
           { label: "Monitored", value: formatNumber(summary?.monitored_count) },
@@ -171,6 +179,9 @@ function ProviderShell({ slug }: { slug: string }) {
           {summary?.by_layer ? <BreakdownCard title="By layer" data={summary.by_layer} /> : null}
         </aside>
       </div>
+      <ApiSourceFooter
+        paths={[`/api/v1/providers/${slug}`, `/api/v1/providers/${slug}/endpoints`]}
+      />
     </>
   );
 }

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -17,6 +17,7 @@ import {
   Filter,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import {
   EmptyState,
   PageHeading,
@@ -334,6 +335,7 @@ function ProfileShell({ netuid }: { netuid: number }) {
           ) : null}
           {tab === "api" ? <ApiPanel netuid={netuid} /> : null}
         </div>
+        <ApiSourceFooter paths={[`/api/v1/subnets/${netuid}/profile`]} />
       </SubnetFilterProvider>
     </TimeRangeProvider>
   );


### PR DESCRIPTION
Closes #5481

## What

Every other entity-detail route (`accounts.$ss58.tsx`, `blocks.$ref.tsx`, `extrinsics.$hash.tsx`, `validators.$hotkey.tsx`) renders both a `ShareButton` and an `ApiSourceFooter`. The two busiest detail pages didn't:

- `subnets.$netuid.tsx` renders `SubnetMasthead` as its header (not `PageHero`/`EntityHero`) — no `ShareButton` anywhere, and the route never rendered `ApiSourceFooter`.
- `providers.$slug.tsx` renders `EntityHero`, which already supports an `actions` prop (documented as "was PageHero's `actions`") — but the call site never passed it, and the route never rendered `ApiSourceFooter` either.

## Fix

- **`subnet-masthead.tsx`**: added a `ShareButton` (wrapped in the shared `ActionBar` from #5601/#5666, so it matches the rest of the app's now-unified action-pill treatment instead of introducing a new bordered box) right below the Website/Docs/Repo/Dashboard links row.
- **`subnets.$netuid.tsx`**: added `<ApiSourceFooter paths={[\`/api/v1/subnets/${netuid}/profile\`]} />` at the end of the page content.
- **`providers.$slug.tsx`**: passed `actions={<ActionBar><ShareButton bare /></ActionBar>}` to the existing `EntityHero` call, and added `<ApiSourceFooter paths={[...]} />` citing the two provider-specific endpoints the page actually reads (`/api/v1/providers/{slug}` and `/api/v1/providers/{slug}/endpoints`).

Both `ShareButton` additions use the shared `ActionBar` component from #5666 (merged), so they render consistently with the rest of the app's action-pill treatment from day one, rather than needing a second follow-up redesign pass.

## Verification

Confirmed both gaps on current `main` before making any change — neither page had a `ShareButton`, `data sources` footer text, or `ApiSourceFooter` anywhere in the rendered DOM. After the fix, both are present and functional on live data.

## Screenshots

3 viewports × 2 themes, before/after, both pages:

### Subnet detail

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-before-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-after-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/subnet-after-mobile-dark.png)<br><sub>after</sub> |

### Provider detail

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-before-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-after-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/assets-detail-pages-share-footer-5481/provider-after-mobile-dark.png)<br><sub>after</sub> |

## Acceptance criteria

- [x] `providers.$slug.tsx`: `EntityHero` call passes `actions={<ShareButton />}` (via `ActionBar`)
- [x] `providers.$slug.tsx`: renders `ApiSourceFooter` with the correct API path(s)
- [x] `subnet-masthead.tsx`: renders a `ShareButton`
- [x] `subnets.$netuid.tsx`: renders `ApiSourceFooter` with the correct API path(s)
- [x] Before/after screenshots included

## Testing

```
npx tsc --noEmit                 # no new errors in the 3 changed files
npx eslint <changed files>       # 0 errors (only pre-existing fast-refresh warnings)
npx prettier --check <changed files>   # clean
```

Diff: 3 files changed.
