### PR TITLE
feat(graphql): add Query.subnet_recycled mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -54,6 +54,7 @@ import { buildExtrinsic, buildExtrinsicFeed } from "./extrinsics.mjs";
 import { buildBlock, buildBlockFeed } from "./blocks.mjs";
 import { buildBlocksSummary } from "./blocks-summary.mjs";
 import { buildChainYield } from "./chain-yield.mjs";
+import { loadSubnetRecycled, isU16Netuid } from "./subnet-recycled.mjs";
 import {
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
@@ -188,6 +189,8 @@ export const SDL = `
     health_trends: HealthTrends!
     "Network-wide emission-yield (return rate) aggregated across every subnet's neurons -- the aggregate network return, the same split by validator vs miner role, and the distribution of the per-neuron return rate. Every aggregate is null (never a GraphQL error) on a cold store. Mirrors GET /api/v1/chain/yield."
     chain_yield: ChainYield!
+    "Live cumulative TAO recycled for registration on one subnet, read directly from chain via RPC (not the Postgres tier). recycled_tao is null on RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/recycled."
+    subnet_recycled(netuid: Int!): SubnetRecycled
   }
 
   type SubnetList {
@@ -748,6 +751,14 @@ export const SDL = `
     p90: Float!
   }
 
+  "Live cumulative TAO recycled for registration on one subnet, read directly from chain via RPC. recycled_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/recycled."
+  type SubnetRecycled {
+    schema_version: Int!
+    netuid: Int!
+    recycled_tao: Float
+    queried_at: String!
+  }
+
   "Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary."
   type BlocksSummary {
     schema_version: Int!
@@ -1111,6 +1122,9 @@ schema.getSubscriptionType().getFields().chainEvents.subscribe =
 // trips it. Keyed by field name; everything else defaults to 1.
 export const DEFAULT_FIELD_COMPLEXITY = 1;
 const RELATIONSHIP_FIELD_COMPLEXITY = 5;
+// Live chain RPC (not the cached Postgres tier) -- costs more per-call than a
+// relationship read, so it's weighted double.
+const LIVE_RPC_FIELD_COMPLEXITY = 10;
 export const FIELD_COMPLEXITY = {
   subnets: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1144,6 +1158,7 @@ export const FIELD_COMPLEXITY = {
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_yield: RELATIONSHIP_FIELD_COMPLEXITY,
   account_prometheus: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_recycled: LIVE_RPC_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -2523,6 +2538,21 @@ const rootValue = {
           }
         : null,
     };
+  },
+
+  async subnet_recycled({ netuid }, context) {
+    if (!isU16Netuid(netuid)) {
+      throw new GraphQLError(
+        "netuid must be an integer in the u16 range 0..65535.",
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Live chain RPC, not the Postgres tier -- reuses loadSubnetRecycled's own
+    // KV cache/TTL, matching REST's handleSubnetRecycled exactly. recycled_tao
+    // stays null on RPC failure (schema-stable), never a GraphQL error.
+    // loadSubnetRecycled always sets schema_version/netuid/queried_at
+    // unconditionally, so no `??` fallback is needed for those.
+    return loadSubnetRecycled(context.env, netuid);
   },
 };
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -4985,6 +4985,8 @@ describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled
 
   test("subnet_recycled is weighted heavier than a Postgres-tier relationship field, since it hits live chain RPC", () => {
     assert.equal(FIELD_COMPLEXITY.subnet_recycled, 10);
-    assert.ok(FIELD_COMPLEXITY.subnet_recycled > FIELD_COMPLEXITY.chain_weights);
+    assert.ok(
+      FIELD_COMPLEXITY.subnet_recycled > FIELD_COMPLEXITY.chain_weights,
+    );
   });
 });

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -4901,3 +4901,90 @@ describe("graphql — chain_yield (Postgres-tier + cold-store fallback)", () => 
     assert.equal(FIELD_COMPLEXITY.chain_yield, FIELD_COMPLEXITY.blocks_summary);
   });
 });
