### PR TITLE
feat(api): add Query.account_prometheus mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -71,6 +71,11 @@ import {
   buildAccountsList,
 } from "./accounts-list.mjs";
 import { buildAccountSummary } from "./account-events.mjs";
+import {
+  DEFAULT_PROMETHEUS_WINDOW,
+  PROMETHEUS_WINDOWS,
+  buildAccountPrometheus,
+} from "./account-prometheus.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
 import { SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
 import {
@@ -169,6 +174,8 @@ export const SDL = `
     accounts(sort: String, limit: Int): AccountList!
     "One account's cross-subnet event-history summary by ss58 address; an address with no matching account_events rows resolves to a schema-stable zero summary, never null. Mirrors GET /api/v1/accounts/{ss58}."
     account(ss58: String!): AccountSummary
+    "One account's Prometheus telemetry-serving footprint across subnets over a 7d/30d/90d window (default 30d) -- which subnets it announces a Prometheus endpoint on, how often, first/last announcement times, and an HHI concentration of where that activity is focused. An address with no matching announcements resolves to a schema-stable zeroed footprint, never null. Mirrors GET /api/v1/accounts/{ss58}/prometheus."
+    account_prometheus(ss58: String!, window: String): AccountPrometheus!
     "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
     economics_trends(window: String): EconomicsTrends!
     "Cross-subnet momentum leaderboard: every subnet ranked by its stake/emission/validator change between a window's start and end snapshots; movers is empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/subnets/movers."
@@ -962,6 +969,27 @@ export const SDL = `
     count: Int!
   }
 
+  "One account's Prometheus telemetry-serving footprint (#5703) across subnets over a 7d/30d/90d window. Mirrors GET /api/v1/accounts/{ss58}/prometheus."
+  type AccountPrometheus {
+    schema_version: Int!
+    address: String!
+    window: String
+    total_announcements: Int!
+    subnet_count: Int!
+    "Herfindahl-Hirschman index of announcements across subnets: 1 = all on one subnet, -> 1/n as it spreads evenly; null when the account has no announcements."
+    concentration: Float
+    dominant_netuid: Int
+    subnets: [AccountPrometheusSubnet!]!
+  }
+
+  "One subnet's Prometheus-announcement activity in an account's footprint, ranked most-active-first."
+  type AccountPrometheusSubnet {
+    netuid: Int!
+    announcements: Int!
+    first_announced_at: String
+    last_announced_at: String
+  }
+
   # Realtime chain-event firehose (#4983, ADR 0015) -- a thin protocol adapter
   # over the SAME ChainFirehoseHub Durable Object connection #4982's SSE/WS
   # transports use, not a second event pipeline. Reached over WebSocket only
@@ -1115,6 +1143,7 @@ export const FIELD_COMPLEXITY = {
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_yield: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_prometheus: RELATIONSHIP_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -2195,6 +2224,49 @@ const rootValue = {
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) ?? buildAccountSummary(ss58, {});
     return accountSummaryNode(data, ss58);
+  },
+
+  async account_prometheus({ ss58, window }, context) {
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const requestedWindow = window ?? DEFAULT_PROMETHEUS_WINDOW;
+    if (!Object.hasOwn(PROMETHEUS_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(requestedWindow, PROMETHEUS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    // This account-footprint route's Postgres-tier body is { data, generatedAt }
+    // (unlike account's own flat body) -- same shape REST's makeAccountEventHandler
+    // destructures. No live D1 fallback exists for this route family (the account
+    // event footprints' D1 write path is retired); a cold/absent tier degrades to
+    // the pure builder over an empty row set, same as REST's own fallback.
+    const pg = await tryPostgresTier(
+      context.env,
+      postgresTierRequest(
+        context,
+        `/api/v1/accounts/${encodeURIComponent(ss58)}/prometheus`,
+        params,
+      ),
+      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+    );
+    const data =
+      pg?.data ?? buildAccountPrometheus([], ss58, { window: requestedWindow });
+    return {
+      schema_version: data.schema_version ?? 1,
+      address: data.address ?? ss58,
+      window: data.window ?? requestedWindow,
+      total_announcements: data.total_announcements ?? 0,
+      subnet_count: data.subnet_count ?? 0,
+      concentration: data.concentration ?? null,
+      dominant_netuid: data.dominant_netuid ?? null,
+      subnets: data.subnets || [],
+    };
   },
 
   async economics_trends({ window }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -2853,6 +2853,176 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
   });
 });
 
+describe("graphql — account_prometheus (#5703, Postgres-tier { data, generatedAt } + zeroed-card fallback)", () => {
+  const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  function query(argsClause) {
+    return `{ account_prometheus${argsClause} {
+      schema_version address window total_announcements subnet_count concentration dominant_netuid
+      subnets { netuid announcements first_announced_at last_announced_at }
+    } }`;
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed footprint, never null", async () => {
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`));
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_prometheus, {
+      schema_version: 1,
+      address: SS58,
+      window: "30d",
+      total_announcements: 0,
+      subnet_count: 0,
+      concentration: null,
+      dominant_netuid: null,
+      subnets: [],
+    });
+  });
+
+  test("resolves the Postgres-tier footprint for the requested window", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            data: {
+              schema_version: 1,
+              address: SS58,
+              window: "7d",
+              total_announcements: 5,
+              subnet_count: 2,
+              concentration: 0.68,
+              dominant_netuid: 3,
+              subnets: [
+                {
+                  netuid: 3,
+                  announcements: 4,
+                  first_announced_at: "2026-07-01T00:00:00.000Z",
+                  last_announced_at: "2026-07-10T00:00:00.000Z",
+                },
+                {
+                  netuid: 7,
+                  announcements: 1,
+                  first_announced_at: "2026-07-05T00:00:00.000Z",
+                  last_announced_at: "2026-07-05T00:00:00.000Z",
+                },
+              ],
+            },
+            generatedAt: "2026-07-10T00:00:00.000Z",
+          }),
+      },
+    };
+    const { status, body } = await gql(
+      query(`(ss58: "${SS58}", window: "7d")`),
+      env,
+    );
+    assert.equal(status, 200);
+    const p = body.data.account_prometheus;
+    assert.equal(p.window, "7d");
+    assert.equal(p.total_announcements, 5);
+    assert.equal(p.subnet_count, 2);
+    assert.equal(p.concentration, 0.68);
+    assert.equal(p.dominant_netuid, 3);
+    assert.equal(p.subnets[0].netuid, 3);
+    assert.equal(p.subnets[0].announcements, 4);
+    assert.equal(p.subnets[1].netuid, 7);
+  });
+
+  test("window is forwarded as a query param to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            data: { schema_version: 1, address: SS58, subnets: [] },
+            generatedAt: null,
+          });
+        },
+      },
+    };
+    await gql(query(`(ss58: "${SS58}", window: "90d")`), env);
+    assert.equal(capturedUrl.pathname, `/api/v1/accounts/${SS58}/prometheus`);
+    assert.equal(capturedUrl.searchParams.get("window"), "90d");
+  });
+
+  test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed footprint", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_prometheus, {
+      schema_version: 1,
+      address: SS58,
+      window: "30d",
+      total_announcements: 0,
+      subnet_count: 0,
+      concentration: null,
+      dominant_netuid: null,
+      subnets: [],
+    });
+  });
+
+  test("a partial data envelope degrades missing fields to their defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => Response.json({ data: {}, generatedAt: null }),
+      },
+    };
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_prometheus, {
+      schema_version: 1,
+      address: SS58,
+      window: "30d",
+      total_announcements: 0,
+      subnet_count: 0,
+      concentration: null,
+      dominant_netuid: null,
+      subnets: [],
+    });
+  });
+
+  test("an invalid ss58 is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      query('(ss58: "not-a-valid-address")'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { status, body } = await gql(
+      query(`(ss58: "${SS58}", window: "99d")`),
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|30d/i.test(body.errors[0].message));
+    assert.equal(body.data, null);
+  });
+
+  test("account_prometheus is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.account_prometheus, 5);
+  });
+});
+
 // --- Subscription.chainEvents (#4983, ADR 0015) ---------------------------------
 //
 // The DO-runtime side of this wiring (ChainFirehoseHub.subscribeChainEvents,


### PR DESCRIPTION
## Summary
- Adds `Query.account_prometheus(ss58: String!, window: String): AccountPrometheus!` to the GraphQL SDL, mirroring `GET /api/v1/accounts/{ss58}/prometheus` and the `get_account_prometheus` MCP tool.
- Resolver follows the `tryPostgresTier` -> zeroed-card fallback contract this account-event-footprint route family uses (via `buildAccountPrometheus` from `src/account-prometheus.mjs`), degrading to a schema-stable empty footprint (never null, never a GraphQL error) for an address with no matching announcements.
- Added `account_prometheus` to `FIELD_COMPLEXITY`.

## Validation
- `npm run lint` / `npm run format:check`
- `npm run validate`, `validate:contract-drift`, `validate:schemas`, `validate:api`, `validate:openapi`, `validate:mcp`, `validate:types`
- `npm run test:coverage` — full suite green; `src/graphql.mjs` new code covered at 100% (only pre-existing, unrelated lines uncovered)

Closes #5703