### PR TITLE
feat(graphql): add Query.account_identity mirroring REST

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -136,6 +136,7 @@ import {
   ACCOUNT_STAKE_MOVES_WINDOWS,
   DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW,
 } from "./account-stake-moves.mjs";
+import { loadAccountIdentity } from "./account-identity.mjs";
 import { loadAccountIdentityHistory } from "./account-identity-history.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
 import { SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
@@ -289,6 +290,8 @@ export const SDL = `
     account_axon_removals(ss58: String!, window: String): AccountAxonRemovals!
     "One account's per-subnet StakeMoved footprint over a 7d/30d/90d window (default 30d): movement count, first/last timestamps, and the alpha price (TAO) at its most recent move per subnet, an HHI concentration of where its re-delegation churn is focused, and the dominant subnet; an address with no moves in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/stake-moves."
     account_stake_moves(ss58: String!, window: String): AccountStakeMoves!
+    "One account's on-chain identity (its latest set_identity values, sanitized at serve time). has_identity is false with every field null for an account that never set one -- the common case, so this is a schema-stable card, never null and never a GraphQL error. Mirrors GET /api/v1/accounts/{ss58}/identity."
+    account_identity(ss58: String!): AccountIdentity!
     "One account's on-chain identity change history, newest first -- an append-only diff-tracking timeline (name/url/github/image/discord/description/additional plus a stable hash per entry). Page with limit/offset or cursor (opaque keyset from a prior response's next_cursor). An address with no identity-history rows resolves to a schema-stable empty timeline, never null. Mirrors GET /api/v1/accounts/{ss58}/identity-history."
     account_identity_history(ss58: String!, limit: Int, offset: Int, cursor: String): AccountIdentityHistory!
     "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
@@ -1556,6 +1559,20 @@ export const SDL = `
     identity_hash: String
   }
 
+  type AccountIdentity {
+    schema_version: Int!
+    account: String!
+    has_identity: Boolean!
+    name: String
+    url: String
+    github: String
+    image: String
+    discord: String
+    description: String
+    additional: String
+    captured_at: String
+  }
+
   type AccountIdentityHistory {
     schema_version: Int!
     account: String!
@@ -1831,6 +1848,7 @@ export const FIELD_COMPLEXITY = {
   account_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   account_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   account_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_identity: RELATIONSHIP_FIELD_COMPLEXITY,
   account_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   // A single latest-only row -- but it fans out into the full hyperparameter
@@ -3679,6 +3697,42 @@ const rootValue = {
         last_moved_at: s.last_moved_at ?? null,
         price_tao_at_last_move: s.price_tao_at_last_move ?? null,
       })),
+    };
+  },
+
+  async account_identity({ ss58 }, context) {
+    // Same SS58 validation every account_* resolver uses -- a malformed address
+    // is a GraphQL BAD_USER_INPUT error, not a silent empty card.
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_IDENTITY_SOURCE) -> D1
+    // (loadAccountIdentity) fallback handleAccountIdentity uses. Most accounts
+    // have never called set_identity, so a row-less account is the common case:
+    // has_identity:false with every field null, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}/identity`,
+        ),
+        "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
+      )) ?? (await loadAccountIdentity(d1Runner(context.env), ss58));
+    return {
+      schema_version: data.schema_version ?? 1,
+      account: data.account ?? ss58,
+      has_identity: data.has_identity ?? false,
+      name: data.name ?? null,
+      url: data.url ?? null,
+      github: data.github ?? null,
+      image: data.image ?? null,
+      discord: data.discord ?? null,
+      description: data.description ?? null,
+      additional: data.additional ?? null,
+      captured_at: data.captured_at ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7990,3 +7990,168 @@ describe("Query.subnet_hyperparameters / subnet_hyperparameters_history", () => 
     );
   });
 });
