### PR TITLE
feat(graphql): add Query.subnet_yield mirroring REST /subnets/{netuid}/yield (#5713)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -29,6 +29,7 @@ import {
   SUBNET_AXON_REMOVALS_WINDOWS,
   DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
 } from "./subnet-axon-removals.mjs";
+import { buildSubnetYield } from "./subnet-yield.mjs";
 import {
   analyticsWindow,
   loadGlobalIncidentsLedger,
@@ -136,6 +137,8 @@ export const SDL = `
     subnet_serving(netuid: Int!, window: String): SubnetServing!
     "Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
     subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
+    "Per-subnet emission-per-stake yield over the current metagraph snapshot: each UID's yield plus the subnet-wide aggregate and p25/median/p75/p90 distribution; a subnet with no neurons resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/yield."
+    subnet_yield(netuid: Int!): SubnetYield!
     "Paginated provider/source registry."
     providers(limit: Int, cursor: String): ProviderList!
     "One provider with its subnets."
@@ -633,6 +636,35 @@ export const SDL = `
     distinct_removers: Int!
     removals: Int!
     removals_per_remover: Float
+  }
+
+  "One UID's emission-per-stake yield within a subnet's current metagraph snapshot."
+  type SubnetYieldNeuron {
+    uid: Int!
+    hotkey: String
+    role: String!
+    stake_tao: Float
+    emission_tao: Float
+    yield: Float
+  }
+
+  type SubnetYield {
+    schema_version: Int!
+    netuid: Int!
+    captured_at: String
+    block_number: Int
+    neuron_count: Int!
+    validator_count: Int!
+    miner_count: Int!
+    total_stake_tao: Float
+    total_emission_tao: Float
+    subnet_yield: Float
+    mean_yield: Float
+    median_yield: Float
+    p25_yield: Float
+    p75_yield: Float
+    p90_yield: Float
+    neurons: [SubnetYieldNeuron!]!
   }
 
   "Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope."
@@ -1134,6 +1166,7 @@ export const FIELD_COMPLEXITY = {
   subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_yield: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1799,6 +1832,43 @@ const rootValue = {
       distinct_removers: data.distinct_removers ?? 0,
       removals: data.removals ?? 0,
       removals_per_remover: data.removals_per_remover ?? null,
+    };
+  },
+
+  async subnet_yield({ netuid }, context) {
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetYield cold
+    // fallback contract handleSubnetYield uses: a subnet with no neurons is a
+    // schema-stable zeroed card, never a GraphQL error. No window param — the
+    // route reads the CURRENT metagraph snapshot.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/yield`,
+          new URLSearchParams(),
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildSubnetYield([], netuid);
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      captured_at: data.captured_at ?? null,
+      block_number: data.block_number ?? null,
+      neuron_count: data.neuron_count ?? 0,
+      validator_count: data.validator_count ?? 0,
+      miner_count: data.miner_count ?? 0,
+      total_stake_tao: data.total_stake_tao ?? null,
+      total_emission_tao: data.total_emission_tao ?? null,
+      subnet_yield: data.subnet_yield ?? null,
+      mean_yield: data.mean_yield ?? null,
+      median_yield: data.median_yield ?? null,
+      p25_yield: data.p25_yield ?? null,
+      p75_yield: data.p75_yield ?? null,
+      p90_yield: data.p90_yield ?? null,
+      // buildSubnetYield's neuron shape matches SubnetYieldNeuron field-for-field,
+      // so GraphQL resolves the nested selection off the raw rows directly.
+      neurons: data.neurons ?? [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3444,6 +3444,138 @@ describe("graphql — subnet_registrations (#5720, Postgres-tier + zeroed-card f
   });
 });
 
