### PR TITLE
feat(graphql): add Query.subnet_stake_transfers mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -30,6 +30,11 @@ import {
   DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
 } from "./subnet-axon-removals.mjs";
 import {
+  buildSubnetStakeTransfers,
+  SUBNET_STAKE_TRANSFERS_WINDOWS,
+  DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW,
+} from "./subnet-stake-transfers.mjs";
+import {
   buildSubnetWeights,
   SUBNET_WEIGHTS_WINDOWS,
   DEFAULT_SUBNET_WEIGHTS_WINDOW,
@@ -179,6 +184,8 @@ export const SDL = `
     subnet_serving(netuid: Int!, window: String): SubnetServing!
     "Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
     subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
+    "Per-subnet stake-transfer activity over a 7d/30d window (distinct senders, StakeTransferred count, and transfers per sender); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/stake-transfers."
+    subnet_stake_transfers(netuid: Int!, window: String): SubnetStakeTransfers!
     "Per-subnet validator weight-setting activity over a 7d/30d window (distinct weight-setters, WeightsSet count, and sets per setter); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/weights."
     subnet_weights(netuid: Int!, window: String): SubnetWeights!
     "Per-subnet emission-per-stake yield over the current metagraph snapshot: each UID's yield plus the subnet-wide aggregate and p25/median/p75/p90 distribution; a subnet with no neurons resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/yield."
@@ -721,6 +728,16 @@ export const SDL = `
     distinct_removers: Int!
     removals: Int!
     removals_per_remover: Float
+  }
+
+  type SubnetStakeTransfers {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    distinct_senders: Int!
+    transfers: Int!
+    transfers_per_sender: Float
   }
 
   type SubnetWeights {
@@ -1409,6 +1426,7 @@ export const FIELD_COMPLEXITY = {
   subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_stake_transfers: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_yield: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2121,6 +2139,43 @@ const rootValue = {
       offset: data.offset ?? safeOffset,
       next_cursor: data.next_cursor ?? null,
       entries: data.entries || [],
+    };
+  },
+
+  async subnet_stake_transfers({ netuid, window }, context) {
+    // Same 7d/30d window validation handleSubnetStakeTransfers uses -- an
+    // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW;
+    if (!Object.hasOwn(SUBNET_STAKE_TRANSFERS_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, SUBNET_STAKE_TRANSFERS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> buildSubnetStakeTransfers
+    // zeroed-card fallback contract handleSubnetStakeTransfers uses; a subnet with no
+    // StakeTransferred events in the window is a schema-stable zeroed card, never a
+    // GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/stake-transfers`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildSubnetStakeTransfers(null, netuid, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      observed_at: data.observed_at ?? null,
+      distinct_senders: data.distinct_senders ?? 0,
+      transfers: data.transfers ?? 0,
+      transfers_per_sender: data.transfers_per_sender ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -4346,6 +4346,94 @@ describe("graphql — subnet_axon_removals (#5718, Postgres-tier + zeroed-card f
   });
 });
 
+describe("graphql — subnet_stake_transfers (#5717, Postgres-tier + zeroed-card fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_stake_transfers(netuid: 5) {
+          schema_version netuid window observed_at
+          distinct_senders transfers transfers_per_sender
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_stake_transfers, {
+      schema_version: 1,
+      netuid: 5,
+      window: "7d",
+      observed_at: null,
+      distinct_senders: 0,
+      transfers: 0,
+      transfers_per_sender: null,
+    });
+  });
+
+  test("resolves the Postgres-tier card for the requested window", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          window: "30d",
+          observed_at: "2026-07-01T00:00:00.000Z",
+          distinct_senders: 3,
+          transfers: 9,
+          transfers_per_sender: 3,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_stake_transfers(netuid: 5, window: "30d") {
+          netuid window observed_at distinct_senders transfers transfers_per_sender
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const r = body.data.subnet_stake_transfers;
+    assert.equal(r.window, "30d");
+    assert.equal(r.observed_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(r.distinct_senders, 3);
+    assert.equal(r.transfers, 9);
+    assert.equal(r.transfers_per_sender, 3);
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_stake_transfers(netuid: 9, window: "30d") {
+          schema_version netuid window observed_at distinct_senders transfers transfers_per_sender
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_stake_transfers, {
+      schema_version: 1,
+      netuid: 9,
+      window: "30d",
+      observed_at: null,
+      distinct_senders: 0,
+      transfers: 0,
+      transfers_per_sender: null,
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ subnet_stake_transfers(netuid: 5, window: "99d") { transfers } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_stake_transfers ?? null, null);
+  });
+});
+
 describe("graphql — account_registrations (#5704, Postgres-tier + zeroed-card fallback)", () => {
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 


### PR DESCRIPTION
Adds a \`subnet_stake_transfers(netuid, window)\` GraphQL query mirroring \`GET /api/v1/subnets/{netuid}/stake-transfers\` and the \`get_subnet_stake_transfers\` MCP tool: per-subnet stake-transfer activity over a 7d/30d window (distinct senders, StakeTransferred count, and transfers per sender).

Rebased fresh on \`main\` (the prior #5798 was auto-closed on a base-branch conflict after a concurrent GraphQL merge landed — no code changes, review was clean).

## What
- New \`SubnetStakeTransfers\` type + \`Query.subnet_stake_transfers(netuid: Int!, window: String)\` in \`src/graphql.mjs\`, weighted \`RELATIONSHIP_FIELD_COMPLEXITY\`.
- Resolver reuses \`buildSubnetStakeTransfers\` and \`SUBNET_STAKE_TRANSFERS_WINDOWS\`/\`DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW\` from \`src/subnet-stake-transfers.mjs\`, resolving through the same \`tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)\` path as the REST handler with a schema-stable zeroed-card fallback.
- An unsupported window is a \`BAD_USER_INPUT\` GraphQL error, matching the sibling \`subnet_serving\`/\`subnet_axon_removals\` queries.

## Tests
Four cases in \`tests/graphql.test.mjs\`: cold-store zeroed card, Postgres-tier resolve for the requested window, partial-body degradation, and unsupported-window error. Full graphql suite green (283 tests); resolver 100% covered (statements + branches).

Closes #5717