### PR TITLE
feat(graphql): add Query.health_trends mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -85,6 +85,7 @@ import {
   DEFAULT_CHAIN_WEIGHT_SETTERS_WINDOW,
   loadChainWeightSetters,
 } from "./chain-weight-setters.mjs";
+import { loadBulkHealthTrends } from "./bulk-health-trends.mjs";
 
 export const GRAPHQL_MAX_DEPTH = 7;
 export const GRAPHQL_MAX_COMPLEXITY = 50;
@@ -151,6 +152,8 @@ export const SDL = `
     chain_weights(window: String, limit: Int): ChainWeights!
     "Network-wide weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators driving consensus network-wide, each with its total WeightsSet count, share of the network total, and first/last set times, ranked by activity. The setter-level drill-in behind chain_weights. Mirrors GET /api/v1/chain/weights/setters."
     chain_weight_setters(window: String, limit: Int): ChainWeightSetters!
+    "Compact all-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history (probed every ~15 minutes); a cold store still returns both windows, schema-stable and zeroed, never a GraphQL error. Mirrors GET /api/v1/health/trends."
+    health_trends: HealthTrends!
   }
 
   type SubnetList {
@@ -379,6 +382,15 @@ export const SDL = `
     share: Float
     first_set_at: String
     last_set_at: String
+  }
+
+  "All-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history. Mirrors GET /api/v1/health/trends' data envelope."
+  type HealthTrends {
+    schema_version: Int!
+    observed_at: String
+    source: String
+    "The 7d/30d windows keyed by window label (7d, 30d), each holding days/granularity/subnet_count and the per-subnet daily point series. Opaque JSON: dynamic-keyed by window label, matching the get_health_trends MCP/REST shape."
+    windows: JSON!
   }
 
   type SurfaceList {
@@ -992,6 +1004,7 @@ export const FIELD_COMPLEXITY = {
   subnet_movers: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
+  health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -2119,6 +2132,30 @@ const rootValue = {
       weight_sets: data.weight_sets ?? 0,
       setter_count: data.setter_count ?? 0,
       setters: data.setters || [],
+    };
+  },
+
+  async health_trends(_args, context) {
+    // Same tryPostgresTier(METAGRAPH_HEALTH_SOURCE) -> loadBulkHealthTrends
+    // fallback contract REST's handleBulkHealthTrends and the get_health_trends
+    // MCP tool share -- a cold store yields both windows zeroed, never a
+    // GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/health/trends"),
+        "METAGRAPH_HEALTH_SOURCE",
+      )) ??
+      (
+        await loadBulkHealthTrends(graphqlD1(context), {
+          observedAt: await loadObservedAt(context),
+        })
+      ).data;
+    return {
+      schema_version: data.schema_version ?? 1,
+      observed_at: data.observed_at ?? null,
+      source: data.source ?? null,
+      windows: data.windows ?? {},
     };
   },
 };

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3856,6 +3856,150 @@ describe("graphql — chain_weight_setters (#5689, Postgres-tier + D1-live fallb
   });
 });
 
+describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", () => {
+  function trendsQuery() {
+    return `{ health_trends { schema_version observed_at source windows } }`;
+  }
+
+  // No GROUP BY window label -- loadBulkHealthTrends issues a single query
+  // over the full 30d cutoff and buckets rows into 7d/30d itself.
+  function bulkTrendsD1(rows = []) {
+    return {
+      prepare() {
+        return {
+          bind() {
+            return {
+              async all() {
+                return { results: rows };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  test("cold store: schema-stable zeroed windows", async () => {
+    const { status, body } = await gql(trendsQuery());
+    assert.equal(status, 200);
+    assert.equal(body.data.health_trends.schema_version, 1);
+    assert.equal(body.data.health_trends.observed_at, null);
+    assert.equal(body.data.health_trends.windows["7d"].subnet_count, 0);
+    assert.deepEqual(body.data.health_trends.windows["7d"].subnets, []);
+    assert.equal(body.data.health_trends.windows["30d"].subnet_count, 0);
+    assert.deepEqual(body.data.health_trends.windows["30d"].subnets, []);
+  });
+
+  test("resolves Postgres-tier data, forwarding the request unchanged", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            observed_at: "2026-07-10T00:00:00.000Z",
+            source: "live-cron-prober",
+            windows: {
+              "7d": {
+                days: 7,
+                granularity: "1d",
+                subnet_count: 1,
+                subnets: [{ netuid: 3, samples: 10 }],
+              },
+              "30d": {
+                days: 30,
+                granularity: "1d",
+                subnet_count: 1,
+                subnets: [{ netuid: 3, samples: 40 }],
+              },
+            },
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(trendsQuery(), env);
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.pathname, "/api/v1/health/trends");
+    assert.equal(
+      body.data.health_trends.observed_at,
+      "2026-07-10T00:00:00.000Z",
+    );
+    assert.equal(body.data.health_trends.windows["7d"].subnet_count, 1);
+    assert.equal(body.data.health_trends.windows["30d"].subnets[0].netuid, 3);
+  });
+
+  test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(trendsQuery(), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.health_trends.schema_version, 1);
+    assert.equal(body.data.health_trends.observed_at, null);
+    assert.equal(body.data.health_trends.source, null);
+    assert.deepEqual(body.data.health_trends.windows, {});
+  });
+
+  test("no Postgres tier flag: aggregates surface_uptime_daily rows straight off D1", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: bulkTrendsD1([
+        {
+          netuid: 7,
+          date: "2026-07-09",
+          total: 10,
+          ok_count: 9,
+          avg_latency_ms: 50,
+        },
+      ]),
+    };
+    const { status, body } = await gql(trendsQuery(), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.health_trends.schema_version, 1);
+    assert.equal(body.data.health_trends.windows["7d"].subnet_count, 1);
+    assert.equal(body.data.health_trends.windows["7d"].subnets[0].netuid, 7);
+    assert.equal(body.data.health_trends.windows["30d"].subnet_count, 1);
+  });
+
+  test("observed_at is stamped from the health:meta KV freshness on the D1-live path", async () => {
+    const env = {
+      METAGRAPH_CONTROL: {
+        async get(key) {
+          return key === KV_HEALTH_META
+            ? { last_run_at: "2026-06-23T00:00:00.000Z" }
+            : null;
+        },
+      },
+      METAGRAPH_HEALTH_DB: bulkTrendsD1([]),
+    };
+    const { body } = await gql(trendsQuery(), env);
+    assert.equal(
+      body.data.health_trends.observed_at,
+      "2026-06-23T00:00:00.000Z",
+    );
+  });
+
+  test("a D1 query error degrades to a schema-stable empty matrix (no throw)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          throw new Error("db unavailable");
+        },
+      },
+    };
+    const { status, body } = await gql(trendsQuery(), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.health_trends.windows["7d"].subnet_count, 0);
+    assert.deepEqual(body.data.health_trends.windows["7d"].subnets, []);
+  });
+
+  test("health_trends is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.health_trends, 5);
+  });
+});
+
 describe("Subscription.chainEvents", () => {
   test("yields a properly-shaped GraphQL execution result for each pushed payload", async () => {
     const hub = fakeChainFirehose((repeater) => {


### PR DESCRIPTION
## Summary

Adds `Query.health_trends` to the GraphQL schema, mirroring `GET /api/v1/health/trends` and the `get_health_trends` MCP tool — closing the last gap in that gap-closure batch (sibling to `Query.incidents`, `Query.chain_weights`/`chain_weight_setters`, `Query.subnet_registrations`).

- New `HealthTrends` SDL type (`schema_version`, `observed_at`, `source`, `windows`) and `Query.health_trends: HealthTrends!` field, doc-commented in the existing "Mirrors GET /api/v1/..." style.
- `windows` is dynamic-keyed by window label (`7d`/`30d`) so it's carried as the existing `JSON` scalar — same pattern `GlobalIncidents.summary`'s `by_kind`/`by_provider` maps already use.
- Resolver reuses `loadBulkHealthTrends` from `src/bulk-health-trends.mjs` directly (no duplicated `surface_uptime_daily` query logic), behind the same `tryPostgresTier(METAGRAPH_HEALTH_SOURCE)` → D1-live fallback contract REST's `handleBulkHealthTrends` and the MCP tool both already use.
- Degrades to a schema-stable zeroed result on a cold D1 store or malformed Postgres-tier body, never a GraphQL error — matching every sibling `Query.*` resolver.
- `health_trends` added to `FIELD_COMPLEXITY` at the same fan-out weight as the other all-subnet bulk resolvers (`chain_weights`, `subnet_movers`, `economics_trends`).

## Test plan

- [x] `tests/graphql.test.mjs`: new `health_trends` describe block — cold-store zeroed windows, Postgres-tier hit, malformed Postgres-tier body fallback, D1-live aggregation off `surface_uptime_daily`, D1 query error fallback, `observed_at` KV-freshness stamping, complexity weight.
- [x] `npx vitest run tests/graphql.test.mjs` — 194 passed
- [x] `npx eslint src/graphql.mjs tests/graphql.test.mjs` — clean
- [x] `npx prettier --check src/graphql.mjs tests/graphql.test.mjs` — clean
- [x] Patch coverage on the new lines in `src/graphql.mjs`: 100% lines/statements/functions (verified via `npx vitest run --coverage tests/graphql.test.mjs`; the file's two uncovered branches predate this change, in the unrelated `health`/`opportunity_boards` resolvers)

Closes #5722