+
+describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled.mjs)", () => {
+  // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
+  // in tests/subnet-recycled.test.mjs.
+  function withFetchStub(stub, fn) {
+    const orig = globalThis.fetch;
+    globalThis.fetch = stub;
+    return Promise.resolve(fn()).finally(() => {
+      globalThis.fetch = orig;
+    });
+  }
+
+  test("resolves recycled_tao from a live RPC hit", async () => {
+    await withFetchStub(
+      async () => ({
+        ok: true,
+        json: async () => ({
+          jsonrpc: "2.0",
+          id: 1,
+          result: "0x626ac0f623000000", // little-endian u64 for 154463660642 rao
+        }),
+      }),
+      async () => {
+        const { status, body } = await gql(
+          "{ subnet_recycled(netuid: 101) { schema_version netuid recycled_tao queried_at } }",
+        );
+        assert.equal(status, 200);
+        assert.equal(body.errors, undefined);
+        const r = body.data.subnet_recycled;
+        assert.equal(r.schema_version, 1);
+        assert.equal(r.netuid, 101);
+        assert.equal(r.recycled_tao, 154.463660642);
+        assert.ok(r.queried_at);
+      },
+    );
+  });
+
+  test("RPC failure degrades recycled_tao to null, never a GraphQL error", async () => {
+    await withFetchStub(
+      async () => {
+        throw new Error("network unreachable");
+      },
+      async () => {
+        const { status, body } = await gql(
+          "{ subnet_recycled(netuid: 1) { recycled_tao } }",
+        );
+        assert.equal(status, 200);
+        assert.equal(body.errors, undefined);
+        assert.equal(body.data.subnet_recycled.recycled_tao, null);
+      },
+    );
+  });
+
+  test("an out-of-range netuid is BAD_USER_INPUT and never reaches the RPC", async () => {
+    let called = false;
+    await withFetchStub(
+      async () => {
+        called = true;
+        return { ok: true, json: async () => ({ result: "0x0" }) };
+      },
+      async () => {
+        const { status, body } = await gql(
+          "{ subnet_recycled(netuid: 99999) { recycled_tao } }",
+        );
+        assert.equal(status, 200);
+        assert.equal(body.data.subnet_recycled, null);
+        assert.ok(
+          body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+        );
+        assert.equal(called, false);
+      },
+    );
+  });
+
+  test("a negative netuid is BAD_USER_INPUT", async () => {
+    const { status, body } = await gql(
+      "{ subnet_recycled(netuid: -1) { recycled_tao } }",
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+  });
+
+  test("subnet_recycled is weighted heavier than a Postgres-tier relationship field, since it hits live chain RPC", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_recycled, 10);
+    assert.ok(FIELD_COMPLEXITY.subnet_recycled > FIELD_COMPLEXITY.chain_weights);
+  });
+});


### PR DESCRIPTION
Closes #5691

## What

`GET /api/v1/subnets/{netuid}/recycled` and the `get_subnet_recycled` MCP tool exist, but there was no GraphQL mirror. Distinct from the other `Query.*` mirror issues in one way: this field hits the live chain RPC directly (via `src/subnet-recycled.mjs`'s `loadSubnetRecycled`), not the Postgres tier.

## Fix

- Added `Query.subnet_recycled(netuid: Int!): SubnetRecycled` to the SDL, plus a `SubnetRecycled` type mirroring the handler's real response shape (`recycled_tao: Float` nullable per the RPC-failure case).
- Resolver validates `netuid` with the existing `isU16Netuid` guard and throws a `BAD_USER_INPUT` `GraphQLError` on an out-of-range value — matching how `account`/`accounts`/`subnet_movers` already validate their args, and never reaching the RPC on invalid input.
- On a valid netuid, the resolver is a direct pass-through to `loadSubnetRecycled(context.env, netuid)`, reusing its existing KV cache/TTL and RPC call — no duplicated chain-RPC logic. `recycled_tao` degrades to `null` on RPC failure (schema-stable), never a GraphQL error, matching REST's own contract.
- Added a new `LIVE_RPC_FIELD_COMPLEXITY = 10` weight (double `RELATIONSHIP_FIELD_COMPLEXITY`), since this is the first schema field that costs a live chain RPC call rather than a cached Postgres-tier read.

## Testing

```
npx vitest run tests/graphql.test.mjs
# all passing (pre-existing suite + 5 new subnet_recycled tests)

npx eslint src/graphql.mjs tests/graphql.test.mjs
# clean

npx prettier --check src/graphql.mjs tests/graphql.test.mjs
# clean (actually re-run and verified this time -- a prior attempt on this branch had a
# real prettier violation that was previously misdiagnosed; npx prettier --write fixed the
# one affected line, a too-long assertion, and this is confirmed clean now)
```

New tests cover: a successful live-RPC hit (golden decoded value, mirroring the existing `subnet-recycled.test.mjs` fixture), RPC failure degrading `recycled_tao` to `null` without surfacing a GraphQL error, an out-of-range netuid rejected as `BAD_USER_INPUT` before ever reaching the RPC (asserted via a call-tracking stub), a negative netuid rejected the same way, and the new `FIELD_COMPLEXITY` weight.

Note: this supersedes #5749, #5765, and #5768. The first two were mechanically closed by LoopOver for a stale base as sibling GraphQL mirror PRs merged into `main` in rapid succession; the third failed the `format:check` CI gate on a genuine prettier violation, now fixed. Rebased onto current `main` here with the fix included.