### PR TITLE
fix(ui): add the missing ShareButton + ApiSourceFooter to the subnet and provider detail pages

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -27,6 +27,7 @@ import {
   DotRow,
   NoDataSpark,
   Sparkline,
+  ShareButton,
 } from "@jsonbored/ui-kit";
 import {
   subnetEndpointsQuery,
@@ -395,56 +396,58 @@ export function SubnetMasthead({
               {description}
             </p>
           ) : null}
-          {links.length > 0 ? (
-            <div className="mt-3 flex flex-wrap items-center gap-1.5">
-              {links.map((l) => {
-                const Icon = l.icon;
-                const safeHref = safeExternalUrl(l.href);
-                const className =
-                  "group inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong transition-colors " +
-                  (safeHref
-                    ? "hover:border-accent/50 hover:text-accent"
-                    : "cursor-default opacity-70");
-                const content = (
-                  <>
-                    <Icon
-                      className={
-                        "size-3 text-ink-muted " + (safeHref ? "group-hover:text-accent" : "")
-                      }
-                    />
-                    <span>{l.label}</span>
-                    {safeHref ? (
-                      <ExternalLinkIcon className="size-2.5 text-ink-muted opacity-60" />
-                    ) : null}
-                  </>
-                );
+          {/* Links + actions row. Renders even with no external links so the
+              share affordance every other entity-detail hero has is present
+              here too (#5481). */}
+          <div className="mt-3 flex flex-wrap items-center gap-1.5">
+            {links.map((l) => {
+              const Icon = l.icon;
+              const safeHref = safeExternalUrl(l.href);
+              const className =
+                "group inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong transition-colors " +
+                (safeHref
+                  ? "hover:border-accent/50 hover:text-accent"
+                  : "cursor-default opacity-70");
+              const content = (
+                <>
+                  <Icon
+                    className={
+                      "size-3 text-ink-muted " + (safeHref ? "group-hover:text-accent" : "")
+                    }
+                  />
+                  <span>{l.label}</span>
+                  {safeHref ? (
+                    <ExternalLinkIcon className="size-2.5 text-ink-muted opacity-60" />
+                  ) : null}
+                </>
+              );
 
-                return (
-                  <Tooltip key={l.label} delayDuration={150}>
-                    <TooltipTrigger asChild>
-                      {safeHref ? (
-                        <a
-                          href={safeHref}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className={className}
-                        >
-                          {content}
-                        </a>
-                      ) : (
-                        <span className={className} title="Blocked unsafe external URL">
-                          {content}
-                        </span>
-                      )}
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="font-mono text-[11px]">
-                      {safeHref ? host(safeHref) : "Blocked unsafe external URL"}
-                    </TooltipContent>
-                  </Tooltip>
-                );
-              })}
-            </div>
-          ) : null}
+              return (
+                <Tooltip key={l.label} delayDuration={150}>
+                  <TooltipTrigger asChild>
+                    {safeHref ? (
+                      <a
+                        href={safeHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={className}
+                      >
+                        {content}
+                      </a>
+                    ) : (
+                      <span className={className} title="Blocked unsafe external URL">
+                        {content}
+                      </span>
+                    )}
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="font-mono text-[11px]">
+                    {safeHref ? host(safeHref) : "Blocked unsafe external URL"}
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+            <ShareButton />
+          </div>
         </div>
         {/* Desktop/tablet: health + curation beside the identity block. Mobile
             counterpart lives in the status row above so the body column stays wide. */}

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -10,12 +10,14 @@ import {
   RECOVERY,
 } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import {
   EntityHero,
   BrandIcon,
   PrimaryLinksRail,
   CopyableCode,
   SectionAnchor,
+  ShareButton,
 } from "@jsonbored/ui-kit";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { EndpointsGlance } from "@/components/metagraphed/endpoints-glance";
@@ -130,6 +132,7 @@ function ProviderShell({ slug }: { slug: string }) {
         title={p?.name ?? slug}
         subtitle={shouldShowProviderSlugSubtitle(p?.name, slug) ? <>· {slug}</> : null}
         description={p?.notes}
+        actions={<ShareButton />}
         links={<PrimaryLinksRail website={p?.website ?? p?.homepage} docs={p?.docs} />}
         stats={[
           { label: "Endpoints", value: formatNumber(summary?.endpoint_count) },
@@ -171,6 +174,10 @@ function ProviderShell({ slug }: { slug: string }) {
           {summary?.by_layer ? <BreakdownCard title="By layer" data={summary.by_layer} /> : null}
         </aside>
       </div>
+
+      <ApiSourceFooter
+        paths={[`/api/v1/providers/${slug}`, `/api/v1/providers/${slug}/endpoints`]}
+      />
     </>
   );
 }

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -105,6 +105,7 @@ import type {
 import { IncidentTimeline } from "@/components/metagraphed/incident-timeline";
 import { TimeRangeProvider } from "@/components/metagraphed/analytics/time-range-context";
 import { SubnetMasthead } from "@/components/metagraphed/subnet-masthead";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { OperationalPanel } from "@/components/metagraphed/operational-panel";
 import { ResourceExplorer } from "@/components/metagraphed/resource-explorer";
 import { GittensorRegisteredRepos } from "@/components/metagraphed/gittensor-registered-repos";
@@ -336,6 +337,17 @@ function ProfileShell({ netuid }: { netuid: number }) {
           ) : null}
           {tab === "api" ? <ApiPanel netuid={netuid} /> : null}
         </div>
+
+        <ApiSourceFooter
+          paths={[
+            `/api/v1/subnets/${netuid}/profile`,
+            `/api/v1/subnets/${netuid}/overview`,
+            `/api/v1/subnets/${netuid}/surfaces`,
+            `/api/v1/subnets/${netuid}/endpoints`,
+            `/api/v1/subnets/${netuid}/health`,
+            `/api/v1/subnets/${netuid}/gaps`,
+          ]}
+        />
       </SubnetFilterProvider>
     </TimeRangeProvider>
   );


### PR DESCRIPTION
## Summary

Closes #5481

Every other entity-detail route ships two pieces of standard page furniture — a **ShareButton** (copy-current-URL) in the hero and an **ApiSourceFooter** (data provenance) at the foot. `accounts.$ss58`, `blocks.$ref`, `extrinsics.$hash` and `validators.$hotkey` all have both. The two remaining detail pages had **neither**.

- **`providers.$slug`** — `EntityHero` already supports `actions`; the call just never passed it. Now passes `actions={<ShareButton />}`, plus an `ApiSourceFooter` citing the paths the route actually reads (`/api/v1/providers/{slug}`, `/api/v1/providers/{slug}/endpoints` — from `providerQuery` / `providerEndpointsQuery`).
- **`subnets.$netuid`** — uses `SubnetMasthead` rather than a shared hero, so the `ShareButton` drops into the masthead's existing links/actions row. **That row now renders even when a subnet has no external links**, so the affordance is never conditional on unrelated data. Plus an `ApiSourceFooter` citing the profile/overview/surfaces/endpoints/health/gaps paths the page reads.

No hero-layout redesign — scoped to the two concrete missing pieces, as the issue asks.

3 files, +71/-49 (the masthead's diff is mostly re-indentation from un-nesting that links row).

## Verified on both pages, not just eyeballed

```
PASS: providers/$slug renders ShareButton (1) + ApiSourceFooter paths (4)
PASS: subnets/$netuid renders ShareButton (1) + ApiSourceFooter paths (12)
```

Worth noting for anyone writing similar checks: `ShareButton` sets `aria-label="Copy link with current filters, sort, and page"`, which overrides its visible "Share view" text as the accessible name — my first assertion matched `/share/i` and failed against working code until I matched the real label.

## Gates

typecheck OK · eslint `.` OK (0 errors) · prettier OK · rebased onto latest `main`

## Screenshots

Playwright, 375x812 / 768x1024 / 1280x800 x light/dark, fixed-viewport, real data, on `/providers/404-gen`. The Share view button appears under the hero links; the API footer lands at the page foot.

| Viewport - Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/5481/after-mobile-dark.png)<br><sub>after</sub> |
