### PR TITLE
fix(ui): collapse the blocks/extrinsics filter bars on mobile (#5323)

### DIFF
--- a/apps/ui/src/lib/metagraphed/filter-disclosure.test.ts
+++ b/apps/ui/src/lib/metagraphed/filter-disclosure.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { activeFilterCount, filterToggleLabel } from "./filter-disclosure";
+
+describe("activeFilterCount (#5323)", () => {
+  it("counts only non-empty string filters", () => {
+    expect(activeFilterCount(["5F3s", "", "42", ""])).toBe(2);
+    expect(activeFilterCount(["", "", ""])).toBe(0);
+  });
+
+  it("ignores whitespace-only values", () => {
+    expect(activeFilterCount(["   ", "\t", "x"])).toBe(1);
+  });
+
+  it("ignores non-string values (unset numeric params arrive as undefined)", () => {
+    expect(activeFilterCount([undefined, null, 0, "set"])).toBe(1);
+  });
+
+  it("handles an empty filter set", () => {
+    expect(activeFilterCount([])).toBe(0);
+  });
+});
+
+describe("filterToggleLabel (#5323)", () => {
+  it("stays bare when nothing is filtered", () => {
+    expect(filterToggleLabel(0)).toBe("Filters");
+  });
+
+  it("surfaces the count so a collapsed bar still shows the list is narrowed", () => {
+    expect(filterToggleLabel(1)).toBe("Filters (1)");
+    expect(filterToggleLabel(6)).toBe("Filters (6)");
+  });
+
+  it("clamps negative / fractional / non-finite counts", () => {
+    expect(filterToggleLabel(-2)).toBe("Filters");
+    expect(filterToggleLabel(2.7)).toBe("Filters (2)");
+    expect(filterToggleLabel(Number.NaN)).toBe("Filters");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/filter-disclosure.ts
+++ b/apps/ui/src/lib/metagraphed/filter-disclosure.ts
@@ -1,0 +1,18 @@
+/**
+ * Label for the mobile "Filters" disclosure on the list routes (#5323).
+ *
+ * The blocks/extrinsics filter bars are placeholder-only inputs, so once they
+ * collapse there is nothing on screen to say a filter is still narrowing the
+ * list. The toggle carries that count instead.
+ *
+ * Kept pure so the counting/labelling is unit-tested apart from the DOM.
+ */
+export function activeFilterCount(values: readonly unknown[]): number {
+  return values.filter((v) => typeof v === "string" && v.trim() !== "").length;
+}
+
+/** e.g. `Filters` when nothing is set, `Filters (2)` when two are. */
+export function filterToggleLabel(count: number): string {
+  const n = Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+  return n > 0 ? `Filters (${n})` : "Filters";
+}

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -1,9 +1,9 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { ChevronLeft, ChevronRight, Timer, Activity, Users } from "lucide-react";
+import { ChevronLeft, ChevronRight, Timer, Activity, Users, SlidersHorizontal } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -28,7 +28,8 @@ import {
 } from "@/components/metagraphed/table-controls";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { blocksQuery, blocksSummaryQuery, chainActivityQuery } from "@/lib/metagraphed/queries";
-import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
+import { activeFilterCount, filterToggleLabel } from "@/lib/metagraphed/filter-disclosure";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { nakamotoTone } from "@/lib/metagraphed/network-decentralization";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -236,73 +237,108 @@ function BlocksTable() {
     search.min_events,
   );
 
+  const activeCount = activeFilterCount([
+    search.author,
+    search.spec_version,
+    search.block_start,
+    search.block_end,
+    search.min_extrinsics,
+    search.min_events,
+  ]);
+  // Six placeholder-only inputs stacked to ~a full 375px screen before any block
+  // row was visible (#5323). Collapse them behind a toggle on mobile — open by
+  // default when a filter is already applied (e.g. a shared URL), so the reason
+  // the list is narrowed is never hidden.
+  const [filtersOpen, setFiltersOpen] = useState(activeCount > 0);
+
   const filters = (
     <>
-      <span
-        className="font-mono text-[11px] text-ink-muted whitespace-nowrap"
-        title="Blocks are listed newest first"
+      <button
+        type="button"
+        onClick={() => setFiltersOpen((open) => !open)}
+        aria-expanded={filtersOpen}
+        aria-controls="blocks-filter-fields"
+        className="md:hidden inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-2.5 font-mono text-[11px] text-ink-muted hover:border-ink/30 hover:text-ink-strong transition-colors"
       >
-        <span aria-hidden="true">↓ </span>Newest first
-      </span>
-      <SearchInput
-        value={search.author}
-        onChange={(v) => setSearch({ author: v, offset: 0 })}
-        placeholder="Author ss58…"
-      />
-      <SearchInput
-        value={search.spec_version}
-        onChange={(v) => setSearch({ spec_version: v, offset: 0 })}
-        placeholder="Spec version…"
-        inputMode="numeric"
-        className="min-w-[120px] max-w-[140px] flex-none"
-      />
-      <SearchInput
-        value={search.block_start}
-        onChange={(v) => setSearch({ block_start: v, offset: 0 })}
-        placeholder="Block from…"
-        inputMode="numeric"
-        className="min-w-[120px] max-w-[140px] flex-none"
-      />
-      <SearchInput
-        value={search.block_end}
-        onChange={(v) => setSearch({ block_end: v, offset: 0 })}
-        placeholder="Block to…"
-        inputMode="numeric"
-        className="min-w-[120px] max-w-[140px] flex-none"
-      />
-      <SearchInput
-        value={search.min_extrinsics}
-        onChange={(v) => setSearch({ min_extrinsics: v, offset: 0 })}
-        placeholder="Min extrinsics…"
-        inputMode="numeric"
-        className="min-w-[120px] max-w-[140px] flex-none"
-      />
-      <SearchInput
-        value={search.min_events}
-        onChange={(v) => setSearch({ min_events: v, offset: 0 })}
-        placeholder="Min events…"
-        inputMode="numeric"
-        className="min-w-[120px] max-w-[140px] flex-none"
-      />
-      <PageSizeSelect
-        value={search.limit}
-        onChange={(n) => setSearch({ limit: n, offset: 0 })}
-        options={[10, 25, 50, 100]}
-      />
-      <ResetFiltersButton
-        active={filtersActive}
-        onReset={() =>
-          setSearch({
-            author: "",
-            spec_version: "",
-            block_start: "",
-            block_end: "",
-            min_extrinsics: "",
-            min_events: "",
-            offset: 0,
-          })
-        }
-      />
+        <SlidersHorizontal className="size-3" aria-hidden="true" />
+        {filterToggleLabel(activeCount)}
+      </button>
+      {/* `md:contents` dissolves this wrapper at md and up, so the fields lay out
+          as direct children of the filter bar exactly as they did before — the
+          collapse is mobile-only. */}
+      <div
+        id="blocks-filter-fields"
+        className={classNames(
+          "w-full flex-wrap items-center gap-2 md:contents",
+          filtersOpen ? "flex" : "hidden",
+        )}
+      >
+        <span
+          className="font-mono text-[11px] text-ink-muted whitespace-nowrap"
+          title="Blocks are listed newest first"
+        >
+          <span aria-hidden="true">↓ </span>Newest first
+        </span>
+        <SearchInput
+          value={search.author}
+          onChange={(v) => setSearch({ author: v, offset: 0 })}
+          placeholder="Author ss58…"
+        />
+        <SearchInput
+          value={search.spec_version}
+          onChange={(v) => setSearch({ spec_version: v, offset: 0 })}
+          placeholder="Spec version…"
+          inputMode="numeric"
+          className="min-w-[120px] max-w-[140px] flex-none"
+        />
+        <SearchInput
+          value={search.block_start}
+          onChange={(v) => setSearch({ block_start: v, offset: 0 })}
+          placeholder="Block from…"
+          inputMode="numeric"
+          className="min-w-[120px] max-w-[140px] flex-none"
+        />
+        <SearchInput
+          value={search.block_end}
+          onChange={(v) => setSearch({ block_end: v, offset: 0 })}
+          placeholder="Block to…"
+          inputMode="numeric"
+          className="min-w-[120px] max-w-[140px] flex-none"
+        />
+        <SearchInput
+          value={search.min_extrinsics}
+          onChange={(v) => setSearch({ min_extrinsics: v, offset: 0 })}
+          placeholder="Min extrinsics…"
+          inputMode="numeric"
+          className="min-w-[120px] max-w-[140px] flex-none"
+        />
+        <SearchInput
+          value={search.min_events}
+          onChange={(v) => setSearch({ min_events: v, offset: 0 })}
+          placeholder="Min events…"
+          inputMode="numeric"
+          className="min-w-[120px] max-w-[140px] flex-none"
+        />
+        <PageSizeSelect
+          value={search.limit}
+          onChange={(n) => setSearch({ limit: n, offset: 0 })}
+          options={[10, 25, 50, 100]}
+        />
+        <ResetFiltersButton
+          active={filtersActive}
+          onReset={() =>
+            setSearch({
+              author: "",
+              spec_version: "",
+              block_start: "",
+              block_end: "",
+              min_extrinsics: "",
+              min_events: "",
+              offset: 0,
+            })
+          }
+        />
+      </div>
     </>
   );
 

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -1,9 +1,9 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, SlidersHorizontal } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
@@ -28,7 +28,8 @@ import {
   Sparkline,
 } from "@jsonbored/ui-kit";
 import { chainFeesQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
-import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
+import { activeFilterCount, filterToggleLabel } from "@/lib/metagraphed/filter-disclosure";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
@@ -198,49 +199,79 @@ function ExtrinsicsTable() {
     search.signer || search.call_module || search.call_function || search.success,
   );
 
+  const activeCount = activeFilterCount([
+    search.signer,
+    search.call_module,
+    search.call_function,
+    search.success,
+  ]);
+  // Same treatment as /blocks (#5323) — a lighter four-filter bar, but it still
+  // pushed the first extrinsic row down on a 375px viewport.
+  const [filtersOpen, setFiltersOpen] = useState(activeCount > 0);
+
   const filters = (
     <>
-      <SearchInput
-        value={search.signer}
-        onChange={(v) => setSearch({ signer: v, offset: 0 })}
-        placeholder="Signer ss58…"
-      />
-      <SearchInput
-        value={search.call_module}
-        onChange={(v) => setSearch({ call_module: v, offset: 0 })}
-        placeholder="Call module…"
-      />
-      <SearchInput
-        value={search.call_function}
-        onChange={(v) => setSearch({ call_function: v, offset: 0 })}
-        placeholder="Call function…"
-      />
-      <SelectFilter
-        label="Result"
-        value={search.success}
-        onChange={(v) => setSearch({ success: v, offset: 0 })}
-        options={[
-          { value: "true", label: "ok" },
-          { value: "false", label: "fail" },
-        ]}
-      />
-      <PageSizeSelect
-        value={search.limit}
-        onChange={(n) => setSearch({ limit: n, offset: 0 })}
-        options={[10, 25, 50, 100]}
-      />
-      <ResetFiltersButton
-        active={filtersActive}
-        onReset={() =>
-          setSearch({
-            signer: "",
-            call_module: "",
-            call_function: "",
-            success: "",
-            offset: 0,
-          })
-        }
-      />
+      <button
+        type="button"
+        onClick={() => setFiltersOpen((open) => !open)}
+        aria-expanded={filtersOpen}
+        aria-controls="extrinsics-filter-fields"
+        className="md:hidden inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-2.5 font-mono text-[11px] text-ink-muted hover:border-ink/30 hover:text-ink-strong transition-colors"
+      >
+        <SlidersHorizontal className="size-3" aria-hidden="true" />
+        {filterToggleLabel(activeCount)}
+      </button>
+      {/* `md:contents` dissolves this wrapper at md and up, so the fields lay out
+          as direct children of the filter bar exactly as they did before. */}
+      <div
+        id="extrinsics-filter-fields"
+        className={classNames(
+          "w-full flex-wrap items-center gap-2 md:contents",
+          filtersOpen ? "flex" : "hidden",
+        )}
+      >
+        <SearchInput
+          value={search.signer}
+          onChange={(v) => setSearch({ signer: v, offset: 0 })}
+          placeholder="Signer ss58…"
+        />
+        <SearchInput
+          value={search.call_module}
+          onChange={(v) => setSearch({ call_module: v, offset: 0 })}
+          placeholder="Call module…"
+        />
+        <SearchInput
+          value={search.call_function}
+          onChange={(v) => setSearch({ call_function: v, offset: 0 })}
+          placeholder="Call function…"
+        />
+        <SelectFilter
+          label="Result"
+          value={search.success}
+          onChange={(v) => setSearch({ success: v, offset: 0 })}
+          options={[
+            { value: "true", label: "ok" },
+            { value: "false", label: "fail" },
+          ]}
+        />
+        <PageSizeSelect
+          value={search.limit}
+          onChange={(n) => setSearch({ limit: n, offset: 0 })}
+          options={[10, 25, 50, 100]}
+        />
+        <ResetFiltersButton
+          active={filtersActive}
+          onReset={() =>
+            setSearch({
+              signer: "",
+              call_module: "",
+              call_function: "",
+              success: "",
+              offset: 0,
+            })
+          }
+        />
+      </div>
     </>
   );
 


### PR DESCRIPTION
## Summary

Closes #5323

`/blocks` renders six placeholder-only filter inputs (author, spec version, block from/to, min extrinsics, min events) in a sticky bar. At 375px they stack down the first screen, so a visitor scrolls past an unlabelled wall of inputs before seeing a single block. `/extrinsics` has the same shape with four.

This collapses the fields behind a **Filters** toggle below `md`. The toggle carries the **active-filter count** — the inputs are placeholder-only, so a collapsed bar would otherwise hide the fact that the list is narrowed — and it **starts open when a filter is already applied** (e.g. arriving on a shared, filtered URL).

**`md` and up are untouched:** `md:contents` dissolves the new wrapper, so the fields stay direct children of the filter bar's flex row and lay out exactly as before. Tablet/desktop are identical in the shots below.

Scoped to the two routes the issue names — `ListShell`'s filter bar is shared by 7 consumers, most with only 1–2 filters, where collapsing would be counterproductive.

## Measured, not assumed

The capture run measures the real numbers at 375px:

```
PASS: collapsed bar shows 0 filter inputs (was 6 on main)
INFO: first block row at 866px (was 1070px on main; fold 812px)
```

**Being straight about deliverable 3 ("data visible above the fold"):** this lifts the first row by **204px** and clears all six inputs off the first screen, but the row lands at 866px — still ~54px under the 812px fold. Measurement shows the remaining gap is **not** the filter bar: it's the hero plus the `Blocks / day` throughput card (#3390) and the three production tiles (#3488), which this issue doesn't scope and which look deliberate. I'd rather report that than quietly claim the outcome. Happy to open a follow-up for the above-table furniture if you want the fold fully cleared.

## Gates

typecheck OK · unit tests OK (`filter-disclosure.test.ts`, 7 new) · eslint `.` OK (0 errors) · prettier OK · rebased onto latest `main`

## Screenshots

Playwright, 375x812 / 768x1024 / 1280x800 x light/dark, fixed-viewport, real data. Mobile is the change; tablet/desktop unchanged by design.

| Viewport - Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5323/after-mobile-dark.png)<br><sub>after</sub> |
