### PR TITLE
feat(graphql): add Query.account_balance mirroring REST /accounts/{ss58}/balance + MCP (#5700)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -77,6 +77,7 @@ import { buildBlock, buildBlockFeed } from "./blocks.mjs";
 import { buildBlocksSummary } from "./blocks-summary.mjs";
 import { buildChainYield } from "./chain-yield.mjs";
 import { loadSubnetRecycled, isU16Netuid } from "./subnet-recycled.mjs";
+import { loadAccountBalance, isFinneySs58Address } from "./account-balance.mjs";
 import {
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
@@ -288,6 +289,8 @@ export const SDL = `
     chain_yield: ChainYield!
     "Live cumulative TAO recycled for registration on one subnet, read directly from chain via RPC (not the Postgres tier). recycled_tao is null on RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/recycled."
     subnet_recycled(netuid: Int!): SubnetRecycled
+    "Live free+reserved balance in TAO for one Finney ss58 account, read directly from chain via RPC (KV-cached, not the Postgres tier). balance_tao is null on RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/accounts/{ss58}/balance."
+    account_balance(ss58: String!): AccountBalance
   }
 
   type SubnetList {
@@ -1049,6 +1052,14 @@ export const SDL = `
     queried_at: String!
   }
 
+  "Live free+reserved balance in TAO for one Finney ss58 account, read directly from chain via RPC (KV-cached). balance_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/accounts/{ss58}/balance."
+  type AccountBalance {
+    schema_version: Int!
+    ss58: String!
+    balance_tao: Float
+    queried_at: String!
+  }
+
   "Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary."
   type BlocksSummary {
     schema_version: Int!
@@ -1657,6 +1668,7 @@ export const FIELD_COMPLEXITY = {
   // economics tier -- same cost class as the other relationship fields.
   registry_leaderboards: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_recycled: LIVE_RPC_FIELD_COMPLEXITY,
+  account_balance: LIVE_RPC_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -3775,6 +3787,20 @@ const rootValue = {
     // loadSubnetRecycled always sets schema_version/netuid/queried_at
     // unconditionally, so no `??` fallback is needed for those.
     return loadSubnetRecycled(context.env, netuid);
+  },
+
+  async account_balance({ ss58 }, context) {
+    if (!isFinneySs58Address(ss58)) {
+      throw new GraphQLError("ss58 must be a valid Finney ss58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Live chain RPC, not the Postgres tier -- reuses loadAccountBalance's own
+    // KV cache/TTL, matching REST's handleAccountBalance exactly. balance_tao
+    // stays null on RPC failure (schema-stable), never a GraphQL error.
+    // loadAccountBalance always sets schema_version/ss58/queried_at
+    // unconditionally, so no `??` fallback is needed for those.
+    return loadAccountBalance(context.env, ss58);
   },
 };
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7160,6 +7160,89 @@ describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled
   });
 });
 
+describe("graphql — account_balance (#5700, live chain RPC via account-balance.mjs)", () => {
+  const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+  // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
+  // in tests/account-balance.test.mjs.
+  function withFetchStub(stub, fn) {
+    const orig = globalThis.fetch;
+    globalThis.fetch = stub;
+    return Promise.resolve(fn()).finally(() => {
+      globalThis.fetch = orig;
+    });
+  }
+
+  test("resolves balance_tao (free + reserved) from a live RPC hit", async () => {
+    await withFetchStub(
+      async () => ({
+        ok: true,
+        json: async () => ({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { data: { free: 2_000_000_000, reserved: 500_000_000 } },
+        }),
+      }),
+      async () => {
+        const { status, body } = await gql(
+          `{ account_balance(ss58: "${SS58}") { schema_version ss58 balance_tao queried_at } }`,
+        );
+        assert.equal(status, 200);
+        assert.equal(body.errors, undefined);
+        const r = body.data.account_balance;
+        assert.equal(r.schema_version, 1);
+        assert.equal(r.ss58, SS58);
+        assert.equal(r.balance_tao, 2.5);
+        assert.ok(r.queried_at);
+      },
+    );
+  });
+
+  test("RPC failure degrades balance_tao to null, never a GraphQL error", async () => {
+    await withFetchStub(
+      async () => {
+        throw new Error("network unreachable");
+      },
+      async () => {
+        const { status, body } = await gql(
+          `{ account_balance(ss58: "${SS58}") { balance_tao } }`,
+        );
+        assert.equal(status, 200);
+        assert.equal(body.errors, undefined);
+        assert.equal(body.data.account_balance.balance_tao, null);
+      },
+    );
+  });
+
+  test("an invalid ss58 is BAD_USER_INPUT and never reaches the RPC", async () => {
+    let called = false;
+    await withFetchStub(
+      async () => {
+        called = true;
+        return { ok: true, json: async () => ({ result: { data: {} } }) };
+      },
+      async () => {
+        const { status, body } = await gql(
+          '{ account_balance(ss58: "not-an-address") { balance_tao } }',
+        );
+        assert.equal(status, 200);
+        assert.equal(body.data.account_balance, null);
+        assert.ok(
+          body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"),
+        );
+        assert.equal(called, false);
+      },
+    );
+  });
+
+  test("account_balance is weighted at the live-RPC complexity, heavier than a Postgres-tier relationship field", () => {
+    assert.equal(FIELD_COMPLEXITY.account_balance, 10);
+    assert.ok(
+      FIELD_COMPLEXITY.account_balance > FIELD_COMPLEXITY.chain_weights,
+    );
+  });
+});
+
 describe("graphql — registry_leaderboards (#5661, shared composer + REST-matching validation)", () => {
   // Every D1 query in the composer returns no rows, so the boards resolve from
   // an empty projection without a live DB. No profiles artifact is injected, so


### PR DESCRIPTION
## What

Adds `account_balance(ss58: String!): AccountBalance` to the GraphQL `Query` type, closing the gap where a REST route and MCP tool exist without a GraphQL mirror:

- REST: `GET /api/v1/accounts/{ss58}/balance` (`src/account-balance.mjs`)
- MCP: `get_account_balance` (`src/mcp-server.mjs`)

## How

- **SDL**: new `account_balance(ss58: String!)` field + `AccountBalance` type (`schema_version`, `ss58`, `balance_tao`, `queried_at`) mirroring `loadAccountBalance`'s real response shape.
- **Resolver**: reuses `src/account-balance.mjs`'s `loadAccountBalance` (live chain RPC, reusing its own KV cache/TTL — no duplicated RPC call), exactly as REST's `handleAccountBalance` does. `ss58` is validated via `isFinneySs58Address` -> `BAD_USER_INPUT` before any RPC. `balance_tao` is `null` on RPC failure (schema-stable, never a GraphQL error). Follows the RPC-backed `subnet_recycled` precedent.
- **FIELD_COMPLEXITY**: `LIVE_RPC_FIELD_COMPLEXITY` (heavier than a Postgres-tier relationship field, since it hits live chain RPC).

## Tests

`tests/graphql.test.mjs` — live RPC hit (free+reserved -> `balance_tao`), RPC-failure `null` degrade, invalid-`ss58` `BAD_USER_INPUT` (never reaches the RPC), and the complexity-weight assertion. Full suite green; 100% patch coverage on the added lines.

Closes #5700.