### PR TITLE
feat(data-refresh): neurons drift reconciler (#5776)

### DIFF
--- a/scripts/data-refresh-node-entrypoint.sh
+++ b/scripts/data-refresh-node-entrypoint.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 # Runs one step of the box-side Node-only data-refresh jobs (registry-sync,
-# registry-sync-fast, testnet-discovery, export-parquet) -- see
-# deploy/data-refresh-node.Dockerfile's header. Unlike deploy/economics-
-# refresh.Dockerfile's two-container split, none of these need a separate
-# untrusted-fetch step: all are pure JS with no PyPI/uvx involved, so npm
-# ci's own --ignore-scripts + integrity check (below) is the only
-# supply-chain guard needed, in ONE container.
+# registry-sync-fast, testnet-discovery, export-parquet, reconcile-neurons)
+# -- see deploy/data-refresh-node.Dockerfile's header. Unlike deploy/
+# economics-refresh.Dockerfile's two-container split, none of THIS
+# container's own work needs a separate untrusted-fetch step: everything
+# below is pure JS with no PyPI/uvx involved, so npm ci's own
+# --ignore-scripts + integrity check is the only supply-chain guard needed,
+# in ONE container. reconcile-neurons is the one exception to "no separate
+# fetch step needed" at the JOB level, not the container level: its chain
+# read runs in a DIFFERENT container entirely (the existing untrusted
+# metagraph-fetch image, unmodified) orchestrated by the infra role's
+# custom wrapper script -- this container only ever sees the fetch's
+# already-written JSON output, never runs bittensor/PyPI itself.
 set -euo pipefail
 
-: "${STEP:?STEP env var required (registry-sync|registry-sync-fast|testnet-discovery|export-parquet)}"
+: "${STEP:?STEP env var required (registry-sync|registry-sync-fast|testnet-discovery|export-parquet|reconcile-neurons)}"
 
 REPO_DIR=/repo
 GIT_REPO_URL="https://github.com/JSONbored/metagraphed.git"
@@ -162,8 +168,14 @@ case "$STEP" in
     echo "entrypoint: nightly Parquet bulk export to R2"
     exec node scripts/export-parquet.mjs
     ;;
+  reconcile-neurons)
+    : "${LIVE_SNAPSHOT_JSON:?LIVE_SNAPSHOT_JSON env var required for the reconcile-neurons step}"
+    : "${DATABASE_URL:?DATABASE_URL env var required for the reconcile-neurons step}"
+    echo "entrypoint: reconciling neurons against a fresh chain snapshot"
+    exec node scripts/reconcile-neurons.mjs
+    ;;
   *)
-    echo "entrypoint: unknown STEP '$STEP' (want registry-sync|registry-sync-fast|testnet-discovery|export-parquet)" >&2
+    echo "entrypoint: unknown STEP '$STEP' (want registry-sync|registry-sync-fast|testnet-discovery|export-parquet|reconcile-neurons)" >&2
     exit 1
     ;;
 esac

