### PR TITLE
fix(validate-schemas): exclude _capture-report.json from fixture-detail check

### DIFF
--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -310,7 +310,16 @@ async function artifactValidationTargets() {
                 templatedArtifactDirectory(artifact.id),
               )
             ).filter((filePath) => path.basename(filePath) === "endpoints.json")
-          : await listJsonFiles(templatedArtifactDirectory(artifact.id));
+          : (
+              await listJsonFiles(templatedArtifactDirectory(artifact.id))
+            ).filter(
+              // capture-fixtures.mjs writes this report/summary file alongside
+              // the real per-surface fixture-detail records in the same
+              // directory (build-artifacts.mjs already excludes it the same
+              // way when reading fixtures back in) -- it has no request/
+              // response and was never meant to validate as one.
+              (filePath) => path.basename(filePath) !== "_capture-report.json",
+            );
       for (const filePath of filePaths) {
         targets.push({
           file_path: filePath,


### PR DESCRIPTION
## Summary

Triggered `sync-subnets.yml` manually today (it's been manual-dispatch-only since ADR 0006, hasn't run successfully since 2026-06-14) to refresh a stale adapter snapshot. The run failed — but not where expected:

- `adapters:snapshot` itself **passed** cleanly (18.2s).
- The job died several steps later at `validate:schemas`, before ever reaching `create-pull-request`, so **no PR was opened** and nothing got refreshed despite the actual refresh logic working fine.

Root cause: `scripts/capture-fixtures.mjs` writes a run summary (`_capture-report.json`) into the same `fixtures/` directory as the real per-surface fixture-detail records. `validate-schemas.mjs`'s `artifactValidationTargets()` sweeps that whole directory with `listJsonFiles()` and validates every file against the fixture-detail schema (which requires `request`/`response`) — including the summary file, which was never meant to look like one.

`build-artifacts.mjs` already excludes this exact file by the same literal name when reading fixtures back in (`if (file === "_capture-report.json") { ...; continue; }`) — this brings `validate-schemas.mjs`'s directory sweep in line with that existing convention instead of inventing a new one.

Given `capture-fixtures.mjs` always writes this file, this has very likely been failing this way on every `capture:fixtures` run since that file was introduced — independent of whatever registry data the pipeline was meant to refresh. It just never got caught because `sync-subnets.yml`'s schedule was disabled for an unrelated reason (git-churn, ADR 0006) around the same time, so nobody's been running it regularly enough to notice.

## Test plan

- [x] Ran `npm run capture:fixtures` for real locally, confirmed it produces `_capture-report.json`
- [x] Verified directly against that real file: `listJsonFiles()` includes it before the fix, the new filter excludes it after — 0 fixture-detail validation targets from that file where there was previously 1 false-failing one
- [x] `node --check`, `prettier --check`, `eslint` all clean on the changed file
- [ ] Once merged, re-triggering `sync-subnets.yml` should be the real end-to-end confirmation — planning to do that next to actually get the stale Gittensor (SN74) adapter data refreshed