### PR TITLE
feat(graphql): add Query.subnet_deregistrations mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -15,6 +15,11 @@ import {
   DEFAULT_SUBNET_REGISTRATIONS_WINDOW,
 } from "./subnet-registrations.mjs";
 import {
+  buildSubnetDeregistrations,
+  SUBNET_DEREGISTRATIONS_WINDOWS,
+  DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW,
+} from "./subnet-deregistrations.mjs";
+import {
   analyticsWindow,
   loadGlobalIncidentsLedger,
 } from "../workers/request-handlers/analytics.mjs";
@@ -107,6 +112,8 @@ export const SDL = `
     subnet(netuid: Int!): Subnet
     "Per-subnet neuron-registration activity over a 7d/30d window (distinct registrants, NeuronRegistered count, and registrations per registrant); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/registrations."
     subnet_registrations(netuid: Int!, window: String): SubnetRegistrations!
+    "Per-subnet neuron-deregistration activity over a 7d/30d window (distinct deregistered hotkeys, NeuronDeregistered count, and deregistrations per hotkey); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/deregistrations."
+    subnet_deregistrations(netuid: Int!, window: String): SubnetDeregistrations!
     "Paginated provider/source registry."
     providers(limit: Int, cursor: String): ProviderList!
     "One provider with its subnets."
@@ -558,6 +565,17 @@ export const SDL = `
     registrations_per_registrant: Float
   }
 
+  "Per-subnet neuron-deregistration activity over a window (#5719). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/deregistrations."
+  type SubnetDeregistrations {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    distinct_deregistered_hotkeys: Int!
+    deregistrations: Int!
+    deregistrations_per_hotkey: Float
+  }
+
   "Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope."
   type GlobalIncidents {
     schema_version: Int!
@@ -985,6 +1003,7 @@ export const FIELD_COMPLEXITY = {
   account: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1536,6 +1555,43 @@ const rootValue = {
       distinct_registrants: data.distinct_registrants ?? 0,
       registrations: data.registrations ?? 0,
       registrations_per_registrant: data.registrations_per_registrant ?? null,
+    };
+  },
+
+  async subnet_deregistrations({ netuid, window }, context) {
+    // Same 7d/30d window validation handleSubnetDeregistrations uses -- an
+    // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW;
+    if (!Object.hasOwn(SUBNET_DEREGISTRATIONS_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, SUBNET_DEREGISTRATIONS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> buildSubnetDeregistrations
+    // zeroed-card fallback contract handleSubnetDeregistrations uses; a subnet with no
+    // NeuronDeregistered events in the window is a schema-stable zeroed card, never a
+    // GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/deregistrations`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildSubnetDeregistrations(null, netuid, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      observed_at: data.observed_at ?? null,
+      distinct_deregistered_hotkeys: data.distinct_deregistered_hotkeys ?? 0,
+      deregistrations: data.deregistrations ?? 0,
+      deregistrations_per_hotkey: data.deregistrations_per_hotkey ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3154,6 +3154,94 @@ describe("graphql — subnet_registrations (#5720, Postgres-tier + zeroed-card f
   });
 });
 
+describe("graphql — subnet_deregistrations (#5719, Postgres-tier + zeroed-card fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_deregistrations(netuid: 5) {
+          schema_version netuid window observed_at
+          distinct_deregistered_hotkeys deregistrations deregistrations_per_hotkey
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_deregistrations, {
+      schema_version: 1,
+      netuid: 5,
+      window: "7d",
+      observed_at: null,
+      distinct_deregistered_hotkeys: 0,
+      deregistrations: 0,
+      deregistrations_per_hotkey: null,
+    });
+  });
+
+  test("resolves the Postgres-tier card for the requested window", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          window: "30d",
+          observed_at: "2026-07-01T00:00:00.000Z",
+          distinct_deregistered_hotkeys: 2,
+          deregistrations: 5,
+          deregistrations_per_hotkey: 2.5,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_deregistrations(netuid: 5, window: "30d") {
+          netuid window observed_at distinct_deregistered_hotkeys deregistrations deregistrations_per_hotkey
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const r = body.data.subnet_deregistrations;
+    assert.equal(r.window, "30d");
+    assert.equal(r.observed_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(r.distinct_deregistered_hotkeys, 2);
+    assert.equal(r.deregistrations, 5);
+    assert.equal(r.deregistrations_per_hotkey, 2.5);
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_deregistrations(netuid: 9, window: "30d") {
+          schema_version netuid window observed_at distinct_deregistered_hotkeys deregistrations deregistrations_per_hotkey
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_deregistrations, {
+      schema_version: 1,
+      netuid: 9,
+      window: "30d",
+      observed_at: null,
+      distinct_deregistered_hotkeys: 0,
+      deregistrations: 0,
+      deregistrations_per_hotkey: null,
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ subnet_deregistrations(netuid: 5, window: "99d") { deregistrations } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_deregistrations ?? null, null);
+  });
+});
+
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Per-subnet neuron-deregistration activity had a REST route (`GET /api/v1/subnets/{netuid}/deregistrations`) and an MCP tool (`get_subnet_deregistrations`) but no GraphQL mirror — the deregistration-side twin of the just-merged `Query.subnet_registrations`.

- **SDL:** a `subnet_deregistrations(netuid: Int!, window: String): SubnetDeregistrations!` root field next to `Query.subnet_registrations`, plus a `SubnetDeregistrations` type mirroring `buildSubnetDeregistrations`' real shape (`distinct_deregistered_hotkeys`, `deregistrations`, `deregistrations_per_hotkey`, `observed_at`, `window`, `schema_version`, `netuid`).
- **Resolver:** reuses REST's exact contract — the same `SUBNET_DEREGISTRATIONS_WINDOWS` (7d/30d) validation `handleSubnetDeregistrations` uses (an unsupported window is a GraphQL `BAD_USER_INPUT` error), then `tryPostgresTier(env, …, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")` with the `buildSubnetDeregistrations(null, …)` zeroed-card fallback. A subnet with no `NeuronDeregistered` events in the window resolves to a schema-stable zeroed card, never a GraphQL error.
- **`FIELD_COMPLEXITY`** entry at `RELATIONSHIP_FIELD_COMPLEXITY` weight.

## Tests

`tests/graphql.test.mjs` — the Postgres-tier hit, the zeroed-card fallback, a partial Postgres body degrading to the resolver's defaults, and the unsupported-`window` GraphQL error. **100% of the new resolver's statements and branches are covered**; the full 191-test graphql suite is green. No REST schema/OpenAPI change (SDL is inline). `eslint` / `prettier` clean.

`{ subnet_deregistrations(netuid: 5, window: "30d") { … } }` over `POST /api/v1/graphql` now matches REST (`GET /api/v1/subnets/{netuid}/deregistrations`) and MCP (`get_subnet_deregistrations`).

Closes #5719
