### PR TITLE
feat(graphql): add Query.chain_performance mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -166,6 +166,7 @@ import {
   CHAIN_TURNOVER_WINDOWS,
   DEFAULT_CHAIN_TURNOVER_WINDOW,
 } from "./chain-turnover.mjs";
+import { buildChainPerformance } from "./chain-performance.mjs";
 import {
   CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
   CHAIN_ALPHA_VOLUME_LIMIT_MAX,
@@ -289,6 +290,8 @@ export const SDL = `
     chain_weight_setters(window: String, limit: Int): ChainWeightSetters!
     "Compact all-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history (probed every ~15 minutes); a cold store still returns both windows, schema-stable and zeroed, never a GraphQL error. Mirrors GET /api/v1/health/trends."
     health_trends: HealthTrends!
+    "Network-wide reward-distribution & score-spread card across every subnet's neurons: incentive/dividends concentration (who actually captures rewards network-wide) plus the trust/consensus/validator_trust score spread. Current snapshot only (no window/params). Every metric block is null (never a GraphQL error) on a cold store. The network analog of subnet_performance. Mirrors GET /api/v1/chain/performance."
+    chain_performance: ChainPerformance!
     "Network-wide emission-yield (return rate) aggregated across every subnet's neurons -- the aggregate network return, the same split by validator vs miner role, and the distribution of the per-neuron return rate. Every aggregate is null (never a GraphQL error) on a cold store. Mirrors GET /api/v1/chain/yield."
     chain_yield: ChainYield!
     "Network-wide rolling 24h buy/sell alpha-volume leaderboard: every subnet with StakeAdded (buy) or StakeRemoved (sell) volume in the last 24h ranked by total_volume_tao, each carrying its full buy/sell/total volume + sentiment scorecard (vol_mcap_ratio always null here -- no per-subnet market-cap input at the network level), plus a network rollup with its own net/gross sentiment reading and the per-subnet total-volume spread, summed live from the account_events stream. Fixed 24h window (no window arg); limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/alpha-volume."
@@ -978,6 +981,27 @@ export const SDL = `
     p50: Float
     p75: Float
     p90: Float
+  }
+
+  "Network-wide reward-distribution & score-spread card (#5688) -- the network analog of SubnetPerformance, spanning every subnet's neurons in one snapshot. Metric blocks are null on a cold/empty store. Mirrors GET /api/v1/chain/performance."
+  type ChainPerformance {
+    schema_version: Int!
+    "Distinct subnets the snapshot spans."
+    subnet_count: Int!
+    neuron_count: Int!
+    validator_count: Int!
+    active_count: Int!
+    captured_at: String
+    "Incentive concentration across all neurons network-wide with positive incentive."
+    incentive: ConcentrationMetrics
+    "Dividends concentration across permitted validators network-wide only."
+    dividends: ConcentrationMetrics
+    "Trust score spread across all neurons network-wide."
+    trust: ScoreDistribution
+    "Consensus score spread across all neurons network-wide."
+    consensus: ScoreDistribution
+    "Validator-trust score spread across permitted validators network-wide only."
+    validator_trust: ScoreDistribution
   }
 
   "Per-subnet reward-distribution & score-spread card (#5714). Metric blocks are null on a cold/empty subnet. Mirrors GET /api/v1/subnets/{netuid}/performance."
@@ -1721,6 +1745,7 @@ export const FIELD_COMPLEXITY = {
   chain_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_performance: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_yield: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_alpha_volume: RELATIONSHIP_FIELD_COMPLEXITY,
   account_prometheus: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3834,6 +3859,34 @@ const rootValue = {
       observed_at: data.observed_at,
       source: data.source,
       boards: data.boards,
+    };
+  },
+
+  async chain_performance(_args, context) {
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildChainPerformance([])
+    // cold fallback contract handleChainPerformance / MCP get_chain_performance
+    // use: a cold/absent tier yields a schema-stable zeroed card (every metric
+    // block null), never a GraphQL error. handleChainPerformance validates
+    // against an EMPTY param allowlist, so there is no window/limit arg to
+    // mirror -- current snapshot only.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/performance"),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildChainPerformance([]);
+    return {
+      schema_version: data.schema_version ?? 1,
+      subnet_count: data.subnet_count ?? 0,
+      neuron_count: data.neuron_count ?? 0,
+      validator_count: data.validator_count ?? 0,
+      active_count: data.active_count ?? 0,
+      captured_at: data.captured_at ?? null,
+      incentive: data.incentive ?? null,
+      dividends: data.dividends ?? null,
+      trust: data.trust ?? null,
+      consensus: data.consensus ?? null,
+      validator_trust: data.validator_trust ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7137,6 +7137,106 @@ describe("Subscription.chainEvents", () => {
   });
 });
 
