### PR TITLE
feat(graphql): add Query.subnet_stake_transfers mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -40,6 +40,11 @@ import {
   DEFAULT_SUBNET_STAKE_MOVES_WINDOW,
 } from "./subnet-stake-moves.mjs";
 import {
+  buildSubnetStakeTransfers,
+  SUBNET_STAKE_TRANSFERS_WINDOWS,
+  DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW,
+} from "./subnet-stake-transfers.mjs";
+import {
   buildSubnetWeightSetters,
   SUBNET_WEIGHT_SETTERS_WINDOWS,
   DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
@@ -212,6 +217,8 @@ export const SDL = `
     subnet_weights(netuid: Int!, window: String): SubnetWeights!
     "Per-subnet stake-movement (re-delegation) activity over a 7d/30d window (distinct movers, StakeMoved count, and movements per mover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/stake-moves."
     subnet_stake_moves(netuid: Int!, window: String): SubnetStakeMoves!
+    "Per-subnet stake-transfer activity over a 7d/30d window (distinct senders, StakeTransferred count, and transfers per sender); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/stake-transfers."
+    subnet_stake_transfers(netuid: Int!, window: String): SubnetStakeTransfers!
     "Per-subnet weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators behind /weights ranked by WeightsSet activity, each with count, share, and first/last set times; a subnet with no events resolves to a schema-stable empty leaderboard, never null. Mirrors GET /api/v1/subnets/{netuid}/weights/setters."
     subnet_weight_setters(netuid: Int!, window: String): SubnetWeightSetters!
     "Per-subnet emission-per-stake yield over the current metagraph snapshot: each UID's yield plus the subnet-wide aggregate and p25/median/p75/p90 distribution; a subnet with no neurons resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/yield."
@@ -916,6 +923,18 @@ export const SDL = `
     distinct_movers: Int!
     movements: Int!
     movements_per_mover: Float
+  }
+
+  "Per-subnet stake-transfer activity over a window (#5717). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/stake-transfers."
+  type SubnetStakeTransfers {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    distinct_senders: Int!
+    transfers: Int!
+    "Transfers per distinct sender; null when the subnet had no senders in the window."
+    transfers_per_sender: Float
   }
 
   "Per-subnet weight-setter leaderboard (#5712). Empty setters on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/weights/setters."
@@ -1732,6 +1751,7 @@ export const FIELD_COMPLEXITY = {
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_stake_transfers: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_yield: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_performance: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2598,6 +2618,43 @@ const rootValue = {
       distinct_movers: data.distinct_movers ?? 0,
       movements: data.movements ?? 0,
       movements_per_mover: data.movements_per_mover ?? null,
+    };
+  },
+
+  async subnet_stake_transfers({ netuid, window }, context) {
+    // Same 7d/30d window validation handleSubnetStakeTransfers uses -- an
+    // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW;
+    if (!Object.hasOwn(SUBNET_STAKE_TRANSFERS_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, SUBNET_STAKE_TRANSFERS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> buildSubnetStakeTransfers
+    // zeroed-card fallback contract handleSubnetStakeTransfers uses; a subnet with no
+    // StakeTransferred events in the window is a schema-stable zeroed card, never a
+    // GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/stake-transfers`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildSubnetStakeTransfers(null, netuid, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      observed_at: data.observed_at ?? null,
+      distinct_senders: data.distinct_senders ?? 0,
+      transfers: data.transfers ?? 0,
+      transfers_per_sender: data.transfers_per_sender ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -4662,6 +4662,94 @@ describe("graphql — subnet_stake_moves (#5716, Postgres-tier + zeroed-card fal
   });
 });
 
