### PR TITLE
fix(ui-kit): correct Gittensor provider icon override

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -769,7 +769,19 @@ var PROVIDER_ICONS = {
   targon: "https://github.com/manifold-inc.png?size=192",
   manifold: "https://github.com/manifold-inc.png?size=192",
   "cortex-t": "https://github.com/corcel-api.png?size=192",
-  allways: "https://github.com/allways-ai.png?size=192",
+  // NOT allways-ai (a real GitHub org, but empty -- 0 public repos, no bio/
+  // blog/avatar of its own -- confirmed 2026-07-15 its ".png" avatar is just
+  // GitHub's auto-generated default identicon for a repo-less org, not any
+  // real Allways branding; visually confirmed against the real logo below,
+  // they share nothing in common). Allways' real GitHub org (entrius, same
+  // team as Gittensor/SN74) has no set avatar either. The subnet's
+  // on-chain-declared logo_url (SubnetIdentitiesV3, same source the masthead
+  // uses) is the SAME mark but hosted on an S3 bucket with no CORS headers
+  // -- verified live it fails to load here (this override is fetched with
+  // crossOrigin="anonymous" downstream). all-ways.io's own hosted copy is
+  // pixel-identical and Cloudflare-fronted with a proper
+  // access-control-allow-origin, so use that instead.
+  allways: "https://all-ways.io/icons/icon-512.png",
   // NOT eden-network (a real, unrelated GitHub org — confirmed via the GitHub
   // API while auditing this file 2026-07-15; likely a stale copy-paste). This
   // fallback only fires for provider-attribution UI (Providers/Surfaces/

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -770,7 +770,15 @@ var PROVIDER_ICONS = {
   manifold: "https://github.com/manifold-inc.png?size=192",
   "cortex-t": "https://github.com/corcel-api.png?size=192",
   allways: "https://github.com/allways-ai.png?size=192",
-  gittensor: "https://github.com/eden-network.png?size=192",
+  // NOT eden-network (a real, unrelated GitHub org — confirmed via the GitHub
+  // API while auditing this file 2026-07-15; likely a stale copy-paste). This
+  // fallback only fires for provider-attribution UI (Providers/Surfaces/
+  // Endpoints listings) since the subnet masthead itself sources its icon
+  // from profile.icon_url (on-chain SubnetIdentitiesV3 logo_url, correct).
+  // Gittensor's real GitHub org (entrius) has no set avatar worth using, so
+  // this points at their own self-hosted logo instead, matching the asset
+  // scripts/gittensor-impact-card.mjs already treats as authoritative.
+  gittensor: "https://gittensor.io/gt-logo.svg",
   bitads: "https://github.com/FirstTensorLabs.png?size=192",
   academia: "https://github.com/fx-integral.png?size=192",
   adtao: "https://github.com/ippcteam.png?size=192",

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -740,7 +740,19 @@ var PROVIDER_ICONS = {
   targon: "https://github.com/manifold-inc.png?size=192",
   manifold: "https://github.com/manifold-inc.png?size=192",
   "cortex-t": "https://github.com/corcel-api.png?size=192",
-  allways: "https://github.com/allways-ai.png?size=192",
+  // NOT allways-ai (a real GitHub org, but empty -- 0 public repos, no bio/
+  // blog/avatar of its own -- confirmed 2026-07-15 its ".png" avatar is just
+  // GitHub's auto-generated default identicon for a repo-less org, not any
+  // real Allways branding; visually confirmed against the real logo below,
+  // they share nothing in common). Allways' real GitHub org (entrius, same
+  // team as Gittensor/SN74) has no set avatar either. The subnet's
+  // on-chain-declared logo_url (SubnetIdentitiesV3, same source the masthead
+  // uses) is the SAME mark but hosted on an S3 bucket with no CORS headers
+  // -- verified live it fails to load here (this override is fetched with
+  // crossOrigin="anonymous" downstream). all-ways.io's own hosted copy is
+  // pixel-identical and Cloudflare-fronted with a proper
+  // access-control-allow-origin, so use that instead.
+  allways: "https://all-ways.io/icons/icon-512.png",
   // NOT eden-network (a real, unrelated GitHub org — confirmed via the GitHub
   // API while auditing this file 2026-07-15; likely a stale copy-paste). This
   // fallback only fires for provider-attribution UI (Providers/Surfaces/

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -741,7 +741,15 @@ var PROVIDER_ICONS = {
   manifold: "https://github.com/manifold-inc.png?size=192",
   "cortex-t": "https://github.com/corcel-api.png?size=192",
   allways: "https://github.com/allways-ai.png?size=192",
-  gittensor: "https://github.com/eden-network.png?size=192",
+  // NOT eden-network (a real, unrelated GitHub org — confirmed via the GitHub
+  // API while auditing this file 2026-07-15; likely a stale copy-paste). This
+  // fallback only fires for provider-attribution UI (Providers/Surfaces/
+  // Endpoints listings) since the subnet masthead itself sources its icon
+  // from profile.icon_url (on-chain SubnetIdentitiesV3 logo_url, correct).
+  // Gittensor's real GitHub org (entrius) has no set avatar worth using, so
+  // this points at their own self-hosted logo instead, matching the asset
+  // scripts/gittensor-impact-card.mjs already treats as authoritative.
+  gittensor: "https://gittensor.io/gt-logo.svg",
   bitads: "https://github.com/FirstTensorLabs.png?size=192",
   academia: "https://github.com/fx-integral.png?size=192",
   adtao: "https://github.com/ippcteam.png?size=192",

--- a/packages/ui-kit/src/components/metagraphed/brand-overrides.ts
+++ b/packages/ui-kit/src/components/metagraphed/brand-overrides.ts
@@ -148,7 +148,15 @@ const PROVIDER_ICONS: Record<string, IconSource> = {
   manifold: "https://github.com/manifold-inc.png?size=192",
   "cortex-t": "https://github.com/corcel-api.png?size=192",
   allways: "https://github.com/allways-ai.png?size=192",
-  gittensor: "https://github.com/eden-network.png?size=192",
+  // NOT eden-network (a real, unrelated GitHub org — confirmed via the GitHub
+  // API while auditing this file 2026-07-15; likely a stale copy-paste). This
+  // fallback only fires for provider-attribution UI (Providers/Surfaces/
+  // Endpoints listings) since the subnet masthead itself sources its icon
+  // from profile.icon_url (on-chain SubnetIdentitiesV3 logo_url, correct).
+  // Gittensor's real GitHub org (entrius) has no set avatar worth using, so
+  // this points at their own self-hosted logo instead, matching the asset
+  // scripts/gittensor-impact-card.mjs already treats as authoritative.
+  gittensor: "https://gittensor.io/gt-logo.svg",
   bitads: "https://github.com/FirstTensorLabs.png?size=192",
   academia: "https://github.com/fx-integral.png?size=192",
   adtao: "https://github.com/ippcteam.png?size=192",

--- a/packages/ui-kit/src/components/metagraphed/brand-overrides.ts
+++ b/packages/ui-kit/src/components/metagraphed/brand-overrides.ts
@@ -147,7 +147,19 @@ const PROVIDER_ICONS: Record<string, IconSource> = {
   targon: "https://github.com/manifold-inc.png?size=192",
   manifold: "https://github.com/manifold-inc.png?size=192",
   "cortex-t": "https://github.com/corcel-api.png?size=192",
-  allways: "https://github.com/allways-ai.png?size=192",
+  // NOT allways-ai (a real GitHub org, but empty -- 0 public repos, no bio/
+  // blog/avatar of its own -- confirmed 2026-07-15 its ".png" avatar is just
+  // GitHub's auto-generated default identicon for a repo-less org, not any
+  // real Allways branding; visually confirmed against the real logo below,
+  // they share nothing in common). Allways' real GitHub org (entrius, same
+  // team as Gittensor/SN74) has no set avatar either. The subnet's
+  // on-chain-declared logo_url (SubnetIdentitiesV3, same source the masthead
+  // uses) is the SAME mark but hosted on an S3 bucket with no CORS headers
+  // -- verified live it fails to load here (this override is fetched with
+  // crossOrigin="anonymous" downstream). all-ways.io's own hosted copy is
+  // pixel-identical and Cloudflare-fronted with a proper
+  // access-control-allow-origin, so use that instead.
+  allways: "https://all-ways.io/icons/icon-512.png",
   // NOT eden-network (a real, unrelated GitHub org — confirmed via the GitHub
   // API while auditing this file 2026-07-15; likely a stale copy-paste). This
   // fallback only fires for provider-attribution UI (Providers/Surfaces/

--- a/registry/providers/allways.json
+++ b/registry/providers/allways.json
@@ -5,6 +5,7 @@
   "kind": "subnet-team",
   "website_url": "https://all-ways.io",
   "docs_url": "https://docs.all-ways.io/how-it-works.html",
+  "logo_url": "https://all-ways.io/icons/icon-512.png",
   "authority": "provider-claimed",
   "notes": "Seed provider entry for the Allways SN7 pilot."
 }

--- a/registry/providers/gittensor.json
+++ b/registry/providers/gittensor.json
@@ -5,6 +5,7 @@
   "kind": "subnet-team",
   "website_url": "https://gittensor.io",
   "docs_url": "https://docs.gittensor.io/",
+  "logo_url": "https://gittensor.io/gt-logo.svg",
   "authority": "provider-claimed",
   "notes": "Seed provider entry for the Gittensor SN74 pilot."
 }


### PR DESCRIPTION
## Summary

Auditing SN74 Gittensor's data/branding accuracy (core partner). Expanded to include their sibling subnet **SN7 Allways** (same team, `entrius`) per follow-up request — same category of bug found there too.

Two layers of icon bugs, both fixed:

### 1. `packages/ui-kit/brand-overrides.ts` — wrong/meaningless fallback icons
- **gittensor**: was `github.com/eden-network.png` — Eden Network is a real, entirely unrelated GitHub org (confirmed via the GitHub API), most likely a stale copy-paste.
- **allways**: was `github.com/allways-ai.png` — that org is real but empty (0 public repos, no bio/avatar set), so its `.png` is just GitHub's auto-generated default identicon for a repo-less org, not any real Allways branding. See the comparison below — they share nothing in common.

### 2. `registry/providers/{gittensor,allways}.json` — the actual dominant bug
Neither provider record had a curated `logo_url` set, so `build-artifacts.mjs`'s own documented fallback (**"curated logo wins; else borrow the on-chain logo of the single subnet this provider operates"**) was serving each provider's raw on-chain `SubnetIdentitiesV3.logo_url` directly. This field **wins over everything in brand-overrides.ts** whenever it's set, and it's live in production right now for both — confirmed via the real `/api/v1/providers` response. Both on-chain logos happen to be hosted on S3 buckets with **no CORS headers**; verified live that this makes the image fail to load entirely (`crossOrigin="anonymous"` + no CORS response header → load fails, `naturalWidth` stays 0) anywhere the icon renders with that attribute.

Fixed by setting each provider's own curated `logo_url` to a CORS-friendly, pixel-identical copy of the exact same real logo, hosted on their own Cloudflare-fronted sites instead of the bare S3 buckets:
- `gittensor.io/gt-logo.svg` (already used by `scripts/gittensor-impact-card.mjs`)
- `all-ways.io/icons/icon-512.png` (verified pixel-identical to the on-chain logo via direct visual comparison — see below)

The subnet masthead pages themselves (`/subnets/74`, `/subnets/7`) are unaffected by either bug — they source from `profile.icon_url`, a separate on-chain data path that was already correct.

## Test plan

- [x] Typecheck, lint, prettier clean on all changed files
- [x] `npm run validate:schemas` passes clean against the full built artifact set
- [x] Ran the full `npm run build` pipeline locally and inspected the real generated `dist/metagraph-r2/metagraph/providers.json` — both providers now carry the correct, CORS-safe `logo_url`
- [x] Live-verified the CORS failure mechanism directly (before this fix): both on-chain S3 logo URLs return 200 to a plain `curl`/direct navigation, but fail to render as `<img crossOrigin="anonymous">` specifically because neither S3 bucket sends `Access-Control-Allow-Origin`
- [x] Screenshots below for the brand-overrides.ts layer (Providers list, search-filtered) + a direct visual comparison for Allways' logo specifically

## Screenshots

**Gittensor — Providers list, before/after:**

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/icon-fix-mobile-dark-after.png)<br><sub>after</sub> |

**Allways — direct logo comparison** (the wrong GitHub identicon vs. the real logo now used; the registry `logo_url` fix isn't visible via a dev-server screenshot since the dev server reads live production data until this merges and deploys):

| Wrong (`allways-ai` GitHub identicon) | Correct (`all-ways.io`'s own hosted logo, pixel-identical to their on-chain-declared one) |
| --- | --- |
| [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/allways-broken-identicon.png" width="200">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/allways-broken-identicon.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/allways-correct-logo.png" width="200">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/allways-correct-logo.png) |