### PR TITLE
feat(mcp): add a query_graphql bridge tool for /api/v1/graphql

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -55,6 +55,11 @@ import {
 } from "../workers/mcp-session-hub.mjs";
 import { CONTRACT_VERSION, PRIMARY_DOMAIN, QUERY_ENUMS } from "./contracts.mjs";
 import {
+  GRAPHQL_MAX_COMPLEXITY,
+  GRAPHQL_MAX_DEPTH,
+  handleGraphQLRequest,
+} from "./graphql.mjs";
+import {
   GET_ECONOMICS_INSTRUCTIONS,
   GET_ECONOMICS_MCP_TOOL,
   GET_ECONOMICS_OUTPUT_SCHEMA,
@@ -1706,6 +1711,20 @@ function requireString(args, key) {
     );
   }
   return value.trim();
+}
+
+// A plain object (not an array) for GraphQL `variables`, or undefined when
+// absent — matches the shape handleGraphQLRequest destructures from the POST body.
+function optionalVariables(args) {
+  const value = args?.variables;
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw toolError(
+      "invalid_params",
+      "Argument `variables` must be an object when provided.",
+    );
+  }
+  return value;
 }
 
 // A trimmed optional string, or null when absent/blank — for free-form filters
@@ -9665,6 +9684,62 @@ export const MCP_TOOLS = [
       });
     },
   },
+  {
+    name: "query_graphql",
+    title: "Run a GraphQL query against /api/v1/graphql",
+    description:
+      "Forward an arbitrary read-only query (+ optional variables) to the " +
+      "metagraphed GraphQL endpoint and return its JSON result ({ data, " +
+      "errors }). Prefer this over the individual REST-mirrored tools " +
+      "(get_subnet, list_subnets, ...) when you need arbitrary field " +
+      "selection or several nested relations in one round-trip; prefer a " +
+      "dedicated tool instead when the lookup is a single well-known shape, " +
+      "since it needs no query string. Mutations are not supported -- the " +
+      `schema is query-only. Subject to the same limits as the REST ` +
+      `endpoint: max depth ${GRAPHQL_MAX_DEPTH}, max complexity ` +
+      `${GRAPHQL_MAX_COMPLEXITY}; a query over either limit returns an ` +
+      "error instead of executing.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "GraphQL query document, e.g. '{ health { status } }'.",
+        },
+        variables: {
+          type: "object",
+          description: "Optional variables object for the query.",
+        },
+        operationName: {
+          type: "string",
+          description:
+            "Optional operation name, required only when `query` defines more than one operation.",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const query = requireString(args, "query");
+      const variables = optionalVariables(args);
+      const operationName = optionalString(args, "operationName");
+      const request = new Request("https://internal/api/v1/graphql", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          query,
+          variables,
+          operationName: operationName ?? undefined,
+        }),
+      });
+      const response = await handleGraphQLRequest(request, ctx.env);
+      const result = await response.json();
+      if (response.status >= 400) {
+        throw toolError("invalid_params", result.errors[0].message);
+      }
+      return result;
+    },
+  },
 ];
 
 const TOOLS_BY_NAME = new Map(MCP_TOOLS.map((tool) => [tool.name, tool]));
@@ -13311,6 +13386,14 @@ const TOOL_OUTPUT_SCHEMAS = {
       error: NULLABLE_STRING,
       probed_at: NULLABLE_STRING,
       from_cache: { type: "boolean" },
+    },
+  },
+  query_graphql: {
+    type: "object",
+    additionalProperties: true,
+    properties: {
+      data: { type: ["object", "null"] },
+      errors: { type: "array", items: { type: "object" } },
     },
   },
 };

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -1471,3 +1471,67 @@ describe("get_build — branch coverage", () => {
     assert.match(res.body.result.content[0].text, /build-summary\.json/);
   });
 });
+
+// ── query_graphql — GraphQL bridge branches ───────────────────────────────
+describe("query_graphql — branch coverage", () => {
+  test("forwards query + variables + operationName and returns the endpoint's data", async () => {
+    const res = await callTool("query_graphql", {
+      query: "query GetSubnet($n: Int!) { subnet(netuid: $n) { netuid } }",
+      variables: { n: 1 },
+      operationName: "GetSubnet",
+    });
+    assert.equal(res.body.result.isError, false);
+    assert.deepEqual(res.body.result.structuredContent, {
+      data: { subnet: null },
+    });
+  });
+
+  test("runs without optional variables/operationName", async () => {
+    const res = await callTool("query_graphql", {
+      query: "{ health { status } }",
+    });
+    assert.equal(res.body.result.isError, false);
+    assert.deepEqual(res.body.result.structuredContent, {
+      data: { health: null },
+    });
+  });
+
+  test("rejects a missing query", async () => {
+    const res = await callTool("query_graphql", {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Argument `query` must be a non-empty string/,
+    );
+  });
+
+  test("rejects a non-object `variables`", async () => {
+    const res = await callTool("query_graphql", {
+      query: "{ health { status } }",
+      variables: [1, 2],
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /Argument `variables` must be an object/,
+    );
+  });
+
+  test("surfaces the endpoint's parse error as invalid_params", async () => {
+    const res = await callTool("query_graphql", { query: "{ subnet(" });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /^invalid_params:/);
+  });
+
+  test("a GraphQL-level execution error still resolves (not an invalid_params throw)", async () => {
+    const res = await callTool("query_graphql", {
+      query: '{ validators(sort: "not_a_real_sort") { total } }',
+    });
+    assert.equal(res.body.result.isError, false);
+    assert.equal(res.body.result.structuredContent.data, null);
+    assert.match(
+      res.body.result.structuredContent.errors[0].message,
+      /not a supported sort/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `query_graphql` MCP tool (`src/mcp-server.mjs`) that forwards an arbitrary read-only GraphQL query (+ optional `variables`/`operationName`) to the existing `/api/v1/graphql` endpoint via `handleGraphQLRequest`, returning its `{ data, errors }` result.
- Bridges the gap in the other direction from the REST-mirror GraphQL-parity issues: agents currently can only reach the individual REST-mirrored MCP tools (`get_subnet`, `list_subnets`, ...), which don't cover arbitrary field selection or several nested relations in one round-trip. This tool exposes that directly.
- Subject to the exact same limits the REST GraphQL endpoint already enforces (`GRAPHQL_MAX_DEPTH`, `GRAPHQL_MAX_COMPLEXITY`) since it forwards through the same handler — no new bypass surface.
- A malformed/oversized query or an unparseable document surfaces as `invalid_params` (mirrors the endpoint's own 4xx handling); a resolver-level GraphQL error (e.g. an invalid enum arg) still resolves normally as `{ data: null, errors: [...] }` rather than throwing, since that's part of the GraphQL result contract, not a tool-call failure.
- New `optionalVariables` helper validates `variables` is a plain object (not an array) when provided, following the existing `optionalString`/`requireString` helper conventions in this file.
- Read-only, no mutations (the schema itself is query-only), so no new auth/abuse surface.

## Test plan
- [x] `tests/mcp-server-branch-coverage.test.mjs`: forwards query+variables+operationName, runs without optional args, rejects a missing `query`, rejects a non-object `variables`, surfaces a parse error as `invalid_params`, and confirms a resolver-level GraphQL error (invalid `sort` arg) still resolves rather than throwing.
- [x] `npm run lint` / `npm run format:check` clean
- [x] `npm run test:ci` (the coverage-generating pass CI uses) green; new code at 100% line/branch coverage
- [x] `npm run validate:contract-drift` passes

Closes #5591