--- a/scripts/reconcile-neurons.mjs
+++ b/scripts/reconcile-neurons.mjs
@@ -1,0 +1,173 @@
+// Drift-detection reconciler (#5776, successor to #2115's "reconciler" half
+// -- see #2538 for the sibling "exporter" half, which this deliberately
+// does NOT share a job with: exporting is a bulk dump, reconciling needs a
+// FRESH chain read to compare against, a different trust/cost shape).
+//
+// Compares Postgres's `neurons` table (folded/aggregated state, written by
+// the existing refresh-metagraph box job) against a fresh, independently-
+// fetched live chain snapshot, and alerts on drift beyond tolerance. Does
+// NOT auto-correct anything -- alert-only, so a human decides whether a
+// flagged row is a real bug or expected sync lag.
+//
+// Scope: stake_tao + emission_tao on `neurons` only. #5776's issue text
+// also mentions "balances" and "yield" -- balances aren't part of this
+// dataset at all (a separate Balances-pallet read, out of scope for v1),
+// and "yield" has no direct on-chain storage to reconcile against (it's a
+// derived/computed metric from stake changes over time, not a value this
+// kind of point-in-time diff can meaningfully verify). stake_tao/
+// emission_tao are the two fields this fetch already produces that have a
+// genuine "folded value vs. runtime truth" comparison.
+//
+// Input: LIVE_SNAPSHOT_JSON, the exact output of
+// scripts/fetch-metagraph-native.py (run as a separate, untrusted,
+// no-secrets container -- see scripts/data-refresh-node-entrypoint.sh's
+// reconcile-neurons STEP and the infra role's custom wrapper script for
+// why this is two containers, not one: same fetch/authenticated-step trust
+// split every other chain-reading box job already uses).
+//
+// Usage: node scripts/reconcile-neurons.mjs
+import postgres from "postgres";
+import { readFile } from "node:fs/promises";
+import { stableStringify } from "./lib.mjs";
+
+// Below this absolute TAO delta, a mismatch is never flagged regardless of
+// relative size -- avoids false positives on near-zero stakes where a tiny
+// absolute change looks like a huge percentage. Above it, tolerate up to 2%
+// relative drift before flagging a single row: ordinary staking/unstaking
+// activity between refresh-metagraph's last write and this reconciler's own
+// fetch produces real, benign per-row differences at this scale.
+const ABSOLUTE_FLOOR_TAO = 0.01;
+const RELATIVE_TOLERANCE = 0.02;
+// RATIO, not a fixed count: refresh-metagraph runs DAILY (not hourly --
+// corrected after live testing against the real box, 2026-07-15), so
+// Postgres can legitimately be up to ~24h stale depending on where in the
+// cycle this job runs relative to it. A fixed small count would alert on
+// every single run purely from that lag (confirmed live: 15% of all rows
+// individually exceeded per-row tolerance after ~7h of staleness, entirely
+// explained by ordinary network-wide staking activity, not a bug). A ratio
+// scales with however stale Postgres happens to be and stays meaningful
+// regardless of network size. 30% is deliberately conservative pending real
+// drift history to tune against -- scheduled to run shortly after
+// refresh-metagraph's own daily fire (roles/data-refresh-node's job vars)
+// specifically to keep legitimate lag-driven drift low, so a genuine
+// systemic break (stalled sync, decode bug) should clear this threshold by
+// a wide margin rather than needing to be tuned razor-close to it.
+const ALERT_THRESHOLD_RATIO = 0.3;
+const MAX_EXAMPLES_IN_ALERT = 10;
+
+function fieldsDiffer(liveValue, storedValue) {
+  const live = Number(liveValue);
+  const stored = storedValue === null ? null : Number(storedValue);
+  if (!Number.isFinite(live)) return false; // fetch didn't produce a value for this field -- not this reconciler's problem
+  if (stored === null || !Number.isFinite(stored)) return true; // Postgres has no comparable value at all
+  const delta = Math.abs(live - stored);
+  if (delta <= ABSOLUTE_FLOOR_TAO) return false;
+  const tolerance = Math.max(
+    ABSOLUTE_FLOOR_TAO,
+    RELATIVE_TOLERANCE * Math.abs(live),
+  );
+  return delta > tolerance;
+}
+
+async function main() {
+  const snapshotPath = process.env.LIVE_SNAPSHOT_JSON;
+  if (!snapshotPath) throw new Error("LIVE_SNAPSHOT_JSON env var required");
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) throw new Error("DATABASE_URL env var required");
+
+  const liveRows = JSON.parse(await readFile(snapshotPath, "utf8"));
+  if (!Array.isArray(liveRows) || !liveRows.length) {
+    throw new Error(
+      `LIVE_SNAPSHOT_JSON (${snapshotPath}) is empty or not an array`,
+    );
+  }
+
+  const sql = postgres(databaseUrl, { max: 1 });
+  let storedRows;
+  try {
+    storedRows = await sql`
+      SELECT netuid, uid, stake_tao, emission_tao FROM neurons
+    `;
+  } finally {
+    await sql.end();
+  }
+
+  const storedByKey = new Map(
+    storedRows.map((row) => [`${row.netuid}:${row.uid}`, row]),
+  );
+
+  const mismatches = [];
+  for (const live of liveRows) {
+    const key = `${live.netuid}:${live.uid}`;
+    const stored = storedByKey.get(key);
+    if (!stored) {
+      mismatches.push({
+        netuid: live.netuid,
+        uid: live.uid,
+        reason: "missing_in_postgres",
+      });
+      continue;
+    }
+    const fields = [];
+    if (fieldsDiffer(live.stake_tao, stored.stake_tao))
+      fields.push("stake_tao");
+    if (fieldsDiffer(live.emission_tao, stored.emission_tao))
+      fields.push("emission_tao");
+    if (fields.length) {
+      mismatches.push({
+        netuid: live.netuid,
+        uid: live.uid,
+        reason: "value_drift",
+        fields,
+        live_stake_tao: live.stake_tao,
+        stored_stake_tao: stored.stake_tao,
+      });
+    }
+  }
+
+  const mismatchRatio = mismatches.length / liveRows.length;
+  const summary = {
+    compared: liveRows.length,
+    mismatches: mismatches.length,
+    mismatch_ratio: Number(mismatchRatio.toFixed(4)),
+    tolerance: {
+      absolute_floor_tao: ABSOLUTE_FLOOR_TAO,
+      relative: RELATIVE_TOLERANCE,
+      alert_ratio: ALERT_THRESHOLD_RATIO,
+    },
+  };
+  console.log(stableStringify(summary));
+
+  if (mismatchRatio >= ALERT_THRESHOLD_RATIO) {
+    await sendAlert(summary, mismatches.slice(0, MAX_EXAMPLES_IN_ALERT));
+  }
+}
+
+async function sendAlert(summary, examples) {
+  const webhookUrl = process.env.LIVE_ALERT_WEBHOOK_URL;
+  if (!webhookUrl) {
+    console.log(
+      "no LIVE_ALERT_WEBHOOK_URL configured -- skipping alert, drift logged above",
+    );
+    return;
+  }
+  const exampleLines = examples
+    .map((m) =>
+      m.reason === "missing_in_postgres"
+        ? `netuid ${m.netuid} uid ${m.uid}: missing in Postgres`
+        : `netuid ${m.netuid} uid ${m.uid}: ${m.fields.join(",")} live=${m.live_stake_tao} stored=${m.stored_stake_tao}`,
+    )
+    .join("\n");
+  const pct = (summary.mismatch_ratio * 100).toFixed(1);
+  const content = `🟠 metagraphed reconciler: ${summary.mismatches}/${summary.compared} (${pct}%) neurons rows drifted beyond tolerance\n\`\`\`\n${exampleLines}\n\`\`\``;
+  const response = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ content }),
+  });
+  if (!response.ok) {
+    console.error(`reconciler alert webhook failed (${response.status})`);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- Adds a `reconcile-neurons` STEP to the box-side `data-refresh-node` entrypoint: compares Postgres's `neurons` table (folded state written by the existing `refresh-metagraph` box job) against a fresh, independently-fetched live chain snapshot, and alerts on drift beyond tolerance. Alert-only, never auto-corrects -- a human decides whether flagged drift is a real bug or expected sync lag.
- Successor to #2115's "reconciler" half (its "exporter" half already shipped as #2538, closes out the split from #2115's closure).
- Reuses the existing untrusted `metagraph-fetch` image **unmodified** for the chain read (`fetch-metagraph-native.py`, zero new chain-RPC code) and the existing `postgres` npm dependency for the Postgres-side diff -- no new Dockerfile, no new npm dependency, same fetch/authenticated-step trust split every other chain-reading box job already uses.
- Scope: `stake_tao` + `emission_tao` on `neurons` only. The issue text also mentions "balances" and "yield" -- balances aren't part of this dataset (a separate Balances-pallet read, out of scope for v1), and yield has no direct on-chain storage to reconcile against (a derived metric from stake changes over time, not something a point-in-time diff can meaningfully verify).

## A real calibration finding from live testing
Alert threshold is a **ratio**, not a fixed count. `refresh-metagraph` runs **daily** (confirmed live -- not hourly as I initially assumed), so Postgres can legitimately be stale by design depending on where in the cycle this runs. Verified against the real box: 15% of all 30,106 neurons rows individually exceeded per-row tolerance (2% relative / 0.01 TAO floor) after ~7h of staleness, entirely explained by ordinary network-wide staking activity, not a bug. A fixed small count (my first draft) would have alerted on every single run. 30% ratio is deliberately conservative pending real drift history to tune against -- the box-side job is scheduled shortly after `refresh-metagraph`'s own daily fire specifically to keep legitimate lag-driven drift low.

## Test plan
- [x] `npx eslint`, `npx prettier --check`, `shellcheck`, `node scripts/scan-public-safety.mjs`, `npm run validate` all pass
- [x] Full pipeline verified live on the box: real chain fetch (30,106 neurons across 129 subnets) via the existing untrusted fetch image, real Postgres diff against the indexer database, correct ratio computed (15.04%, below the 30% alert threshold -- no false alert)
- [x] Alert-sending code path independently verified: lowered the threshold to force a trigger, confirmed a real POST reaches Discord's API (404 for a deliberately-invalid test token) and the failure is handled without crashing
- [ ] Live re-verification once deployed via the infra role (follow-up in the private infra repo)