### PR TITLE
fix(ui): restore a way to open global search on mobile (#5319)

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -2,7 +2,16 @@ import { Link, useRouterState } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronLeft, ChevronRight, Compass, Github, Menu, Rss, Webhook } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Compass,
+  Github,
+  Menu,
+  Rss,
+  Search,
+  Webhook,
+} from "lucide-react";
 import {
   API_BASE,
   DEFAULT_DISCORD_URL,
@@ -141,6 +150,21 @@ export function AppShell({ children }: { children: ReactNode }) {
               <NavMegaMenu />
               <div className="flex-1 min-w-0 flex justify-end">
                 <NavOmnibox onOpenPalette={() => setPaletteOpen(true)} />
+                {/* Below md the omnibox is hidden (#5034), which left the palette
+                    reachable only via ⌘K / Ctrl+K / "/" — none of which exist on a
+                    touch device, so mobile had no way into global search at all.
+                    This is that missing entry point: same setPaletteOpen the
+                    keyboard shortcuts use, shown exactly where the omnibox isn't
+                    (#5319). */}
+                <button
+                  type="button"
+                  onClick={() => setPaletteOpen(true)}
+                  aria-label="Open search"
+                  title="Search"
+                  className="md:hidden inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
+                >
+                  <Search className="size-4" aria-hidden="true" />
+                </button>
               </div>
               <div className="flex items-center gap-1">
                 <ApiDrawerTrigger />


### PR DESCRIPTION
## Summary

Closes #5319

#5034 hid `NavOmnibox` below `md` to stop it squeezing to zero width — but the omnibox was the header's **only** search entry point. That left the command palette reachable only through `Cmd/Ctrl+K` or `/`, none of which exist on a touch device, so **mobile visitors had no way to open global search at all**.

This adds the missing entry point: a search button in the header's search slot, shown exactly where the omnibox isn't (`md:hidden`), calling the same `setPaletteOpen(true)` the keyboard shortcuts already use. Styled and sized like its sibling header icon buttons (44px min touch target).

**`md` and up are unchanged** — the omnibox still owns search there, so tablet/desktop are identical before and after.

1 file, +25/-1.

## Verified by a real tap, not just a screenshot

The capture run asserts the actual deliverable at 375px — it taps the trigger and waits for the palette dialog:

```
PASS: tap on the mobile search trigger opened the command palette
```

(It fails loudly if no trigger renders or the palette doesn't open.)

## Gates

typecheck OK · eslint `.` OK (0 errors) · prettier OK · rebased onto the latest `main` (the previous attempt, #5459, was closed purely for a base conflict — this one is current as of push)

## Screenshots

Captured with Playwright at the three SKILL viewports (375x812 / 768x1024 / 1280x800), each theme forced via `mg-theme`, fixed-viewport (never full-page), against the live dev server with real data. Mobile is the meaningful change — before has no search affordance in the header at all; after shows the search button. Tablet/desktop are unchanged by design.

| Viewport - Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5319/after-mobile-dark.png)<br><sub>after</sub> |
