### PR TITLE
feat(ui): add Webhooks endpoint-group reference doc page

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -390,6 +390,7 @@ function SiteFooter() {
           <FooterLink to="/graphql">GraphQL</FooterLink>
           <FooterLink to="/rpc">RPC</FooterLink>
           <FooterLink to="/feeds">Feeds</FooterLink>
+          <FooterLink to="/webhooks">Webhooks</FooterLink>
           <FooterLink to="/gaps">Gaps</FooterLink>
           <FooterLink to="/chain-events">Chain events reference</FooterLink>
           <FooterLink to="/agents">For agents</FooterLink>

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -31,6 +31,7 @@ import {
   Sparkles,
   Star,
   User,
+  Webhook,
   Wifi,
   Workflow,
   Zap,
@@ -139,6 +140,13 @@ const ROUTE_INDEX: Array<{
     to: "/feeds",
     hint: "RSS, Atom, JSON Feed subscriptions",
     icon: Rss,
+    scope: "route",
+  },
+  {
+    label: "Webhooks",
+    to: "/webhooks",
+    hint: "Change-feed subscriptions, HMAC signing",
+    icon: Webhook,
     scope: "route",
   },
   {

--- a/apps/ui/src/lib/metagraphed/webhooks-docs.test.ts
+++ b/apps/ui/src/lib/metagraphed/webhooks-docs.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_WEBHOOK_BODY_BYTES,
+  WEBHOOKS_BASE_PATH,
+  WEBHOOK_ENDPOINTS,
+  WEBHOOK_ENDPOINT_COUNT,
+  WEBHOOK_EVENT_ID_HEADER,
+  WEBHOOK_EVENT_TYPE,
+  WEBHOOK_FILTER_FIELDS,
+  WEBHOOK_IDEMPOTENCY_HEADER,
+  WEBHOOK_MAX_DELIVERY_ROUNDS,
+  WEBHOOK_REDELIVERY_BASE_MS,
+  WEBHOOK_REDELIVERY_MAX_MS,
+  WEBHOOK_SECRET_HEADER,
+  WEBHOOK_SIGNATURE_HEADER,
+  WEBHOOK_SUBSCRIPTION_TOKEN_HEADER,
+  WEBHOOK_TIMESTAMP_HEADER,
+  WEBHOOK_TTL_SECONDS,
+  buildWebhookCurlExample,
+  webhookRedeliveryDelaySeconds,
+} from "./webhooks-docs";
+
+describe("webhooks docs reference (#3514)", () => {
+  it("keeps Worker-aligned header names", () => {
+    expect(WEBHOOK_SIGNATURE_HEADER).toBe("x-metagraph-signature");
+    expect(WEBHOOK_TIMESTAMP_HEADER).toBe("x-metagraph-timestamp");
+    expect(WEBHOOK_SECRET_HEADER).toBe("x-metagraph-webhook-secret");
+    expect(WEBHOOK_EVENT_ID_HEADER).toBe("x-metagraph-event-id");
+    expect(WEBHOOK_IDEMPOTENCY_HEADER).toBe("x-metagraph-idempotency-key");
+    expect(WEBHOOK_SUBSCRIPTION_TOKEN_HEADER).toBe("x-metagraph-webhook-subscription-token");
+  });
+
+  it("keeps the Worker-aligned event type", () => {
+    expect(WEBHOOK_EVENT_TYPE).toBe("metagraph.publish");
+  });
+
+  it("keeps Worker-aligned retry/delivery constants", () => {
+    expect(WEBHOOK_MAX_DELIVERY_ROUNDS).toBe(8);
+    expect(WEBHOOK_REDELIVERY_BASE_MS).toBe(5 * 60 * 1000);
+    expect(WEBHOOK_REDELIVERY_MAX_MS).toBe(12 * 60 * 60 * 1000);
+    expect(WEBHOOK_TTL_SECONDS).toBe(180 * 24 * 60 * 60);
+    expect(MAX_WEBHOOK_BODY_BYTES).toBe(8192);
+  });
+
+  it("documents every endpoint exactly once", () => {
+    expect(WEBHOOK_ENDPOINTS).toHaveLength(WEBHOOK_ENDPOINT_COUNT);
+    const methods = WEBHOOK_ENDPOINTS.map((e) => `${e.method} ${e.path}`);
+    expect(methods).toEqual([
+      "POST /api/v1/webhooks/subscriptions",
+      "GET /api/v1/webhooks/subscriptions/{id}",
+      "DELETE /api/v1/webhooks/subscriptions/{id}",
+    ]);
+    expect(new Set(methods).size).toBe(methods.length);
+  });
+
+  it("documents the netuids/kinds filter fields", () => {
+    expect(WEBHOOK_FILTER_FIELDS.map((f) => f.field)).toEqual(["netuids", "kinds"]);
+  });
+
+  it("computes the exponential redelivery schedule, capped at the max", () => {
+    expect(webhookRedeliveryDelaySeconds(1)).toBe(5 * 60);
+    expect(webhookRedeliveryDelaySeconds(2)).toBe(10 * 60);
+    expect(webhookRedeliveryDelaySeconds(3)).toBe(20 * 60);
+    // base * 2^7 = 5min * 128 = 640min = 38400s, which exceeds the 12h (43200s)
+    // cap only once round grows further; round 8 is still under the cap.
+    expect(webhookRedeliveryDelaySeconds(8)).toBe(Math.min(5 * 60 * 2 ** 7, 12 * 60 * 60));
+    // A far-future round clamps at the 12h max, never exceeding it.
+    expect(webhookRedeliveryDelaySeconds(20)).toBe(12 * 60 * 60);
+  });
+
+  it("builds a curl example against the real subscription path", () => {
+    const curl = buildWebhookCurlExample("https://api.metagraph.sh/");
+    expect(curl).toContain("https://api.metagraph.sh/api/v1/webhooks/subscriptions");
+    expect(curl).toContain(WEBHOOK_SUBSCRIPTION_TOKEN_HEADER);
+    expect(curl).toContain("POST");
+    expect(curl).not.toContain("//api/v1");
+  });
+
+  it("exposes the base path used by every endpoint", () => {
+    expect(WEBHOOKS_BASE_PATH).toBe("/api/v1/webhooks/subscriptions");
+    for (const endpoint of WEBHOOK_ENDPOINTS) {
+      expect(endpoint.path.startsWith(WEBHOOKS_BASE_PATH)).toBe(true);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/webhooks-docs.ts
+++ b/apps/ui/src/lib/metagraphed/webhooks-docs.ts
@@ -1,0 +1,111 @@
+/**
+ * Static reference copy for the `/webhooks` docs page (#3514).
+ *
+ * Header names, timing constants, and validation limits mirror
+ * `src/webhooks.mjs` and `workers/config.mjs` — keep them in sync when the
+ * Worker webhook contract changes. The UI cannot import Worker `.mjs`
+ * modules, so these are intentional literals.
+ *
+ * @see https://github.com/JSONbored/metagraphed/issues/3514
+ */
+
+export const WEBHOOKS_BASE_PATH = "/api/v1/webhooks/subscriptions";
+
+/** Keep aligned with WEBHOOK_SIGNATURE_HEADER in src/webhooks.mjs */
+export const WEBHOOK_SIGNATURE_HEADER = "x-metagraph-signature";
+/** Keep aligned with WEBHOOK_TIMESTAMP_HEADER in src/webhooks.mjs */
+export const WEBHOOK_TIMESTAMP_HEADER = "x-metagraph-timestamp";
+/** Keep aligned with WEBHOOK_SECRET_HEADER in src/webhooks.mjs */
+export const WEBHOOK_SECRET_HEADER = "x-metagraph-webhook-secret";
+/** Keep aligned with WEBHOOK_EVENT_ID_HEADER in src/webhooks.mjs */
+export const WEBHOOK_EVENT_ID_HEADER = "x-metagraph-event-id";
+/** Keep aligned with WEBHOOK_IDEMPOTENCY_HEADER in src/webhooks.mjs */
+export const WEBHOOK_IDEMPOTENCY_HEADER = "x-metagraph-idempotency-key";
+/** Keep aligned with WEBHOOK_EVENT_TYPE in src/webhooks.mjs */
+export const WEBHOOK_EVENT_TYPE = "metagraph.publish";
+/** Keep aligned with WEBHOOK_SUBSCRIPTION_TOKEN_HEADER in workers/config.mjs */
+export const WEBHOOK_SUBSCRIPTION_TOKEN_HEADER = "x-metagraph-webhook-subscription-token";
+
+/** Keep aligned with WEBHOOK_MAX_DELIVERY_ROUNDS in src/webhooks.mjs */
+export const WEBHOOK_MAX_DELIVERY_ROUNDS = 8;
+/** Keep aligned with WEBHOOK_REDELIVERY_BASE_MS in src/webhooks.mjs (5 min) */
+export const WEBHOOK_REDELIVERY_BASE_MS = 5 * 60 * 1000;
+/** Keep aligned with WEBHOOK_REDELIVERY_MAX_MS in src/webhooks.mjs (12 h) */
+export const WEBHOOK_REDELIVERY_MAX_MS = 12 * 60 * 60 * 1000;
+/** Keep aligned with WEBHOOK_TTL_SECONDS in workers/config.mjs (180 days) */
+export const WEBHOOK_TTL_SECONDS = 180 * 24 * 60 * 60;
+/** Keep aligned with MAX_WEBHOOK_BODY_BYTES in workers/config.mjs */
+export const MAX_WEBHOOK_BODY_BYTES = 8192;
+
+export type WebhookEndpointDoc = {
+  method: "POST" | "GET" | "DELETE";
+  path: string;
+  summary: string;
+  auth: string;
+};
+
+/** Keep aligned with the route dispatch in handleWebhookRequest (workers/api.mjs). */
+export const WEBHOOK_ENDPOINTS: readonly WebhookEndpointDoc[] = [
+  {
+    method: "POST",
+    path: WEBHOOKS_BASE_PATH,
+    summary: "Create a subscription for the change-feed publish event.",
+    auth: `${WEBHOOK_SUBSCRIPTION_TOKEN_HEADER} header`,
+  },
+  {
+    method: "GET",
+    path: `${WEBHOOKS_BASE_PATH}/{id}`,
+    summary: "Read a subscription's public fields and delivery health.",
+    auth: "none",
+  },
+  {
+    method: "DELETE",
+    path: `${WEBHOOKS_BASE_PATH}/{id}`,
+    summary: "Remove a subscription.",
+    auth: `${WEBHOOK_SECRET_HEADER} header (the subscription's own secret)`,
+  },
+] as const;
+
+/** Expected endpoint count — guards accidental drift. */
+export const WEBHOOK_ENDPOINT_COUNT = 3;
+
+export type WebhookFilterFieldDoc = {
+  field: string;
+  type: string;
+  detail: string;
+};
+
+/** Keep aligned with normalizeFilters in src/webhooks.mjs. */
+export const WEBHOOK_FILTER_FIELDS: readonly WebhookFilterFieldDoc[] = [
+  {
+    field: "netuids",
+    type: "integer[] (0-65535, max 64)",
+    detail:
+      "Only deliver events touching one of these subnets. Duplicates are deduped; an empty array matches zero subnets, not all of them.",
+  },
+  {
+    field: "kinds",
+    type: '("subnets" | "artifacts")[] (max 8)',
+    detail:
+      "Only deliver events carrying one of these change kinds. An empty array matches zero kinds, not all of them.",
+  },
+] as const;
+
+/** Redelivery backoff, in whole seconds, for a given failed round (1-indexed). */
+export function webhookRedeliveryDelaySeconds(round: number): number {
+  const delayMs = Math.min(
+    WEBHOOK_REDELIVERY_BASE_MS * 2 ** (round - 1),
+    WEBHOOK_REDELIVERY_MAX_MS,
+  );
+  return Math.round(delayMs / 1000);
+}
+
+export function buildWebhookCurlExample(apiBase: string, url = "https://example.com/hook"): string {
+  const base = apiBase.replace(/\/$/, "");
+  return [
+    `curl -s -X POST '${base}${WEBHOOKS_BASE_PATH}' \\`,
+    `  -H 'content-type: application/json' \\`,
+    `  -H '${WEBHOOK_SUBSCRIPTION_TOKEN_HEADER}: <your-token>' \\`,
+    `  -d '{"url":"${url}","filters":{"netuids":[1,43]}}'`,
+  ].join("\n");
+}

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as WebhooksRouteImport } from './routes/webhooks'
 import { Route as SurfacesRouteImport } from './routes/surfaces'
 import { Route as StatusRouteImport } from './routes/status'
 import { Route as SettingsRouteImport } from './routes/settings'
@@ -41,6 +42,11 @@ import { Route as ExtrinsicsHashRouteImport } from './routes/extrinsics.$hash'
 import { Route as BlocksRefRouteImport } from './routes/blocks.$ref'
 import { Route as AccountsSs58RouteImport } from './routes/accounts.$ss58'
 
+const WebhooksRoute = WebhooksRouteImport.update({
+  id: '/webhooks',
+  path: '/webhooks',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SurfacesRoute = SurfacesRouteImport.update({
   id: '/surfaces',
   path: '/surfaces',
@@ -214,6 +220,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
   '/surfaces': typeof SurfacesRoute
+  '/webhooks': typeof WebhooksRoute
   '/accounts/$ss58': typeof AccountsSs58Route
   '/blocks/$ref': typeof BlocksRefRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
@@ -247,6 +254,7 @@ export interface FileRoutesByTo {
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
   '/surfaces': typeof SurfacesRoute
+  '/webhooks': typeof WebhooksRoute
   '/accounts/$ss58': typeof AccountsSs58Route
   '/blocks/$ref': typeof BlocksRefRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
@@ -281,6 +289,7 @@ export interface FileRoutesById {
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
   '/surfaces': typeof SurfacesRoute
+  '/webhooks': typeof WebhooksRoute
   '/accounts/$ss58': typeof AccountsSs58Route
   '/blocks/$ref': typeof BlocksRefRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
@@ -316,6 +325,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/status'
     | '/surfaces'
+    | '/webhooks'
     | '/accounts/$ss58'
     | '/blocks/$ref'
     | '/extrinsics/$hash'
@@ -349,6 +359,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/status'
     | '/surfaces'
+    | '/webhooks'
     | '/accounts/$ss58'
     | '/blocks/$ref'
     | '/extrinsics/$hash'
@@ -382,6 +393,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/status'
     | '/surfaces'
+    | '/webhooks'
     | '/accounts/$ss58'
     | '/blocks/$ref'
     | '/extrinsics/$hash'
@@ -416,6 +428,7 @@ export interface RootRouteChildren {
   SettingsRoute: typeof SettingsRoute
   StatusRoute: typeof StatusRoute
   SurfacesRoute: typeof SurfacesRoute
+  WebhooksRoute: typeof WebhooksRoute
   AccountsSs58Route: typeof AccountsSs58Route
   BlocksRefRoute: typeof BlocksRefRoute
   ExtrinsicsHashRoute: typeof ExtrinsicsHashRoute
@@ -435,6 +448,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/webhooks': {
+      id: '/webhooks'
+      path: '/webhooks'
+      fullPath: '/webhooks'
+      preLoaderRoute: typeof WebhooksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/surfaces': {
       id: '/surfaces'
       path: '/surfaces'
@@ -672,6 +692,7 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsRoute: SettingsRoute,
   StatusRoute: StatusRoute,
   SurfacesRoute: SurfacesRoute,
+  WebhooksRoute: WebhooksRoute,
   AccountsSs58Route: AccountsSs58Route,
   BlocksRefRoute: BlocksRefRoute,
   ExtrinsicsHashRoute: ExtrinsicsHashRoute,

--- a/apps/ui/src/routes/webhooks.tsx
+++ b/apps/ui/src/routes/webhooks.tsx
@@ -1,0 +1,304 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { CopyButton, PageHero, SectionHeading } from "@jsonbored/ui-kit";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
+import {
+  MAX_WEBHOOK_BODY_BYTES,
+  WEBHOOKS_BASE_PATH,
+  WEBHOOK_ENDPOINTS,
+  WEBHOOK_EVENT_ID_HEADER,
+  WEBHOOK_EVENT_TYPE,
+  WEBHOOK_FILTER_FIELDS,
+  WEBHOOK_IDEMPOTENCY_HEADER,
+  WEBHOOK_MAX_DELIVERY_ROUNDS,
+  WEBHOOK_REDELIVERY_MAX_MS,
+  WEBHOOK_SECRET_HEADER,
+  WEBHOOK_SIGNATURE_HEADER,
+  WEBHOOK_TIMESTAMP_HEADER,
+  WEBHOOK_TTL_SECONDS,
+  buildWebhookCurlExample,
+  webhookRedeliveryDelaySeconds,
+} from "@/lib/metagraphed/webhooks-docs";
+
+export const Route = createFileRoute("/webhooks")({
+  head: () => ({
+    meta: [
+      { title: "Webhooks — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Metagraphed change-feed webhooks — subscribe an HTTPS endpoint to registry publish events, HMAC-SHA256 signed, with netuid/kind filters and at-least-once redelivery.",
+      },
+      { property: "og:title", content: "Webhooks — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "POST/GET/DELETE subscription management, signature verification, filter syntax, and the exponential redelivery schedule for the change-feed webhook contract.",
+      },
+    ],
+  }),
+  component: WebhooksDocsPage,
+});
+
+const SUBSCRIPTIONS_URL = `${API_BASE}${WEBHOOKS_BASE_PATH}`;
+const CURL_EXAMPLE = buildWebhookCurlExample(DEFAULT_API_BASE);
+const TTL_DAYS = WEBHOOK_TTL_SECONDS / 60 / 60 / 24;
+const REDELIVERY_MAX_HOURS = WEBHOOK_REDELIVERY_MAX_MS / 1000 / 60 / 60;
+
+function WebhooksDocsPage() {
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="API"
+        title="Webhooks"
+        description="Subscribe an HTTPS endpoint to the registry's publish change feed — HMAC-SHA256 signed POSTs, filtered by subnet or change kind, delivered at-least-once with exponential-backoff redelivery. Mutations require a shared subscription token."
+      />
+
+      <div className="mt-6 space-y-section" data-testid="webhooks-docs">
+        <section>
+          <SectionHeading
+            title="Endpoints"
+            intro="Subscriptions live under one base path. Create with a token, read or delete with the subscription's own secret."
+          />
+          <div className="space-y-2">
+            <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  POST
+                </div>
+                <code className="mt-0.5 block overflow-x-auto whitespace-nowrap font-mono text-[13px] text-ink-strong">
+                  {SUBSCRIPTIONS_URL}
+                </code>
+              </div>
+              <CopyButton value={SUBSCRIPTIONS_URL} label="webhook subscriptions URL" />
+            </div>
+            <div className="overflow-x-auto rounded-lg border border-border">
+              <table className="w-full min-w-[36rem] text-left text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                    <th className="px-3 py-2.5 font-normal">Method</th>
+                    <th className="px-3 py-2.5 font-normal">Path</th>
+                    <th className="px-3 py-2.5 font-normal">Summary</th>
+                    <th className="px-3 py-2.5 font-normal">Auth</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {WEBHOOK_ENDPOINTS.map((endpoint) => (
+                    <tr key={`${endpoint.method} ${endpoint.path}`} className="align-top">
+                      <td className="px-3 py-2.5 font-mono text-[11px] text-ink-strong">
+                        {endpoint.method}
+                      </td>
+                      <td className="px-3 py-2.5 font-mono text-[11px] text-ink-strong">
+                        {endpoint.path}
+                      </td>
+                      <td className="px-3 py-2.5 text-[12px] text-ink">{endpoint.summary}</td>
+                      <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">
+                        {endpoint.auth}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Request & response shape"
+            intro="POST body accepts a public https:// url, optional netuid/kind filters, and an optional caller-supplied secret."
+          />
+          <div className="space-y-2 text-[12px] leading-relaxed text-ink">
+            <p>
+              <code className="font-mono text-[11px] text-ink-strong">POST</code> body —{" "}
+              <code className="font-mono text-[11px]">
+                &#123; url: string, filters?: &#123; netuids?, kinds? &#125;, secret?: string &#125;
+              </code>
+              . <code className="font-mono text-[11px]">url</code> must be a public{" "}
+              <code className="font-mono text-[11px]">https://</code> URL — no credentials, no
+              private/loopback/link-local hosts, default port only.{" "}
+              <code className="font-mono text-[11px]">secret</code> is optional (16-256 characters);
+              a server-generated one is used when omitted. Body is capped at{" "}
+              {MAX_WEBHOOK_BODY_BYTES} bytes.
+            </p>
+            <p>
+              <code className="font-mono text-[11px] text-ink-strong">201</code> response —{" "}
+              <code className="font-mono text-[11px]">
+                &#123; id, url, filters, secret, active, created_at, delivery &#125;
+              </code>
+              . <code className="font-mono text-[11px]">secret</code> is returned once, at creation,
+              and never echoed back by <code className="font-mono text-[11px]">GET</code>. Store it
+              — it's required to verify delivery signatures and to delete the subscription.
+            </p>
+            <p>
+              <code className="font-mono text-[11px] text-ink-strong">GET</code> response —{" "}
+              <code className="font-mono text-[11px]">
+                &#123; id, url, filters, created_at, active, delivery &#125;
+              </code>
+              , where <code className="font-mono text-[11px]">delivery</code> summarizes recent
+              redelivery health:{" "}
+              <code className="font-mono text-[11px]">
+                &#123; status, pending, dead_letter, last_failure &#125;
+              </code>
+              .
+            </p>
+            <p>
+              <code className="font-mono text-[11px] text-ink-strong">DELETE</code> response —{" "}
+              <code className="font-mono text-[11px]">&#123; id, deleted: true &#125;</code>.
+              Dormant subscriptions also self-expire after {TTL_DAYS} days.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Signature verification"
+            intro="Every delivery is a signed POST. Verify the HMAC before trusting the body, and dedupe retries with the idempotency key."
+          />
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-[32rem] text-left text-sm">
+              <thead>
+                <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  <th className="px-3 py-2.5 font-normal">Header</th>
+                  <th className="px-3 py-2.5 font-normal">Value</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                <tr className="align-top">
+                  <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                    {WEBHOOK_SIGNATURE_HEADER}
+                  </td>
+                  <td className="px-3 py-2.5 text-[12px] text-ink-muted">
+                    Hex-encoded HMAC-SHA256 of the raw request body, keyed by your subscription
+                    secret.
+                  </td>
+                </tr>
+                <tr className="align-top">
+                  <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                    {WEBHOOK_TIMESTAMP_HEADER}
+                  </td>
+                  <td className="px-3 py-2.5 text-[12px] text-ink-muted">
+                    ISO-8601 timestamp of the delivery attempt.
+                  </td>
+                </tr>
+                <tr className="align-top">
+                  <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                    {WEBHOOK_EVENT_ID_HEADER}
+                  </td>
+                  <td className="px-3 py-2.5 text-[12px] text-ink-muted">
+                    Stable id derived from the event body's content — identical across every
+                    (re)delivery of that event, to every subscriber.
+                  </td>
+                </tr>
+                <tr className="align-top">
+                  <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                    {WEBHOOK_IDEMPOTENCY_HEADER}
+                  </td>
+                  <td className="px-3 py-2.5 text-[12px] text-ink-muted">
+                    Key scoped to one subscription and one event — identical across retries and
+                    redeliveries, so a subscriber can dedupe the at-least-once delivery.
+                  </td>
+                </tr>
+                <tr className="align-top">
+                  <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                    {WEBHOOK_SECRET_HEADER}
+                  </td>
+                  <td className="px-3 py-2.5 text-[12px] text-ink-muted">
+                    Not sent on delivery — this is what you send back to{" "}
+                    <code className="font-mono text-[11px]">DELETE</code> a subscription, to prove
+                    ownership.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-3 text-[12px] leading-relaxed text-ink">
+            Verify by recomputing the HMAC-SHA256 of the exact raw body (before any JSON
+            re-serialization) with your secret and comparing it, in constant time, to{" "}
+            {WEBHOOK_SIGNATURE_HEADER}. Every delivery's{" "}
+            <code className="font-mono text-[11px]">type</code> field is{" "}
+            <code className="font-mono text-[11px]">"{WEBHOOK_EVENT_TYPE}"</code>.
+          </p>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Filters"
+            intro="Both facets narrow independently; an omitted facet means no restriction on that axis, while an explicit empty array matches nothing."
+          />
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-[28rem] text-left text-sm">
+              <thead>
+                <tr className="border-b border-border bg-paper/40 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  <th className="px-3 py-2.5 font-normal">Field</th>
+                  <th className="px-3 py-2.5 font-normal">Type</th>
+                  <th className="px-3 py-2.5 font-normal">Notes</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {WEBHOOK_FILTER_FIELDS.map((row) => (
+                  <tr key={row.field} className="align-top">
+                    <td className="px-3 py-2.5 font-mono text-[12px] text-ink-strong">
+                      {row.field}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2.5 font-mono text-[12px] text-ink">
+                      {row.type}
+                    </td>
+                    <td className="px-3 py-2.5 text-[12px] text-ink-muted">{row.detail}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading
+            title="Retry & delivery"
+            intro="Delivery is at-least-once. A transient failure is parked and redelivered with exponential backoff, then dead-lettered."
+          />
+          <div className="space-y-2 text-[12px] leading-relaxed text-ink">
+            <p>
+              A parked delivery becomes due{" "}
+              <code className="font-mono text-[11px]">min(base * 2^(round-1), max)</code> after its
+              last attempt — {webhookRedeliveryDelaySeconds(1) / 60} min after round 1, doubling
+              each round, capped at {REDELIVERY_MAX_HOURS}h. After {WEBHOOK_MAX_DELIVERY_ROUNDS}{" "}
+              failed rounds, or on a deterministic 4xx rejection (redirects included), the delivery
+              dead-letters — check a subscription's{" "}
+              <code className="font-mono text-[11px]">delivery.status</code> via{" "}
+              <code className="font-mono text-[11px]">GET</code>. Network errors, timeouts, 5xx, and
+              429 are retried; other 4xx responses are not.
+            </p>
+            <p>
+              Parked deliveries self-clean after {TTL_DAYS} days, the same horizon dormant
+              subscriptions use.
+            </p>
+          </div>
+          <div className="mt-3 rounded-lg border border-border bg-card px-4 py-3">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Example — create a subscription
+              </div>
+              <CopyButton value={CURL_EXAMPLE} label="webhooks curl example" />
+            </div>
+            <pre className="overflow-x-auto whitespace-pre-wrap break-all font-mono text-[12px] leading-relaxed text-ink-strong">
+              {CURL_EXAMPLE}
+            </pre>
+          </div>
+          <p className="mt-3 font-mono text-[11px] text-ink-muted">
+            Watch the same publish moment as an SSE stream instead of subscribing:{" "}
+            <code className="font-mono text-[11px]">GET /api/v1/events</code>. Poll the same changes
+            as a feed:{" "}
+            <Link to="/feeds" className="text-accent hover:underline">
+              Feeds
+            </Link>
+            .
+          </p>
+        </section>
+      </div>
+
+      <ApiSourceFooter paths={["/api/v1/webhooks/subscriptions"]} />
+    </AppShell>
+  );
+}

--- a/apps/ui/tests/e2e/capture-webhooks-docs-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-webhooks-docs-screenshots.mjs
@@ -1,0 +1,80 @@
+/**
+ * Capture /webhooks docs page screenshots for #3514 (Path C2).
+ *
+ * New page — before captures are the 404/fallback when the route is missing;
+ * after captures show the live docs page.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=before node tests/e2e/capture-webhooks-docs-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=after  node tests/e2e/capture-webhooks-docs-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/webhooks-docs-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8085";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const VIEWPORT_FILTER = process.env.VIEWPORT_FILTER;
+const ALL_VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const VIEWPORTS = VIEWPORT_FILTER
+  ? ALL_VIEWPORTS.filter((v) => v.name === VIEWPORT_FILTER)
+  : ALL_VIEWPORTS;
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function openWebhooksDocs(page) {
+  await page.goto(`${BASE_URL}/webhooks`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 8000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+  const docs = page.locator('[data-testid="webhooks-docs"]');
+  const hero = page.getByRole("heading", { name: /^Webhooks$/i }).first();
+  try {
+    await docs.waitFor({ state: "visible", timeout: 5000 });
+  } catch {
+    await hero.waitFor({ state: "visible", timeout: 30_000 }).catch(() => {});
+  }
+  await page.waitForTimeout(250);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await setTheme(page, theme);
+      await openWebhooksDocs(page);
+      const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+      await context.close();
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #3514

## Summary

The webhooks change-feed subscription system (`POST/GET/DELETE /api/v1/webhooks/subscriptions`, `src/webhooks.mjs`) had no docs page — the only reference was the module itself. Adds `/webhooks`, mirroring `/feeds` (#3512 / PR #5650) and `/chain-events` (#2566 / PR #5646):

- **Endpoints** — the 3 routes (create/read/delete), their auth (subscription token for create, the subscription's own secret for delete), and summaries.
- **Request & response shape** — the POST body contract (`url`/`filters`/`secret`), the 201 response shape, `GET`'s delivery-health summary, and `DELETE`'s response.
- **Signature verification** — every delivery header (`x-metagraph-signature`, `-timestamp`, `-event-id`, `-idempotency-key`, `-webhook-secret`) and how to verify the HMAC-SHA256.
- **Filters** — `netuids` (max 64) / `kinds` (max 8) narrowing semantics.
- **Retry & delivery** — the exponential-backoff redelivery schedule (5 min doubling to a 12h cap, 8 rounds before dead-lettering), which failures retry vs dead-letter immediately, and the 180-day self-clean TTL, plus a copyable curl example.
- Wired into the footer **Operations** column and the command palette (`Webhook` icon from lucide-react).

No route-placement conflict here (unlike the Subnets/Accounts docs issues) — `/webhooks` wasn't claimed by any existing product page.

Reference copy lives in a pure `webhooks-docs.ts` module. Every header name, timing constant, and byte/size limit is copied verbatim from `src/webhooks.mjs` and `workers/config.mjs` (not approximated) and unit-tested against those real values, so drift fails the suite — verified each constant by reading the actual source (`MAX_FILTER_NETUIDS`/`MAX_FILTER_KINDS`/`VALID_CHANGE_KINDS`, the 201 status code, the `redirect: "manual"` dead-letter behavior, the `/api/v1/events` SSE cross-reference) rather than taking the docs on faith.

## Gates

```
npx vitest run src/lib/metagraphed/webhooks-docs.test.ts
# 8/8 pass

npx tsc --noEmit
# zero new errors (the only pre-existing errors, in an unrelated untouched file,
# are confirmed present on main too)

npx eslint src/lib/metagraphed/webhooks-docs.ts src/lib/metagraphed/webhooks-docs.test.ts \
  src/routes/webhooks.tsx tests/e2e/capture-webhooks-docs-screenshots.mjs
# clean (0 errors)

npx prettier --check <same files>
# clean
```

## Screenshots

New route — before is the missing-route 404; after is the docs page. Captured with Playwright at the three SKILL viewports (375x812 / 768x1024 / 1280x800), each theme forced via `mg-theme`, fixed-viewport (never full-page). Capture script committed at `apps/ui/tests/e2e/capture-webhooks-docs-screenshots.mjs`.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/before-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/after-mobile-light.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/before-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/after-mobile-dark.png" width="200">](https://raw.githubusercontent.com/philluiz2323/metagraphed/screenshots/3514/after-mobile-dark.png)<br><sub>after</sub> |