### PR TITLE
feat(registry): Allways (SN7) full accuracy pass -- pilot batch for the root->128 audit

### DIFF
--- a/registry/providers/allways.json
+++ b/registry/providers/allways.json
@@ -1,11 +1,12 @@
 {
   "authority": "provider-claimed",
   "docs_url": "https://docs.all-ways.io/how-it-works.html",
+  "github_url": "https://github.com/entrius/allways",
   "id": "allways",
   "kind": "subnet-team",
   "logo_url": "https://metagraph.sh/logos/allways.png",
   "name": "Allways",
-  "notes": "Seed provider entry for the Allways SN7 pilot.",
+  "notes": "Provider entry for Allways SN7. Trustless native cross-chain swaps (no wrapped tokens, no bridges, no custodian) settled by a Solana program (allways_swap_manager) that holds miner collateral, runs a reservation lottery, and enforces outcomes via validator consensus voting and slashing. Hub-and-spoke design with SOL as the hub numeraire and BTC/TAO as spokes (SOL<->BTC, SOL<->TAO). Same team (entrius) operates Gittensor/SN74.",
   "schema_version": 1,
   "website_url": "https://all-ways.io"
 }

--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -1,10 +1,5 @@
 {
-  "categories": [
-    "defi",
-    "bitcoin",
-    "subnet-api",
-    "pilot"
-  ],
+  "categories": ["defi", "bitcoin", "subnet-api", "pilot"],
   "curation": {
     "gap_notes": [
       "No verified dashboard surface yet (no dashboard link found on the website as of 2026-07-15).",
@@ -297,9 +292,7 @@
         "state": "community-submitted",
         "submitted_by": "kiannidev"
       },
-      "source_urls": [
-        "https://api.all-ways.io/swagger-json"
-      ],
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/miners/leaderboard"
     },
     {
@@ -321,9 +314,7 @@
         "state": "community-submitted",
         "submitted_by": "jsonbored"
       },
-      "source_urls": [
-        "https://api.all-ways.io/swagger"
-      ],
+      "source_urls": ["https://api.all-ways.io/swagger"],
       "url": "https://api.all-ways.io/swaps"
     },
     {

--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -1,9 +1,14 @@
 {
-  "categories": ["bitcoin", "subnet-api", "pilot"],
+  "categories": [
+    "defi",
+    "bitcoin",
+    "subnet-api",
+    "pilot"
+  ],
   "curation": {
     "gap_notes": [
-      "No verified dashboard surface yet.",
-      "No verified data artifact yet."
+      "No verified dashboard surface yet (no dashboard link found on the website as of 2026-07-15).",
+      "Data-artifact surface exists (sn-7-allways-data-artifact) but is community-submitted, not yet maintainer-verified."
     ],
     "level": "adapter-backed",
     "review_state": "maintainer-reviewed",
@@ -247,15 +252,15 @@
       "id": "allways-crown-history",
       "kind": "subnet-api",
       "name": "Allways crown history",
-      "notes": "Listed as a public surface, but excluded from the default smoke probe because the endpoint may require query parameters and returns HTTP 400 for a blind GET.",
+      "notes": "Requires the direction query param (one of SOL-BTC, BTC-SOL, SOL-TAO, TAO-SOL -- SOL-BTC tracked here as the representative probe, confirmed live 2026-07-15). A blind GET without it returns HTTP 400, which previously left this surface unprobed entirely.",
       "probe": {
-        "enabled": false,
+        "enabled": true,
         "expect": "json",
         "method": "GET"
       },
       "provider": "allways",
       "public_safe": true,
-      "url": "https://api.all-ways.io/crown/history"
+      "url": "https://api.all-ways.io/crown/history?direction=SOL-BTC"
     },
     {
       "auth_required": false,
@@ -292,7 +297,9 @@
         "state": "community-submitted",
         "submitted_by": "kiannidev"
       },
-      "source_urls": ["https://api.all-ways.io/swagger-json"],
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json"
+      ],
       "url": "https://api.all-ways.io/miners/leaderboard"
     },
     {
@@ -314,7 +321,9 @@
         "state": "community-submitted",
         "submitted_by": "jsonbored"
       },
