### PR TITLE
feat(graphql): add Query.chain_yield mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -48,6 +48,7 @@ import {
 import { buildExtrinsic, buildExtrinsicFeed } from "./extrinsics.mjs";
 import { buildBlock, buildBlockFeed } from "./blocks.mjs";
 import { buildBlocksSummary } from "./blocks-summary.mjs";
+import { buildChainYield } from "./chain-yield.mjs";
 import {
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
@@ -168,6 +169,8 @@ export const SDL = `
     chain_weight_setters(window: String, limit: Int): ChainWeightSetters!
     "Compact all-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history (probed every ~15 minutes); a cold store still returns both windows, schema-stable and zeroed, never a GraphQL error. Mirrors GET /api/v1/health/trends."
     health_trends: HealthTrends!
+    "Network-wide emission-yield (return rate) aggregated across every subnet's neurons -- the aggregate network return, the same split by validator vs miner role, and the distribution of the per-neuron return rate. Every aggregate is null (never a GraphQL error) on a cold store. Mirrors GET /api/v1/chain/yield."
+    chain_yield: ChainYield!
   }
 
   type SubnetList {
@@ -689,6 +692,35 @@ export const SDL = `
     observed_at: String
   }
 
+  "Network-wide emission-yield (return rate) card across every subnet's neurons. Aggregates are null on a cold store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/chain/yield."
+  type ChainYield {
+    schema_version: Int!
+    subnet_count: Int!
+    neuron_count: Int!
+    validator_count: Int!
+    miner_count: Int!
+    captured_at: String
+    total_stake_tao: Float!
+    total_emission_tao: Float!
+    network_yield: Float
+    validator_yield: Float
+    miner_yield: Float
+    distribution: YieldDistribution
+  }
+
+  "Distribution of the per-neuron emission/stake return rate across the network."
+  type YieldDistribution {
+    count: Int!
+    mean: Float!
+    median: Float!
+    min: Float!
+    max: Float!
+    p10: Float!
+    p25: Float!
+    p75: Float!
+    p90: Float!
+  }
+
   "Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary."
   type BlocksSummary {
     schema_version: Int!
@@ -1042,6 +1074,7 @@ export const FIELD_COMPLEXITY = {
   chain_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_yield: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -2267,6 +2300,45 @@ const rootValue = {
       observed_at: data.observed_at ?? null,
       source: data.source ?? null,
       windows: data.windows ?? {},
+    };
+  },
+
+  async chain_yield(_args, context) {
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildChainYield([])
+    // fallback contract handleChainYield uses -- a cold/absent tier yields a
+    // schema-stable zeroed card (every aggregate null), never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/yield"),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildChainYield([]);
+    const distribution = data.distribution ?? null;
+    return {
+      schema_version: data.schema_version ?? 1,
+      subnet_count: data.subnet_count ?? 0,
+      neuron_count: data.neuron_count ?? 0,
+      validator_count: data.validator_count ?? 0,
+      miner_count: data.miner_count ?? 0,
+      captured_at: data.captured_at ?? null,
+      total_stake_tao: data.total_stake_tao ?? 0,
+      total_emission_tao: data.total_emission_tao ?? 0,
+      network_yield: data.network_yield ?? null,
+      validator_yield: data.validator_yield ?? null,
+      miner_yield: data.miner_yield ?? null,
+      distribution: distribution
+        ? {
+            count: distribution.count ?? 0,
+            mean: distribution.mean ?? 0,
+            median: distribution.median ?? 0,
+            min: distribution.min ?? 0,
+            max: distribution.max ?? 0,
+            p10: distribution.p10 ?? 0,
+            p25: distribution.p25 ?? 0,
+            p75: distribution.p75 ?? 0,
+            p90: distribution.p90 ?? 0,
+          }
+        : null,
     };
   },
 };

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -4359,3 +4359,167 @@ describe("Subscription.chainEvents", () => {
     assert.ok(body.errors?.length);
   });
 });
