### PR TITLE
feat(graphql): add Query.subnet_weight_setters

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -34,6 +34,11 @@ import {
   SUBNET_WEIGHTS_WINDOWS,
   DEFAULT_SUBNET_WEIGHTS_WINDOW,
 } from "./subnet-weights.mjs";
+import {
+  buildSubnetWeightSetters,
+  SUBNET_WEIGHT_SETTERS_WINDOWS,
+  DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
+} from "./subnet-weight-setters.mjs";
 import { buildSubnetYield } from "./subnet-yield.mjs";
 import { buildSubnetPerformance } from "./subnet-performance.mjs";
 import {
@@ -182,6 +187,8 @@ export const SDL = `
     subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
     "Per-subnet validator weight-setting activity over a 7d/30d window (distinct weight-setters, WeightsSet count, and sets per setter); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/weights."
     subnet_weights(netuid: Int!, window: String): SubnetWeights!
+    "Per-subnet weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators behind /weights ranked by WeightsSet activity, each with count, share, and first/last set times; a subnet with no events resolves to a schema-stable empty leaderboard, never null. Mirrors GET /api/v1/subnets/{netuid}/weights/setters."
+    subnet_weight_setters(netuid: Int!, window: String): SubnetWeightSetters!
     "Per-subnet emission-per-stake yield over the current metagraph snapshot: each UID's yield plus the subnet-wide aggregate and p25/median/p75/p90 distribution; a subnet with no neurons resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/yield."
     subnet_yield(netuid: Int!): SubnetYield!
     "Per-subnet reward-distribution and score-spread card over the current neurons snapshot: incentive/dividends concentration plus p10–p90 trust/consensus/validator_trust; a subnet with no neurons resolves to a schema-stable zeroed card (metric blocks null), never null. Mirrors GET /api/v1/subnets/{netuid}/performance."
@@ -734,6 +741,29 @@ export const SDL = `
     distinct_setters: Int!
     weight_sets: Int!
     sets_per_setter: Float
+  }
+
+  "Per-subnet weight-setter leaderboard (#5712). Empty setters on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/weights/setters."
+  type SubnetWeightSetters {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    distinct_setters: Int!
+    weight_sets: Int!
+    setter_count: Int!
+    setters: [SubnetWeightSetter!]!
+  }
+
+  "One validator's weight-setting activity within one subnet over the lookback window."
+  type SubnetWeightSetter {
+    hotkey: String
+    uid: Int
+    weight_sets: Int!
+    "This setter's share of the subnet total weight_sets; null when the subnet total is 0."
+    share: Float
+    first_set_at: String
+    last_set_at: String
   }
 
   "One UID's emission-per-stake yield within a subnet's current metagraph snapshot."
@@ -1446,6 +1476,7 @@ export const FIELD_COMPLEXITY = {
   subnet_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_yield: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_performance: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2267,6 +2298,48 @@ const rootValue = {
       distinct_setters: data.distinct_setters ?? 0,
       weight_sets: data.weight_sets ?? 0,
       sets_per_setter: data.sets_per_setter ?? null,
+    };
+  },
+
+  async subnet_weight_setters({ netuid, window }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same 7d/30d window validation handleSubnetWeightSetters uses -- an
+    // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW;
+    if (!Object.hasOwn(SUBNET_WEIGHT_SETTERS_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, SUBNET_WEIGHT_SETTERS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) ->
+    // buildSubnetWeightSetters([], null, ...) empty-leaderboard fallback
+    // contract handleSubnetWeightSetters / MCP get_subnet_weight_setters use.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/weights/setters`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildSubnetWeightSetters([], null, netuid, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      observed_at: data.observed_at ?? null,
+      distinct_setters: data.distinct_setters ?? 0,
+      weight_sets: data.weight_sets ?? 0,
+      setter_count: data.setter_count ?? 0,
+      setters: data.setters || [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -4268,6 +4268,152 @@ describe("graphql — subnet_weights (#5711, Postgres-tier + zeroed-card fallbac
   });
 });
 
