### PR TITLE
feat(graphql): add Query.account_identity mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -119,6 +119,7 @@ import {
   ACCOUNT_STAKE_MOVES_WINDOWS,
   DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW,
 } from "./account-stake-moves.mjs";
+import { loadAccountIdentity } from "./account-identity.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
 import { SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
 import {
@@ -237,6 +238,8 @@ export const SDL = `
     account_axon_removals(ss58: String!, window: String): AccountAxonRemovals!
     "One account's per-subnet StakeMoved footprint over a 7d/30d/90d window (default 30d): movement count, first/last timestamps, and the alpha price (TAO) at its most recent move per subnet, an HHI concentration of where its re-delegation churn is focused, and the dominant subnet; an address with no moves in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/stake-moves."
     account_stake_moves(ss58: String!, window: String): AccountStakeMoves!
+    "One account's latest-only on-chain personal identity (the MetagraphInfo.identities fields set via set_identity: name, url, github, image, discord, description, additional). has_identity is false for the common case -- most accounts never call set_identity -- with every field null; an address that never set an identity resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/identity."
+    account_identity(ss58: String!): AccountIdentity!
     "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
     economics_trends(window: String): EconomicsTrends!
     "Cross-subnet momentum leaderboard: every subnet ranked by its stake/emission/validator change between a window's start and end snapshots; movers is empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/subnets/movers."
@@ -1173,6 +1176,21 @@ export const SDL = `
     subnets: [AccountStakeMoveSubnet!]!
   }
 
+  "One account's latest-only on-chain personal identity (SubtensorModule::set_identity). has_identity is false -- and every field null -- for the common case of an account that never set an identity."
+  type AccountIdentity {
+    schema_version: Int!
+    account: String!
+    has_identity: Boolean!
+    name: String
+    url: String
+    github: String
+    image: String
+    discord: String
+    description: String
+    additional: String
+    captured_at: String
+  }
+
   type AccountEvent {
     block_number: Int
     event_index: Int
@@ -1404,6 +1422,7 @@ export const FIELD_COMPLEXITY = {
   account_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   account_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   account_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_identity: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2973,6 +2992,44 @@ const rootValue = {
         last_moved_at: s.last_moved_at ?? null,
         price_tao_at_last_move: s.price_tao_at_last_move ?? null,
       })),
+    };
+  },
+
+  async account_identity({ ss58 }, context) {
+    // Same SS58 validation handleAccountIdentity's route enforces -- a malformed
+    // address is a GraphQL BAD_USER_INPUT error, not a silent card.
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_IDENTITY_SOURCE) -> loadAccountIdentity
+    // D1 fallback contract handleAccountIdentity uses (this route keeps a live D1
+    // fallback -- unlike the retired account-event footprints -- since its Postgres
+    // outage is the realistic failure mode). An account that never called
+    // set_identity resolves to a schema-stable has_identity:false card (every field
+    // null), never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}/identity`,
+        ),
+        "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
+      )) ?? (await loadAccountIdentity(graphqlD1(context), ss58));
+    return {
+      schema_version: data.schema_version ?? 1,
+      account: data.account ?? ss58,
+      has_identity: data.has_identity ?? false,
+      name: data.name ?? null,
+      url: data.url ?? null,
+      github: data.github ?? null,
+      image: data.image ?? null,
+      discord: data.discord ?? null,
+      description: data.description ?? null,
+      additional: data.additional ?? null,
+      captured_at: data.captured_at ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -4994,6 +4994,173 @@ describe("graphql — account_stake_moves (#5707, Postgres-tier + zeroed-card fa
   });
 });
 
