### PR TITLE
feat(graphql): add Query.chain_performance mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -33,6 +33,7 @@ import {
 import { buildExtrinsic, buildExtrinsicFeed } from "./extrinsics.mjs";
 import { buildBlock, buildBlockFeed } from "./blocks.mjs";
 import { buildBlocksSummary } from "./blocks-summary.mjs";
+import { buildChainPerformance } from "./chain-performance.mjs";
 import {
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
@@ -126,6 +127,8 @@ export const SDL = `
     economics_trends(window: String): EconomicsTrends!
     "Cross-subnet momentum leaderboard: every subnet ranked by its stake/emission/validator change between a window's start and end snapshots; movers is empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/subnets/movers."
     subnet_movers(window: String, sort: String, limit: Int): SubnetMovers!
+    "Network-wide reward-distribution & score-spread aggregate over every subnet's neurons -- Gini/HHI/Nakamoto/top-share concentration of incentive across all neurons and dividends across validators, plus the p10-p90 spread of the 0-1 trust/consensus/validator_trust scores. Every metric block is null (never a GraphQL error) on a cold neurons store. Mirrors GET /api/v1/chain/performance."
+    chain_performance: ChainPerformance!
   }
 
   type SubnetList {
@@ -595,6 +598,34 @@ export const SDL = `
     entropy_normalized: Float
   }
 
+  "Network-wide reward-distribution & score-spread aggregate (#5688) across every subnet's neurons -- the reward-flow companion to chain concentration. Every metric block is null on a cold neurons store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/chain/performance."
+  type ChainPerformance {
+    schema_version: Int!
+    subnet_count: Int!
+    neuron_count: Int!
+    validator_count: Int!
+    active_count: Int!
+    captured_at: String
+    incentive: ConcentrationMetrics
+    dividends: ConcentrationMetrics
+    trust: ScoreDistribution
+    consensus: ScoreDistribution
+    validator_trust: ScoreDistribution
+  }
+
+  "Distribution summary for a bounded 0..1 performance score across the whole network -- count, mean, min/max, and the p10..p90 percentile spread."
+  type ScoreDistribution {
+    count: Int!
+    mean: Float
+    min: Float
+    max: Float
+    p10: Float
+    p25: Float
+    p50: Float
+    p75: Float
+    p90: Float
+  }
+
   type BlockDetail {
     ref: String
     block: Block
@@ -891,6 +922,7 @@ export const FIELD_COMPLEXITY = {
   block: RELATIONSHIP_FIELD_COMPLEXITY,
   economics_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_movers: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_performance: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -1898,6 +1930,32 @@ const rootValue = {
         unchanged: network.unchanged ?? 0,
       },
       movers: data.movers || [],
+    };
+  },
+
+  async chain_performance(_args, context) {
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildChainPerformance([])
+    // fallback contract handleChainPerformance uses -- a cold/absent neurons
+    // store degrades to the schema-stable empty aggregate (every metric block
+    // null), never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/performance"),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildChainPerformance([]);
+    return {
+      schema_version: data.schema_version ?? 1,
+      subnet_count: data.subnet_count ?? 0,
+      neuron_count: data.neuron_count ?? 0,
+      validator_count: data.validator_count ?? 0,
+      active_count: data.active_count ?? 0,
+      captured_at: data.captured_at ?? null,
+      incentive: data.incentive ?? null,
+      dividends: data.dividends ?? null,
+      trust: data.trust ?? null,
+      consensus: data.consensus ?? null,
+      validator_trust: data.validator_trust ?? null,
     };
   },
 };

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3066,6 +3066,194 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
   });
 });
 
