### PR TITLE
feat(graphql): add Query.subnet_axon_removals mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -15,6 +15,11 @@ import {
   DEFAULT_SUBNET_REGISTRATIONS_WINDOW,
 } from "./subnet-registrations.mjs";
 import {
+  buildSubnetAxonRemovals,
+  SUBNET_AXON_REMOVALS_WINDOWS,
+  DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
+} from "./subnet-axon-removals.mjs";
+import {
   analyticsWindow,
   loadGlobalIncidentsLedger,
 } from "../workers/request-handlers/analytics.mjs";
@@ -107,6 +112,8 @@ export const SDL = `
     subnet(netuid: Int!): Subnet
     "Per-subnet neuron-registration activity over a 7d/30d window (distinct registrants, NeuronRegistered count, and registrations per registrant); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/registrations."
     subnet_registrations(netuid: Int!, window: String): SubnetRegistrations!
+    "Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
+    subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
     "Paginated provider/source registry."
     providers(limit: Int, cursor: String): ProviderList!
     "One provider with its subnets."
@@ -558,6 +565,17 @@ export const SDL = `
     registrations_per_registrant: Float
   }
 
+  "Per-subnet axon-removal activity over a window (#5718). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
+  type SubnetAxonRemovals {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    distinct_removers: Int!
+    removals: Int!
+    removals_per_remover: Float
+  }
+
   "Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope."
   type GlobalIncidents {
     schema_version: Int!
@@ -985,6 +1003,7 @@ export const FIELD_COMPLEXITY = {
   account: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1536,6 +1555,43 @@ const rootValue = {
       distinct_registrants: data.distinct_registrants ?? 0,
       registrations: data.registrations ?? 0,
       registrations_per_registrant: data.registrations_per_registrant ?? null,
+    };
+  },
+
+  async subnet_axon_removals({ netuid, window }, context) {
+    // Same 7d/30d window validation handleSubnetAxonRemovals uses -- an
+    // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_SUBNET_AXON_REMOVALS_WINDOW;
+    if (!Object.hasOwn(SUBNET_AXON_REMOVALS_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, SUBNET_AXON_REMOVALS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> buildSubnetAxonRemovals
+    // zeroed-card fallback contract handleSubnetAxonRemovals uses; a subnet with no
+    // AxonInfoRemoved events in the window is a schema-stable zeroed card, never a
+    // GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/axon-removals`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildSubnetAxonRemovals(null, netuid, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      observed_at: data.observed_at ?? null,
+      distinct_removers: data.distinct_removers ?? 0,
+      removals: data.removals ?? 0,
+      removals_per_remover: data.removals_per_remover ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3154,6 +3154,94 @@ describe("graphql — subnet_registrations (#5720, Postgres-tier + zeroed-card f
   });
 });
 
+describe("graphql — subnet_axon_removals (#5718, Postgres-tier + zeroed-card fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_axon_removals(netuid: 5) {
+          schema_version netuid window observed_at
+          distinct_removers removals removals_per_remover
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_axon_removals, {
+      schema_version: 1,
+      netuid: 5,
+      window: "7d",
+      observed_at: null,
+      distinct_removers: 0,
+      removals: 0,
+      removals_per_remover: null,
+    });
+  });
+
+  test("resolves the Postgres-tier card for the requested window", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          window: "30d",
+          observed_at: "2026-07-01T00:00:00.000Z",
+          distinct_removers: 4,
+          removals: 9,
+          removals_per_remover: 2.25,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_axon_removals(netuid: 5, window: "30d") {
+          netuid window observed_at distinct_removers removals removals_per_remover
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const r = body.data.subnet_axon_removals;
+    assert.equal(r.window, "30d");
+    assert.equal(r.observed_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(r.distinct_removers, 4);
+    assert.equal(r.removals, 9);
+    assert.equal(r.removals_per_remover, 2.25);
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_axon_removals(netuid: 9, window: "30d") {
+          schema_version netuid window observed_at distinct_removers removals removals_per_remover
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_axon_removals, {
+      schema_version: 1,
+      netuid: 9,
+      window: "30d",
+      observed_at: null,
+      distinct_removers: 0,
+      removals: 0,
+      removals_per_remover: null,
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ subnet_axon_removals(netuid: 5, window: "99d") { removals } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_axon_removals ?? null, null);
+  });
+});
+
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Per-subnet axon-removal activity had a REST route (`GET /api/v1/subnets/{netuid}/axon-removals`) and an MCP tool (`get_subnet_axon_removals`) but no GraphQL mirror — the axon-teardown companion of `Query.subnet_registrations`/`subnet_deregistrations`.

- **SDL:** a `subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!` root field, plus a `SubnetAxonRemovals` type mirroring `buildSubnetAxonRemovals`' real shape (`distinct_removers`, `removals`, `removals_per_remover`, `observed_at`, `window`, `schema_version`, `netuid`).
- **Resolver:** reuses REST's exact contract — the same `SUBNET_AXON_REMOVALS_WINDOWS` (7d/30d) validation `handleSubnetAxonRemovals` uses (unsupported window → GraphQL `BAD_USER_INPUT` error), then `tryPostgresTier(env, …, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")` with the `buildSubnetAxonRemovals(null, …)` zeroed-card fallback. A subnet with no `AxonInfoRemoved` events in the window resolves to a schema-stable zeroed card, never a GraphQL error.
- **`FIELD_COMPLEXITY`** entry at `RELATIONSHIP_FIELD_COMPLEXITY` weight.

## Tests

`tests/graphql.test.mjs` — the Postgres-tier hit, the zeroed-card fallback, a partial Postgres body degrading to the resolver's defaults, and the unsupported-`window` GraphQL error. **100% of the new resolver's statements and branches are covered**; the full 191-test graphql suite is green. No REST schema/OpenAPI change (SDL is inline). `eslint` / `prettier` clean.

Closes #5718
