### PR TITLE
feat(graphql): add Query.account_identity mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -6,9 +6,10 @@ import {
   specifiedRules,
   validate,
 } from "graphql";
+import { SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
+import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 import { readArtifact, readHealthKv } from "../workers/storage.mjs";
 import { contractVersion } from "../workers/responses.mjs";
-import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 import {
   buildSubnetRegistrations,
   SUBNET_REGISTRATIONS_WINDOWS,
@@ -135,8 +136,8 @@ import {
   DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW,
 } from "./account-stake-moves.mjs";
 import { loadAccountIdentityHistory } from "./account-identity-history.mjs";
+import { loadAccountIdentity } from "./account-identity.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
-import { SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
 import {
   parseHistoryWindow,
   unsupportedWindowMessage,
@@ -228,6 +229,8 @@ export const SDL = `
     health: GlobalHealth
     "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
     opportunity_boards(limit: Int): OpportunityBoards!
+    "Latest-only personal on-chain identity for one account. Mirrors GET /api/v1/accounts/{ss58}/identity."
+    account_identity(ss58: String!): AccountIdentity!
     "Cross-subnet comparison: registry structure, live economics, and live health placed side by side for the requested netuids, in requested order. Mirrors GET /api/v1/compare."
     compare(netuids: [Int!]!, dimensions: [String!]): Compare!
     "Global endpoint-incident ledger over a 7d/30d window; degrades to a schema-stable empty ledger (never a GraphQL error) on a cold/retired health tier. Mirrors GET /api/v1/incidents."
@@ -711,6 +714,20 @@ export const SDL = `
     miner_count: Int
     validator_headroom: Int
     max_validators: Int
+  }
+
+  type AccountIdentity {
+    schema_version: Int!
+    account: String!
+    has_identity: Boolean!
+    name: String
+    url: String
+    github: String
+    image: String
+    discord: String
+    description: String
+    additional: String
+    captured_at: String
   }
 
   type Compare {
@@ -1615,6 +1632,7 @@ export const FIELD_COMPLEXITY = {
   endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_identity: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -1965,6 +1983,14 @@ function loadObservedAt(context) {
     const meta = await readHealthKv(context.env, KV_HEALTH_META);
     return meta?.last_run_at || null;
   });
+}
+
+// Synthetic GET /api/v1/accounts/{ss58}/identity request, forwarded unchanged
+// to DATA_API via tryPostgresTier when the account-identity cutover is active.
+function graphqlAccountIdentityRequest(ss58) {
+  return new Request(
+    `https://d/api/v1/accounts/${encodeURIComponent(ss58)}/identity`,
+  );
 }
 
 // Economics subnet rows for compare, reusing the live-preferring economics memo
@@ -2628,6 +2654,22 @@ const rootValue = {
       highest_emission: boards["highest-emission"] || [],
       validator_headroom: boards["validator-headroom"] || [],
     };
+  },
+
+  async account_identity({ ss58 }, context) {
+    if (typeof ss58 !== "string" || !SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError(
+        "ss58 must be a valid SS58 account address (base58, 47-48 chars).",
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    return (
+      (await tryPostgresTier(
+        context.env,
+        graphqlAccountIdentityRequest(ss58),
+        "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
+      )) ?? (await loadAccountIdentity(graphqlD1(context), ss58))
+    );
   },
 
   async compare({ netuids, dimensions }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -32,6 +32,7 @@ import {
 
 // Minimal fake env — no R2 or ASSETS, so readArtifact always returns ok:false.
 const emptyEnv = {};
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
 async function gql(query, env = emptyEnv, extras = {}) {
   const req = new Request("https://api.metagraph.sh/api/v1/graphql", {
@@ -75,6 +76,28 @@ function fixtureEnv(fixtures = {}, { reads, kv, kvReads } = {}) {
     };
   }
   return env;
+}
+
+function accountIdentityEnv({ identity } = {}, capture = []) {
+  return {
+    METAGRAPH_HEALTH_DB: {
+      prepare(sql) {
+        return {
+          bind(...params) {
+            capture.push({ sql, params });
+            return {
+              all() {
+                if (/FROM account_identity WHERE/.test(sql)) {
+                  return Promise.resolve({ results: identity || [] });
+                }
+                return Promise.resolve({ results: [] });
+              },
+            };
+          },
+        };
+      },
+    },
+  };
 }
 
 describe("handleGraphQLRequest — method guard", () => {
@@ -1322,6 +1345,7 @@ describe("graphql — complexity weights keep the guard meaningful", () => {
       "endpoints",
       "health",
       "opportunity_boards",
+      "account_identity",
     ]) {
       assert.equal(FIELD_COMPLEXITY[field], 5, `${field} should be weighted`);
     }
@@ -1377,6 +1401,95 @@ describe("graphql — complexity weights keep the guard meaningful", () => {
 // --- Branch coverage for the changed resolvers/handler ----------------------
 
 describe("graphql — resolver branch coverage", () => {
+  test("account_identity returns the latest identity from D1", async () => {
+    const env = accountIdentityEnv({
+      identity: [
+        {
+          account: SS58,
+          name: "Alice",
+          url: "https://alice.example",
+          github: "https://github.com/alice",
+          image: null,
+          discord: "alice#0001",
+          description: "validator",
+          additional: null,
+          captured_at: 1_700_000_000_000,
+        },
+      ],
+    });
+    const { status, body } = await gql(
+      `{ account_identity(ss58: "${SS58}") {
+          account has_identity name url github captured_at
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.account_identity.account, SS58);
+    assert.equal(body.data.account_identity.has_identity, true);
+    assert.equal(body.data.account_identity.name, "Alice");
+    assert.equal(body.data.account_identity.url, "https://alice.example/");
+    assert.equal(body.data.account_identity.github, "https://github.com/alice");
+    assert.ok(body.data.account_identity.captured_at);
+  });
+
+  test("account_identity returns a schema-stable empty identity on cold D1", async () => {
+    const { status, body } = await gql(
+      `{ account_identity(ss58: "${SS58}") {
+          account has_identity name captured_at
+        } }`,
+      accountIdentityEnv(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.account_identity.account, SS58);
+    assert.equal(body.data.account_identity.has_identity, false);
+    assert.equal(body.data.account_identity.name, null);
+    assert.equal(body.data.account_identity.captured_at, null);
+  });
+
+  test("account_identity rejects an invalid ss58 with BAD_USER_INPUT", async () => {
+    const { status, body } = await gql(
+      '{ account_identity(ss58: "not-ss58") { account } }',
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+  });
+
+  test("account_identity uses the Postgres tier when enabled", async () => {
+    const capture = [];
+    const env = {
+      ...accountIdentityEnv(
+        {
+          identity: [{ account: SS58, name: "D1Alice", captured_at: 1 }],
+        },
+        capture,
+      ),
+      METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            account: SS58,
+            has_identity: true,
+            name: "PgAlice",
+            url: null,
+            github: null,
+            image: null,
+            discord: null,
+            description: null,
+            additional: null,
+            captured_at: null,
+          }),
+      },
+    };
+    const { status, body } = await gql(
+      `{ account_identity(ss58: "${SS58}") { account has_identity name } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.account_identity.name, "PgAlice");
+    assert.deepEqual(capture, []);
+  });
+
   test("a spread to an undefined fragment is handled by the depth/complexity guards", async () => {
     // frag is undefined, so the rules skip the spread instead of throwing.
     const { status } = await gql("{ ...Ghost }");


### PR DESCRIPTION
## What

Adds `Query.account_identity(ss58)` to the GraphQL API, mirroring the existing REST route `GET /api/v1/accounts/{ss58}/identity` and the `get_account_identity` MCP tool.

## Why

The account identity surface already exists in REST and MCP, but GraphQL was missing the same read path. This closes that schema gap for issue `#5708`.

## How

- adds `account_identity` to the SDL with an `AccountIdentity` response type matching the existing loader shape
- reuses `loadAccountIdentity` for the D1/live fallback path instead of duplicating query logic
- uses the same Postgres-tier cutover route as REST/MCP when `METAGRAPH_ACCOUNT_IDENTITY_SOURCE=postgres`
- validates `ss58` input and adds the new field to `FIELD_COMPLEXITY`
- adds GraphQL tests for D1 hit, empty fallback, invalid input, and Postgres-tier behavior

## Validation

- `npm test -- tests/graphql.test.mjs`
- `npx vitest run tests/graphql.test.mjs --coverage --coverage.include=src/graphql.mjs --coverage.thresholds.lines=0 --coverage.thresholds.functions=0 --coverage.thresholds.statements=0 --coverage.thresholds.branches=0`

Closes #5708
