### PR TITLE
feat(data-refresh): nightly Parquet bulk-dump to R2 (#2538)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "packages/ui-kit"
       ],
       "dependencies": {
+        "@duckdb/node-api": "^1.5.4-r.1",
         "@noble/hashes": "^2.2.0",
         "graphql": "^17.0.2",
         "graphql-ws": "^6.1.0",
@@ -993,6 +994,138 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@duckdb/node-api": {
+      "version": "1.5.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.4-r.1.tgz",
+      "integrity": "sha512-3PYk/4//svuYmb9RYVM71cCoNa6ngoYWwrMhJaqbm010txzIMWbJCbxrFeqDl+krdIug+Hc/MNCeS0gHsTXSIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@duckdb/node-bindings": "1.5.4-r.1"
+      }
+    },
+    "node_modules/@duckdb/node-bindings": {
+      "version": "1.5.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.4-r.1.tgz",
+      "integrity": "sha512-v834OZZKQ59yAvh8GOEmM+R1foPNgdMGL0VTBgHywgblgQNyq11HvWgT4QGJIUFfo/cQ9WFyf1MFhK0+hV1aiA==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "optionalDependencies": {
+        "@duckdb/node-bindings-darwin-arm64": "1.5.4-r.1",
+        "@duckdb/node-bindings-darwin-x64": "1.5.4-r.1",
+        "@duckdb/node-bindings-linux-arm64": "1.5.4-r.1",
+        "@duckdb/node-bindings-linux-arm64-musl": "1.5.4-r.1",
+        "@duckdb/node-bindings-linux-x64": "1.5.4-r.1",
+        "@duckdb/node-bindings-linux-x64-musl": "1.5.4-r.1",
+        "@duckdb/node-bindings-win32-arm64": "1.5.4-r.1",
+        "@duckdb/node-bindings-win32-x64": "1.5.4-r.1"
+      }
+    },
+    "node_modules/@duckdb/node-bindings-darwin-arm64": {
+      "version": "1.5.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.4-r.1.tgz",
+      "integrity": "sha512-fl8EC5xdmI7VAI7bX4W6D7lOGNtxyLvSxGjOY8Ov7viVEKwIcBXXKlMPgh3sw+PiVlwZhKlknuCI8BL5xXpSDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-darwin-x64": {
+      "version": "1.5.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.4-r.1.tgz",
+      "integrity": "sha512-E8bECZ6abJqunPqVR1NA0Zho7qxanfDWWFuJrKMsU1NCUqyGLyhXqZwsRHAx7J6jrM+lhQ7wOZj1x/N4OVml3A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-arm64": {
+      "version": "1.5.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.4-r.1.tgz",
+      "integrity": "sha512-4EsB+cgRqOE++mdPQ2ZoGJCg4ylmuqdbLDtmo3L19B+C5OzGmrhxlKD4o75eGEtfO52M+w+TdL0qhy0H5XvaKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-arm64-musl": {
+      "version": "1.5.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64-musl/-/node-bindings-linux-arm64-musl-1.5.4-r.1.tgz",
+      "integrity": "sha512-96Pyk5Syy18S5DSN0CKkOQ7/CsyVGRML8ewox1qpFDjYvPH1VsULlQoIRwbpw7mkFEy17wuWmbwzb7oKu/nGMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-x64": {
+      "version": "1.5.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.4-r.1.tgz",
+      "integrity": "sha512-IldapRydno5kf4VkPCe8yK+j4pCg+j6Qs46UmLnKex/mtIdJa7ifhMYRkvdc5KIAFEC0eEL5c830QeuwcUROyg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-x64-musl": {
+      "version": "1.5.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64-musl/-/node-bindings-linux-x64-musl-1.5.4-r.1.tgz",
+      "integrity": "sha512-tWgnttlKfWTktyv+m9YbxaedKBon5wmUoJ9DaIbE3D98KhhUaqmJhnjzso9O8hp6WUeRmwXR//hpT/X6Ft9nYA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-arm64": {
+      "version": "1.5.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.4-r.1.tgz",
+      "integrity": "sha512-77apmuNo51bPZzv8xjdeCp+hlU6JLwMPtS1CMViy83ONTsah+CGnpBx1lCnEqPL5Va0meufZyjSdZCVCijLdDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-x64": {
+      "version": "1.5.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.4-r.1.tgz",
+      "integrity": "sha512-Wme7dScBGqjn2PUJ+RLFiFAblW1qQRBraX7SJc4uKtftZiUJJWZapEUh+doGfb68Qxvw8JhlMBSdaUsSUDJYsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "endpoint:brief": "node scripts/endpoint-ops-brief.mjs"
   },
   "dependencies": {
+    "@duckdb/node-api": "^1.5.4-r.1",
     "@noble/hashes": "^2.2.0",
     "graphql": "^17.0.2",
     "graphql-ws": "^6.1.0",

--- a/scripts/data-refresh-node-entrypoint.sh
+++ b/scripts/data-refresh-node-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Runs one step of the box-side Node-only data-refresh jobs (registry-sync,
-# registry-sync-fast, testnet-discovery) -- see
+# registry-sync-fast, testnet-discovery, export-parquet) -- see
 # deploy/data-refresh-node.Dockerfile's header. Unlike deploy/economics-
 # refresh.Dockerfile's two-container split, none of these need a separate
 # untrusted-fetch step: all are pure JS with no PyPI/uvx involved, so npm
@@ -8,7 +8,7 @@
 # supply-chain guard needed, in ONE container.
 set -euo pipefail
 
-: "${STEP:?STEP env var required (registry-sync|registry-sync-fast|testnet-discovery)}"
+: "${STEP:?STEP env var required (registry-sync|registry-sync-fast|testnet-discovery|export-parquet)}"
 
 REPO_DIR=/repo
 GIT_REPO_URL="https://github.com/JSONbored/metagraphed.git"
@@ -150,8 +150,20 @@ case "$STEP" in
       fi
     fi
     ;;
+  export-parquet)
+    : "${REGISTRY_PG_DB:?REGISTRY_PG_DB env var required for the export-parquet step}"
+    : "${REGISTRY_PG_USER:?REGISTRY_PG_USER env var required for the export-parquet step}"
+    : "${REGISTRY_PG_PASSWORD:?REGISTRY_PG_PASSWORD env var required for the export-parquet step}"
+    : "${INDEXER_PG_DB:?INDEXER_PG_DB env var required for the export-parquet step}"
+    : "${INDEXER_PG_USER:?INDEXER_PG_USER env var required for the export-parquet step}"
+    : "${INDEXER_PG_PASSWORD:?INDEXER_PG_PASSWORD env var required for the export-parquet step}"
+    : "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN env var required for the export-parquet step}"
+    : "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID env var required for the export-parquet step}"
+    echo "entrypoint: nightly Parquet bulk export to R2"
+    exec node scripts/export-parquet.mjs
+    ;;
   *)
-    echo "entrypoint: unknown STEP '$STEP' (want registry-sync|registry-sync-fast|testnet-discovery)" >&2
+    echo "entrypoint: unknown STEP '$STEP' (want registry-sync|registry-sync-fast|testnet-discovery|export-parquet)" >&2
     exit 1
     ;;
 esac

--- a/scripts/export-parquet.mjs
+++ b/scripts/export-parquet.mjs
@@ -1,0 +1,218 @@
+// Nightly bulk export of core registry + chain tables to Parquet, uploaded
+// to R2 under a dated prefix + a `latest/` alias, with a discovery manifest
+// (#2538, successor to #2115's "exporter" half — see that issue's closing
+// comment for why this replaced a "Railway cron" plan with a box-side job).
+//
+// Runs on the box that hosts BOTH source Postgres databases (registry and
+// indexer) locally -- see scripts/data-refresh-node-entrypoint.sh's
+// export-parquet STEP, which runs this with --network host so
+// 127.0.0.1:5432/5433 are reachable. DuckDB's postgres extension reads each
+// table directly; nothing is loaded into this process's own memory beyond
+// what DuckDB's COPY needs.
+//
+// R2 upload goes through `wrangler r2 object put --remote`, the same
+// mechanism scripts/r2-upload.mjs already uses (CLOUDFLARE_API_TOKEN +
+// CLOUDFLARE_ACCOUNT_ID env vars) -- there is no S3-compatible credential
+// anywhere in this codebase, and this doesn't introduce one.
+//
+// Retention: dated runs (metagraph/bulk/parquet/{date}/) are NOT pruned by
+// this script -- `wrangler r2 object` has no list/delete-by-prefix command
+// (confirmed: only get/put/delete-by-exact-key), so automated pruning would
+// need direct calls to Cloudflare's R2 REST API rather than the wrangler CLI
+// this job otherwise relies on. Deliberately deferred rather than rushed: a
+// delete-capable path against a public bucket deserves its own careful pass,
+// not a bolt-on here. `metagraph/bulk/parquet/latest/` (overwritten every
+// run) is the primary, bounded-size discovery point for downloaders in the
+// meantime; dated history accumulates until a follow-up adds pruning.
+//
+// Usage: node scripts/export-parquet.mjs [--dry-run]
+import { DuckDBInstance } from "@duckdb/node-api";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { sha256Hex, stableStringify } from "./lib.mjs";
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run");
+
+const BUCKET = "metagraphed-artifacts";
+const RUN_PREFIX_ROOT = "metagraph/bulk/parquet";
+const SCHEMA_VERSION = 1;
+
+// (table, source database) pairs -- matches #2538's explicit scope (subnets,
+// economics, endpoints, neurons/metagraph, blocks, extrinsics, chain-events
+// daily rollups). Deliberately the DAILY ROLLUP tables, not the raw
+// high-volume hypertables (account_events is 40M+ rows, chain_events 17M+ --
+// a full nightly dump of those would be a fundamentally different,
+// incremental-export design, not what this issue scoped).
+const EXPORTS = [
+  { table: "subnets", db: "registry" },
+  { table: "providers", db: "registry" },
+  { table: "surfaces", db: "registry" },
+  { table: "subnet_snapshots", db: "indexer" },
+  { table: "neurons", db: "indexer" },
+  { table: "neuron_daily", db: "indexer" },
+  { table: "blocks", db: "indexer" },
+  { table: "extrinsics", db: "indexer" },
+  { table: "account_events_daily", db: "indexer" },
+];
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} env var required`);
+  return value;
+}
+
+// DuckDB's postgres extension ATTACH takes a single libpq connection string
+// (not named sub-options, and ATTACH doesn't support $-parameter binding the
+// way a SELECT/INSERT literal would) -- built here, in-process, and only
+// ever passed to connection.run() directly, never through a subprocess/shell.
+// Minimal libpq escaping (backslash, single-quote) for robustness; this
+// project's generated passwords are alphanumeric-only in practice, but the
+// escaping costs nothing.
+function libpqConnString({ host, port, dbname, user, password }) {
+  const esc = (value) => String(value).replace(/([\\'])/g, "\\$1");
+  return `host=${esc(host)} port=${esc(port)} dbname=${esc(dbname)} user=${esc(user)} password=${esc(password)}`;
+}
+
+// DuckDB's own ATTACH failure errors embed the full connection string --
+// password included -- verbatim (confirmed live: a connection-refused error
+// during local testing printed the plaintext password to stderr). Never let
+// that reach a log/journal: attach with a scrubbed error on failure instead
+// of letting DuckDB's own message propagate.
+async function attachPostgres(connection, alias, conn) {
+  try {
+    await connection.run(
+      `ATTACH '${libpqConnString(conn)}' AS ${alias} (TYPE postgres, READ_ONLY)`,
+    );
+  } catch {
+    throw new Error(
+      `failed to attach ${alias} Postgres at ${conn.host}:${conn.port}/${conn.dbname} (credentials redacted)`,
+    );
+  }
+}
+
+async function main() {
+  const registryConn = {
+    host: process.env.REGISTRY_PG_HOST || "127.0.0.1",
+    port: Number(process.env.REGISTRY_PG_PORT || 5433),
+    dbname: requireEnv("REGISTRY_PG_DB"),
+    user: requireEnv("REGISTRY_PG_USER"),
+    password: requireEnv("REGISTRY_PG_PASSWORD"),
+  };
+  const indexerConn = {
+    host: process.env.INDEXER_PG_HOST || "127.0.0.1",
+    port: Number(process.env.INDEXER_PG_PORT || 5432),
+    dbname: requireEnv("INDEXER_PG_DB"),
+    user: requireEnv("INDEXER_PG_USER"),
+    password: requireEnv("INDEXER_PG_PASSWORD"),
+  };
+
+  const instance = await DuckDBInstance.create(":memory:");
+  const connection = await instance.connect();
+  await connection.run("INSTALL postgres; LOAD postgres;");
+
+  await attachPostgres(connection, "registry", registryConn);
+  await attachPostgres(connection, "indexer", indexerConn);
+
+  const workDir = await mkdtemp(path.join(tmpdir(), "export-parquet-"));
+  const generatedAt = new Date().toISOString();
+  const date = generatedAt.slice(0, 10);
+  const runPrefix = `${RUN_PREFIX_ROOT}/${date}/`;
+  const latestPrefix = `${RUN_PREFIX_ROOT}/latest/`;
+
+  const artifacts = [];
+  try {
+    for (const { table, db } of EXPORTS) {
+      const localPath = path.join(workDir, `${table}.parquet`);
+      // ZSTD: DuckDB's default is snappy; zstd trades a little CPU for
+      // meaningfully smaller files, which matters more than write speed for
+      // a once-nightly, R2-egress-conscious export.
+      await connection.run(
+        `COPY (SELECT * FROM ${db}.${table}) TO '${localPath}' (FORMAT PARQUET, COMPRESSION ZSTD)`,
+      );
+      const buffer = await readFile(localPath);
+      const { size } = await stat(localPath);
+      artifacts.push({
+        table,
+        source_db: db,
+        path: `${table}.parquet`,
+        key: `${runPrefix}${table}.parquet`,
+        latest_key: `${latestPrefix}${table}.parquet`,
+        sha256: sha256Hex(buffer),
+        size_bytes: size,
+        row_count: await rowCount(connection, db, table),
+      });
+    }
+
+    const manifest = {
+      schema_version: SCHEMA_VERSION,
+      generated_at: generatedAt,
+      bucket_name: BUCKET,
+      run_prefix: runPrefix,
+      latest_prefix: latestPrefix,
+      artifact_count: artifacts.length,
+      artifact_size_bytes: artifacts.reduce((sum, a) => sum + a.size_bytes, 0),
+      artifacts,
+    };
+    const manifestPath = path.join(workDir, "bulk-manifest.json");
+    await writeManifest(manifestPath, manifest);
+
+    if (dryRun) {
+      console.log(stableStringify({ dry_run: true, ...summarize(manifest) }));
+      return;
+    }
+
+    for (const artifact of artifacts) {
+      const localPath = path.join(workDir, artifact.path);
+      uploadToR2(localPath, `${BUCKET}/${artifact.key}`);
+      uploadToR2(localPath, `${BUCKET}/${artifact.latest_key}`);
+    }
+    uploadToR2(manifestPath, `${BUCKET}/${runPrefix}bulk-manifest.json`);
+    uploadToR2(manifestPath, `${BUCKET}/${latestPrefix}bulk-manifest.json`);
+
+    console.log(stableStringify(summarize(manifest)));
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+}
+
+async function rowCount(connection, db, table) {
+  const reader = await connection.runAndReadAll(
+    `SELECT count(*) AS n FROM ${db}.${table}`,
+  );
+  return Number(reader.getRows()[0][0]);
+}
+
+async function writeManifest(manifestPath, manifest) {
+  const { writeFile } = await import("node:fs/promises");
+  await writeFile(manifestPath, `${stableStringify(manifest)}\n`);
+}
+
+function uploadToR2(localPath, remoteKey) {
+  execFileSync(
+    "npx",
+    [
+      "wrangler",
+      "r2",
+      "object",
+      "put",
+      remoteKey,
+      `--file=${localPath}`,
+      "--remote",
+    ],
+    { stdio: "inherit" },
+  );
+}
+
+function summarize(manifest) {
+  return {
+    generated_at: manifest.generated_at,
+    run_prefix: manifest.run_prefix,
+    artifact_count: manifest.artifact_count,
+    artifact_size_bytes: manifest.artifact_size_bytes,
+  };
+}
+
+await main();


### PR DESCRIPTION
## Summary
- Adds an `export-parquet` STEP to the box-side `data-refresh-node` entrypoint: reads core registry + chain tables directly from the box's own co-located Postgres databases via DuckDB's postgres extension, writes ZSTD-compressed Parquet, uploads to R2 under a dated prefix + a `latest/` alias, with a discovery manifest (`bulk-manifest.json`) matching `scripts/r2-manifest.mjs`'s shape.
- Successor to #2115's "exporter" half (closed, split into this + #5776's reconciler): that issue scoped a Railway cron per ADR 0013, but Railway's Postgres/Redis/indexer no longer exist (#2956). This targets the self-hosted box instead, reusing the existing `data-refresh-node` Docker image/role rather than a new one -- the only per-job addition is `--network host` (the box hosts both source databases locally, so no Hyperdrive/Worker hop is needed for reads).
- R2 upload reuses the existing `wrangler r2 object put --remote` mechanism (`CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID`, matching `scripts/r2-upload.mjs`) -- confirmed no S3-compatible credential exists anywhere in this codebase, and this doesn't introduce one.
- Table scope is deliberately the daily-rollup tables (`subnets`, `providers`, `surfaces`, `subnet_snapshots`, `neurons`, `neuron_daily`, `blocks`, `extrinsics`, `account_events_daily`) per #2538's explicit list -- not the raw high-volume hypertables (`account_events` 40M+ rows, `chain_events` 17M+ rows), which would need a fundamentally different incremental-export design.
- A real bug found during testing: DuckDB's own `ATTACH` failure error embeds the full libpq connection string (password included) verbatim. Fixed with a scrubbing wrapper so a connection failure in production never leaks a plaintext password into the systemd journal.

## Deliberately deferred
Public discovery (making `metagraph/bulk/parquet/*` reachable at `api.metagraph.sh`) is a follow-up, not bundled here: the Worker only serves contract-declared R2 paths (`src/artifact-storage.mjs`'s `R2_ONLY_PATTERNS`), so wiring this up needs a schema/contract change + `openapi.json` regen -- better scoped once there's real data in R2 to point at, not spliced into the data-production job itself.

Retention/pruning of old dated runs is also deferred and documented in the script's header: `wrangler r2 object` has no list/delete-by-prefix command, so automated pruning would need direct Cloudflare R2 REST API calls rather than the wrangler CLI this job otherwise relies on -- a delete-capable path against a public bucket deserves its own careful pass. `metagraph/bulk/parquet/latest/` (overwritten every run) is the bounded-size primary access point in the meantime.

## Test plan
- [x] `npx eslint`, `npx prettier --check`, `shellcheck`, `node scripts/scan-public-safety.mjs`, `npm run validate` all pass
- [x] `@duckdb/node-api` vetted: MIT license, official DuckDB repo, 0 `npm audit` vulnerabilities in isolation
- [x] Verified ATTACH + COPY + Parquet readback against the box's real Postgres via SSH tunnel (small table) and directly on the box (large table, `--network host`, zero network hop): `extrinsics` (3.16M rows) ~67s, `account_events_daily` (115K rows) ~133ms -- comfortably within the existing 900s `TimeoutStartSec`
- [x] Confirmed R2 write access works with a real test object (uploaded + deleted)
- [ ] Live verification once the box-side Ansible role picks up the new job (follow-up in the private infra repo, needs a newly-provisioned R2-scoped Cloudflare API token)