### PR TITLE
style: fix prettier drift in contributor-pipeline-gardening reference.md

### DIFF
--- a/.claude/skills/contributor-pipeline-gardening/reference.md
+++ b/.claude/skills/contributor-pipeline-gardening/reference.md
@@ -12,6 +12,7 @@ shell) for content/structure/search, rendered through existing ui-kit primitives
 once proven, as a shared package both apps import rather than a second from-scratch integration.
 
 **Until that spike lands and a metagraphed port issue exists:**
+
 - Don't file new issues asking a contributor to hand-build a `docs.*.tsx` route. If a genuine docs
   gap is found during Pass 2, note it in the digest instead of filing it under the old pattern.
 - The open "Docs page: X" family (#3504/3505/3506/3507/3508/3509/3510/3511/3514/3516) was


### PR DESCRIPTION
## Summary
- Fixes a one-line prettier formatting drift (missing blank line after a heading) introduced in #5679, which was failing the `checks` job's `format:check` step for every PR against main since that merge.

## Test plan
- [x] `npx prettier --check .claude/skills/contributor-pipeline-gardening/reference.md` passes