### PR TITLE
feat(api): add CSV export to account counterparties list mode

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -96,7 +96,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present. */
+        /** Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present. Pass ?format=csv to download the list-mode leaderboard as CSV; it's rejected alongside ?counterparty since the drilldown returns a single composite object, not rows. */
         get: operations["accountCounterparties"];
         put?: never;
         post?: never;
@@ -8661,6 +8661,8 @@ export interface operations {
             query?: {
                 counterparty?: string;
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -8670,7 +8672,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8757,6 +8759,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountCounterpartiesArtifact"];
                     };
+                    /**
+                     * @example address,sent_tao,received_tao,net_tao,transfer_count,last_block
+                     *     5G_sample,12.5,4.25,-8.25,3,6702485
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -6277,7 +6277,7 @@
     {
       "artifact_path": "/metagraph/accounts/{ss58}/counterparties.json",
       "cache": "short",
-      "description": "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present.",
+      "description": "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present. Pass ?format=csv to download the list-mode leaderboard as CSV; it's rejected alongside ?counterparty since the drilldown returns a single composite object, not rows.",
       "id": "account-counterparties",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/counterparties",
@@ -6300,6 +6300,17 @@
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -840,7 +840,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Per-counterparty fund-flow rollup for one account, with optional ?counterparty=<ss58> relationship evidence — native-TAO transfers from the account_events D1 tier at /api/v1/accounts/{ss58}/counterparties (no static file).",
+      "description": "Per-counterparty fund-flow rollup for one account, with optional ?counterparty=<ss58> relationship evidence — native-TAO transfers from the account_events D1 tier at /api/v1/accounts/{ss58}/counterparties; pass ?format=csv to download the list-mode rollup as CSV (no static file).",
       "id": "account-counterparties",
       "path": "/metagraph/accounts/{ss58}/counterparties.json",
       "schema_ref": "#/components/schemas/AccountCounterpartiesArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -22875,6 +22875,19 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -22969,9 +22982,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "address,sent_tao,received_tao,net_tao,transfer_count,last_block\r\n5G_sample,12.5,4.25,-8.25,3,6702485",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -23028,7 +23047,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present.",
+        "summary": "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present. Pass ?format=csv to download the list-mode leaderboard as CSV; it's rejected alongside ?counterparty since the drilldown returns a single composite object, not rows.",
         "tags": [
           "accounts",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -96,7 +96,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present. */
+        /** Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present. Pass ?format=csv to download the list-mode leaderboard as CSV; it's rejected alongside ?counterparty since the drilldown returns a single composite object, not rows. */
         get: operations["accountCounterparties"];
         put?: never;
         post?: never;
@@ -8661,6 +8661,8 @@ export interface operations {
             query?: {
                 counterparty?: string;
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -8670,7 +8672,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -8757,6 +8759,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountCounterpartiesArtifact"];
                     };
+                    /**
+                     * @example address,sent_tao,received_tao,net_tao,transfer_count,last_block
+                     *     5G_sample,12.5,4.25,-8.25,3,6702485
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1190,7 +1190,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "account-counterparties",
     "/metagraph/accounts/{ss58}/counterparties.json",
-    "Per-counterparty fund-flow rollup for one account, with optional ?counterparty=<ss58> relationship evidence — native-TAO transfers from the account_events D1 tier at /api/v1/accounts/{ss58}/counterparties (no static file).",
+    "Per-counterparty fund-flow rollup for one account, with optional ?counterparty=<ss58> relationship evidence — native-TAO transfers from the account_events D1 tier at /api/v1/accounts/{ss58}/counterparties; pass ?format=csv to download the list-mode rollup as CSV (no static file).",
     "AccountCounterpartiesArtifact",
   ),
   artifact(
@@ -2767,10 +2767,10 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/counterparties",
     "/metagraph/accounts/{ss58}/counterparties.json",
-    "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present.",
+    "Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events D1 tier. ?counterparty switches the route from ranked list mode into relationship drilldown mode; ?limit is 1-100, default 20 in list mode, and default 50 when ?counterparty is present. Pass ?format=csv to download the list-mode leaderboard as CSV; it's rejected alongside ?counterparty since the drilldown returns a single composite object, not rows.",
     "short",
     ["accounts", "analytics"],
-    [
+    csvRouteQuery([
       {
         name: "counterparty",
         schema: {
@@ -2790,7 +2790,7 @@ export const API_ROUTES = [
             "Max counterparties to return in list mode (default 20), or max transfer evidence rows in relationship drilldown mode when ?counterparty is present (default 50).",
         },
       },
-    ],
+    ]),
     [{ name: "ss58", schema: { type: "string" } }],
   ),
   route(
@@ -4487,6 +4487,12 @@ function csvExampleForRoute(entry) {
     return [
       "block_number,event_index,from,to,amount_tao,direction,observed_at",
       "6702485,3,5F_sample,5G_sample,12.5,sent,2026-06-02T00:00:00.000Z",
+    ].join("\r\n");
+  }
+  if (entry.id === "account-counterparties") {
+    return [
+      "address,sent_tao,received_tao,net_tao,transfer_count,last_block",
+      "5G_sample,12.5,4.25,-8.25,3,6702485",
     ].join("\r\n");
   }
   return "netuid,name\r\n7,Allways";

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2996,6 +2996,108 @@ describe("handleAccountCounterparties", () => {
     assert.equal(body.data.counterparty_count, 0);
     assert.deepEqual(body.data.counterparties, []);
   });
+
+  test("rejects an unsupported format value with 400", async () => {
+    const res = await handleAccountCounterparties(
+      req(`/api/v1/accounts/${SS58}/counterparties?format=xml`),
+      emptyEnv(),
+      SS58,
+      url(`/api/v1/accounts/${SS58}/counterparties?format=xml`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("?format=csv exports the list-mode leaderboard as CSV", async () => {
+    const { env } = dbWith({ accountEvents: [accountEventRow()] });
+    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          counterparty_count: 1,
+          transfers_scanned: 1,
+          scan_capped: false,
+          total_sent_tao: 4.2,
+          total_received_tao: 0,
+          counterparties: [
+            {
+              address: COUNTERPARTY,
+              sent_tao: 4.2,
+              received_tao: 0,
+              net_tao: -4.2,
+              transfer_count: 1,
+              last_block: BLOCK_NUM,
+            },
+          ],
+        }),
+    };
+    const res = await handleAccountCounterparties(
+      req(`/api/v1/accounts/${SS58}/counterparties?format=csv`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/counterparties?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      await res.text(),
+      [
+        "address,sent_tao,received_tao,net_tao,transfer_count,last_block",
+        `${COUNTERPARTY},4.2,0,'-4.2,1,${BLOCK_NUM}`,
+      ].join("\r\n"),
+    );
+  });
+
+  test("empty CSV export still emits the header row", async () => {
+    const res = await handleAccountCounterparties(
+      req(`/api/v1/accounts/${SS58}/counterparties?format=csv`),
+      emptyEnv(),
+      SS58,
+      url(`/api/v1/accounts/${SS58}/counterparties?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      await res.text(),
+      "address,sent_tao,received_tao,net_tao,transfer_count,last_block",
+    );
+  });
+
+  test("?format=csv combined with counterparty is rejected, not silently ignored", async () => {
+    const res = await handleAccountCounterparties(
+      req(
+        `/api/v1/accounts/${SS58}/counterparties?format=csv&counterparty=${COUNTERPARTY}`,
+      ),
+      emptyEnv(),
+      SS58,
+      url(
+        `/api/v1/accounts/${SS58}/counterparties?format=csv&counterparty=${COUNTERPARTY}`,
+      ),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("Accept: text/csv combined with counterparty is rejected the same as ?format=csv", async () => {
+    const res = await handleAccountCounterparties(
+      new Request(
+        `https://api.metagraph.sh/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}`,
+        { headers: { accept: "text/csv" } },
+      ),
+      emptyEnv(),
+      SS58,
+      url(
+        `/api/v1/accounts/${SS58}/counterparties?counterparty=${COUNTERPARTY}`,
+      ),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "format");
+  });
 });
 
 describe("handleAccountCounterparties relationship drilldown", () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -413,6 +413,17 @@ const ACCOUNT_TRANSFERS_CSV_COLUMNS = [
   "direction",
   "observed_at",
 ];
+// The buildCounterparties row shape (list mode only -- the relationship
+// drilldown's single-object shape doesn't map onto CSV rows, see
+// handleAccountCounterparties).
+const ACCOUNT_COUNTERPARTIES_CSV_COLUMNS = [
+  "address",
+  "sent_tao",
+  "received_tao",
+  "net_tao",
+  "transfer_count",
+  "last_block",
+];
 // Shared column order for the subnet + account event-stream feeds — the
 // formatAccountEvent row shape, stable so a CSV consumer's columns never shift.
 const EVENTS_CSV_COLUMNS = [
@@ -3018,9 +3029,15 @@ export async function handleAccountTransfers(request, env, ss58, url) {
 
 // GET /api/v1/accounts/{ss58}/counterparties?limit=N: who this account transacts
 // with. Add ?counterparty=<ss58> to return a focused relationship drilldown on
-// the same route without expanding the public path surface.
+// the same route without expanding the public path surface. ?format=csv exports
+// the list-mode leaderboard (mirrors handleAccountsList); it's rejected alongside
+// ?counterparty since the drilldown's single composite object has no CSV rows.
 export async function handleAccountCounterparties(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, ["counterparty", "limit"]);
+  const validationError = validateEntityQuery(url, [
+    "counterparty",
+    "limit",
+    "format",
+  ]);
   if (validationError) return analyticsQueryError(validationError);
   const counterparty = url.searchParams.get("counterparty");
   const parsedLimit = parseBoundedIntParam(url, "limit", {
@@ -3031,6 +3048,15 @@ export async function handleAccountCounterparties(request, env, ss58, url) {
   if (parsedLimit.error) return analyticsQueryError(parsedLimit.error);
   const limit = parsedLimit.value;
   if (counterparty != null) {
+    // CSV export only covers the list-mode leaderboard below -- the
+    // relationship drilldown returns a single composite object, not rows.
+    if (csvRequested(url, request)) {
+      return analyticsQueryError({
+        parameter: "format",
+        message:
+          "format=csv is not supported with counterparty; remove counterparty to export the list-mode counterparties CSV.",
+      });
+    }
     if (!SS58_ADDRESS_PATTERN.test(counterparty)) {
       return analyticsQueryError({
         parameter: "counterparty",
@@ -3085,6 +3111,15 @@ export async function handleAccountCounterparties(request, env, ss58, url) {
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
     buildCounterparties([], ss58, { limit });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.counterparties,
+      "account-counterparties",
+      "short",
+      request,
+      ACCOUNT_COUNTERPARTIES_CSV_COLUMNS,
+    );
+  }
   return accountEnvelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

`GET /api/v1/accounts/{ss58}/counterparties` now supports `?format=csv`, scoped to
list mode only (no `?counterparty=`), mirroring `handleAccountsList`'s CSV pattern:

- List mode (`buildCounterparties` rows): `?format=csv` returns the ranked
  counterparties leaderboard as `text/csv`, with a new `ACCOUNT_COUNTERPARTIES_CSV_COLUMNS`
  constant (`address,sent_tao,received_tao,net_tao,transfer_count,last_block`).
- A cold/empty account still emits the CSV header row with no data rows (via
  `csvResponse`'s explicit-columns path, same as every other CSV-enabled route).
- `?format=csv&counterparty=<ss58>` (or `Accept: text/csv` combined with
  `?counterparty=`) is rejected with the existing `analyticsQueryError` shape —
  the relationship drilldown returns one composite object, not rows, so it can't
  be forced into CSV.
- An unsupported `?format` value (e.g. `xml`) still hits the existing
  `format must be one of: json, csv.` validation error, now reused here via
  `validateEntityQuery` (previously this route used the narrower `validateQueryParams`
  and didn't validate `format`'s value at all).
- `src/contracts.mjs`: the `account-counterparties` route now declares its query
  params via `csvRouteQuery(...)` (matching `account-transfers`) and gets a
  proper CSV example row instead of falling through to the generic placeholder.
  Regenerated `openapi.json` / `types.d.ts` / `packages/contract/index.d.ts` /
  `api-index.json` / `contracts.json` via `npm run build` and committed them;
  `public/metagraph/r2-manifest.json` / `schemas/index.json` were reverted
  against `upstream/main` as usual (deploy-owned, not part of this contract).

On caching: this route is dispatched directly in `workers/api.mjs` (never wired
through `withEdgeCache`/a `canonical*CachePath` helper), same as its real CSV-enabled
sibling `handleAccountTransfers` — per-account routes are live/volatile and aren't
edge-cached at all (see the neighboring "served direct, no edge cache" comment for
the account-events/subnet-events family). There's no cache-key path to thread
`format=csv` into here; the response ETag is already derived from the actual body
(`weakEtag`), so CSV and JSON responses to the same query naturally get distinct
validators without any extra work.

## Test plan

- `npm run lint && npm run format:check`
- `npm run validate`
- `npm test` (full suite, 283 files / 8562 tests, all passing)
- `npm run test:coverage` (unsharded; `entities.mjs` 99.33%/98.39% stmt/branch,
  `contracts.mjs` 100%/97.29%, no new diff lines left uncovered)
- `npm run validate:contract-drift && npm run validate:schemas && npm run validate:api && npm run validate:openapi`
- New tests in `tests/request-handlers-entities.test.mjs`: successful list-mode CSV
  export, empty-list CSV header-only export, `?format=csv&counterparty=` rejected,
  `Accept: text/csv` + `?counterparty=` rejected the same way, and an unsupported
  `?format` value still 400s.

Closes #5747
