### PR TITLE
feat(api): add ?format=csv to performance/history and hyperparameters/history

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -2102,7 +2102,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
         get: operations["subnetHyperparametersHistory"];
         put?: never;
         post?: never;
@@ -2238,7 +2238,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. */
+        /** Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV. */
         get: operations["subnetPerformanceHistory"];
         put?: never;
         post?: never;
@@ -24772,6 +24772,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -24781,7 +24783,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -24835,6 +24837,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetHyperparamsHistoryArtifact"];
                     };
+                    /**
+                     * @example block_number,observed_at,hyperparameters,hyperparams_hash
+                     *     8454388,2026-06-27T00:00:00.000Z,"{""kappa"":0.5}",hash_sample
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -25943,6 +25950,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -25952,7 +25961,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -26003,6 +26012,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetPerformanceHistoryArtifact"];
                     };
+                    /**
+                     * @example snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median
+                     *     2026-06-27,2,1,2,0.490099,1,0.990099,0.409091,1,0.909091,0.5,0.5,0.4,0.4,0.6,0.6
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -5012,7 +5012,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/performance/history.json",
       "cache": "short",
-      "description": "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history.",
+      "description": "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV.",
       "id": "subnet-performance-history",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/performance/history",
@@ -5027,6 +5027,17 @@
               "7d",
               "30d",
               "90d"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
             ],
             "type": "string"
           }
@@ -5721,7 +5732,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/hyperparameters/history.json",
       "cache": "short",
-      "description": "Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+      "description": "Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
       "id": "subnet-hyperparameters-history",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/hyperparameters/history",
@@ -5747,6 +5758,17 @@
         {
           "name": "cursor",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
             "type": "string"
           }
         }

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -489,7 +489,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Per-day reward-flow & trust trend (incentive/dividends Gini, Nakamoto coefficient, top-10% share, plus trust/consensus/validator_trust mean & median) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/performance/history (no static file). The reward-flow twin of /concentration/history.",
+      "description": "Per-day reward-flow & trust trend (incentive/dividends Gini, Nakamoto coefficient, top-10% share, plus trust/consensus/validator_trust mean & median) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/performance/history; pass ?format=csv to download the per-day series as CSV (no static file). The reward-flow twin of /concentration/history.",
       "id": "subnet-performance-history",
       "path": "/metagraph/subnets/{netuid}/performance/history.json",
       "schema_ref": "#/components/schemas/SubnetPerformanceHistoryArtifact",
@@ -714,7 +714,7 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
-      "description": "Append-only hyperparameter-change timeline for one subnet (subnet_hyperparams field snapshots on change), served live from the subnet_hyperparams_history D1 tier at /api/v1/subnets/{netuid}/hyperparameters/history (no static file). Forward-only.",
+      "description": "Append-only hyperparameter-change timeline for one subnet (subnet_hyperparams field snapshots on change), served live from the subnet_hyperparams_history D1 tier at /api/v1/subnets/{netuid}/hyperparameters/history; pass ?format=csv to download the page as CSV (no static file). Forward-only.",
       "id": "subnet-hyperparameters-history",
       "path": "/metagraph/subnets/{netuid}/hyperparameters/history.json",
       "schema_ref": "#/components/schemas/SubnetHyperparamsHistoryArtifact",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -46959,6 +46959,19 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -47020,9 +47033,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,observed_at,hyperparameters,hyperparams_hash\r\n8454388,2026-06-27T00:00:00.000Z,\"{\"\"kappa\"\":0.5}\",hash_sample",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -47079,7 +47098,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+        "summary": "Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
         "tags": [
           "subnets",
           "analytics"
@@ -48450,6 +48469,19 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -48508,9 +48540,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median\r\n2026-06-27,2,1,2,0.490099,1,0.990099,0.409091,1,0.909091,0.5,0.5,0.4,0.4,0.6,0.6",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -48567,7 +48605,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history.",
+        "summary": "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV.",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2102,7 +2102,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
         get: operations["subnetHyperparametersHistory"];
         put?: never;
         post?: never;
@@ -2238,7 +2238,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. */
+        /** Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV. */
         get: operations["subnetPerformanceHistory"];
         put?: never;
         post?: never;
