### PR TITLE
feat(graphql): add Query.account_identity_history mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -52,6 +52,7 @@ import {
   clampOffset,
 } from "../workers/request-params.mjs";
 import { loadSubnetIdentityHistory } from "./subnet-identity-history.mjs";
+import { loadAccountIdentityHistory } from "./account-identity-history.mjs";
 import {
   buildGlobalHealth,
   formatLeaderboards,
@@ -257,6 +258,8 @@ export const SDL = `
     account_axon_removals(ss58: String!, window: String): AccountAxonRemovals!
     "One account's per-subnet StakeMoved footprint over a 7d/30d/90d window (default 30d): movement count, first/last timestamps, and the alpha price (TAO) at its most recent move per subnet, an HHI concentration of where its re-delegation churn is focused, and the dominant subnet; an address with no moves in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/stake-moves."
     account_stake_moves(ss58: String!, window: String): AccountStakeMoves!
+    "Append-only diff-tracked chain-identity timeline for one account (coldkey), newest first — a row each time a tracked identity field (name, url, github, image, discord, description, additional) changed; page with limit/offset or follow next_cursor. An account with no recorded changes resolves to a schema-stable empty timeline (entry_count 0), never null. Mirrors GET /api/v1/accounts/{ss58}/identity-history."
+    account_identity_history(ss58: String!, limit: Int, offset: Int, cursor: String): AccountIdentityHistory!
     "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
     economics_trends(window: String): EconomicsTrends!
     "Cross-subnet momentum leaderboard: every subnet ranked by its stake/emission/validator change between a window's start and end snapshots; movers is empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/subnets/movers."
@@ -1303,6 +1306,30 @@ export const SDL = `
     subnets: [AccountStakeMoveSubnet!]!
   }
 
+  "Append-only diff-tracked account (coldkey) identity timeline (#4326, epic #4301/5.4). Empty entries on a cold/absent store. Mirrors GET /api/v1/accounts/{ss58}/identity-history."
+  type AccountIdentityHistory {
+    schema_version: Int!
+    account: String!
+    entry_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    entries: [AccountIdentityHistoryEntry!]!
+  }
+
+  "One account_identity snapshot recorded when a tracked identity field changed. No block_number column — account_identity carries no chain block height, only observed_at."
+  type AccountIdentityHistoryEntry {
+    observed_at: String
+    name: String
+    url: String
+    github: String
+    image: String
+    discord: String
+    description: String
+    additional: String
+    identity_hash: String
+  }
+
   type AccountEvent {
     block_number: Int
     event_index: Int
@@ -1568,6 +1595,7 @@ export const FIELD_COMPLEXITY = {
   account_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   account_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   account_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3253,6 +3281,50 @@ const rootValue = {
         last_moved_at: s.last_moved_at ?? null,
         price_tao_at_last_move: s.price_tao_at_last_move ?? null,
       })),
