### PR TITLE
feat(registry): add SN31 Recall TaoMarketCap subnet-api surface

### DIFF
--- a/registry/subnets/recall.json
+++ b/registry/subnets/recall.json
@@ -34,5 +34,22 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-31-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Recall TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/31 on api.taomarketcap.com returning machine-readable JSON for SN31 Recall on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Recall has no verified first-party public subnet-state API; this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jaytbarimbao-collab"
+      },
+      "source_urls": ["https://api.taomarketcap.com/developer/documentation/"],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/31"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enriches **SN31 Recall** with a public, no-auth **subnet-api** surface — the machine-readable TaoMarketCap subnet-snapshot feed. Recall's registry entry currently has **no surfaces at all**, and its own `gap_notes` flag "No verified safe public subnet API endpoint yet" — this fills exactly that gap.

## Surface

- **kind:** `subnet-api` · **url:** `https://api.taomarketcap.com/public/v1/subnets/31` · **auth_required:** `false`
- `GET /public/v1/subnets/31` returns machine-readable JSON for SN31's on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — the same community indexed-feed pattern as the merged SN115/SN118/SN24/SN92/SN128 subnet-api surfaces.

## Verification

- `GET https://api.taomarketcap.com/public/v1/subnets/31` → `200`, real JSON (`{"id":"31","netuid":31,"is_active":...}`).
- Single additive surface; `prettier --check` clean.

Closes #4032
