### PR TITLE
feat(graphql): add Query.registry_leaderboards mirroring REST

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -50,10 +50,12 @@ import { loadSubnetIdentityHistory } from "./subnet-identity-history.mjs";
 import {
   buildGlobalHealth,
   formatLeaderboards,
+  LEADERBOARD_BOARDS,
   resolveLiveEconomics,
   resolveLiveHealth,
   subnetBadgeStatus,
 } from "./health-serving.mjs";
+import { composeLeaderboardsData } from "../workers/request-handlers/analytics-routes.mjs";
 import {
   loadCompareSubnets,
   parseCompareDimensionList,
@@ -242,6 +244,8 @@ export const SDL = `
     account_stake_moves(ss58: String!, window: String): AccountStakeMoves!
     "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
     economics_trends(window: String): EconomicsTrends!
+    "Registry leaderboards: the operational boards (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable) and the economic-opportunity boards (open-slots, cheapest-registration, highest-emission, validator-headroom), composed live from the registry profiles projection plus D1 health/rpc/growth/reliability rows and the economics tier. Pass board to return just that board (default: every board); limit caps each board's entries (default 20, max 100). An unknown board is a BAD_USER_INPUT error, matching REST's invalid_query 400. Mirrors GET /api/v1/registry/leaderboards."
+    registry_leaderboards(board: String, limit: Int): RegistryLeaderboards!
     "Cross-subnet momentum leaderboard: every subnet ranked by its stake/emission/validator change between a window's start and end snapshots; movers is empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/subnets/movers."
     subnet_movers(window: String, sort: String, limit: Int): SubnetMovers!
     "Network-wide validator weight-setting activity leaderboard over a 7d/30d window (default 7d): subnets ranked by WeightsSet events with each's distinct-setter count and sets-per-setter update intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. Mirrors GET /api/v1/chain/weights."
@@ -491,6 +495,17 @@ export const SDL = `
     source: String
     "The 7d/30d windows keyed by window label (7d, 30d), each holding days/granularity/subnet_count and the per-subnet daily point series. Opaque JSON: dynamic-keyed by window label, matching the get_health_trends MCP/REST shape."
     windows: JSON!
+  }
+
+  "Registry leaderboards over the operational + economic-opportunity boards. Mirrors GET /api/v1/registry/leaderboards."
+  type RegistryLeaderboards {
+    schema_version: Int!
+    "The board filter that was applied, or null when every board is returned."
+    board: String
+    observed_at: String
+    source: String
+    "Every board keyed by board name, each an array of ranked subnet entries capped at limit. Opaque JSON like HealthTrends.windows: the keys are dynamic AND hyphenated (fastest-rpc, most-complete, open-slots, …) so they are not expressible as GraphQL field names, and each board carries its own metric columns (healthiest has uptime_ratio/surfaces_ok, fastest-rpc has latency_ms, fastest-growing has completeness_delta, …). Passing it through verbatim keeps the REST/MCP get_registry_leaderboards shape byte-for-byte."
+    boards: JSON!
   }
 
   type SurfaceList {
@@ -1460,6 +1475,9 @@ export const FIELD_COMPLEXITY = {
   chain_yield: RELATIONSHIP_FIELD_COMPLEXITY,
   account_prometheus: RELATIONSHIP_FIELD_COMPLEXITY,
   account_stake_flow: RELATIONSHIP_FIELD_COMPLEXITY,
+  // Fans out into leaderboardProfilesProjection plus several D1 reads and the
+  // economics tier -- same cost class as the other relationship fields.
+  registry_leaderboards: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_recycled: LIVE_RPC_FIELD_COMPLEXITY,
 };
 
@@ -3262,6 +3280,43 @@ const rootValue = {
       observed_at: data.observed_at ?? null,
       source: data.source ?? null,
       windows: data.windows ?? {},
+    };
+  },
+
+  async registry_leaderboards({ board, limit }, context) {
+    // Same board allowlist handleLeaderboards enforces -- an unknown board is a
+    // GraphQL BAD_USER_INPUT error, mirroring REST's invalid_query 400 rather
+    // than silently resolving to an empty board.
+    if (board != null && !LEADERBOARD_BOARDS.includes(board)) {
+      throw new GraphQLError(
+        `Unknown board "${board}". Valid boards: ${LEADERBOARD_BOARDS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same default 20 / max 100 parseLimitParam gives REST. A non-integer or
+    // out-of-range limit is rejected there, so reject it here too instead of
+    // silently clamping.
+    if (
+      limit != null &&
+      (!Number.isInteger(limit) || limit < 1 || limit > 100)
+    ) {
+      throw new GraphQLError(
+        `\`limit\` must be an integer between 1 and 100. Received "${limit}".`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Reuses handleLeaderboards' own projection + D1 reads via the shared
+    // composer, so REST and GraphQL can never drift apart on board composition.
+    const { data } = await composeLeaderboardsData(context.env, {
+      board: board ?? null,
+      limit: limit ?? 20,
+    });
+    return {
+      schema_version: data.schema_version ?? 1,
+      board: data.board ?? null,
+      observed_at: data.observed_at ?? null,
+      source: data.source ?? null,
+      boards: data.boards ?? {},
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -21,6 +21,7 @@ import {
   maxDepthRule,
   schema as chainEventsSchema,
 } from "../src/graphql.mjs";
+import { LEADERBOARD_BOARDS } from "../src/health-serving.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { resolveClientIp } from "../workers/config.mjs";
 import {
@@ -6459,6 +6460,127 @@ describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled
     assert.equal(FIELD_COMPLEXITY.subnet_recycled, 10);
     assert.ok(
       FIELD_COMPLEXITY.subnet_recycled > FIELD_COMPLEXITY.chain_weights,
+    );
+  });
+});
+
+describe("graphql — registry_leaderboards (#5661, shared composer + REST-matching validation)", () => {
+  // Every D1 query in the composer returns no rows, so the boards resolve from
+  // an empty projection without a live DB. No profiles artifact is injected, so
+  // leaderboardProfilesProjection's module-level cache is never populated —
+  // these tests can't leak a projection into each other.
+  const emptyHealthDb = {
+    prepare: () => ({ bind: () => ({ all: async () => ({ results: [] }) }) }),
+  };
+
+  // Same shape handleLeaderboards' surface_status aggregate yields; the stub
+  // ignores the SQL, so a single board is asserted at a time.
+  function healthDb(results) {
+    return {
+      prepare: () => ({ bind: () => ({ all: async () => ({ results }) }) }),
+    };
+  }
+
+  test("cold store: every board resolves schema-stable and empty, never null", async () => {
+    const { status, body } = await gql(
+      `{ registry_leaderboards { schema_version board observed_at source boards } }`,
+      { METAGRAPH_HEALTH_DB: emptyHealthDb },
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.registry_leaderboards;
+    assert.equal(r.schema_version, 1);
+    // No board filter -> every board key present, each an empty ranked list.
+    assert.equal(r.board, null);
+    assert.equal(r.source, "registry+live-cron-prober");
+    for (const key of LEADERBOARD_BOARDS) {
+      assert.deepEqual(
+        r.boards[key],
+        [],
+        `board ${key} should be an empty list`,
+      );
+    }
+  });
+
+  test("an explicit board returns only that board, ranked from the D1 rows", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: healthDb([
+        { netuid: 7, total: 4, ok_count: 2, avg_latency_ms: 90 },
+        { netuid: 3, total: 4, ok_count: 4, avg_latency_ms: 42 },
+      ]),
+    };
+    const { status, body } = await gql(
+      `{ registry_leaderboards(board: "healthiest") { board boards } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.registry_leaderboards;
+    assert.equal(r.board, "healthiest");
+    // Filtered response carries just the requested board, matching REST.
+    assert.deepEqual(Object.keys(r.boards), ["healthiest"]);
+    // Ranked by uptime_ratio desc — the fully-ok subnet leads.
+    assert.deepEqual(
+      r.boards.healthiest.map((e) => e.netuid),
+      [3, 7],
+    );
+    assert.equal(r.boards.healthiest[0].surfaces_ok, 4);
+    assert.equal(r.boards.healthiest[0].avg_latency_ms, 42);
+  });
+
+  test("limit caps each board's entries", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: healthDb([
+        { netuid: 7, total: 4, ok_count: 2, avg_latency_ms: 90 },
+        { netuid: 3, total: 4, ok_count: 4, avg_latency_ms: 42 },
+      ]),
+    };
+    const { body } = await gql(
+      `{ registry_leaderboards(board: "healthiest", limit: 1) { boards } }`,
+      env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.registry_leaderboards.boards.healthiest.length, 1);
+  });
+
+  test("an unknown board is a BAD_USER_INPUT error, not a silent empty board", async () => {
+    const { status, body } = await gql(
+      `{ registry_leaderboards(board: "not-a-board") { board } }`,
+      { METAGRAPH_HEALTH_DB: emptyHealthDb },
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors?.length, "expected a GraphQL error");
+    assert.match(body.errors[0].message, /Unknown board "not-a-board"/);
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+    assert.equal(body.data?.registry_leaderboards ?? null, null);
+  });
+
+  test("a limit outside REST's 1..100 range is a BAD_USER_INPUT error", async () => {
+    for (const limit of [0, 101]) {
+      const { body } = await gql(
+        `{ registry_leaderboards(limit: ${limit}) { board } }`,
+        { METAGRAPH_HEALTH_DB: emptyHealthDb },
+      );
+      assert.ok(body.errors?.length, `limit ${limit} should error`);
+      assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+      assert.match(body.errors[0].message, /between 1 and 100/);
+    }
+  });
+
+  test("the boundary limits REST accepts are accepted here too", async () => {
+    for (const limit of [1, 100]) {
+      const { body } = await gql(
+        `{ registry_leaderboards(limit: ${limit}) { board } }`,
+        { METAGRAPH_HEALTH_DB: emptyHealthDb },
+      );
+      assert.equal(body.errors, undefined, `limit ${limit} should be accepted`);
+    }
+  });
+
+  test("is priced as a relationship field — it fans out into several D1 reads", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.registry_leaderboards,
+      FIELD_COMPLEXITY.health_trends,
     );
   });
 });

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -507,23 +507,22 @@ async function resolveEconomicsRows(env) {
     : [];
 }
 
-export async function handleLeaderboards(request, env, url) {
-  const validationError = validateQueryParams(url, ["board", "limit"]);
-  if (validationError) return analyticsQueryError(validationError);
-  const requestedBoard = url.searchParams.get("board");
-  if (requestedBoard && !LEADERBOARD_BOARDS.includes(requestedBoard)) {
-    return errorResponse(
-      "invalid_query",
-      `Unknown board "${requestedBoard}". Valid boards: ${LEADERBOARD_BOARDS.join(", ")}.`,
-      400,
-    );
-  }
-  const parsedLimit = parseLimitParam(url, { defaultLimit: 20, maxLimit: 100 });
-  if (parsedLimit.error) {
-    return errorResponse("invalid_query", parsedLimit.error.message, 400);
-  }
-  const limit = parsedLimit.limit;
-
+/**
+ * Compose the registry-leaderboards payload: the profiles projection plus the
+ * D1 health/rpc/growth/reliability reads and the economics tier, folded through
+ * formatLeaderboards.
+ *
+ * Split out of handleLeaderboards so the GraphQL mirror
+ * (Query.registry_leaderboards, #5661) reuses this exact projection instead of
+ * duplicating the D1 queries. Callers own argument validation and response
+ * wrapping; this only builds the payload. `d1Rows` is returned alongside it
+ * because the HTTP path needs the raw row-sets for its cold-store fallback
+ * signal — GraphQL ignores them.
+ */
+export async function composeLeaderboardsData(
+  env,
+  { board = null, limit = 20 } = {},
+) {
   const { subnetMeta, mostComplete } = await leaderboardProfilesProjection(env);
 
   const sevenDaysAgo = new Date(Date.now() - 7 * DAY_MS)
@@ -581,7 +580,7 @@ export async function handleLeaderboards(request, env, url) {
 
   const meta = await readHealthMetaKv(env);
   const data = formatLeaderboards({
-    board: requestedBoard || null,
+    board,
     limit,
     observedAt: meta?.last_run_at || null,
     healthRows,
@@ -591,6 +590,32 @@ export async function handleLeaderboards(request, env, url) {
     reliabilityRows,
     economicsRows,
     subnetMeta,
+  });
+  return {
+    data,
+    d1Rows: [healthRows, rpcRows, growthSamples, reliabilityRows],
+  };
+}
+
+export async function handleLeaderboards(request, env, url) {
+  const validationError = validateQueryParams(url, ["board", "limit"]);
+  if (validationError) return analyticsQueryError(validationError);
+  const requestedBoard = url.searchParams.get("board");
+  if (requestedBoard && !LEADERBOARD_BOARDS.includes(requestedBoard)) {
+    return errorResponse(
+      "invalid_query",
+      `Unknown board "${requestedBoard}". Valid boards: ${LEADERBOARD_BOARDS.join(", ")}.`,
+      400,
+    );
+  }
+  const parsedLimit = parseLimitParam(url, { defaultLimit: 20, maxLimit: 100 });
+  if (parsedLimit.error) {
+    return errorResponse("invalid_query", parsedLimit.error.message, 400);
+  }
+
+  const { data, d1Rows } = await composeLeaderboardsData(env, {
+    board: requestedBoard || null,
+    limit: parsedLimit.limit,
   });
   return envelopeWithD1Fallback(
     request,
@@ -605,7 +630,7 @@ export async function handleLeaderboards(request, env, url) {
       },
     },
     "standard",
-    [healthRows, rpcRows, growthSamples, reliabilityRows],
+    d1Rows,
   );
 }
 


### PR DESCRIPTION
## Summary

Closes #5661

Registry leaderboards had a REST route and an MCP tool but no GraphQL mirror — the same gap the `Query.blocks`/`extrinsics`/`validators`/`accounts` issues closed.

- **SDL**: `registry_leaderboards(board: String, limit: Int): RegistryLeaderboards!` + the `RegistryLeaderboards` type, with a doc-comment on the field.
- **Validation**: `board` is checked against the same `LEADERBOARD_BOARDS` allowlist REST uses, and `limit` against the same 1..100 range `parseLimitParam` enforces — both as `BAD_USER_INPUT` errors rather than a silent empty board or a quiet clamp, translating REST's `invalid_query` 400 into GraphQL's error contract.
- **`FIELD_COMPLEXITY`**: `RELATIONSHIP_FIELD_COMPLEXITY`, since it fans out into `leaderboardProfilesProjection` plus several D1 reads and the economics tier.

## Reused REST's composition — no duplicated D1 queries

The issue called this out explicitly, so rather than re-issue the queries I extracted `handleLeaderboards`' projection + 5 D1/economics reads + `formatLeaderboards` fold into **`composeLeaderboardsData(env, { board, limit })`**, which REST and GraphQL both call. The two can't drift on board composition. `handleLeaderboards` keeps its own validation and response wrapping, and the composer hands back the raw row-sets it needs for the cold-store fallback signal.

`src/graphql.mjs` already imports from `workers/request-handlers/analytics.mjs`, and `analytics-routes.mjs` has no graphql import, so there's no cycle.

## Why `boards` is the JSON scalar

`boards` is **dynamic-keyed and hyphenated** — `fastest-rpc`, `most-complete`, `open-slots` — which are not expressible as GraphQL field names, and each board carries its own metric columns (`healthiest` has `uptime_ratio`/`surfaces_ok`, `fastest-rpc` has `latency_ms`, `fastest-growing` has `completeness_delta`). Passing it through verbatim keeps the REST/MCP `get_registry_leaderboards` shape byte-for-byte, and it matches the existing `HealthTrends.windows` precedent ("Opaque JSON: dynamic-keyed by window label"). A hand-typed object would have had to rename every board and still couldn't mirror REST.

## Tests (`tests/graphql.test.mjs`, 7 new)

Cold store (every board schema-stable and empty, never null) · an explicit board returning only that board, ranked from the D1 rows · `limit` capping entries · unknown board → `BAD_USER_INPUT` · `limit` 0/101 → `BAD_USER_INPUT` · the 1/100 boundaries accepted · complexity pricing.

They drive the boards from D1 rows and never populate `leaderboardProfilesProjection`'s module-level TTL cache, so they can't leak a projection into each other.

## Gates

`tests/graphql.test.mjs` **292 passed** · REST side proven unregressed by the refactor: `analytics.test.mjs` 73 · `analytics-live.test.mjs` 55 · `analytics-edge-cache.test.mjs` 44 · eslint 0 errors · prettier clean · rebased onto latest `main`

3 files, +221/-19.