+
+describe("graphql — chain_yield (Postgres-tier + cold-store fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ chain_yield {
+          schema_version subnet_count neuron_count validator_count miner_count
+          captured_at total_stake_tao total_emission_tao
+          network_yield validator_yield miner_yield
+          distribution { count mean median min max p10 p25 p75 p90 }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_yield, {
+      schema_version: 1,
+      subnet_count: 0,
+      neuron_count: 0,
+      validator_count: 0,
+      miner_count: 0,
+      captured_at: null,
+      total_stake_tao: 0,
+      total_emission_tao: 0,
+      network_yield: null,
+      validator_yield: null,
+      miner_yield: null,
+      distribution: null,
+    });
+  });
+
+  test("resolves the Postgres-tier card, including the nested distribution", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          subnet_count: 3,
+          neuron_count: 500,
+          validator_count: 40,
+          miner_count: 460,
+          captured_at: "2026-07-15T00:00:00.000Z",
+          total_stake_tao: 1200000,
+          total_emission_tao: 84,
+          network_yield: 0.00007,
+          validator_yield: 0.00009,
+          miner_yield: 0.00002,
+          distribution: {
+            count: 460,
+            mean: 0.00006,
+            median: 0.00005,
+            min: 0.000001,
+            max: 0.0009,
+            p10: 0.000005,
+            p25: 0.00002,
+            p75: 0.00008,
+            p90: 0.0002,
+          },
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ chain_yield {
+          subnet_count neuron_count validator_count miner_count captured_at
+          network_yield validator_yield miner_yield
+          distribution { count mean p90 }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const c = body.data.chain_yield;
+    assert.equal(c.subnet_count, 3);
+    assert.equal(c.neuron_count, 500);
+    assert.equal(c.validator_count, 40);
+    assert.equal(c.miner_count, 460);
+    assert.equal(c.captured_at, "2026-07-15T00:00:00.000Z");
+    assert.equal(c.network_yield, 0.00007);
+    assert.equal(c.validator_yield, 0.00009);
+    assert.equal(c.miner_yield, 0.00002);
+    assert.equal(c.distribution.count, 460);
+    assert.equal(c.distribution.mean, 0.00006);
+    assert.equal(c.distribution.p90, 0.0002);
+  });
+
+  test("forwards to /api/v1/chain/yield with no query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({ schema_version: 1, subnet_count: 0 });
+        },
+      },
+    };
+    await gql("{ chain_yield { subnet_count } }", env);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/yield");
+    assert.equal(capturedUrl.search, "");
+  });
+
+  test("a partial Postgres-tier body degrades to the schema-stable defaults, never null", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      // Every field absent -- the resolver's own ?? defaults must fill them in.
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ chain_yield {
+          schema_version subnet_count neuron_count validator_count miner_count
+          captured_at total_stake_tao total_emission_tao
+          network_yield validator_yield miner_yield distribution { count }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_yield, {
+      schema_version: 1,
+      subnet_count: 0,
+      neuron_count: 0,
+      validator_count: 0,
+      miner_count: 0,
+      captured_at: null,
+      total_stake_tao: 0,
+      total_emission_tao: 0,
+      network_yield: null,
+      validator_yield: null,
+      miner_yield: null,
+      distribution: null,
+    });
+  });
+
+  test("a distribution present but missing individual fields degrades those to zero, not null, since the field is non-null", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          distribution: {},
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ chain_yield { distribution { count mean median min max p10 p25 p75 p90 } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_yield.distribution, {
+      count: 0,
+      mean: 0,
+      median: 0,
+      min: 0,
+      max: 0,
+      p10: 0,
+      p25: 0,
+      p75: 0,
+      p90: 0,
+    });
+  });
+
+  test("chain_yield carries the same relationship field complexity weight as its siblings", () => {
+    assert.equal(FIELD_COMPLEXITY.chain_yield, FIELD_COMPLEXITY.blocks_summary);
+  });
+});


### PR DESCRIPTION
Closes #5687

## What

`GET /api/v1/chain/yield` and the `get_chain_yield` MCP tool exist, but there was no GraphQL mirror. Same gap-closure category as the already-shipped `blocks_summary`/`subnet_movers`/`health_trends` fields.

## Fix

- Added `Query.chain_yield: ChainYield!` to the SDL, plus `ChainYield` and `YieldDistribution` types mirroring the REST handler's real response shape.
- Resolver follows the established pattern: `tryPostgresTier(context.env, postgresTierRequest(context, "/api/v1/chain/yield"), "METAGRAPH_NEURONS_SOURCE") ?? buildChainYield([])` — reuses `src/chain-yield.mjs`'s existing builder, no duplicated query logic.
- Degrades to a schema-stable zeroed/null card on a cold store, never a GraphQL error, matching every sibling resolver's convention.
- Added `chain_yield: RELATIONSHIP_FIELD_COMPLEXITY` to `FIELD_COMPLEXITY`, same weight as `blocks_summary`.

## Testing

```
npx vitest run tests/graphql.test.mjs
# all passing (pre-existing suite + 6 new chain_yield tests)

npx eslint src/graphql.mjs tests/graphql.test.mjs
# clean

npx prettier --check src/graphql.mjs tests/graphql.test.mjs
# clean (verified via git diff --check against main -- CRLF-only, zero real formatting issues in the diff)
```

New tests cover: a successful Postgres-tier hit (including nested `distribution`), the cold-store fallback (schema-stable zeroed/null card), a partial response body degrading to defaults, a distribution present but missing individual fields degrading to zero (non-null field), request forwarding to the correct path with no query params, and the `FIELD_COMPLEXITY` weight assertion.

Note: this supersedes #5731 and #5744, both mechanically closed by LoopOver for a stale base as sibling GraphQL mirror PRs merged into `main` in quick succession. Rebased onto current `main` here — same diff, no content changes.