### PR TITLE
feat(graphql): add Query.validator_history mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -71,6 +71,7 @@ import {
   parseHistoryWindow,
   unsupportedWindowMessage,
 } from "./neuron-history.mjs";
+import { buildValidatorHistory } from "./validator-history.mjs";
 import { loadEconomicsTrends } from "./economics-trends.mjs";
 import {
   DEFAULT_MOVERS_SORT,
@@ -154,6 +155,8 @@ export const SDL = `
     validators(sort: String, limit: Int): ValidatorList!
     "One validator's cross-subnet aggregate by hotkey; a hotkey with no validator_permit=1 rows resolves to a schema-stable zeroed aggregate, never null. Mirrors GET /api/v1/validators/{hotkey}."
     validator(hotkey: String!): Validator
+    "One validator's cross-subnet staked-over-time history: one point per day (window: 7d/30d/90d/1y/all, default 30d), summed across every subnet it validates in, plus a rewards-per-1000-TAO rate. A hotkey with no matching neuron_daily rows resolves to a schema-stable empty-points card, never null. Mirrors GET /api/v1/validators/{hotkey}/history."
+    validator_history(hotkey: String!, window: String): ValidatorHistory!
     "Site-wide accounts leaderboard -- every currently-registered hotkey, aggregated cross-subnet from the current neurons snapshot. Mirrors GET /api/v1/accounts."
     accounts(sort: String, limit: Int): AccountList!
     "One account's cross-subnet event-history summary by ss58 address; an address with no matching account_events rows resolves to a schema-stable zero summary, never null. Mirrors GET /api/v1/accounts/{ss58}."
@@ -781,6 +784,24 @@ export const SDL = `
     subnets: [ValidatorSubnet!]!
   }
 
+  "One validator's cross-subnet staked-over-time history. Mirrors GET /api/v1/validators/{hotkey}/history."
+  type ValidatorHistory {
+    schema_version: Int!
+    hotkey: String!
+    window: String
+    point_count: Int!
+    points: [ValidatorHistoryPoint!]!
+  }
+
+  "One day's cross-subnet rollup for a validator hotkey, summed across every subnet it validates in that day."
+  type ValidatorHistoryPoint {
+    snapshot_date: String!
+    subnet_count: Int
+    total_stake_tao: Float
+    total_emission_tao: Float
+    rewards_per_1000_tao: Float
+  }
+
   type ValidatorSubnet {
     netuid: Int!
     uid: Int
@@ -1028,6 +1049,7 @@ export const FIELD_COMPLEXITY = {
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
   validators: RELATIONSHIP_FIELD_COMPLEXITY,
   validator: RELATIONSHIP_FIELD_COMPLEXITY,
+  validator_history: RELATIONSHIP_FIELD_COMPLEXITY,
   accounts: RELATIONSHIP_FIELD_COMPLEXITY,
   account: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1999,6 +2021,40 @@ const rootValue = {
         "METAGRAPH_NEURONS_SOURCE",
       )) ?? buildValidatorDetail([], hotkey);
     return validatorNode(data);
+  },
+
+  async validator_history({ hotkey, window }, context) {
+    // Same parseHistoryWindow REST's handleValidatorHistory uses, so accepted
+    // window labels (7d/30d/90d/1y/all, default 30d) match exactly.
+    const { label, error } = parseHistoryWindow(window);
+    if (error) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const params = new URLSearchParams();
+    params.set("window", label);
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildValidatorHistory
+    // fallback contract handleValidatorHistory uses; a hotkey with no
+    // neuron_daily rows in the window is a schema-stable empty-points card,
+    // never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/validators/${encodeURIComponent(hotkey)}/history`,
+          params,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildValidatorHistory([], hotkey, { window: label });
+    return {
+      schema_version: data.schema_version ?? 1,
+      hotkey: data.hotkey ?? hotkey,
+      window: data.window ?? label,
+      point_count: data.point_count ?? 0,
+      points: data.points || [],
+    };
   },
 
   async accounts({ sort, limit }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -2433,6 +2433,126 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
   });
 });
 
