### PR TITLE
feat(api): add CSV export to subnet performance/history and hyperparameters/history

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -2102,7 +2102,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download each entry's flattened hyperparameter snapshot as CSV. */
         get: operations["subnetHyperparametersHistory"];
         put?: never;
         post?: never;
@@ -2238,7 +2238,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. */
+        /** Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV. */
         get: operations["subnetPerformanceHistory"];
         put?: never;
         post?: never;
@@ -24772,6 +24772,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -24781,7 +24783,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -24835,6 +24837,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetHyperparamsHistoryArtifact"];
                     };
+                    /**
+                     * @example block_number,observed_at,hyperparams_hash,kappa_ratio,immunity_period,min_allowed_weights,max_weight_limit_ratio,tempo,weights_version,weights_rate_limit,activity_cutoff,activity_cutoff_factor,registration_allowed,target_regs_per_interval,min_burn_tao,max_burn_tao,burn_half_life,burn_increase_mult,bonds_moving_avg_raw,max_regs_per_block,serving_rate_limit,max_validators,commit_reveal_period,commit_reveal_enabled,alpha_high_ratio,alpha_low_ratio,liquid_alpha_enabled,alpha_sigmoid_steepness,yuma_version,subnet_is_active,transfers_enabled,bonds_reset_enabled,user_liquidity_enabled,owner_cut_enabled,owner_cut_auto_lock_enabled,min_childkey_take_ratio
+                     *     8454388,2026-06-27T00:00:00.000Z,a1b2c3d4e5f6,0.18,4096,1,1,99,0,0,5000,0,true,1,0.001,0.01,0,1.5,0,1,50,64,0,false,0.3,0.1,false,,1,true,true,false,false,false,false,0.1
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -25943,6 +25950,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -25952,7 +25961,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -26003,6 +26012,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetPerformanceHistoryArtifact"];
                     };
+                    /**
+                     * @example snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median
+                     *     2026-06-27,2,1,2,0.490099,1,0.990099,0.409091,1,0.909091,0.82,0.82,0.75,0.75,0.9,0.9
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5012,7 +5012,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/performance/history.json",
       "cache": "short",
-      "description": "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history.",
+      "description": "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV.",
       "id": "subnet-performance-history",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/performance/history",
@@ -5027,6 +5027,17 @@
               "7d",
               "30d",
               "90d"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
             ],
             "type": "string"
           }
@@ -5721,7 +5732,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/hyperparameters/history.json",
       "cache": "short",
-      "description": "Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+      "description": "Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download each entry's flattened hyperparameter snapshot as CSV.",
       "id": "subnet-hyperparameters-history",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/hyperparameters/history",
@@ -5747,6 +5758,17 @@
         {
           "name": "cursor",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
             "type": "string"
           }
         }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -46959,6 +46959,19 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -47020,9 +47033,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,observed_at,hyperparams_hash,kappa_ratio,immunity_period,min_allowed_weights,max_weight_limit_ratio,tempo,weights_version,weights_rate_limit,activity_cutoff,activity_cutoff_factor,registration_allowed,target_regs_per_interval,min_burn_tao,max_burn_tao,burn_half_life,burn_increase_mult,bonds_moving_avg_raw,max_regs_per_block,serving_rate_limit,max_validators,commit_reveal_period,commit_reveal_enabled,alpha_high_ratio,alpha_low_ratio,liquid_alpha_enabled,alpha_sigmoid_steepness,yuma_version,subnet_is_active,transfers_enabled,bonds_reset_enabled,user_liquidity_enabled,owner_cut_enabled,owner_cut_auto_lock_enabled,min_childkey_take_ratio\r\n8454388,2026-06-27T00:00:00.000Z,a1b2c3d4e5f6,0.18,4096,1,1,99,0,0,5000,0,true,1,0.001,0.01,0,1.5,0,1,50,64,0,false,0.3,0.1,false,,1,true,true,false,false,false,false,0.1",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -47079,7 +47098,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+        "summary": "Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download each entry's flattened hyperparameter snapshot as CSV.",
         "tags": [
           "subnets",
           "analytics"
@@ -48450,6 +48469,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -48508,9 +48540,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median\r\n2026-06-27,2,1,2,0.490099,1,0.990099,0.409091,1,0.909091,0.82,0.82,0.75,0.75,0.9,0.9",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -48567,7 +48605,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history.",
+        "summary": "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV.",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2102,7 +2102,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download each entry's flattened hyperparameter snapshot as CSV. */
         get: operations["subnetHyperparametersHistory"];
         put?: never;
         post?: never;
