### PR TITLE
feat(graphql): add Query.chain_alpha_volume mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -167,6 +167,11 @@ import {
   DEFAULT_CHAIN_TURNOVER_WINDOW,
 } from "./chain-turnover.mjs";
 import {
+  CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
+  CHAIN_ALPHA_VOLUME_LIMIT_MAX,
+  loadChainAlphaVolume,
+} from "./chain-alpha-volume.mjs";
+import {
   CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
   CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
   CHAIN_WEIGHT_SETTERS_WINDOWS,
@@ -286,6 +291,8 @@ export const SDL = `
     health_trends: HealthTrends!
     "Network-wide emission-yield (return rate) aggregated across every subnet's neurons -- the aggregate network return, the same split by validator vs miner role, and the distribution of the per-neuron return rate. Every aggregate is null (never a GraphQL error) on a cold store. Mirrors GET /api/v1/chain/yield."
     chain_yield: ChainYield!
+    "Network-wide rolling 24h buy/sell alpha-volume leaderboard: every subnet with StakeAdded (buy) or StakeRemoved (sell) volume in the last 24h ranked by total_volume_tao, each carrying its full buy/sell/total volume + sentiment scorecard (vol_mcap_ratio always null here -- no per-subnet market-cap input at the network level), plus a network rollup with its own net/gross sentiment reading and the per-subnet total-volume spread, summed live from the account_events stream. Fixed 24h window (no window arg); limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/alpha-volume."
+    chain_alpha_volume(limit: Int): ChainAlphaVolume!
     "Live cumulative TAO recycled for registration on one subnet, read directly from chain via RPC (not the Postgres tier). recycled_tao is null on RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/recycled."
     subnet_recycled(netuid: Int!): SubnetRecycled
   }
@@ -545,6 +552,71 @@ export const SDL = `
     distinct_setters: Int!
     weight_sets: Int!
     sets_per_setter: Float
+  }
+
+  "Network-wide rolling 24h buy/sell alpha-volume leaderboard, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/alpha-volume's data envelope."
+  type ChainAlphaVolume {
+    schema_version: Int!
+    "Fixed rolling window label (always 24h)."
+    window: String
+    "Newest event observed_at across the window; null on a cold store."
+    observed_at: String
+    subnet_count: Int!
+    network: ChainAlphaVolumeNetwork!
+    "Spread of per-subnet total_volume_tao across every subnet with volume; null when no subnet had volume."
+    volume_distribution: ChainAlphaVolumeDistribution
+    subnets: [ChainAlphaVolumeSubnet!]!
+  }
+
+  "Network-wide buy/sell volume rollup across every subnet with volume in the window."
+  type ChainAlphaVolumeNetwork {
+    buy_volume_alpha: Float!
+    sell_volume_alpha: Float!
+    total_volume_alpha: Float!
+    buy_volume_tao: Float!
+    sell_volume_tao: Float!
+    total_volume_tao: Float!
+    buy_count: Int!
+    sell_count: Int!
+    net_volume_alpha: Float!
+    "net/gross alpha lean in [-1, 1]; null when there was no volume in the window."
+    sentiment_ratio: Float
+    "Coarse sentiment label (bullish/bearish/neutral); neutral both for balanced volume and an empty window."
+    sentiment: String!
+  }
+
+  "Spread of per-subnet total_volume_tao across EVERY subnet with volume (not just the returned page, so the spread stays network-wide when limit truncates the leaderboard)."
+  type ChainAlphaVolumeDistribution {
+    count: Int!
+    mean: Float!
+    min: Float!
+    p25: Float!
+    median: Float!
+    p75: Float!
+    p90: Float!
+    max: Float!
+  }
+
+  "One subnet's rolling 24h buy/sell volume scorecard, ranked by total_volume_tao then netuid."
+  type ChainAlphaVolumeSubnet {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    buy_volume_alpha: Float!
+    sell_volume_alpha: Float!
+    total_volume_alpha: Float!
+    buy_volume_tao: Float!
+    sell_volume_tao: Float!
+    total_volume_tao: Float!
+    buy_count: Int!
+    sell_count: Int!
+    net_volume_alpha: Float!
+    "net/gross alpha lean in [-1, 1]; null when this subnet had no volume."
+    sentiment_ratio: Float
+    "Coarse sentiment label (bullish/bearish/neutral)."
+    sentiment: String!
+    "24h volume / market-cap turnover ratio; always null here (no per-subnet market-cap input in scope at the network level)."
+    vol_mcap_ratio: Float
   }
 
   "Network-wide weight-setter leaderboard over a lookback window, summed live from the account_events WeightsSet stream. The setter-level drill-in behind ChainWeights. Mirrors GET /api/v1/chain/weights/setters."
