### PR TITLE
feat(graphql): add Query.subnet_identity_history

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -41,9 +41,11 @@ import {
 } from "../workers/request-handlers/analytics.mjs";
 import {
   BLOCK_PAGINATION,
+  FEED_PAGINATION,
   clampLimit,
   clampOffset,
 } from "../workers/request-params.mjs";
+import { loadSubnetIdentityHistory } from "./subnet-identity-history.mjs";
 import {
   buildGlobalHealth,
   formatLeaderboards,
@@ -176,6 +178,8 @@ export const SDL = `
     subnet_weights(netuid: Int!, window: String): SubnetWeights!
     "Per-subnet emission-per-stake yield over the current metagraph snapshot: each UID's yield plus the subnet-wide aggregate and p25/median/p75/p90 distribution; a subnet with no neurons resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/yield."
     subnet_yield(netuid: Int!): SubnetYield!
+    "Append-only on-chain SubnetIdentitiesV3 change timeline for one subnet (name, symbol, description, repo, website, discord, logo), newest first; page with limit/offset or follow next_cursor. A subnet with no matching events resolves to a schema-stable empty timeline (entry_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/identity-history."
+    subnet_identity_history(netuid: Int!, limit: Int, offset: Int, cursor: String): SubnetIdentityHistory!
     "Paginated provider/source registry."
     providers(limit: Int, cursor: String): ProviderList!
     "One provider with its subnets."
@@ -643,6 +647,31 @@ export const SDL = `
     surface_count: Int
     ok_count: Int
     avg_latency_ms: Int
+  }
+
+  "Append-only on-chain subnet identity timeline (#1647 / #5721). Empty entries on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/identity-history."
+  type SubnetIdentityHistory {
+    schema_version: Int!
+    netuid: Int!
+    entry_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    entries: [SubnetIdentityHistoryEntry!]!
+  }
+
+  "One SubnetIdentitiesV3 snapshot recorded when a tracked identity field changed."
+  type SubnetIdentityHistoryEntry {
+    block_number: Int
+    observed_at: String
+    subnet_name: String
+    symbol: String
+    description: String
+    github_repo: String
+    subnet_url: String
+    discord: String
+    logo_url: String
+    identity_hash: String
   }
 
   "Per-subnet neuron-registration activity over a window (#5720). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/registrations."
