### PR TITLE
feat(graphql): add Query.account_registrations mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -76,6 +76,11 @@ import {
   PROMETHEUS_WINDOWS,
   buildAccountPrometheus,
 } from "./account-prometheus.mjs";
+import {
+  buildAccountRegistrations,
+  REGISTRATION_WINDOWS,
+  DEFAULT_REGISTRATION_WINDOW,
+} from "./account-registrations.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
 import { SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
 import {
@@ -176,6 +181,8 @@ export const SDL = `
     account(ss58: String!): AccountSummary
     "One account's Prometheus telemetry-serving footprint across subnets over a 7d/30d/90d window (default 30d) -- which subnets it announces a Prometheus endpoint on, how often, first/last announcement times, and an HHI concentration of where that activity is focused. An address with no matching announcements resolves to a schema-stable zeroed footprint, never null. Mirrors GET /api/v1/accounts/{ss58}/prometheus."
     account_prometheus(ss58: String!, window: String): AccountPrometheus!
+    "One account's per-subnet registration footprint over a 7d/30d/90d window (default 30d): NeuronRegistered count and first/last timestamps per subnet, an HHI concentration of where its registration activity is focused, and the dominant subnet; an address with no registrations in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/registrations."
+    account_registrations(ss58: String!, window: String): AccountRegistrations!
     "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
     economics_trends(window: String): EconomicsTrends!
     "Cross-subnet momentum leaderboard: every subnet ranked by its stake/emission/validator change between a window's start and end snapshots; movers is empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/subnets/movers."
@@ -941,6 +948,25 @@ export const SDL = `
     active: Boolean!
   }
 
+  "One subnet's slice of an account's registration footprint over the window."
+  type AccountRegistrationSubnet {
+    netuid: Int!
+    registrations: Int!
+    first_registered_at: String
+    last_registered_at: String
+  }
+
+  type AccountRegistrations {
+    schema_version: Int!
+    address: String!
+    window: String
+    total_registrations: Int!
+    subnet_count: Int!
+    concentration: Float
+    dominant_netuid: Int
+    subnets: [AccountRegistrationSubnet!]!
+  }
+
   type AccountEvent {
     block_number: Int
     event_index: Int
@@ -1129,6 +1155,7 @@ export const FIELD_COMPLEXITY = {
   validator_history: RELATIONSHIP_FIELD_COMPLEXITY,
   accounts: RELATIONSHIP_FIELD_COMPLEXITY,
   account: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2266,6 +2293,57 @@ const rootValue = {
       concentration: data.concentration ?? null,
       dominant_netuid: data.dominant_netuid ?? null,
       subnets: data.subnets || [],
+    };
+  },
+
+  async account_registrations({ ss58, window }, context) {
+    // Same SS58 + window validation handleAccountRegistrations (via
+    // makeAccountEventHandler) uses -- a malformed address or unsupported
+    // window is a GraphQL BAD_USER_INPUT error, not a silent card.
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const windowParam = window ?? DEFAULT_REGISTRATION_WINDOW;
+    if (!Object.hasOwn(REGISTRATION_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, REGISTRATION_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> { data } envelope
+    // (with the buildAccountRegistrations([], ...) zeroed-card cold fallback) the
+    // REST handler uses; an account with no NeuronRegistered events in the window
+    // is a schema-stable zeroed card, never a GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const tier = await tryPostgresTier(
+      context.env,
+      postgresTierRequest(
+        context,
+        `/api/v1/accounts/${encodeURIComponent(ss58)}/registrations`,
+        params,
+      ),
+      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+    );
+    const data =
+      tier?.data ??
+      buildAccountRegistrations([], ss58, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      address: data.address ?? ss58,
+      window: data.window ?? windowParam,
+      total_registrations: data.total_registrations ?? 0,
+      subnet_count: data.subnet_count ?? 0,
+      concentration: data.concentration ?? null,
+      dominant_netuid: data.dominant_netuid ?? null,
+      subnets: (data.subnets ?? []).map((s) => ({
+        netuid: s.netuid,
+        registrations: s.registrations,
+        first_registered_at: s.first_registered_at ?? null,
+        last_registered_at: s.last_registered_at ?? null,
+      })),
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3708,6 +3708,135 @@ describe("graphql — subnet_axon_removals (#5718, Postgres-tier + zeroed-card f
   });
 });
 
+describe("graphql — account_registrations (#5704, Postgres-tier + zeroed-card fallback)", () => {
+  const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ account_registrations(ss58: "${SS58}") {
+          schema_version address window total_registrations subnet_count
+          concentration dominant_netuid subnets { netuid registrations }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_registrations, {
+      schema_version: 1,
+      address: SS58,
+      window: "30d",
+      total_registrations: 0,
+      subnet_count: 0,
+      concentration: null,
+      dominant_netuid: null,
+      subnets: [],
+    });
+  });
+
+  test("resolves the Postgres-tier { data } envelope, mapping the per-subnet footprint", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          data: {
+            schema_version: 1,
+            address: SS58,
+            window: "90d",
+            total_registrations: 7,
+            subnet_count: 2,
+            concentration: 0.63,
+            dominant_netuid: 1,
+            subnets: [
+              {
+                netuid: 1,
+                registrations: 5,
+                first_registered_at: "2026-04-01T00:00:00.000Z",
+                last_registered_at: "2026-06-01T00:00:00.000Z",
+              },
+              { netuid: 2, registrations: 2 },
+            ],
+          },
+          generatedAt: "2026-06-01T00:00:00.000Z",
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ account_registrations(ss58: "${SS58}", window: "90d") {
+          address window total_registrations subnet_count concentration dominant_netuid
+          subnets { netuid registrations first_registered_at last_registered_at }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const r = body.data.account_registrations;
+    assert.equal(r.window, "90d");
+    assert.equal(r.total_registrations, 7);
+    assert.equal(r.subnet_count, 2);
+    assert.equal(r.concentration, 0.63);
+    assert.equal(r.dominant_netuid, 1);
+    assert.deepEqual(r.subnets, [
+      {
+        netuid: 1,
+        registrations: 5,
+        first_registered_at: "2026-04-01T00:00:00.000Z",
+        last_registered_at: "2026-06-01T00:00:00.000Z",
+      },
+      {
+        netuid: 2,
+        registrations: 2,
+        first_registered_at: null,
+        last_registered_at: null,
+      },
+    ]);
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({ data: {} })),
+    };
+    const { status, body } = await gql(
+      `{ account_registrations(ss58: "${SS58}", window: "7d") {
+          schema_version address window total_registrations subnet_count
+          concentration dominant_netuid subnets { netuid }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_registrations, {
+      schema_version: 1,
+      address: SS58,
+      window: "7d",
+      total_registrations: 0,
+      subnet_count: 0,
+      concentration: null,
+      dominant_netuid: null,
+      subnets: [],
+    });
+  });
+
+  test("a malformed ss58 address is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ account_registrations(ss58: "not-an-address") { total_registrations } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/ss58/i.test(body.errors[0].message));
+    assert.equal(body.data?.account_registrations ?? null, null);
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      `{ account_registrations(ss58: "${SS58}", window: "99d") { total_registrations } }`,
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|30d/i.test(body.errors[0].message));
+    assert.equal(body.data?.account_registrations ?? null, null);
+  });
+});
+
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
Adds an \`account_registrations(ss58, window)\` GraphQL query mirroring \`GET /api/v1/accounts/{ss58}/registrations\` and the \`get_account_registrations\` MCP tool: one account's per-subnet NeuronRegistered footprint over a 7d/30d/90d window (default 30d).

Rebased fresh on \`main\` (the prior #5762 was auto-closed on a base-branch conflict after concurrent GraphQL merges landed — no code changes, review was clean).

## What
- New \`AccountRegistrations\` + \`AccountRegistrationSubnet\` types and \`Query.account_registrations(ss58: String!, window: String)\` in \`src/graphql.mjs\`, weighted \`RELATIONSHIP_FIELD_COMPLEXITY\`. Each per-subnet slice carries registration count + first/last timestamps; the card also carries the HHI \`concentration\`, \`dominant_netuid\`, and totals.
- Resolver reuses \`buildAccountRegistrations\` and \`REGISTRATION_WINDOWS\`/\`DEFAULT_REGISTRATION_WINDOW\` from \`src/account-registrations.mjs\`, resolving through the same \`tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)\` \`{ data }\` envelope with the \`buildAccountRegistrations([], ...)\` zeroed-card cold fallback the REST handler uses (an account with no registrations in the window resolves to a zeroed card, never null).
- A malformed SS58 address or an unsupported window is a \`BAD_USER_INPUT\` GraphQL error, matching the sibling \`account\`/\`account_prometheus\` queries.

## Tests
Five cases in \`tests/graphql.test.mjs\`: cold-store zeroed card, Postgres-tier \`{ data }\` envelope with the full per-subnet mapping (including a subnet missing timestamps), partial-body degradation to resolver defaults, malformed-ss58 error, and unsupported-window error. Full graphql suite green; resolver 100% covered (statements + branches).

Closes #5704