### PR TITLE
feat(graphql): add Query.subnet_hyperparameters + _history mirroring REST

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -9,6 +9,8 @@ import {
 import { readArtifact, readHealthKv } from "../workers/storage.mjs";
 import { contractVersion } from "../workers/responses.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
+import { buildSubnetHyperparams } from "./subnet-hyperparams.mjs";
+import { buildSubnetHyperparamsHistory } from "./subnet-hyperparams-history.mjs";
 import {
   buildSubnetRegistrations,
   SUBNET_REGISTRATIONS_WINDOWS,
@@ -202,6 +204,10 @@ export const SDL = `
     subnet(netuid: Int!): Subnet
     "Per-subnet neuron-registration activity over a 7d/30d window (distinct registrants, NeuronRegistered count, and registrations per registrant); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/registrations."
     subnet_registrations(netuid: Int!, window: String): SubnetRegistrations!
+    "One subnet's live on-chain hyperparameters (latest snapshot only). The hyperparameters block is null when the subnet has no captured row -- a schema-stable card, never a GraphQL error, matching the Query.block ref-lookup convention. Mirrors GET /api/v1/subnets/{netuid}/hyperparameters."
+    subnet_hyperparameters(netuid: Int!): SubnetHyperparameters
+    "One subnet's append-only hyperparameter-change history, newest first, one entry per observed change. Forward-only: entries exist only from when the diff-on-change write started. A subnet with no recorded changes resolves to an empty entry list, never null. Mirrors GET /api/v1/subnets/{netuid}/hyperparameters/history."
+    subnet_hyperparameters_history(netuid: Int!, limit: Int, offset: Int): SubnetHyperparamsHistory!
     "Per-subnet neuron-deregistration activity over a 7d/30d window (distinct deregistered hotkeys, NeuronDeregistered count, and deregistrations per hotkey); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/deregistrations."
     subnet_deregistrations(netuid: Int!, window: String): SubnetDeregistrations!
     "Per-subnet axon-serving activity over a 7d/30d window (distinct servers, AxonServed announcement count, and announcements per server); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/serving."
@@ -857,6 +863,69 @@ export const SDL = `
   }
 
   "Per-subnet neuron-registration activity over a window (#5720). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/registrations."
+  type SubnetHyperparameters {
+    schema_version: Int!
+    netuid: Int!
+    captured_at: String
+    block_number: Int
+    hyperparameters: Hyperparameters
+  }
+
+  "One subnet's on-chain hyperparameter block. Every field is nullable: a value absent from the captured row stays null rather than being coerced. *_ratio fields are 0..1 U16-derived ratios; *_tao fields are rao-exact (9dp); bonds_moving_avg_raw is the unscaled on-chain integer."
+  type Hyperparameters {
+    kappa_ratio: Float
+    immunity_period: Int
+    min_allowed_weights: Int
+    max_weight_limit_ratio: Float
+    tempo: Int
+    weights_version: Int
+    weights_rate_limit: Int
+    activity_cutoff: Int
+    activity_cutoff_factor: Int
+    registration_allowed: Boolean
+    target_regs_per_interval: Int
+    min_burn_tao: Float
+    max_burn_tao: Float
+    burn_half_life: Int
+    burn_increase_mult: Float
+    bonds_moving_avg_raw: Int
+    max_regs_per_block: Int
+    serving_rate_limit: Int
+    max_validators: Int
+    commit_reveal_period: Int
+    commit_reveal_enabled: Boolean
+    alpha_high_ratio: Float
+    alpha_low_ratio: Float
+    liquid_alpha_enabled: Boolean
+    alpha_sigmoid_steepness: Float
+    yuma_version: Int
+    subnet_is_active: Boolean
+    transfers_enabled: Boolean
+    bonds_reset_enabled: Boolean
+    user_liquidity_enabled: Boolean
+    owner_cut_enabled: Boolean
+    owner_cut_auto_lock_enabled: Boolean
+    min_childkey_take_ratio: Float
+  }
+
+  type SubnetHyperparamsHistory {
+    schema_version: Int!
+    netuid: Int!
+    entry_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    entries: [HyperparamsHistoryEntry!]!
+  }
+
+  "One observed hyperparameter change: the full block as of that block_number, plus the hash the diff-on-change writer keyed it by."
+  type HyperparamsHistoryEntry {
+    block_number: Int
+    observed_at: String
+    hyperparameters: Hyperparameters
+    hyperparams_hash: String
+  }
+
   type SubnetRegistrations {
     schema_version: Int!
     netuid: Int!
@@ -1726,6 +1795,11 @@ export const FIELD_COMPLEXITY = {
   account_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
   account_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
+  // A single latest-only row -- but it fans out into the full hyperparameter
+  // block, so it is priced with the other per-subnet relationship fields.
+  subnet_hyperparameters: RELATIONSHIP_FIELD_COMPLEXITY,
+  // Paginated fan-out: one hyperparameter block per recorded change.
+  subnet_hyperparameters_history: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_serving: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2263,6 +2337,66 @@ const rootValue = {
       surfaces: data.surfaces,
       endpoints: data.endpoints,
     });
+  },
+
+  async subnet_hyperparameters({ netuid }, context) {
+    // Same tryPostgresTier(METAGRAPH_SUBNET_HYPERPARAMS_SOURCE) -> buildSubnetHyperparams
+    // fallback contract handleSubnetHyperparams uses. The D1 write path is retired, so a
+    // cold tier is an expected steady state, not an error: it yields a schema-stable card
+    // with hyperparameters:null rather than a GraphQL error or a 404.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/hyperparameters`,
+        ),
+        "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
+      )) ?? buildSubnetHyperparams(null, netuid);
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      captured_at: data.captured_at ?? null,
+      block_number: data.block_number ?? null,
+      // The hyperparameter block is passed through whole -- graphql's default
+      // field resolver reads it, so an absent key surfaces as null without a
+      // per-field fallback here.
+      hyperparameters: data.hyperparameters ?? null,
+    };
+  },
+
+  async subnet_hyperparameters_history({ netuid, limit, offset }, context) {
+    // Same FEED_PAGINATION bounds parsePagination applies for REST, so a GraphQL
+    // caller cannot request a wider page than the route allows.
+    const safeLimit = clampLimit(limit, FEED_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/hyperparameters/history`,
+          params,
+        ),
+        "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
+      )) ??
+      buildSubnetHyperparamsHistory([], netuid, {
+        limit: safeLimit,
+        offset: safeOffset,
+        nextCursor: null,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      entry_count: data.entry_count ?? 0,
+      limit: data.limit ?? safeLimit,
+      offset: data.offset ?? safeOffset,
+      next_cursor: data.next_cursor ?? null,
+      entries: data.entries ?? [],
+    };
   },
 
   async subnet_registrations({ netuid, window }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7610,3 +7610,210 @@ describe("graphql — registry_leaderboards (#5661, shared composer + REST-match
     );
   });
 });
+
+describe("Query.subnet_hyperparameters / subnet_hyperparameters_history", () => {
+  const HP_FIELDS =
+    "kappa_ratio immunity_period tempo registration_allowed min_burn_tao bonds_moving_avg_raw liquid_alpha_enabled min_childkey_take_ratio";
+  const HP_ROW = {
+    kappa_ratio: 0.5,
+    immunity_period: 4096,
+    tempo: 360,
+    registration_allowed: true,
+    min_burn_tao: 0.5,
+    bonds_moving_avg_raw: 900000,
+    liquid_alpha_enabled: false,
+    min_childkey_take_ratio: 0.1,
+  };
+
+  function hpEnv(body) {
+    return {
+      METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json(body) },
+    };
+  }
+
+  test("subnet_hyperparameters resolves the Postgres-tier card", async () => {
+    const { status, body } = await gql(
+      `{ subnet_hyperparameters(netuid: 1) { schema_version netuid captured_at block_number hyperparameters { ${HP_FIELDS} } } }`,
+      hpEnv({
+        schema_version: 1,
+        netuid: 1,
+        captured_at: "2026-07-01T00:00:00.000Z",
+        block_number: 5000000,
+        hyperparameters: HP_ROW,
+      }),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_hyperparameters, {
+      schema_version: 1,
+      netuid: 1,
+      captured_at: "2026-07-01T00:00:00.000Z",
+      block_number: 5000000,
+      hyperparameters: HP_ROW,
+    });
+  });
+
+  test("subnet_hyperparameters: a subnet with no captured row resolves to a card with a null block, never an error", async () => {
+    const { status, body } = await gql(
+      `{ subnet_hyperparameters(netuid: 99) { schema_version netuid captured_at block_number hyperparameters { tempo } } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_hyperparameters, {
+      schema_version: 1,
+      netuid: 99,
+      captured_at: null,
+      block_number: null,
+      hyperparameters: null,
+    });
+  });
+
+  test("subnet_hyperparameters: a sparse upstream payload still resolves a schema-stable card", async () => {
+    const { status, body } = await gql(
+      `{ subnet_hyperparameters(netuid: 7) { schema_version netuid captured_at block_number hyperparameters { tempo } } }`,
+      hpEnv({}),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_hyperparameters, {
+      schema_version: 1,
+      netuid: 7,
+      captured_at: null,
+      block_number: null,
+      hyperparameters: null,
+    });
+  });
+
+  test("subnet_hyperparameters requests the subnet's own hyperparameters route", async () => {
+    let seen = null;
+    await gql(`{ subnet_hyperparameters(netuid: 12) { netuid } }`, {
+      METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          seen = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    });
+    assert.equal(seen.pathname, "/api/v1/subnets/12/hyperparameters");
+  });
+
+  test("subnet_hyperparameters_history resolves the Postgres-tier page", async () => {
+    const { status, body } = await gql(
+      `{ subnet_hyperparameters_history(netuid: 1) { schema_version netuid entry_count limit offset next_cursor entries { block_number observed_at hyperparams_hash hyperparameters { tempo } } } }`,
+      hpEnv({
+        schema_version: 1,
+        netuid: 1,
+        entry_count: 1,
+        limit: 100,
+        offset: 0,
+        next_cursor: "abc",
+        entries: [
+          {
+            block_number: 5000000,
+            observed_at: "2026-07-01T00:00:00.000Z",
+            hyperparams_hash: "deadbeef",
+            hyperparameters: { tempo: 360 },
+          },
+        ],
+      }),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_hyperparameters_history, {
+      schema_version: 1,
+      netuid: 1,
+      entry_count: 1,
+      limit: 100,
+      offset: 0,
+      next_cursor: "abc",
+      entries: [
+        {
+          block_number: 5000000,
+          observed_at: "2026-07-01T00:00:00.000Z",
+          hyperparams_hash: "deadbeef",
+          hyperparameters: { tempo: 360 },
+        },
+      ],
+    });
+  });
+
+  test("subnet_hyperparameters_history: no recorded changes resolves to an empty list, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_hyperparameters_history(netuid: 99) { schema_version netuid entry_count limit offset next_cursor entries { block_number } } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_hyperparameters_history, {
+      schema_version: 1,
+      netuid: 99,
+      entry_count: 0,
+      limit: 100,
+      offset: 0,
+      next_cursor: null,
+      entries: [],
+    });
+  });
+
+  test("subnet_hyperparameters_history: a sparse upstream payload falls back to the requested page bounds", async () => {
+    const { status, body } = await gql(
+      `{ subnet_hyperparameters_history(netuid: 3, limit: 5, offset: 10) { schema_version netuid entry_count limit offset next_cursor entries { block_number } } }`,
+      hpEnv({}),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_hyperparameters_history, {
+      schema_version: 1,
+      netuid: 3,
+      entry_count: 0,
+      limit: 5,
+      offset: 10,
+      next_cursor: null,
+      entries: [],
+    });
+  });
+
+  test("subnet_hyperparameters_history forwards limit/offset, clamped to the REST feed bounds", async () => {
+    let seen = null;
+    const env = {
+      METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          seen = new URL(req.url);
+          return Response.json({ entries: [] });
+        },
+      },
+    };
+    await gql(
+      `{ subnet_hyperparameters_history(netuid: 2, limit: 5, offset: 10) { netuid } }`,
+      env,
+    );
+    assert.equal(seen.pathname, "/api/v1/subnets/2/hyperparameters/history");
+    assert.equal(seen.searchParams.get("limit"), "5");
+    assert.equal(seen.searchParams.get("offset"), "10");
+
+    // Over-wide pages are clamped to MAX_LIMIT rather than forwarded verbatim.
+    await gql(
+      `{ subnet_hyperparameters_history(netuid: 2, limit: 99999) { netuid } }`,
+      env,
+    );
+    assert.equal(seen.searchParams.get("limit"), "1000");
+
+    // An absent limit/offset falls back to the feed defaults.
+    await gql(`{ subnet_hyperparameters_history(netuid: 2) { netuid } }`, env);
+    assert.equal(seen.searchParams.get("limit"), "100");
+    assert.equal(seen.searchParams.get("offset"), "0");
+  });
+
+  test("both fields are priced at the relationship-field complexity weight", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.subnet_hyperparameters,
+      FIELD_COMPLEXITY.subnet_registrations,
+    );
+    assert.equal(
+      FIELD_COMPLEXITY.subnet_hyperparameters_history,
+      FIELD_COMPLEXITY.subnet_registrations,
+    );
+  });
+});