-      "source_urls": ["https://api.all-ways.io/swagger"],
+      "source_urls": [
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/swaps"
     },
     {
@@ -366,6 +375,281 @@
         "https://api.all-ways.io/swagger"
       ],
       "url": "https://api.all-ways.io/history/state"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "allways-network-stats",
+      "kind": "subnet-api",
+      "name": "Allways network stats",
+      "notes": "Public no-auth GET returning aggregate totals: total swap count, total volume (SOL), active miner count, active swap count. Documented in the subnet's own OpenAPI (api.all-ways.io/swagger-json, path /stats); same host as existing subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
+      "url": "https://api.all-ways.io/stats"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "allways-network-halt-state",
+      "kind": "subnet-api",
+      "name": "Allways network halt state",
+      "notes": "Public no-auth GET returning whether the network is currently halted plus the as-of timestamp. Documented in the subnet's own OpenAPI (path /network/halt-state); same host as existing subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
+      "url": "https://api.all-ways.io/network/halt-state"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "allways-network-scoring-state",
+      "kind": "subnet-api",
+      "name": "Allways network scoring state",
+      "notes": "Public no-auth GET returning the last-scored timestamp and updated-at time for the network's miner scoring cycle. Documented in the subnet's own OpenAPI (path /network/scoring-state); same host as existing subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
+      "url": "https://api.all-ways.io/network/scoring-state"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "allways-swaps-active",
+      "kind": "subnet-api",
+      "name": "Allways active swaps",
+      "notes": "Public no-auth GET returning the list of currently in-flight swaps. Documented in the subnet's own OpenAPI (path /swaps/active); same host as existing subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
+      "url": "https://api.all-ways.io/swaps/active"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "allways-swaps-count",
+      "kind": "subnet-api",
+      "name": "Allways swap count",
+      "notes": "Public no-auth GET returning the cumulative total swap count. Documented in the subnet's own OpenAPI (path /swaps/count); same host as existing subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
+      "url": "https://api.all-ways.io/swaps/count"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "allways-events",
+      "kind": "subnet-api",
+      "name": "Allways full event feed",
+      "notes": "Public no-auth GET returning the full protocol event feed (SwapCompleted and related on-chain events), unfiltered -- distinct from the already-tracked /events/latest convenience endpoint. Documented in the subnet's own OpenAPI (path /events); same host as existing subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
+      "url": "https://api.all-ways.io/events"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "allways-reservations",
+      "kind": "subnet-api",
+      "name": "Allways reservations",
+      "notes": "Public no-auth GET returning the full list of swap reservations. Documented in the subnet's own OpenAPI (path /reservations); same host as existing subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
+      "url": "https://api.all-ways.io/reservations"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "allways-reservations-active",
+      "kind": "subnet-api",
+      "name": "Allways active reservations",
+      "notes": "Public no-auth GET returning only currently-active swap reservations. Documented in the subnet's own OpenAPI (path /reservations/active); same host as existing subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
+      "url": "https://api.all-ways.io/reservations/active"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "allways-crown-time",
+      "kind": "subnet-api",
+      "name": "Allways crown time-share",
+      "notes": "Public no-auth GET returning per-miner crown time-share (seconds held, share of window, rate) for a swap direction; requires the direction query param (one of SOL-BTC, BTC-SOL, SOL-TAO, TAO-SOL -- SOL-BTC tracked here as the representative probe). Documented in the subnet's own OpenAPI (path /crown/time); same host as existing subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
+      "url": "https://api.all-ways.io/crown/time?direction=SOL-BTC"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "allways-crown-rate-history",
+      "kind": "subnet-api",
+      "name": "Allways crown rate history",
+      "notes": "Public no-auth GET returning the crown-holder rate history for a swap direction; requires the direction query param (one of SOL-BTC, BTC-SOL, SOL-TAO, TAO-SOL -- SOL-BTC tracked here as the representative probe). Documented in the subnet's own OpenAPI (path /crown/rate-history); same host as existing subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
+      "url": "https://api.all-ways.io/crown/rate-history?direction=SOL-BTC"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "allways-history-rate",
+      "kind": "subnet-api",
+      "name": "Allways historical exchange rate",
+      "notes": "Public no-auth GET returning daily historical exchange rate time-series for a swap direction; requires the direction query param (one of SOL-BTC, BTC-SOL, SOL-TAO, TAO-SOL -- SOL-BTC tracked here as the representative probe). Documented in the subnet's own OpenAPI (path /history/rate); same host as existing subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
+      "url": "https://api.all-ways.io/history/rate?direction=SOL-BTC"
     }
   ],
   "website_url": "https://all-ways.io/"

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -1225,10 +1225,15 @@ test("public artifacts are internally consistent", () => {
     allwaysSseFixtureService.fixture_status.status,
     "unsupported-kind",
   );
+  // allways-crown-history used to be tracked with probe.enabled: false (a
+  // blind GET 400s without the direction query param), classifying it
+  // "non-get" here. Fixed to probe `?direction=SOL-BTC` and enabled -- it's
+  // now a normal enabled GET probe with no fixture captured in this
+  // deterministic no-capture build, same as allwaysFixtureService above.
   const allwaysHistoryFixtureService = readArtifact(
     "agent-catalog/7.json",
   ).services.find((service) => service.surface_id === "allways-crown-history");
-  assert.equal(allwaysHistoryFixtureService.fixture_status.status, "non-get");
+  assert.equal(allwaysHistoryFixtureService.fixture_status.status, "missing");
 
   // AI-resources index: the copyable agent + the live MCP tool list + resources.
   assert.match(agentResources.copyable_agent.url, /\/agent\.md$/);


### PR DESCRIPTION
## Summary

Pilot batch establishing the pattern for the full root->128 subnet accuracy audit, per the user's request to start with Allways before scaling out.

- **11 new surfaces found by diffing the subnet's own OpenAPI spec** (`api.all-ways.io/swagger-json`, 36 documented paths) against the 19 already-tracked surfaces. Every one individually verified live before adding: network stats, halt-state, scoring-state, active swaps, swap count, full event feed, reservations (+active), and three swap-direction endpoints (crown time-share, crown rate history, historical exchange rate — each requires a `direction` query param; tracked with `SOL-BTC` as the representative probe, matching this file's own existing convention for parameterized endpoints).
- **Fixed `allways-crown-history`**: was tracked with probing disabled entirely because a blind GET 400s without the same `direction` param. Added the param to the URL and enabled probing — it now contributes real uptime/latency data instead of none.
- **Fixed a stale `curation.gap_notes` entry** claiming "no verified data artifact yet" despite one already being tracked (`sn-7-allways-data-artifact`, community-submitted).
- **Fixed `categories`**: `"bitcoin"` was the *only* subnet in the entire 129-subnet registry using that tag, and undersold the actual protocol — Allways does SOL-hub swaps to *both* BTC and TAO (confirmed by reading the docs). Added `"defi"`, the established category for this class of subnet.
- **Enriched the provider profile** with the protocol's real mechanics (Solana settlement program `allways_swap_manager`, hub-and-spoke design, reservation lottery, validator consensus + slashing) read directly from `docs.all-ways.io/how-it-works.html`, plus the missing `github_url`.
- **Fixed surface-id and probe-config quality**: `surface:add` disambiguates same-host/same-kind collisions with numeric suffixes (`-2`, `-3`, ...) and doesn't set a `probe` block by default. Renamed the 11 new surfaces to descriptive ids matching this file's existing convention, and added explicit probe blocks — without one, a surface is invisible to operational health tracking (confirmed: the build's `operational-surfaces.json` only grew by +1 until this fix, +12 after).

**19 → 30 tracked surfaces; 26 of them now visible to health tracking (was 15).**

## Test plan

- [x] `npm run validate:schemas` — passes
- [x] `npm run validate:surface` — passes (862 surfaces across 129 subnet files)
- [x] `npm run build` — full build passes; confirmed `operational-surfaces.json` correctly includes all 26 Allways probe-eligible surfaces post-build
- [x] Every new endpoint fetched live and its response inspected before being added (not schema-valid-but-untested)
- [x] Cross-checked the docs page content directly rather than assuming from the subnet name/existing tags