### PR TITLE
fix(registry): add curated CORS-safe logo_url for 12 more providers (batch 2)

### DIFF
--- a/registry/providers/ditto-assistant.json
+++ b/registry/providers/ditto-assistant.json
@@ -4,6 +4,7 @@
   "github_url": "https://github.com/orgs/ditto-assistant/repositories",
   "id": "ditto-assistant",
   "kind": "subnet-team",
+  "logo_url": "https://github.com/ditto-assistant.png",
   "name": "Ditto",
   "notes": "Provider entry for Ditto SN118. Public surfaces include the Ditto website, docs, assistant app, and GitHub organization repository listing; no specific live source repository has been confirmed yet.",
   "schema_version": 1,

--- a/registry/providers/harnyx.json
+++ b/registry/providers/harnyx.json
@@ -3,6 +3,7 @@
   "github_url": "https://github.com/harnyx/harnyx",
   "id": "harnyx",
   "kind": "subnet-team",
+  "logo_url": "https://github.com/harnyx.png",
   "name": "Harnyx",
   "public_notes": "Subnet 67 (Harnyx) team profile — deep research as a commodity, produced by a competitive swarm of miners on Bittensor SN67. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle verified on the official site (harnyx.ai) and taostats. Review input only (authority: community).",
   "schema_version": 1,

--- a/registry/providers/its-ai.json
+++ b/registry/providers/its-ai.json
@@ -5,6 +5,7 @@
   "kind": "subnet-team",
   "website_url": "https://its-ai.org/en",
   "github_url": "https://github.com/It-s-AI/llm-detection",
+  "logo_url": "https://github.com/It-s-AI.png",
   "authority": "official",
   "notes": "Provider entry for ItsAI SN32 website and source repository."
 }

--- a/registry/providers/leadpoet.json
+++ b/registry/providers/leadpoet.json
@@ -3,6 +3,7 @@
   "github_url": "https://github.com/leadpoet/leadpoet",
   "id": "leadpoet",
   "kind": "subnet-team",
+  "logo_url": "https://github.com/leadpoet.png",
   "name": "Leadpoet",
   "public_notes": "Subnet 71 (Leadpoet) team profile — intent-driven AI for modern sales teams. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo). Review input only (authority: community).",
   "schema_version": 1,

--- a/registry/providers/minos.json
+++ b/registry/providers/minos.json
@@ -3,6 +3,7 @@
   "github_url": "https://github.com/minos-protocol/minos_subnet",
   "id": "minos",
   "kind": "subnet-team",
+  "logo_url": "https://github.com/minos-protocol.png",
   "name": "Minos",
   "public_notes": "Subnet 107 (Minos) team profile — the foundational layer of genomics. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
   "schema_version": 1,

--- a/registry/providers/minotaur.json
+++ b/registry/providers/minotaur.json
@@ -3,6 +3,7 @@
   "github_url": "https://github.com/subnet112/minotaur_subnet",
   "id": "minotaur",
   "kind": "subnet-team",
+  "logo_url": "https://github.com/subnet112.png",
   "name": "minotaur",
   "public_notes": "Subnet 112 (minotaur) team profile — distributed DEX aggregator and swap-intent network. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
   "schema_version": 1,

--- a/registry/providers/mobiusfund.json
+++ b/registry/providers/mobiusfund.json
@@ -5,6 +5,7 @@
   "kind": "subnet-team",
   "website_url": "https://investing88.ai/",
   "github_url": "https://github.com/mobiusfund/investing",
+  "logo_url": "https://github.com/mobiusfund.png",
   "authority": "official",
   "notes": "Provider entry for Mobius Fund Investing SN88 public dashboard, data surface, and source repository."
 }

--- a/registry/providers/numinous.json
+++ b/registry/providers/numinous.json
@@ -6,6 +6,7 @@
   "website_url": "https://numinouslabs.io/",
   "docs_url": "https://api.numinouslabs.io/api/docs",
   "github_url": "https://github.com/numinouslabs/numinous",