@@ -1353,6 +1382,7 @@ export const FIELD_COMPLEXITY = {
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_yield: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2020,6 +2050,48 @@ const rootValue = {
       distinct_removers: data.distinct_removers ?? 0,
       removals: data.removals ?? 0,
       removals_per_remover: data.removals_per_remover ?? null,
+    };
+  },
+
+  async subnet_identity_history({ netuid, limit, offset, cursor }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const safeLimit = clampLimit(limit, FEED_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    if (cursor) params.set("cursor", cursor);
+    // Same tryPostgresTier(METAGRAPH_SUBNET_IDENTITY_SOURCE) ->
+    // loadSubnetIdentityHistory fallback contract handleSubnetIdentityHistory
+    // uses; a subnet with no matching events is a schema-stable empty
+    // timeline (entry_count 0), never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/identity-history`,
+          params,
+        ),
+        "METAGRAPH_SUBNET_IDENTITY_SOURCE",
+      )) ??
+      (await loadSubnetIdentityHistory(graphqlD1(context), netuid, {
+        limit: safeLimit,
+        offset: safeOffset,
+        cursor,
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      entry_count: data.entry_count ?? 0,
+      limit: data.limit ?? safeLimit,
+      offset: data.offset ?? safeOffset,
+      next_cursor: data.next_cursor ?? null,
+      entries: data.entries || [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -2553,6 +2553,202 @@ describe("graphql — validator_history (#5710, Postgres-tier + empty-points fal
   });
 });
 
+describe("graphql — subnet_identity_history (#5721, Postgres-tier + empty timeline fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag / no D1 rows returns a schema-stable empty timeline, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_identity_history(netuid: 1) {
+          schema_version netuid entry_count limit offset next_cursor
+          entries { subnet_name identity_hash }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_identity_history, {
+      schema_version: 1,
+      netuid: 1,
+      entry_count: 0,
+      limit: 100,
+      offset: 0,
+      next_cursor: null,
+      entries: [],
+    });
+  });
+
+  test("resolves the Postgres-tier timeline entries", async () => {
+    const env = {
+      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 7,
+          entry_count: 1,
+          limit: 50,
+          offset: 0,
+          next_cursor: null,
+          entries: [
+            {
+              block_number: 4200,
+              observed_at: "2026-07-01T00:00:00.000Z",
+              subnet_name: "Example",
+              symbol: "EX",
+              description: "desc",
+              github_repo: "https://github.com/example/repo",
+              subnet_url: "https://example.com",
+              discord: "https://discord.gg/example",
+              logo_url: "https://example.com/logo.png",
+              identity_hash: "abc123",
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_identity_history(netuid: 7, limit: 50) {
+          netuid entry_count limit
+          entries {
+            block_number observed_at subnet_name symbol description
+            github_repo subnet_url discord logo_url identity_hash
+          }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const r = body.data.subnet_identity_history;
+    assert.equal(r.netuid, 7);
+    assert.equal(r.entry_count, 1);
+    assert.equal(r.limit, 50);
+    assert.deepEqual(r.entries, [
+      {
+        block_number: 4200,
+        observed_at: "2026-07-01T00:00:00.000Z",
+        subnet_name: "Example",
+        symbol: "EX",
+        description: "desc",
+        github_repo: "https://github.com/example/repo",
+        subnet_url: "https://example.com",
+        discord: "https://discord.gg/example",
+        logo_url: "https://example.com/logo.png",
+        identity_hash: "abc123",
+      },
+    ]);
+  });
+
+  test("D1 fallback path shapes rows through loadSubnetIdentityHistory", async () => {
+    const observedAt = Date.parse("2026-06-15T12:00:00.000Z");
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  return {
+                    results: [
+                      {
+                        id: 11,
+                        block_number: 100,
+                        observed_at: observedAt,
+                        subnet_name: "Alpha",
+                        symbol: "A",
+                        description: "alpha desc",
+                        github_repo: "https://github.com/jsonbored/alpha",
+                        subnet_url: "https://metagraph.sh",
+                        discord: "alpha#1234",
+                        logo_url: null,
+                        identity_hash: "deadbeef",
+                      },
+                    ],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const { status, body } = await gql(
+      `{ subnet_identity_history(netuid: 86, limit: 10) {
+          netuid entry_count limit
+          entries { block_number observed_at subnet_name symbol identity_hash }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.subnet_identity_history;
+    assert.equal(r.netuid, 86);
+    assert.equal(r.entry_count, 1);
+    assert.equal(r.limit, 10);
+    assert.equal(r.entries.length, 1);
+    assert.equal(r.entries[0].block_number, 100);
+    assert.equal(r.entries[0].observed_at, "2026-06-15T12:00:00.000Z");
+    assert.equal(r.entries[0].subnet_name, "Alpha");
+    assert.equal(r.entries[0].symbol, "A");
+    assert.equal(r.entries[0].identity_hash, "deadbeef");
+  });
+
+  test("pagination args are forwarded to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(
+      '{ subnet_identity_history(netuid: 3, limit: 25, offset: 10, cursor: "abc") { entry_count } }',
+      env,
+    );
+    assert.equal(capturedUrl.searchParams.get("limit"), "25");
+    assert.equal(capturedUrl.searchParams.get("offset"), "10");
+    assert.equal(capturedUrl.searchParams.get("cursor"), "abc");
+    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/identity-history"));
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_identity_history(netuid: 9) {
+          schema_version netuid entry_count limit offset next_cursor entries { subnet_name }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_identity_history, {
+      schema_version: 1,
+      netuid: 9,
+      entry_count: 0,
+      limit: 100,
+      offset: 0,
+      next_cursor: null,
+      entries: [],
+    });
+  });
+
+  test("a negative netuid is a GraphQL error, not an empty card", async () => {
+    const { body } = await gql(
+      "{ subnet_identity_history(netuid: -1) { entry_count } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/netuid/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_identity_history ?? null, null);
+  });
+
+  test("subnet_identity_history is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_identity_history, 5);
+  });
+});
+
 describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderboard)", () => {
   const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 


### PR DESCRIPTION
﻿## Summary
- Add GraphQL `Query.subnet_identity_history(netuid, limit, offset, cursor)` mirroring REST `GET /api/v1/subnets/{netuid}/identity-history` and MCP `get_subnet_identity_history`.
- Resolver uses `tryPostgresTier(METAGRAPH_SUBNET_IDENTITY_SOURCE)` with `loadSubnetIdentityHistory` D1 fallback; empty timeline is schema-stable (never null).
- `FIELD_COMPLEXITY.subnet_identity_history = 5` (relationship weight).

Closes #5721

## Test plan
- [x] `npx vitest run tests/graphql.test.mjs -t "subnet_identity_history"` (7 tests)
- [ ] CI `Validate` + codecov/patch ≥99%
