### PR TITLE
feat(ui): add StateBlock, a typed entry point for empty/stale/error blocks

### DIFF
--- a/apps/ui/src/components/metagraphed/state-block.test.ts
+++ b/apps/ui/src/components/metagraphed/state-block.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { ReactElement } from "react";
+import { TableState } from "@jsonbored/ui-kit";
+import { StateBlock, type StateContext } from "./state-block";
+import { EmptyState } from "./states";
+import { RegistryEmpty } from "./states/registry-empty";
+
+// StateBlock is a plain dispatch function, so calling it returns the element it
+// would render without needing a DOM — the same technique validator-columns.test
+// uses for its cell renderers.
+const render = (props: Parameters<typeof StateBlock>[0]) =>
+  StateBlock(props) as ReactElement<Record<string, unknown>>;
+
+describe("StateBlock (#5341)", () => {
+  it("routes a section context to EmptyState", () => {
+    expect(render({ context: "section", title: "No rows" }).type).toBe(EmptyState);
+  });
+
+  it("routes a table context to TableState", () => {
+    expect(render({ context: "table", variant: "empty", title: "No rows" }).type).toBe(TableState);
+  });
+
+  it("routes a registry context to RegistryEmpty", () => {
+    expect(render({ context: "registry", variant: "empty", title: "No surfaces" }).type).toBe(
+      RegistryEmpty,
+    );
+  });
+
+  it("maps every context to a distinct primitive", () => {
+    const contexts: StateContext[] = ["section", "table", "registry"];
+    const types = contexts.map(
+      (context) =>
+        render({ context, variant: "empty", title: "t" } as Parameters<typeof StateBlock>[0]).type,
+    );
+    expect(new Set(types).size).toBe(contexts.length);
+  });
+
+  it("forwards the caller's props and never leaks `context` to the primitive", () => {
+    const onRetry = () => {};
+    const el = render({
+      context: "table",
+      variant: "error",
+      title: "Boom",
+      onRetry,
+      error: { status: 500, url: "https://api.example/x" },
+    });
+    expect(el.props).not.toHaveProperty("context");
+    expect(el.props).toMatchObject({ variant: "error", title: "Boom", onRetry });
+  });
+
+  it("keeps EmptyState's own defaults intact (no title forced by the wrapper)", () => {
+    const el = render({ context: "section" });
+    expect(el.props).not.toHaveProperty("context");
+    expect(el.props.title).toBeUndefined();
+  });
+});

--- a/apps/ui/src/components/metagraphed/state-block.tsx
+++ b/apps/ui/src/components/metagraphed/state-block.tsx
@@ -1,0 +1,56 @@
+import type { ComponentProps } from "react";
+import { TableState } from "@jsonbored/ui-kit";
+import { EmptyState } from "./states";
+import { RegistryEmpty } from "./states/registry-empty";
+
+/**
+ * The context a "nothing here" block is rendering in. This is the axis the
+ * #3962 decision rule is actually about — callers name the situation, not the
+ * component.
+ */
+export type StateContext = "section" | "table" | "registry";
+
+export type StateBlockProps =
+  | ({ context: "section" } & ComponentProps<typeof EmptyState>)
+  | ({ context: "table" } & ComponentProps<typeof TableState>)
+  | ({ context: "registry" } & ComponentProps<typeof RegistryEmpty>);
+
+/**
+ * Single entry point for empty / stale / error blocks (#5341).
+ *
+ * The app deliberately keeps three primitives with different densities, and
+ * `states.tsx` documents a decision rule (#3962) for choosing between them.
+ * That rule was prose only, so picking the wrong one stayed a silent mistake.
+ *
+ * This wrapper makes it mechanical instead: a caller declares the `context`
+ * and the union above resolves BOTH the component and its prop type, so the
+ * compiler rejects a table-only prop (`onRetry`, `error`) on a plain section,
+ * or registry provenance (`evidenceHref`) on a table. The three primitives and
+ * their distinct treatments are unchanged — this only removes the choice.
+ *
+ * Rendered output is identical to calling the primitive directly, so existing
+ * call sites keep working and can migrate incrementally.
+ *
+ * - `section` → {@link EmptyState} — the DEFAULT for general list / card-grid /
+ *   section emptiness.
+ * - `table` → `TableState` — paginated / query-backed table emptiness that
+ *   shares empty / stale / error and a retry CTA with its table.
+ * - `registry` → {@link RegistryEmpty} — registry-PROVENANCE content (variant
+ *   badge, freshness row, evidence link).
+ */
+export function StateBlock(props: StateBlockProps) {
+  switch (props.context) {
+    case "table": {
+      const { context: _context, ...rest } = props;
+      return <TableState {...rest} />;
+    }
+    case "registry": {
+      const { context: _context, ...rest } = props;
+      return <RegistryEmpty {...rest} />;
+    }
+    default: {
+      const { context: _context, ...rest } = props;
+      return <EmptyState {...rest} />;
+    }
+  }
+}

