### PR TITLE
feat(graphql): add Query.incidents mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -10,6 +10,10 @@ import { readArtifact, readHealthKv } from "../workers/storage.mjs";
 import { contractVersion } from "../workers/responses.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 import {
+  analyticsWindow,
+  loadGlobalIncidentsLedger,
+} from "../workers/request-handlers/analytics.mjs";
+import {
   BLOCK_PAGINATION,
   clampLimit,
   clampOffset,
@@ -74,6 +78,9 @@ export const GRAPHQL_MAX_QUERY_BYTES = 16 * 1024;
 // artifact and so cost a read / fan out per parent) are the only ones backed by
 // explicit resolver thunks, and each carries a complexity weight below.
 export const SDL = `
+  "Opaque JSON value, for dynamic-keyed maps with no fixed field set (e.g. the incident summary's by_kind/by_provider/by_status count maps) -- matching how the MCP mirror serves them."
+  scalar JSON
+
   type Query {
     "Paginated active-subnet index."
     subnets(limit: Int, cursor: String): SubnetList!
@@ -95,6 +102,8 @@ export const SDL = `
     opportunity_boards(limit: Int): OpportunityBoards!
     "Cross-subnet comparison: registry structure, live economics, and live health placed side by side for the requested netuids, in requested order. Mirrors GET /api/v1/compare."
     compare(netuids: [Int!]!, dimensions: [String!]): Compare!
+    "Global endpoint-incident ledger over a 7d/30d window; degrades to a schema-stable empty ledger (never a GraphQL error) on a cold/retired health tier. Mirrors GET /api/v1/incidents."
+    incidents(window: String): GlobalIncidents!
     "Recent-extrinsic feed (newest first), optionally filtered. Mirrors GET /api/v1/extrinsics."
     extrinsics(limit: Int, offset: Int, cursor: String, block: Int, signer: String, call_module: String, call_function: String, success: Boolean): ExtrinsicList!
     "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}."
@@ -449,6 +458,45 @@ export const SDL = `
     surface_count: Int
     ok_count: Int
     avg_latency_ms: Int
+  }
+
+  "Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope."
+  type GlobalIncidents {
+    schema_version: Int!
+    window: String
+    observed_at: String
+    source: String
+    "Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape."
+    summary: JSON
+    surfaces: [EndpointIncident!]!
+  }
+
+  "One endpoint incident in the global ledger. Mirrors the REST EndpointIncident shape (enum-valued fields carried as their string values)."
+  type EndpointIncident {
+    id: String
+    endpoint_id: String
+    state: String
+    severity: String
+    status: String
+    reason: String
+    kind: String
+    layer: String
+    classification: String
+    netuid: Int
+    provider: String
+    operator: String
+    subnet_name: String
+    subnet_slug: String
+    surface_id: String
+    surface_key: String
+    detected_at: String
+    last_checked: String
+    last_ok: String
+    observed_at: String
+    health_stale: Boolean
+    health_source: String
+    pool_eligible: Boolean
+    user_reported: Boolean
   }
 
   type ExtrinsicList {
@@ -838,6 +886,7 @@ export const FIELD_COMPLEXITY = {
   accounts: RELATIONSHIP_FIELD_COMPLEXITY,
   account: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
+  incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
   economics_trends: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1468,6 +1517,41 @@ const rootValue = {
       dimensions: parsedDimensions,
       observedAt: await loadObservedAt(context),
     });
+  },
+
+  async incidents({ window }, context) {
+    // Reuse the exact analyticsWindow parse/validate REST's handleGlobalIncidents
+    // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL BAD_USER_INPUT
+    // error, not a silent empty result. analyticsWindow reads only the ?window param.
+    const windowUrl = new URL(context.request.url);
+    windowUrl.search = "";
+    if (window != null) windowUrl.searchParams.set("window", window);
+    const { label, days, error } = analyticsWindow(windowUrl);
+    if (error) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same METAGRAPH_HEALTH_SOURCE Postgres tier -> loadGlobalIncidentsLedger D1
+    // fallback contract handleGlobalIncidents uses; the ledger is schema-stable on
+    // a cold/retired tier (empty surfaces + zeroed summary), never a GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", label);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/incidents", params),
+        "METAGRAPH_HEALTH_SOURCE",
+      )) ??
+      (await loadGlobalIncidentsLedger(context.env, { label, days })).data;
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? label,
+      observed_at: data.observed_at ?? null,
+      source: data.source ?? null,
+      summary: data.summary ?? null,
+      surfaces: data.surfaces ?? [],
+    };
   },
 
   async extrinsics(

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -2951,6 +2951,121 @@ describe("graphql — blocks_summary (#5664, Postgres-tier + retired-D1 fallback
   });
 });
 
+describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledger)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+  // Minimal D1 stub: every query returns no rows, so loadGlobalIncidentsLedger's
+  // fallback path runs to a schema-stable empty ledger without a live DB.
+  const emptyHealthDb = {
+    prepare: () => ({ bind: () => ({ all: async () => ({ results: [] }) }) }),
+  };
+
+  test("cold store: no Postgres flag falls back to the D1 ledger, schema-stable empty, never null", async () => {
+    const { status, body } = await gql(
+      "{ incidents { schema_version window surfaces { id } } }",
+      { METAGRAPH_HEALTH_DB: emptyHealthDb },
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.incidents.schema_version, 1);
+    assert.equal(body.data.incidents.window, "7d");
+    assert.deepEqual(body.data.incidents.surfaces, []);
+  });
+
+  test("resolves the Postgres-tier ledger, including the JSON summary and typed surfaces", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          window: "30d",
+          observed_at: "2026-07-01T00:00:00.000Z",
+          source: "postgres",
+          summary: {
+            incident_count: 2,
+            active_count: 1,
+            by_status: { down: 1, warn: 1 },
+            by_severity: { high: 1, medium: 1 },
+            by_kind: {},
+            by_layer: {},
+            by_provider: { acme: 2 },
+          },
+          surfaces: [
+            {
+              id: "inc-1",
+              endpoint_id: "ep-1",
+              state: "down",
+              severity: "high",
+              status: "down",
+              reason: "probe timeout",
+              netuid: 5,
+              provider: "acme",
+              health_stale: false,
+              pool_eligible: true,
+              user_reported: false,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ incidents(window: "30d") {
+          schema_version window observed_at source
+          summary
+          surfaces { id endpoint_id state severity status reason netuid provider health_stale pool_eligible user_reported }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const inc = body.data.incidents;
+    assert.equal(inc.window, "30d");
+    assert.equal(inc.observed_at, "2026-07-01T00:00:00.000Z");
+    // JSON scalar passes the dynamic-keyed summary through as-is.
+    assert.equal(inc.summary.incident_count, 2);
+    assert.equal(inc.summary.active_count, 1);
+    assert.deepEqual(inc.summary.by_status, { down: 1, warn: 1 });
+    assert.deepEqual(inc.summary.by_provider, { acme: 2 });
+    assert.equal(inc.surfaces.length, 1);
+    assert.equal(inc.surfaces[0].id, "inc-1");
+    assert.equal(inc.surfaces[0].state, "down");
+    assert.equal(inc.surfaces[0].netuid, 5);
+    assert.equal(inc.surfaces[0].pool_eligible, true);
+  });
+
+  test("a partial Postgres-tier body degrades to the schema-stable defaults", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      '{ incidents(window: "30d") { schema_version window observed_at source summary surfaces { id } } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.incidents, {
+      schema_version: 1,
+      window: "30d",
+      observed_at: null,
+      source: null,
+      summary: null,
+      surfaces: [],
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent empty ledger", async () => {
+    const { body } = await gql(
+      '{ incidents(window: "99d") { schema_version } }',
+      {
+        METAGRAPH_HEALTH_DB: emptyHealthDb,
+      },
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data?.incidents ?? null, null);
+  });
+});
+
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Global endpoint incidents had a REST route (`GET /api/v1/incidents`) and an MCP tool (`get_global_incidents`) but no GraphQL mirror — the same gap-closure category as the closed `Query.blocks`/`Query.extrinsics`/`Query.validators`/`Query.accounts` issues.

- **SDL:** an `incidents(window: String): GlobalIncidents!` root field placed next to `Query.compare`, plus a `GlobalIncidents` type (`schema_version`, `window`, `observed_at`, `source`, `summary`, `surfaces`) and a fully-typed `EndpointIncident` (all 24 fields, enum-valued fields carried as their string values). The `summary`'s `by_kind`/`by_layer`/`by_provider`/`by_severity`/`by_status` are **dynamic-keyed** count maps with no fixed field set, so `summary` is a `JSON` scalar — matching exactly how the MCP `get_global_incidents` tool serves it (`type: ["object","null"]`). This adds a minimal `scalar JSON` (identity-serialized under `buildSchema`, output-only) used only for that genuinely-dynamic value.
- **Resolver:** reuses REST's exact contract — `analyticsWindow` for the 7d/30d window parse+validate (an unsupported window surfaces as a GraphQL `BAD_USER_INPUT` error, not a silent empty result), then `tryPostgresTier(env, …, "METAGRAPH_HEALTH_SOURCE")` with the `loadGlobalIncidentsLedger` D1 fallback `handleGlobalIncidents` uses. Degrades to a schema-stable empty ledger (empty `surfaces`, defaults filled) on a cold/retired tier, never a GraphQL error.
- **`FIELD_COMPLEXITY`** entry at `RELATIONSHIP_FIELD_COMPLEXITY` weight.

## Tests

`tests/graphql.test.mjs` — the Postgres-tier hit (JSON summary passthrough + typed surfaces), the D1-fallback path (schema-stable empty), a partial/empty Postgres body degrading to the resolver's defaults, and the unsupported-`window` GraphQL error. **100% of the new resolver's statements and branches are covered** (verified via `vitest --coverage`); the full 169-test graphql suite is green. No REST schema/OpenAPI change (SDL is inline). `eslint` / `prettier` clean.

`{ incidents(window: "30d") { … } }` over `POST /api/v1/graphql` now matches REST (`GET /api/v1/incidents`) and MCP (`get_global_incidents`).

Closes #5660