+    };
+  },
+
+  async account_identity_history({ ss58, limit, offset, cursor }, context) {
+    // Same SS58 validation handleAccountIdentityHistory's route uses -- a
+    // malformed address is a GraphQL BAD_USER_INPUT error, not a silent card.
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const safeLimit = clampLimit(limit, FEED_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    if (cursor) params.set("cursor", cursor);
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_IDENTITY_SOURCE) ->
+    // loadAccountIdentityHistory fallback contract handleAccountIdentityHistory
+    // uses; an account with no recorded changes is a schema-stable empty
+    // timeline (entry_count 0), never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}/identity-history`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
+      )) ??
+      (await loadAccountIdentityHistory(graphqlD1(context), ss58, {
+        limit: safeLimit,
+        offset: safeOffset,
+        cursor,
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      account: data.account ?? ss58,
+      entry_count: data.entry_count ?? 0,
+      limit: data.limit ?? safeLimit,
+      offset: data.offset ?? safeOffset,
+      next_cursor: data.next_cursor ?? null,
+      entries: data.entries || [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -5485,6 +5485,207 @@ describe("graphql — account_stake_moves (#5707, Postgres-tier + zeroed-card fa
   });
 });
 
+describe("graphql — account_identity_history (#5709, Postgres-tier + empty timeline fallback)", () => {
+  const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag / no D1 rows returns a schema-stable empty timeline, never null", async () => {
+    const { status, body } = await gql(
+      `{ account_identity_history(ss58: "${SS58}") {
+          schema_version account entry_count limit offset next_cursor
+          entries { name identity_hash }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_identity_history, {
+      schema_version: 1,
+      account: SS58,
+      entry_count: 0,
+      limit: 100,
+      offset: 0,
+      next_cursor: null,
+      entries: [],
+    });
+  });
+
+  test("resolves the Postgres-tier timeline entries verbatim", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          account: SS58,
+          entry_count: 1,
+          limit: 50,
+          offset: 0,
+          next_cursor: "next-page-token",
+          entries: [
+            {
+              observed_at: "2026-07-01T00:00:00.000Z",
+              name: "Example",
+              url: "https://example-account.sh",
+              github: "https://github.com/example/acct",
+              image: "https://example-account.sh/logo.png",
+              discord: "example#1234",
+              description: "desc",
+              additional: "extra",
+              identity_hash: "abc123",
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ account_identity_history(ss58: "${SS58}", limit: 50) {
+          account entry_count limit next_cursor
+          entries {
+            observed_at name url github image discord description additional identity_hash
+          }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const r = body.data.account_identity_history;
+    assert.equal(r.account, SS58);
+    assert.equal(r.entry_count, 1);
+    assert.equal(r.limit, 50);
+    assert.equal(r.next_cursor, "next-page-token");
+    assert.deepEqual(r.entries, [
+      {
+        observed_at: "2026-07-01T00:00:00.000Z",
+        name: "Example",
+        url: "https://example-account.sh",
+        github: "https://github.com/example/acct",
+        image: "https://example-account.sh/logo.png",
+        discord: "example#1234",
+        description: "desc",
+        additional: "extra",
+        identity_hash: "abc123",
+      },
+    ]);
+  });
+
+  test("D1 fallback path shapes rows through loadAccountIdentityHistory", async () => {
+    const observedAt = Date.parse("2026-06-15T12:00:00.000Z");
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  return {
+                    results: [
+                      {
+                        id: 11,
+                        observed_at: observedAt,
+                        name: "Alice",
+                        url: "https://metagraph.sh/alice",
+                        github: "https://github.com/jsonbored/alpha",
+                        image: null,
+                        discord: "alice#1234",
+                        description: "alpha desc",
+                        additional: null,
+                        identity_hash: "deadbeef",
+                      },
+                    ],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const { status, body } = await gql(
+      `{ account_identity_history(ss58: "${SS58}", limit: 10) {
+          account entry_count limit
+          entries { observed_at name url github discord description identity_hash }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.account_identity_history;
+    assert.equal(r.account, SS58);
+    assert.equal(r.entry_count, 1);
+    assert.equal(r.limit, 10);
+    assert.equal(r.entries.length, 1);
+    assert.equal(r.entries[0].observed_at, "2026-06-15T12:00:00.000Z");
+    assert.equal(r.entries[0].name, "Alice");
+    assert.equal(r.entries[0].url, "https://metagraph.sh/alice");
+    assert.equal(r.entries[0].github, "https://github.com/jsonbored/alpha");
+    assert.equal(r.entries[0].discord, "alice#1234");
+    assert.equal(r.entries[0].description, "alpha desc");
+    assert.equal(r.entries[0].identity_hash, "deadbeef");
+  });
+
+  test("pagination args are forwarded to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(
+      `{ account_identity_history(ss58: "${SS58}", limit: 25, offset: 10, cursor: "abc") { entry_count } }`,
+      env,
+    );
+    assert.equal(capturedUrl.searchParams.get("limit"), "25");
+    assert.equal(capturedUrl.searchParams.get("offset"), "10");
+    assert.equal(capturedUrl.searchParams.get("cursor"), "abc");
+    assert.ok(
+      capturedUrl.pathname.endsWith(
+        `/accounts/${encodeURIComponent(SS58)}/identity-history`,
+      ),
+    );
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ account_identity_history(ss58: "${SS58}") {
+          schema_version account entry_count limit offset next_cursor entries { name }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_identity_history, {
+      schema_version: 1,
+      account: SS58,
+      entry_count: 0,
+      limit: 100,
+      offset: 0,
+      next_cursor: null,
+      entries: [],
+    });
+  });
+
+  test("a malformed ss58 address is a GraphQL error, not an empty timeline", async () => {
+    const { body } = await gql(
+      '{ account_identity_history(ss58: "not-an-address") { entry_count } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/ss58/i.test(body.errors[0].message));
+    assert.equal(body.data?.account_identity_history ?? null, null);
+  });
+
+  test("account_identity_history is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.account_identity_history, 5);
+  });
+});
+
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## What

Adds `Query.account_identity_history(ss58, limit, offset, cursor)` to the GraphQL API, mirroring the existing REST route `GET /api/v1/accounts/{ss58}/identity-history` and the `get_account_identity_history` MCP tool. Closes the last GraphQL gap in the account-identity-history surface (same category as the recently-landed `Query.subnet_identity_history` #5796).

## How

- **SDL**: new `account_identity_history` field on `Query` plus `AccountIdentityHistory` / `AccountIdentityHistoryEntry` types mirroring the handler's real response shape — entries carry `observed_at`, the seven tracked identity fields (`name`, `url`, `github`, `image`, `discord`, `description`, `additional`), and `identity_hash`. No `block_number` column, matching `src/account-identity-history.mjs` (account identity carries no chain block height, only `observed_at`). Doc-comment follows the established "Mirrors GET /api/v1/…" convention.
- **Resolver**: reuses `loadAccountIdentityHistory` from `src/account-identity-history.mjs` (no duplicated D1 query logic) behind the same `tryPostgresTier(METAGRAPH_ACCOUNT_IDENTITY_SOURCE)` → D1 fallback the REST handler uses. A malformed SS58 address is a `BAD_USER_INPUT` error; an account with no recorded changes resolves to a schema-stable empty timeline (`entry_count` 0), never null and never a GraphQL error.
- **FIELD_COMPLEXITY**: `account_identity_history` added at the standard relationship weight.

## Tests

`tests/graphql.test.mjs` — cold-store empty-timeline fallback, Postgres-tier verbatim entries, D1 fallback shaping through `loadAccountIdentityHistory`, pagination forwarding, partial-body defaults, malformed-SS58 error, and the FIELD_COMPLEXITY weight. Patch coverage on the new lines is 100% (statements/lines/functions), branch-counted.

Closes #5709
