### PR TITLE
feat(graphql): add Query.incidents mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -10,6 +10,10 @@ import { readArtifact, readHealthKv } from "../workers/storage.mjs";
 import { contractVersion } from "../workers/responses.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 import {
+  analyticsWindow,
+  loadGlobalIncidentsLedger,
+} from "../workers/request-handlers/analytics.mjs";
+import {
   BLOCK_PAGINATION,
   clampLimit,
   clampOffset,
@@ -117,6 +121,8 @@ export const SDL = `
     economics_trends(window: String): EconomicsTrends!
     "Cross-subnet momentum leaderboard: every subnet ranked by its stake/emission/validator change between a window's start and end snapshots; movers is empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/subnets/movers."
     subnet_movers(window: String, sort: String, limit: Int): SubnetMovers!
+    "Cross-subnet incident ledger: surfaces with a probe-failure gap-island in the window, newest-started first per surface; surfaces is empty on a cold store, never null. Mirrors GET /api/v1/incidents."
+    incidents(window: String): GlobalIncidents!
   }
 
   type SubnetList {
@@ -283,6 +289,37 @@ export const SDL = `
     neurons_start: Int!
     neurons_end: Int!
     neurons_delta: Int!
+  }
+
+  type GlobalIncidents {
+    schema_version: Int!
+    window: String
+    observed_at: String
+    summary: GlobalIncidentsSummary!
+    surfaces: [GlobalIncidentSurface!]!
+  }
+
+  "Ledger-wide totals for the window."
+  type GlobalIncidentsSummary {
+    incident_count: Int!
+    affected_surface_count: Int!
+  }
+
+  "One surface's incident history within the window."
+  type GlobalIncidentSurface {
+    netuid: Int!
+    surface_id: String
+    incident_count: Int!
+    downtime_ms: Float!
+    incidents: [GlobalIncident!]!
+  }
+
+  "One probe-failure gap-island (a contiguous run of failed checks) for a surface. started_at/ended_at/duration_ms are raw epoch-ms, not ISO -- mirrors the REST ledger's own D1 checked_at values rather than the toIso-formatted timestamps elsewhere in this schema."
+  type GlobalIncident {
+    started_at: Float!
+    ended_at: Float!
+    duration_ms: Float!
+    failed_samples: Int!
   }
 
   type SurfaceList {
@@ -842,6 +879,7 @@ export const FIELD_COMPLEXITY = {
   block: RELATIONSHIP_FIELD_COMPLEXITY,
   economics_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_movers: RELATIONSHIP_FIELD_COMPLEXITY,
+  incidents: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -1814,6 +1852,43 @@ const rootValue = {
         unchanged: network.unchanged ?? 0,
       },
       movers: data.movers || [],
+    };
+  },
+
+  async incidents({ window }, context) {
+    // Same analyticsWindow label/days parsing REST's handleGlobalIncidents
+    // uses, so accepted window labels stay identical between REST and GraphQL.
+    const windowUrl = new URL(context.request.url);
+    windowUrl.search = "";
+    if (window != null) windowUrl.searchParams.set("window", window);
+    const { label, days, error } = analyticsWindow(windowUrl);
+    if (error) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const params = new URLSearchParams();
+    params.set("window", label);
+    // Same tryPostgresTier + loadGlobalIncidentsLedger fallback contract
+    // REST's handleGlobalIncidents uses -- a cold/absent tier yields a
+    // schema-stable empty ledger, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/incidents", params),
+        "METAGRAPH_HEALTH_SOURCE",
+      )) ??
+      (await loadGlobalIncidentsLedger(context.env, { label, days })).data;
+    const summary = data.summary ?? {};
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? label,
+      observed_at: data.observed_at ?? null,
+      summary: {
+        incident_count: summary.incident_count ?? 0,
+        affected_surface_count: summary.affected_surface_count ?? 0,
+      },
+      surfaces: data.surfaces || [],
     };
   },
 };

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3321,6 +3321,186 @@ describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback
   });
 });
 
