### PR TITLE
feat(graphql): add Query.account_identity_history mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -38,6 +38,7 @@ import { buildSubnetYield } from "./subnet-yield.mjs";
 import { buildSubnetPerformance } from "./subnet-performance.mjs";
 import {
   analyticsWindow,
+  d1Runner,
   loadGlobalIncidentsLedger,
 } from "../workers/request-handlers/analytics.mjs";
 import {
@@ -120,6 +121,7 @@ import {
   ACCOUNT_STAKE_MOVES_WINDOWS,
   DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW,
 } from "./account-stake-moves.mjs";
+import { loadAccountIdentityHistory } from "./account-identity-history.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
 import { SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
 import {
@@ -240,6 +242,8 @@ export const SDL = `
     account_axon_removals(ss58: String!, window: String): AccountAxonRemovals!
     "One account's per-subnet StakeMoved footprint over a 7d/30d/90d window (default 30d): movement count, first/last timestamps, and the alpha price (TAO) at its most recent move per subnet, an HHI concentration of where its re-delegation churn is focused, and the dominant subnet; an address with no moves in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/stake-moves."
     account_stake_moves(ss58: String!, window: String): AccountStakeMoves!
+    "One account's on-chain identity change history, newest first -- an append-only diff-tracking timeline (name/url/github/image/discord/description/additional plus a stable hash per entry). Page with limit/offset or cursor (opaque keyset from a prior response's next_cursor). An address with no identity-history rows resolves to a schema-stable empty timeline, never null. Mirrors GET /api/v1/accounts/{ss58}/identity-history."
+    account_identity_history(ss58: String!, limit: Int, offset: Int, cursor: String): AccountIdentityHistory!
     "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
     economics_trends(window: String): EconomicsTrends!
     "Cross-subnet momentum leaderboard: every subnet ranked by its stake/emission/validator change between a window's start and end snapshots; movers is empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/subnets/movers."
@@ -1209,6 +1213,30 @@ export const SDL = `
     subnets: [AccountStakeMoveSubnet!]!
   }
 
+  "One diff-tracked snapshot of an account's on-chain identity, taken when any tracked field changed since the previous entry."
+  type AccountIdentityHistoryEntry {
+    observed_at: String
+    name: String
+    url: String
+    github: String
+    image: String
+    discord: String
+    description: String
+    additional: String
+    "Stable hash of this entry's tracked identity fields -- unchanged across entries where nothing actually differs."
+    identity_hash: String
+  }
+
+  type AccountIdentityHistory {
+    schema_version: Int!
+    account: String!
+    entry_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    entries: [AccountIdentityHistoryEntry!]!
+  }
+
   type AccountEvent {
     block_number: Int
     event_index: Int
@@ -1440,6 +1468,7 @@ export const FIELD_COMPLEXITY = {
   account_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   account_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   account_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3044,6 +3073,59 @@ const rootValue = {
         first_moved_at: s.first_moved_at ?? null,
         last_moved_at: s.last_moved_at ?? null,
         price_tao_at_last_move: s.price_tao_at_last_move ?? null,
+      })),
+    };
+  },
+
+  async account_identity_history({ ss58, limit, offset, cursor }, context) {
+    // Same SS58 validation every account_* resolver uses -- a malformed
+    // address is a GraphQL BAD_USER_INPUT error, not a silent empty timeline.
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_IDENTITY_SOURCE) -> D1
+    // (loadAccountIdentityHistory) fallback handleAccountIdentityHistory uses,
+    // forwarding limit/offset/cursor as query params -- an address with no
+    // identity-history rows is a schema-stable empty timeline, never a
+    // GraphQL error.
+    const params = new URLSearchParams();
+    if (limit != null) params.set("limit", String(limit));
+    if (offset != null) params.set("offset", String(offset));
+    if (cursor != null) params.set("cursor", cursor);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}/identity-history`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
+      )) ??
+      (await loadAccountIdentityHistory(d1Runner(context.env), ss58, {
+        limit,
+        offset,
+        cursor,
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      account: data.account ?? ss58,
+      entry_count: data.entry_count ?? 0,
+      limit: data.limit ?? null,
+      offset: data.offset ?? null,
+      next_cursor: data.next_cursor ?? null,
+      entries: (data.entries ?? []).map((e) => ({
+        observed_at: e.observed_at ?? null,
+        name: e.name ?? null,
+        url: e.url ?? null,
+        github: e.github ?? null,
+        image: e.image ?? null,
+        discord: e.discord ?? null,
+        description: e.description ?? null,
+        additional: e.additional ?? null,
+        identity_hash: e.identity_hash ?? null,
       })),
     };
   },

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -5180,6 +5180,188 @@ describe("graphql — account_stake_moves (#5707, Postgres-tier + zeroed-card fa
   });
 });
 
+describe("graphql — account_identity_history (#5709, Postgres-tier + D1-live fallback)", () => {
+  const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+  function historyQuery(argsClause) {
+    return `{ account_identity_history${argsClause} {
+      schema_version account entry_count limit offset next_cursor
+      entries { observed_at name url github image discord description additional identity_hash }
+    } }`;
+  }
+
+  // loadAccountIdentityHistory issues exactly one SELECT per call (no
+  // two-query branching like chain_weight_setters), so the mock ignores the
+  // SQL text and always returns the given rows.
+  function accountIdentityHistoryD1(rows = []) {
+    return {
+      prepare: () => ({
+        bind: () => ({ all: async () => ({ results: rows }) }),
+      }),
+    };
+  }
+
+  test("cold store, default args: schema-stable empty timeline, never null", async () => {
+    const { status, body } = await gql(historyQuery(`(ss58: "${SS58}")`));
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_identity_history, {
+      schema_version: 1,
+      account: SS58,
+      entry_count: 0,
+      limit: 100,
+      offset: 0,
+      next_cursor: null,
+      entries: [],
+    });
+  });
+
+  test("resolves Postgres-tier data as-is, forwarding limit/offset/cursor as query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            account: SS58,
+            entry_count: 1,
+            limit: 5,
+            offset: 10,
+            next_cursor: null,
+            entries: [
+              {
+                observed_at: "2026-07-10T00:00:00.000Z",
+                name: "Example",
+                url: "https://example.com",
+                github: "example",
+                image: null,
+                discord: null,
+                description: null,
+                additional: null,
+                identity_hash: "abc123",
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      historyQuery(`(ss58: "${SS58}", limit: 5, offset: 10, cursor: "xyz")`),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(
+      capturedUrl.pathname,
+      `/api/v1/accounts/${SS58}/identity-history`,
+    );
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl.searchParams.get("offset"), "10");
+    assert.equal(capturedUrl.searchParams.get("cursor"), "xyz");
+    assert.equal(body.data.account_identity_history.entry_count, 1);
+    assert.equal(body.data.account_identity_history.entries[0].name, "Example");
+    assert.equal(
+      body.data.account_identity_history.entries[0].identity_hash,
+      "abc123",
+    );
+  });
+
+  test("a bare Postgres-tier response ({}) still resolves schema-stable defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(historyQuery(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_identity_history, {
+      schema_version: 1,
+      account: SS58,
+      entry_count: 0,
+      limit: null,
+      offset: null,
+      next_cursor: null,
+      entries: [],
+    });
+  });
+
+  test("an entry missing observed_at/name/identity_hash resolves those fields as null", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({ entries: [{}] }) },
+    };
+    const { status, body } = await gql(historyQuery(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_identity_history.entries, [
+      {
+        observed_at: null,
+        name: null,
+        url: null,
+        github: null,
+        image: null,
+        discord: null,
+        description: null,
+        additional: null,
+        identity_hash: null,
+      },
+    ]);
+  });
+
+  test("no Postgres tier flag: reads the diff-tracked timeline straight off D1", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: accountIdentityHistoryD1([
+        {
+          id: 2,
+          observed_at: 1_750_000_000_000,
+          name: "Example",
+          url: "https://example.com",
+          github: "example",
+          image: null,
+          discord: null,
+          description: null,
+          additional: null,
+          identity_hash: "abc123",
+        },
+      ]),
+    };
+    const { status, body } = await gql(historyQuery(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.account_identity_history.account, SS58);
+    assert.equal(body.data.account_identity_history.entry_count, 1);
+    assert.equal(body.data.account_identity_history.entries[0].name, "Example");
+    assert.equal(
+      body.data.account_identity_history.entries[0].identity_hash,
+      "abc123",
+    );
+    assert.ok(body.data.account_identity_history.entries[0].observed_at);
+  });
+
+  test("a D1 query error degrades to a schema-stable empty timeline (no throw)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          throw new Error("db unavailable");
+        },
+      },
+    };
+    const { status, body } = await gql(historyQuery(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.account_identity_history.entry_count, 0);
+    assert.deepEqual(body.data.account_identity_history.entries, []);
+  });
+
+  test("an invalid ss58 is a GraphQL error, not a silent empty timeline", async () => {
+    const { body } = await gql(historyQuery('(ss58: "not-an-address")'));
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/ss58/i.test(body.errors[0].message));
+    assert.equal(body.data?.account_identity_history ?? null, null);
+  });
+
+  test("account_identity_history is weighted as a relationship field", () => {
+    assert.equal(FIELD_COMPLEXITY.account_identity_history, 5);
+  });
+});
+
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
Adds an `account_identity_history(ss58, limit, offset, cursor)` GraphQL query mirroring `GET /api/v1/accounts/{ss58}/identity-history` and the `get_account_identity_history` MCP tool: one account's on-chain identity change history, newest first — an append-only diff-tracking timeline.

## What
- New `AccountIdentityHistory` + `AccountIdentityHistoryEntry` types and `Query.account_identity_history(ss58: String!, limit: Int, offset: Int, cursor: String)` in `src/graphql.mjs`, weighted `RELATIONSHIP_FIELD_COMPLEXITY`. Each entry carries `observed_at` plus the tracked identity fields (`name`/`url`/`github`/`image`/`discord`/`description`/`additional`) and a stable `identity_hash`.
- Resolver reuses `loadAccountIdentityHistory` from `src/account-identity-history.mjs`, resolving through the same `tryPostgresTier(METAGRAPH_ACCOUNT_IDENTITY_SOURCE)` → D1 (`loadAccountIdentityHistory` via `d1Runner`) fallback `handleAccountIdentityHistory` uses, forwarding `limit`/`offset`/`cursor` as query params. An address with no identity-history rows resolves to a schema-stable empty timeline, never null.
- A malformed SS58 address is a `BAD_USER_INPUT` GraphQL error, matching the sibling account-scoped queries.

## Tests
Eight cases in `tests/graphql.test.mjs`: cold-store empty timeline, Postgres-tier data forwarded as-is with limit/offset/cursor params, a bare `{}` Postgres-tier response degrading to schema-stable defaults, an entry missing optional fields resolving those as null, D1-live fallback, a D1 query error degrading to an empty timeline (no throw), an invalid-ss58 error, and a FIELD_COMPLEXITY weight assertion. Full graphql suite green (293 tests); resolver 100% covered (statements + branches, verified against the diff's own line range).

Closes #5709