### PR TITLE
feat(graphql): add Query.subnet_weights mirroring REST /subnets/{netuid}/weights (#5711)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -30,6 +30,11 @@ import {
   DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
 } from "./subnet-axon-removals.mjs";
 import {
+  buildSubnetWeights,
+  SUBNET_WEIGHTS_WINDOWS,
+  DEFAULT_SUBNET_WEIGHTS_WINDOW,
+} from "./subnet-weights.mjs";
+import {
   analyticsWindow,
   loadGlobalIncidentsLedger,
 } from "../workers/request-handlers/analytics.mjs";
@@ -147,6 +152,8 @@ export const SDL = `
     subnet_serving(netuid: Int!, window: String): SubnetServing!
     "Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
     subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
+    "Per-subnet validator weight-setting activity over a 7d/30d window (distinct weight-setters, WeightsSet count, and sets per setter); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/weights."
+    subnet_weights(netuid: Int!, window: String): SubnetWeights!
     "Paginated provider/source registry."
     providers(limit: Int, cursor: String): ProviderList!
     "One provider with its subnets."
@@ -650,6 +657,16 @@ export const SDL = `
     distinct_removers: Int!
     removals: Int!
     removals_per_remover: Float
+  }
+
+  type SubnetWeights {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    distinct_setters: Int!
+    weight_sets: Int!
+    sets_per_setter: Float
   }
 
   "Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope."
@@ -1202,6 +1219,7 @@ export const FIELD_COMPLEXITY = {
   subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1868,6 +1886,43 @@ const rootValue = {
       distinct_removers: data.distinct_removers ?? 0,
       removals: data.removals ?? 0,
       removals_per_remover: data.removals_per_remover ?? null,
+    };
+  },
+
+  async subnet_weights({ netuid, window }, context) {
+    // Same 7d/30d window validation handleSubnetWeights uses -- an unsupported
+    // window is a GraphQL BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_SUBNET_WEIGHTS_WINDOW;
+    if (!Object.hasOwn(SUBNET_WEIGHTS_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, SUBNET_WEIGHTS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> buildSubnetWeights
+    // zeroed-card fallback contract handleSubnetWeights uses; a subnet with no
+    // WeightsSet events in the window is a schema-stable zeroed card, never a
+    // GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/weights`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildSubnetWeights(null, netuid, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      observed_at: data.observed_at ?? null,
+      distinct_setters: data.distinct_setters ?? 0,
+      weight_sets: data.weight_sets ?? 0,
+      sets_per_setter: data.sets_per_setter ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3444,6 +3444,94 @@ describe("graphql — subnet_registrations (#5720, Postgres-tier + zeroed-card f
   });
 });
 
+describe("graphql — subnet_weights (#5711, Postgres-tier + zeroed-card fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_weights(netuid: 5) {
+          schema_version netuid window observed_at
+          distinct_setters weight_sets sets_per_setter
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_weights, {
+      schema_version: 1,
+      netuid: 5,
+      window: "7d",
+      observed_at: null,
+      distinct_setters: 0,
+      weight_sets: 0,
+      sets_per_setter: null,
+    });
+  });
+
+  test("resolves the Postgres-tier card for the requested window", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          window: "30d",
+          observed_at: "2026-07-01T00:00:00.000Z",
+          distinct_setters: 4,
+          weight_sets: 10,
+          sets_per_setter: 2.5,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_weights(netuid: 5, window: "30d") {
+          netuid window observed_at distinct_setters weight_sets sets_per_setter
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const w = body.data.subnet_weights;
+    assert.equal(w.window, "30d");
+    assert.equal(w.observed_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(w.distinct_setters, 4);
+    assert.equal(w.weight_sets, 10);
+    assert.equal(w.sets_per_setter, 2.5);
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_weights(netuid: 9, window: "30d") {
+          schema_version netuid window observed_at distinct_setters weight_sets sets_per_setter
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_weights, {
+      schema_version: 1,
+      netuid: 9,
+      window: "30d",
+      observed_at: null,
+      distinct_setters: 0,
+      weight_sets: 0,
+      sets_per_setter: null,
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ subnet_weights(netuid: 5, window: "99d") { weight_sets } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_weights ?? null, null);
+  });
+});
+
 describe("graphql — subnet_deregistrations (#5719, Postgres-tier + zeroed-card fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary
`GET /api/v1/subnets/{netuid}/weights` (and MCP `get_subnet_weights`) had no GraphQL mirror. This adds `Query.subnet_weights`, following the exact pattern of the sibling windowed subnet-detail fields (`subnet_serving`, `subnet_registrations`, `subnet_axon_removals`).

## Change (`src/graphql.mjs`)
- **SDL**: a `subnet_weights(netuid: Int!, window: String): SubnetWeights!` field with the "Mirrors GET /api/v1/…" doc-comment, plus a `SubnetWeights` type mirroring `buildSubnetWeights`'s real shape (`distinct_setters`, `weight_sets`, `sets_per_setter`).
- **Resolver**: same 7d/30d window validation (unsupported window → `BAD_USER_INPUT`) and `tryPostgresTier(…, "METAGRAPH_ACCOUNT_EVENTS_SOURCE") ?? buildSubnetWeights(null, netuid, { window })` zeroed-card fallback contract `handleSubnetWeights` uses — reuses the existing pure builder, no duplicated `account_events` logic. A subnet with no `WeightsSet` events resolves to a schema-stable zeroed card, never null / never a GraphQL error.
- **`FIELD_COMPLEXITY`**: `subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY`.

## Tests (`tests/graphql.test.mjs`)
Mirrors the `subnet_registrations` suite: cold-store zeroed card, a Postgres-tier hit for the requested window, a partial-Postgres-body case exercising every resolver default, and an unsupported-window GraphQL error.

## Verification
- `tests/graphql.test.mjs` — **245 pass** (4 new); schema builds.
- Patch coverage on `src/graphql.mjs`: **100%** for the added lines/branches (the file's remaining uncovered branches are pre-existing, in unrelated resolvers).
- `eslint` + `prettier --check` — clean.

Closes #5711
