### PR TITLE
feat(api): add CSV export to GET /api/v1/subnets/{netuid}/uptime

### DIFF
--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -700,6 +700,93 @@ describe("handleUptime", () => {
     assert.equal(body.data.netuid, NETUID);
     assert.deepEqual(body.data.surfaces, []);
   });
+
+  test("returns CSV response when ?format=csv is present, flattening surfaces into one row per (surface, day)", async () => {
+    const env = d1Env({
+      "FROM surface_uptime_daily": [
+        {
+          surface_id: "sn-7-acme-subnet-api",
+          surface_key: "subnet-api",
+          day: "2026-06-01",
+          samples: 10,
+          ok_count: 9,
+          uptime_ratio: 0.9,
+          avg_latency_ms: 120,
+          latency_samples: 10,
+          p50: 100,
+          p95: 200,
+          p99: 250,
+          status: "degraded",
+        },
+      ],
+    });
+    const res = await handleUptime(
+      req("/"),
+      env,
+      NETUID,
+      url("/?window=1y&format=csv"),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+    assert.ok(
+      res.headers
+        .get("content-disposition")
+        .includes(`filename="subnet-${NETUID}-uptime.csv"`),
+    );
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(
+      lines[0],
+      "surface_id,day,samples,uptime_ratio,avg_latency_ms,latency_sample_count,p50,p95,p99,status",
+    );
+    assert.equal(
+      lines[1],
+      "sn-7-acme-subnet-api,2026-06-01,10,0.9,120,10,100,200,250,degraded",
+    );
+  });
+
+  test("returns CSV response when Accept: text/csv header is present", async () => {
+    const env = d1Env({
+      "FROM surface_uptime_daily": [
+        {
+          surface_id: "sn-7-acme-subnet-api",
+          surface_key: "subnet-api",
+          day: "2026-06-01",
+          samples: 10,
+          ok_count: 9,
+          avg_latency_ms: 120,
+          latency_samples: 10,
+          p50: 100,
+          p95: 200,
+          p99: 250,
+          status: "ok",
+        },
+      ],
+    });
+    const request = new Request("https://api.metagraph.sh/", {
+      headers: { accept: "text/csv" },
+    });
+    const res = await handleUptime(request, env, NETUID, url("/"));
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
+  });
+
+  test("returns a header-only CSV on cold D1, with no surfaces to flatten", async () => {
+    const res = await handleUptime(req("/"), {}, NETUID, url("/?format=csv"));
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(
+      lines[0],
+      "surface_id,day,samples,uptime_ratio,avg_latency_ms,latency_sample_count,p50,p95,p99,status",
+    );
+    assert.equal(lines.length, 1);
+  });
+
+  test("rejects an unsupported format value", async () => {
+    const res = await handleUptime(req("/"), {}, NETUID, url("/?format=pdf"));
+    const body = await errorJson(res);
+    assert.equal(res.status, 400);
+    assert.equal(body.meta.parameter, "format");
+  });
 });
 
 describe("handleLeaderboards", () => {
@@ -1075,6 +1162,35 @@ describe("canonicalUptimeCachePath", () => {
   test("falls back to raw search on an invalid min_samples value", () => {
     const raw = "/api/v1/subnets/7/uptime?min_samples=-1";
     assert.equal(canonicalUptimeCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on an unsupported format value", () => {
+    const raw = "/api/v1/subnets/7/uptime?format=pdf";
+    assert.equal(canonicalUptimeCachePath(url(raw)), raw);
+  });
+
+  test("?format=csv gets a distinct cache key from the JSON default", () => {
+    const json = canonicalUptimeCachePath(url("/api/v1/subnets/7/uptime"));
+    const csv = canonicalUptimeCachePath(
+      url("/api/v1/subnets/7/uptime?format=csv"),
+    );
+    assert.equal(json, "/api/v1/subnets/7/uptime?window=90d");
+    assert.equal(csv, "/api/v1/subnets/7/uptime?window=90d&format=csv");
+    assert.notEqual(json, csv);
+  });
+
+  test("an Accept: text/csv request gets the same cache key as ?format=csv", () => {
+    const request = new Request("https://api.metagraph.sh/", {
+      headers: { accept: "text/csv" },
+    });
+    const viaHeader = canonicalUptimeCachePath(
+      url("/api/v1/subnets/7/uptime"),
+      request,
+    );
+    const viaParam = canonicalUptimeCachePath(
+      url("/api/v1/subnets/7/uptime?format=csv"),
+    );
+    assert.equal(viaHeader, viaParam);
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1673,7 +1673,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         env,
         "uptime",
         () => handleUptime(request, env, Number(uptimeMatch[1]), resolved.url),
-        canonicalUptimeCachePath(resolved.url),
+        canonicalUptimeCachePath(resolved.url, request),
       );
     }
     const concentrationHistoryMatch =

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -80,6 +80,41 @@ const TRAJECTORY_CSV_COLUMNS = [
   "subnet_volume_tao",
 ];
 
+// formatUptime nests per-day rows under each surface (data.surfaces[].days[]),
+// since one subnet can have several probed surfaces. The CSV flattens that to
+// one row per (surface, day) pair, tagged with surface_id since a subnet's
+// rows would otherwise be indistinguishable across its surfaces, and unnests
+// latency_ms.{p50,p95,p99} into their own columns.
+const UPTIME_CSV_COLUMNS = [
+  "surface_id",
+  "day",
+  "samples",
+  "uptime_ratio",
+  "avg_latency_ms",
+  "latency_sample_count",
+  "p50",
+  "p95",
+  "p99",
+  "status",
+];
+
+function uptimeCsvRows(surfaces) {
+  return (Array.isArray(surfaces) ? surfaces : []).flatMap((surface) =>
+    (Array.isArray(surface?.days) ? surface.days : []).map((d) => ({
+      surface_id: surface.surface_id,
+      day: d.day,
+      samples: d.samples,
+      uptime_ratio: d.uptime_ratio,
+      avg_latency_ms: d.avg_latency_ms,
+      latency_sample_count: d.latency_sample_count,
+      p50: d.latency_ms?.p50 ?? null,
+      p95: d.latency_ms?.p95 ?? null,
+      p99: d.latency_ms?.p99 ?? null,
+      status: d.status,
+    })),
+  );
+}
+
 function validateFormatParam(url) {
   const raw = url.searchParams.get("format");
   if (raw === null && !url.searchParams.has("format")) return null;
@@ -106,6 +141,15 @@ function trajectoryCacheVariant(url, request, canonicalPath) {
     format === "csv" || (request != null && csvRequested(url, request));
   if (!wantsCsv) return canonicalPath;
   return `${canonicalPath}?format=csv`;
+}
+
+function uptimeCacheVariant(url, request, canonicalPath) {
+  const format = url.searchParams.get("format")?.toLowerCase();
+  const wantsCsv =
+    format === "csv" || (request != null && csvRequested(url, request));
+  if (!wantsCsv) return canonicalPath;
+  // canonicalUptimeCachePath always supplies ?window=…, so & is safe.
+  return `${canonicalPath}&format=csv`;
 }
 
 export function configureAnalyticsRoutes(deps) {
@@ -238,8 +282,14 @@ export async function handleEconomicsTrends(request, env, url) {
 
 // Long-term daily uptime history for one subnet's operational surfaces.
 export async function handleUptime(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, ["window", "min_samples"]);
+  const validationError = validateQueryParams(url, [
+    "window",
+    "min_samples",
+    "format",
+  ]);
   if (validationError) return analyticsQueryError(validationError);
+  const formatError = validateFormatParam(url);
+  if (formatError) return analyticsQueryError(formatError);
   const windowParam = url.searchParams.get("window") || "90d";
   if (!Object.hasOwn(UPTIME_WINDOWS, windowParam)) {
     return analyticsQueryError({
@@ -306,6 +356,16 @@ export async function handleUptime(request, env, netuid, url) {
     });
     isFallback = hasD1FallbackRows(rows);
   }
+  if (csvRequested(url, request)) {
+    const csvRes = csvResponse(
+      uptimeCsvRows(data.surfaces),
+      `subnet-${netuid}-uptime`,
+      "short",
+      request,
+      UPTIME_CSV_COLUMNS,
+    );
+    return isFallback ? markD1FallbackResponse(csvRes) : csvRes;
+  }
   const response = await envelopeResponse(
     request,
     {
@@ -324,9 +384,15 @@ export async function handleUptime(request, env, netuid, url) {
 // Normalises the uptime URL so that a bare ?-free request and an explicit
 // ?window=90d request both resolve to the same edge-cache entry — mirrors
 // canonicalSubnetConcentrationHistoryCachePath in entities.mjs.
-export function canonicalUptimeCachePath(url) {
-  const validationError = validateQueryParams(url, ["window", "min_samples"]);
+export function canonicalUptimeCachePath(url, request = null) {
+  const validationError = validateQueryParams(url, [
+    "window",
+    "min_samples",
+    "format",
+  ]);
   if (validationError) return `${url.pathname}${url.search}`;
+  const formatError = validateFormatParam(url);
+  if (formatError) return `${url.pathname}${url.search}`;
   const windowParam = url.searchParams.get("window") || "90d";
   if (!Object.hasOwn(UPTIME_WINDOWS, windowParam))
     return `${url.pathname}${url.search}`;
@@ -341,7 +407,11 @@ export function canonicalUptimeCachePath(url) {
   if (minSamples.error) return `${url.pathname}${url.search}`;
   const params = [`window=${encodeURIComponent(windowParam)}`];
   if (minSamples.value !== null) params.push(`min_samples=${minSamples.value}`);
-  return `${url.pathname}?${params.join("&")}`;
+  return uptimeCacheVariant(
+    url,
+    request,
+    `${url.pathname}?${params.join("&")}`,
+  );
 }
 
 // Normalises the economics-trends URL so that a bare ?-free request and an explicit


### PR DESCRIPTION
Closes #5743

## What

`handleUptime` was the outlier among its immediate siblings in `analytics-routes.mjs` — `handleTrajectory` and `handleEconomicsTrends` both validate `?format=csv` and export via `csvResponse`, but `handleUptime`'s allowlist (`["window", "min_samples"]`) had no `format` param and no CSV path.

## Fix

- Added `"format"` to `handleUptime`'s query-param allowlist and `validateFormatParam` validation, following `handleTrajectory`'s exact pattern.
- `formatUptime`'s response nests per-day rows under each probed surface (`data.surfaces[].days[]`), since one subnet can have multiple operational surfaces — this isn't a flat per-day series like `handleTrajectory`/`handleEconomicsTrends`. Added `uptimeCsvRows()` to flatten that into one row per `(surface, day)` pair, tagging each row with `surface_id` so rows stay distinguishable across a subnet's surfaces, and unnesting `latency_ms.{p50,p95,p99}` into their own columns.
- Added `UPTIME_CSV_COLUMNS`: `surface_id, day, samples, uptime_ratio, avg_latency_ms, latency_sample_count, p50, p95, p99, status`.
- A cold store (no surfaces) still emits the CSV header row with zero data rows.
- Added `uptimeCacheVariant`, mirroring `trajectoryCacheVariant`/`economicsTrendsCacheVariant`, so `?format=csv` gets a distinct edge-cache entry from the JSON default. Threaded `request` through `canonicalUptimeCachePath` (now `(url, request = null)`, backward-compatible with its other single-arg callers) and updated its one call site in `workers/api.mjs` to pass `request`.

## Testing

```
npx vitest run tests/request-handlers-analytics-routes.test.mjs
# 84 passed (77 pre-existing + 7 new: CSV export, Accept: text/csv, cold-store
# header-only CSV, invalid format rejection, plus 3 canonicalUptimeCachePath
# cache-key tests for the new format param)

npx vitest run tests/analytics-edge-cache.test.mjs tests/analytics.test.mjs tests/api-coverage.test.mjs \
  tests/badge.test.mjs tests/data-api.test.mjs tests/health-meta-kv-cache.test.mjs \
  tests/health-prober.test.mjs tests/health-serving.test.mjs tests/mcp-server.test.mjs \
  tests/request-handlers-analytics.test.mjs
# 2344 passed -- broader sweep of every other test file touching this shared
# handler file/route, zero regressions

npx eslint workers/request-handlers/analytics-routes.mjs workers/api.mjs tests/request-handlers-analytics-routes.test.mjs
# clean

npx prettier --check workers/request-handlers/analytics-routes.mjs workers/api.mjs tests/request-handlers-analytics-routes.test.mjs
# clean
```

Coverage scoped to the changed file confirms every new line is exercised; the one pre-existing uncovered branch nearby (`min_samples` error path) is untouched by this diff.