### PR DESCRIPTION
Closes #5690

## What

Adds the `Query.subnet_hyperparameters` / `Query.subnet_hyperparameters_history` pair, mirroring `GET /api/v1/subnets/{netuid}/hyperparameters(/history)` and the matching MCP tools (`get_subnet_hyperparams`, `get_subnet_hyperparams_history`).

## How

**No query logic is duplicated.** Both resolvers reuse the existing loaders (`buildSubnetHyperparams`, `buildSubnetHyperparamsHistory`) through the same `tryPostgresTier(METAGRAPH_SUBNET_HYPERPARAMS_SOURCE)` path the REST handlers take, so the GraphQL and REST shapes cannot drift apart. Since `subnet_hyperparams`' D1 write path is retired, a cold tier is an expected steady state, not an error — the builders reproduce the same schema-stable empty shape a cold store returned.

**Zero-result contracts, per the issue:**

- `subnet_hyperparameters` resolves to a schema-stable card whose `hyperparameters` block is `null` for a subnet with no captured row — the established `Query.block` ref-lookup convention (the card is always returned; the inner entity nulls), never a GraphQL error and never a 404.
- `subnet_hyperparameters_history` resolves to an empty `entries` list on no recorded history, never null.

**Pagination:** `limit`/`offset` are clamped with `clampLimit(limit, FEED_PAGINATION)` / `clampOffset(offset)` — the same bounds `parsePagination` applies for REST — so a GraphQL caller cannot request a wider page than the route allows (`limit: 99999` forwards as `1000`).

