### PR TITLE
feat(graphql): add Query.chain_weights + chain_weight_setters mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -66,6 +66,20 @@ import {
   MOVERS_WINDOWS,
   buildMovers,
 } from "./movers.mjs";
+import {
+  CHAIN_WEIGHTS_LIMIT_DEFAULT,
+  CHAIN_WEIGHTS_LIMIT_MAX,
+  CHAIN_WEIGHTS_WINDOWS,
+  DEFAULT_CHAIN_WEIGHTS_WINDOW,
+  loadChainWeights,
+} from "./chain-weights.mjs";
+import {
+  CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
+  CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
+  CHAIN_WEIGHT_SETTERS_WINDOWS,
+  DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW,
+  loadChainWeightSetters,
+} from "./chain-weight-setters.mjs";
 
 export const GRAPHQL_MAX_DEPTH = 7;
 export const GRAPHQL_MAX_COMPLEXITY = 50;
@@ -126,6 +140,10 @@ export const SDL = `
     economics_trends(window: String): EconomicsTrends!
     "Cross-subnet momentum leaderboard: every subnet ranked by its stake/emission/validator change between a window's start and end snapshots; movers is empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/subnets/movers."
     subnet_movers(window: String, sort: String, limit: Int): SubnetMovers!
+    "Network-wide validator weight-setting activity leaderboard over a 7d/30d window (default 7d): subnets ranked by WeightsSet events with each's distinct-setter count and sets-per-setter update intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. Mirrors GET /api/v1/chain/weights."
+    chain_weights(window: String, limit: Int): ChainWeights!
+    "Network-wide weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators driving consensus network-wide, each with its total WeightsSet count, share of the network total, and first/last set times, ranked by activity. The setter-level drill-in behind chain_weights. Mirrors GET /api/v1/chain/weights/setters."
+    chain_weight_setters(window: String, limit: Int): ChainWeightSetters!
   }
 
   type SubnetList {
@@ -292,6 +310,68 @@ export const SDL = `
     neurons_start: Int!
     neurons_end: Int!
     neurons_delta: Int!
+  }
+
+  "Network-wide validator weight-setting activity over a lookback window, summed live from the account_events WeightsSet stream. Mirrors GET /api/v1/chain/weights."
+  type ChainWeights {
+    schema_version: Int!
+    window: String
+    observed_at: String
+    subnet_count: Int!
+    network: ChainWeightsNetwork!
+    intensity_distribution: ChainWeightsIntensityDistribution
+    subnets: [ChainWeightsSubnet!]!
+  }
+
+  "Network-wide weight-setting rollup: every subnet that set weights in the window, combined."
+  type ChainWeightsNetwork {
+    distinct_setters: Int!
+    weight_sets: Int!
+    "Null when distinct_setters is 0 (no defined intensity without setters)."
+    sets_per_setter: Float
+  }
+
+  "Spread of per-subnet update intensity (WeightsSet events per validator) across every subnet that set weights in the window."
+  type ChainWeightsIntensityDistribution {
+    count: Int!
+    mean: Float!
+    min: Float!
+    p25: Float!
+    median: Float!
+    p75: Float!
+    p90: Float!
+    max: Float!
+  }
+
+  "One subnet's weight-setting activity in the window, ranked by weight_sets."
+  type ChainWeightsSubnet {
+    netuid: Int!
+    distinct_setters: Int!
+    weight_sets: Int!
+    sets_per_setter: Float
+  }
+
+  "Network-wide weight-setter leaderboard over a lookback window, summed live from the account_events WeightsSet stream. The setter-level drill-in behind ChainWeights. Mirrors GET /api/v1/chain/weights/setters."
+  type ChainWeightSetters {
+    schema_version: Int!
+    window: String
+    observed_at: String
+    distinct_setters: Int!
+    weight_sets: Int!
+    setter_count: Int!
+    setters: [ChainWeightSetter!]!
+  }
+
+  "One validator's network-wide weight-setting activity in the window. netuid is set only when hotkey is null (a uid-only identity has no meaning outside its own subnet)."
+  type ChainWeightSetter {
+    hotkey: String
+    netuid: Int
+    uid: Int
+    weight_sets: Int!
+    "This setter's share of the network total weight_sets; null when the network total is 0."
+    share: Float
+    first_set_at: String
+    last_set_at: String
   }
 
   type SurfaceList {
@@ -891,6 +971,8 @@ export const FIELD_COMPLEXITY = {
   block: RELATIONSHIP_FIELD_COMPLEXITY,
   economics_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_movers: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_weights: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -1898,6 +1980,89 @@ const rootValue = {
         unchanged: network.unchanged ?? 0,
       },
       movers: data.movers || [],
+    };
+  },
+
+  async chain_weights({ window, limit }, context) {
+    const requestedWindow = window ?? DEFAULT_CHAIN_WEIGHTS_WINDOW;
+    if (!Object.hasOwn(CHAIN_WEIGHTS_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(requestedWindow, CHAIN_WEIGHTS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: CHAIN_WEIGHTS_LIMIT_DEFAULT,
+      maxLimit: CHAIN_WEIGHTS_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    params.set("limit", String(safeLimit));
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> loadChainWeights
+    // fallback contract REST's handleChainWeights uses -- a cold store yields a
+    // schema-stable empty leaderboard, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/weights", params),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      (await loadChainWeights(graphqlD1(context), {
+        windowLabel: requestedWindow,
+        windowDays: CHAIN_WEIGHTS_WINDOWS[requestedWindow],
+        limit: safeLimit,
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? requestedWindow,
+      observed_at: data.observed_at ?? null,
+      subnet_count: data.subnet_count ?? 0,
+      network: data.network ?? {
+        distinct_setters: 0,
+        weight_sets: 0,
+        sets_per_setter: null,
+      },
+      intensity_distribution: data.intensity_distribution ?? null,
+      subnets: data.subnets || [],
+    };
+  },
+
+  async chain_weight_setters({ window, limit }, context) {
+    const requestedWindow = window ?? DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW;
+    if (!Object.hasOwn(CHAIN_WEIGHT_SETTERS_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(requestedWindow, CHAIN_WEIGHT_SETTERS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
+      maxLimit: CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    params.set("limit", String(safeLimit));
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> loadChainWeightSetters
+    // fallback contract REST's handleChainWeightSetters uses.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/weights/setters", params),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      (await loadChainWeightSetters(graphqlD1(context), {
+        windowLabel: requestedWindow,
+        windowDays: CHAIN_WEIGHT_SETTERS_WINDOWS[requestedWindow],
+        limit: safeLimit,
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? requestedWindow,
+      observed_at: data.observed_at ?? null,
+      distinct_setters: data.distinct_setters ?? 0,
+      weight_sets: data.weight_sets ?? 0,
+      setter_count: data.setter_count ?? 0,
+      setters: data.setters || [],
     };
   },
 };

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3436,6 +3436,338 @@ describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback
   });
 });
 
+describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", () => {
+  function weightsQuery(argsClause) {
+    return `{ chain_weights${argsClause} {
+      schema_version window observed_at subnet_count
+      network { distinct_setters weight_sets sets_per_setter }
+      intensity_distribution { count mean min p25 median p75 p90 max }
+      subnets { netuid distinct_setters weight_sets sets_per_setter }
+    } }`;
+  }
+
+  // The network aggregate (COUNT/COUNT DISTINCT/MAX(observed_at)) has no GROUP
+  // BY; the per-subnet leaderboard is GROUP BY netuid -- same two-query shape
+  // loadChainWeights always issues (mirrors the mcp-server.test.mjs fixture).
+  function chainWeightsD1({ network, subnets = [] } = {}) {
+    return {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              async all() {
+                if (sql.includes("GROUP BY netuid")) {
+                  return { results: subnets };
+                }
+                return { results: network ? [network] : [] };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  test("cold store, default args: schema-stable empty leaderboard", async () => {
+    const { status, body } = await gql(weightsQuery(""));
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_weights, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      subnet_count: 0,
+      network: { distinct_setters: 0, weight_sets: 0, sets_per_setter: null },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            observed_at: "2026-07-10T00:00:00.000Z",
+            subnet_count: 1,
+            network: {
+              distinct_setters: 4,
+              weight_sets: 40,
+              sets_per_setter: 10,
+            },
+            intensity_distribution: {
+              count: 1,
+              mean: 10,
+              min: 10,
+              p25: 10,
+              median: 10,
+              p75: 10,
+              p90: 10,
+              max: 10,
+            },
+            subnets: [
+              {
+                netuid: 3,
+                distinct_setters: 4,
+                weight_sets: 40,
+                sets_per_setter: 10,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      weightsQuery('(window: "30d", limit: 5)'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/weights");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(body.data.chain_weights.window, "30d");
+    assert.equal(body.data.chain_weights.subnet_count, 1);
+    assert.equal(body.data.chain_weights.network.weight_sets, 40);
+    assert.equal(body.data.chain_weights.intensity_distribution.median, 10);
+    assert.equal(body.data.chain_weights.subnets[0].netuid, 3);
+  });
+
+  test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(weightsQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.chain_weights.window, "7d");
+    assert.equal(body.data.chain_weights.subnet_count, 0);
+    assert.equal(body.data.chain_weights.network.weight_sets, 0);
+    assert.equal(body.data.chain_weights.intensity_distribution, null);
+    assert.deepEqual(body.data.chain_weights.subnets, []);
+  });
+
+  test("no Postgres tier flag: rolls up the account_events WeightsSet stream straight off D1", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: chainWeightsD1({
+        network: {
+          weight_sets: 40,
+          distinct_setters: 4,
+          newest_observed: 1_750_000_000_000,
+        },
+        subnets: [{ netuid: 3, weight_sets: 40, distinct_setters: 4 }],
+      }),
+    };
+    const { status, body } = await gql(weightsQuery('(window: "7d")'), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.chain_weights.window, "7d");
+    assert.equal(body.data.chain_weights.subnet_count, 1);
+    assert.equal(body.data.chain_weights.network.distinct_setters, 4);
+    assert.equal(body.data.chain_weights.network.weight_sets, 40);
+    assert.equal(body.data.chain_weights.network.sets_per_setter, 10);
+    assert.equal(body.data.chain_weights.subnets[0].netuid, 3);
+    assert.equal(body.data.chain_weights.intensity_distribution.count, 1);
+    assert.ok(body.data.chain_weights.observed_at);
+  });
+
+  test("a D1 query error degrades to a schema-stable empty leaderboard (no throw)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          throw new Error("db unavailable");
+        },
+      },
+    };
+    const { status, body } = await gql(weightsQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.chain_weights.subnet_count, 0);
+    assert.deepEqual(body.data.chain_weights.subnets, []);
+  });
+
+  test("an unsupported window is a GraphQL error, not a silently substituted default", async () => {
+    const { status, body } = await gql(weightsQuery('(window: "99d")'));
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    const err = body.errors.find(
+      (e) => e.extensions?.code === "BAD_USER_INPUT",
+    );
+    assert.ok(err);
+    assert.match(err.message, /99d/);
+  });
+
+  test("chain_weights is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.chain_weights, 5);
+  });
+});
+
+describe("graphql — chain_weight_setters (#5689, Postgres-tier + D1-live fallback)", () => {
+  function weightSettersQuery(argsClause) {
+    return `{ chain_weight_setters${argsClause} {
+      schema_version window observed_at distinct_setters weight_sets setter_count
+      setters { hotkey netuid uid weight_sets share first_set_at last_set_at }
+    } }`;
+  }
+
+  // The per-setter leaderboard is GROUP BY the hotkey-or-(netuid,uid) identity
+  // and ORDER BY weight_sets DESC; the network-wide totals query has no GROUP
+  // BY -- same two-query shape loadChainWeightSetters always issues.
+  function chainWeightSettersD1({ rows = [], totals } = {}) {
+    return {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              async all() {
+                if (sql.includes("ORDER BY weight_sets DESC")) {
+                  return { results: rows };
+                }
+                return { results: totals ? [totals] : [] };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  test("cold store, default args: schema-stable empty leaderboard", async () => {
+    const { status, body } = await gql(weightSettersQuery(""));
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_weight_setters, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      distinct_setters: 0,
+      weight_sets: 0,
+      setter_count: 0,
+      setters: [],
+    });
+  });
+
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            observed_at: "2026-07-10T00:00:00.000Z",
+            distinct_setters: 2,
+            weight_sets: 40,
+            setter_count: 1,
+            setters: [
+              {
+                hotkey: "5Setter",
+                netuid: null,
+                uid: null,
+                weight_sets: 40,
+                share: 1,
+                first_set_at: "2026-06-20T00:00:00.000Z",
+                last_set_at: "2026-07-10T00:00:00.000Z",
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      weightSettersQuery('(window: "30d", limit: 5)'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/weights/setters");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(body.data.chain_weight_setters.window, "30d");
+    assert.equal(body.data.chain_weight_setters.setter_count, 1);
+    assert.equal(body.data.chain_weight_setters.setters[0].hotkey, "5Setter");
+    assert.equal(body.data.chain_weight_setters.setters[0].share, 1);
+  });
+
+  test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(weightSettersQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.chain_weight_setters.window, "7d");
+    assert.equal(body.data.chain_weight_setters.distinct_setters, 0);
+    assert.equal(body.data.chain_weight_setters.weight_sets, 0);
+    assert.equal(body.data.chain_weight_setters.setter_count, 0);
+    assert.deepEqual(body.data.chain_weight_setters.setters, []);
+  });
+
+  test("no Postgres tier flag: rolls up the account_events WeightsSet stream straight off D1", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: chainWeightSettersD1({
+        rows: [
+          {
+            hotkey: "5Setter",
+            netuid: null,
+            uid: null,
+            weight_sets: 40,
+            first_set: 1_749_000_000_000,
+            last_set: 1_750_000_000_000,
+          },
+        ],
+        totals: {
+          weight_sets: 40,
+          distinct_setters: 1,
+          newest_observed: 1_750_000_000_000,
+        },
+      }),
+    };
+    const { status, body } = await gql(
+      weightSettersQuery('(window: "7d")'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.chain_weight_setters.window, "7d");
+    assert.equal(body.data.chain_weight_setters.distinct_setters, 1);
+    assert.equal(body.data.chain_weight_setters.weight_sets, 40);
+    assert.equal(body.data.chain_weight_setters.setter_count, 1);
+    assert.equal(body.data.chain_weight_setters.setters[0].hotkey, "5Setter");
+    assert.equal(body.data.chain_weight_setters.setters[0].share, 1);
+    assert.ok(body.data.chain_weight_setters.observed_at);
+  });
+
+  test("a D1 query error degrades to a schema-stable empty leaderboard (no throw)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          throw new Error("db unavailable");
+        },
+      },
+    };
+    const { status, body } = await gql(weightSettersQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.chain_weight_setters.setter_count, 0);
+    assert.deepEqual(body.data.chain_weight_setters.setters, []);
+  });
+
+  test("an unsupported window is a GraphQL error, not a silently substituted default", async () => {
+    const { status, body } = await gql(weightSettersQuery('(window: "99d")'));
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    const err = body.errors.find(
+      (e) => e.extensions?.code === "BAD_USER_INPUT",
+    );
+    assert.ok(err);
+    assert.match(err.message, /99d/);
+  });
+
+  test("chain_weight_setters is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.chain_weight_setters, 5);
+  });
+});
+
 describe("Subscription.chainEvents", () => {
   test("yields a properly-shaped GraphQL execution result for each pushed payload", async () => {
     const hub = fakeChainFirehose((repeater) => {


### PR DESCRIPTION
## Summary

- Adds `Query.chain_weights` and `Query.chain_weight_setters` to the GraphQL SDL, mirroring the existing REST routes (`GET /api/v1/chain/weights`, `GET /api/v1/chain/weights/setters`) and MCP tools (`get_chain_weights`, `get_chain_weight_setters`).

## What Changed

- `src/graphql.mjs`: SDL fields `chain_weights(window: String, limit: Int): ChainWeights!` and `chain_weight_setters(window: String, limit: Int): ChainWeightSetters!` next to `subnet_movers`, plus the response types (`ChainWeights`, `ChainWeightsNetwork`, `ChainWeightsIntensityDistribution`, `ChainWeightsSubnet`, `ChainWeightSetters`, `ChainWeightSetter`) shaped straight off `buildChainWeights`/`buildChainWeightSetters`.
- Resolvers reuse the existing loaders (`loadChainWeights`/`loadChainWeightSetters` from `src/chain-weights.mjs`/`src/chain-weight-setters.mjs`) via the same `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` fallback contract the REST handlers use — no duplicated D1 query logic.
- A cold store (no Postgres-tier flag, no matching D1 rows) degrades to the schema-stable empty leaderboard both loaders already return, never a GraphQL error. An unsupported `window` raises a `BAD_USER_INPUT` GraphQL error with the same message REST/MCP use, rather than silently substituting a default.
- Both fields added to `FIELD_COMPLEXITY` at `RELATIONSHIP_FIELD_COMPLEXITY`, matching every other fan-out field.
- `tests/graphql.test.mjs`: cold-store defaults, Postgres-tier resolution with window/limit forwarded as query params, a malformed Postgres-tier body falling back to defaults, a live D1 read (two-query network + per-subnet / per-setter shape), a D1 query error degrading to the empty leaderboard, the unsupported-window GraphQL error, and the `FIELD_COMPLEXITY` weight — for each of the two new fields.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5689`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none committed — this PR only touches `src/graphql.mjs` and `tests/graphql.test.mjs`).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (no `schemas/` change — this only extends the GraphQL SDL, not the REST/OpenAPI contract).

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage` (full unsharded run, 283 files / 8519 tests passed; `src/graphql.mjs` at 100% line/statement coverage, no uncovered branches in the new resolvers)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

Closes #5689
