### PR TITLE
feat(graphql): add Query.subnet_axon_removals mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -25,6 +25,11 @@ import {
   DEFAULT_SUBNET_SERVING_WINDOW,
 } from "./subnet-serving.mjs";
 import {
+  buildSubnetAxonRemovals,
+  SUBNET_AXON_REMOVALS_WINDOWS,
+  DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
+} from "./subnet-axon-removals.mjs";
+import {
   analyticsWindow,
   loadGlobalIncidentsLedger,
 } from "../workers/request-handlers/analytics.mjs";
@@ -122,6 +127,8 @@ export const SDL = `
     subnet_deregistrations(netuid: Int!, window: String): SubnetDeregistrations!
     "Per-subnet axon-serving activity over a 7d/30d window (distinct servers, AxonServed announcement count, and announcements per server); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/serving."
     subnet_serving(netuid: Int!, window: String): SubnetServing!
+    "Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
+    subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
     "Paginated provider/source registry."
     providers(limit: Int, cursor: String): ProviderList!
     "One provider with its subnets."
@@ -605,6 +612,16 @@ export const SDL = `
     announcements_per_server: Float
   }
 
+  type SubnetAxonRemovals {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    distinct_removers: Int!
+    removals: Int!
+    removals_per_remover: Float
+  }
+
   "Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope."
   type GlobalIncidents {
     schema_version: Int!
@@ -1034,6 +1051,7 @@ export const FIELD_COMPLEXITY = {
   subnet_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_serving: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1660,6 +1678,43 @@ const rootValue = {
       distinct_servers: data.distinct_servers ?? 0,
       announcements: data.announcements ?? 0,
       announcements_per_server: data.announcements_per_server ?? null,
+    };
+  },
+
+  async subnet_axon_removals({ netuid, window }, context) {
+    // Same 7d/30d window validation handleSubnetAxonRemovals uses -- an
+    // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_SUBNET_AXON_REMOVALS_WINDOW;
+    if (!Object.hasOwn(SUBNET_AXON_REMOVALS_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, SUBNET_AXON_REMOVALS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> buildSubnetAxonRemovals
+    // zeroed-card fallback contract handleSubnetAxonRemovals uses; a subnet with no
+    // AxonInfoRemoved events in the window is a schema-stable zeroed card, never a
+    // GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/axon-removals`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildSubnetAxonRemovals(null, netuid, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      observed_at: data.observed_at ?? null,
+      distinct_removers: data.distinct_removers ?? 0,
+      removals: data.removals ?? 0,
+      removals_per_remover: data.removals_per_remover ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3330,6 +3330,94 @@ describe("graphql — subnet_serving (#5715, Postgres-tier + zeroed-card fallbac
   });
 });
 
+describe("graphql — subnet_axon_removals (#5718, Postgres-tier + zeroed-card fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_axon_removals(netuid: 5) {
+          schema_version netuid window observed_at
+          distinct_removers removals removals_per_remover
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_axon_removals, {
+      schema_version: 1,
+      netuid: 5,
+      window: "7d",
+      observed_at: null,
+      distinct_removers: 0,
+      removals: 0,
+      removals_per_remover: null,
+    });
+  });
+
+  test("resolves the Postgres-tier card for the requested window", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          window: "30d",
+          observed_at: "2026-07-01T00:00:00.000Z",
+          distinct_removers: 2,
+          removals: 5,
+          removals_per_remover: 2.5,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_axon_removals(netuid: 5, window: "30d") {
+          netuid window observed_at distinct_removers removals removals_per_remover
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const r = body.data.subnet_axon_removals;
+    assert.equal(r.window, "30d");
+    assert.equal(r.observed_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(r.distinct_removers, 2);
+    assert.equal(r.removals, 5);
+    assert.equal(r.removals_per_remover, 2.5);
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_axon_removals(netuid: 9, window: "30d") {
+          schema_version netuid window observed_at distinct_removers removals removals_per_remover
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_axon_removals, {
+      schema_version: 1,
+      netuid: 9,
+      window: "30d",
+      observed_at: null,
+      distinct_removers: 0,
+      removals: 0,
+      removals_per_remover: null,
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ subnet_axon_removals(netuid: 5, window: "99d") { removals } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_axon_removals ?? null, null);
+  });
+});
+
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
Adds a \`subnet_axon_removals(netuid, window)\` GraphQL query mirroring \`GET /api/v1/subnets/{netuid}/axon-removals\` and the \`get_subnet_axon_removals\` MCP tool: per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover).

## What
- New \`SubnetAxonRemovals\` type + \`Query.subnet_axon_removals(netuid: Int!, window: String)\` in \`src/graphql.mjs\`, weighted \`RELATIONSHIP_FIELD_COMPLEXITY\`.
- Resolver reuses \`buildSubnetAxonRemovals\` and \`SUBNET_AXON_REMOVALS_WINDOWS\`/\`DEFAULT_SUBNET_AXON_REMOVALS_WINDOW\` from \`src/subnet-axon-removals.mjs\`, resolving through the same \`tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)\` path as the REST handler with a schema-stable zeroed-card fallback (a subnet with no events in the window resolves to a zeroed card, never null).
- An unsupported window is a \`BAD_USER_INPUT\` GraphQL error, matching the sibling \`subnet_registrations\`/\`subnet_deregistrations\`/\`subnet_serving\` queries.

## Tests
Four cases in \`tests/graphql.test.mjs\`: cold-store zeroed card, Postgres-tier resolve for the requested window, partial-body degradation to resolver defaults, and unsupported-window error. Full graphql suite green; resolver 100% covered (statements + branches).

Closes #5718