### PR TITLE
feat(graphql): add Query.validator_nominators mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -62,6 +62,14 @@ import {
   MOVERS_WINDOWS,
   buildMovers,
 } from "./movers.mjs";
+import {
+  DEFAULT_NOMINATOR_SORT,
+  DEFAULT_NOMINATOR_WINDOW,
+  NOMINATOR_LIMIT_DEFAULT,
+  NOMINATOR_SORTS,
+  NOMINATOR_WINDOWS,
+  buildValidatorNominators,
+} from "./validator-nominators.mjs";
 
 export const GRAPHQL_MAX_DEPTH = 7;
 export const GRAPHQL_MAX_COMPLEXITY = 50;
@@ -117,6 +125,8 @@ export const SDL = `
     economics_trends(window: String): EconomicsTrends!
     "Cross-subnet momentum leaderboard: every subnet ranked by its stake/emission/validator change between a window's start and end snapshots; movers is empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/subnets/movers."
     subnet_movers(window: String, sort: String, limit: Int): SubnetMovers!
+    "Nominators (stakers) of one validator across every subnet it operates in, over a window, ranked by net/gross flow or recency; a hotkey with no nominators resolves to a schema-stable empty list, never null. Mirrors GET /api/v1/validators/{hotkey}/nominators."
+    validator_nominators(hotkey: String!, window: String, sort: String): NominatorList!
   }
 
   type SubnetList {
@@ -596,6 +606,29 @@ export const SDL = `
     validator_trust: Float
   }
 
