### PR TITLE
feat(graphql): add Query.subnet_registrations mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -10,6 +10,11 @@ import { readArtifact, readHealthKv } from "../workers/storage.mjs";
 import { contractVersion } from "../workers/responses.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 import {
+  buildSubnetRegistrations,
+  SUBNET_REGISTRATIONS_WINDOWS,
+  DEFAULT_SUBNET_REGISTRATIONS_WINDOW,
+} from "./subnet-registrations.mjs";
+import {
   analyticsWindow,
   loadGlobalIncidentsLedger,
 } from "../workers/request-handlers/analytics.mjs";
@@ -86,6 +91,8 @@ export const SDL = `
     subnets(limit: Int, cursor: String): SubnetList!
     "One subnet with its health, surfaces, endpoints, and economics."
     subnet(netuid: Int!): Subnet
+    "Per-subnet neuron-registration activity over a 7d/30d window (distinct registrants, NeuronRegistered count, and registrations per registrant); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/registrations."
+    subnet_registrations(netuid: Int!, window: String): SubnetRegistrations!
     "Paginated provider/source registry."
     providers(limit: Int, cursor: String): ProviderList!
     "One provider with its subnets."
@@ -458,6 +465,17 @@ export const SDL = `
     surface_count: Int
     ok_count: Int
     avg_latency_ms: Int
+  }
+
+  "Per-subnet neuron-registration activity over a window (#5720). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/registrations."
+  type SubnetRegistrations {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    distinct_registrants: Int!
+    registrations: Int!
+    registrations_per_registrant: Float
   }
 
   "Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope."
@@ -886,6 +904,7 @@ export const FIELD_COMPLEXITY = {
   accounts: RELATIONSHIP_FIELD_COMPLEXITY,
   account: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1399,6 +1418,43 @@ const rootValue = {
       surfaces: data.surfaces,
       endpoints: data.endpoints,
     });
+  },
+
+  async subnet_registrations({ netuid, window }, context) {
+    // Same 7d/30d window validation handleSubnetRegistrations uses -- an
+    // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_SUBNET_REGISTRATIONS_WINDOW;
+    if (!Object.hasOwn(SUBNET_REGISTRATIONS_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, SUBNET_REGISTRATIONS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> buildSubnetRegistrations
+    // zeroed-card fallback contract handleSubnetRegistrations uses; a subnet with no
+    // NeuronRegistered events in the window is a schema-stable zeroed card, never a
+    // GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/registrations`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildSubnetRegistrations(null, netuid, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      observed_at: data.observed_at ?? null,
+      distinct_registrants: data.distinct_registrants ?? 0,
+      registrations: data.registrations ?? 0,
+      registrations_per_registrant: data.registrations_per_registrant ?? null,
+    };
   },
 
   providers({ limit, cursor }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3066,6 +3066,94 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
   });
 });
 
+describe("graphql — subnet_registrations (#5720, Postgres-tier + zeroed-card fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_registrations(netuid: 5) {
+          schema_version netuid window observed_at
+          distinct_registrants registrations registrations_per_registrant
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_registrations, {
+      schema_version: 1,
+      netuid: 5,
+      window: "7d",
+      observed_at: null,
+      distinct_registrants: 0,
+      registrations: 0,
+      registrations_per_registrant: null,
+    });
+  });
+
+  test("resolves the Postgres-tier card for the requested window", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          window: "30d",
+          observed_at: "2026-07-01T00:00:00.000Z",
+          distinct_registrants: 3,
+          registrations: 7,
+          registrations_per_registrant: 2.33,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_registrations(netuid: 5, window: "30d") {
+          netuid window observed_at distinct_registrants registrations registrations_per_registrant
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const r = body.data.subnet_registrations;
+    assert.equal(r.window, "30d");
+    assert.equal(r.observed_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(r.distinct_registrants, 3);
+    assert.equal(r.registrations, 7);
+    assert.equal(r.registrations_per_registrant, 2.33);
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_registrations(netuid: 9, window: "30d") {
+          schema_version netuid window observed_at distinct_registrants registrations registrations_per_registrant
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_registrations, {
+      schema_version: 1,
+      netuid: 9,
+      window: "30d",
+      observed_at: null,
+      distinct_registrants: 0,
+      registrations: 0,
+      registrations_per_registrant: null,
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ subnet_registrations(netuid: 5, window: "99d") { registrations } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_registrations ?? null, null);
+  });
+});
+
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Per-subnet neuron-registration activity had a REST route (`GET /api/v1/subnets/{netuid}/registrations`) and an MCP tool (`get_subnet_registrations`) but no GraphQL mirror — the same gap-closure category as the merged `Query.blocks_summary`/`Query.incidents` and the closed `Query.blocks`/`Query.accounts` issues.

- **SDL:** a `subnet_registrations(netuid: Int!, window: String): SubnetRegistrations!` root field next to `Query.subnet`, plus a `SubnetRegistrations` type mirroring `buildSubnetRegistrations`' real shape (`distinct_registrants`, `registrations`, `registrations_per_registrant`, `observed_at`, `window`, `schema_version`, `netuid`).
- **Resolver:** reuses REST's exact contract — the same `SUBNET_REGISTRATIONS_WINDOWS` (7d/30d) validation `handleSubnetRegistrations` uses (an unsupported window is a GraphQL `BAD_USER_INPUT` error, not a silent card), then `tryPostgresTier(env, …, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")` with the `buildSubnetRegistrations(null, …)` zeroed-card fallback. A subnet with no `NeuronRegistered` events in the window resolves to a schema-stable zeroed card (0 counts), never a GraphQL error.
- **`FIELD_COMPLEXITY`** entry at `RELATIONSHIP_FIELD_COMPLEXITY` weight.

## Tests

`tests/graphql.test.mjs` — the Postgres-tier hit, the zeroed-card fallback (no `NeuronRegistered` events), a partial Postgres body degrading to the resolver's defaults, and the unsupported-`window` GraphQL error. **100% of the new resolver's statements and branches are covered**; the full 173-test graphql suite is green. No REST schema/OpenAPI change (SDL is inline). `eslint` / `prettier` clean.

`{ subnet_registrations(netuid: 5, window: "30d") { … } }` over `POST /api/v1/graphql` now matches REST (`GET /api/v1/subnets/{netuid}/registrations`) and MCP (`get_subnet_registrations`).

Closes #5720