@@ -1650,6 +1722,7 @@ export const FIELD_COMPLEXITY = {
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_yield: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_alpha_volume: RELATIONSHIP_FIELD_COMPLEXITY,
   account_prometheus: RELATIONSHIP_FIELD_COMPLEXITY,
   account_stake_flow: RELATIONSHIP_FIELD_COMPLEXITY,
   account_portfolio: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3654,6 +3727,47 @@ const rootValue = {
       weight_sets: data.weight_sets ?? 0,
       setter_count: data.setter_count ?? 0,
       setters: data.setters || [],
+    };
+  },
+
+  async chain_alpha_volume({ limit }, context) {
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
+      maxLimit: CHAIN_ALPHA_VOLUME_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> loadChainAlphaVolume
+    // fallback contract REST's handleChainAlphaVolume uses -- a cold store yields
+    // a schema-stable zeroed card (subnet_count 0, empty leaderboard, neutral
+    // sentiment), never a GraphQL error. Fixed 24h window, no window arg.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/alpha-volume", params),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      (await loadChainAlphaVolume(graphqlD1(context), { limit: safeLimit }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? "24h",
+      observed_at: data.observed_at ?? null,
+      subnet_count: data.subnet_count ?? 0,
+      network: data.network ?? {
+        buy_volume_alpha: 0,
+        sell_volume_alpha: 0,
+        total_volume_alpha: 0,
+        buy_volume_tao: 0,
+        sell_volume_tao: 0,
+        total_volume_tao: 0,
+        buy_count: 0,
+        sell_count: 0,
+        net_volume_alpha: 0,
+        sentiment_ratio: null,
+        sentiment: "neutral",
+      },
+      volume_distribution: data.volume_distribution ?? null,
+      subnets: data.subnets || [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -6579,6 +6579,236 @@ describe("graphql — chain_weight_setters (#5689, Postgres-tier + D1-live fallb
   });
 });
 