+describe("graphql — account_identity (#5708, Postgres-tier + D1-fallback latest-only identity)", () => {
+  const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag / no D1 rows returns a schema-stable has_identity:false card, never null", async () => {
+    const { status, body } = await gql(
+      `{ account_identity(ss58: "${SS58}") {
+          schema_version account has_identity
+          name url github image discord description additional captured_at
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_identity, {
+      schema_version: 1,
+      account: SS58,
+      has_identity: false,
+      name: null,
+      url: null,
+      github: null,
+      image: null,
+      discord: null,
+      description: null,
+      additional: null,
+      captured_at: null,
+    });
+  });
+
+  test("resolves the Postgres-tier flat identity body", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          account: SS58,
+          has_identity: true,
+          name: "Example Coldkey",
+          url: "https://example.com",
+          github: "https://github.com/example",
+          image: "https://example.com/logo.png",
+          discord: "example#1234",
+          description: "An example identity",
+          additional: "misc",
+          captured_at: "2026-07-01T00:00:00.000Z",
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ account_identity(ss58: "${SS58}") {
+          schema_version account has_identity
+          name url github image discord description additional captured_at
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_identity, {
+      schema_version: 1,
+      account: SS58,
+      has_identity: true,
+      name: "Example Coldkey",
+      url: "https://example.com",
+      github: "https://github.com/example",
+      image: "https://example.com/logo.png",
+      discord: "example#1234",
+      description: "An example identity",
+      additional: "misc",
+      captured_at: "2026-07-01T00:00:00.000Z",
+    });
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's schema-stable defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ account_identity(ss58: "${SS58}") {
+          schema_version account has_identity
+          name url github image discord description additional captured_at
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_identity, {
+      schema_version: 1,
+      account: SS58,
+      has_identity: false,
+      name: null,
+      url: null,
+      github: null,
+      image: null,
+      discord: null,
+      description: null,
+      additional: null,
+      captured_at: null,
+    });
+  });
+
+  test("D1 fallback path shapes a stored row through loadAccountIdentity", async () => {
+    const capturedAt = Date.parse("2026-06-15T12:00:00.000Z");
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  return {
+                    results: [
+                      {
+                        account: SS58,
+                        name: "Alpha Coldkey",
+                        url: "https://metagraph.sh/about",
+                        github: "https://github.com/jsonbored/alpha",
+                        image: "https://metagraph.sh/logo.png",
+                        discord: "alpha#1234",
+                        description: "alpha desc",
+                        additional: null,
+                        captured_at: capturedAt,
+                      },
+                    ],
+                  };
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+    const { status, body } = await gql(
+      `{ account_identity(ss58: "${SS58}") {
+          schema_version account has_identity
+          name url github image discord description additional captured_at
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_identity, {
+      schema_version: 1,
+      account: SS58,
+      has_identity: true,
+      name: "Alpha Coldkey",
+      url: "https://metagraph.sh/about",
+      github: "https://github.com/jsonbored/alpha",
+      image: "https://metagraph.sh/logo.png",
+      discord: "alpha#1234",
+      description: "alpha desc",
+      additional: null,
+      captured_at: "2026-06-15T12:00:00.000Z",
+    });
+  });
+
+  test("a malformed ss58 address is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ account_identity(ss58: "not-an-address") { has_identity } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/ss58/i.test(body.errors[0].message));
+    assert.equal(body.data?.account_identity ?? null, null);
+  });
+});
+
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
Adds an `account_identity(ss58: String!): AccountIdentity!` GraphQL query
mirroring `GET /api/v1/accounts/{ss58}/identity` and the `get_account_identity`
MCP tool: one account's latest-only on-chain personal identity (the
`MetagraphInfo.identities` fields set via `set_identity` — name, url, github,
image, discord, description, additional — plus `captured_at`).

The resolver reuses `loadAccountIdentity` from `src/account-identity.mjs`
through the same `tryPostgresTier(METAGRAPH_ACCOUNT_IDENTITY_SOURCE)` →
`loadAccountIdentity(d1, ss58)` fallback contract `handleAccountIdentity`
uses. This route deliberately keeps a live D1 fallback (unlike the retired
account-event footprints) since a Postgres outage is its realistic failure
mode. An account that never called `set_identity` — the common case — resolves
to a schema-stable `has_identity: false` card with every field null, never a
GraphQL error and never null. A malformed SS58 address is a `BAD_USER_INPUT`
error.

`account_identity` is added to `FIELD_COMPLEXITY` at
`RELATIONSHIP_FIELD_COMPLEXITY`, matching the sibling per-account queries.

Tests cover the cold-store zeroed card, the Postgres-tier flat body, a partial
tier body degrading to the resolver's schema-stable defaults, the D1 fallback
shaping a stored row through `loadAccountIdentity`, and the malformed-address
error.

Closes #5708