+describe("graphql — chain_performance (#5688, Postgres-tier + zeroed-card fallback)", () => {
+  const PERFORMANCE_QUERY = `{ chain_performance {
+    schema_version subnet_count neuron_count validator_count active_count captured_at
+    incentive { holders total gini hhi hhi_normalized nakamoto_coefficient top_1pct_share top_5pct_share top_10pct_share top_20pct_share entropy entropy_normalized }
+    dividends { holders gini nakamoto_coefficient }
+    trust { count mean min max p10 p25 p50 p75 p90 }
+    consensus { count mean }
+    validator_trust { count mean }
+  } }`;
+
+  test("cold store: schema-stable zeroed card with every metric block null", async () => {
+    const { status, body } = await gql(PERFORMANCE_QUERY);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_performance, {
+      schema_version: 1,
+      subnet_count: 0,
+      neuron_count: 0,
+      validator_count: 0,
+      active_count: 0,
+      captured_at: null,
+      incentive: null,
+      dividends: null,
+      trust: null,
+      consensus: null,
+      validator_trust: null,
+    });
+  });
+
+  test("resolves Postgres-tier data, requesting the mirrored REST path", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            subnet_count: 2,
+            neuron_count: 3,
+            validator_count: 2,
+            active_count: 3,
+            captured_at: "2026-07-10T00:00:00.000Z",
+            incentive: {
+              holders: 3,
+              total: 6,
+              gini: 0.22,
+              hhi: 0.38,
+              hhi_normalized: 0.07,
+              nakamoto_coefficient: 2,
+              top_1pct_share: 0.5,
+              top_5pct_share: 0.5,
+              top_10pct_share: 0.5,
+              top_20pct_share: 0.5,
+              entropy: 1.46,
+              entropy_normalized: 0.92,
+            },
+            dividends: { holders: 2, gini: 0.11, nakamoto_coefficient: 1 },
+            trust: {
+              count: 3,
+              mean: 0.5,
+              min: 0.2,
+              max: 0.8,
+              p10: 0.2,
+              p25: 0.3,
+              p50: 0.5,
+              p75: 0.7,
+              p90: 0.8,
+            },
+            consensus: { count: 3, mean: 0.4 },
+            validator_trust: { count: 2, mean: 0.6 },
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(PERFORMANCE_QUERY, env);
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/performance");
+    assert.equal(body.data.chain_performance.subnet_count, 2);
+    assert.equal(body.data.chain_performance.neuron_count, 3);
+    assert.equal(body.data.chain_performance.incentive.nakamoto_coefficient, 2);
+    assert.equal(body.data.chain_performance.dividends.holders, 2);
+    assert.equal(body.data.chain_performance.trust.p90, 0.8);
+    assert.equal(body.data.chain_performance.validator_trust.mean, 0.6);
+  });
+
+  test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(PERFORMANCE_QUERY, env);
+    assert.equal(status, 200);
+    assert.equal(body.data.chain_performance.schema_version, 1);
+    assert.equal(body.data.chain_performance.subnet_count, 0);
+    assert.equal(body.data.chain_performance.captured_at, null);
+    assert.equal(body.data.chain_performance.incentive, null);
+    assert.equal(body.data.chain_performance.trust, null);
+  });
+});
+
 describe("graphql — chain_yield (Postgres-tier + cold-store fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Adds `Query.chain_performance` to the GraphQL SDL, mirroring `GET /api/v1/chain/performance` (routed at `workers/api.mjs:2602` to `handleChainPerformance`) and the MCP `get_chain_performance` tool — the network analog of the recently-merged `Query.subnet_performance` (#5714), spanning every subnet's neurons in one snapshot.

**No args**, because `handleChainPerformance` validates against an *empty* param allowlist (`validateQueryParams(url, [])`) — read directly rather than assumed, so there is no window/limit to mirror. This matches the sibling no-arg `Query.chain_yield`.

The resolver reuses `src/chain-performance.mjs` and mirrors REST's fallback contract exactly: `tryPostgresTier(env, ..., "METAGRAPH_NEURONS_SOURCE") ?? buildChainPerformance([])`, so a cold/absent tier yields a schema-stable zeroed card (every metric block null) rather than a GraphQL error — the same convention every sibling `Query.*` resolver follows.

The response type reuses the existing `ConcentrationMetrics` and `ScoreDistribution` types rather than declaring near-duplicates: `buildChainPerformance` builds `incentive`/`dividends` via `computeConcentration` and `trust`/`consensus`/`validator_trust` via `scoreDistribution`, whose outputs match those two types field-for-field (`SCORE_PERCENTILES = [10, 25, 50, 75, 90]`).

Closes #5688

## Changes

- `src/graphql.mjs`: `chain_performance: ChainPerformance!` on `Query` (with the "Mirrors GET /api/v1/..." doc-comment convention), the `ChainPerformance` type mirroring `buildChainPerformance`'s real return shape (reusing `ConcentrationMetrics` + `ScoreDistribution`), a `FIELD_COMPLEXITY` entry at `RELATIONSHIP_FIELD_COMPLEXITY` (matching the `chain_yield`/`subnet_performance` siblings), and the resolver.
- `tests/graphql.test.mjs`: 3 tests — cold-store zeroed card (every metric block null), a Postgres-tier hit asserting the mirrored `/api/v1/chain/performance` path and the full concentration/distribution payload, and a malformed tier body degrading to schema-stable defaults.

## Validation

- [x] `tests/graphql.test.mjs` — **331 passed** (328 pre-existing + 3 new), on a tip rebased onto current `main` (`832a1add`)
- [x] `npm run format:check` (prettier) — clean on both files
- [x] `npm run lint` (eslint) — clean on both files
- [x] `git diff --check` — clean
- [x] Coverage: every changed line/branch is exercised — both `tryPostgresTier` arms (tier hit + cold-store `buildChainPerformance([])` fallback) and each `??` default via the malformed-body test. GraphQL SDL is not the REST OpenAPI contract, so no `openapi.json` regen (matching the merged `Query.subnet_performance` #5714 / `Query.chain_turnover` #5803 diff shape).

## Safety

- [x] No secrets, PATs, wallet paths, or private URLs.
- [x] Purely additive (+153/−0, 2 files); no existing resolver, type, or REST/MCP behavior changed.
- [x] Health/uptime/latency untouched (probe-derived only).
- [x] No visual/UI output — no screenshot table required.
