### PR TITLE
feat(graphql): add Query.registry_leaderboards mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -15,6 +15,7 @@ import {
   clampOffset,
 } from "../workers/request-params.mjs";
 import {
+  LEADERBOARD_BOARDS,
   buildGlobalHealth,
   formatLeaderboards,
   resolveLiveEconomics,
@@ -23,6 +24,7 @@ import {
 } from "./health-serving.mjs";
 import {
   loadCompareSubnets,
+  loadRegistryLeaderboards,
   parseCompareDimensionList,
   parseCompareNetuidList,
 } from "./analytics-live.mjs";
@@ -92,6 +94,8 @@ export const SDL = `
     health: GlobalHealth
     "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
     opportunity_boards(limit: Int): OpportunityBoards!
+    "Registry-wide leaderboards (health, RPC latency, completeness, enrichment depth, growth, reliability, plus the economic opportunity boards), optionally narrowed to one board. Mirrors GET /api/v1/registry/leaderboards."
+    registry_leaderboards(board: String, limit: Int): RegistryLeaderboards!
     "Cross-subnet comparison: registry structure, live economics, and live health placed side by side for the requested netuids, in requested order. Mirrors GET /api/v1/compare."
     compare(netuids: [Int!]!, dimensions: [String!]): Compare!
     "Recent-extrinsic feed (newest first), optionally filtered. Mirrors GET /api/v1/extrinsics."
@@ -393,6 +397,54 @@ export const SDL = `
     netuid: Int!
     slug: String
     name: String
+    open_slots: Int
+    max_uids: Int
+    registration_cost_tao: Float
+    registration_allowed: Boolean
+    emission_share: Float
+    total_stake_tao: Float
+    validator_count: Int
+    miner_count: Int
+    validator_headroom: Int
+    max_validators: Int
+  }
+
+  type RegistryLeaderboards {
+    schema_version: Int!
+    "The single board requested, or null when every board was returned."
+    board: String
+    observed_at: String
+    source: String
+    healthiest: [LeaderboardEntry!]!
+    fastest_rpc: [LeaderboardEntry!]!
+    most_complete: [LeaderboardEntry!]!
+    most_enriched: [LeaderboardEntry!]!
+    fastest_growing: [LeaderboardEntry!]!
+    most_reliable: [LeaderboardEntry!]!
+    open_slots: [LeaderboardEntry!]!
+    cheapest_registration: [LeaderboardEntry!]!
+    highest_emission: [LeaderboardEntry!]!
+    validator_headroom: [LeaderboardEntry!]!
+  }
+
+  "Union of every board's fields (RegistryLeaderboards' entry shape is board-specific); only the fields relevant to the board an entry came from are populated, the rest are null."
+  type LeaderboardEntry {
+    netuid: Int!
+    slug: String
+    name: String
+    uptime_ratio: Float
+    surfaces_ok: Int
+    surfaces_total: Int
+    avg_latency_ms: Int
+    latency_ms: Int
+    completeness_score: Int
+    surface_count: Int
+    operational_interface_count: Int
+    completeness_delta: Int
+    score: Int
+    grade: String
+    sample_count: Int
+    latency_sample_count: Int
     open_slots: Int
     max_uids: Int
     registration_cost_tao: Float
@@ -776,6 +828,7 @@ export const FIELD_COMPLEXITY = {
   endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
+  registry_leaderboards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1375,6 +1428,44 @@ const rootValue = {
     return {
       observed_at: ranked.observed_at,
       with_economics_count: rows.length,
+      open_slots: boards["open-slots"] || [],
+      cheapest_registration: boards["cheapest-registration"] || [],
+      highest_emission: boards["highest-emission"] || [],
+      validator_headroom: boards["validator-headroom"] || [],
+    };
+  },
+
+  async registry_leaderboards({ board, limit }, context) {
+    if (board != null && !LEADERBOARD_BOARDS.includes(board)) {
+      throw new GraphQLError(
+        `Unknown board "${board}". Valid boards: ${LEADERBOARD_BOARDS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = clampLimit(limit, { defaultLimit: 20, maxLimit: 100 });
+    const profilesData = await loadArtifact(context, ARTIFACT.profiles);
+    const profiles = Array.isArray(profilesData?.profiles)
+      ? profilesData.profiles
+      : [];
+    const data = await loadRegistryLeaderboards(graphqlD1(context), {
+      profiles,
+      economicsRows: await loadEconomicsRows(context),
+      board: board || null,
+      limit: safeLimit,
+      observedAt: await loadObservedAt(context),
+    });
+    const boards = data.boards;
+    return {
+      schema_version: data.schema_version,
+      board: data.board,
+      observed_at: data.observed_at,
+      source: data.source,
+      healthiest: boards.healthiest || [],
+      fastest_rpc: boards["fastest-rpc"] || [],
+      most_complete: boards["most-complete"] || [],
+      most_enriched: boards["most-enriched"] || [],
+      fastest_growing: boards["fastest-growing"] || [],
+      most_reliable: boards["most-reliable"] || [],
       open_slots: boards["open-slots"] || [],
       cheapest_registration: boards["cheapest-registration"] || [],
       highest_emission: boards["highest-emission"] || [],

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1309,6 +1309,112 @@ describe("graphql — opportunity boards (reuse the leaderboard ranking)", () =>
   });
 });
 
+describe("graphql — registry_leaderboards (#5661, reuse the shared leaderboard loader)", () => {
+  const env = () =>
+    fixtureEnv({
+      "/metagraph/profiles.json": {
+        profiles: [
+          {
+            netuid: 1,
+            slug: "a",
+            name: "A",
+            completeness_score: 90,
+            surface_count: 4,
+            operational_interface_count: 2,
+          },
+          {
+            netuid: 2,
+            slug: "b",
+            name: "B",
+            completeness_score: 50,
+            surface_count: 1,
+            operational_interface_count: 0,
+          },
+        ],
+      },
+      "/metagraph/economics.json": {
+        captured_at: "2026-06-23T00:00:00.000Z",
+        subnets: [
+          {
+            netuid: 1,
+            slug: "a",
+            name: "A",
+            open_slots: 5,
+            registration_cost_tao: 0.5,
+            registration_allowed: true,
+            emission_share: 0.1,
+          },
+        ],
+      },
+    });
+
+  test("no board filter: every board is populated, D1-backed boards degrade to [] with no D1 binding", async () => {
+    const { status, body } = await gql(
+      `{ registry_leaderboards {
+          schema_version board source
+          most_complete { netuid completeness_score }
+          most_enriched { netuid surface_count operational_interface_count }
+          open_slots { netuid open_slots }
+          healthiest { netuid }
+          fastest_rpc { netuid }
+          fastest_growing { netuid }
+          most_reliable { netuid }
+        } }`,
+      env(),
+    );
+    assert.equal(status, 200);
+    const rl = body.data.registry_leaderboards;
+    assert.equal(rl.schema_version, 1);
+    assert.equal(rl.board, null);
+    assert.equal(rl.most_complete[0].netuid, 1);
+    assert.equal(rl.most_complete[0].completeness_score, 90);
+    assert.equal(rl.most_enriched[0].surface_count, 4);
+    assert.equal(rl.open_slots[0].open_slots, 5);
+    // No METAGRAPH_HEALTH_DB binding -> the D1-backed boards degrade to [].
+    assert.deepEqual(rl.healthiest, []);
+    assert.deepEqual(rl.fastest_rpc, []);
+    assert.deepEqual(rl.fastest_growing, []);
+    assert.deepEqual(rl.most_reliable, []);
+  });
+
+  test("a valid board filter narrows the response to that one board", async () => {
+    const { status, body } = await gql(
+      `{ registry_leaderboards(board: "most-complete", limit: 1) {
+          board most_complete { netuid } open_slots { netuid }
+        } }`,
+      env(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.registry_leaderboards.board, "most-complete");
+    assert.equal(body.data.registry_leaderboards.most_complete.length, 1);
+    // Every OTHER board key is absent from the filtered response -> [] fallback.
+    assert.deepEqual(body.data.registry_leaderboards.open_slots, []);
+  });
+
+  test("an unknown board is BAD_USER_INPUT and never reaches the profiles/economics reads", async () => {
+    const reads = new Map();
+    const badEnv = fixtureEnv({}, { reads });
+    const { status, body } = await gql(
+      '{ registry_leaderboards(board: "not-a-real-board") { board } }',
+      badEnv,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(reads.size, 0);
+  });
+
+  test("registry_leaderboards degrades to empty boards on a fully cold store", async () => {
+    const { status, body } = await gql(
+      "{ registry_leaderboards { open_slots { netuid } most_complete { netuid } } }",
+      emptyEnv,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.registry_leaderboards.open_slots, []);
+    assert.deepEqual(body.data.registry_leaderboards.most_complete, []);
+  });
+});
+
 describe("graphql — complexity weights keep the guard meaningful", () => {
   test("FIELD_COMPLEXITY weights the read/fan-out fields above scalars", () => {
     for (const field of [
@@ -1321,6 +1427,7 @@ describe("graphql — complexity weights keep the guard meaningful", () => {
       "endpoints",
       "health",
       "opportunity_boards",
+      "registry_leaderboards",
     ]) {
       assert.equal(FIELD_COMPLEXITY[field], 5, `${field} should be weighted`);
     }


### PR DESCRIPTION
## Summary
- Adds `Query.registry_leaderboards(board: String, limit: Int): RegistryLeaderboards!` to the GraphQL SDL, mirroring `GET /api/v1/registry/leaderboards` and MCP's `get_registry_leaderboards`.
- Reuses the exact same pure loader both REST and MCP already share: `loadRegistryLeaderboards` (`src/analytics-live.mjs`), fed profiles (`/metagraph/profiles.json`) + live economics rows + a D1 runner (`graphqlD1`, the same one `compare`'s health dimension already uses) — no duplicated SQL.
- `board` validates against the same `LEADERBOARD_BOARDS` list REST uses; an unknown value returns a `BAD_USER_INPUT` GraphQL error before any read happens, matching the `validators`/`accounts`/`incidents` validation pattern already in this file. `limit` clamps to the same default (20) / max (100) via the existing `clampLimit` helper.
- Since each board's entries carry different fields (health boards vs. RPC latency vs. completeness vs. the four economic boards), the response models a `RegistryLeaderboards` type with one list field per board (`healthiest`, `fastest_rpc`, `most_complete`, `most_enriched`, `fastest_growing`, `most_reliable`, `open_slots`, `cheapest_registration`, `highest_emission`, `validator_headroom`) against a single union `LeaderboardEntry` type — the same pattern this file's existing `OpportunityEntry` type already established for the 4 economic boards, just widened to all 10.
- Added `registry_leaderboards` to `FIELD_COMPLEXITY` at the standard relationship weight.

## Test plan
- [x] `tests/graphql.test.mjs`: no-filter query (every board populated from profiles/economics fixtures, D1-backed boards degrading to `[]` with no D1 binding), an explicit valid `board` filter narrowing the response (every other board's `[]` fallback), an unknown `board` returning `BAD_USER_INPUT` without touching profiles/economics reads, a fully-cold-store degrade case, and the `FIELD_COMPLEXITY` weight.
- [x] `npm run lint` / `npm run format:check` clean
- [x] `npm run test:ci` (the coverage-generating pass CI uses) green; new code at 100% line/branch coverage
- [x] `npm run validate:contract-drift` passes

Closes #5661