### PR TITLE
feat(graphql): add Query.subnet_serving mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -20,6 +20,11 @@ import {
   DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW,
 } from "./subnet-deregistrations.mjs";
 import {
+  buildSubnetServing,
+  SUBNET_SERVING_WINDOWS,
+  DEFAULT_SUBNET_SERVING_WINDOW,
+} from "./subnet-serving.mjs";
+import {
   analyticsWindow,
   loadGlobalIncidentsLedger,
 } from "../workers/request-handlers/analytics.mjs";
@@ -114,6 +119,8 @@ export const SDL = `
     subnet_registrations(netuid: Int!, window: String): SubnetRegistrations!
     "Per-subnet neuron-deregistration activity over a 7d/30d window (distinct deregistered hotkeys, NeuronDeregistered count, and deregistrations per hotkey); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/deregistrations."
     subnet_deregistrations(netuid: Int!, window: String): SubnetDeregistrations!
+    "Per-subnet axon-serving activity over a 7d/30d window (distinct servers, AxonServed announcement count, and announcements per server); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/serving."
+    subnet_serving(netuid: Int!, window: String): SubnetServing!
     "Paginated provider/source registry."
     providers(limit: Int, cursor: String): ProviderList!
     "One provider with its subnets."
@@ -576,6 +583,16 @@ export const SDL = `
     deregistrations_per_hotkey: Float
   }
 
+  type SubnetServing {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    distinct_servers: Int!
+    announcements: Int!
+    announcements_per_server: Float
+  }
+
   "Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope."
   type GlobalIncidents {
     schema_version: Int!
@@ -1004,6 +1021,7 @@ export const FIELD_COMPLEXITY = {
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1592,6 +1610,43 @@ const rootValue = {
       distinct_deregistered_hotkeys: data.distinct_deregistered_hotkeys ?? 0,
       deregistrations: data.deregistrations ?? 0,
       deregistrations_per_hotkey: data.deregistrations_per_hotkey ?? null,
+    };
+  },
+
+  async subnet_serving({ netuid, window }, context) {
+    // Same 7d/30d window validation handleSubnetServing uses -- an
+    // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_SUBNET_SERVING_WINDOW;
+    if (!Object.hasOwn(SUBNET_SERVING_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, SUBNET_SERVING_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> buildSubnetServing
+    // zeroed-card fallback contract handleSubnetServing uses; a subnet with no
+    // AxonServed events in the window is a schema-stable zeroed card, never a
+    // GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/serving`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildSubnetServing(null, netuid, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      observed_at: data.observed_at ?? null,
+      distinct_servers: data.distinct_servers ?? 0,
+      announcements: data.announcements ?? 0,
+      announcements_per_server: data.announcements_per_server ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3242,6 +3242,94 @@ describe("graphql — subnet_deregistrations (#5719, Postgres-tier + zeroed-card
   });
 });
 
+describe("graphql — subnet_serving (#5715, Postgres-tier + zeroed-card fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_serving(netuid: 5) {
+          schema_version netuid window observed_at
+          distinct_servers announcements announcements_per_server
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_serving, {
+      schema_version: 1,
+      netuid: 5,
+      window: "7d",
+      observed_at: null,
+      distinct_servers: 0,
+      announcements: 0,
+      announcements_per_server: null,
+    });
+  });
+
+  test("resolves the Postgres-tier card for the requested window", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          window: "30d",
+          observed_at: "2026-07-01T00:00:00.000Z",
+          distinct_servers: 3,
+          announcements: 9,
+          announcements_per_server: 3,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_serving(netuid: 5, window: "30d") {
+          netuid window observed_at distinct_servers announcements announcements_per_server
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const r = body.data.subnet_serving;
+    assert.equal(r.window, "30d");
+    assert.equal(r.observed_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(r.distinct_servers, 3);
+    assert.equal(r.announcements, 9);
+    assert.equal(r.announcements_per_server, 3);
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_serving(netuid: 9, window: "30d") {
+          schema_version netuid window observed_at distinct_servers announcements announcements_per_server
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_serving, {
+      schema_version: 1,
+      netuid: 9,
+      window: "30d",
+      observed_at: null,
+      distinct_servers: 0,
+      announcements: 0,
+      announcements_per_server: null,
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ subnet_serving(netuid: 5, window: "99d") { announcements } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_serving ?? null, null);
+  });
+});
+
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
Adds a \`subnet_serving(netuid, window)\` GraphQL query mirroring \`GET /api/v1/subnets/{netuid}/serving\` and the \`get_subnet_serving\` MCP tool: per-subnet axon-serving activity over a 7d/30d window (distinct servers, AxonServed announcement count, announcements per server).

## What
- New \`SubnetServing\` type + \`Query.subnet_serving(netuid: Int!, window: String)\` in \`src/graphql.mjs\`, weighted \`RELATIONSHIP_FIELD_COMPLEXITY\`.
- Resolver reuses \`buildSubnetServing\` and \`SUBNET_SERVING_WINDOWS\`/\`DEFAULT_SUBNET_SERVING_WINDOW\` from \`src/subnet-serving.mjs\`, resolving through the same \`tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)\` path as the REST handler with a schema-stable zeroed-card fallback (a subnet with no events in the window resolves to a zeroed card, never null).
- An unsupported window is a \`BAD_USER_INPUT\` GraphQL error, matching the sibling \`subnet_registrations\`/\`subnet_deregistrations\` queries.

## Tests
Four cases in \`tests/graphql.test.mjs\`: cold-store zeroed card, Postgres-tier resolve for the requested window, partial-body degradation to resolver defaults, and unsupported-window error. Full graphql suite green (195 tests); resolver 100% covered (statements + branches).

Closes #5715