### PR TITLE
feat(graphql): add Query.chain_turnover mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -145,6 +145,13 @@ import {
   loadChainWeights,
 } from "./chain-weights.mjs";
 import {
+  buildChainTurnover,
+  CHAIN_TURNOVER_LIMIT_DEFAULT,
+  CHAIN_TURNOVER_LIMIT_MAX,
+  CHAIN_TURNOVER_WINDOWS,
+  DEFAULT_CHAIN_TURNOVER_WINDOW,
+} from "./chain-turnover.mjs";
+import {
   CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
   CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
   CHAIN_WEIGHT_SETTERS_WINDOWS,
@@ -244,6 +251,8 @@ export const SDL = `
     economics_trends(window: String): EconomicsTrends!
     "Cross-subnet momentum leaderboard: every subnet ranked by its stake/emission/validator change between a window's start and end snapshots; movers is empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/subnets/movers."
     subnet_movers(window: String, sort: String, limit: Int): SubnetMovers!
+    "Network-wide validator-set churn across all subnets over a 7d/30d/90d window (default 30d): every subnet ranked by gross validator churn (entered + exited) between the window's start and end snapshots, each with its retention and 0-100 stability score, plus a network rollup and the network-wide stability spread. neuron_daily-derived; comparable is false and the leaderboard empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/chain/turnover."
+    chain_turnover(window: String, limit: Int): ChainTurnover!
     "Network-wide validator weight-setting activity leaderboard over a 7d/30d window (default 7d): subnets ranked by WeightsSet events with each's distinct-setter count and sets-per-setter update intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. Mirrors GET /api/v1/chain/weights."
     chain_weights(window: String, limit: Int): ChainWeights!
     "Network-wide weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators driving consensus network-wide, each with its total WeightsSet count, share of the network total, and first/last set times, ranked by activity. The setter-level drill-in behind chain_weights. Mirrors GET /api/v1/chain/weights/setters."
@@ -420,6 +429,58 @@ export const SDL = `
     neurons_start: Int!
     neurons_end: Int!
     neurons_delta: Int!
+  }
+
+  "Network-wide validator-set churn across all subnets (#5686). Mirrors GET /api/v1/chain/turnover's data envelope."
+  type ChainTurnover {
+    schema_version: Int!
+    window: String
+    "Start snapshot date; null on a cold store."
+    start_date: String
+    "End snapshot date; null on a cold store."
+    end_date: String
+    "False when the window resolved to fewer than two distinct snapshots, so start/end churn is not measurable."
+    comparable: Boolean!
+    subnet_count: Int!
+    network: ChainTurnoverNetwork!
+    "Null when no subnet had a stability score in the window (nothing to distribute)."
+    stability_distribution: ChainTurnoverStabilityDistribution
+    subnets: [ChainTurnoverSubnet!]!
+  }
+
+  "Network-wide validator-set rollup: every subnet's validators combined, deduplicated across the network."
+  type ChainTurnoverNetwork {
+    validators_start: Int!
+    validators_end: Int!
+    validators_entered: Int!
+    validators_exited: Int!
+    "Jaccard retention of the start set into the end set; null on a cold/non-comparable window."
+    validator_retention: Float
+    "0-100 stability score; null on a cold/non-comparable window."
+    stability_score: Float
+  }
+
+  "Spread of per-subnet stability score across EVERY subnet in the window (not just the returned page, so the spread stays network-wide when limit truncates the leaderboard)."
+  type ChainTurnoverStabilityDistribution {
+    count: Int!
+    mean: Float!
+    min: Float!
+    p25: Float!
+    median: Float!
+    p75: Float!
+    p90: Float!
+    max: Float!
+  }
+
+  "One subnet's validator-set churn, ranked by gross churn (entered + exited) then netuid."
+  type ChainTurnoverSubnet {
+    netuid: Int!
+    validators_start: Int!
+    validators_end: Int!
+    validators_entered: Int!
+    validators_exited: Int!
+    validator_retention: Float
+    stability_score: Float
   }
 
   "Network-wide validator weight-setting activity over a lookback window, summed live from the account_events WeightsSet stream. Mirrors GET /api/v1/chain/weights."
