### PR TITLE
feat(graphql): add Query.subnet_stake_moves mirroring REST /subnets/{netuid}/stake-moves (#5716)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -35,6 +35,11 @@ import {
   DEFAULT_SUBNET_WEIGHTS_WINDOW,
 } from "./subnet-weights.mjs";
 import {
+  buildSubnetStakeMoves,
+  SUBNET_STAKE_MOVES_WINDOWS,
+  DEFAULT_SUBNET_STAKE_MOVES_WINDOW,
+} from "./subnet-stake-moves.mjs";
+import {
   buildSubnetWeightSetters,
   SUBNET_WEIGHT_SETTERS_WINDOWS,
   DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
@@ -195,6 +200,8 @@ export const SDL = `
     subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
     "Per-subnet validator weight-setting activity over a 7d/30d window (distinct weight-setters, WeightsSet count, and sets per setter); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/weights."
     subnet_weights(netuid: Int!, window: String): SubnetWeights!
+    "Per-subnet stake-movement (re-delegation) activity over a 7d/30d window (distinct movers, StakeMoved count, and movements per mover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/stake-moves."
+    subnet_stake_moves(netuid: Int!, window: String): SubnetStakeMoves!
     "Per-subnet weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators behind /weights ranked by WeightsSet activity, each with count, share, and first/last set times; a subnet with no events resolves to a schema-stable empty leaderboard, never null. Mirrors GET /api/v1/subnets/{netuid}/weights/setters."
     subnet_weight_setters(netuid: Int!, window: String): SubnetWeightSetters!
     "Per-subnet emission-per-stake yield over the current metagraph snapshot: each UID's yield plus the subnet-wide aggregate and p25/median/p75/p90 distribution; a subnet with no neurons resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/yield."
@@ -805,6 +812,16 @@ export const SDL = `
     distinct_setters: Int!
     weight_sets: Int!
     sets_per_setter: Float
+  }
+
+  type SubnetStakeMoves {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    distinct_movers: Int!
+    movements: Int!
+    movements_per_mover: Float
   }
 
   "Per-subnet weight-setter leaderboard (#5712). Empty setters on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/weights/setters."
@@ -1574,6 +1591,7 @@ export const FIELD_COMPLEXITY = {
   subnet_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_yield: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_performance: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2398,6 +2416,43 @@ const rootValue = {
       distinct_setters: data.distinct_setters ?? 0,
       weight_sets: data.weight_sets ?? 0,
       sets_per_setter: data.sets_per_setter ?? null,
+    };
+  },
+
+  async subnet_stake_moves({ netuid, window }, context) {
+    // Same 7d/30d window validation handleSubnetStakeMoves uses -- an
+    // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_SUBNET_STAKE_MOVES_WINDOW;
+    if (!Object.hasOwn(SUBNET_STAKE_MOVES_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, SUBNET_STAKE_MOVES_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> buildSubnetStakeMoves
+    // zeroed-card fallback contract handleSubnetStakeMoves uses; a subnet with no
+    // StakeMoved events in the window is a schema-stable zeroed card, never a
+    // GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/stake-moves`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildSubnetStakeMoves(null, netuid, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      observed_at: data.observed_at ?? null,
+      distinct_movers: data.distinct_movers ?? 0,
+      movements: data.movements ?? 0,
+      movements_per_mover: data.movements_per_mover ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -4573,6 +4573,94 @@ describe("graphql — subnet_weight_setters (#5712, Postgres-tier + empty-leader
   });
 });
 
+describe("graphql — subnet_stake_moves (#5716, Postgres-tier + zeroed-card fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_stake_moves(netuid: 5) {
+          schema_version netuid window observed_at
+          distinct_movers movements movements_per_mover
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_stake_moves, {
+      schema_version: 1,
+      netuid: 5,
+      window: "7d",
+      observed_at: null,
+      distinct_movers: 0,
+      movements: 0,
+      movements_per_mover: null,
+    });
+  });
+
+  test("resolves the Postgres-tier card for the requested window", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          window: "30d",
+          observed_at: "2026-07-01T00:00:00.000Z",
+          distinct_movers: 6,
+          movements: 15,
+          movements_per_mover: 2.5,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_stake_moves(netuid: 5, window: "30d") {
+          netuid window observed_at distinct_movers movements movements_per_mover
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const m = body.data.subnet_stake_moves;
+    assert.equal(m.window, "30d");
+    assert.equal(m.observed_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(m.distinct_movers, 6);
+    assert.equal(m.movements, 15);
+    assert.equal(m.movements_per_mover, 2.5);
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_stake_moves(netuid: 9, window: "30d") {
+          schema_version netuid window observed_at distinct_movers movements movements_per_mover
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_stake_moves, {
+      schema_version: 1,
+      netuid: 9,
+      window: "30d",
+      observed_at: null,
+      distinct_movers: 0,
+      movements: 0,
+      movements_per_mover: null,
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ subnet_stake_moves(netuid: 5, window: "99d") { movements } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_stake_moves ?? null, null);
+  });
+});
+
 describe("graphql — subnet_deregistrations (#5719, Postgres-tier + zeroed-card fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary
`GET /api/v1/subnets/{netuid}/stake-moves` (and MCP `get_subnet_stake_moves`) had no GraphQL mirror. This adds `Query.subnet_stake_moves`, following the exact pattern of the sibling windowed subnet-detail fields (`subnet_weights`, `subnet_serving`, `subnet_registrations`).

## Change (`src/graphql.mjs`)
- **SDL**: a `subnet_stake_moves(netuid: Int!, window: String): SubnetStakeMoves!` field with the "Mirrors GET /api/v1/…" doc-comment, plus a `SubnetStakeMoves` type mirroring `buildSubnetStakeMoves`'s real shape (`distinct_movers`, `movements`, `movements_per_mover`).
- **Resolver**: same 7d/30d window validation (unsupported → `BAD_USER_INPUT`) and `tryPostgresTier(…, "METAGRAPH_ACCOUNT_EVENTS_SOURCE") ?? buildSubnetStakeMoves(null, netuid, { window })` zeroed-card fallback contract `handleSubnetStakeMoves` uses — reuses the existing pure builder, no duplicated `account_events` logic. A subnet with no `StakeMoved` events resolves to a schema-stable zeroed card, never null / never a GraphQL error.
- **`FIELD_COMPLEXITY`**: `subnet_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY`.

## Tests (`tests/graphql.test.mjs`)
Mirrors the sibling suites: cold-store zeroed card, a Postgres-tier hit for the requested window, a partial-Postgres-body case exercising every resolver default, and an unsupported-window GraphQL error.

## Verification
- `tests/graphql.test.mjs` — **306 pass** (4 new); schema builds.
- Patch coverage on `src/graphql.mjs`: **100%** for the added lines/branches (the file's remaining uncovered branches are pre-existing, in unrelated resolvers).
- `eslint` + `prettier --check` — clean.

Closes #5716
