### PR TITLE
fix(registry): backfill verified_at + source_urls on root/gittensor/allways

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -9,7 +9,7 @@
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-06T00:00:00.000Z",
     "source_count": 3,
-    "verified_at": null
+    "verified_at": "2026-06-06T00:00:00.000Z"
   },
   "dashboard_url": null,
   "docs_url": "https://docs.all-ways.io/how-it-works.html",
@@ -57,6 +57,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://docs.all-ways.io/how-it-works.html"],
       "url": "https://docs.all-ways.io/how-it-works.html"
     },
     {
@@ -72,6 +73,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://all-ways.io/"],
       "url": "https://all-ways.io/"
     },
     {
@@ -87,6 +89,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://github.com/entrius/allways"],
       "url": "https://github.com/entrius/allways"
     },
     {
@@ -104,6 +107,7 @@
       "public_safe": true,
       "schema_status": "machine-readable",
       "schema_url": "https://api.all-ways.io/swagger-json",
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/swagger"
     },
     {
@@ -119,6 +123,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/health"
     },
     {
@@ -134,6 +139,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/protocol/constants"
     },
     {
@@ -149,6 +155,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/protocol/chain-state"
     },
     {
@@ -164,6 +171,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/network/overview"
     },
     {
@@ -179,6 +187,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/miners"
     },
     {
@@ -194,6 +203,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/miners/leaderboard"
     },
     {
@@ -209,6 +219,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/miners/reliability"
     },
     {
@@ -224,6 +235,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/events/latest"
     },
     {
@@ -239,6 +251,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/crown"
     },
     {
@@ -255,6 +268,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/crown/history"
     },
     {
@@ -271,6 +285,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger-json"],
       "url": "https://api.all-ways.io/sse"
     },
     {

--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -11,7 +11,7 @@
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-06T00:00:00.000Z",
     "source_count": 5,
-    "verified_at": null
+    "verified_at": "2026-06-06T00:00:00.000Z"
   },
   "dashboard_url": null,
   "docs_url": "https://docs.gittensor.io/",
@@ -63,6 +63,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://docs.gittensor.io/"],
       "url": "https://docs.gittensor.io/"
     },
     {
@@ -78,6 +79,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://gittensor.io/"],
       "url": "https://gittensor.io/"
     },
     {
@@ -93,6 +95,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://github.com/entrius/gittensor"],
       "url": "https://github.com/entrius/gittensor"
     },
     {
@@ -108,6 +111,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://docs.gittensor.io/register-repository.html"],
       "url": "https://docs.gittensor.io/register-repository.html"
     },
     {
@@ -123,6 +127,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://docs.gittensor.io/repository-hyperparameters"],
       "url": "https://docs.gittensor.io/repository-hyperparameters"
     },
     {
@@ -207,6 +212,7 @@
       },
       "provider": "gittensory",
       "public_safe": true,
+      "source_urls": ["https://gittensory.aethereal.dev/"],
       "url": "https://gittensory.aethereal.dev/"
     },
     {

--- a/registry/subnets/root.json
+++ b/registry/subnets/root.json
@@ -9,7 +9,7 @@
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-06T00:00:00.000Z",
     "source_count": 6,
-    "verified_at": null
+    "verified_at": "2026-06-06T00:00:00.000Z"
   },
   "dashboard_url": "https://taomarketcap.com/subnets/0",
   "docs_url": "https://docs.learnbittensor.org/concepts/bittensor-networks",
@@ -35,6 +35,9 @@
       },
       "provider": "opentensor",
       "public_safe": true,
+      "source_urls": [
+        "https://docs.learnbittensor.org/concepts/bittensor-networks"
+      ],
       "url": "https://docs.learnbittensor.org/concepts/bittensor-networks"
     },
     {
@@ -50,6 +53,7 @@
       },
       "provider": "opentensor",
       "public_safe": true,
