### PR TITLE
feat(graphql): add Query.blocks_summary mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -28,6 +28,7 @@ import {
 } from "./analytics-live.mjs";
 import { buildExtrinsic, buildExtrinsicFeed } from "./extrinsics.mjs";
 import { buildBlock, buildBlockFeed } from "./blocks.mjs";
+import { buildBlocksSummary } from "./blocks-summary.mjs";
 import {
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
@@ -90,6 +91,8 @@ export const SDL = `
     blocks(limit: Int, offset: Int, cursor: String): BlockList!
     "One block by numeric height or 0x block hash; block is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/{ref}."
     block(ref: String!): BlockDetail
+    "Block-production summary over the recent-block window -- counts, inter-block timing, throughput, and author-concentration. Every aggregate is null (never a GraphQL error) when the retired-D1 store is cold. Mirrors GET /api/v1/blocks/summary."
+    blocks_summary: BlocksSummary!
     "Network-wide validator/operator leaderboard, grouped by hotkey across every subnet it operates in. Mirrors GET /api/v1/validators."
     validators(sort: String, limit: Int): ValidatorList!
     "One validator's cross-subnet aggregate by hotkey; a hotkey with no validator_permit=1 rows resolves to a schema-stable zeroed aggregate, never null. Mirrors GET /api/v1/validators/{hotkey}."
@@ -428,6 +431,57 @@ export const SDL = `
     observed_at: String
   }
 
