### PR TITLE
feat(graphql): add Query.subnet_stake_transfers mirroring REST /subnets/{netuid}/stake-transfers (#5717)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -42,6 +42,11 @@ import {
   DEFAULT_SUBNET_STAKE_MOVES_WINDOW,
 } from "./subnet-stake-moves.mjs";
 import {
+  buildSubnetStakeTransfers,
+  SUBNET_STAKE_TRANSFERS_WINDOWS,
+  DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW,
+} from "./subnet-stake-transfers.mjs";
+import {
   buildSubnetWeightSetters,
   SUBNET_WEIGHT_SETTERS_WINDOWS,
   DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
@@ -225,6 +230,8 @@ export const SDL = `
     subnet_weights(netuid: Int!, window: String): SubnetWeights!
     "Per-subnet stake-movement (re-delegation) activity over a 7d/30d window (distinct movers, StakeMoved count, and movements per mover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/stake-moves."
     subnet_stake_moves(netuid: Int!, window: String): SubnetStakeMoves!
+    "Per-subnet stake-transfer activity over a 7d/30d window (distinct senders, StakeTransferred count, and transfers per sender); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/stake-transfers."
+    subnet_stake_transfers(netuid: Int!, window: String): SubnetStakeTransfers!
     "Per-subnet weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators behind /weights ranked by WeightsSet activity, each with count, share, and first/last set times; a subnet with no events resolves to a schema-stable empty leaderboard, never null. Mirrors GET /api/v1/subnets/{netuid}/weights/setters."
     subnet_weight_setters(netuid: Int!, window: String): SubnetWeightSetters!
     "Per-subnet emission-per-stake yield over the current metagraph snapshot: each UID's yield plus the subnet-wide aggregate and p25/median/p75/p90 distribution; a subnet with no neurons resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/yield."
@@ -994,6 +1001,17 @@ export const SDL = `
     distinct_movers: Int!
     movements: Int!
     movements_per_mover: Float
+  }
+
+  "Per-subnet stake-transfer activity (#5717) over a 7d/30d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/stake-transfers."
+  type SubnetStakeTransfers {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    distinct_senders: Int!
+    transfers: Int!
+    transfers_per_sender: Float
   }
 
   "Per-subnet weight-setter leaderboard (#5712). Empty setters on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/weights/setters."
@@ -1844,6 +1862,7 @@ export const FIELD_COMPLEXITY = {
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_stake_transfers: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_yield: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_performance: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2771,6 +2790,43 @@ const rootValue = {
       distinct_movers: data.distinct_movers ?? 0,
       movements: data.movements ?? 0,
       movements_per_mover: data.movements_per_mover ?? null,
+    };
+  },
+
+  async subnet_stake_transfers({ netuid, window }, context) {
+    // Same 7d/30d window validation handleSubnetStakeTransfers uses -- an
+    // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW;
+    if (!Object.hasOwn(SUBNET_STAKE_TRANSFERS_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, SUBNET_STAKE_TRANSFERS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) ->
+    // buildSubnetStakeTransfers zeroed-card fallback contract
+    // handleSubnetStakeTransfers uses; a subnet with no StakeTransferred events
+    // in the window is a schema-stable zeroed card, never a GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/stake-transfers`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildSubnetStakeTransfers(null, netuid, { window: windowParam });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      observed_at: data.observed_at ?? null,
+      distinct_senders: data.distinct_senders ?? 0,
+      transfers: data.transfers ?? 0,
+      transfers_per_sender: data.transfers_per_sender ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -4662,6 +4662,94 @@ describe("graphql — subnet_stake_moves (#5716, Postgres-tier + zeroed-card fal
   });
 });
 
+describe("graphql — subnet_stake_transfers (#5717, Postgres-tier + zeroed-card fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_stake_transfers(netuid: 5) {
+          schema_version netuid window observed_at
+          distinct_senders transfers transfers_per_sender
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_stake_transfers, {
+      schema_version: 1,
+      netuid: 5,
+      window: "7d",
+      observed_at: null,
+      distinct_senders: 0,
+      transfers: 0,
+      transfers_per_sender: null,
+    });
+  });
+
+  test("resolves the Postgres-tier card for the requested window", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          window: "30d",
+          observed_at: "2026-07-01T00:00:00.000Z",
+          distinct_senders: 4,
+          transfers: 11,
+          transfers_per_sender: 2.75,
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_stake_transfers(netuid: 5, window: "30d") {
+          netuid window observed_at distinct_senders transfers transfers_per_sender
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const t = body.data.subnet_stake_transfers;
+    assert.equal(t.window, "30d");
+    assert.equal(t.observed_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(t.distinct_senders, 4);
+    assert.equal(t.transfers, 11);
+    assert.equal(t.transfers_per_sender, 2.75);
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_stake_transfers(netuid: 9, window: "30d") {
+          schema_version netuid window observed_at distinct_senders transfers transfers_per_sender
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_stake_transfers, {
+      schema_version: 1,
+      netuid: 9,
+      window: "30d",
+      observed_at: null,
+      distinct_senders: 0,
+      transfers: 0,
+      transfers_per_sender: null,
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ subnet_stake_transfers(netuid: 5, window: "99d") { transfers } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|7d/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_stake_transfers ?? null, null);
+  });
+});
+
 describe("graphql — subnet_deregistrations (#5719, Postgres-tier + zeroed-card fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## What

Adds `subnet_stake_transfers(netuid: Int!, window: String): SubnetStakeTransfers!` to the GraphQL `Query` type, closing the gap where a REST route and MCP tool exist without a GraphQL mirror:

- REST: `GET /api/v1/subnets/{netuid}/stake-transfers` (`src/subnet-stake-transfers.mjs`)

## How

Mirrors the merged `subnet_stake_moves` (#5716) / `subnet_weights` (#5711) windowed-card pattern exactly:

- **SDL**: new `subnet_stake_transfers` field + `SubnetStakeTransfers` type (`schema_version`, `netuid`, `window`, `observed_at`, `distinct_senders`, `transfers`, `transfers_per_sender`) mirroring `buildSubnetStakeTransfers`'s real shape.
- **Resolver**: reuses `src/subnet-stake-transfers.mjs`'s builder (no duplicated query logic). Validates the 7d/30d `window` (`BAD_USER_INPUT` on an unsupported window), then `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` ?? `buildSubnetStakeTransfers(null, netuid, { window })` — a subnet with no `StakeTransferred` events in the window resolves to a schema-stable zeroed card, never a GraphQL error.
- **FIELD_COMPLEXITY**: `RELATIONSHIP_FIELD_COMPLEXITY`, matching the sibling windowed cards.

## Tests

`tests/graphql.test.mjs` — cold-store zeroed card, Postgres-tier hit for a non-default window, partial-tier-body default degradation, and unsupported-window `BAD_USER_INPUT`. Full suite green; 100% patch coverage on the added lines.

Closes #5717.