### PR TITLE
fix(registry): drop redundant nodexo source-repo surface

### DIFF
--- a/registry/subnets/nodexo.json
+++ b/registry/subnets/nodexo.json
@@ -86,22 +86,6 @@
       "notes": "Official Nodexo console surface. Authentication may be required for account-specific workflows."
     },
     {
-      "id": "sn-106-nodexo-source-repo",
-      "name": "Nodexo subnet source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/nodexo-ai/nodexo",
-      "provider": "nodexo",
-      "auth_required": false,
-      "authority": "community",
-      "public_safe": true,
-      "source_urls": ["https://nodexo.ai/", "https://github.com/nodexo-ai"],
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "minion1227"
-      },
-      "notes": "Official Nodexo (SN106) miner/validator/CLI source repo under the github.com/nodexo-ai org linked from the project website."
-    },
-    {
       "id": "sn-106-nodexo-subnet-api",
       "name": "Nodexo inventory API",
       "kind": "subnet-api",


### PR DESCRIPTION
## Summary

Found while re-triggering \`sync-subnets.yml\` for an unrelated Gittensor/Allways data-accuracy fix. The full pipeline's \`validate:surface\` step has been failing on every run — blocking the whole refresh entirely, unrelated to whatever data it was actually trying to refresh.

Cause: \`sn-106-nodexo-source-repo\` (a community-submitted surface) duplicates a signal the build pipeline already injects automatically from on-chain \`SubnetIdentitiesV3\` — the validator's own error says as much: *"this surface adds no new signal ... Submit a surface the machine cannot discover."*

## Test plan

- [x] Removed the one redundant surface entry
- [x] \`npm run validate:surface\` passes (849 surfaces across 129 subnet files)
- [x] Confirmed no other file references this surface id