### PR TITLE
feat(graphql): add Query.subnet_performance

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -35,6 +35,7 @@ import {
   DEFAULT_SUBNET_WEIGHTS_WINDOW,
 } from "./subnet-weights.mjs";
 import { buildSubnetYield } from "./subnet-yield.mjs";
+import { buildSubnetPerformance } from "./subnet-performance.mjs";
 import {
   analyticsWindow,
   loadGlobalIncidentsLedger,
@@ -183,6 +184,8 @@ export const SDL = `
     subnet_weights(netuid: Int!, window: String): SubnetWeights!
     "Per-subnet emission-per-stake yield over the current metagraph snapshot: each UID's yield plus the subnet-wide aggregate and p25/median/p75/p90 distribution; a subnet with no neurons resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/yield."
     subnet_yield(netuid: Int!): SubnetYield!
+    "Per-subnet reward-distribution and score-spread card over the current neurons snapshot: incentive/dividends concentration plus p10–p90 trust/consensus/validator_trust; a subnet with no neurons resolves to a schema-stable zeroed card (metric blocks null), never null. Mirrors GET /api/v1/subnets/{netuid}/performance."
+    subnet_performance(netuid: Int!): SubnetPerformance!
     "Append-only on-chain SubnetIdentitiesV3 change timeline for one subnet (name, symbol, description, repo, website, discord, logo), newest first; page with limit/offset or follow next_cursor. A subnet with no matching events resolves to a schema-stable empty timeline (entry_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/identity-history."
     subnet_identity_history(netuid: Int!, limit: Int, offset: Int, cursor: String): SubnetIdentityHistory!
     "Paginated provider/source registry."
@@ -760,6 +763,39 @@ export const SDL = `
     p75_yield: Float
     p90_yield: Float
     neurons: [SubnetYieldNeuron!]!
+  }
+
+  "0..1 score column spread (count/mean/min/max plus nearest-rank percentiles). Null when no neuron carries a finite value."
+  type ScoreDistribution {
+    count: Int!
+    mean: Float
+    min: Float
+    max: Float
+    p10: Float
+    p25: Float
+    p50: Float
+    p75: Float
+    p90: Float
+  }
+
+  "Per-subnet reward-distribution & score-spread card (#5714). Metric blocks are null on a cold/empty subnet. Mirrors GET /api/v1/subnets/{netuid}/performance."
+  type SubnetPerformance {
+    schema_version: Int!
+    netuid: Int!
+    neuron_count: Int!
+    validator_count: Int!
+    active_count: Int!
+    captured_at: String
+    "Incentive concentration across all neurons with positive incentive."
+    incentive: ConcentrationMetrics
+    "Dividends concentration across permitted validators only."
+    dividends: ConcentrationMetrics
+    "Trust score spread across all neurons."
+    trust: ScoreDistribution
+    "Consensus score spread across all neurons."
+    consensus: ScoreDistribution
+    "Validator-trust score spread across permitted validators only."
+    validator_trust: ScoreDistribution
   }
 
   "Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope."
@@ -1411,6 +1447,7 @@ export const FIELD_COMPLEXITY = {
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_yield: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_performance: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2121,6 +2158,41 @@ const rootValue = {
       offset: data.offset ?? safeOffset,
       next_cursor: data.next_cursor ?? null,
       entries: data.entries || [],
+    };
+  },
+
+  async subnet_performance({ netuid }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetPerformance([])
+    // cold fallback contract handleSubnetPerformance / MCP get_subnet_performance
+    // use: a subnet with no neurons is a schema-stable zeroed card (metric
+    // blocks null), never a GraphQL error. No window — current snapshot only.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/performance`,
+          new URLSearchParams(),
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildSubnetPerformance([], netuid);
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      neuron_count: data.neuron_count ?? 0,
+      validator_count: data.validator_count ?? 0,
+      active_count: data.active_count ?? 0,
+      captured_at: data.captured_at ?? null,
+      incentive: data.incentive ?? null,
+      dividends: data.dividends ?? null,
+      trust: data.trust ?? null,
+      consensus: data.consensus ?? null,
+      validator_trust: data.validator_trust ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3862,6 +3862,192 @@ describe("graphql — subnet_registrations (#5720, Postgres-tier + zeroed-card f
   });
 });
 
