### PR TITLE
fix(registry): add curated CORS-safe logo_url for 7 providers

### DIFF
--- a/registry/providers/babelbit.json
+++ b/registry/providers/babelbit.json
@@ -3,6 +3,7 @@
   "github_url": "https://github.com/babelbit/babelbit_subnet",
   "id": "babelbit",
   "kind": "subnet-team",
+  "logo_url": "https://babelbit.ai/icon.png",
   "name": "Babelbit",
   "public_notes": "Subnet 59 (Babelbit) team profile — harnessing the predictive power of language. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
   "schema_version": 1,

--- a/registry/providers/chutes.json
+++ b/registry/providers/chutes.json
@@ -6,6 +6,7 @@
   "website_url": "https://chutes.ai/",
   "docs_url": "https://chutes.ai/docs",
   "github_url": "https://github.com/chutesai/chutes",
+  "logo_url": "https://chutes.ai/favicon.png",
   "authority": "official",
   "notes": "Provider entry for Chutes SN64 website, docs, SDK, miner, validator/API source repositories, app catalog, and public pricing data."
 }

--- a/registry/providers/hone.json
+++ b/registry/providers/hone.json
@@ -5,6 +5,7 @@
   "kind": "subnet-team",
   "website_url": "https://www.hone.training/",
   "github_url": "https://github.com/manifold-inc/hone",
+  "logo_url": "https://www.hone.training/favicon.ico",
   "authority": "official",
   "public_notes": "Provider profile for Hone / SN5. Public surfaces include the Hone website, network pages, and source repository.",
   "notes": "No safe public subnet API, OpenAPI schema, SSE stream, or standalone data artifact has been verified yet."

--- a/registry/providers/inference-labs.json
+++ b/registry/providers/inference-labs.json
@@ -6,6 +6,7 @@
   "website_url": "https://subnet2.inferencelabs.com/",
   "docs_url": "https://sn2-docs.inferencelabs.com/",
   "github_url": "https://github.com/inference-labs-inc/subnet-2",
+  "logo_url": "https://subnet2.inferencelabs.com/logo.png",
   "authority": "official",
   "public_notes": "Provider profile for Inference Labs / DSperse SN2. Public surfaces include the DSperse website, GitBook docs, and source repository.",
   "notes": "Common API/OpenAPI probe paths currently serve the public SPA shell, so they are not promoted as machine-readable API/schema surfaces."

--- a/registry/providers/oxmarkets.json
+++ b/registry/providers/oxmarkets.json
@@ -3,6 +3,7 @@
   "github_url": "https://github.com/General-Tao-Ventures/cartha-validator",
   "id": "oxmarkets",
   "kind": "subnet-team",
+  "logo_url": "https://www.0xmarkets.io/favicon.ico",
   "name": "OxMarkets",
   "public_notes": "Subnet 35 (OxMarkets) team profile — liquidity-as-a-service powering 0xMarkets. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
   "schema_version": 1,

--- a/registry/providers/synth.json
+++ b/registry/providers/synth.json
@@ -3,6 +3,7 @@
   "github_url": "https://github.com/mode-network/synth-subnet",
   "id": "synth",
   "kind": "subnet-team",
+  "logo_url": "https://synthdata.co/favicon.png",
   "name": "Synth",
   "public_notes": "Subnet 50 (Synth) team profile — predictive intelligence for financial markets, operated by Mode Network. Public-safe identity from the subnet's on-chain SubnetIdentitiesV3 (name, website, source repo).",
   "schema_version": 1,

--- a/registry/providers/zipcode.json
+++ b/registry/providers/zipcode.json
@@ -3,6 +3,7 @@
   "github_url": "https://github.com/resi-labs-ai/RESI-models",
   "id": "zipcode",
   "kind": "subnet-team",
+  "logo_url": "https://zipcode.ai/favicons/android-chrome-512.png",
   "name": "Zipcode",
   "public_notes": "Subnet 46 (Zipcode) team profile — the real estate intelligence network. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
   "schema_version": 1,


### PR DESCRIPTION
## Summary

Follow-up to the Gittensor/Allways icon fix. Ran an automated audit against the live `/api/v1/providers` response for the same bug class (a raw on-chain-declared `logo_url` hosted somewhere with no CORS headers, failing wherever `BrandIcon` applies `crossOrigin="anonymous"`).

**Scale of the issue**: 37 of 88 providers with a `logo_url` had no `Access-Control-Allow-Origin` header at all, plus 7 more whose `logo_url` is fully dead (404/timeout/402). This is a systemic registry data-quality issue, not an edge case.

This PR is the **first verified batch of 7** — for each, found their own website's CORS-friendly hosted copy of their real logo, and visually confirmed each one is an actual legible brand mark before using it. This visual check mattered: automated candidate discovery also surfaced a "logo" for `tao-colosseum` that turned out to be GitHub's own Octocat mascot (a misconfigured `manifest.json` reference) — rejected, not shipped.

## Test plan

- [x] Ran the full `npm run build` pipeline and confirmed the real generated `providers.json` artifact carries each new `logo_url` correctly
- [x] `npm run validate:schemas` passes clean
- [x] Preferred stable URLs without deploy-specific cache-busting query params where a bare path works identically (verified CORS headers match)
- [x] Visually verified each candidate is a real, legible logo before including it

## Remaining scope (follow-up, not in this PR)

- 30 more providers where no website-hosted CORS-safe candidate was found automatically — need manual investigation
- 2 rejected candidates (`tao-colosseum`, `desearch`) still need a real replacement logo found
- 2 borderline candidates held back pending a quality call: `gradients` (candidate has a suspicious repeated watermark, may be a placeholder asset) and `almanac` (real logo but only 15×14px, likely too small to render usefully)
- 7 providers with fully broken `logo_url` (404/timeout/402) need a fresh source entirely