@@ -1454,6 +1515,7 @@ export const FIELD_COMPLEXITY = {
   block: RELATIONSHIP_FIELD_COMPLEXITY,
   economics_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_movers: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_turnover: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3155,6 +3217,59 @@ const rootValue = {
         unchanged: network.unchanged ?? 0,
       },
       movers: data.movers || [],
+    };
+  },
+
+  async chain_turnover({ window, limit }, context) {
+    const requestedWindow = window ?? DEFAULT_CHAIN_TURNOVER_WINDOW;
+    if (!Object.hasOwn(CHAIN_TURNOVER_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(requestedWindow, CHAIN_TURNOVER_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: CHAIN_TURNOVER_LIMIT_DEFAULT,
+      maxLimit: CHAIN_TURNOVER_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    params.set("limit", String(safeLimit));
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildChainTurnover([])
+    // fallback contract REST's handleChainTurnover uses: unlike the chain_weights
+    // family there is no D1 live-rollup loader here (the churn needs two
+    // neuron_daily snapshots, which only the Postgres tier serves), so a cold
+    // store yields the schema-stable empty/non-comparable envelope, never a
+    // GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/turnover", params),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ??
+      buildChainTurnover([], {
+        window: requestedWindow,
+        startDate: null,
+        endDate: null,
+        limit: safeLimit,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? requestedWindow,
+      start_date: data.start_date ?? null,
+      end_date: data.end_date ?? null,
+      comparable: data.comparable ?? false,
+      subnet_count: data.subnet_count ?? 0,
+      network: data.network ?? {
+        validators_start: 0,
+        validators_end: 0,
+        validators_entered: 0,
+        validators_exited: 0,
+        validator_retention: null,
+        stability_score: null,
+      },
+      stability_distribution: data.stability_distribution ?? null,
+      subnets: data.subnets || [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -5550,6 +5550,127 @@ describe("graphql — subnet_movers (#5662, Postgres-tier + buildMovers fallback
   });
 });
 
+describe("graphql — chain_turnover (#5686, Postgres-tier + cold-store fallback)", () => {
+  function turnoverQuery(argsClause) {
+    return `{ chain_turnover${argsClause} {
+      schema_version window start_date end_date comparable subnet_count
+      network { validators_start validators_end validators_entered validators_exited validator_retention stability_score }
+      stability_distribution { count mean min p25 median p75 p90 max }
+      subnets { netuid validators_start validators_end validators_entered validators_exited validator_retention stability_score }
+    } }`;
+  }
+
+  test("cold store, default args: schema-stable non-comparable empty leaderboard", async () => {
+    const { status, body } = await gql(turnoverQuery(""));
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_turnover, {
+      schema_version: 1,
+      window: "30d",
+      start_date: null,
+      end_date: null,
+      comparable: false,
+      subnet_count: 0,
+      network: {
+        validators_start: 0,
+        validators_end: 0,
+        validators_entered: 0,
+        validators_exited: 0,
+        validator_retention: null,
+        stability_score: null,
+      },
+      stability_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            window: "7d",
+            start_date: "2026-07-03",
+            end_date: "2026-07-10",
+            comparable: true,
+            subnet_count: 1,
+            network: {
+              validators_start: 10,
+              validators_end: 12,
+              validators_entered: 4,
+              validators_exited: 2,
+              validator_retention: 0.67,
+              stability_score: 67,
+            },
+            stability_distribution: {
+              count: 1,
+              mean: 67,
+              min: 67,
+              p25: 67,
+              median: 67,
+              p75: 67,
+              p90: 67,
+              max: 67,
+            },
+            subnets: [
+              {
+                netuid: 3,
+                validators_start: 10,
+                validators_end: 12,
+                validators_entered: 4,
+                validators_exited: 2,
+                validator_retention: 0.67,
+                stability_score: 67,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      turnoverQuery('(window: "7d", limit: 5)'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/turnover");
+    assert.equal(capturedUrl.searchParams.get("window"), "7d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(body.data.chain_turnover.window, "7d");
+    assert.equal(body.data.chain_turnover.comparable, true);
+    assert.equal(body.data.chain_turnover.subnet_count, 1);
+    assert.equal(body.data.chain_turnover.network.validators_entered, 4);
+    assert.equal(body.data.chain_turnover.stability_distribution.median, 67);
+    assert.equal(body.data.chain_turnover.subnets[0].netuid, 3);
+  });
+
+  test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(turnoverQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.chain_turnover.window, "30d");
+    assert.equal(body.data.chain_turnover.comparable, false);
+    assert.equal(body.data.chain_turnover.subnet_count, 0);
+    assert.equal(body.data.chain_turnover.network.validators_start, 0);
+    assert.equal(body.data.chain_turnover.network.validator_retention, null);
+    assert.equal(body.data.chain_turnover.stability_distribution, null);
+    assert.deepEqual(body.data.chain_turnover.subnets, []);
+  });
+
+  test("an unsupported window is a GraphQL error, not a silently substituted default", async () => {
+    const { status, body } = await gql(turnoverQuery('(window: "99d")'));
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.match(body.errors[0].message, /99d/);
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+});
+
 describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", () => {
   function weightsQuery(argsClause) {
     return `{ chain_weights${argsClause} {


### PR DESCRIPTION
## Summary

Adds `Query.chain_turnover` to the GraphQL SDL, mirroring `GET /api/v1/chain/turnover` (routed at `workers/api.mjs:2603` to `handleChainTurnover`) and the MCP `get_chain_turnover` tool — the same gap-closure category as the merged `Query.incidents` / `Query.subnet_performance` / `Query.blocks` siblings.

Args match what `handleChainTurnover`/`canonicalChainTurnoverCachePath` actually accept (read directly, not assumed): `window` (`7d`/`30d`/`90d`, default **30d** — `CHAIN_TURNOVER_WINDOWS`/`DEFAULT_CHAIN_TURNOVER_WINDOW`) and `limit` (default 20, max 100 — `CHAIN_TURNOVER_LIMIT_DEFAULT`/`CHAIN_TURNOVER_LIMIT_MAX`). `format` is a REST/CSV-only concern and is deliberately not a GraphQL arg.

The resolver reuses `src/chain-turnover.mjs` rather than duplicating any query logic, and mirrors REST's fallback contract exactly: `tryPostgresTier(env, ..., "METAGRAPH_NEURONS_SOURCE") ?? buildChainTurnover([], { window, startDate: null, endDate: null, limit })`. Worth noting for reviewers — unlike the `chain_weights` family there is **no D1 live-rollup loader** here: the churn needs two `neuron_daily` snapshots, which only the Postgres tier serves, so `handleChainTurnover` itself falls back to the schema-stable empty/non-comparable envelope. The resolver does the same, so a cold store yields `comparable: false` + an empty leaderboard, never a GraphQL error. An unsupported `window` is a `BAD_USER_INPUT` GraphQL error rather than a silently substituted default, matching every sibling resolver.

Closes #5686

## Changes

- `src/graphql.mjs`: `chain_turnover(window: String, limit: Int): ChainTurnover!` on `Query` (with the "Mirrors GET /api/v1/..." doc-comment convention), the `ChainTurnover` / `ChainTurnoverNetwork` / `ChainTurnoverStabilityDistribution` / `ChainTurnoverSubnet` types mirroring `buildChainTurnover`'s real response shape, a `FIELD_COMPLEXITY` entry at `RELATIONSHIP_FIELD_COMPLEXITY` (matching the `chain_weights` sibling), and the resolver.
- `tests/graphql.test.mjs`: 4 tests — cold-store default (schema-stable non-comparable empty), Postgres-tier hit asserting both `window`/`limit` are forwarded as query params on `/api/v1/chain/turnover`, a malformed tier body degrading to schema-stable defaults, and an unsupported window returning `BAD_USER_INPUT`.

## Validation

- [x] `tests/graphql.test.mjs` — **289 passed** (285 pre-existing + 4 new), on a tip rebased onto current `main` (`ad691fd5`, `Query.subnet_performance` #5799)
- [x] `npm run format:check` (prettier) — clean on both files
- [x] `npm run lint` (eslint) — clean on both files
- [x] `npm run validate:contract-drift` — passed (GraphQL SDL is not the REST OpenAPI contract; no `openapi.json` regen needed, matching the merged `Query.incidents` #5694 diff shape)
- [x] `npm run validate:docs` — passed
- [x] `git diff --check` — clean
- [x] Coverage: every changed line/branch is exercised — both `window` arms (valid + `BAD_USER_INPUT`), both `tryPostgresTier` arms (tier hit + cold-store `buildChainTurnover` fallback), the `limit` clamp (forwarded as `5`), and each `?? ` default via the malformed-body test.

## Safety

- [x] No secrets, PATs, wallet paths, or private URLs.
- [x] Purely additive (+236/−0, 2 files); no existing resolver, type, or REST/MCP behavior changed.
- [x] Health/uptime/latency untouched (probe-derived only).
- [x] No visual/UI output — no screenshot table required.
