### PR TITLE
feat(ui): compact registered-repositories card for Gittensor subnet page

### DIFF
--- a/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
+++ b/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
@@ -61,8 +61,7 @@ export function GittensorRegisteredRepos({ slug }: { slug: string }) {
       <ol className="space-y-0.5">
         {rows.map((row, i) => {
           const repoUrl = `https://github.com/${row.repository}`;
-          const sharePct =
-            typeof row.emission_share === "number" ? row.emission_share * 100 : null;
+          const sharePct = typeof row.emission_share === "number" ? row.emission_share * 100 : null;
           return (
             <li key={row.repository}>
               <a

--- a/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
+++ b/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
@@ -30,9 +30,13 @@ interface GittensorMasterRepositories {
 
 export function GittensorRegisteredRepos({ slug }: { slug: string }) {
   const { data: res, isError } = useQuery(adapterQuery(slug));
-  const dimensions = res?.data?.dimensions as
-    | { master_repositories?: GittensorMasterRepositories }
-    | undefined;
+  // The adapter envelope nests the actual snapshot (and its `dimensions`) one
+  // level deeper than AdapterSnapshot's loose typing suggests: `data.snapshot
+  // .dimensions`, not `data.dimensions` -- verified directly against the real
+  // /api/v1/adapters/gittensor response, not assumed from the registry file's
+  // own on-disk shape (which is what `data.snapshot` mirrors).
+  const dimensions = (res?.data as { snapshot?: { dimensions?: unknown } })?.snapshot
+    ?.dimensions as { master_repositories?: GittensorMasterRepositories } | undefined;
   const master = dimensions?.master_repositories;
   const rows = (master?.top_emission_repositories ?? []).slice(0, ROWS_SHOWN);
 
@@ -43,7 +47,7 @@ export function GittensorRegisteredRepos({ slug }: { slug: string }) {
   const total = master?.repository_count;
 
   return (
-    <div className="rounded-xl border border-border bg-card p-4">
+    <div id="registered-repos" className="rounded-xl border border-border bg-card p-4">
       <div className="mb-3 flex items-center justify-between gap-2">
         <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
           Registered repositories

--- a/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
+++ b/apps/ui/src/components/metagraphed/gittensor-registered-repos.tsx
@@ -1,0 +1,97 @@
+import { useQuery } from "@tanstack/react-query";
+import { BrandIcon } from "@jsonbored/ui-kit";
+import { adapterQuery } from "@/lib/metagraphed/queries";
+
+// Gittensor-specific extra (netuid 74 only — see subnets.$netuid.tsx's gate).
+// Compact, capped preview of Gittensor's registered repositories, not folded
+// into ResourceExplorer's surfaces list: these are ecosystem member projects
+// with emission-share/maintainer-cut metadata, not infrastructure endpoints,
+// so mixing them into the surfaces grid would muddy both concepts and (at
+// 19 entries) flood the page. Mirrors leaderboards.tsx's BoardCard pattern
+// for visual consistency — same compact ranked-row shape, same
+// self-contained "hide on error/empty" discovery-extra behavior — and reuses
+// its already-live /api/v1/adapters/:slug data (dimensions.master_repositories,
+// refreshed by scripts/snapshot-adapters.mjs's snapshotGittensor()) rather
+// than inventing a new endpoint.
+
+const ROWS_SHOWN = 6;
+
+interface MasterRepoRow {
+  repository: string;
+  emission_share?: number;
+  issue_discovery_share?: number;
+  maintainer_cut?: number;
+}
+
+interface GittensorMasterRepositories {
+  top_emission_repositories?: MasterRepoRow[];
+  repository_count?: number;
+}
+
+export function GittensorRegisteredRepos({ slug }: { slug: string }) {
+  const { data: res, isError } = useQuery(adapterQuery(slug));
+  const dimensions = res?.data?.dimensions as
+    | { master_repositories?: GittensorMasterRepositories }
+    | undefined;
+  const master = dimensions?.master_repositories;
+  const rows = (master?.top_emission_repositories ?? []).slice(0, ROWS_SHOWN);
+
+  // Discovery extra — never break the subnet page. Hide entirely on error or
+  // until there's at least one row to show (matches leaderboards.tsx).
+  if (isError || rows.length === 0) return null;
+
+  const total = master?.repository_count;
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          Registered repositories
+        </span>
+        {total ? (
+          <span className="shrink-0 font-mono text-[10px] text-ink-muted tabular-nums">
+            {total} total
+          </span>
+        ) : null}
+      </div>
+      <ol className="space-y-0.5">
+        {rows.map((row, i) => {
+          const repoUrl = `https://github.com/${row.repository}`;
+          const sharePct =
+            typeof row.emission_share === "number" ? row.emission_share * 100 : null;
+          return (
+            <li key={row.repository}>
+              <a
+                href={repoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mg-row-hover flex items-center justify-between gap-2 rounded-md px-2 py-1.5"
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  <span className="w-4 shrink-0 text-right font-mono text-[10px] text-ink-muted tabular-nums">
+                    {i + 1}
+                  </span>
+                  <BrandIcon size={18} name={row.repository} repoUrl={repoUrl} fallback={i + 1} />
+                  <span className="truncate text-sm text-ink-strong">{row.repository}</span>
+                </span>
+                <span className="shrink-0 font-mono text-[12px] tabular-nums text-ink-muted">
+                  {sharePct !== null ? `${sharePct.toFixed(1)}%` : "—"}
+                </span>
+              </a>
+            </li>
+          );
+        })}
+      </ol>
+      {total && total > rows.length ? (
+        <a
+          href="https://gittensor.io/repositories"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 block text-center text-xs text-accent hover:underline"
+        >
+          View all {total} registered repositories →
+        </a>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -107,6 +107,7 @@ import { TimeRangeProvider } from "@/components/metagraphed/analytics/time-range
 import { SubnetMasthead } from "@/components/metagraphed/subnet-masthead";
 import { OperationalPanel } from "@/components/metagraphed/operational-panel";
 import { ResourceExplorer } from "@/components/metagraphed/resource-explorer";
+import { GittensorRegisteredRepos } from "@/components/metagraphed/gittensor-registered-repos";
 import { SubnetProfilePanel } from "@/components/metagraphed/subnet-profile-panel";
 import { SubnetPulseStrip } from "@/components/metagraphed/subnet-pulse-strip";
 import { SubnetFilterProvider } from "@/components/metagraphed/subnet-filter-context";
@@ -393,6 +394,15 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
       <QueryErrorBoundary>
         <ResourceExplorer netuid={netuid} />
       </QueryErrorBoundary>
+
+      {/* 3b — Gittensor's registered repositories (netuid 74 only): ecosystem
+          member projects with emission-share metadata, not infrastructure
+          surfaces, so kept out of ResourceExplorer above. */}
+      {netuid === 74 ? (
+        <QueryErrorBoundary>
+          <GittensorRegisteredRepos slug="gittensor" />
+        </QueryErrorBoundary>
+      ) : null}
 
       {/* 4 — Subnet profile (lineage + economics + ownership + curation) */}
       <QueryErrorBoundary>


### PR DESCRIPTION
## Summary

- Adds a compact "Registered repositories" card to the Gittensor subnet page (`/subnets/74` only), listing the top 6 emission-share repos from the adapter's `master_repositories` dimension (19 total, including our own `JSONbored/metagraphed` and `JSONbored/loopover`), each linking straight to GitHub with a `BrandIcon` avatar and emission-share percentage.
- Fixes a parsing bug found while building it: the adapter envelope nests dimensions one level deeper (`data.snapshot.dimensions`) than the loose `AdapterSnapshot` typing suggested — verified against the live `/api/v1/adapters/gittensor` response, not assumed from the on-disk registry shape.
- Mirrors `leaderboards.tsx`'s `BoardCard` pattern: self-contained discovery extra, hides entirely on error or empty data, doesn't touch `ResourceExplorer`'s surfaces grid since these are ecosystem member projects with emission/maintainer-cut metadata, not infrastructure endpoints.
- Kept separate from PR #5772 (Gittensor adapter data refresh), which this depends on for correct `master_repositories` roster data — PR #5772 is being fixed in parallel for an unrelated `repository_metadata` auth regression, not the `master_repositories` dimension this card reads.

Prompted directly by the repo owner (no linked issue — owner PRs are exempt from the gate's linked-issue requirement).

## Screenshots

3 viewports × 2 themes × {before, after}, `/subnets/74` scrolled to the new card (fallback anchor `endpoints-glance` for `before`, which doesn't have the card yet):

| | Before | After |
|---|---|---|
| Mobile · Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/gittensor-registered-repos-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/gittensor-registered-repos-after-mobile-light.png) |
| Mobile · Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/gittensor-registered-repos-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/gittensor-registered-repos-after-mobile-dark.png) |
| Tablet · Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/gittensor-registered-repos-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/gittensor-registered-repos-after-tablet-light.png) |
| Tablet · Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/gittensor-registered-repos-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/gittensor-registered-repos-after-tablet-dark.png) |
| Desktop · Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/gittensor-registered-repos-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/gittensor-registered-repos-after-desktop-light.png) |
| Desktop · Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/gittensor-registered-repos-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/gittensor-registered-repos-after-desktop-dark.png) |

## Test plan

- [x] `tsc --noEmit` on `apps/ui` — clean
- [x] `eslint` on changed files — 0 errors (pre-existing `react-refresh/only-export-components` warnings in `subnets.$netuid.tsx` are unrelated to this change)
- [x] Verified live against `/api/v1/adapters/gittensor` in-browser: card renders 19 total, top 6 rows with correct emission shares, "View all 19" link
- [x] Verified `before` state genuinely lacks the card (screenshots above)
- [x] Verified other subnets (`netuid !== 74`) don't render the card