### PR TITLE
feat(registry): add SN76 Byzantium TaoMarketCap subnet-api surface

### DIFF
--- a/registry/subnets/byzantium.json
+++ b/registry/subnets/byzantium.json
@@ -103,6 +103,22 @@
         "https://raw.githubusercontent.com/byzantiumaitao-arch/byzantium/main/link-service/app/api/validator/weights/route.ts"
       ],
       "url": "https://link.byzantiumai.net/api/validator/weights"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-76-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Byzantium TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/76 on api.taomarketcap.com returning machine-readable JSON for SN76 Byzantium on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — the indexed subnet-state snapshot feed, complementary to the subnet's first-party validator-weights endpoint. Documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jaytbarimbao-collab"
+      },
+      "source_urls": ["https://api.taomarketcap.com/developer/documentation/"],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/76"
     }
   ],
   "website_url": "https://www.byzantiumai.net/"


### PR DESCRIPTION
## Summary

Enriches **SN76 Byzantium** with the public, no-auth TaoMarketCap **subnet-api** — the machine-readable subnet-state snapshot feed. This complements the subnet's existing first-party validator-*weights* API (which serves per-miner weights only); the TaoMarketCap feed serves on-chain subnet **state/economics/market** data the weights endpoint doesn't. Same dual-subnet-api arrangement already merged for SN107 Minos.

## Surface

- **kind:** `subnet-api` · **url:** `https://api.taomarketcap.com/public/v1/subnets/76` · **auth_required:** `false`
- `GET /public/v1/subnets/76` → machine-readable JSON for SN76's on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — same community indexed-feed pattern as the merged SN115/118/24/92/128 subnet-api surfaces.

## Verification

- `GET https://api.taomarketcap.com/public/v1/subnets/76` → `200`, real JSON (`{"id":"76","netuid":76,...}`).
- Single additive surface; `prettier --check` clean.

Closes #4091