+describe("graphql — subnet_weight_setters (#5712, Postgres-tier + empty-leaderboard fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty leaderboard, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_weight_setters(netuid: 5) {
+          schema_version netuid window observed_at
+          distinct_setters weight_sets setter_count
+          setters { hotkey uid weight_sets share }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_weight_setters, {
+      schema_version: 1,
+      netuid: 5,
+      window: "7d",
+      observed_at: null,
+      distinct_setters: 0,
+      weight_sets: 0,
+      setter_count: 0,
+      setters: [],
+    });
+  });
+
+  test("resolves the Postgres-tier leaderboard for the requested window", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          window: "30d",
+          observed_at: "2026-07-01T00:00:00.000Z",
+          distinct_setters: 2,
+          weight_sets: 10,
+          setter_count: 2,
+          setters: [
+            {
+              hotkey: "5SetterA",
+              uid: 1,
+              weight_sets: 7,
+              share: 0.7,
+              first_set_at: "2026-06-20T00:00:00.000Z",
+              last_set_at: "2026-07-01T00:00:00.000Z",
+            },
+            {
+              hotkey: null,
+              uid: 2,
+              weight_sets: 3,
+              share: 0.3,
+              first_set_at: "2026-06-25T00:00:00.000Z",
+              last_set_at: "2026-06-30T00:00:00.000Z",
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_weight_setters(netuid: 5, window: "30d") {
+          netuid window observed_at distinct_setters weight_sets setter_count
+          setters { hotkey uid weight_sets share first_set_at last_set_at }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const w = body.data.subnet_weight_setters;
+    assert.equal(w.window, "30d");
+    assert.equal(w.weight_sets, 10);
+    assert.equal(w.setter_count, 2);
+    assert.equal(w.setters[0].hotkey, "5SetterA");
+    assert.equal(w.setters[0].share, 0.7);
+    assert.equal(w.setters[1].hotkey, null);
+    assert.equal(w.setters[1].uid, 2);
+  });
+
+  test("window is forwarded as a query param to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(
+      '{ subnet_weight_setters(netuid: 3, window: "30d") { setter_count } }',
+      env,
+    );
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/weights/setters"));
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_weight_setters(netuid: 9, window: "30d") {
+          schema_version netuid window observed_at
+          distinct_setters weight_sets setter_count setters { hotkey }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_weight_setters, {
+      schema_version: 1,
+      netuid: 9,
+      window: "30d",
+      observed_at: null,
+      distinct_setters: 0,
+      weight_sets: 0,
+      setter_count: 0,
+      setters: [],
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ subnet_weight_setters(netuid: 5, window: "99d") { setter_count } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_weight_setters ?? null, null);
+  });
+
+  test("a negative netuid is a GraphQL error, not an empty card", async () => {
+    const { body } = await gql(
+      "{ subnet_weight_setters(netuid: -1) { setter_count } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/netuid/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_weight_setters ?? null, null);
+  });
+
+  test("subnet_weight_setters is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_weight_setters, 5);
+  });
+});
+
 describe("graphql — subnet_deregistrations (#5719, Postgres-tier + zeroed-card fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
﻿## Summary
- Add GraphQL `Query.subnet_weight_setters(netuid, window)` mirroring REST `GET /api/v1/subnets/{netuid}/weights/setters` and MCP `get_subnet_weight_setters`.
- Resolver uses `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` with `buildSubnetWeightSetters([], null, …)` empty-leaderboard fallback; unsupported windows are GraphQL errors.
- `FIELD_COMPLEXITY.subnet_weight_setters = 5`.

Closes #5712

## Test plan
- [x] `npx vitest run tests/graphql.test.mjs -t "subnet_weight_setters"` (7 tests)
- [ ] CI `Validate` + codecov/patch ≥99%