+describe("graphql — subnet_yield (#5713, Postgres-tier + zeroed-card fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_yield(netuid: 5) {
+          schema_version netuid captured_at block_number
+          neuron_count validator_count miner_count
+          subnet_yield mean_yield median_yield p25_yield p75_yield p90_yield
+          neurons { uid }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const y = body.data.subnet_yield;
+    assert.equal(y.schema_version, 1);
+    assert.equal(y.netuid, 5);
+    assert.equal(y.neuron_count, 0);
+    assert.equal(y.validator_count, 0);
+    assert.equal(y.miner_count, 0);
+    assert.equal(y.subnet_yield, null);
+    assert.deepEqual(y.neurons, []);
+  });
+
+  test("resolves the Postgres-tier card, including the per-UID neuron rows", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          captured_at: "2026-07-01T00:00:00.000Z",
+          block_number: 8621331,
+          neuron_count: 2,
+          validator_count: 1,
+          miner_count: 1,
+          total_stake_tao: 1500.5,
+          total_emission_tao: 12.25,
+          subnet_yield: 0.0081,
+          mean_yield: 0.009,
+          median_yield: 0.009,
+          p25_yield: 0.005,
+          p75_yield: 0.013,
+          p90_yield: 0.02,
+          neurons: [
+            {
+              uid: 0,
+              hotkey: "5Val",
+              role: "validator",
+              stake_tao: 1000.5,
+              emission_tao: 9.1,
+              yield: 0.0091,
+            },
+            {
+              uid: 1,
+              hotkey: "5Min",
+              role: "miner",
+              stake_tao: 500,
+              emission_tao: null,
+              yield: null,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_yield(netuid: 5) {
+          netuid captured_at block_number neuron_count validator_count miner_count
+          total_stake_tao total_emission_tao subnet_yield mean_yield median_yield
+          p25_yield p75_yield p90_yield
+          neurons { uid hotkey role stake_tao emission_tao yield }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const y = body.data.subnet_yield;
+    assert.equal(y.block_number, 8621331);
+    assert.equal(y.neuron_count, 2);
+    assert.equal(y.validator_count, 1);
+    assert.equal(y.subnet_yield, 0.0081);
+    assert.equal(y.neurons.length, 2);
+    assert.deepEqual(y.neurons[0], {
+      uid: 0,
+      hotkey: "5Val",
+      role: "validator",
+      stake_tao: 1000.5,
+      emission_tao: 9.1,
+      yield: 0.0091,
+    });
+    // A stakeless/blank-emission neuron keeps its nulls, not a coerced 0.
+    assert.equal(y.neurons[1].emission_tao, null);
+    assert.equal(y.neurons[1].yield, null);
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_yield(netuid: 9) {
+          schema_version netuid captured_at block_number
+          neuron_count validator_count miner_count
+          subnet_yield mean_yield median_yield p25_yield p75_yield p90_yield
+          neurons { uid }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_yield, {
+      schema_version: 1,
+      netuid: 9,
+      captured_at: null,
+      block_number: null,
+      neuron_count: 0,
+      validator_count: 0,
+      miner_count: 0,
+      subnet_yield: null,
+      mean_yield: null,
+      median_yield: null,
+      p25_yield: null,
+      p75_yield: null,
+      p90_yield: null,
+      neurons: [],
+    });
+  });
+});
+
 describe("graphql — subnet_deregistrations (#5719, Postgres-tier + zeroed-card fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary
`GET /api/v1/subnets/{netuid}/yield` (and MCP `get_subnet_yield`) had no GraphQL mirror. This adds `Query.subnet_yield`, following the exact pattern of the sibling `subnet_serving` / `subnet_axon_removals` fields.

## Change (`src/graphql.mjs`)
- **SDL**: a `subnet_yield(netuid: Int!): SubnetYield!` field (no `window` — the route reads the *current* metagraph snapshot, per `src/subnet-yield.mjs`'s `loadSubnetYield(d1, netuid)`), with the "Mirrors GET /api/v1/…" doc-comment convention. New `SubnetYield` type mirroring `buildSubnetYield`'s real response shape, plus a nested `SubnetYieldNeuron` type for the per-UID rows.
- **Resolver**: `tryPostgresTier(…, "METAGRAPH_NEURONS_SOURCE") ?? buildSubnetYield([], netuid)` — the same tier + zeroed-card fallback contract `handleSubnetYield` uses (reuses the existing pure builder, no duplicated `account_events`/snapshot logic). A subnet with no neurons resolves to a schema-stable zeroed card, never null / never a GraphQL error. `buildSubnetYield`'s neuron shape matches `SubnetYieldNeuron` field-for-field, so GraphQL resolves the nested selection off the raw rows.
- **`FIELD_COMPLEXITY`**: `subnet_yield: RELATIONSHIP_FIELD_COMPLEXITY` (same weight as its sibling subnet-detail fields).

## Tests (`tests/graphql.test.mjs`)
Mirrors the `subnet_registrations` suite: cold-store zeroed card, a Postgres-tier hit exercising the aggregate fields **and** the per-UID neuron rows (including a stakeless neuron that keeps its `null` emission/yield rather than a coerced 0), and a partial-Postgres-body case that exercises every resolver default.

## Verification
- `tests/graphql.test.mjs` — **229 pass** (3 new); the schema builds with the new SDL.
- Patch coverage on `src/graphql.mjs`: **100%** for the added lines/branches (the resolver's `??` defaults are all hit by the partial-body test; the file's remaining uncovered branches are pre-existing and unrelated).
- `eslint` + `prettier --check` — clean.

Closes #5713
