### PR TITLE
feat(registry): add SN27 NI Compute TaoMarketCap subnet-api surface

### DIFF
--- a/registry/subnets/ni-compute.json
+++ b/registry/subnets/ni-compute.json
@@ -70,6 +70,22 @@
         "https://github.com/neuralinternet/SN27-opencompute/blob/main/.env.example"
       ],
       "url": "https://wandb.ai/neuralinternet/opencompute"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-27-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "NI Compute TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/27 on api.taomarketcap.com returning machine-readable JSON for SN27 NI Compute on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. NI Compute has no separately registered first-party public subnet-state API; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jaytbarimbao-collab"
+      },
+      "source_urls": ["https://api.taomarketcap.com/developer/documentation/"],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/27"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enriches **SN27 NI Compute** with a public, no-auth **subnet-api** surface — the machine-readable TaoMarketCap subnet-snapshot feed. NI Compute's registry entry has no `subnet-api` kind yet (only source-repo, a data-artifact, and the OpenCompute W&B dashboard).

## Surface

- **kind:** `subnet-api` · **url:** `https://api.taomarketcap.com/public/v1/subnets/27` · **auth_required:** `false`
- `GET /public/v1/subnets/27` returns machine-readable JSON for SN27's on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Documented in the TaoMarketCap developer API. Byte-for-byte the same community indexed-feed pattern as the merged SN115/SN118/SN24/SN92/SN128 subnet-api surfaces.

## Verification

- `GET https://api.taomarketcap.com/public/v1/subnets/27` → `200`, real JSON (`{"id":"27","netuid":27,"is_active":true,...}`).
- Single additive append; `prettier --check` clean.

Closes #4025