+  "Nominators (stakers) of one validator, ranked by net/gross flow or recency over the window. nominators is empty on a cold store or a hotkey with no nominators, never null."
+  type NominatorList {
+    schema_version: Int!
+    hotkey: String!
+    window: String
+    sort: String!
+    limit: Int!
+    offset: Int!
+    nominator_count: Int!
+    nominators: [Nominator!]!
+  }
+
+  "One coldkey's staked/unstaked flow into a validator hotkey over the requested window."
+  type Nominator {
+    coldkey: String!
+    staked_tao: Float!
+    unstaked_tao: Float!
+    net_staked_tao: Float!
+    gross_staked_tao: Float!
+    event_count: Int!
+    last_observed_at: String
+  }
+
   "Self-reported on-chain identity (SubtensorModule::set_identity) for a coldkey."
   type Identity {
     has_identity: Boolean!
@@ -842,6 +875,7 @@ export const FIELD_COMPLEXITY = {
   block: RELATIONSHIP_FIELD_COMPLEXITY,
   economics_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_movers: RELATIONSHIP_FIELD_COMPLEXITY,
+  validator_nominators: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -1814,6 +1848,56 @@ const rootValue = {
         unchanged: network.unchanged ?? 0,
       },
       movers: data.movers || [],
+    };
+  },
+
+  async validator_nominators({ hotkey, window, sort }, context) {
+    const requestedWindow = window ?? DEFAULT_NOMINATOR_WINDOW;
+    if (!Object.hasOwn(NOMINATOR_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(requestedWindow, NOMINATOR_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const requestedSort = sort ?? DEFAULT_NOMINATOR_SORT;
+    if (!NOMINATOR_SORTS.includes(requestedSort)) {
+      throw new GraphQLError(
+        `"${requestedSort}" is not a supported sort. Supported: ${NOMINATOR_SORTS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    params.set("sort", requestedSort);
+    // Same tryPostgresTier ?? buildValidatorNominators([], hotkey, ...) fallback
+    // contract REST's handleValidatorNominators and MCP's get_validator_nominators
+    // both use -- account_events' D1 copy is frozen (#4826), so a cold/absent
+    // Postgres tier degrades straight to the schema-stable empty list rather
+    // than a D1 read.
+    const body = await tryPostgresTier(
+      context.env,
+      postgresTierRequest(
+        context,
+        `/api/v1/validators/${encodeURIComponent(hotkey)}/nominators`,
+        params,
+      ),
+      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+    );
+    const data =
+      body?.data ??
+      buildValidatorNominators([], hotkey, {
+        window: requestedWindow,
+        sort: requestedSort,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      hotkey: data.hotkey ?? hotkey,
+      window: data.window ?? requestedWindow,
+      sort: data.sort ?? requestedSort,
+      limit: data.limit ?? NOMINATOR_LIMIT_DEFAULT,
+      offset: data.offset ?? 0,
+      nominator_count: data.nominator_count ?? 0,
+      nominators: data.nominators || [],
     };
   },
 };

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3321,6 +3321,181 @@ describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback
   });
 });
 
+describe("graphql — validator_nominators (#5692, Postgres-tier + buildValidatorNominators fallback list)", () => {
+  const HOTKEY = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+  function nominatorsQuery(argsClause) {
+    return `{ validator_nominators(hotkey: "${HOTKEY}"${argsClause}) {
+      schema_version hotkey window sort limit offset nominator_count
+      nominators { coldkey staked_tao unstaked_tao net_staked_tao gross_staked_tao event_count last_observed_at }
+    } }`;
+  }
+
+  test("cold store, default args: schema-stable empty list (a hotkey with no nominators)", async () => {
+    const { status, body } = await gql(nominatorsQuery(""));
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.validator_nominators, {
+      schema_version: 1,
+      hotkey: HOTKEY,
+      window: "30d",
+      sort: "net_staked",
+      limit: 20,
+      offset: 0,
+      nominator_count: 0,
+      nominators: [],
+    });
+  });
+
+  test("resolves Postgres-tier nominators for a valid non-default window/sort combination", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            data: {
+              schema_version: 1,
+              hotkey: HOTKEY,
+              window: "7d",
+              sort: "gross_staked",
+              limit: 20,
+              offset: 0,
+              nominator_count: 1,
+              nominators: [
+                {
+                  coldkey: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+                  staked_tao: 12.5,
+                  unstaked_tao: 2.5,
+                  net_staked_tao: 10,
+                  gross_staked_tao: 15,
+                  event_count: 4,
+                  last_observed_at: "2026-07-14T00:00:00.000Z",
+                },
+              ],
+            },
+            generatedAt: "2026-07-14T00:00:00.000Z",
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      nominatorsQuery(', window: "7d", sort: "gross_staked"'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(
+      capturedUrl.pathname,
+      `/api/v1/validators/${HOTKEY}/nominators`,
+    );
+    assert.equal(capturedUrl.searchParams.get("window"), "7d");
+    assert.equal(capturedUrl.searchParams.get("sort"), "gross_staked");
+    assert.equal(body.data.validator_nominators.window, "7d");
+    assert.equal(body.data.validator_nominators.sort, "gross_staked");
+    assert.equal(body.data.validator_nominators.nominator_count, 1);
+    assert.equal(body.data.validator_nominators.nominators.length, 1);
+    assert.equal(
+      body.data.validator_nominators.nominators[0].coldkey,
+      "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    );
+    assert.equal(
+      body.data.validator_nominators.nominators[0].net_staked_tao,
+      10,
+    );
+  });
+
+  test("a Postgres-tier body missing the data envelope falls back to buildValidatorNominators (no throw)", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(nominatorsQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.validator_nominators.nominator_count, 0);
+    assert.deepEqual(body.data.validator_nominators.nominators, []);
+    assert.equal(body.data.validator_nominators.hotkey, HOTKEY);
+  });
+
+  test("a Postgres-tier body with an empty data envelope degrades each field to its schema-stable default (no throw)", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({ data: {} }) },
+    };
+    const { status, body } = await gql(nominatorsQuery(""), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.validator_nominators, {
+      schema_version: 1,
+      hotkey: HOTKEY,
+      window: "30d",
+      sort: "net_staked",
+      limit: 20,
+      offset: 0,
+      nominator_count: 0,
+      nominators: [],
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silently substituted default", async () => {
+    const { status, body } = await gql(nominatorsQuery(', window: "1y"'));
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    const err = body.errors.find(
+      (e) => e.extensions?.code === "BAD_USER_INPUT",
+    );
+    assert.ok(err);
+    assert.match(err.message, /1y/);
+  });
+
+  test("an unsupported sort is a GraphQL error, not a silently substituted default", async () => {
+    const { status, body } = await gql(nominatorsQuery(', sort: "bogus"'));
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    const err = body.errors.find(
+      (e) => e.extensions?.code === "BAD_USER_INPUT",
+    );
+    assert.ok(err);
+    assert.match(err.message, /bogus/);
+  });
+
+  test("the largest supported window (90d) and last-activity sort resolve as a valid boundary combination", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            data: {
+              schema_version: 1,
+              hotkey: HOTKEY,
+              window: "90d",
+              sort: "last_activity",
+              limit: 20,
+              offset: 0,
+              nominator_count: 0,
+              nominators: [],
+            },
+            generatedAt: null,
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      nominatorsQuery(', window: "90d", sort: "last_activity"'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.searchParams.get("window"), "90d");
+    assert.equal(capturedUrl.searchParams.get("sort"), "last_activity");
+    assert.equal(body.data.validator_nominators.window, "90d");
+    assert.equal(body.data.validator_nominators.sort, "last_activity");
+  });
+
+  test("validator_nominators is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.validator_nominators, 5);
+  });
+});
+
 describe("Subscription.chainEvents", () => {
   test("yields a properly-shaped GraphQL execution result for each pushed payload", async () => {
     const hub = fakeChainFirehose((repeater) => {


### PR DESCRIPTION
## Summary

Validator nominators had a REST route (`GET /api/v1/validators/{hotkey}/nominators`) and an MCP tool (`get_validator_nominators`) but no GraphQL mirror. Adds a `validator_nominators(hotkey: String!, window: String, sort: String): NominatorList!` root field next to `Query.validator`, with `NominatorList` + `Nominator` types mirroring `buildValidatorNominators`'s real response shape.

- Resolver reuses the same `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> buildValidatorNominators([], hotkey, ...)` fallback contract `handleValidatorNominators` (REST) and `get_validator_nominators` (MCP) both use — `account_events`' D1 copy is frozen (#4826), so a cold/absent Postgres tier degrades to a schema-stable empty list (`nominator_count: 0`, `nominators: []`) rather than a GraphQL error, never null.
- `window`/`sort` are validated against the exact same allow-lists REST uses (`NOMINATOR_WINDOWS`, `NOMINATOR_SORTS` from `src/validator-nominators.mjs`), returning a GraphQL `BAD_USER_INPUT` error for an invalid value instead of silently substituting a default.
- Added the `validator_nominators` `FIELD_COMPLEXITY` entry at the relationship-field weight (fans out per-nominator).
- SDL doc-comment follows the existing "Mirrors GET /api/v1/..." convention.

## Test plan

- `tests/graphql.test.mjs`: cold-store empty list, a successful Postgres-tier hit (window/sort forwarded as query params), a data-envelope-missing degrade, a data-envelope-empty degrade (each field falls back individually), an invalid `window` GraphQL error, an invalid `sort` GraphQL error, a window/sort boundary combination (`90d`/`last_activity`), and the `FIELD_COMPLEXITY` weight assertion.
- `npx vitest run tests/graphql.test.mjs tests/validator-nominators.test.mjs` — 202 passed.
- `npm run lint` / `npx prettier --check` — clean.
- Coverage scoped to the new resolver's lines/branches — 100%.

Closes #5692