+
+describe("Query.account_identity", () => {
+  const AI_SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+  const AI_FIELDS =
+    "schema_version account has_identity name url github image discord description additional captured_at";
+
+  // Same D1 stub shape the account_identity_history tests use.
+  function identityD1(rows) {
+    return {
+      prepare: () => ({
+        bind: () => ({ all: async () => ({ results: rows }) }),
+      }),
+    };
+  }
+
+  test("resolves an account's identity from D1", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: identityD1([
+        {
+          account: AI_SS58,
+          name: "Alice",
+          url: "https://example.com",
+          github: "https://github.com/alice",
+          image: "https://example.com/a.png",
+          discord: "alice#1",
+          description: "a validator",
+          additional: "extra",
+          captured_at: 1780000000000,
+        },
+      ]),
+    };
+    const { status, body } = await gql(
+      `{ account_identity(ss58: "${AI_SS58}") { ${AI_FIELDS} } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const got = body.data.account_identity;
+    assert.equal(got.schema_version, 1);
+    assert.equal(got.account, AI_SS58);
+    assert.equal(got.has_identity, true);
+    assert.equal(got.name, "Alice");
+    assert.equal(got.description, "a validator");
+    assert.equal(got.additional, "extra");
+    assert.equal(got.captured_at, new Date(1780000000000).toISOString());
+  });
+
+  test("an account that never set an identity resolves to has_identity:false with null fields, never null", async () => {
+    const { status, body } = await gql(
+      `{ account_identity(ss58: "${AI_SS58}") { ${AI_FIELDS} } }`,
+      { METAGRAPH_HEALTH_DB: identityD1([]) },
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_identity, {
+      schema_version: 1,
+      account: AI_SS58,
+      has_identity: false,
+      name: null,
+      url: null,
+      github: null,
+      image: null,
+      discord: null,
+      description: null,
+      additional: null,
+      captured_at: null,
+    });
+  });
+
+  test("the Postgres tier takes precedence over D1", async () => {
+    let d1Called = false;
+    let seen = null;
+    const env = {
+      METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          seen = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            account: AI_SS58,
+            has_identity: true,
+            name: "FromPostgres",
+            url: null,
+            github: null,
+            image: null,
+            discord: null,
+            description: null,
+            additional: null,
+            captured_at: "2026-07-01T00:00:00.000Z",
+          });
+        },
+      },
+      METAGRAPH_HEALTH_DB: {
+        prepare: () => {
+          d1Called = true;
+          return { bind: () => ({ all: async () => ({ results: [] }) }) };
+        },
+      },
+    };
+    const { status, body } = await gql(
+      `{ account_identity(ss58: "${AI_SS58}") { ${AI_FIELDS} } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.account_identity.name, "FromPostgres");
+    assert.equal(body.data.account_identity.has_identity, true);
+    assert.equal(seen.pathname, `/api/v1/accounts/${AI_SS58}/identity`);
+    // The `??` short-circuits: D1 is only read when the tier returns nothing.
+    assert.equal(d1Called, false);
+  });
+
+  test("a sparse upstream payload still resolves a schema-stable card", async () => {
+    const { status, body } = await gql(
+      `{ account_identity(ss58: "${AI_SS58}") { ${AI_FIELDS} } }`,
+      {
+        METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
+        DATA_API: { fetch: async () => Response.json({}) },
+      },
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_identity, {
+      schema_version: 1,
+      account: AI_SS58,
+      has_identity: false,
+      name: null,
+      url: null,
+      github: null,
+      image: null,
+      discord: null,
+      description: null,
+      additional: null,
+      captured_at: null,
+    });
+  });
+
+  test("an invalid ss58 is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      '{ account_identity(ss58: "not-a-valid-address") { account } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("is priced at the relationship-field complexity weight", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.account_identity,
+      FIELD_COMPLEXITY.account_identity_history,
+    );
+  });
+});


### PR DESCRIPTION
Closes #5708

## What

Adds `Query.account_identity`, mirroring `GET /api/v1/accounts/{ss58}/identity` and MCP `get_account_identity`: one account's latest `set_identity` values, sanitized at serve time.

## How

**No query logic is duplicated.** The resolver reuses `account-identity.mjs`'s `loadAccountIdentity` through the same `tryPostgresTier(METAGRAPH_ACCOUNT_IDENTITY_SOURCE)` -> D1 fallback that `handleAccountIdentity` takes, so the GraphQL and REST shapes cannot drift apart. The `??` short-circuit means D1 is only read when the Postgres tier returns nothing — asserted directly by a test rather than assumed.

**Zero-result contract, per the issue:** most accounts have never called `set_identity`, so a row-less account is the common case rather than an error. It resolves to `has_identity: false` with every field null — a schema-stable card, never null and never a GraphQL error. This matches `Query.account`'s established zero-result precedent.

**Validation:** a malformed `ss58` raises `BAD_USER_INPUT`, matching every other `account_*` resolver (and verified to never reach the tier).

**Type:** `AccountIdentity` mirrors `buildAccountIdentity`'s real output — `schema_version` / `account` / `has_identity` plus the 7 `IDENTITY_FIELDS` (`name`, `url`, `github`, `image`, `discord`, `description`, `additional`) and `captured_at`. The identity fields are nullable since they're null whenever `has_identity` is false; sanitization stays in the loader, so GraphQL serves the same sanitized values REST does.

`FIELD_COMPLEXITY` entry at `RELATIONSHIP_FIELD_COMPLEXITY`, matching the sibling `account_identity_history`.

## Tests

6 new cases in `tests/graphql.test.mjs`: a D1 hit with a full identity, the no-identity empty-result fallback (the branch the issue calls out), Postgres-tier precedence over D1 (including the assertion that D1 is never touched), a sparse-upstream payload, an invalid `ss58`, and the complexity weight.

```
tests/graphql.test.mjs                    passed
tests/account-identity.test.mjs           passed   (loader unregressed)
tests/account-identity-api.test.mjs       passed
tests/request-handlers-entities.test.mjs  passed   (REST unregressed)
```

Patch coverage measured locally the way codecov measures it — every added line mapped against `coverage-final.json`'s `statementMap`/`branchMap`: **30/30 covered statements and branch arms = 100%** (target 99%), no partials. `eslint` clean, `prettier --check` clean, rebased to `behind: 0` immediately before pushing.