+describe("graphql — subnet_stake_transfers (#5717, Postgres-tier + zeroed-card fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_stake_transfers(netuid: 5) {
+          schema_version netuid window observed_at
+          distinct_senders transfers transfers_per_sender
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_stake_transfers, {
+      schema_version: 1,
+      netuid: 5,
+      window: "7d",
+      observed_at: null,
+      distinct_senders: 0,
+      transfers: 0,
+      transfers_per_sender: null,
+    });
+  });
+
+  test("resolves the Postgres-tier card for the requested window", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          window: "30d",
+          observed_at: "2026-07-01T00:00:00.000Z",
+          distinct_senders: 4,
+          transfers: 10,
+          transfers_per_sender: 2.5,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_stake_transfers(netuid: 5, window: "30d") {
+          netuid window observed_at distinct_senders transfers transfers_per_sender
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const r = body.data.subnet_stake_transfers;
+    assert.equal(r.window, "30d");
+    assert.equal(r.observed_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(r.distinct_senders, 4);
+    assert.equal(r.transfers, 10);
+    assert.equal(r.transfers_per_sender, 2.5);
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_stake_transfers(netuid: 9, window: "30d") {
+          schema_version netuid window observed_at distinct_senders transfers transfers_per_sender
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_stake_transfers, {
+      schema_version: 1,
+      netuid: 9,
+      window: "30d",
+      observed_at: null,
+      distinct_senders: 0,
+      transfers: 0,
+      transfers_per_sender: null,
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ subnet_stake_transfers(netuid: 5, window: "99d") { transfers } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_stake_transfers ?? null, null);
+  });
+});
+
 describe("graphql — subnet_deregistrations (#5719, Postgres-tier + zeroed-card fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Closes #5717.

Adds `Query.subnet_stake_transfers(netuid: Int!, window: String): SubnetStakeTransfers!` to the GraphQL SDL in `src/graphql.mjs`, mirroring `GET /api/v1/subnets/{netuid}/stake-transfers` (backed by `src/subnet-stake-transfers.mjs`) and the MCP `get_subnet_stake_transfers` tool (`src/mcp-server.mjs`) — the same gap-closure category as the just-merged `Query.subnet_stake_moves` (#5716/#5812, this field's exact sibling), `Query.chain_turnover` (#5803), and `Query.chain_alpha_volume` (#5817).

Args match what `src/subnet-stake-transfers.mjs` actually accepts (read directly, not assumed): `window` (`7d`/`30d`, default **7d** — `SUBNET_STAKE_TRANSFERS_WINDOWS`/`DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW`). An unsupported window is a GraphQL `BAD_USER_INPUT` error, matching the sibling resolvers' validation convention.

The resolver reuses `src/subnet-stake-transfers.mjs`'s existing pure-shaping function rather than duplicating any `account_events` query logic: the same `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` → `buildSubnetStakeTransfers(null, netuid, { window })` zeroed-card fallback contract `handleSubnetStakeTransfers` and the MCP tool use. A subnet with no `StakeTransferred` events in the window resolves to the schema-stable zeroed card (`distinct_senders: 0`, `transfers: 0`, `transfers_per_sender: null`) — never null and never a GraphQL error, matching this schema's established zero-result convention.

Also adds:
- `type SubnetStakeTransfers` mirroring `buildSubnetStakeTransfers`'s real response shape (`schema_version`, `netuid`, `window`, `observed_at`, `distinct_senders`, `transfers`, `transfers_per_sender`), placed directly after its sibling `SubnetStakeMoves`.
- A `FIELD_COMPLEXITY` entry (`RELATIONSHIP_FIELD_COMPLEXITY`, same weight as the sibling per-subnet activity cards).
- An SDL doc-comment following the existing "Mirrors GET /api/v1/..." convention.

Anchored on two analogues traced end-to-end: the just-merged `subnet_stake_moves` (#5812 — the exact sibling; import → SDL field → type → `FIELD_COMPLEXITY` → resolver → tests all placed adjacently and shaped identically) and `subnet_registrations` (#5720 — the per-netuid windowed `account_events` card family this joins).

## Template Used

- Backend/code change (`backend-code.md`)

## Validation

- `git diff --check` — clean
- `npm run lint` — clean
- `npm run format:check` — all files use Prettier style
- `npm run validate` — 129 native subnets, 1615 surfaces, 133 providers validated (run against a fresh `npm run build`; the diff touches only `src/graphql.mjs` + `tests/graphql.test.mjs`, the same 2-file shape as the merged #5812/#5803 siblings — no generated artifacts, no lockfile churn)
- `npx vitest run tests/graphql.test.mjs` — **332 tests pass** (328 existing + 4 new), covering: the cold-store zeroed card (no Postgres flag), the Postgres-tier card for a requested window, a partial Postgres-tier body degrading to the resolver defaults (every `??` fallback arm), and the unsupported-window GraphQL error — both sides of every new branch are exercised for the 99% branch-counted `codecov/patch` gate.

No `schemas/` change → no OpenAPI/contract regeneration required (the GraphQL SDL is code, not the JSON Schema contract — same as #5812/#5803). No client SDK version bump (auto-sync workflow owns it).