+describe("graphql — validator_history (#5710, Postgres-tier + empty-points fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag / no neuron_daily rows returns a schema-stable empty-points card, never null", async () => {
+    const { status, body } = await gql(
+      `{ validator_history(hotkey: "5NoRows") {
+          schema_version hotkey window point_count points { snapshot_date }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.validator_history, {
+      schema_version: 1,
+      hotkey: "5NoRows",
+      window: "30d",
+      point_count: 0,
+      points: [],
+    });
+  });
+
+  test("resolves the Postgres-tier points for the requested window", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          hotkey: "5Validator",
+          window: "90d",
+          point_count: 1,
+          points: [
+            {
+              snapshot_date: "2026-07-01",
+              subnet_count: 2,
+              total_stake_tao: 1000,
+              total_emission_tao: 4,
+              rewards_per_1000_tao: 4,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ validator_history(hotkey: "5Validator", window: "90d") {
+          hotkey window point_count
+          points { snapshot_date subnet_count total_stake_tao total_emission_tao rewards_per_1000_tao }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const r = body.data.validator_history;
+    assert.equal(r.hotkey, "5Validator");
+    assert.equal(r.window, "90d");
+    assert.equal(r.point_count, 1);
+    assert.deepEqual(r.points, [
+      {
+        snapshot_date: "2026-07-01",
+        subnet_count: 2,
+        total_stake_tao: 1000,
+        total_emission_tao: 4,
+        rewards_per_1000_tao: 4,
+      },
+    ]);
+  });
+
+  test("window is forwarded as a query param to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(
+      '{ validator_history(hotkey: "5Validator", window: "7d") { window } }',
+      env,
+    );
+    assert.equal(capturedUrl.searchParams.get("window"), "7d");
+    assert.ok(capturedUrl.pathname.endsWith("/validators/5Validator/history"));
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ validator_history(hotkey: "5Validator", window: "30d") {
+          schema_version hotkey window point_count points { snapshot_date }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.validator_history, {
+      schema_version: 1,
+      hotkey: "5Validator",
+      window: "30d",
+      point_count: 0,
+      points: [],
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ validator_history(hotkey: "5Validator", window: "99d") { point_count } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|30d/i.test(body.errors[0].message));
+    assert.equal(body.data?.validator_history ?? null, null);
+  });
+
+  test("validator_history is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.validator_history, 5);
+  });
+});
+
 describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderboard)", () => {
   const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 


### PR DESCRIPTION
## Summary

- Adds `Query.validator_history` to the GraphQL SDL, mirroring `GET /api/v1/validators/{hotkey}/history` (backed by `src/validator-history.mjs`) and the existing `get_validator_history` MCP tool.

## What Changed

- `src/graphql.mjs`: new `validator_history(hotkey: String!, window: String): ValidatorHistory!` field on `Query`, plus `ValidatorHistory` / `ValidatorHistoryPoint` SDL types mirroring the handler's real response shape (`schema_version`, `hotkey`, `window`, `point_count`, `points[]` with `snapshot_date`/`subnet_count`/`total_stake_tao`/`total_emission_tao`/`rewards_per_1000_tao`).
- Resolver reuses `parseHistoryWindow`/`HISTORY_WINDOWS` (already imported from `src/validator-history.mjs`'s sibling `src/neuron-history.mjs`, same windows REST's `handleValidatorHistory` accepts: `7d/30d/90d/1y/all`, default `30d`) and `buildValidatorHistory` from `src/validator-history.mjs` directly — no rollup logic duplicated. Same `tryPostgresTier(..., "METAGRAPH_NEURONS_SOURCE")` proxy + fallback contract as `Query.validator` and the REST/MCP handlers.
- A hotkey with no matching `neuron_daily` rows resolves to a schema-stable empty-points card (`point_count: 0, points: []`), never `null` — matching `Query.validator`'s zeroed-aggregate precedent for an unregistered hotkey.
- Added `validator_history` to `FIELD_COMPLEXITY` at the same weight as the other single-entity relationship fields (`validator`, `account`, etc.).
- Tests in `tests/graphql.test.mjs`: cold-store empty-points card, a successful Postgres-tier hit with points, the window forwarded as a query param, a partial-body degrade to defaults, an unsupported-window `BAD_USER_INPUT` error, and the complexity-weight check.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5710`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (None touched by this PR — no schema/OpenAPI/contract changes.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (GraphQL SDL is the only surface changed; no REST/OpenAPI contract touched.)

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx vitest run tests/graphql.test.mjs` (193 passed)
- [x] `npm run test:coverage` (full suite green; `src/graphql.mjs` patch lines/branches added by this PR are 100% covered — the file's only uncovered branches are pre-existing, in the unrelated `health`/`opportunity_boards` resolvers)

Closes #5710
