### PR TITLE
feat(graphql): add Query.validator_nominators mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -168,6 +168,13 @@ import {
 } from "./chain-turnover.mjs";
 import { buildChainPerformance } from "./chain-performance.mjs";
 import {
+  DEFAULT_NOMINATOR_SORT,
+  DEFAULT_NOMINATOR_WINDOW,
+  loadValidatorNominators,
+  NOMINATOR_SORTS,
+  NOMINATOR_WINDOWS,
+} from "./validator-nominators.mjs";
+import {
   CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
   CHAIN_ALPHA_VOLUME_LIMIT_MAX,
   loadChainAlphaVolume,
@@ -252,6 +259,8 @@ export const SDL = `
     validators(sort: String, limit: Int): ValidatorList!
     "One validator's cross-subnet aggregate by hotkey; a hotkey with no validator_permit=1 rows resolves to a schema-stable zeroed aggregate, never null. Mirrors GET /api/v1/validators/{hotkey}."
     validator(hotkey: String!): Validator
+    "One validator's nominator leaderboard over a 7d/30d/90d window (default 30d): every coldkey that staked to or unstaked from this hotkey in the window, with its staked/unstaked/net/gross TAO, event count, and last-activity time, ranked by sort (net_staked | gross_staked | last_activity, default net_staked). An unsupported window/sort is a GraphQL error, not a silently substituted default; a hotkey with no nominators resolves to a schema-stable empty list, never null and never a GraphQL error. Mirrors GET /api/v1/validators/{hotkey}/nominators."
+    validator_nominators(hotkey: String!, window: String, sort: String): NominatorList!
     "One validator's cross-subnet staked-over-time history: one point per day (window: 7d/30d/90d/1y/all, default 30d), summed across every subnet it validates in, plus a rewards-per-1000-TAO rate. A hotkey with no matching neuron_daily rows resolves to a schema-stable empty-points card, never null. Mirrors GET /api/v1/validators/{hotkey}/history."
     validator_history(hotkey: String!, window: String): ValidatorHistory!
     "Site-wide accounts leaderboard -- every currently-registered hotkey, aggregated cross-subnet from the current neurons snapshot. Mirrors GET /api/v1/accounts."
@@ -981,6 +990,35 @@ export const SDL = `
     p50: Float
     p75: Float
     p90: Float
+  }
+
+  "One validator's nominator leaderboard (#5692). Mirrors GET /api/v1/validators/{hotkey}/nominators' data envelope."
+  type NominatorList {
+    schema_version: Int!
+    hotkey: String!
+    "The resolved window label; null only if the builder was handed no window."
+    window: String
+    "The resolved sort actually applied (an omitted sort resolves to net_staked)."
+    sort: String!
+    limit: Int!
+    offset: Int!
+    "Total distinct nominating coldkeys in the window, before limit/offset paging."
+    nominator_count: Int!
+    nominators: [Nominator!]!
+  }
+
+  "One nominating coldkey's staking activity toward a validator within the window."
+  type Nominator {
+    coldkey: String!
+    staked_tao: Float!
+    unstaked_tao: Float!
+    "staked_tao - unstaked_tao."
+    net_staked_tao: Float!
+    "staked_tao + unstaked_tao (total churn, regardless of direction)."
+    gross_staked_tao: Float!
+    event_count: Int!
+    "Most recent StakeAdded/StakeRemoved time for this coldkey; null when unstamped."
+    last_observed_at: String
   }
 
   "Network-wide reward-distribution & score-spread card (#5688) -- the network analog of SubnetPerformance, spanning every subnet's neurons in one snapshot. Metric blocks are null on a cold/empty store. Mirrors GET /api/v1/chain/performance."
