### PR TITLE
feat(registry): add SN31 Recall TaoMarketCap subnet-api surface

### DIFF
--- a/registry/subnets/recall.json
+++ b/registry/subnets/recall.json
@@ -34,5 +34,22 @@
       "No verified standalone static data artifact yet."
     ]
   },
-  "surfaces": []
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-31-taomarketcap-subnet-api",
+      "kind": "subnet-api",
+      "name": "Recall TaoMarketCap subnet snapshot API",
+      "notes": "Public no-auth GET /public/v1/subnets/31 on api.taomarketcap.com returning machine-readable JSON for SN31 Recall on-chain subnet state, subnet_identities_v3 metadata, economics, and dTAO market fields. Recall has no verified first-party public API surface (its manifest registers none); this indexed feed is documented in the TaoMarketCap developer API.",
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "luciferlive112116"
+      },
+      "source_urls": ["https://api.taomarketcap.com/developer/documentation/"],
+      "url": "https://api.taomarketcap.com/public/v1/subnets/31"
+    }
+  ]
 }


### PR DESCRIPTION
Closes #4032

## Summary

Enriches **SN31 Recall** with a public, no-auth **subnet-api** surface — the machine-readable TaoMarketCap subnet-snapshot feed.

Recall's manifest currently registers **no surfaces at all**, and its own `curation.gap_notes` records *"No verified safe public subnet API endpoint yet."* — so this closes a real gap rather than duplicating an existing surface.

## Surface

- **kind:** `subnet-api`
- **url:** `https://api.taomarketcap.com/public/v1/subnets/31`
- **source_url:** `https://api.taomarketcap.com/developer/documentation/`
- **provider:** `taomarketcap`
- **authority:** `community` / **review.state:** `community-submitted`
- `public_safe: true`, `auth_required: false`

## Verification

The issue asks for a link that is real, public, no-auth, and genuinely SN31's, and warns that identity links are often stale — so I checked the live endpoint rather than assuming:

- `GET /public/v1/subnets/31` -> **HTTP 200**, ~4.6 KB of JSON, no auth (it 301s only to the canonical trailing-slash form, exactly as the already-merged SN27/SN76 surfaces do).
- The payload is genuinely SN31's (`"netuid": 31`, `registered_at: 2024-04-07`) and contains what the surface's `notes` claim: `subnet_identities_v3` metadata, economics (`subnet_tao_in_emission`, `subnet_alpha_in/out`, `rao_recycled_for_registration`), and dTAO market fields (`price`, `subnet_volume`, `subnet_moving_price`, `alpha_sqrt_price`).

Every claim in the `notes` was checked against that response; nothing is asserted that the endpoint doesn't actually return.

## Scope

Appends **exactly one surface** to **exactly one file**, matching the merged TaoMarketCap `subnet-api` precedent for SN27 (#5754) and SN76 (#5760) field-for-field. No other surface, no `curation` field, no top-level field, and no generated artifact is touched — the diff is `+18/-1`, where the single deletion is the now-non-empty `"surfaces": []`.

```
npm run validate:surface  ->  passed: 852 surface(s) across 129 subnet file(s)   (851 before: +1)
```

`prettier --check` clean; rebased to `behind: 0` immediately before pushing.