+describe("graphql — chain_performance (#5688, Postgres-tier + buildChainPerformance fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty aggregate, never null", async () => {
+    const { status, body } = await gql(
+      `{ chain_performance {
+          schema_version subnet_count neuron_count validator_count active_count
+          captured_at
+          incentive { gini } dividends { gini }
+          trust { count } consensus { count } validator_trust { count }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_performance, {
+      schema_version: 1,
+      subnet_count: 0,
+      neuron_count: 0,
+      validator_count: 0,
+      active_count: 0,
+      captured_at: null,
+      incentive: null,
+      dividends: null,
+      trust: null,
+      consensus: null,
+      validator_trust: null,
+    });
+  });
+
+  test("resolves the Postgres-tier aggregate, including nested concentration/score-distribution blocks", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          subnet_count: 3,
+          neuron_count: 500,
+          validator_count: 40,
+          active_count: 480,
+          captured_at: "2026-07-01T00:00:00.000Z",
+          incentive: {
+            holders: 500,
+            total: 1000,
+            gini: 0.4,
+            hhi: 0.02,
+            hhi_normalized: 0.01,
+            nakamoto_coefficient: 50,
+            top_1pct_share: 0.1,
+            top_5pct_share: 0.2,
+            top_10pct_share: 0.3,
+            top_20pct_share: 0.4,
+            entropy: 8.5,
+            entropy_normalized: 0.95,
+          },
+          dividends: {
+            holders: 40,
+            total: 200,
+            gini: 0.3,
+            hhi: 0.05,
+            hhi_normalized: 0.03,
+            nakamoto_coefficient: 10,
+            top_1pct_share: 0.2,
+            top_5pct_share: 0.3,
+            top_10pct_share: 0.4,
+            top_20pct_share: 0.5,
+            entropy: 5.2,
+            entropy_normalized: 0.8,
+          },
+          trust: {
+            count: 500,
+            mean: 0.6,
+            min: 0.1,
+            max: 0.9,
+            p10: 0.2,
+            p25: 0.35,
+            p50: 0.6,
+            p75: 0.75,
+            p90: 0.85,
+          },
+          consensus: {
+            count: 500,
+            mean: 0.55,
+            min: 0.05,
+            max: 0.95,
+            p10: 0.15,
+            p25: 0.3,
+            p50: 0.55,
+            p75: 0.7,
+            p90: 0.9,
+          },
+          validator_trust: {
+            count: 40,
+            mean: 0.7,
+            min: 0.3,
+            max: 0.99,
+            p10: 0.4,
+            p25: 0.5,
+            p50: 0.7,
+            p75: 0.85,
+            p90: 0.95,
+          },
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ chain_performance {
+          subnet_count neuron_count validator_count active_count captured_at
+          incentive { gini nakamoto_coefficient top_1pct_share entropy_normalized }
+          dividends { holders total hhi_normalized }
+          trust { count mean p50 p90 }
+          consensus { count mean min max }
+          validator_trust { count p10 p90 }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const c = body.data.chain_performance;
+    assert.equal(c.subnet_count, 3);
+    assert.equal(c.neuron_count, 500);
+    assert.equal(c.validator_count, 40);
+    assert.equal(c.active_count, 480);
+    assert.equal(c.captured_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(c.incentive.gini, 0.4);
+    assert.equal(c.incentive.nakamoto_coefficient, 50);
+    assert.equal(c.incentive.top_1pct_share, 0.1);
+    assert.equal(c.dividends.holders, 40);
+    assert.equal(c.dividends.hhi_normalized, 0.03);
+    assert.equal(c.trust.count, 500);
+    assert.equal(c.trust.mean, 0.6);
+    assert.equal(c.trust.p90, 0.85);
+    assert.equal(c.consensus.min, 0.05);
+    assert.equal(c.consensus.max, 0.95);
+    assert.equal(c.validator_trust.p10, 0.4);
+  });
+
+  test("forwards to /api/v1/chain/performance with no query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({ schema_version: 1, subnet_count: 0 });
+        },
+      },
+    };
+    await gql("{ chain_performance { subnet_count } }", env);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/performance");
+    assert.equal(capturedUrl.search, "");
+  });
+
+  test("a partial Postgres-tier body degrades to the schema-stable defaults, never null", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      // Every field absent -- the resolver's own ?? defaults must fill them in.
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ chain_performance {
+          schema_version subnet_count neuron_count validator_count active_count
+          captured_at
+          incentive { gini } dividends { gini }
+          trust { count } consensus { count } validator_trust { count }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_performance, {
+      schema_version: 1,
+      subnet_count: 0,
+      neuron_count: 0,
+      validator_count: 0,
+      active_count: 0,
+      captured_at: null,
+      incentive: null,
+      dividends: null,
+      trust: null,
+      consensus: null,
+      validator_trust: null,
+    });
+  });
+
+  test("chain_performance is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.chain_performance, 5);
+  });
+});
+
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
Network-wide reward-distribution & score-spread metrics had a REST route (`GET /api/v1/chain/performance`, routed at `workers/api.mjs:2602` to `handleChainPerformance`) and an MCP tool (`get_chain_performance`) but no GraphQL mirror.

Adds a no-arg `chain_performance: ChainPerformance!` root field next to `blocks_summary`/`subnet_movers`, with `ChainPerformance` + `ScoreDistribution` types mirroring `buildChainPerformance`'s real shape (reward concentration for `incentive`/`dividends` via the existing `ConcentrationMetrics` type, score spread for `trust`/`consensus`/`validator_trust`).

The resolver reuses the same `tryPostgresTier(METAGRAPH_NEURONS_SOURCE)` -> `buildChainPerformance([])` fallback contract `handleChainPerformance` already uses — no duplicated D1/Postgres-tier query logic. A cold/absent neurons store degrades to the schema-stable empty aggregate (every metric block `null`), never a GraphQL error, matching every sibling `Query.*` resolver.

Also adds the `chain_performance` `FIELD_COMPLEXITY` entry and a doc-comment on the new SDL field mirroring the existing "Mirrors GET /api/v1/..." convention.

Tests in `tests/graphql.test.mjs` cover:
- the cold-store fallback (no Postgres flag)
- a full Postgres-tier hit with nested concentration/score-distribution blocks
- the `/api/v1/chain/performance` forward with no query params
- a partial Postgres-tier body degrading to schema-stable defaults
- the field's complexity weight

Closes #5688