@@ -24772,6 +24772,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -24781,7 +24783,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -24835,6 +24837,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetHyperparamsHistoryArtifact"];
                     };
+                    /**
+                     * @example block_number,observed_at,hyperparameters,hyperparams_hash
+                     *     8454388,2026-06-27T00:00:00.000Z,"{""kappa"":0.5}",hash_sample
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -25943,6 +25950,8 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d" | "90d";
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -25952,7 +25961,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -26003,6 +26012,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetPerformanceHistoryArtifact"];
                     };
+                    /**
+                     * @example snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median
+                     *     2026-06-27,2,1,2,0.490099,1,0.990099,0.409091,1,0.909091,0.5,0.5,0.4,0.4,0.6,0.6
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -956,7 +956,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "subnet-performance-history",
     "/metagraph/subnets/{netuid}/performance/history.json",
-    "Per-day reward-flow & trust trend (incentive/dividends Gini, Nakamoto coefficient, top-10% share, plus trust/consensus/validator_trust mean & median) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/performance/history (no static file). The reward-flow twin of /concentration/history.",
+    "Per-day reward-flow & trust trend (incentive/dividends Gini, Nakamoto coefficient, top-10% share, plus trust/consensus/validator_trust mean & median) over a 7d/30d/90d window for one subnet, served live from the neuron_daily D1 rollup at /api/v1/subnets/{netuid}/performance/history; pass ?format=csv to download the per-day series as CSV (no static file). The reward-flow twin of /concentration/history.",
     "SubnetPerformanceHistoryArtifact",
   ),
   artifact(
@@ -1106,7 +1106,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "subnet-hyperparameters-history",
     "/metagraph/subnets/{netuid}/hyperparameters/history.json",
-    "Append-only hyperparameter-change timeline for one subnet (subnet_hyperparams field snapshots on change), served live from the subnet_hyperparams_history D1 tier at /api/v1/subnets/{netuid}/hyperparameters/history (no static file). Forward-only.",
+    "Append-only hyperparameter-change timeline for one subnet (subnet_hyperparams field snapshots on change), served live from the subnet_hyperparams_history D1 tier at /api/v1/subnets/{netuid}/hyperparameters/history; pass ?format=csv to download the page as CSV (no static file). Forward-only.",
     "SubnetHyperparamsHistoryArtifact",
   ),
   artifact(
@@ -2155,15 +2155,15 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/performance/history",
     "/metagraph/subnets/{netuid}/performance/history.json",
-    "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history.",
+    "Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily D1 rollup). The reward-flow twin of /concentration/history. Pass ?format=csv to download the per-day series as CSV.",
     "short",
     ["subnets", "analytics"],
-    [
+    csvRouteQuery([
       {
         name: "window",
         schema: { type: "string", enum: ["7d", "30d", "90d"] },
       },
-    ],
+    ]),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(
@@ -2545,14 +2545,14 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/hyperparameters/history",
     "/metagraph/subnets/{netuid}/hyperparameters/history.json",
-    "Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+    "Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed. Forward-only (no pre-feature history). Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
     "short",
     ["subnets", "analytics"],
-    [
+    csvRouteQuery([
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "cursor", schema: { type: "string" } },
-    ],
+    ]),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/src/csv-route-examples.mjs
+++ b/src/csv-route-examples.mjs
@@ -21,6 +21,14 @@ export const ROUTE_CSV_EXAMPLES = {
     "snapshot_date,neuron_count,validator_count,yield_count,subnet_yield,mean_yield,median_yield,p25_yield,p75_yield,p90_yield",
     "2026-06-27,2,1,2,0.075,0.075,0.075,0.05,0.1,0.1",
   ].join("\r\n"),
+  "subnet-performance-history": [
+    "snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median",
+    "2026-06-27,2,1,2,0.490099,1,0.990099,0.409091,1,0.909091,0.5,0.5,0.4,0.4,0.6,0.6",
+  ].join("\r\n"),
+  "subnet-hyperparameters-history": [
+    "block_number,observed_at,hyperparameters,hyperparams_hash",
+    '8454388,2026-06-27T00:00:00.000Z,"{""kappa"":0.5}",hash_sample',
+  ].join("\r\n"),
   "subnet-events": EVENTS_CSV_EXAMPLE,
   "account-events": EVENTS_CSV_EXAMPLE,
   // The Postgres all-events feed: flat scalar columns of each raw pallet.method

--- a/tests/subnet-hyperparams-history-csv.test.mjs
+++ b/tests/subnet-hyperparams-history-csv.test.mjs
@@ -1,0 +1,119 @@
+// CSV export tests for GET /api/v1/subnets/{netuid}/hyperparameters/history —
+// kept in a dedicated file so this PR does not contend with open entity-handler
+// PRs on the shared request-handlers-entities.test.mjs harness.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
+import { handleSubnetHyperparamsHistory } from "../workers/request-handlers/entities.mjs";
+
+const NETUID = 7;
+const CSV_HEADER = "block_number,observed_at,hyperparameters,hyperparams_hash";
+
+function req(path) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+function url(path) {
+  return new URL(`https://api.metagraph.sh${path}`);
+}
+
+async function errorJson(res) {
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.ok, false);
+  return body;
+}
+
+describe("subnet hyperparameters history OpenAPI CSV contract", () => {
+  test("documents the CSV header on the hyperparameters/history route", async () => {
+    const openapi = buildOpenApiArtifact(
+      "1970-01-01T00:00:00.000Z",
+      await loadOpenApiComponentSchemas(),
+    );
+    const csvContent =
+      openapi.paths["/api/v1/subnets/{netuid}/hyperparameters/history"].get
+        .responses["200"].content["text/csv"];
+    assert.equal(csvContent.schema.type, "string");
+    assert.equal(csvContent.example.split("\r\n")[0], CSV_HEADER);
+  });
+});
+
+describe("handleSubnetHyperparamsHistory CSV export", () => {
+  test("returns header-only CSV when Postgres is unconfigured", async () => {
+    const res = await handleSubnetHyperparamsHistory(
+      req(`/api/v1/subnets/${NETUID}/hyperparameters/history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/hyperparameters/history?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(lines[0], CSV_HEADER);
+    assert.equal(lines.length, 1);
+  });
+
+  test("exports paginated entries via the Postgres tier, hyperparameters serialized as one JSON cell", async () => {
+    const env = {
+      METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            netuid: NETUID,
+            entry_count: 1,
+            limit: 50,
+            offset: 0,
+            next_cursor: null,
+            entries: [
+              {
+                block_number: 100,
+                observed_at: "2026-06-21T00:00:00.000Z",
+                hyperparameters: { tempo: 360 },
+                hyperparams_hash: "abc",
+              },
+            ],
+          }),
+      },
+    };
+    const res = await handleSubnetHyperparamsHistory(
+      req(`/api/v1/subnets/${NETUID}/hyperparameters/history`),
+      env,
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/hyperparameters/history?limit=50&format=csv`,
+      ),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines[0], CSV_HEADER);
+    assert.equal(
+      lines[1],
+      `100,2026-06-21T00:00:00.000Z,"{""tempo"":360}",abc`,
+    );
+    assert.equal(lines.length, 2);
+  });
+
+  test("rejects an unsupported format value", async () => {
+    const res = await handleSubnetHyperparamsHistory(
+      req(`/api/v1/subnets/${NETUID}/hyperparameters/history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/hyperparameters/history?format=pdf`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("rejects an empty format parameter", async () => {
+    const res = await handleSubnetHyperparamsHistory(
+      req(`/api/v1/subnets/${NETUID}/hyperparameters/history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/hyperparameters/history?format=`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+});

--- a/tests/subnet-performance-history-csv.test.mjs
+++ b/tests/subnet-performance-history-csv.test.mjs
@@ -1,0 +1,217 @@
+// CSV export tests for GET /api/v1/subnets/{netuid}/performance/history — kept in
+// a dedicated file so this PR does not contend with open entity-handler PRs on the
+// shared request-handlers-entities.test.mjs harness.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
+import {
+  canonicalSubnetPerformanceHistoryCachePath,
+  handleSubnetPerformanceHistory,
+} from "../workers/request-handlers/entities.mjs";
+
+const NETUID = 7;
+const CSV_HEADER =
+  "snapshot_date,neuron_count,validator_count,active_count,incentive_gini,incentive_nakamoto_coefficient,incentive_top_10pct_share,dividends_gini,dividends_nakamoto_coefficient,dividends_top_10pct_share,trust_mean,trust_median,consensus_mean,consensus_median,validator_trust_mean,validator_trust_median";
+
+function req(path) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+function url(path) {
+  return new URL(`https://api.metagraph.sh${path}`);
+}
+
+async function errorJson(res) {
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.ok, false);
+  return body;
+}
+
+describe("subnet performance history OpenAPI CSV contract", () => {
+  test("documents the CSV header on the performance/history route", async () => {
+    const openapi = buildOpenApiArtifact(
+      "1970-01-01T00:00:00.000Z",
+      await loadOpenApiComponentSchemas(),
+    );
+    const csvContent =
+      openapi.paths["/api/v1/subnets/{netuid}/performance/history"].get
+        .responses["200"].content["text/csv"];
+    assert.equal(csvContent.schema.type, "string");
+    assert.equal(csvContent.example.split("\r\n")[0], CSV_HEADER);
+  });
+});
+
+describe("handleSubnetPerformanceHistory CSV export", () => {
+  test("returns header-only CSV when D1 is cold", async () => {
+    const res = await handleSubnetPerformanceHistory(
+      req(`/api/v1/subnets/${NETUID}/performance/history`),
+      {},
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/performance/history?window=30d&format=csv`,
+      ),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(lines[0], CSV_HEADER);
+    assert.equal(lines.length, 1);
+  });
+
+  test("sorts and exports real points ascending by snapshot_date via the Postgres tier", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            netuid: NETUID,
+            window: "30d",
+            points: [
+              {
+                snapshot_date: "2026-06-21",
+                neuron_count: 5,
+                validator_count: 2,
+                active_count: 5,
+                incentive_gini: 0.4,
+                incentive_nakamoto_coefficient: 2,
+                incentive_top_10pct_share: 0.5,
+                dividends_gini: 0.3,
+                dividends_nakamoto_coefficient: 1,
+                dividends_top_10pct_share: 0.6,
+                trust_mean: 0.5,
+                trust_median: 0.5,
+                consensus_mean: 0.4,
+                consensus_median: 0.4,
+                validator_trust_mean: 0.6,
+                validator_trust_median: 0.6,
+              },
+              {
+                snapshot_date: "2026-06-20",
+                neuron_count: 4,
+                validator_count: 2,
+                active_count: 4,
+                incentive_gini: 0.35,
+                incentive_nakamoto_coefficient: 2,
+                incentive_top_10pct_share: 0.45,
+                dividends_gini: 0.25,
+                dividends_nakamoto_coefficient: 1,
+                dividends_top_10pct_share: 0.55,
+                trust_mean: 0.45,
+                trust_median: 0.45,
+                consensus_mean: 0.35,
+                consensus_median: 0.35,
+                validator_trust_mean: 0.55,
+                validator_trust_median: 0.55,
+              },
+            ],
+          }),
+      },
+    };
+    const res = await handleSubnetPerformanceHistory(
+      req(`/api/v1/subnets/${NETUID}/performance/history`),
+      env,
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/performance/history?window=30d&format=csv`,
+      ),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines.length, 3);
+    // CSV export re-sorts newest-first `points` into ascending snapshot_date.
+    assert.match(lines[1], /^2026-06-20,/);
+    assert.match(lines[2], /^2026-06-21,/);
+  });
+
+  test("rejects an unsupported format value", async () => {
+    const res = await handleSubnetPerformanceHistory(
+      req(`/api/v1/subnets/${NETUID}/performance/history`),
+      {},
+      NETUID,
+      url(
+        `/api/v1/subnets/${NETUID}/performance/history?window=30d&format=pdf`,
+      ),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("rejects an empty format parameter", async () => {
+    const res = await handleSubnetPerformanceHistory(
+      req(`/api/v1/subnets/${NETUID}/performance/history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/performance/history?format=`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+});
+
+describe("canonicalSubnetPerformanceHistoryCachePath", () => {
+  test("default window stays canonical for JSON", () => {
+    assert.equal(
+      canonicalSubnetPerformanceHistoryCachePath(
+        url(`/api/v1/subnets/${NETUID}/performance/history`),
+      ),
+      `/api/v1/subnets/${NETUID}/performance/history?window=30d`,
+    );
+  });
+
+  test("explicit CSV and JSON format overrides produce distinct cache variants", () => {
+    const csv = canonicalSubnetPerformanceHistoryCachePath(
+      url(`/api/v1/subnets/${NETUID}/performance/history?window=7d&format=csv`),
+    );
+    assert.equal(
+      csv,
+      `/api/v1/subnets/${NETUID}/performance/history?window=7d&format=csv`,
+    );
+
+    const csvAccept = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/performance/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    const json = canonicalSubnetPerformanceHistoryCachePath(
+      url(
+        `/api/v1/subnets/${NETUID}/performance/history?window=7d&format=json`,
+      ),
+      csvAccept,
+    );
+    assert.equal(
+      json,
+      `/api/v1/subnets/${NETUID}/performance/history?window=7d`,
+    );
+  });
+
+  test("adds format=csv when only Accept: text/csv is present", () => {
+    const csvAccept = new Request(
+      `https://api.metagraph.sh/api/v1/subnets/${NETUID}/performance/history`,
+      { headers: { accept: "text/csv" } },
+    );
+    assert.equal(
+      canonicalSubnetPerformanceHistoryCachePath(
+        url(`/api/v1/subnets/${NETUID}/performance/history?window=90d`),
+        csvAccept,
+      ),
+      `/api/v1/subnets/${NETUID}/performance/history?window=90d&format=csv`,
+    );
+  });
+
+  test("falls back to raw search on unknown query param", () => {
+    const raw = `/api/v1/subnets/${NETUID}/performance/history?bogus=1`;
+    assert.equal(canonicalSubnetPerformanceHistoryCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid format", () => {
+    const raw = `/api/v1/subnets/${NETUID}/performance/history?format=pdf`;
+    assert.equal(canonicalSubnetPerformanceHistoryCachePath(url(raw)), raw);
+  });
+
+  test("falls back to raw search on invalid window", () => {
+    const raw = `/api/v1/subnets/${NETUID}/performance/history?window=1y`;
+    assert.equal(canonicalSubnetPerformanceHistoryCachePath(url(raw)), raw);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1713,7 +1713,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
             Number(performanceHistoryMatch[1]),
             resolved.url,
           ),
-        canonicalSubnetPerformanceHistoryCachePath(resolved.url),
+        canonicalSubnetPerformanceHistoryCachePath(resolved.url, request),
       );
     }
     const yieldHistoryMatch = SUBNET_YIELD_HISTORY_PATH_PATTERN.exec(

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -403,6 +403,35 @@ const SUBNET_YIELD_HISTORY_CSV_COLUMNS = [
   "p75_yield",
   "p90_yield",
 ];
+// performanceHistoryPoint's flat row shape (src/subnet-performance.mjs) — the
+// reward-flow twin of SUBNET_CONCENTRATION_HISTORY_CSV_COLUMNS.
+const SUBNET_PERFORMANCE_HISTORY_CSV_COLUMNS = [
+  "snapshot_date",
+  "neuron_count",
+  "validator_count",
+  "active_count",
+  "incentive_gini",
+  "incentive_nakamoto_coefficient",
+  "incentive_top_10pct_share",
+  "dividends_gini",
+  "dividends_nakamoto_coefficient",
+  "dividends_top_10pct_share",
+  "trust_mean",
+  "trust_median",
+  "consensus_mean",
+  "consensus_median",
+  "validator_trust_mean",
+  "validator_trust_median",
+];
+// formatHyperparamsHistoryEntry's row shape (src/subnet-hyperparams-history.mjs);
+// `hyperparameters` is the nested 33-field object, serialized as one JSON cell
+// like the `axon` column on NEURON_CSV_COLUMNS.
+const SUBNET_HYPERPARAMS_HISTORY_CSV_COLUMNS = [
+  "block_number",
+  "observed_at",
+  "hyperparameters",
+  "hyperparams_hash",
+];
 const ACCOUNT_EXTRINSICS_CSV_COLUMNS = [
   "extrinsic_id",
   "block_number",
@@ -669,10 +698,11 @@ export async function handleSubnetHyperparamsHistory(
   netuid,
   url,
 ) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset } = parsePagination(url, FEED_PAGINATION);
@@ -687,6 +717,18 @@ export async function handleSubnetHyperparamsHistory(
       offset,
       nextCursor: null,
     });
+  // CSV mirrors handleAccountHistory: the page is already limit/offset-bounded,
+  // so the CSV path carries the identical page the JSON path would. Cold store
+  // -> empty entries -> header-only CSV.
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.entries,
+      `subnet-${netuid}-hyperparameters-history`,
+      "short",
+      request,
+      SUBNET_HYPERPARAMS_HISTORY_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {
@@ -1362,8 +1404,23 @@ export function canonicalSubnetConcentrationHistoryCachePath(
   );
 }
 
-export function canonicalSubnetPerformanceHistoryCachePath(url) {
-  return canonicalWindowedCachePath(url, parseSubnetPerformanceHistoryWindow);
+export function canonicalSubnetPerformanceHistoryCachePath(
+  url,
+  request = null,
+) {
+  const validationError = validateQueryParams(url, ["window", "format"]);
+  if (validationError) return `${url.pathname}${url.search}`;
+  const formatError = validateResponseFormat(url);
+  if (formatError) return `${url.pathname}${url.search}`;
+  const { label, error } = parseSubnetPerformanceHistoryWindow(
+    url.searchParams.get("window"),
+  );
+  if (error) return `${url.pathname}${url.search}`;
+  return csvCacheVariant(
+    url,
+    request,
+    `${url.pathname}?window=${encodeURIComponent(label)}`,
+  );
 }
 
 export function canonicalSubnetYieldHistoryCachePath(url, request = null) {
@@ -1636,8 +1693,10 @@ export async function handleSubnetPerformanceHistory(
   netuid,
   url,
 ) {
-  const validationError = validateQueryParams(url, ["window"]);
+  const validationError = validateQueryParams(url, ["window", "format"]);
   if (validationError) return analyticsQueryError(validationError);
+  const formatError = validateResponseFormat(url);
+  if (formatError) return analyticsQueryError(formatError);
   const { label, error } = parseSubnetPerformanceHistoryWindow(
     url.searchParams.get("window"),
   );
@@ -1650,6 +1709,18 @@ export async function handleSubnetPerformanceHistory(
       window: label,
       capped: false,
     });
+  if (csvRequested(url, request)) {
+    const points = [...data.points].sort((a, b) =>
+      String(a.snapshot_date).localeCompare(String(b.snapshot_date)),
+    );
+    return csvResponse(
+      points,
+      `subnet-${netuid}-performance-history`,
+      "short",
+      request,
+      SUBNET_PERFORMANCE_HISTORY_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
Closes #5740

## What

Two "history" routes in `workers/request-handlers/entities.mjs` never got the repo's well-established `?format=csv` convention, even though their closest neighbors did:

- `handleSubnetPerformanceHistory` — the reward-flow twin of `handleSubnetConcentrationHistory` (which already supports CSV), same per-day `points[]` shape, but its allowlist omitted `"format"` entirely.
- `handleSubnetHyperparamsHistory` — a paginated append-only change-timeline with no `format` param or CSV path at all.

## Fix

- **`handleSubnetPerformanceHistory`**: added `"format"` to the allowlist + `validateResponseFormat` check, and a `csvRequested` branch exporting `data.points` re-sorted ascending by `snapshot_date` (matching `handleSubnetConcentrationHistory`/`handleSubnetYieldHistory`'s own re-sort convention). New `SUBNET_PERFORMANCE_HISTORY_CSV_COLUMNS` mirrors `performanceHistoryPoint`'s flat field order exactly (`src/subnet-performance.mjs`).
- **`handleSubnetHyperparamsHistory`**: same `format` validation via `validateEntityQuery`, plus a CSV branch mirroring `handleAccountHistory`'s paginated-CSV pattern (the page is already limit/offset-bounded, so CSV carries the identical page JSON would). Each entry's `hyperparameters` field is a nested 33-field object, kept as one JSON-serialized cell — the same convention the existing `axon` column on `NEURON_CSV_COLUMNS` already uses for a nested value, rather than flattening it into 33 extra columns.
- Cold/absent stores still emit the CSV header row with zero data rows for both routes.
- **Cache keys**: replaced `canonicalSubnetPerformanceHistoryCachePath`'s generic `canonicalWindowedCachePath` call with a dedicated implementation (mirroring `canonicalSubnetYieldHistoryCachePath`) that threads `request` through the shared `csvCacheVariant` helper, so `?format=csv` gets a distinct edge-cache entry from JSON. Updated its one `workers/api.mjs` call site to pass `request`. `handleSubnetHyperparamsHistory` has no edge-cache wrapper (dispatched directly, same cost class as `handleSubnetIdentityHistory`), so no cache-path change was needed there.
- **OpenAPI contract**: wrapped both routes' query parameters in `csvRouteQuery(...)`, updated their descriptions to mention `?format=csv`, and added CSV examples for both to `src/csv-route-examples.mjs`. Ran `npm run build` and committed the regenerated `openapi.json`/`api-index.json`/`types.d.ts`/`index.d.ts`.

## Testing

```
npx vitest run tests/subnet-performance-history-csv.test.mjs tests/subnet-hyperparams-history-csv.test.mjs
# 16 passed

npm test
# 288 files, 8620 tests passed

npm run test:coverage
# every new/changed line and branch in entities.mjs, api.mjs, contracts.mjs, and
# csv-route-examples.mjs is covered (confirmed against lcov.info directly)

npx eslint . && npx prettier --check .
# clean

npm run validate && npm run validate:contract-drift && npm run validate:api \
  && npm run validate:openapi && npm run validate:openapi-examples && npm run validate:schemas
# all pass
```

New tests cover: the OpenAPI CSV contract (header + example) for both routes, a successful CSV export for each (ascending re-sort for performance/history; a real Postgres-tier row with a nested hyperparameters cell for hyperparameters/history), the cold/unconfigured header-only case, invalid/empty `format` rejection, and `canonicalSubnetPerformanceHistoryCachePath`'s new CSV-variant cache-key behavior.
