### PR TITLE
feat(api): add ?format=csv to GET /api/v1/accounts/{ss58}/history (#5741)

### DIFF
--- a/tests/account-history-csv.test.mjs
+++ b/tests/account-history-csv.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+// #5741: ?format=csv on GET /api/v1/accounts/{ss58}/history, mirroring the
+// CSV-export convention of the sibling account-events/extrinsics/transfers feeds.
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+const CSV_HEADER = "day,netuid,event_count,event_kinds,first_block,last_block";
+
+function req(path, init) {
+  return new Request(`https://api.metagraph.sh${path}`, init);
+}
+
+test("GET /accounts/{ss58}/history?format=csv emits a header-only CSV when cold", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/history?format=csv`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  assert.equal((await res.text()).trim(), CSV_HEADER);
+});
+
+test("GET /accounts/{ss58}/history?format=csv exports the per-day rows via the Postgres tier", async () => {
+  const env = {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () =>
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          day_count: 1,
+          limit: 1000,
+          offset: 0,
+          next_cursor: null,
+          days: [
+            {
+              day: "2026-06-25",
+              netuid: 1,
+              event_count: 5,
+              event_kinds: ["StakeAdded", "Transfer"],
+              first_block: 8454300,
+              last_block: 8454388,
+            },
+          ],
+        }),
+    },
+  };
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/history?format=csv`),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines[0], CSV_HEADER);
+  assert.equal(lines.length, 2);
+  assert.match(lines[1], /^2026-06-25,1,5,/);
+  assert.match(lines[1], /8454388$/);
+});
+
+test("GET /accounts/{ss58}/history rejects an invalid ?format with 400", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/accounts/${SS58}/history?format=xml`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error.code, "invalid_query");
+});

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -404,6 +404,17 @@ const ACCOUNT_EXTRINSICS_CSV_COLUMNS = [
   "tip_tao",
   "observed_at",
 ];
+// formatAccountDay row shape (#5741); event_kinds is a string[] that
+// csvResponse serializes as a single cell, like the nested `subnets` column on
+// the leaderboard exports.
+const ACCOUNT_HISTORY_CSV_COLUMNS = [
+  "day",
+  "netuid",
+  "event_count",
+  "event_kinds",
+  "first_block",
+  "last_block",
+];
 const ACCOUNT_TRANSFERS_CSV_COLUMNS = [
   "block_number",
   "event_index",
@@ -2759,13 +2770,14 @@ const ACCOUNT_DAY_COLUMNS =
   "day, netuid, event_count, event_kinds, first_block, last_block";
 
 export async function handleAccountHistory(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "netuid",
     "from",
     "to",
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const range = parseDateRange(url);
@@ -2791,6 +2803,17 @@ export async function handleAccountHistory(request, env, ss58, url) {
       offset,
       nextCursor: null,
     });
+    // Honour ?format=csv on the short-circuit too, so an inverted range yields
+    // a header-only CSV rather than a JSON body for a CSV request (#5741).
+    if (csvRequested(url, request)) {
+      return csvResponse(
+        data.days,
+        "account-history",
+        "short",
+        request,
+        ACCOUNT_HISTORY_CSV_COLUMNS,
+      );
+    }
     // Use the account envelope so this short-circuit exposes the
     // x-metagraph-artifact-source header too — the normal path below does (#2618),
     // and the payload stamps the same meta.source, so a browser must not lose the
@@ -2860,6 +2883,18 @@ export async function handleAccountHistory(request, env, ss58, url) {
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_ACCOUNT_EVENTS_SOURCE")) ??
     (await fromD1());
+  // CSV export mirrors handleAccountEvents/Extrinsics/Transfers: the rows are
+  // already range/netuid-filtered and paginated, so the CSV path carries the
+  // identical set the JSON path would (#5741). Cold → empty array → header-only.
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.days,
+      "account-history",
+      "short",
+      request,
+      ACCOUNT_HISTORY_CSV_COLUMNS,
+    );
+  }
   return accountEnvelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary
`handleAccountHistory` (`GET /api/v1/accounts/{ss58}/history`) is a paginated per-day activity feed, but had no `?format=csv` path — unlike its three sibling account feeds in the same file (`handleAccountEvents`, `handleAccountExtrinsics`, `handleAccountTransfers`), which all export CSV.

## Change (`workers/request-handlers/entities.mjs`)
Mirror the sibling pattern:
- Switch the route's `validateQueryParams(...)` to `validateEntityQuery(..., "format")` — same as the siblings — so `?format=csv` is allowed and an unsupported `?format=` value returns the existing `invalid_query` 400.
- Add an `ACCOUNT_HISTORY_CSV_COLUMNS` constant matching the real `formatAccountDay` row shape (read directly from `src/account-events.mjs`): `day`, `netuid`, `event_count`, `event_kinds`, `first_block`, `last_block`. `event_kinds` is a `string[]`, serialized as a single cell exactly like the nested `subnets` column on the leaderboard CSV exports.
- Early-return `csvResponse(data.days, "account-history", "short", request, …)` when `csvRequested(url, request)` — on **both** return paths: the normal query and the inverted-date-range short-circuit (so a CSV request with `from > to` gets a header-only CSV, not a JSON body).

`data.days` is already range/netuid-filtered and paginated, so the CSV path carries the identical set the JSON path would; filtering/pagination behaviour is unchanged. A cold/empty result yields an empty array → a header-only CSV. CSV caching is handled by `csvResponse` (keyed off the `?format=csv` URL), same as the siblings.

## Tests (`tests/account-history-csv.test.mjs`)
- **header-only CSV when cold**: 200, `text/csv`, body is exactly the header row.
- **per-day rows via the Postgres tier**: mocks `DATA_API` returning one day; asserts the header + a data row.
- **invalid `?format`** → 400 `invalid_query`.

## Verification
- New tests (3) pass; `account-routes` / `request-handlers-entities` suites (372) — no regressions.
- `eslint` + `prettier --check` on both files — clean.

Closes #5741