+describe("graphql — subnet_performance (#5714, Postgres-tier + zeroed-card fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_performance(netuid: 5) {
+          schema_version netuid neuron_count validator_count active_count captured_at
+          incentive { holders gini } dividends { holders }
+          trust { count } consensus { count } validator_trust { count }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_performance, {
+      schema_version: 1,
+      netuid: 5,
+      neuron_count: 0,
+      validator_count: 0,
+      active_count: 0,
+      captured_at: null,
+      incentive: null,
+      dividends: null,
+      trust: null,
+      consensus: null,
+      validator_trust: null,
+    });
+  });
+
+  test("resolves the Postgres-tier reward + score blocks", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 7,
+          neuron_count: 4,
+          validator_count: 2,
+          active_count: 3,
+          captured_at: "2026-07-01T00:00:00.000Z",
+          incentive: {
+            holders: 3,
+            total: 1,
+            gini: 0.4,
+            hhi: 0.5,
+            hhi_normalized: 0.25,
+            nakamoto_coefficient: 1,
+            top_1pct_share: 0.6,
+            top_5pct_share: 0.6,
+            top_10pct_share: 0.6,
+            top_20pct_share: 0.9,
+            entropy: 1.4,
+            entropy_normalized: 0.8,
+          },
+          dividends: {
+            holders: 2,
+            total: 0.6,
+            gini: 0.2,
+            hhi: 0.7,
+            hhi_normalized: 0.4,
+            nakamoto_coefficient: 1,
+            top_1pct_share: 0.83,
+            top_5pct_share: 0.83,
+            top_10pct_share: 0.83,
+            top_20pct_share: 1,
+            entropy: 0.9,
+            entropy_normalized: 0.9,
+          },
+          trust: {
+            count: 4,
+            mean: 0.7,
+            min: 0.4,
+            max: 0.9,
+            p10: 0.4,
+            p25: 0.5,
+            p50: 0.75,
+            p75: 0.85,
+            p90: 0.9,
+          },
+          consensus: {
+            count: 4,
+            mean: 0.6,
+            min: 0.3,
+            max: 0.8,
+            p10: 0.3,
+            p25: 0.4,
+            p50: 0.65,
+            p75: 0.75,
+            p90: 0.8,
+          },
+          validator_trust: {
+            count: 2,
+            mean: 0.9,
+            min: 0.85,
+            max: 0.95,
+            p10: 0.85,
+            p25: 0.85,
+            p50: 0.95,
+            p75: 0.95,
+            p90: 0.95,
+          },
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_performance(netuid: 7) {
+          netuid neuron_count validator_count active_count captured_at
+          incentive { holders gini nakamoto_coefficient top_10pct_share }
+          dividends { holders total }
+          trust { count mean max }
+          validator_trust { count min max }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const p = body.data.subnet_performance;
+    assert.equal(p.netuid, 7);
+    assert.equal(p.neuron_count, 4);
+    assert.equal(p.validator_count, 2);
+    assert.equal(p.active_count, 3);
+    assert.equal(p.captured_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(p.incentive.holders, 3);
+    assert.equal(p.incentive.nakamoto_coefficient, 1);
+    assert.equal(p.dividends.holders, 2);
+    assert.equal(p.dividends.total, 0.6);
+    assert.equal(p.trust.count, 4);
+    assert.equal(p.trust.max, 0.9);
+    assert.equal(p.validator_trust.count, 2);
+    assert.equal(p.validator_trust.min, 0.85);
+  });
+
+  test("forwards the performance path to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql("{ subnet_performance(netuid: 3) { neuron_count } }", env);
+    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/performance"));
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_performance(netuid: 9) {
+          schema_version netuid neuron_count validator_count active_count
+          incentive { holders } trust { count }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_performance, {
+      schema_version: 1,
+      netuid: 9,
+      neuron_count: 0,
+      validator_count: 0,
+      active_count: 0,
+      incentive: null,
+      trust: null,
+    });
+  });
+
+  test("a negative netuid is a GraphQL error, not an empty card", async () => {
+    const { body } = await gql(
+      "{ subnet_performance(netuid: -1) { neuron_count } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/netuid/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_performance ?? null, null);
+  });
+
+  test("subnet_performance is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_performance, 5);
+  });
+});
+
 describe("graphql — subnet_yield (#5713, Postgres-tier + zeroed-card fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
﻿## Summary
- Add GraphQL `Query.subnet_performance(netuid)` mirroring REST `GET /api/v1/subnets/{netuid}/performance` and MCP `get_subnet_performance`.
- Resolver uses `tryPostgresTier(METAGRAPH_NEURONS_SOURCE)` with `buildSubnetPerformance([], netuid)` cold fallback; empty subnet is schema-stable (metric blocks null).
- Reuses existing `ConcentrationMetrics` plus new `ScoreDistribution` SDL types; `FIELD_COMPLEXITY.subnet_performance = 5`.

Closes #5714

## Test plan
- [x] `npx vitest run tests/graphql.test.mjs -t "subnet_performance"` (6 tests)
- [ ] CI `Validate` + codecov/patch ≥99%