+      "source_urls": ["https://docs.learnbittensor.org/subtensor-nodes"],
       "url": "https://docs.learnbittensor.org/subtensor-nodes"
     },
     {
@@ -65,6 +69,7 @@
       },
       "provider": "opentensor",
       "public_safe": true,
+      "source_urls": ["https://bittensor.com"],
       "url": "https://bittensor.com"
     },
     {
@@ -80,6 +85,7 @@
       },
       "provider": "opentensor",
       "public_safe": true,
+      "source_urls": ["https://github.com/opentensor/subtensor"],
       "url": "https://github.com/opentensor/subtensor"
     },
     {


### PR DESCRIPTION
Closes #5739

## Decision: accidental drift, not an intentional exemption

The issue asks first for a **decision** on whether these 3 files' deviation is a legitimate special case. I compared them against every other reviewed-tier file in the corpus:

| | reviewed-tier files | surfaces |
|---|---|---|
| All **other** `maintainer-reviewed`/`adapter-backed` files | **87** | **631** |
| ...with a null `curation.verified_at` | **0** | - |
| ...with a surface missing `source_urls` | - | **0** |
| `root.json` / `gittensor.json` / `allways.json` | 3 | 25 surfaces missing |

There is **not a single exception** among the other 87 files: every one pairs `reviewed_at` with a non-null `verified_at`, and all 631 surfaces carry `source_urls`.

The "self-referential entry" theory does not survive the data either. If these files were deliberately exempt, the exemption would be uniform -- but they already carry `source_urls` on **most** of their surfaces (13/17 on root, 15/21 on gittensor, 4/19 on allways). A deliberate policy would not be partial, and it would not stop halfway through the same file. `allways.json` (SN7) is also an ordinary third-party subnet, not self-referential at all, yet it drifted the same way -- consistent with the issue's own observation that all three share an identical hand-seeded `2026-06-06T00:00:00.000Z` midnight stamp.

So: **accidental drift**. Per the issue's "if accidental" branch, this PR backfills rather than documenting an exemption.

## Changes

**`verified_at`** -- paired with each file's existing `reviewed_at`, matching all 87 peers. No new claim is invented; the issue explicitly directs `verified_at` to match `reviewed_at`.

**`source_urls`** -- added to the 25 surfaces that lacked one, following the pattern established both corpus-wide and *within the same files*:

- **13 `docs` / `website` / `source-repo` surfaces** -> the surface's own url. These are first-party surfaces where the url *is* the authority (e.g. `bittensor.com` evidences the Bittensor website). This is the dominant corpus convention (46 `source-repo`, 22 `docs`, 21 `website` surfaces use exactly `[own url]`).
- **12 `allways` `openapi` / `subnet-api` / `sse` surfaces** -> `https://api.all-ways.io/swagger-json`. Citing the subnet's own OpenAPI spec is the dominant convention for `subnet-api` (68 of the corpus's sourced `subnet-api` surfaces do this), and matches how `allways.json`'s existing `data-artifact` surface is already sourced.

I did not want to assert provenance I had not checked, so I **fetched the live spec and verified all 11 allways endpoints are actually documented in it** (`/health`, `/protocol/constants`, `/protocol/chain-state`, `/network/overview`, `/miners`, `/miners/leaderboard`, `/miners/reliability`, `/events/latest`, `/crown`, `/crown/history`, `/sse`) -- 11/11 present in `Allways DAS v1.0`.

Per the issue's scope note, `curation.gap_notes` is untouched.

## Verification

```
npm run validate:surface   ->  passed: 851 surfaces across 129 subnet file(s)
```

After this change the corpus has **0** reviewed-tier files with a null `verified_at` and **0** surfaces missing `source_urls` -- the 3 outliers now match all 87 peers.

The diff is data-only and touches nothing but those two keys (30 insertions / 3 deletions across 3 files); `prettier --check` is clean. No generated artifacts are affected, matching the shape of other merged registry-data PRs (#5750, and the recent TaoMarketCap surface additions).
