### PR TITLE
feat(registry): validate-surface.mjs catches duplicate surface URLs within one file

### DIFF
--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -34,6 +34,21 @@ const providerIds = new Set(
 // PR gap) without touching the probe-derived endpoint pipeline. See issue #1680.
 const BASE_LAYER_KINDS = new Set(["subtensor-rpc", "subtensor-wss", "archive"]);
 
+// Pre-existing duplicate-URL registrations, grandfathered so the new
+// duplicate-URL check below (added for #5737) only fails a contributor PR
+// that introduces a NEW duplicate rather than breaking `validate:surface`
+// repo-wide on debt this check wasn't around to prevent. The data-fix for
+// the first 3 (#5736) is blocked behind a maintainer-only registry-deletion
+// review gate, not something a contributor PR can land; 8-ball.json's is a
+// 4th instance this check additionally surfaced. Remove an entry here once
+// its underlying duplicate is actually resolved in the registry file.
+const GRANDFATHERED_DUPLICATE_URLS = new Set([
+  "8-ball.json|https://github.com/Barbariandev/8Ball_miner",
+  "allways.json|https://api.all-ways.io/miners/leaderboard",
+  "bitmind.json|https://api.bitmind.ai/health",
+  "gradients.json|https://api.gradients.io/v1/network/status",
+]);
+
 // Build the set of (netuid, normalized-url) keys for native-chain candidates that
 // are already machine-promoted (classification live or redirected). A community
 // surface duplicating one of these adds no signal — the build pipeline injects it
@@ -103,9 +118,22 @@ for (const file of files) {
         'set a real curated display name, or tag the subnet "identity-placeholder" if it genuinely has no on-chain identity.',
     );
   }