@@ -1745,6 +1783,7 @@ export const FIELD_COMPLEXITY = {
   chain_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
+  validator_nominators: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_performance: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_yield: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_alpha_volume: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2965,6 +3004,59 @@ const rootValue = {
       sort: data.sort ?? requestedSort,
       captured_at: data.captured_at ?? null,
       block_number: data.block_number ?? null,
+    };
+  },
+
+  async validator_nominators({ hotkey, window, sort }, context) {
+    // Same window/sort allow-lists handleValidatorNominators validates against --
+    // an unsupported value is a GraphQL BAD_USER_INPUT error, not a silently
+    // substituted default. `sort` is optional: omitted resolves to
+    // DEFAULT_NOMINATOR_SORT inside the builder, so only a SUPPLIED bad value errors.
+    const requestedWindow = window ?? DEFAULT_NOMINATOR_WINDOW;
+    if (!Object.hasOwn(NOMINATOR_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(requestedWindow, NOMINATOR_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    if (sort != null && !NOMINATOR_SORTS.includes(sort)) {
+      throw new GraphQLError(
+        `"${sort}" is not a supported sort. Supported: ${NOMINATOR_SORTS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    if (sort != null) params.set("sort", sort);
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> loadValidatorNominators
+    // fallback contract REST uses. Both sides return the SAME { data, generatedAt }
+    // envelope, so the destructure covers either tier; `generatedAt` is REST
+    // envelope meta with no GraphQL field to carry it. A hotkey with no nominators
+    // yields a schema-stable empty list, never a GraphQL error. limit/offset are
+    // deliberately not GraphQL args, so the module's own defaults apply.
+    const { data } =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/validators/${encodeURIComponent(hotkey)}/nominators`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      (await loadValidatorNominators(graphqlD1(context), hotkey, {
+        windowLabel: requestedWindow,
+        sort: sort ?? undefined,
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      hotkey: data.hotkey ?? hotkey,
+      window: data.window ?? requestedWindow,
+      sort: data.sort ?? sort ?? DEFAULT_NOMINATOR_SORT,
+      limit: data.limit ?? 0,
+      offset: data.offset ?? 0,
+      nominator_count: data.nominator_count ?? 0,
+      nominators: data.nominators || [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7137,6 +7137,179 @@ describe("Subscription.chainEvents", () => {
   });
 });
 
+describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallback)", () => {
+  const HOTKEY = "5FTestValidatorHotkeyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+  function nominatorsQuery(argsClause) {
+    return `{ validator_nominators${argsClause} {
+      schema_version hotkey window sort limit offset nominator_count
+      nominators { coldkey staked_tao unstaked_tao net_staked_tao gross_staked_tao event_count last_observed_at }
+    } }`;
+  }
+
+  // loadValidatorNominators issues TWO queries: a COUNT(DISTINCT coldkey) total
+  // (paging-independent) and the per-coldkey GROUP BY rows -- same two-query shape
+  // the chainWeightsD1 fixture above models, so branch on the SQL.
+  function nominatorsD1(rows = [], nominatorCount = rows.length) {
+    return {
+      prepare(sql) {
+        return {
+          bind: () => ({
+            all: async () =>
+              sql.includes("COUNT(DISTINCT coldkey)")
+                ? { results: [{ nominator_count: nominatorCount }] }
+                : { results: rows },
+          }),
+        };
+      },
+    };
+  }
+
+  test("cold store, default args: schema-stable empty list (never a GraphQL error)", async () => {
+    const { status, body } = await gql(
+      nominatorsQuery(`(hotkey: "${HOTKEY}")`),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.validator_nominators.hotkey, HOTKEY);
+    assert.equal(body.data.validator_nominators.window, "30d");
+    assert.equal(body.data.validator_nominators.sort, "net_staked");
+    assert.equal(body.data.validator_nominators.nominator_count, 0);
+    assert.deepEqual(body.data.validator_nominators.nominators, []);
+  });
+
+  test("resolves Postgres-tier data for a valid non-default window/sort, forwarding both as query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            data: {
+              schema_version: 1,
+              hotkey: HOTKEY,
+              window: "7d",
+              sort: "gross_staked",
+              limit: 20,
+              offset: 0,
+              nominator_count: 1,
+              nominators: [
+                {
+                  coldkey: "5FNominatorColdkeyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+                  staked_tao: 12.5,
+                  unstaked_tao: 2.5,
+                  net_staked_tao: 10,
+                  gross_staked_tao: 15,
+                  event_count: 3,
+                  last_observed_at: "2026-07-10T00:00:00.000Z",
+                },
+              ],
+            },
+            generatedAt: "2026-07-10T00:00:00.000Z",
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      nominatorsQuery(
+        `(hotkey: "${HOTKEY}", window: "7d", sort: "gross_staked")`,
+      ),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(
+      capturedUrl.pathname,
+      `/api/v1/validators/${HOTKEY}/nominators`,
+    );
+    assert.equal(capturedUrl.searchParams.get("window"), "7d");
+    assert.equal(capturedUrl.searchParams.get("sort"), "gross_staked");
+    assert.equal(body.data.validator_nominators.window, "7d");
+    assert.equal(body.data.validator_nominators.sort, "gross_staked");
+    assert.equal(body.data.validator_nominators.nominator_count, 1);
+    assert.equal(
+      body.data.validator_nominators.nominators[0].net_staked_tao,
+      10,
+    );
+    assert.equal(body.data.validator_nominators.nominators[0].event_count, 3);
+  });
+
+  test("no Postgres tier flag: buckets the account_events stake stream straight off D1", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: nominatorsD1([
+        {
+          coldkey: "5FNominatorColdkeyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          staked_tao: 12.5,
+          unstaked_tao: 2.5,
+          event_count: 3,
+          last_observed: 1_750_000_000_000,
+        },
+      ]),
+    };
+    const { status, body } = await gql(
+      nominatorsQuery(`(hotkey: "${HOTKEY}")`),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.validator_nominators.nominator_count, 1);
+    const first = body.data.validator_nominators.nominators[0];
+    assert.equal(
+      first.coldkey,
+      "5FNominatorColdkeyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    );
+    assert.equal(first.net_staked_tao, 10);
+    assert.equal(first.gross_staked_tao, 15);
+    assert.ok(first.last_observed_at);
+  });
+
+  test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
+    // The tier answers with the right { data, generatedAt } envelope but an empty
+    // data object -- every field falls through to its own default rather than
+    // surfacing undefined or throwing.
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => Response.json({ data: {}, generatedAt: null }),
+      },
+    };
+    const { status, body } = await gql(
+      nominatorsQuery(`(hotkey: "${HOTKEY}")`),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.validator_nominators, {
+      schema_version: 1,
+      hotkey: HOTKEY,
+      window: "30d",
+      sort: "net_staked",
+      limit: 0,
+      offset: 0,
+      nominator_count: 0,
+      nominators: [],
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silently substituted default", async () => {
+    const { status, body } = await gql(
+      nominatorsQuery(`(hotkey: "${HOTKEY}", window: "99d")`),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.match(body.errors[0].message, /99d/);
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("an unsupported sort is a GraphQL error listing the supported values", async () => {
+    const { status, body } = await gql(
+      nominatorsQuery(`(hotkey: "${HOTKEY}", sort: "bogus")`),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.match(body.errors[0].message, /not a supported sort/);
+    assert.match(body.errors[0].message, /net_staked/);
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+});
+
 describe("graphql — chain_performance (#5688, Postgres-tier + zeroed-card fallback)", () => {
   const PERFORMANCE_QUERY = `{ chain_performance {
     schema_version subnet_count neuron_count validator_count active_count captured_at


### PR DESCRIPTION
## Summary

Adds `Query.validator_nominators` to the GraphQL SDL, mirroring `GET /api/v1/validators/{hotkey}/nominators` (`workers/request-handlers/entities.mjs:979`, `handleValidatorNominators`) and the MCP `get_validator_nominators` tool — the same gap-closure category as the merged `Query.validator`/`Query.validators` pairing.

Args and allow-lists were read from the handler and `src/validator-nominators.mjs` directly rather than assumed: `window` ∈ `NOMINATOR_WINDOWS` (`7d`/`30d`/`90d`, default **30d**) and `sort` ∈ `NOMINATOR_SORTS` (`net_staked`/`gross_staked`/`last_activity`, default `net_staked`). Both are validated against the same allow-lists REST uses, and an unsupported value raises a `BAD_USER_INPUT` GraphQL error rather than silently substituting a default. `sort` is optional, so only a *supplied* bad value errors. REST's `limit`/`offset`/`coldkey`/`format` params are deliberately not GraphQL args (per the issue's specified signature), so the module's own defaults apply.

The resolver reuses `loadValidatorNominators` rather than duplicating the D1 query logic, and mirrors REST's fallback contract: `tryPostgresTier(env, ..., "METAGRAPH_ACCOUNT_EVENTS_SOURCE") ?? loadValidatorNominators(...)`. Worth flagging for reviewers — unlike the `chain_*` siblings, **both sides of that `??` return the same `{ data, generatedAt }` envelope** (the loader's own return shape, which is why `handleValidatorNominators` destructures it), so the resolver destructures `.data` once and covers either tier. `generatedAt` is REST envelope meta with no GraphQL field to carry it. A hotkey with no nominators resolves to a schema-stable empty list — never null, never a GraphQL error.

> Supersedes #5822, which was auto-closed on `codecov/patch`: its tests never handed the resolver an empty tier payload, so the right-hand arm of each `??` default in the return block was never taken (8 partial branches, 57.89% patch). This PR adds the missing malformed-tier-body case, and I verified locally against the v8 coverage report that the resolver region now has **zero uncovered statements and zero partial branches**.

Closes #5692

## Changes

- `src/graphql.mjs`: `validator_nominators(hotkey: String!, window: String, sort: String): NominatorList!` on `Query` (with the "Mirrors GET /api/v1/..." doc-comment convention), the `NominatorList` + `Nominator` types mirroring `buildValidatorNominators`'s real return shape (`last_observed_ms` is an internal sort key the builder deletes, so it is correctly absent), a `FIELD_COMPLEXITY` entry at `RELATIONSHIP_FIELD_COMPLEXITY` (matching the `validator`/`subnet_performance` siblings), and the resolver.
- `tests/graphql.test.mjs`: 6 tests — cold-store empty list, a Postgres-tier hit asserting the mirrored `/api/v1/validators/{hotkey}/nominators` path plus forwarded `window`/`sort`, a D1-live rollup bucketing the `account_events` stake stream, a malformed tier body degrading to schema-stable defaults, and `BAD_USER_INPUT` for both an unsupported `window` and an unsupported `sort`.

## Validation

- [x] `tests/graphql.test.mjs` — **337 passed** (331 pre-existing + 6 new), on a tip rebased onto current `main` (`a4feb916`)
- [x] **Patch coverage verified locally** against the v8 coverage report: **0 uncovered statements, 0 partial branches** across the new resolver — both `window` arms (valid + BAD_USER_INPUT), both `sort` arms (omitted/valid + BAD_USER_INPUT), both `tryPostgresTier` arms (tier hit + D1 loader fallback), and every `??`/`||` default's right-hand arm via the malformed-body test.
- [x] `npm run format:check` (prettier) — clean on both files
- [x] `npm run lint` (eslint) — clean on both files
- [x] `git diff --check` — clean
- [x] No `openapi.json` regen: GraphQL SDL is not the REST OpenAPI contract (matching the merged `Query.chain_turnover` #5803 / `Query.chain_performance` #5820 diff shape).

## Safety

- [x] No secrets, PATs, wallet paths, or private URLs — the test hotkey/coldkey are synthetic fixtures.
- [x] Purely additive (+265/−0, 2 files); no existing resolver, type, or REST/MCP behavior changed.
- [x] Health/uptime/latency untouched (probe-derived only).
- [x] No visual/UI output — no screenshot table required.