+describe("graphql — chain_alpha_volume (#5685, Postgres-tier + D1-live fallback)", () => {
+  function alphaVolumeQuery(argsClause = "") {
+    return `{ chain_alpha_volume${argsClause} {
+      schema_version window observed_at subnet_count
+      network {
+        buy_volume_alpha sell_volume_alpha total_volume_alpha
+        buy_volume_tao sell_volume_tao total_volume_tao
+        buy_count sell_count net_volume_alpha sentiment_ratio sentiment
+      }
+      volume_distribution { count mean min p25 median p75 p90 max }
+      subnets {
+        schema_version netuid window
+        buy_volume_alpha sell_volume_alpha total_volume_alpha
+        buy_volume_tao sell_volume_tao total_volume_tao
+        buy_count sell_count net_volume_alpha sentiment_ratio sentiment vol_mcap_ratio
+      }
+    } }`;
+  }
+
+  // loadChainAlphaVolume issues a single (netuid, event_kind) GROUP BY over
+  // account_events; the mock returns those aggregate rows for the one query.
+  function chainAlphaVolumeD1(rows = []) {
+    return {
+      prepare() {
+        return {
+          bind() {
+            return {
+              async all() {
+                return { results: rows };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  test("cold store, default args: schema-stable zeroed card", async () => {
+    const { status, body } = await gql(alphaVolumeQuery());
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_alpha_volume, {
+      schema_version: 1,
+      window: "24h",
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        buy_volume_alpha: 0,
+        sell_volume_alpha: 0,
+        total_volume_alpha: 0,
+        buy_volume_tao: 0,
+        sell_volume_tao: 0,
+        total_volume_tao: 0,
+        buy_count: 0,
+        sell_count: 0,
+        net_volume_alpha: 0,
+        sentiment_ratio: null,
+        sentiment: "neutral",
+      },
+      volume_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("resolves Postgres-tier data for an explicit limit, forwarding it as a query param", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            window: "24h",
+            observed_at: "2026-07-10T00:00:00.000Z",
+            subnet_count: 1,
+            network: {
+              buy_volume_alpha: 100,
+              sell_volume_alpha: 40,
+              total_volume_alpha: 140,
+              buy_volume_tao: 50,
+              sell_volume_tao: 20,
+              total_volume_tao: 70,
+              buy_count: 10,
+              sell_count: 5,
+              net_volume_alpha: 60,
+              sentiment_ratio: 0.4286,
+              sentiment: "bullish",
+            },
+            volume_distribution: {
+              count: 1,
+              mean: 70,
+              min: 70,
+              p25: 70,
+              median: 70,
+              p75: 70,
+              p90: 70,
+              max: 70,
+            },
+            subnets: [
+              {
+                schema_version: 1,
+                netuid: 3,
+                window: "24h",
+                buy_volume_alpha: 100,
+                sell_volume_alpha: 40,
+                total_volume_alpha: 140,
+                buy_volume_tao: 50,
+                sell_volume_tao: 20,
+                total_volume_tao: 70,
+                buy_count: 10,
+                sell_count: 5,
+                net_volume_alpha: 60,
+                sentiment_ratio: 0.4286,
+                sentiment: "bullish",
+                vol_mcap_ratio: null,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(alphaVolumeQuery("(limit: 5)"), env);
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/alpha-volume");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    const card = body.data.chain_alpha_volume;
+    assert.equal(card.window, "24h");
+    assert.equal(card.subnet_count, 1);
+    assert.equal(card.observed_at, "2026-07-10T00:00:00.000Z");
+    assert.equal(card.network.total_volume_tao, 70);
+    assert.equal(card.network.sentiment, "bullish");
+    assert.equal(card.volume_distribution.median, 70);
+    assert.equal(card.subnets[0].netuid, 3);
+    assert.equal(card.subnets[0].vol_mcap_ratio, null);
+  });
+
+  test("clamps an over-max limit before forwarding it to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({});
+        },
+      },
+    };
+    const { status } = await gql(alphaVolumeQuery("(limit: 9999)"), env);
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+  });
+
+  test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(alphaVolumeQuery(), env);
+    assert.equal(status, 200);
+    const card = body.data.chain_alpha_volume;
+    assert.equal(card.schema_version, 1);
+    assert.equal(card.window, "24h");
+    assert.equal(card.observed_at, null);
+    assert.equal(card.subnet_count, 0);
+    assert.equal(card.network.total_volume_tao, 0);
+    assert.equal(card.network.sentiment, "neutral");
+    assert.equal(card.volume_distribution, null);
+    assert.deepEqual(card.subnets, []);
+  });
+
+  test("no Postgres tier flag: rolls up the account_events StakeAdded/StakeRemoved stream straight off D1", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: chainAlphaVolumeD1([
+        {
+          netuid: 3,
+          event_kind: "StakeAdded",
+          alpha_volume: 100,
+          tao_volume: 50,
+          event_count: 10,
+          last_observed: 1_750_000_000_000,
+        },
+        {
+          netuid: 3,
+          event_kind: "StakeRemoved",
+          alpha_volume: 40,
+          tao_volume: 20,
+          event_count: 5,
+          last_observed: 1_749_000_000_000,
+        },
+      ]),
+    };
+    const { status, body } = await gql(alphaVolumeQuery(), env);
+    assert.equal(status, 200);
+    const card = body.data.chain_alpha_volume;
+    assert.equal(card.subnet_count, 1);
+    assert.equal(card.network.buy_volume_alpha, 100);
+    assert.equal(card.network.sell_volume_alpha, 40);
+    assert.equal(card.network.total_volume_tao, 70);
+    assert.equal(card.network.net_volume_alpha, 60);
+    assert.equal(card.network.sentiment_ratio, 0.4286);
+    assert.equal(card.network.sentiment, "bullish");
+    assert.equal(card.volume_distribution.count, 1);
+    assert.equal(card.volume_distribution.median, 70);
+    assert.equal(card.subnets[0].netuid, 3);
+    assert.equal(card.subnets[0].total_volume_tao, 70);
+    assert.equal(card.subnets[0].vol_mcap_ratio, null);
+    assert.equal(card.observed_at, new Date(1_750_000_000_000).toISOString());
+  });
+
+  test("a D1 query error degrades to a schema-stable zeroed card (no throw)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          throw new Error("db unavailable");
+        },
+      },
+    };
+    const { status, body } = await gql(alphaVolumeQuery(), env);
+    assert.equal(status, 200);
+    const card = body.data.chain_alpha_volume;
+    assert.equal(card.subnet_count, 0);
+    assert.equal(card.network.total_volume_tao, 0);
+    assert.deepEqual(card.subnets, []);
+  });
+
+  test("chain_alpha_volume is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.chain_alpha_volume, 5);
+  });
+});
+
 describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", () => {
   function trendsQuery() {
     return `{ health_trends { schema_version observed_at source windows } }`;


### PR DESCRIPTION
## What

Adds `chain_alpha_volume(limit: Int): ChainAlphaVolume!` to the GraphQL `Query`
type, closing the last gap where a REST route and MCP tool exist without a
GraphQL mirror:

- REST: `GET /api/v1/chain/alpha-volume` (`handleChainAlphaVolume`)
- MCP: `get_chain_alpha_volume`

It returns the network-wide rolling 24h buy/sell alpha-volume leaderboard: every
subnet with `StakeAdded` (buy) or `StakeRemoved` (sell) volume in the last 24h,
ranked by `total_volume_tao`, each carrying its full buy/sell/total volume +
sentiment scorecard, plus a network rollup (with its own net/gross sentiment
reading) and the per-subnet total-volume distribution.

## How

- SDL: `chain_alpha_volume` field + `ChainAlphaVolume`, `ChainAlphaVolumeNetwork`,
  `ChainAlphaVolumeDistribution`, and `ChainAlphaVolumeSubnet` types mirroring the
  handler's real response shape, with the `Mirrors GET /api/v1/...` doc-comment
  convention.
- Resolver reuses `src/chain-alpha-volume.mjs`'s existing `loadChainAlphaVolume`
  loader behind the same `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)`
  fallback `handleChainAlphaVolume` uses — no duplicated D1 query logic, so REST
  and GraphQL cannot drift.
- Degrades to a schema-stable zeroed card on a cold store (`subnet_count: 0`,
  empty leaderboard, neutral sentiment), never a GraphQL error, matching every
  sibling `Query.*` resolver.
- `FIELD_COMPLEXITY` entry at the relationship fan-out weight (5), matching the
  other network-wide `chain_*` aggregates.
- Fixed 24h window (no window arg, matching the REST route); `limit` clamped to
  1–100 (default 20).

## Tests

`tests/graphql.test.mjs` — new `chain_alpha_volume` suite:

- cold store / default args → schema-stable zeroed card
- Postgres-tier hit → forwards `limit` as a query param, maps the full envelope
- over-max `limit` clamped to 100 before forwarding
- malformed Postgres-tier body → schema-stable defaults (no throw)
- no-tier D1 live rollup off the `account_events` StakeAdded/StakeRemoved stream
- D1 query error → schema-stable zeroed card (no throw)
- complexity weight assertion

100% patch coverage on the changed lines (`npx vitest run tests/graphql.test.mjs
--coverage`).

Closes #5685
