### PR TITLE
fix(r2-upload): bound wrangler r2 put calls with a hard timeout

### DIFF
--- a/scripts/r2-upload.mjs
+++ b/scripts/r2-upload.mjs
@@ -21,6 +21,8 @@ const uploadRetries =
 const uploadRetryBaseDelayMs =
   parsePositiveInteger(process.env.METAGRAPH_R2_UPLOAD_RETRY_BASE_DELAY_MS) ||
   1000;
+const uploadTimeoutMs =
+  parsePositiveInteger(process.env.METAGRAPH_R2_UPLOAD_TIMEOUT_MS) || 45_000;
 const manifest = await readJson(
   path.join(repoRoot, R2_STAGING_RELATIVE_ROOT, "r2-manifest.json"),
 );
@@ -52,6 +54,7 @@ if (!write) {
       upload_history: uploadHistory,
       upload_limit: uploadLimit,
       upload_retries: uploadRetries,
+      upload_timeout_ms: uploadTimeoutMs,
       planned_object_count: plannedObjectCount,
       remote_manifest_status: "not-checked",
     }),
@@ -181,6 +184,7 @@ console.log(
     upload_concurrency: uploadConcurrency,
     upload_limit: uploadLimit,
     upload_retries: uploadRetries,
+    upload_timeout_ms: uploadTimeoutMs,
     uploaded_control_count: uploadedControlCount,
     uploaded_history_count: uploadedHistoryCount,
     uploaded_latest_count: uploadedLatestCount,
@@ -370,6 +374,7 @@ function putObjectOnce({ localPath, key, bucketName, contentType }) {
     });
     let stdout = "";
     let stderr = "";
+    let settled = false;
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk) => {
@@ -378,8 +383,33 @@ function putObjectOnce({ localPath, key, bucketName, contentType }) {
     child.stderr.on("data", (chunk) => {
       stderr += chunk;
     });
-    child.on("error", reject);
+    // A single stalled wrangler call (network stall, hung TLS handshake, R2
+    // API wedge) previously had no ceiling and blocked this promise forever
+    // -- Promise.all in putObjects() then never resolves, wedging the whole
+    // publish job until GitHub Actions' job-level timeout-minutes kills it
+    // (up to 45m of stale production data). Force a bounded failure instead
+    // so the existing retry/backoff loop in putObject() can recover in
+    // seconds.
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      reject(
+        new Error(
+          `wrangler r2 object put timed out after ${uploadTimeoutMs}ms for ${key}`,
+        ),
+      );
+    }, uploadTimeoutMs);
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
     child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
       if (code === 0) {
         resolve();
         return;


### PR DESCRIPTION
## Summary

- `putObjectOnce()` in `scripts/r2-upload.mjs` spawned `wrangler r2 object put` with no timeout on the child process. A stalled call (network stall, hung TLS handshake, R2 API wedge) never resolved or rejected, so `Promise.all` in `putObjects()` hung forever — wedging the whole `publish-cloudflare.yml` `publish` job until GitHub Actions' 45-minute job-level `timeout-minutes` eventually killed it.
- Observed live: the "Upload artifact history to R2" step stalled 28+ minutes (run [29404683980](https://github.com/JSONbored/metagraphed/actions/runs/29404683980)) with two already-merged registry fixes (#5772, #5777) queued behind it in the `publish-cloudflare-refs/heads/main` concurrency group (`cancel-in-progress: false`), blocking them from reaching production. I cancelled the stuck run manually.
- Adds `METAGRAPH_R2_UPLOAD_TIMEOUT_MS` (default 45s) per `wrangler` invocation: on timeout the child is `SIGKILL`ed and the call rejects, letting the existing retry/backoff loop in `putObject()` recover in seconds instead of relying on the job-level timeout as the only backstop. Surfaced in both the dry-run and write-mode diagnostic JSON output alongside the other upload tunables.

## Test plan

- [x] `node --check scripts/r2-upload.mjs`
- [x] `eslint scripts/r2-upload.mjs` — clean
- [x] `npx vitest run tests/r2-upload.test.mjs` — passes (existing fake-wrangler fixture unaffected, since it exits immediately and never reaches the timeout ceiling)
- [x] `scripts/r2-upload.mjs` is not in `vitest.config.mjs`'s `coverage.include` list, so no codecov/patch impact