### PR TITLE
feat(api): add ?format=csv to block-scoped extrinsics + events feeds (#5746)

### DIFF
--- a/tests/block-csv.test.mjs
+++ b/tests/block-csv.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+// #5746: ?format=csv on the block-scoped extrinsics/events feeds, reusing the
+// unscoped/account-scoped siblings' CSV-columns constants (same row shapes).
+const REF = "8621331";
+const EXTRINSICS_CSV_HEADER =
+  "extrinsic_id,block_number,signer,call_module,call_function,success";
+const EVENTS_CSV_HEADER =
+  "block_number,event_index,event_kind,hotkey,coldkey,netuid,uid,amount_tao,alpha_amount,observed_at,extrinsic_index";
+
+function req(path, init) {
+  return new Request(`https://api.metagraph.sh${path}`, init);
+}
+
+test("GET /blocks/{ref}/extrinsics?format=csv emits a header-only CSV for an empty block", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/blocks/${REF}/extrinsics?format=csv`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  assert.equal((await res.text()).trim(), EXTRINSICS_CSV_HEADER);
+});
+
+test("GET /blocks/{ref}/extrinsics?format=csv exports the block's extrinsics via the Postgres tier", async () => {
+  const env = {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () =>
+        Response.json({
+          data: {
+            block_number: Number(REF),
+            extrinsics: [
+              {
+                block_number: Number(REF),
+                extrinsic_index: 0,
+                signer: "5Signer",
+                call_module: "SubtensorModule",
+                call_function: "set_weights",
+                success: true,
+              },
+            ],
+          },
+        }),
+    },
+  };
+  const res = await handleRequest(
+    req(`/api/v1/blocks/${REF}/extrinsics?format=csv`),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines[0], EXTRINSICS_CSV_HEADER);
+  assert.equal(lines.length, 2);
+  assert.match(
+    lines[1],
+    /^8621331-0,8621331,5Signer,SubtensorModule,set_weights,/,
+  );
+});
+
+test("GET /blocks/{ref}/extrinsics rejects an invalid ?format with 400", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/blocks/${REF}/extrinsics?format=xml`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error.code, "invalid_query");
+});
+
+test("GET /blocks/{ref}/events?format=csv emits a header-only CSV for an empty block", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/blocks/${REF}/events?format=csv`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  assert.equal((await res.text()).trim(), EVENTS_CSV_HEADER);
+});
+
+test("GET /blocks/{ref}/events?format=csv exports the block's events via the Postgres tier", async () => {
+  const env = {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () =>
+        Response.json({
+          data: {
+            block_number: Number(REF),
+            events: [
+              {
+                block_number: Number(REF),
+                event_index: 0,
+                event_kind: "Transfer",
+                hotkey: "5Hot",
+                coldkey: "5Cold",
+                netuid: 1,
+                uid: 0,
+                amount_tao: 10.5,
+                alpha_amount: null,
+                observed_at: 1750000000000,
+                extrinsic_index: 0,
+              },
+            ],
+          },
+        }),
+    },
+  };
+  const res = await handleRequest(
+    req(`/api/v1/blocks/${REF}/events?format=csv`),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines[0], EVENTS_CSV_HEADER);
+  assert.equal(lines.length, 2);
+  assert.match(lines[1], /^8621331,0,Transfer,5Hot,5Cold,1,0,10\.5,/);
+});
+
+test("GET /blocks/{ref}/events rejects an invalid ?format with 400", async () => {
+  const res = await handleRequest(
+    req(`/api/v1/blocks/${REF}/events?format=xml`),
+    {},
+    {},
+  );
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error.code, "invalid_query");
+});

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -3684,7 +3684,11 @@ export async function handleBlock(request, env, ref) {
 // (<=100) / ?offset. Unknown ref / cold store → 200 with block_number:null +
 // extrinsics:[] (schema-stable, never 404).
 export async function handleBlockExtrinsics(request, env, ref, url) {
-  const validationError = validateQueryParams(url, ["limit", "offset"]);
+  const validationError = validateEntityQuery(url, [
+    "limit",
+    "offset",
+    "format",
+  ]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset } = parsePagination(url, BLOCK_PAGINATION);
   // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
@@ -3694,6 +3698,17 @@ export async function handleBlockExtrinsics(request, env, ref, url) {
     request,
     "METAGRAPH_EXTRINSICS_SOURCE",
   )) ?? { data: buildBlockExtrinsics([], ref, null, { limit, offset }) };
+  // CSV reuses handleExtrinsics's transform + columns — buildBlockExtrinsics maps
+  // the same formatExtrinsic row shape (#5746). Cold block → empty → header-only.
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      extrinsicsToCsvRows(data.extrinsics),
+      `block-${ref}-extrinsics`,
+      "short",
+      request,
+      EXTRINSICS_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {
@@ -3715,7 +3730,11 @@ export async function handleBlockExtrinsics(request, env, ref, url) {
 // (<=1000) / ?offset. Unknown ref / cold store → 200 with block_number:null +
 // events:[] (schema-stable, never 404). Mirrors handleBlockExtrinsics.
 export async function handleBlockEvents(request, env, ref, url) {
-  const validationError = validateQueryParams(url, ["limit", "offset"]);
+  const validationError = validateEntityQuery(url, [
+    "limit",
+    "offset",
+    "format",
+  ]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset } = parsePagination(url, FEED_PAGINATION);
   // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
@@ -3725,6 +3744,17 @@ export async function handleBlockEvents(request, env, ref, url) {
     request,
     "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
   )) ?? { data: buildBlockEvents([], ref, null, { limit, offset }) };
+  // CSV reuses the account-events EVENTS_CSV_COLUMNS — buildBlockEvents maps the
+  // same formatAccountEvent row shape (#5746). Cold block → empty → header-only.
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.events,
+      `block-${ref}-events`,
+      "short",
+      request,
+      EVENTS_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary
`handleBlockExtrinsics` (`GET /api/v1/blocks/{ref}/extrinsics`) and `handleBlockEvents` (`GET …/events`) return block-scoped row lists (`data.extrinsics[]`, `data.events[]`) but had no `?format=csv` path — unlike their unscoped/account-scoped counterparts (`handleExtrinsics`, `handleAccountEvents`) which already export CSV.

## Change (`workers/request-handlers/entities.mjs`)
Each block-scoped feed is a drill-down filter on an already-CSV-exportable shape, so this **reuses the siblings' exact transform + columns constants** rather than duplicating them:
- **`handleBlockExtrinsics`**: switch `validateQueryParams`→`validateEntityQuery(["limit","offset","format"])`, then early-return `csvResponse(extrinsicsToCsvRows(data.extrinsics), "block-{ref}-extrinsics", "short", request, EXTRINSICS_CSV_COLUMNS)` — the same transform + constant `handleExtrinsics` uses (`buildBlockExtrinsics` maps the same `formatExtrinsic` row shape).
- **`handleBlockEvents`**: same allowlist change, then `csvResponse(data.events, "block-{ref}-events", "short", request, EVENTS_CSV_COLUMNS)` — `buildBlockEvents` maps the same `formatAccountEvent` row shape `EVENTS_CSV_COLUMNS` already documents.

`validateEntityQuery` validates the `format` value (unsupported `?format=` → the existing `invalid_query` 400). Rows are already paginated, so the CSV path carries the identical set the JSON path would; a cold/unknown block yields an empty array → a header-only CSV. CSV caching is handled by `csvResponse` (keyed off the `?format=csv` URL), same as the siblings.

## Tests (`tests/block-csv.test.mjs`)
Six cases — for **each** route: empty-block header-only CSV, a with-data export via a mocked Postgres tier, and an invalid `?format` → 400 `invalid_query`.

## Verification
- New tests (6) pass; `request-handlers-entities` / `account-routes` suites (377) — no regressions.
- `eslint` + `prettier --check` on both files — clean.

Closes #5746