+  "logo_url": "https://github.com/numinouslabs.png",
   "authority": "official",
   "public_notes": "Provider profile for Numinous / SN6. Public surfaces include the Numinous website, source repository, Swagger UI, OpenAPI schema, and read-only health/API data surfaces.",
   "notes": "The public API exposes a machine-readable OpenAPI 3.1 schema and a safe read-only health endpoint."

--- a/registry/providers/oneoneone.json
+++ b/registry/providers/oneoneone.json
@@ -5,6 +5,7 @@
   "kind": "subnet-team",
   "website_url": "https://oneoneone.io/",
   "github_url": "https://github.com/oneoneone-io/subnet-111",
+  "logo_url": "https://github.com/oneoneone-io.png",
   "authority": "official",
   "notes": "Provider entry for oneoneone SN111 official website and source repository."
 }

--- a/registry/providers/score.json
+++ b/registry/providers/score.json
@@ -3,6 +3,7 @@
   "github_url": "https://github.com/score-technologies/turbovision",
   "id": "score",
   "kind": "subnet-team",
+  "logo_url": "https://github.com/score-technologies.png",
   "name": "Score",
   "public_notes": "Subnet 44 (Score) team profile — making every camera intelligent. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
   "schema_version": 1,

--- a/registry/providers/soma.json
+++ b/registry/providers/soma.json
@@ -3,6 +3,7 @@
   "github_url": "https://github.com/DendriteHQ/SOMA",
   "id": "soma",
   "kind": "subnet-team",
+  "logo_url": "https://github.com/DendriteHQ.png",
   "name": "SOMA",
   "notes": "Provider entry for SOMA SN114. Public surfaces include the SOMA website, dashboard, MCP/access pages, and source repository; common API/OpenAPI probe paths currently return 404 or fail and are not promoted.",
   "schema_version": 1,

--- a/registry/providers/taos-im.json
+++ b/registry/providers/taos-im.json
@@ -6,6 +6,7 @@
   "website_url": "https://taos.im/",
   "docs_url": "https://simulate.trading/taos-im-paper",
   "github_url": "https://github.com/taos-im/sn-79",
+  "logo_url": "https://github.com/taos-im.png",
   "authority": "official",
   "notes": "Provider entry for MVTRX SN79 website, source repository, and public paper link."
 }


### PR DESCRIPTION
## Summary

Continuing the systematic provider-logo audit from #5758. All 12 fixes here use the provider's own GitHub org avatar as the CORS-safe `logo_url`.

Name-matching the GitHub org to the provider alone isn't sufficient — every candidate was visually verified before shipping. This pass rejected 5 more:

- **compelle, talkhead**: real orgs with real repos, but neither ever set a custom avatar — their `.png` is just GitHub's auto-generated identicon pattern (same failure mode as the `eden-network` bug from the Gittensor fix, just self-inflicted rather than mismatched)
- **unarbos**: avatar is a stock photo of a tree-lined road, not a logo
- **talisman-ai**: `github_url` points at org `Team-Rizzo` (an unrelated personal dev org name); its avatar is a plain "R" with no relation to "Talisman"
- **liquidity**: avatar is a meme image, not a logo

**hippius** was investigated but not fixed: org `thenervelab`'s avatar says "Nerve Labs" and turned out to be a different brand — checked `hippius.com` directly and found their real logo (a hippo mark, matching the name), but that asset has no CORS headers either, so it's left for follow-up rather than shipping a still-broken image.

**cacheon** was left untouched: already has a curated `brand-overrides.ts` entry (`github.com/latent-to`) from prior work — treated as an existing decision, not re-litigated here.

## Test plan

- [x] Ran the full `npm run build` pipeline and confirmed the real generated `providers.json` artifact carries each new `logo_url` correctly
- [x] `npm run validate:schemas` passes clean
- [x] Every candidate visually verified as a real, legible logo before inclusion (not just CORS-reachable)