@@ -2238,7 +2238,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. */
+        /** Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV. */
         get: operations["subnetPerformanceHistory"];
         put?: never;
         post?: never;
@@ -24772,6 +24772,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -24781,7 +24783,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -24835,6 +24837,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetHyperparamsHistoryArtifact"];
                     };
+                    /**
+                     * @example block_number,observed_at,hyperparams_hash,kappa_ratio,immunity_period,min_allowed_weights,max_weight_limit_ratio,tempo,weights_version,weights_rate_limit,activity_cutoff,activity_cutoff_factor,registration_allowed,target_regs_per_interval,min_burn_tao,max_burn_tao,burn_half_life,burn_increase_mult,bonds_moving_avg_raw,max_regs_per_block,serving_rate_limit,max_validators,commit_reveal_period,commit_reveal_enabled,alpha_high_ratio,alpha_low_ratio,liquid_alpha_enabled,alpha_sigmoid_steepness,yuma_version,subnet_is_active,transfers_enabled,bonds_reset_enabled,user_liquidity_enabled,owner_cut_enabled,owner_cut_auto_lock_enabled,min_childkey_take_ratio
+                     *     8454388,2026-06-27T00:00:00.000Z,a1b2c3d4e5f6,0.18,4096,1,1,99,0,0,5000,0,true,1,0.001,0.01,0,1.5,0,1,50,64,0,false,0.3,0.1,false,,1,true,true,false,false,false,false,0.1
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -25943,6 +25950,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -25952,7 +25961,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -26003,6 +26012,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetPerformanceHistoryArtifact"];
                     };
+                    /**
+                     * @example snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median
+                     *     2026-06-27,2,1,2,0.490099,1,0.990099,0.409091,1,0.909091,0.82,0.82,0.75,0.75,0.9,0.9
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2155,15 +2155,15 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/performance/history",
     "/metagraph/subnets/{netuid}/performance/history.json",
-    "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history.",
+    "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV.",
     "short",
     ["subnets", "analytics"],
-    [
+    csvRouteQuery([
       {
         name: "window",
         schema: { type: "string", enum: ["7d", "30d", "90d"] },
       },
-    ],
+    ]),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(
@@ -2545,14 +2545,14 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/hyperparameters/history",
     "/metagraph/subnets/{netuid}/hyperparameters/history.json",
-    "Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+    "Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download each entry's flattened hyperparameter snapshot as CSV.",
     "short",
     ["subnets", "analytics"],
-    [
+    csvRouteQuery([
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "cursor", schema: { type: "string" } },
-    ],
+    ]),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/src/csv-route-examples.mjs
+++ b/src/csv-route-examples.mjs
@@ -21,6 +21,18 @@ export const ROUTE_CSV_EXAMPLES = {
     "snapshot_date,neuron_count,validator_count,yield_count,subnet_yield,mean_yield,median_yield,p25_yield,p75_yield,p90_yield",
     "2026-06-27,2,1,2,0.075,0.075,0.075,0.05,0.1,0.1",
   ].join("\r\n"),
+  "subnet-performance-history": [
+    "snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median",
+    "2026-06-27,2,1,2,0.490099,1,0.990099,0.409091,1,0.909091,0.82,0.82,0.75,0.75,0.9,0.9",
+  ].join("\r\n"),
+  // Each row is one full hyperparameter snapshot at one block (the entire
+  // formatSubnetHyperparams shape flattened alongside the entry's own
+  // block_number/observed_at/hyperparams_hash) -- see hyperparamsHistoryCsvRows
+  // in workers/request-handlers/entities.mjs.
+  "subnet-hyperparameters-history": [
+    "block_number,observed_at,hyperparams_hash,kappa_ratio,immunity_period,min_allowed_weights,max_weight_limit_ratio,tempo,weights_version,weights_rate_limit,activity_cutoff,activity_cutoff_factor,registration_allowed,target_regs_per_interval,min_burn_tao,max_burn_tao,burn_half_life,burn_increase_mult,bonds_moving_avg_raw,max_regs_per_block,serving_rate_limit,max_validators,commit_reveal_period,commit_reveal_enabled,alpha_high_ratio,alpha_low_ratio,liquid_alpha_enabled,alpha_sigmoid_steepness,yuma_version,subnet_is_active,transfers_enabled,bonds_reset_enabled,user_liquidity_enabled,owner_cut_enabled,owner_cut_auto_lock_enabled,min_childkey_take_ratio",
+    "8454388,2026-06-27T00:00:00.000Z,a1b2c3d4e5f6,0.18,4096,1,1,99,0,0,5000,0,true,1,0.001,0.01,0,1.5,0,1,50,64,0,false,0.3,0.1,false,,1,true,true,false,false,false,false,0.1",
+  ].join("\r\n"),
   "subnet-events": EVENTS_CSV_EXAMPLE,
   "account-events": EVENTS_CSV_EXAMPLE,
   // The Postgres all-events feed: flat scalar columns of each raw pallet.method

--- a/tests/subnet-performance-hyperparams-history-csv.test.mjs
+++ b/tests/subnet-performance-hyperparams-history-csv.test.mjs
@@ -1,0 +1,352 @@
+// CSV export tests for GET /api/v1/subnets/{netuid}/performance/history and
+// GET /api/v1/subnets/{netuid}/hyperparameters/history — kept in a dedicated
+// file so this PR does not contend with open entity-handler PRs on the shared
+// request-handlers-entities.test.mjs harness (mirrors
+// subnet-yield-history-csv.test.mjs / subnet-concentration-history-csv.test.mjs).
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
+import {
+  canonicalSubnetPerformanceHistoryCachePath,
+  handleSubnetHyperparamsHistory,
+  handleSubnetPerformanceHistory,
+} from "../workers/request-handlers/entities.mjs";
+
+const NETUID = 7;
+
+function req(path) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+function url(path) {
+  return new URL(`https://api.metagraph.sh${path}`);
+}
+
+async function errorJson(res) {
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.ok, false);
+  return body;
+}
+
+const PERFORMANCE_HISTORY_CSV_HEADER =
+  "snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median";
+
+const HYPERPARAMS_HISTORY_CSV_HEADER =
+  "block_number,observed_at,hyperparams_hash,kappa_ratio,immunity_period,min_allowed_weights,max_weight_limit_ratio,tempo,weights_version,weights_rate_limit,activity_cutoff,activity_cutoff_factor,registration_allowed,target_regs_per_interval,min_burn_tao,max_burn_tao,burn_half_life,burn_increase_mult,bonds_moving_avg_raw,max_regs_per_block,serving_rate_limit,max_validators,commit_reveal_period,commit_reveal_enabled,alpha_high_ratio,alpha_low_ratio,liquid_alpha_enabled,alpha_sigmoid_steepness,yuma_version,subnet_is_active,transfers_enabled,bonds_reset_enabled,user_liquidity_enabled,owner_cut_enabled,owner_cut_auto_lock_enabled,min_childkey_take_ratio";
+
+describe("subnet performance/hyperparameters history OpenAPI CSV contract", () => {
+  test("documents the CSV header on the performance/history route", async () => {
+    const openapi = buildOpenApiArtifact(
+      "1970-01-01T00:00:00.000Z",
+      await loadOpenApiComponentSchemas(),
+    );
+    const csvContent =
+      openapi.paths["/api/v1/subnets/{netuid}/performance/history"].get
+        .responses["200"].content["text/csv"];
+    assert.equal(csvContent.schema.type, "string");
+    assert.equal(
+      csvContent.example.split("\r\n")[0],
+      PERFORMANCE_HISTORY_CSV_HEADER,
+    );
+  });
+
+  test("documents the CSV header on the hyperparameters/history route", async () => {
+    const openapi = buildOpenApiArtifact(
+      "1970-01-01T00:00:00.000Z",
+      await loadOpenApiComponentSchemas(),
+    );
+    const csvContent =
+      openapi.paths["/api/v1/subnets/{netuid}/hyperparameters/history"].get
+        .responses["200"].content["text/csv"];
+    assert.equal(csvContent.schema.type, "string");
+    assert.equal(
+      csvContent.example.split("\r\n")[0],
+      HYPERPARAMS_HISTORY_CSV_HEADER,
+    );
+  });
+});
+
+describe("handleSubnetPerformanceHistory CSV export", () => {
+  test("returns header-only CSV when D1 is cold", async () => {
+    const res = await handleSubnetPerformanceHistory(
+      req(`/api/v1/subnets/${NETUID}/performance/history`),
+      {},
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/performance/history?window=30d&format=csv`,
+      ),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(lines[0], PERFORMANCE_HISTORY_CSV_HEADER);
+    assert.equal(lines.length, 1);
+  });
+
+  test("sorts and exports real points ascending by snapshot_date via the Postgres tier", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            netuid: NETUID,
+            window: "30d",
+            points: [
+              {
+                snapshot_date: "2026-06-21",
+                neuron_count: 5,
+                validator_count: 2,
+                active_count: 5,
+                incentive_gini: 0.4,
+                incentive_nakamoto_coefficient: 2,
+                incentive_top_10pct_share: 0.5,
+                dividends_gini: 0.3,
+                dividends_nakamoto_coefficient: 1,
+                dividends_top_10pct_share: 1,
+                trust_mean: 0.8,
+                trust_median: 0.8,
+                consensus_mean: 0.7,
+                consensus_median: 0.7,
+                validator_trust_mean: 0.9,
+                validator_trust_median: 0.9,
+              },
+              {
+                snapshot_date: "2026-06-20",
+                neuron_count: 4,
+                validator_count: 2,
+                active_count: 4,
+                incentive_gini: 0.35,
+                incentive_nakamoto_coefficient: 2,
+                incentive_top_10pct_share: 0.45,
+                dividends_gini: 0.25,
+                dividends_nakamoto_coefficient: 1,
+                dividends_top_10pct_share: 1,
+                trust_mean: 0.75,
+                trust_median: 0.75,
+                consensus_mean: 0.65,
+                consensus_median: 0.65,
+                validator_trust_mean: 0.85,
+                validator_trust_median: 0.85,
+              },
+            ],
+          }),
+      },
+    };
+    const res = await handleSubnetPerformanceHistory(
+      req(`/api/v1/subnets/${NETUID}/performance/history`),
+      env,
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/performance/history?window=30d&format=csv`,
+      ),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines.length, 3);
+    // CSV export re-sorts newest-first `points` into ascending snapshot_date.
+    assert.match(lines[1], /^2026-06-20,/);
+    assert.match(lines[2], /^2026-06-21,/);
+  });
+
+  test("rejects an unsupported format value", async () => {
+    const res = await handleSubnetPerformanceHistory(
+      req(`/api/v1/subnets/${NETUID}/performance/history`),
+      {},
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/performance/history?window=30d&format=pdf`,
+      ),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("rejects an empty format parameter", async () => {
+    const res = await handleSubnetPerformanceHistory(
+      req(`/api/v1/subnets/${NETUID}/performance/history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/performance/history?format=`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+});
+
+describe("canonicalSubnetPerformanceHistoryCachePath", () => {
+  test("default window stays canonical for JSON", () => {
+    assert.equal(
+      canonicalSubnetPerformanceHistoryCachePath(
+        url(`/api/v1/subnets/${NETUID}/performance/history`),
+      ),
+      `/api/v1/subnets/${NETUID}/performance/history?window=30d`,
+    );
+  });
+
+  test("explicit CSV and JSON format overrides produce distinct cache variants", () => {
+    const csv = canonicalSubnetPerformanceHistoryCachePath(
+      url(`/api/v1/subnets/${NETUID}/performance/history?window=7d&format=csv`),
+    );
+    assert.equal(
+      csv,
+      `/api/v1/subnets/${NETUID}/performance/history?window=7d&format=csv`,
+    );
+
+    const csvAccept = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/performance/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    const json = canonicalSubnetPerformanceHistoryCachePath(
+      url(
+        `/api/v1/subnets/${NETUID}/performance/history?window=7d&format=json`,
+      ),
+      csvAccept,
+    );
+    assert.equal(
+      json,
+      `/api/v1/subnets/${NETUID}/performance/history?window=7d`,
+    );
+  });
+
+  test("adds format=csv when only Accept: text/csv is present", () => {
+    const csvAccept = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/performance/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    assert.equal(
+      canonicalSubnetPerformanceHistoryCachePath(
+        url(`/api/v1/subnets/${NETUID}/performance/history?window=90d`),
+        csvAccept,
+      ),
+      `/api/v1/subnets/${NETUID}/performance/history?window=90d&format=csv`,
+    );
+  });
+
+  test("falls back to raw search on unknown query param", () => {
+    const raw = `/api/v1/subnets/${NETUID}/performance/history?bogus=1`;
+    assert.equal(canonicalSubnetPerformanceHistoryCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid format", () => {
+    const raw = `/api/v1/subnets/${NETUID}/performance/history?format=pdf`;
+    assert.equal(canonicalSubnetPerformanceHistoryCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid window", () => {
+    const raw = `/api/v1/subnets/${NETUID}/performance/history?window=1y`;
+    assert.equal(canonicalSubnetPerformanceHistoryCachePath(url(raw)), raw);
+  });
+});
+
+const HYPERPARAMS_ROW = {
+  block_number: 8454388,
+  observed_at: "2026-06-27T00:00:00.000Z",
+  hyperparams_hash: "a1b2c3d4e5f6",
+  hyperparameters: {
+    kappa_ratio: 0.18,
+    immunity_period: 4096,
+    min_allowed_weights: 1,
+    max_weight_limit_ratio: 1,
+    tempo: 99,
+    weights_version: 0,
+    weights_rate_limit: 0,
+    activity_cutoff: 5000,
+    activity_cutoff_factor: 0,
+    registration_allowed: true,
+    target_regs_per_interval: 1,
+    min_burn_tao: 0.001,
+    max_burn_tao: 0.01,
+    burn_half_life: 0,
+    burn_increase_mult: 1.5,
+    bonds_moving_avg_raw: 0,
+    max_regs_per_block: 1,
+    serving_rate_limit: 50,
+    max_validators: 64,
+    commit_reveal_period: 0,
+    commit_reveal_enabled: false,
+    alpha_high_ratio: 0.3,
+    alpha_low_ratio: 0.1,
+    liquid_alpha_enabled: false,
+    alpha_sigmoid_steepness: null,
+    yuma_version: 1,
+    subnet_is_active: true,
+    transfers_enabled: true,
+    bonds_reset_enabled: false,
+    user_liquidity_enabled: false,
+    owner_cut_enabled: false,
+    owner_cut_auto_lock_enabled: false,
+    min_childkey_take_ratio: 0.1,
+  },
+};
+
+describe("handleSubnetHyperparamsHistory CSV export", () => {
+  test("returns header-only CSV when Postgres is unconfigured", async () => {
+    const res = await handleSubnetHyperparamsHistory(
+      req(`/api/v1/subnets/${NETUID}/hyperparameters/history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/hyperparameters/history?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(lines[0], HYPERPARAMS_HISTORY_CSV_HEADER);
+    assert.equal(lines.length, 1);
+  });
+
+  test("flattens each entry's nested hyperparameters into one CSV row via the Postgres tier", async () => {
+    const env = {
+      METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            netuid: NETUID,
+            entry_count: 1,
+            limit: 25,
+            offset: 0,
+            next_cursor: null,
+            entries: [HYPERPARAMS_ROW],
+          }),
+      },
+    };
+    const res = await handleSubnetHyperparamsHistory(
+      req(`/api/v1/subnets/${NETUID}/hyperparameters/history`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/hyperparameters/history?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines.length, 2);
+    assert.equal(lines[0], HYPERPARAMS_HISTORY_CSV_HEADER);
+    assert.equal(
+      lines[1],
+      "8454388,2026-06-27T00:00:00.000Z,a1b2c3d4e5f6,0.18,4096,1,1,99,0,0,5000,0,true,1,0.001,0.01,0,1.5,0,1,50,64,0,false,0.3,0.1,false,,1,true,true,false,false,false,false,0.1",
+    );
+  });
+
+  test("rejects an unsupported format value", async () => {
+    const res = await handleSubnetHyperparamsHistory(
+      req(`/api/v1/subnets/${NETUID}/hyperparameters/history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/hyperparameters/history?format=pdf`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("rejects an empty format parameter", async () => {
+    const res = await handleSubnetHyperparamsHistory(
+      req(`/api/v1/subnets/${NETUID}/hyperparameters/history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/hyperparameters/history?format=`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1713,7 +1713,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
             Number(performanceHistoryMatch[1]),
             resolved.url,
           ),
-        canonicalSubnetPerformanceHistoryCachePath(resolved.url),
+        canonicalSubnetPerformanceHistoryCachePath(resolved.url, request),
       );
     }
     const yieldHistoryMatch = SUBNET_YIELD_HISTORY_PATH_PATTERN.exec(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -403,6 +403,77 @@ const SUBNET_YIELD_HISTORY_CSV_COLUMNS = [
   "p75_yield",
   "p90_yield",
 ];
+// Mirrors performanceHistoryPoint's flat field order (src/subnet-performance.mjs).
+const SUBNET_PERFORMANCE_HISTORY_CSV_COLUMNS = [
+  "snapshot_date",
+  "neuron_count",
+  "validator_count",
+  "active_count",
+  "incentive_gini",
+  "incentive_nakamoto_coefficient",
+  "incentive_top_10pct_share",
+  "dividends_gini",
+  "dividends_nakamoto_coefficient",
+  "dividends_top_10pct_share",
+  "trust_mean",
+  "trust_median",
+  "consensus_mean",
+  "consensus_median",
+  "validator_trust_mean",
+  "validator_trust_median",
+];
+// Each entry's `hyperparameters` (formatSubnetHyperparams' 33-field shape,
+// src/subnet-hyperparams.mjs) is flattened alongside the entry's own
+// block_number/observed_at/hyperparams_hash, so a CSV row is one full
+// hyperparameter snapshot at one block -- the entire point of a hyperparameter
+// change-history export.
+const SUBNET_HYPERPARAMS_HISTORY_CSV_COLUMNS = [
+  "block_number",
+  "observed_at",
+  "hyperparams_hash",
+  "kappa_ratio",
+  "immunity_period",
+  "min_allowed_weights",
+  "max_weight_limit_ratio",
+  "tempo",
+  "weights_version",
+  "weights_rate_limit",
+  "activity_cutoff",
+  "activity_cutoff_factor",
+  "registration_allowed",
+  "target_regs_per_interval",
+  "min_burn_tao",
+  "max_burn_tao",
+  "burn_half_life",
+  "burn_increase_mult",
+  "bonds_moving_avg_raw",
+  "max_regs_per_block",
+  "serving_rate_limit",
+  "max_validators",
+  "commit_reveal_period",
+  "commit_reveal_enabled",
+  "alpha_high_ratio",
+  "alpha_low_ratio",
+  "liquid_alpha_enabled",
+  "alpha_sigmoid_steepness",
+  "yuma_version",
+  "subnet_is_active",
+  "transfers_enabled",
+  "bonds_reset_enabled",
+  "user_liquidity_enabled",
+  "owner_cut_enabled",
+  "owner_cut_auto_lock_enabled",
+  "min_childkey_take_ratio",
+];
+
+function hyperparamsHistoryCsvRows(entries) {
+  return (Array.isArray(entries) ? entries : []).map((entry) => ({
+    block_number: entry.block_number,
+    observed_at: entry.observed_at,
+    hyperparams_hash: entry.hyperparams_hash,
+    ...(entry.hyperparameters || {}),
+  }));
+}
 const ACCOUNT_EXTRINSICS_CSV_COLUMNS = [
   "extrinsic_id",
   "block_number",
@@ -673,8 +744,11 @@ export async function handleSubnetHyperparamsHistory(
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
+  const formatError = validateResponseFormat(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { limit, offset } = parsePagination(url, FEED_PAGINATION);
   const data =
     (await tryPostgresTier(
@@ -687,6 +761,15 @@ export async function handleSubnetHyperparamsHistory(
       offset,
       nextCursor: null,
     });
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      hyperparamsHistoryCsvRows(data.entries),
+      `subnet-${netuid}-hyperparams-history`,
+      "short",
+      request,
+      SUBNET_HYPERPARAMS_HISTORY_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {
@@ -1362,8 +1445,23 @@ export function canonicalSubnetConcentrationHistoryCachePath(
   );
 }
 
-export function canonicalSubnetPerformanceHistoryCachePath(url) {
-  return canonicalWindowedCachePath(url, parseSubnetPerformanceHistoryWindow);
+export function canonicalSubnetPerformanceHistoryCachePath(
+  url,
+  request = null,
+) {
+  const validationError = validateQueryParams(url, ["window", "format"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const formatError = validateResponseFormat(url);
+  if (formatError) return `${url.pathname}${url.search}`;
+  const { label, error } = parseSubnetPerformanceHistoryWindow(
+    url.searchParams.get("window"),
+  );
+  if (error) return `${url.pathname}${url.search}`;
+  return csvCacheVariant(
+    url,
+    request,
+    `${url.pathname}?window=${encodeURIComponent(label)}`,
+  );
 }
 
 export function canonicalSubnetYieldHistoryCachePath(url, request = null) {
@@ -1636,8 +1734,10 @@ export async function handleSubnetPerformanceHistory(
   netuid,
   url,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "format"]);
   if (validationError) return analyticsQueryError(validationError);
+  const formatError = validateResponseFormat(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { label, error } = parseSubnetPerformanceHistoryWindow(
     url.searchParams.get("window"),
   );
@@ -1650,6 +1750,18 @@ export async function handleSubnetPerformanceHistory(
       window: label,
       capped: false,
     });
+  if (csvRequested(url, request)) {
+    const points = [...data.points].sort((a, b) =>
+      String(a.snapshot_date).localeCompare(String(b.snapshot_date)),
+    );
+    return csvResponse(
+      points,
+      `subnet-${netuid}-performance-history`,
+      "short",
+      request,
+      SUBNET_PERFORMANCE_HISTORY_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
Closes #5740

## What

Two "history" routes in `workers/request-handlers/entities.mjs` never got the repo's well-established `?format=csv` convention, even though their closest neighbors did:

- `handleSubnetPerformanceHistory` — the reward-flow twin of `handleSubnetConcentrationHistory` (which already supports CSV), same per-day `points[]` shape, but its allowlist omitted `"format"` entirely.
- `handleSubnetHyperparamsHistory` — a paginated append-only change-timeline with no `format` param or CSV path at all.

## Fix

- **`handleSubnetPerformanceHistory`**: added `"format"` to the allowlist + `validateResponseFormat` check, and a `csvRequested` branch exporting `data.points` re-sorted ascending by `snapshot_date` (matching `handleSubnetConcentrationHistory`/`handleSubnetYieldHistory`'s own re-sort convention). New `SUBNET_PERFORMANCE_HISTORY_CSV_COLUMNS` mirrors `performanceHistoryPoint`'s flat field order exactly (`src/subnet-performance.mjs`).
- **`handleSubnetHyperparamsHistory`**: same `format` validation, plus a `hyperparamsHistoryCsvRows()` helper. Each entry's `hyperparameters` is a *nested* object (the 33-field `formatSubnetHyperparams` shape) rather than flat fields, so the helper flattens it alongside the entry's own `block_number`/`observed_at`/`hyperparams_hash` — one CSV row is one full hyperparameter snapshot at one block. New `SUBNET_HYPERPARAMS_HISTORY_CSV_COLUMNS` covers all 36 resulting columns.
- Cold/absent stores still emit the CSV header row with zero data rows for both routes.
- **Cache keys**: replaced `canonicalSubnetPerformanceHistoryCachePath`'s generic `canonicalWindowedCachePath` call with a dedicated implementation (mirroring `canonicalSubnetYieldHistoryCachePath`) that threads `request` through the shared `csvCacheVariant` helper, so `?format=csv` gets a distinct edge-cache entry from JSON. Updated its one `workers/api.mjs` call site to pass `request`. `handleSubnetHyperparamsHistory` has no edge-cache wrapper at all (dispatched directly, "same cost class as `handleSubnetIdentityHistory`"), so no cache-path change was needed there.
- **OpenAPI contract**: wrapped both routes' query parameters in `csvRouteQuery(...)`, updated their descriptions to mention `?format=csv`, and added CSV examples for both to `src/csv-route-examples.mjs` (a dedicated module specifically so parallel CSV PRs don't contend on `contracts.mjs`'s example if-chain). Ran `npm run build` and committed the regenerated `openapi.json`/`api-index.json`/`types.d.ts`/`index.d.ts`.

## Testing

New dedicated test file (`tests/subnet-performance-hyperparams-history-csv.test.mjs`, mirroring the existing `subnet-yield-history-csv.test.mjs`/`subnet-concentration-history-csv.test.mjs` pattern — kept separate from the shared `request-handlers-entities.test.mjs` harness specifically so this PR doesn't contend with other open entity-handler PRs):

```
npx vitest run tests/subnet-performance-hyperparams-history-csv.test.mjs tests/request-handlers-entities.test.mjs \
  tests/contracts.test.mjs tests/invariants-contracts.test.mjs
# 369 passed (16 new + 353 pre-existing, zero regressions)

npx eslint workers/request-handlers/entities.mjs workers/api.mjs src/contracts.mjs src/csv-route-examples.mjs \
  tests/subnet-performance-hyperparams-history-csv.test.mjs
# clean

npx prettier --check <same files>
# clean

npm run validate
# Validated 129 native subnet(s), 129 curated overlay(s), 1614 surface(s), 133 provider(s), and 2037 candidate(s).
```

New tests cover: the OpenAPI CSV contract (header + example) for both routes, a successful CSV export for each (ascending re-sort for performance/history; flattened hyperparameter snapshot per row for hyperparameters/history), the cold/unconfigured header-only case, invalid/empty `format` rejection, and `canonicalSubnetPerformanceHistoryCachePath`'s new CSV-variant cache-key behavior. Coverage confirmed scoped to every changed line across all three touched source files (`entities.mjs`, `contracts.mjs`, `csv-route-examples.mjs`) — zero uncovered lines in the diff.