### PR TITLE
feat(api): add ?format=csv to GET /api/v1/chain/transfers

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -929,7 +929,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch network-wide native-TAO transfer analytics over a 7d or 30d window: total Balances.Transfer volume + count, distinct senders/receivers, the top senders and receivers ranked by volume (?limit, <=100), and the top senders' share of total volume. Computed live from the account_events Transfer feed; schema-stable zeros + empty leaderboards when cold. */
+        /** Fetch network-wide native-TAO transfer analytics over a 7d or 30d window: total Balances.Transfer volume + count, distinct senders/receivers, the top senders and receivers ranked by volume (?limit, <=100), and the top senders' share of total volume. Computed live from the account_events Transfer feed; schema-stable zeros + empty leaderboards when cold. Pass ?format=csv to download the top senders and receivers as one CSV tagged by a `direction` column (the totals + top_sender_share stay JSON-only). */
         get: operations["chainTransfers"];
         put?: never;
         post?: never;
@@ -14937,6 +14937,8 @@ export interface operations {
             query?: {
                 window?: "7d" | "30d";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -14944,7 +14946,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -15018,6 +15020,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainTransfersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -7437,7 +7437,7 @@
     {
       "artifact_path": "/metagraph/chain/transfers.json",
       "cache": "short",
-      "description": "Fetch network-wide native-TAO transfer analytics over a 7d or 30d window: total Balances.Transfer volume + count, distinct senders/receivers, the top senders and receivers ranked by volume (?limit, <=100), and the top senders' share of total volume. Computed live from the account_events Transfer feed; schema-stable zeros + empty leaderboards when cold.",
+      "description": "Fetch network-wide native-TAO transfer analytics over a 7d or 30d window: total Balances.Transfer volume + count, distinct senders/receivers, the top senders and receivers ranked by volume (?limit, <=100), and the top senders' share of total volume. Computed live from the account_events Transfer feed; schema-stable zeros + empty leaderboards when cold. Pass ?format=csv to download the top senders and receivers as one CSV tagged by a `direction` column (the totals + top_sender_share stay JSON-only).",
       "id": "chain-transfers",
       "method": "GET",
       "path": "/api/v1/chain/transfers",
@@ -7461,6 +7461,17 @@
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -31446,6 +31446,19 @@
               "minimum": 1,
               "type": "integer"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -31527,9 +31540,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -31586,7 +31605,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch network-wide native-TAO transfer analytics over a 7d or 30d window: total Balances.Transfer volume + count, distinct senders/receivers, the top senders and receivers ranked by volume (?limit, <=100), and the top senders' share of total volume. Computed live from the account_events Transfer feed; schema-stable zeros + empty leaderboards when cold.",
+        "summary": "Fetch network-wide native-TAO transfer analytics over a 7d or 30d window: total Balances.Transfer volume + count, distinct senders/receivers, the top senders and receivers ranked by volume (?limit, <=100), and the top senders' share of total volume. Computed live from the account_events Transfer feed; schema-stable zeros + empty leaderboards when cold. Pass ?format=csv to download the top senders and receivers as one CSV tagged by a `direction` column (the totals + top_sender_share stay JSON-only).",
         "tags": [
           "chain",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -929,7 +929,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch network-wide native-TAO transfer analytics over a 7d or 30d window: total Balances.Transfer volume + count, distinct senders/receivers, the top senders and receivers ranked by volume (?limit, <=100), and the top senders' share of total volume. Computed live from the account_events Transfer feed; schema-stable zeros + empty leaderboards when cold. */
+        /** Fetch network-wide native-TAO transfer analytics over a 7d or 30d window: total Balances.Transfer volume + count, distinct senders/receivers, the top senders and receivers ranked by volume (?limit, <=100), and the top senders' share of total volume. Computed live from the account_events Transfer feed; schema-stable zeros + empty leaderboards when cold. Pass ?format=csv to download the top senders and receivers as one CSV tagged by a `direction` column (the totals + top_sender_share stay JSON-only). */
         get: operations["chainTransfers"];
         put?: never;
         post?: never;
@@ -14937,6 +14937,8 @@ export interface operations {
             query?: {
                 window?: "7d" | "30d";
                 limit?: number;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -14944,7 +14946,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -15018,6 +15020,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChainTransfersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -3354,13 +3354,13 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/chain/transfers",
     "/metagraph/chain/transfers.json",
-    "Fetch network-wide native-TAO transfer analytics over a 7d or 30d window: total Balances.Transfer volume + count, distinct senders/receivers, the top senders and receivers ranked by volume (?limit, <=100), and the top senders' share of total volume. Computed live from the account_events Transfer feed; schema-stable zeros + empty leaderboards when cold.",
+    "Fetch network-wide native-TAO transfer analytics over a 7d or 30d window: total Balances.Transfer volume + count, distinct senders/receivers, the top senders and receivers ranked by volume (?limit, <=100), and the top senders' share of total volume. Computed live from the account_events Transfer feed; schema-stable zeros + empty leaderboards when cold. Pass ?format=csv to download the top senders and receivers as one CSV tagged by a `direction` column (the totals + top_sender_share stay JSON-only).",
     "short",
     ["chain", "analytics"],
-    [
+    csvRouteQuery([
       { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
-    ],
+    ]),
     [],
   ),
   route(

--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -849,6 +849,122 @@ test("GET /api/v1/chain/transfers rejects non-canonical limits", async () => {
   }
 });
 
+function transfersEnv({ senders = [], receivers = [], totals } = {}) {
+  return {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              all: () => {
+                if (/COUNT\(DISTINCT hotkey\)/.test(sql)) {
+                  return Promise.resolve({
+                    results: [
+                      totals ?? {
+                        transfer_count: 0,
+                        total_volume_tao: 0,
+                        unique_senders: 0,
+                        unique_receivers: 0,
+                      },
+                    ],
+                  });
+                }
+                if (/GROUP BY hotkey/.test(sql)) {
+                  return Promise.resolve({ results: senders });
+                }
+                if (/GROUP BY coldkey/.test(sql)) {
+                  return Promise.resolve({ results: receivers });
+                }
+                return Promise.resolve({ results: [] });
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+const TRANSFERS_CSV_HEADER = "direction,address,volume_tao,transfer_count";
+const TRANSFERS_SENDER_ROW = {
+  address: "5Sa",
+  volume_tao: 80,
+  transfer_count: 5,
+};
+const TRANSFERS_RECEIVER_ROW = {
+  address: "5Rx",
+  volume_tao: 60,
+  transfer_count: 4,
+};
+const TRANSFERS_TOTALS = {
+  transfer_count: 10,
+  total_volume_tao: 100,
+  unique_senders: 4,
+  unique_receivers: 6,
+};
+
+test("GET /api/v1/chain/transfers exports top senders + receivers as CSV with ?format=csv", async () => {
+  const res = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/chain/transfers?window=7d&format=csv",
+    ),
+    transfersEnv({
+      senders: [TRANSFERS_SENDER_ROW],
+      receivers: [TRANSFERS_RECEIVER_ROW],
+      totals: TRANSFERS_TOTALS,
+    }),
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  assert.match(
+    res.headers.get("content-disposition"),
+    /attachment; filename="chain-transfers\.csv"/,
+  );
+  const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines[0], TRANSFERS_CSV_HEADER);
+  assert.equal(lines.length, 3); // header + 1 sender row + 1 receiver row
+  assert.equal(lines[1], "sender,5Sa,80,5");
+  assert.equal(lines[2], "receiver,5Rx,60,4");
+});
+
+test("GET /api/v1/chain/transfers honors Accept: text/csv the same as ?format=csv", async () => {
+  const res = await handleRequest(
+    new Request("https://api.metagraph.sh/api/v1/chain/transfers", {
+      headers: { accept: "text/csv" },
+    }),
+    transfersEnv({
+      senders: [TRANSFERS_SENDER_ROW],
+      receivers: [TRANSFERS_RECEIVER_ROW],
+      totals: TRANSFERS_TOTALS,
+    }),
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+});
+
+test("GET /api/v1/chain/transfers emits a header-only CSV on a cold store", async () => {
+  const res = await handleRequest(
+    new Request("https://api.metagraph.sh/api/v1/chain/transfers?format=csv"),
+    transfersEnv({}),
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  assert.equal((await res.text()).trim(), TRANSFERS_CSV_HEADER);
+});
+
+test("GET /api/v1/chain/transfers rejects an unsupported format value with 400", async () => {
+  const res = await handleRequest(
+    new Request("https://api.metagraph.sh/api/v1/chain/transfers?format=xml"),
+    transfersEnv({}),
+    {},
+  );
+  assert.equal(res.status, 400);
+});
+
 // #4832 Tier 2: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events
 // table this handler already reads, no new flag) -- tryPostgresTier's own
 // fallback contract is unit-tested in workers/postgres-tier.mjs's own tests,

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -947,6 +947,17 @@ const CHAIN_TRANSFER_PAIRS_CSV_COLUMNS = [
   "last_observed_at",
 ];
 
+// The transfers CSV exports the top-senders and top-receivers leaderboards as one
+// row set tagged by a `direction` column (sender|receiver) rather than as two
+// separate exports, since both share the same per-address shape; the scorecard
+// totals + top_sender_share rollup stay JSON-only, mirroring chain-transfer-pairs.
+const CHAIN_TRANSFERS_CSV_COLUMNS = [
+  "direction",
+  "address",
+  "volume_tao",
+  "transfer_count",
+];
+
 // Daily network-activity aggregates over the first-party chain D1 tiers (#1987):
 // per-UTC-day extrinsic/event/block counts, success rate, and unique signers —
 // the foundation time-series for the block-explorer "network at a glance" view
@@ -1184,13 +1195,16 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
 // volume (a concentration signal), from the account_events Transfer feed. The
 // network-level companion of /accounts/{ss58}/transfers + /counterparties.
 export async function handleChainTransfers(request, env, url, ctx = {}) {
-  const { label, days, error } = analyticsWindow(url, ["limit"]);
+  const { label, days, error } = analyticsWindow(url, ["limit", "format"]);
   if (error) return analyticsQueryError(error);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { limit, error: limitError } = parseLimitParam(url, {
     defaultLimit: 25,
     maxLimit: 100,
   });
   if (limitError) return analyticsQueryError(limitError);
+  const csv = csvRequested(url, request);
 
   // HEAD probes are globally allowed for read-only API routes. Normalize them
   // through the GET cache key so a transfer-analytics probe cannot bypass the
@@ -1219,6 +1233,24 @@ export async function handleChainTransfers(request, env, url, ctx = {}) {
           observedAt: meta?.last_run_at || null,
           limit,
         }));
+      if (csv) {
+        return csvResponse(
+          [
+            ...data.top_senders.map((row) => ({
+              direction: "sender",
+              ...row,
+            })),
+            ...data.top_receivers.map((row) => ({
+              direction: "receiver",
+              ...row,
+            })),
+          ],
+          "chain-transfers",
+          "short",
+          cacheRequest,
+          CHAIN_TRANSFERS_CSV_COLUMNS,
+        );
+      }
       return envelopeResponse(
         cacheRequest,
         {
@@ -1232,7 +1264,7 @@ export async function handleChainTransfers(request, env, url, ctx = {}) {
         "short",
       );
     },
-    canonicalAnalyticsCacheRoute(url, ["limit"]),
+    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })


### PR DESCRIPTION
`handleChainTransfers` was the sole outlier among the 16 sibling `handleChain*` routes without `?format=csv` support. This mirrors `handleChainTransferPairs`'s exact pattern in the same file: `"format"` added to the `analyticsWindow` extra-params list, `validateFormatParam` + `csvRequested` gate the response format, and `csvResponse` handles the CSV path.

`top_senders` and `top_receivers` are two distinct row lists (not one row-shaped table like the other CSV-enabled siblings), so the CSV combines both into one row set tagged by a `direction` column (`sender`|`receiver`) alongside `address`, `volume_tao`, `transfer_count`. The scorecard totals (`total_volume_tao`, `transfer_count`, `unique_senders`, `unique_receivers`) and `top_sender_share` stay JSON-only, matching how `handleChainTransferPairs` keeps its totals + `top_pair_share` out of the CSV export.

A cold/empty result still emits a CSV header row with no data rows — `csvResponse`'s existing empty-array handling covers that for free, and it's exercised by a dedicated test.

The cache key now includes `format=csv` in the canonical cache path, same as every CSV-enabled sibling.

Regenerated `openapi.json` + `packages/contract/index.d.ts` + `public/metagraph/types.d.ts` via `npm run build`.

Closes #5742