+  // Track normalized-URL -> surface ids so the exact-same-URL-under-two-kinds
+  // mistake (e.g. a subnet-api and a data-artifact surface both pointing at
+  // the same endpoint) fails here instead of silently landing in the
+  // registry — see #5736 for 3 confirmed live instances this would have caught.
+  const surfaceIdsByUrl = new Map();
   for (const surface of document.surfaces || []) {
     surfaceCount += 1;
     const label = `${path.basename(file)} (${surface.id})`;
+    if (surface.url) {
+      const normalized = normalizePublicUrl(surface.url);
+      if (normalized) {
+        const ids = surfaceIdsByUrl.get(normalized) || [];
+        ids.push(surface.id);
+        surfaceIdsByUrl.set(normalized, ids);
+      }
+    }
     if (surface.provider && !providerIds.has(surface.provider)) {
       errors.push(
         `${label}: provider "${surface.provider}" is not a registered slug — ` +
@@ -143,6 +171,19 @@ for (const file of files) {
         `${label}: base-layer endpoint kind "${surface.kind}" is only allowed on the ` +
           "root subnet (netuid 0) — these are maintainer-curated network infrastructure " +
           "(the /rpc endpoint lane), not per-subnet contributor surfaces.",
+      );
+    }
+  }
+  for (const [normalizedUrl, ids] of surfaceIdsByUrl) {
+    if (
+      ids.length > 1 &&
+      !GRANDFATHERED_DUPLICATE_URLS.has(
+        `${path.basename(file)}|${normalizedUrl}`,
+      )
+    ) {
+      errors.push(
+        `${path.basename(file)}: "${normalizedUrl}" is registered by ${ids.length} surfaces (${ids.join(", ")}) — ` +
+          "dedupe to the one surface kind that accurately describes the endpoint.",
       );
     }
   }

--- a/tests/validate-surface-duplicate-url.test.mjs
+++ b/tests/validate-surface-duplicate-url.test.mjs
@@ -1,0 +1,182 @@
+// Regression coverage for #5737: validate-surface.mjs now fails when two
+// surfaces[] entries in the same subnet file register the identical URL
+// under different ids/kinds (the mistake #5736 found 3 live instances of).
+// Mirrors validate-error-messages.test.mjs's subprocess-fixture pattern.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, test } from "vitest";
+import { listJsonFiles, repoRoot } from "../scripts/lib.mjs";
+
+function runNode(args) {
+  try {
+    const stdout = execFileSync(process.execPath, args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return { status: 0, output: stdout };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      output: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+    };
+  }
+}
+
+describe("validate-surface.mjs duplicate-URL check", () => {
+  let tempDir;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  function writeFixture(surfaces) {
+    const document = {
+      schema_version: 1,
+      netuid: 999,
+      slug: "fixture",
+      name: "Fixture Subnet",
+      status: "active",
+      categories: [],
+      links: [],
+      surfaces,
+    };
+    tempDir = mkdtempSync(`${tmpdir()}/metagraphed-validate-surface-dup-`);
+    const fixturePath = path.join(tempDir, "fixture.json");
+    writeFileSync(fixturePath, JSON.stringify(document, null, 2));
+    return fixturePath;
+  }
+
+  test("fails when two surfaces register the exact same URL under different kinds", () => {
+    const fixturePath = writeFixture([
+      {
+        id: "fixture-subnet-api",
+        kind: "subnet-api",
+        name: "Fixture API",
+        url: "https://api.fixture.example/status",
+        provider: "academia",
+        authority: "community",
+        auth_required: false,
+        public_safe: true,
+        review: { state: "community-submitted" },
+      },
+      {
+        id: "fixture-data-artifact",
+        kind: "data-artifact",
+        name: "Fixture data artifact",
+        url: "https://api.fixture.example/status",
+        provider: "academia",
+        authority: "community",
+        auth_required: false,
+        public_safe: true,
+        review: { state: "community-submitted" },
+      },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 1);
+    assert.match(output, /https:\/\/api\.fixture\.example\/status/);
+    assert.match(output, /fixture-subnet-api/);
+    assert.match(output, /fixture-data-artifact/);
+    assert.match(output, /registered by 2 surfaces/);
+  });
+
+  test("catches a duplicate even when only a trailing slash differs", () => {
+    const fixturePath = writeFixture([
+      {
+        id: "fixture-a",
+        kind: "subnet-api",
+        name: "Fixture A",
+        url: "https://api.fixture.example/status",
+        provider: "academia",
+        authority: "community",
+        auth_required: false,
+        public_safe: true,
+        review: { state: "community-submitted" },
+      },
+      {
+        id: "fixture-b",
+        kind: "data-artifact",
+        name: "Fixture B",
+        url: "https://api.fixture.example/status/",
+        provider: "academia",
+        authority: "community",
+        auth_required: false,
+        public_safe: true,
+        review: { state: "community-submitted" },
+      },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 1);
+    assert.match(output, /registered by 2 surfaces/);
+  });
+
+  test("passes when every surface's URL is distinct", () => {
+    const fixturePath = writeFixture([
+      {
+        id: "fixture-a",
+        kind: "subnet-api",
+        name: "Fixture A",
+        url: "https://api.fixture.example/status",
+        provider: "academia",
+        authority: "community",
+        auth_required: false,
+        public_safe: true,
+        review: { state: "community-submitted" },
+      },
+      {
+        id: "fixture-b",
+        kind: "docs",
+        name: "Fixture docs",
+        url: "https://docs.fixture.example/",
+        provider: "academia",
+        authority: "community",
+        auth_required: false,
+        public_safe: true,
+        review: { state: "community-submitted" },
+      },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 0);
+    assert.match(output, /Surface validation passed/);
+  });
+
+  test("the full registry has no unresolved duplicate-URL findings", () => {
+    // Sanity check the check itself against real data: after #5736's fix,
+    // running with no file args (validates every subnet file) must be clean.
+    const { status, output } = runNode(["scripts/validate-surface.mjs"]);
+    assert.equal(status, 0, output);
+  });
+});
+
+describe("validate-surface.mjs duplicate-URL check does not misfire", () => {
+  test("every real subnet file individually passes (no false-positive dedupe)", async () => {
+    const files = await listJsonFiles(path.join(repoRoot, "registry/subnets"));
+    assert.ok(files.length > 0);
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...files,
+    ]);
+    assert.equal(status, 0, output);
+  });
+});


### PR DESCRIPTION
Closes #5737

## What

`scripts/validate-surface.mjs` didn't catch a genuine, already-happened data-quality mistake: registering the exact same URL twice under two different surface `kind`s in one subnet file. A 2026-07-15 static audit found 3 confirmed live instances (`allways.json`, `bitmind.json`, `gradients.json` — see the companion data-fix issue #5736), evidence this slips through review today.

## Fix

- Added a duplicate-URL check: while iterating a file's `surfaces[]`, each surface's `url` is normalized via the existing `normalizePublicUrl` helper (`scripts/lib.mjs` — already handles trailing-slash/hash/credential normalization, reused rather than reinventing) and grouped by normalized value. Any URL claimed by 2+ surface ids fails validation, at the same fail-fast tier as a missing `provider` slug.
- **Grandfathering pre-existing violations**: running this check against the full registry surfaced 4 live duplicates — the 3 from #5736, plus a previously-undiscovered 4th one in `8-ball.json` (`sn-125-eightball-source-repo` / `sn-125-eightball-docs`, both pointing at the same GitHub repo). #5736's own data-fix is blocked behind a maintainer-only registry-deletion review gate that a contributor PR can't clear, so shipping this check as an unconditional hard-fail would break `validate:surface` repo-wide on pre-existing debt this check wasn't around to prevent. Added an explicit, documented `GRANDFATHERED_DUPLICATE_URLS` allowlist (file + normalized-URL pairs) so the check only fails a contributor PR that introduces a **new** duplicate — removing an entry once its underlying data duplicate is actually resolved is a one-line follow-up.

## Testing

```
npx vitest run tests/validate-surface-duplicate-url.test.mjs tests/validate-error-messages.test.mjs
# 8 passed: a fixture with 2 surfaces sharing an exact URL fails with both surface
# ids named; a trailing-slash-only difference is still caught (via normalizePublicUrl);
# a fixture with distinct URLs passes; the full registry (grandfathering applied) passes
# both with no args and with every file passed explicitly; existing enum-error-message
# regression tests for this same script still pass unchanged.

npm run validate:surface
# Surface validation passed: 851 surface(s) across 129 subnet file(s).

npm run validate
# Validated 129 native subnet(s), 129 curated overlay(s), 1614 surface(s), 133 provider(s), and 2037 candidate(s).

npx eslint scripts/validate-surface.mjs tests/validate-surface-duplicate-url.test.mjs
# clean

npx prettier --check scripts/validate-surface.mjs tests/validate-surface-duplicate-url.test.mjs
# clean
```