**Types:** `Hyperparameters` mirrors `formatSubnetHyperparams`'s real output field-for-field, in source order, with each SDL type taken from the actual coercion helper (`ratio`/`round` -> `Float`, `nonNegativeInt` -> `Int`, `toD1Flag` -> `Boolean`). Every field is nullable, so a value absent from a captured row stays null rather than erroring through a non-null field. The block is passed through whole and read by graphql's default field resolver rather than re-mapped per field.

`FIELD_COMPLEXITY` entries for both fields at `RELATIONSHIP_FIELD_COMPLEXITY`, matching `subnet_registrations`.

## Tests

9 new cases in `tests/graphql.test.mjs`: a Postgres-tier hit and a not-found/empty case for **each** field (the two branches the issue calls out), a sparse-upstream case for each, the `limit`/`offset` pagination path including clamping and defaults, route-shape assertions, and the complexity weights.

```
tests/graphql.test.mjs                       passed
tests/subnet-hyperparams.test.mjs            passed   (loader unregressed)
tests/subnet-hyperparams-history.test.mjs    passed
tests/request-handlers-entities.test.mjs     passed   (REST unregressed)
```

Patch coverage measured locally the way codecov measures it — every added line mapped against `coverage-final.json`'s `statementMap`/`branchMap`: **37/37 covered statements and branch arms = 100%** (target 99%), no partials. `eslint` clean, `prettier --check` clean.