+  "Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary."
+  type BlocksSummary {
+    schema_version: Int!
+    block_count: Int!
+    first_block: Int
+    last_block: Int
+    first_observed_at: String
+    last_observed_at: String
+    block_time: BlockTimeDistribution
+    throughput: BlocksThroughput
+    distinct_authors: Int!
+    author_concentration: ConcentrationMetrics
+    distinct_spec_versions: Int!
+    latest_spec_version: Int
+  }
+
+  "Inter-block interval distribution in milliseconds, over genuinely consecutive in-window blocks."
+  type BlockTimeDistribution {
+    count: Int!
+    mean_ms: Float
+    min_ms: Float
+    max_ms: Float
+    p50_ms: Float
+    p90_ms: Float
+  }
+
+  "Extrinsic/event throughput across the summarized block window."
+  type BlocksThroughput {
+    total_extrinsics: Int!
+    total_events: Int!
+    mean_extrinsics_per_block: Float
+    mean_events_per_block: Float
+    max_extrinsics_in_block: Int!
+  }
+
+  "Concentration metrics over a value distribution -- Gini, HHI (raw + holder-count-normalized), Nakamoto coefficient, top-percentile shares, and Shannon entropy."
+  type ConcentrationMetrics {
+    holders: Int!
+    total: Float
+    gini: Float
+    hhi: Float
+    hhi_normalized: Float
+    nakamoto_coefficient: Int
+    top_1pct_share: Float
+    top_5pct_share: Float
+    top_10pct_share: Float
+    top_20pct_share: Float
+    entropy: Float
+    entropy_normalized: Float
+  }
+
   type BlockDetail {
     ref: String
     block: Block
@@ -719,6 +773,7 @@ export const FIELD_COMPLEXITY = {
   accounts: RELATIONSHIP_FIELD_COMPLEXITY,
   account: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
+  blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
   economics_trends: RELATIONSHIP_FIELD_COMPLEXITY,
 };
@@ -1437,6 +1492,34 @@ const rootValue = {
       items: data.blocks || [],
       total: data.block_count ?? 0,
       next_cursor: data.next_cursor ?? null,
+    };
+  },
+
+  async blocks_summary(_args, context) {
+    // #5664: same tryPostgresTier(METAGRAPH_BLOCKS_SOURCE) -> buildBlocksSummary([])
+    // fallback contract handleBlocksSummary uses. blocks' D1 write path is retired
+    // (#4909) so a cold Postgres tier is the steady state -- the empty builder
+    // shape (block_count 0, every aggregate null) satisfies the non-null
+    // BlocksSummary! contract, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/blocks/summary"),
+        "METAGRAPH_BLOCKS_SOURCE",
+      )) ?? buildBlocksSummary([]);
+    return {
+      schema_version: data.schema_version ?? 1,
+      block_count: data.block_count ?? 0,
+      first_block: data.first_block ?? null,
+      last_block: data.last_block ?? null,
+      first_observed_at: data.first_observed_at ?? null,
+      last_observed_at: data.last_observed_at ?? null,
+      block_time: data.block_time ?? null,
+      throughput: data.throughput ?? null,
+      distinct_authors: data.distinct_authors ?? 0,
+      author_concentration: data.author_concentration ?? null,
+      distinct_spec_versions: data.distinct_spec_versions ?? 0,
+      latest_spec_version: data.latest_spec_version ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -2801,6 +2801,156 @@ function asPlainJson(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
+describe("graphql — blocks_summary (#5664, Postgres-tier + retired-D1 fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty summary, never null", async () => {
+    const { status, body } = await gql(
+      `{ blocks_summary {
+          schema_version block_count first_block last_block
+          first_observed_at last_observed_at
+          block_time { count } throughput { total_extrinsics }
+          distinct_authors author_concentration { gini }
+          distinct_spec_versions latest_spec_version
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.blocks_summary, {
+      schema_version: 1,
+      block_count: 0,
+      first_block: null,
+      last_block: null,
+      first_observed_at: null,
+      last_observed_at: null,
+      block_time: null,
+      throughput: null,
+      distinct_authors: 0,
+      author_concentration: null,
+      distinct_spec_versions: 0,
+      latest_spec_version: null,
+    });
+  });
+
+  test("resolves the Postgres-tier summary, including nested time/throughput/concentration", async () => {
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          block_count: 3,
+          first_block: 100,
+          last_block: 102,
+          first_observed_at: "2026-07-01T00:00:00.000Z",
+          last_observed_at: "2026-07-01T00:00:24.000Z",
+          block_time: {
+            count: 2,
+            mean_ms: 12000,
+            min_ms: 11800,
+            max_ms: 12200,
+            p50_ms: 12000,
+            p90_ms: 12200,
+          },
+          throughput: {
+            total_extrinsics: 30,
+            total_events: 90,
+            mean_extrinsics_per_block: 10,
+            mean_events_per_block: 30,
+            max_extrinsics_in_block: 12,
+          },
+          distinct_authors: 2,
+          author_concentration: {
+            holders: 2,
+            total: 3,
+            gini: 0.17,
+            hhi: 0.56,
+            hhi_normalized: 0.11,
+            nakamoto_coefficient: 1,
+            top_1pct_share: 0.67,
+            top_5pct_share: 0.67,
+            top_10pct_share: 0.67,
+            top_20pct_share: 0.67,
+            entropy: 0.92,
+            entropy_normalized: 0.92,
+          },
+          distinct_spec_versions: 1,
+          latest_spec_version: 199,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ blocks_summary {
+          block_count first_block last_block latest_spec_version distinct_authors
+          block_time { count mean_ms p50_ms p90_ms }
+          throughput { total_extrinsics mean_extrinsics_per_block max_extrinsics_in_block }
+          author_concentration { gini nakamoto_coefficient top_1pct_share entropy_normalized }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const s = body.data.blocks_summary;
+    assert.equal(s.block_count, 3);
+    assert.equal(s.first_block, 100);
+    assert.equal(s.last_block, 102);
+    assert.equal(s.latest_spec_version, 199);
+    assert.equal(s.distinct_authors, 2);
+    assert.equal(s.block_time.count, 2);
+    assert.equal(s.block_time.mean_ms, 12000);
+    assert.equal(s.block_time.p90_ms, 12200);
+    assert.equal(s.throughput.total_extrinsics, 30);
+    assert.equal(s.throughput.max_extrinsics_in_block, 12);
+    assert.equal(s.author_concentration.gini, 0.17);
+    assert.equal(s.author_concentration.nakamoto_coefficient, 1);
+    assert.equal(s.author_concentration.top_1pct_share, 0.67);
+  });
+
+  test("forwards to /api/v1/blocks/summary with no query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({ schema_version: 1, block_count: 0 });
+        },
+      },
+    };
+    await gql("{ blocks_summary { block_count } }", env);
+    assert.equal(capturedUrl.pathname, "/api/v1/blocks/summary");
+    assert.equal(capturedUrl.search, "");
+  });
+
+  test("a partial Postgres-tier body degrades to the schema-stable defaults, never null", async () => {
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      // Every field absent -- the resolver's own ?? defaults must fill them in.
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ blocks_summary {
+          schema_version block_count distinct_authors distinct_spec_versions
+          first_block last_block block_time { count } throughput { total_extrinsics }
+          author_concentration { gini } latest_spec_version
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.blocks_summary, {
+      schema_version: 1,
+      block_count: 0,
+      distinct_authors: 0,
+      distinct_spec_versions: 0,
+      first_block: null,
+      last_block: null,
+      block_time: null,
+      throughput: null,
+      author_concentration: null,
+      latest_spec_version: null,
+    });
+  });
+});
+
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Block-production summary had a REST route (`GET /api/v1/blocks/summary`) and an MCP tool (`get_blocks_summary`) but no GraphQL mirror — the same gap the closed `Query.blocks`/`Query.block` issues (#5573–5580) addressed for the rest of the blocks surface. This adds it.

- **SDL:** a no-arg `blocks_summary: BlocksSummary!` root field placed next to `Query.blocks`/`Query.block`, plus `BlocksSummary` + `BlockTimeDistribution` + `BlocksThroughput` + `ConcentrationMetrics` types mirroring `buildBlocksSummary`'s real response shape (counts, inter-block timing, throughput, and author concentration — Gini/HHI/Nakamoto/top-percentile shares/entropy).
- **Resolver:** reuses the exact `tryPostgresTier(env, …, "METAGRAPH_BLOCKS_SOURCE")` → `buildBlocksSummary([])` fallback contract `handleBlocksSummary` uses. Blocks' D1 write path is retired (#4909), so a cold Postgres tier is the steady state — it degrades to the schema-stable empty summary (`block_count: 0`, every aggregate `null`) rather than a GraphQL error, matching the sibling `Query.block`/`Query.blocks` resolvers. It's a sibling of `Query.block`, not a param on it (the REST route is exact-matched before `{ref}`, so `"summary"` is never parsed as a block reference).
- **`FIELD_COMPLEXITY`** entry at `RELATIONSHIP_FIELD_COMPLEXITY` weight.

## Tests

`tests/graphql.test.mjs` — the Postgres-tier hit (nested time/throughput/concentration), the cold-store fallback (schema-stable empty), a partial/empty Postgres body degrading to the resolver's own defaults, and the `/api/v1/blocks/summary` no-param forward. **100% of the new resolver's statements and branches are covered** (verified via `vitest --coverage`); the full 156-test graphql suite is green. No REST schema/OpenAPI change (GraphQL SDL is inline). `eslint` / `prettier` clean.

`{ blocks_summary { … } }` over `POST /api/v1/graphql` now matches REST (`GET /api/v1/blocks/summary`) and MCP (`get_blocks_summary`).

Closes #5664