+describe("graphql — incidents (#5660, Postgres-tier + D1-fallback global gap-island ledger)", () => {
+  function incidentsQuery(argsClause) {
+    return `{ incidents${argsClause} {
+      schema_version window observed_at
+      summary { incident_count affected_surface_count }
+      surfaces {
+        netuid surface_id incident_count downtime_ms
+        incidents { started_at ended_at duration_ms failed_samples }
+      }
+    } }`;
+  }
+
+  test("cold store, default window: schema-stable empty ledger", async () => {
+    const { status, body } = await gql(incidentsQuery(""));
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.incidents, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      summary: { incident_count: 0, affected_surface_count: 0 },
+      surfaces: [],
+    });
+  });
+
+  test("resolves Postgres-tier incidents for a valid non-default window", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            observed_at: "2026-07-10T00:00:00.000Z",
+            summary: { incident_count: 1, affected_surface_count: 1 },
+            surfaces: [
+              {
+                netuid: 5,
+                surface_id: "sn-5-api",
+                incident_count: 1,
+                downtime_ms: 4000,
+                incidents: [
+                  {
+                    started_at: 1000,
+                    ended_at: 5000,
+                    duration_ms: 4000,
+                    failed_samples: 3,
+                  },
+                ],
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(incidentsQuery('(window: "30d")'), env);
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.pathname, "/api/v1/incidents");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(body.data.incidents.window, "30d");
+    assert.equal(body.data.incidents.observed_at, "2026-07-10T00:00:00.000Z");
+    assert.equal(body.data.incidents.summary.incident_count, 1);
+    assert.equal(body.data.incidents.summary.affected_surface_count, 1);
+    assert.equal(body.data.incidents.surfaces.length, 1);
+    assert.equal(body.data.incidents.surfaces[0].netuid, 5);
+    assert.equal(body.data.incidents.surfaces[0].downtime_ms, 4000);
+    assert.equal(
+      body.data.incidents.surfaces[0].incidents[0].failed_samples,
+      3,
+    );
+  });
+
+  test("a bare (window-omitted) request forwards the default label to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({ schema_version: 1, surfaces: [] });
+        },
+      },
+    };
+    await gql(incidentsQuery(""), env);
+    assert.equal(capturedUrl.searchParams.get("window"), "7d");
+  });
+
+  test("a malformed Postgres-tier body degrades to schema-stable defaults (no throw)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(incidentsQuery(""), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.incidents, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      summary: { incident_count: 0, affected_surface_count: 0 },
+      surfaces: [],
+    });
+  });
+
+  test("no Postgres tier flag: rolls up the D1 gap-island ledger", async () => {
+    const env = {
+      METAGRAPH_CONTROL: {
+        async get(key) {
+          return key === KV_HEALTH_META
+            ? { last_run_at: "2026-06-23T00:00:00.000Z" }
+            : null;
+        },
+      },
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  return {
+                    results: [
+                      {
+                        netuid: 5,
+                        surface_id: "sn-5-api",
+                        surface_key: "sn-5-api",
+                        started_at: 1000,
+                        ended_at: 5000,
+                        failed_samples: 3,
+                      },
+                    ],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const { status, body } = await gql(incidentsQuery('(window: "7d")'), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.incidents.window, "7d");
+    assert.equal(body.data.incidents.observed_at, "2026-06-23T00:00:00.000Z");
+    assert.equal(body.data.incidents.summary.incident_count, 1);
+    assert.equal(body.data.incidents.surfaces[0].netuid, 5);
+    assert.equal(
+      body.data.incidents.surfaces[0].incidents[0].duration_ms,
+      4000,
+    );
+  });
+
+  test("a D1 query error degrades to a schema-stable empty ledger (no throw)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          throw new Error("db unavailable");
+        },
+      },
+    };
+    const { status, body } = await gql(incidentsQuery(""), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.incidents.surfaces, []);
+    assert.equal(body.data.incidents.summary.incident_count, 0);
+  });
+
+  test("an unsupported window is a GraphQL error, matching REST's own validation shape", async () => {
+    const { status, body } = await gql(incidentsQuery('(window: "1y")'));
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    const err = body.errors.find(
+      (e) => e.extensions?.code === "BAD_USER_INPUT",
+    );
+    assert.ok(err);
+    assert.match(err.message, /1y/);
+  });
+
+  test("incidents is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.incidents, 5);
+  });
+});
+
 describe("Subscription.chainEvents", () => {
   test("yields a properly-shaped GraphQL execution result for each pushed payload", async () => {
     const hub = fakeChainFirehose((repeater) => {


### PR DESCRIPTION
## Summary

- Adds `Query.incidents(window: String): GlobalIncidents!` to the GraphQL SDL, mirroring `GET /api/v1/incidents` (`handleGlobalIncidents`, `workers/request-handlers/analytics.mjs:761`) and MCP's `get_global_incidents`.

## What Changed

- New `GlobalIncidents` / `GlobalIncidentsSummary` / `GlobalIncidentSurface` / `GlobalIncident` types in `src/graphql.mjs`, mirroring `formatGlobalIncidents`'s (`src/health-serving.mjs`) real `data` shape — `started_at`/`ended_at`/`duration_ms` are typed `Float` (raw epoch-ms from D1 `checked_at`, not the `toIso`-formatted strings used elsewhere in the schema, since that's what the REST ledger itself returns).
- Resolver reuses `analyticsWindow` (already exported from `workers/request-handlers/analytics.mjs`) for the same window-label parsing REST uses, then the same `tryPostgresTier(env, request, "METAGRAPH_HEALTH_SOURCE")` → `loadGlobalIncidentsLedger` D1-fallback contract `handleGlobalIncidents` uses — never a GraphQL error on a cold/retired tier.
- `incidents` added to `FIELD_COMPLEXITY` at `RELATIONSHIP_FIELD_COMPLEXITY` weight, matching every other root-list field.
- Tests in `tests/graphql.test.mjs`: cold-store default, Postgres-tier happy path + window forwarding, malformed Postgres-tier body, D1-fallback happy path, D1 query error, and an unsupported-window `BAD_USER_INPUT` error.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5660`).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none needed here — no `schemas/` change).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (GraphQL SDL only — no REST/OpenAPI surface changed).

## Validation

- [x] `npm run lint`
- [x] `npx prettier --check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:contract-drift`
- [x] `npm run worker:test`
- [x] `npm test` (8509 tests)
- [x] `npm run test:coverage -- tests/graphql.test.mjs` (100% line/statement/function coverage on `src/graphql.mjs`, no gaps in the new `incidents` field/resolver)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

Closes #5660
