### PR TITLE
chore: retire dead NEURON_HISTORY_ROLLUP_CRON

### DIFF
--- a/tests/account-position-history.test.mjs
+++ b/tests/account-position-history.test.mjs
@@ -4,35 +4,11 @@ import {
   formatAccountPosition,
   buildAccountPositionHistory,
 } from "../src/account-position-history.mjs";
-import { handleRequest, handleScheduled } from "../workers/api.mjs";
-import { NEURON_HISTORY_ROLLUP_CRON } from "../workers/config.mjs";
+import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 
 const ctx = { waitUntil: (p) => p };
 const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
-
-// account_position_daily's D1 rollup/prune (formerly rollupAccountPositionDaily/
-// pruneAccountPositionDaily, src/account-position-history.mjs, wired from this
-// cron) are retired: #4908 dropped D1's `neurons` table entirely, and #4839
-// already gave this table its own independent, live-verified Postgres write +
-// read path. This cron tick now has no remaining work.
-describe("handleScheduled NEURON_HISTORY_ROLLUP_CRON (retired, #4329/6.1)", () => {
-  test("is a pure no-op — never touches D1", async () => {
-    const env = {
-      METAGRAPH_HEALTH_DB: {
-        prepare() {
-          throw new Error("D1 must not be queried by a retired cron branch");
-        },
-      },
-    };
-    const result = await handleScheduled(
-      { cron: NEURON_HISTORY_ROLLUP_CRON },
-      env,
-      ctx,
-    );
-    assert.deepEqual(result, { ok: true, retired: true });
-  });
-});
 
 // An ACCOUNT_POSITION_DAILY_READ_COLUMNS-shaped row.
 function positionRow(overrides = {}) {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -317,7 +317,6 @@ import {
   MAX_BACKFILL_INGEST_BODY_BYTES,
   MAX_BACKFILL_INGEST_ROWS,
   MAX_WEBHOOK_BODY_BYTES,
-  NEURON_HISTORY_ROLLUP_CRON,
   PERCENTILES_PATH_PATTERN,
   RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN,
   resolveClientIp,
@@ -625,37 +624,6 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
   }
   if (cron === EMBEDDING_SYNC_CRON) {
     return runEmbeddingSync(env, { readArtifact });
-  }
-  if (cron === NEURON_HISTORY_ROLLUP_CRON) {
-    // #4772 D1 chain-data retirement: the neuron_daily rollup/archive/prune
-    // (rollupNeuronDaily/archiveNeuronDaily/archivePrunableNeuronDaily/
-    // pruneNeuronDaily) that used to run here are removed alongside D1's
-    // neuron_daily table. #4771's Postgres write path (handleNeuronsSync,
-    // called by refresh-metagraph.yml alongside the D1 stage) already populates
-    // Postgres's neuron_daily directly, and Postgres has no D1-style capacity
-    // cap forcing an archive-then-prune dance, so this cron no longer needs
-    // either step.
-    //
-    // account_position_daily's own rollupAccountPositionDaily/
-    // pruneAccountPositionDaily (src/account-position-history.mjs), previously
-    // called from here, are retired too: #4908 dropped D1's `neurons` table
-    // entirely (confirmed live: `SELECT ... FROM neurons` now errors "no such
-    // table: neurons"), so rollupAccountPositionDaily's `FROM neurons` query
-    // has been throwing -- silently swallowed by its own .catch() -- every
-    // tick since #4908 merged (2026-07-11); D1's account_position_daily table
-    // has been frozen at that same date ever since (confirmed via `wrangler
-    // d1 execute`). #4839 already gave this table its own independent
-    // Postgres write path (handleNeuronsSync, the same transaction as
-    // neurons/neuron_daily) and read route (tryPostgresTier +
-    // METAGRAPH_NEURONS_SOURCE, live in production per wrangler.jsonc), so
-    // nothing depends on the D1 side continuing to run. #4910, which asked
-    // for a Postgres read route believing none existed, was stale -- #4839
-    // already shipped it.
-    //
-    // This cron trigger (47 5 * * *, wrangler.jsonc) has no remaining work;
-    // left wired but inert rather than also retiring the schedule trigger
-    // itself, which is a separate deploy-config decision.
-    return { ok: true, retired: true };
   }
   if (cron === ACCOUNT_EVENTS_ROLLUP_CRON) {
     // #4832 gap-closure, moved off GitHub Actions (rollup-account-events-daily.yml,

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -15,11 +15,6 @@ export const HEALTH_PRUNE_CRON = "0 * * * *";
 // Distinct minute (odd) so it never collides with the 15-minute probe or the
 // top-of-hour prune. Must match a wrangler.jsonc `triggers.crons` entry.
 export const EMBEDDING_SYNC_CRON = "37 3 * * *";
-// Daily neuron-history rollup (#1345 Tier-1): snapshots the current `neurons`
-// table into the dated neuron_daily table once a day, on its own minute (distinct
-// from the probe/prune/embed/fast crons) so the ~33k-row INSERT...SELECT runs
-// exactly once/day, not on every tick. Must match a wrangler.jsonc cron entry.
-export const NEURON_HISTORY_ROLLUP_CRON = "47 5 * * *";
 // Hourly account_events_daily rollup (#4832 gap-closure), moved off the
 // former rollup-account-events-daily.yml GitHub Actions workflow onto this
 // Worker-native cron -- offset from the top-of-hour prune (0) so the two

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -428,18 +428,17 @@
     // */15 = health probe; 0 = hourly prune/rollup; 17 = hourly
     // account_events_daily rollup (#4832, moved off GitHub Actions --
     // formerly rollup-account-events-daily.yml, retired); 37 3 = daily
-    // embedding sync; 47 5 = daily neuron-history rollup (#1345). The former
-    // */3 fast drain of R2-staged batches into D1 (#1346 Option A) is
-    // retired: its last consumer, loadStagedAccountIdentity, was removed
-    // once refresh-account-identity moved off the R2/D1 staging path onto a
-    // direct-to-Postgres sync (indexer-box cron migration).
-    "crons": [
-      "*/15 * * * *",
-      "0 * * * *",
-      "17 * * * *",
-      "37 3 * * *",
-      "47 5 * * *",
-    ],
+    // embedding sync. The former */3 fast drain of R2-staged batches into D1
+    // (#1346 Option A) is retired: its last consumer, loadStagedAccountIdentity,
+    // was removed once refresh-account-identity moved off the R2/D1 staging
+    // path onto a direct-to-Postgres sync (indexer-box cron migration). The
+    // former 47 5 daily neuron-history rollup (#1345) is retired too: #4772's
+    // D1 chain-data write-path retirement dropped its target table, leaving
+    // it a permanent no-op (workers/api.mjs's NEURON_HISTORY_ROLLUP_CRON
+    // branch was left wired-but-inert for a while) -- this entry and that
+    // dead branch are removed together rather than left firing daily for
+    // nothing.
+    "crons": ["*/15 * * * *", "0 * * * *", "17 * * * *", "37 3 * * *"],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite
   // for enabling METAGRAPH_ENABLE_RPC_PROXY). 100 requests / 60s per client IP;


### PR DESCRIPTION
## Summary
- Removes the `47 5 * * *` daily cron trigger, which has fired every day for no purpose since #4772's D1 chain-data write-path retirement dropped its target table -- `workers/api.mjs`'s own comment on the dispatch branch already documented this as "left wired but inert... a separate deploy-config decision," now made.
- Removes the dead `NEURON_HISTORY_ROLLUP_CRON` dispatch branch (`workers/api.mjs`), constant (`workers/config.mjs`), and its no-op-assertion test (`tests/account-position-history.test.mjs`).
- No behavior change: the branch has returned `{ ok: true, retired: true }` without touching D1/Postgres since 2026-07-11.

## Test plan
- [x] `npx vitest run tests/account-position-history.test.mjs` — 27/27 pass
- [x] `npx eslint`, `npx prettier --check` on all changed files
- [x] `npm run validate`