### PR TITLE
fix(registry): dedupe 3 subnet files registering the same URL under two surface kinds

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 141,
+  "surface_count": 138,
   "surfaces": [
     {
       "auth_required": false,
@@ -519,24 +519,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "kind": "data-artifact",
-      "netuid": 7,
-      "probe": {
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "allways",
-      "public_safe": true,
-      "subnet_name": "Allways",
-      "subnet_slug": "allways",
-      "surface_id": "sn-7-allways-data-artifact",
-      "surface_key": "srf-c1b8cc4bcbfbe442",
-      "url": "https://api.all-ways.io/miners/leaderboard"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "kind": "subnet-api",
       "netuid": 7,
       "probe": {
@@ -1041,24 +1023,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "kind": "data-artifact",
-      "netuid": 34,
-      "probe": {
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "bitmind",
-      "public_safe": true,
-      "subnet_name": "BitMind",
-      "subnet_slug": "sn-34",
-      "surface_id": "sn-34-bitmind-data-artifact",
-      "surface_key": "srf-4bfccb16de73d4f2",
-      "url": "https://api.bitmind.ai/health"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "kind": "subnet-api",
       "netuid": 34,
       "probe": {
@@ -1307,24 +1271,6 @@
       "surface_id": "sn-55-niome-tasks-api",
       "surface_key": "srf-acced7c8512e4106",
       "url": "https://niome-api.genomes.io/api/tasks"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "data-artifact",
-      "netuid": 56,
-      "probe": {
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "gradients",
-      "public_safe": true,
-      "subnet_name": "Gradients",
-      "subnet_slug": "gradients",
-      "surface_id": "sn-56-gradients-data-artifact",
-      "surface_key": "srf-0c4b158f2a6899cc",
-      "url": "https://api.gradients.io/v1/network/status"
     },
     {
       "auth_required": false,

--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -276,28 +276,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-7-allways-data-artifact",
-      "kind": "data-artifact",
-      "name": "Allways community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "allways",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.all-ways.io/swagger-json"],
-      "url": "https://api.all-ways.io/miners/leaderboard"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-7-allways-subnet-api",
       "kind": "subnet-api",
       "name": "Allways swaps API",

--- a/registry/subnets/bitmind.json
+++ b/registry/subnets/bitmind.json
@@ -110,28 +110,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-34-bitmind-data-artifact",
-      "kind": "data-artifact",
-      "name": "BitMind community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "bitmind",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.bitmind.ai/openapi.json"],
-      "url": "https://api.bitmind.ai/health"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-34-bitmind-openapi",
       "kind": "openapi",
       "name": "BitMind community openapi",

--- a/registry/subnets/gradients.json
+++ b/registry/subnets/gradients.json
@@ -199,28 +199,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-56-gradients-data-artifact",
-      "kind": "data-artifact",
-      "name": "Gradients community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "gradients",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.gradients.io/docs"],
-      "url": "https://api.gradients.io/v1/network/status"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-56-gradients-subnet-api",
       "kind": "subnet-api",
       "name": "Gradients network status API",


### PR DESCRIPTION
Closes #5736

## What

Three subnet registry files each registered the exact same URL twice under two different surface `kind`s, double-counting the same endpoint in any surface-count/coverage aggregate:

- `registry/subnets/allways.json` (SN7): `allways-miners-leaderboard` (`subnet-api`) and `sn-7-allways-data-artifact` (`data-artifact`) both pointed to `https://api.all-ways.io/miners/leaderboard`.
- `registry/subnets/bitmind.json` (SN34): `sn-34-bitmind-data-artifact` and `sn-34-bitmind-subnet-api` both pointed to `https://api.bitmind.ai/health`.
- `registry/subnets/gradients.json` (SN56): `sn-56-gradients-data-artifact` and `sn-56-gradients-subnet-api` both pointed to `https://api.gradients.io/v1/network/status`.

## Fix

In each pair, removed the `data-artifact`-kind entry and kept the `subnet-api`-kind one. All three are live, queryable JSON endpoints (a leaderboard, a health check, a network-status feed) — the behavior `subnet-api` is meant to describe — not static/bulk datasets, which is what `data-artifact` is for. Across all three duplicate pairs, the `data-artifact` entry used an identical generic boilerplate probe (`HEAD`/`expect: any`/10000ms timeout) while the `subnet-api` entry had a `GET` probe matching the endpoint's actual live behavior, reinforcing that the `subnet-api` classification is the accurate one in each case.

Regenerated `public/metagraph/operational-surfaces.json` via `npm run build` (surface_count 141 → 138, the 3 removed duplicates); no other derived artifact changed as a result (contract/schema shape is unaffected by an instance-data-only change).

## Testing

```
npm run validate:surface -- registry/subnets/allways.json registry/subnets/bitmind.json registry/subnets/gradients.json
# Surface validation passed: 40 surface(s) across 3 subnet file(s).

npm run scan:public-safety
# no findings in the changed files

npm run build
# rebuilt derived artifacts; only public/metagraph/operational-surfaces.json changed for real
# (surface_count 141 -> 138); deploy-owned artifacts (r2-manifest.json, schemas/index.json)
# auto-reverted to upstream/main per the build's own DEPLOY_OWNED_ARTIFACTS handling

npm run validate
# Validated 129 native subnet(s), 129 curated overlay(s), 1610 surface(s), 133 provider(s), and 2037 candidate(s).
```