--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -153,6 +153,11 @@ export function ErrorState({
  *   specifically: carries a variant badge, a freshness/staleness row, and an
  *   evidence link. Keep it for surfaces/gaps-style panels where provenance is
  *   part of the empty message; it is not a general-purpose empty state.
+ *
+ * Prefer `StateBlock` (`./state-block`) for new call sites: it takes the
+ * `context` this rule keys on and resolves both the component and its prop
+ * type, so the compiler enforces the choice instead of convention (#5341).
+ * The three primitives above stay as-is — StateBlock only removes the pick.
  */
 export function EmptyState({
   title = "Nothing here yet",


### PR DESCRIPTION
## Summary

Closes #5341

The app renders "nothing here" through three primitives with **deliberately different densities**, and `states.tsx` documents a decision rule (#3962) for choosing between them:

| context | primitive | treatment |
| --- | --- | --- |
| general list / card-grid / section | `EmptyState` | subtle dashed card |
| paginated / query-backed table | `TableState` | table-sized block sharing empty/stale/error + retry with its table |
| registry provenance | `RegistryEmpty` | variant badge, freshness row, evidence link |

That rule was **prose only**, so picking the wrong primitive stayed a silent mistake — which is what the issue is really reporting.

## Approach: (b) enforce the rule, not (a) consolidate

The issue offers either consolidating into one primitive **or** enforcing the existing rule via a shared wrapper. I took the second, deliberately:

`TableState` is *already* the "unified empty/stale/error block with variant props". Folding `EmptyState` into it would make a small, empty card-grid section render a `px-8 py-16` table-sized block — the densities are intentional per #3962, and collapsing them would be a visual regression, not a fix.

So `StateBlock` makes the rule **mechanical without changing it**: a caller names the `context`, and a discriminated union resolves *both* the component and its prop type. The three primitives keep their treatments — this only removes the pick.

```tsx
<StateBlock context="table" variant="empty" title="No rows" onRetry={refetch} />
```

**Rendered output is unchanged** — `StateBlock` returns the same element the primitive would, so existing call sites keep working and migrate incrementally. (No screenshots: this PR changes no rendered output.)

## The enforcement is verified, not asserted

Each of these is now a **compile-time** error (confirmed via `tsc --noEmit` against a throwaway probe):

| misuse | result |
| --- | --- |
| `context="section"` + `onRetry` (table-only prop) | `TS2322` |
| `context="table"` + `evidenceHref` (registry-only prop) | `TS2322` |
| `context="table"` without its required `variant` | `TS2322` |
| correct usage | no error |

## Gates

typecheck OK (verified against a real ui-kit `.d.ts` build — the committed `dist` omits types, so a naive local run silently sees `any`) · unit tests OK (`state-block.test.ts`, 6 new — assert each context dispatches to the right primitive and that `context` never leaks through) · eslint `.` OK (0 errors) · prettier OK

3 files, +117, pure addition.