### PR TITLE
feat(registry): detect stale curation.gap_notes that contradict surfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "test:ci": "vitest run --coverage --fileParallelism --testTimeout=30000 --exclude '**/artifacts.test.mjs' --exclude '**/discovery-artifacts.test.mjs' --exclude '**/public-safety.test.mjs'",
     "test:ci:artifacts": "vitest run tests/artifacts.test.mjs tests/discovery-artifacts.test.mjs tests/public-safety.test.mjs",
     "curation:brief": "node scripts/curation-brief.mjs",
+    "curation:stale-notes": "node scripts/stale-gap-notes.mjs",
     "endpoint:brief": "node scripts/endpoint-ops-brief.mjs"
   },
   "dependencies": {

--- a/scripts/stale-gap-notes.mjs
+++ b/scripts/stale-gap-notes.mjs
@@ -1,0 +1,142 @@
+// Advisory (report-only) check: does a subnet's curation.gap_notes still claim a
+// surface kind is missing when surfaces[] already carries a first-party surface
+// of that kind? Community-submitted-surface PRs add a surface but have no reason
+// to also touch the unrelated curation.gap_notes array, so notes drift stale.
+//
+// This never fails the process — it is a hygiene report for a human to act on
+// (edit or drop the note), not a registry validity check. `npm run
+// validate:surface` stays the pass/fail gate for surface data; this is a
+// separate advisory script so a stale note never blocks a contributor PR.
+//
+//   npm run curation:stale-notes
+//   npm run curation:stale-notes -- --json
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { listJsonFiles, loadProviders, readJson, repoRoot } from "./lib.mjs";
+
+// Keyword → surface kind, checked in this order against a gap_notes entry that
+// already matches the "No verified ... yet" shape. Order only matters where a
+// note could plausibly contain more than one keyword; the observed corpus
+// (issue #5738) has no such overlap, but "openapi" is checked ahead of the
+// generic "docs" match since some notes read "... OpenAPI/Swagger surface".
+const KIND_KEYWORDS = [
+  { kind: "sse", pattern: /\bsse\b|event stream/i },
+  { kind: "openapi", pattern: /openapi|swagger/i },
+  { kind: "subnet-api", pattern: /subnet api/i },
+  { kind: "data-artifact", pattern: /data artifact/i },
+  { kind: "source-repo", pattern: /source repository/i },
+  { kind: "docs", pattern: /docs (url|site)|documentation/i },
+  { kind: "dashboard", pattern: /dashboard/i },
+  { kind: "website", pattern: /website/i },
+];
+
+// A gap_notes entry only describes a still-missing surface when it reads "No
+// verified <thing> yet" — other note shapes (404 observations, identity
+// disputes, auth-boundary explanations) are not "not yet found" claims and are
+// left alone.
+export function classifyGapNote(note) {
+  if (typeof note !== "string" || !note.startsWith("No verified")) {
+    return null;
+  }
+  if (!/\byet\b/i.test(note)) {
+    return null;
+  }
+  for (const { kind, pattern } of KIND_KEYWORDS) {
+    if (pattern.test(note)) return kind;
+  }
+  return null;
+}
+
+// A surface only contradicts a gap note if it is the subnet's OWN first-party
+// surface. A third-party aggregator's wrapper around a subnet's data (e.g.
+// TaoMarketCap's generic per-subnet API) is not the same claim as "the subnet
+// publishes its own API" — see registry/subnets/oneoneone.json (#5738).
+export function isFirstPartySurface(surface, providersById) {
+  const provider = providersById.get(surface.provider);
+  return provider?.kind === "subnet-team";
+}
+
+// Returns the stale gap_notes entries for a single subnet document, or [] if
+// none of its notes are contradicted by its own surfaces[].
+export function findStaleGapNotes(document, providersById) {
+  const notes = document.curation?.gap_notes || [];
+  const surfaces = document.surfaces || [];
+  const stale = [];
+  for (const note of notes) {
+    const kind = classifyGapNote(note);
+    if (!kind) continue;
+    const contradicting = surfaces.find(
+      (surface) =>
+        surface.kind === kind && isFirstPartySurface(surface, providersById),
+    );
+    if (contradicting) {
+      stale.push({ note, kind, surface_id: contradicting.id });
+    }
+  }
+  return stale;
+}
+
+export async function collectStaleGapNotes() {
+  const providersById = new Map(
+    (await loadProviders()).map((provider) => [provider.id, provider]),
+  );
+  const files = await listJsonFiles(path.join(repoRoot, "registry/subnets"));
+  const subnets = [];
+  for (const file of files) {
+    const document = await readJson(file);
+    const stale = findStaleGapNotes(document, providersById);
+    if (stale.length > 0) {
+      subnets.push({
+        slug: document.slug,
+        netuid: document.netuid,
+        name: document.name,
+        file: path.basename(file),
+        stale_notes: stale,
+      });
+    }
+  }
+  const staleNoteCount = subnets.reduce(
+    (sum, subnet) => sum + subnet.stale_notes.length,
+    0,
+  );
+  return {
+    subnet_count: subnets.length,
+    stale_note_count: staleNoteCount,
+    subnets,
+  };
+}
+
+function renderReport(report) {
+  if (report.subnets.length === 0) {
+    return "No stale curation.gap_notes found.\n";
+  }
+  const lines = [
+    `Stale curation.gap_notes: ${report.stale_note_count} across ${report.subnet_count} subnet file(s).`,
+    "This is an advisory report — it does not fail CI. Edit or drop each stale note by hand.",
+    "",
+  ];
+  for (const subnet of report.subnets) {
+    lines.push(`SN${subnet.netuid} ${subnet.name} (${subnet.file})`);
+    for (const entry of subnet.stale_notes) {
+      lines.push(
+        `  - [${entry.kind}] "${entry.note}" — contradicted by surface "${entry.surface_id}"`,
+      );
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+if (isCliEntrypoint()) {
+  const report = await collectStaleGapNotes();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(renderReport(report));
+  }
+}
+
+function isCliEntrypoint() {
+  return process.argv[1]
+    ? import.meta.url === pathToFileURL(process.argv[1]).href
+    : false;
+}

--- a/tests/stale-gap-notes.test.mjs
+++ b/tests/stale-gap-notes.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  classifyGapNote,
+  collectStaleGapNotes,
+  findStaleGapNotes,
+  isFirstPartySurface,
+} from "../scripts/stale-gap-notes.mjs";
+
+describe("classifyGapNote", () => {
+  test("classifies each observed 'No verified ... yet' phrasing", () => {
+    assert.equal(classifyGapNote("No verified SSE/event stream yet."), "sse");
+    assert.equal(
+      classifyGapNote(
+        "No verified machine-readable OpenAPI/Swagger schema yet.",
+      ),
+      "openapi",
+    );
+    assert.equal(
+      classifyGapNote("No verified safe public subnet API endpoint yet."),
+      "subnet-api",
+    );
+    assert.equal(
+      classifyGapNote("No verified standalone static data artifact yet."),
+      "data-artifact",
+    );
+    assert.equal(
+      classifyGapNote("No verified live source repository yet."),
+      "source-repo",
+    );
+    assert.equal(classifyGapNote("No verified docs site yet."), "docs");
+    assert.equal(
+      classifyGapNote("No verified dashboard surface yet."),
+      "dashboard",
+    );
+    assert.equal(
+      classifyGapNote("No verified official website yet."),
+      "website",
+    );
+  });
+
+  test("ignores notes that don't start with 'No verified'", () => {
+    assert.equal(
+      classifyGapNote("Native chain name currently reports as deprecated."),
+      null,
+    );
+  });
+
+  test("ignores 'No verified' notes with no recognizable kind keyword", () => {
+    assert.equal(
+      classifyGapNote("No publicly verified team/operator profile yet."),
+      null,
+    );
+  });
+
+  test("ignores 'No verified ...' notes that aren't a still-missing claim", () => {
+    // No "yet" — this is an explicit exclusion, not a "not found" claim.
+    assert.equal(
+      classifyGapNote(
+        "No verified official website; the domain fails to resolve.",
+      ),
+      null,
+    );
+  });
+
+  test("ignores non-string input", () => {
+    assert.equal(classifyGapNote(undefined), null);
+    assert.equal(classifyGapNote(null), null);
+  });
+});
+
+describe("isFirstPartySurface", () => {
+  const providersById = new Map([
+    ["acme", { id: "acme", kind: "subnet-team" }],
+    ["taomarketcap", { id: "taomarketcap", kind: "data-provider" }],
+  ]);
+
+  test("true for a subnet-team provider", () => {
+    assert.equal(
+      isFirstPartySurface({ provider: "acme" }, providersById),
+      true,
+    );
+  });
+
+  test("false for a third-party aggregator provider", () => {
+    assert.equal(
+      isFirstPartySurface({ provider: "taomarketcap" }, providersById),
+      false,
+    );
+  });
+
+  test("false when the provider id isn't registered", () => {
+    assert.equal(
+      isFirstPartySurface({ provider: "missing-provider" }, providersById),
+      false,
+    );
+  });
+});
+
+describe("findStaleGapNotes", () => {
+  const providersById = new Map([
+    ["acme", { id: "acme", kind: "subnet-team" }],
+    ["taomarketcap", { id: "taomarketcap", kind: "data-provider" }],
+  ]);
+
+  test("flags a note contradicted by the file's own first-party surface", () => {
+    const document = {
+      curation: {
+        gap_notes: ["No verified machine-readable OpenAPI/Swagger schema yet."],
+      },
+      surfaces: [{ id: "acme-openapi", kind: "openapi", provider: "acme" }],
+    };
+    const stale = findStaleGapNotes(document, providersById);
+    assert.deepEqual(stale, [
+      {
+        note: "No verified machine-readable OpenAPI/Swagger schema yet.",
+        kind: "openapi",
+        surface_id: "acme-openapi",
+      },
+    ]);
+  });
+
+  test("does not flag a note describing a surface that genuinely doesn't exist", () => {
+    const document = {
+      curation: { gap_notes: ["No verified SSE/event stream yet."] },
+      surfaces: [{ id: "acme-openapi", kind: "openapi", provider: "acme" }],
+    };
+    assert.deepEqual(findStaleGapNotes(document, providersById), []);
+  });
+
+  test("does not flag when the only matching surface is a third-party aggregator (oneoneone.json case)", () => {
+    const document = {
+      curation: {
+        gap_notes: ["No verified safe public subnet API endpoint yet."],
+      },
+      surfaces: [
+        {
+          id: "sn-111-taomarketcap-subnet-api",
+          kind: "subnet-api",
+          provider: "taomarketcap",
+        },
+      ],
+    };
+    assert.deepEqual(findStaleGapNotes(document, providersById), []);
+  });
+
+  test("handles a document with no curation or surfaces blocks", () => {
+    assert.deepEqual(findStaleGapNotes({}, providersById), []);
+  });
+});
+
+describe("collectStaleGapNotes (real registry)", () => {
+  test("reproduces the documented chutes.json and gittensor.json findings", async () => {
+    const report = await collectStaleGapNotes();
+    assert.ok(report.subnet_count > 0);
+    assert.ok(report.stale_note_count >= report.subnet_count);
+
+    const chutes = report.subnets.find((s) => s.file === "chutes.json");
+    assert.ok(chutes, "chutes.json should have stale notes");
+    const chutesKinds = chutes.stale_notes.map((n) => n.kind).sort();
+    assert.deepEqual(chutesKinds, ["openapi", "sse"]);
+
+    const gittensor = report.subnets.find((s) => s.file === "gittensor.json");
+    assert.ok(gittensor, "gittensor.json should have stale notes");
+    const gittensorKinds = gittensor.stale_notes.map((n) => n.kind).sort();
+    assert.ok(gittensorKinds.includes("dashboard"));
+    assert.ok(gittensorKinds.includes("openapi"));
+  });
+
+  test("does not flag oneoneone.json's third-party subnet-api note", async () => {
+    const report = await collectStaleGapNotes();
+    const oneoneone = report.subnets.find((s) => s.file === "oneoneone.json");
+    const flaggedKinds = (oneoneone?.stale_notes || []).map((n) => n.kind);
+    assert.ok(!flaggedKinds.includes("subnet-api"));
+  });
+});


### PR DESCRIPTION
## Summary

Adds `scripts/stale-gap-notes.mjs` (`npm run curation:stale-notes`), an advisory
report that flags `curation.gap_notes` entries which claim a surface kind is
still missing when the file's own `surfaces[]` already carries a first-party
surface of that kind.

Chosen as a **new standalone script** rather than extending
`scripts/curation-brief.mjs` or `scripts/validate-surface.mjs`:
- `curation-brief.mjs` reads only from post-`npm run build` artifacts
  (`dist/metagraph-r2/metagraph`), so folding this in would make the check
  unusable without a build first — this reads `registry/subnets/*.json` and
  `registry/providers/*.json` directly, same as `validate-surface.mjs` already
  does.
- `validate-surface.mjs`'s contract is pass/fail (`process.exit(1)` on any
  issue); the issue explicitly asks for an advisory report that does **not**
  block `npm run validate:surface`, so it stays untouched.

Running it against the current registry: **156 stale notes across 77 subnet
files** (the 2026-07-15 audit estimated ~175; the delta is phrasing-matching
precision on a few less common note variants, as the issue anticipated).

## Detection logic

- `classifyGapNote(note)` — only classifies notes shaped like "No verified
  \<thing\> yet" (the actual "not yet found" claim shape) into a surface kind
  (`sse`, `openapi`, `subnet-api`, `data-artifact`, `source-repo`, `docs`,
  `dashboard`, `website`). Notes describing something else (404 observations,
  identity disputes, auth-boundary explanations) are left alone.
- `isFirstPartySurface(surface, providersById)` — a surface only contradicts a
  gap note if its provider is the subnet's own team
  (`provider.kind === "subnet-team"`). This is the guard against the
  documented false positive: `registry/subnets/oneoneone.json`'s
  `sn-111-taomarketcap-subnet-api` surface (provider `taomarketcap`, a
  third-party aggregator, `kind: "data-provider"`) does **not** resolve the
  "No verified safe public subnet API endpoint yet." note — verified by test
  and reproduced live against the registry.
- Reproduces both examples named in the issue: `chutes.json` flags its
  OpenAPI and SSE notes (both have live first-party surfaces), `gittensor.json`
  flags its dashboard and OpenAPI notes.

## Test plan

- [x] `npm run curation:stale-notes` — reproduces chutes.json/gittensor.json
      stale notes and correctly skips oneoneone.json's third-party case
- [x] `npx vitest run tests/stale-gap-notes.test.mjs` — 14 tests covering
      `classifyGapNote`, `isFirstPartySurface`, `findStaleGapNotes` (including
      the oneoneone.json false-positive guard), and `collectStaleGapNotes`
      against the real registry
- [x] `npm run lint && npm run format:check` — clean
- [x] `npm run validate:surface` — unaffected (851 surfaces / 129 files, still
      pass/fail only)
- [x] `npm run validate` — unaffected (129 native subnets, 1615 surfaces, 133
      providers)
- [x] `npm run test:ci && npm run test:ci:artifacts` — full suite green after
      `npm run build`

Closes #5738
