### PR TITLE
fix(data-refresh): scope registry-sync-fast's change check to registry paths

### DIFF
--- a/scripts/data-refresh-node-entrypoint.sh
+++ b/scripts/data-refresh-node-entrypoint.sh
@@ -90,6 +90,17 @@ if [ "$STEP" = "registry-sync-fast" ]; then
     exit 0
   fi
 
+  # Path-scope BEFORE paying for a full reset+clean+npm ci: main gets pushed
+  # to far more often than registry/subnets|providers actually change (any
+  # merge moves HEAD), and diffing two already-fetched commits needs no
+  # working-tree checkout. Advance the state file either way -- there's
+  # nothing to sync next run either.
+  if git -C "$REPO_DIR" diff --quiet "$LAST_SYNCED".."$NEW_HEAD" -- registry/subnets registry/providers; then
+    echo "entrypoint: registry-sync-fast: $LAST_SYNCED -> $NEW_HEAD, no registry/subnets or registry/providers changes -- skipping refresh"
+    echo "$NEW_HEAD" > "$STATE_FILE"
+    exit 0
+  fi
+
   echo "entrypoint: registry-sync-fast: $LAST_SYNCED -> $NEW_HEAD"
   git -C "$REPO_DIR" reset --hard "origin/${GIT_REF}"
   git -C "$REPO_DIR" clean -fdx


### PR DESCRIPTION
## Summary
- Fixes a real inefficiency observed live on the box within minutes of deploying `registry-sync-fast` (#5684): the change-detection compares whole-repo HEAD SHAs, so *any* merge to main (not just ones touching `registry/subnets`/`registry/providers`) triggers a full `git reset --hard` + `git clean -fdx` + `npm ci` (633 packages, ~8-10s), which then correctly no-ops at the sync-script layer ("no registry/subnets or registry/providers files changed") -- but only after paying the full cost.
- Adds a `git diff --quiet <last-synced>..<new-head> -- registry/subnets registry/providers` check between the two already-fetched commits before doing the expensive refresh. No extra network round-trip since both SHAs are already local from the `git fetch`.
- The state file still advances on a "nothing relevant changed" skip, same as the existing whole-repo no-op path, so the next run's diff range stays tight.

## Test plan
- [x] `shellcheck`, `npm run validate`, `node scripts/scan-public-safety.mjs` all pass
- [x] Local Docker verification: bootstrap, then (a) state rewound to a commit range with no registry changes -> confirmed npm ci is now skipped entirely (~1.7s vs ~10s), state still advances; (b) state rewound to before a real registry-touching commit -> confirmed the full path still triggers correctly (real `base`/`head`/`changedFiles` computed, real 401 from the registry-sync Worker with a deliberately wrong secret)