### PR TITLE
feat(api): add ?format=csv to GET /api/v1/validators/{hotkey}/nominators (#5745)

### DIFF
--- a/tests/validator-nominators-csv.test.mjs
+++ b/tests/validator-nominators-csv.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+// #5745: ?format=csv on GET /api/v1/validators/{hotkey}/nominators, mirroring
+// the accounts-list / global-validators CSV-export convention.
+const HOTKEY = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+const CSV_HEADER =
+  "coldkey,staked_tao,unstaked_tao,net_staked_tao,gross_staked_tao,event_count,last_observed_at";
+
+function req(path, init) {
+  return new Request(`https://api.metagraph.sh${path}`, init);
+}
+
+test("GET /validators/{hotkey}/nominators?format=csv emits a header-only CSV when there are no nominators (cold)", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/validators/${HOTKEY}/nominators?format=csv`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  assert.equal((await res.text()).trim(), CSV_HEADER);
+});
+
+test("GET /validators/{hotkey}/nominators?format=csv exports the ranked nominator rows via the Postgres tier", async () => {
+  const env = {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () =>
+        Response.json({
+          data: {
+            schema_version: 1,
+            hotkey: HOTKEY,
+            window: "30d",
+            sort: "net_staked",
+            limit: 20,
+            offset: 0,
+            nominator_count: 1,
+            nominators: [
+              {
+                coldkey: "5CoLdKeyExampleAddress000000000000000000000000",
+                staked_tao: 1200.5,
+                unstaked_tao: 200.25,
+                net_staked_tao: 1000.25,
+                gross_staked_tao: 1400.75,
+                event_count: 7,
+                last_observed_at: new Date(1750000000000).toISOString(),
+              },
+            ],
+          },
+          generatedAt: new Date(1750000000000).toISOString(),
+        }),
+    },
+  };
+  const res = await handleRequest(
+    req(`/api/v1/validators/${HOTKEY}/nominators?format=csv&window=30d`),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines[0], CSV_HEADER);
+  assert.equal(lines.length, 2);
+  assert.match(
+    lines[1],
+    /^5CoLdKeyExampleAddress[0]+,1200\.5,200\.25,1000\.25,1400\.75,7,/,
+  );
+});
+
+test("GET /validators/{hotkey}/nominators rejects an invalid ?format with 400", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/validators/${HOTKEY}/nominators?format=xml`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error.code, "invalid_query");
+});

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -335,6 +335,18 @@ const ACCOUNTS_LIST_CSV_COLUMNS = [
   "latest_block_number",
   "subnets",
 ];
+// Public per-nominator row shape from buildValidatorNominators (#5745); the
+// internal `last_observed_ms` sort key is dropped before the response, so it is
+// intentionally not a column here.
+const VALIDATOR_NOMINATOR_CSV_COLUMNS = [
+  "coldkey",
+  "staked_tao",
+  "unstaked_tao",
+  "net_staked_tao",
+  "gross_staked_tao",
+  "event_count",
+  "last_observed_at",
+];
 // CSV column order for the /api/v1/chain/turnover per-subnet churn leaderboard
 // rows (the `subnets` array). The network rollup + stability distribution stay
 // JSON-only, mirroring the chain-analytics leaderboard CSV exports.
@@ -907,6 +919,7 @@ export async function handleValidatorNominators(request, env, hotkey, url) {
     "limit",
     "offset",
     "coldkey",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const windowParam =
@@ -956,6 +969,19 @@ export async function handleValidatorNominators(request, env, hotkey, url) {
     }),
     generatedAt: null,
   };
+  // CSV export mirrors handleAccountsList / handleGlobalValidators: the rows are
+  // already sorted/paginated/coldkey-filtered by buildValidatorNominators, so
+  // the CSV path carries the identical set the JSON path would (#5745). A cold
+  // result yields an empty array → a header-only CSV.
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.nominators,
+      "validator-nominators",
+      "short",
+      request,
+      VALIDATOR_NOMINATOR_CSV_COLUMNS,
+    );
+  }
   return accountEnvelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary
`handleValidatorNominators` (`GET /api/v1/validators/{hotkey}/nominators`) is a paginated, sortable nominator leaderboard, but it had no `?format=csv` path — unlike its sibling leaderboards `handleAccountsList` and `handleGlobalValidators` in the same file, which already export CSV.

## Change (`workers/request-handlers/entities.mjs`)
Mirror the sibling pattern exactly:
- Add `"format"` to the route's `validateEntityQuery` allowlist (which also validates the value via `validateResponseFormat`, so an unsupported `?format=` returns the existing `invalid_query` 400).
- Add a `VALIDATOR_NOMINATOR_CSV_COLUMNS` constant for the public per-nominator row shape (`coldkey`, `staked_tao`, `unstaked_tao`, `net_staked_tao`, `gross_staked_tao`, `event_count`, `last_observed_at` — the internal `last_observed_ms` sort key is dropped before the response, so it is intentionally not a column).
- Early-return `csvResponse(data.nominators, "validator-nominators", "short", request, …)` when `csvRequested(url, request)`, before the JSON envelope.

`data.nominators` is already sorted / paginated / `coldkey`-filtered by `buildValidatorNominators`, so the CSV path carries the identical set the JSON path would — `sort`/`coldkey` behaviour is unchanged for both. A cold/empty result yields an empty array → a header-only CSV. CSV caching is handled by `csvResponse` (which keys off the `?format=csv` URL), the same as the sibling routes.

## Tests (`tests/validator-nominators-csv.test.mjs`)
- **header-only CSV when cold** (no nominators): 200, `text/csv`, body is exactly the header row.
- **ranked rows via the Postgres tier**: mocks `DATA_API` returning one nominator; asserts the header + a data row.
- **invalid `?format`** → 400 `invalid_query`.

## Verification
- New tests (3) pass; `validator-nominators` / `accounts-list` / `request-handlers-entities` / `account-routes` suites (429) — no regressions.
- `eslint` + `prettier --check` on both files — clean.

Closes #5745
