### PR TITLE
fix(registry): document 5 subnets' degraded website/dashboard URLs

### DIFF
--- a/registry/subnets/8-ball.json
+++ b/registry/subnets/8-ball.json
@@ -14,7 +14,7 @@
   "website_url": "https://8ball125.com/",
   "docs_url": "https://github.com/Barbariandev/8Ball_miner#readme",
   "source_repo": "https://github.com/Barbariandev/8Ball_miner",
-  "notes": "Reviewed overlay for SN125 8 Ball. The public website is live and the public miner/source repository documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
+  "notes": "Reviewed overlay for SN125 8 Ball. The public miner/source repository documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -22,11 +22,12 @@
     "verified_at": "2026-06-08T15:00:00.000Z",
     "source_count": 7,
     "gap_notes": [
-      "Official website and miner/source repository are verified live.",
+      "Official miner/source repository is verified live.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified standalone static data artifact yet.",
+      "Official website (https://8ball125.com/) currently returns HTTP 502 to simple probes and should appear degraded until it recovers."
     ]
   },
   "surfaces": [
@@ -44,12 +45,13 @@
         "https://github.com/Barbariandev/8Ball_miner"
       ],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official 8 Ball website linked from the public SN125 miner repository."
+      "notes": "Official 8 Ball website linked from the public SN125 miner repository.",
+      "rate_limit_notes": "Not probe-enabled because the origin currently returns HTTP 502 to simple probes."
     },
     {
       "id": "sn-125-eightball-source-repo",

--- a/registry/subnets/ninja.json
+++ b/registry/subnets/ninja.json
@@ -14,7 +14,8 @@
     "gap_notes": [
       "Swagger/OpenAPI routes currently serve HTML UI only; no verified machine-readable schema URL yet.",
       "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified standalone static data artifact yet.",
+      "Official website and Swagger UI (https://ninja.arbos.life/) currently return HTTP 404 to simple probes and should appear degraded until they recover."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -47,7 +48,7 @@
       "name": "Ninja website",
       "notes": "Official Ninja SN66 public website.",
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "expect": "html",
         "method": "HEAD",
         "timeout_ms": 10000
@@ -55,7 +56,8 @@
       "provider": "unarbos",
       "public_safe": true,
       "source_urls": ["https://ninja.arbos.life/"],
-      "url": "https://ninja.arbos.life/"
+      "url": "https://ninja.arbos.life/",
+      "rate_limit_notes": "Not probe-enabled because the origin currently returns HTTP 404 to simple probes."
     },
     {
       "auth_required": false,
@@ -146,7 +148,7 @@
       "name": "Ninja Swagger UI",
       "notes": "Swagger UI route for Ninja. Obvious JSON schema paths currently serve HTML and are not treated as machine-readable OpenAPI.",
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "expect": "html",
         "method": "HEAD",
         "timeout_ms": 10000
@@ -155,7 +157,8 @@
       "public_safe": true,
       "schema_status": "ui-only",
       "source_urls": ["https://ninja.arbos.life/swagger"],
-      "url": "https://ninja.arbos.life/swagger"
+      "url": "https://ninja.arbos.life/swagger",
+      "rate_limit_notes": "Not probe-enabled because the origin currently returns HTTP 404 to simple probes."
     },
     {
       "auth_required": false,

--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -27,7 +27,8 @@
       "No verified safe public subnet API endpoint yet.",
       "No verified OpenAPI/Swagger schema yet.",
       "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified standalone static data artifact yet.",
+      "Official website (https://oneoneone.io/) currently returns Cloudflare HTTP 530 to simple probes and should appear degraded until it recovers."
     ]
   },
   "surfaces": [
@@ -42,12 +43,13 @@
       "public_safe": true,
       "source_urls": ["https://oneoneone.io/"],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official oneoneone website."
+      "notes": "Official oneoneone website.",
+      "rate_limit_notes": "Not probe-enabled because the origin currently returns Cloudflare HTTP 530 to simple probes."
     },
     {
       "id": "sn-111-oneoneone-source",

--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -34,12 +34,13 @@
     "verified_at": "2026-06-08T20:25:00.000Z",
     "source_count": 5,
     "gap_notes": [
-      "Official TaoFi pool page, docs, and Swap source repository are verified live.",
+      "Official TaoFi docs and Swap source repository are verified live.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
       "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified standalone static data artifact yet.",
+      "Official TaoFi pool page (https://www.taofi.com/pool) currently returns HTTP 402 to simple probes and should appear degraded until it recovers."
     ]
   },
   "surfaces": [
@@ -57,12 +58,13 @@
         "https://github.com/Swap-Subnet/swap-subnet"
       ],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Official TaoFi pool page for SN10 Swap."
+      "notes": "Official TaoFi pool page for SN10 Swap.",
+      "rate_limit_notes": "Not probe-enabled because the origin currently returns HTTP 402 to simple probes."
     },
     {
       "id": "sn-10-taofi-docs",

--- a/registry/subnets/tensorclaw.json
+++ b/registry/subnets/tensorclaw.json
@@ -17,7 +17,7 @@
   "dashboard_url": "https://www.tensorclaw.ai/dashboard",
   "website_url": "https://www.tensorclaw.ai/",
   "baseline_excluded_surface_ids": ["sn-92-taomarketcap-website"],
-  "notes": "Reviewed overlay for SN92 using the live Tensorclaw Network website, dashboard, and source repository. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The website links https://github.com/tensorclaw/tensorclaw and the repository README identifies it as Bittensor Tensorclaw Subnet 92.",
+  "notes": "Reviewed overlay for SN92 using the Tensorclaw Network website, dashboard, and source repository. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The website links https://github.com/tensorclaw/tensorclaw and the repository README identifies it as Bittensor Tensorclaw Subnet 92.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -26,12 +26,13 @@
     "source_count": 6,
     "gap_notes": [
       "Native chain name currently reports as luis while the public website identifies the project as Tensorclaw Network / Subnet 92.",
-      "Official website, dashboard, and source repository are verified live.",
+      "Official source repository is verified live.",
       "No verified docs site yet beyond directory pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified standalone static data artifact yet.",
+      "Official website and dashboard (https://www.tensorclaw.ai/) currently return Cloudflare HTTP 521 (web server is down) to simple probes and should appear degraded until they recover."
     ]
   },
   "surfaces": [
@@ -84,12 +85,13 @@
       "public_safe": true,
       "source_urls": ["https://www.tensorclaw.ai/"],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Website identifies Tensorclaw Network as Bittensor Mainnet Subnet 92 and describes a decentralized LLM inference subnet for autonomous agents."
+      "notes": "Website identifies Tensorclaw Network as Bittensor Mainnet Subnet 92 and describes a decentralized LLM inference subnet for autonomous agents.",
+      "rate_limit_notes": "Not probe-enabled because the origin currently returns Cloudflare HTTP 521 (web server is down) to simple probes."
     },
     {
       "id": "sn-92-tensorclaw-source-repo",
@@ -123,12 +125,13 @@
       "public_safe": true,
       "source_urls": ["https://www.tensorclaw.ai/"],
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "HEAD",
         "expect": "html",
         "timeout_ms": 10000
       },
-      "notes": "Public live-demo page for SN92. The page uses Cloudflare Turnstile to unlock trial requests, so it is listed as an auth-gated dashboard surface rather than a public API."
+      "notes": "Public live-demo page for SN92. The page uses Cloudflare Turnstile to unlock trial requests, so it is listed as an auth-gated dashboard surface rather than a public API.",
+      "rate_limit_notes": "Not probe-enabled because the origin currently returns Cloudflare HTTP 521 (web server is down) to simple probes."
     },
     {
       "auth_required": false,


### PR DESCRIPTION
## Summary

Five subnets' `notes`/`curation` claimed a `website_url`/`dashboard_url` was "verified live", but all five currently return hard errors to simple probes. I re-verified each **twice** with a browser User-Agent and follow-redirects — all still down, consistently:

| Subnet | URL | Status (2 checks) |
| --- | --- | --- |
| swap (SN10) | https://www.taofi.com/pool | HTTP 402 |
| tensorclaw (SN92) | https://www.tensorclaw.ai/ + `/dashboard` | Cloudflare 521 |
| ninja (SN66) | https://ninja.arbos.life/ + `/swagger` | HTTP 404 |
| 8-ball (SN125) | https://8ball125.com/ | HTTP 502 |
| oneoneone (SN111) | https://oneoneone.io/ | Cloudflare 530 |

## Change

For each file, following the precedent already set by `taolend.json` (`curation.gap_notes`) and `nodexo.json` (`surfaces[].rate_limit_notes`):

- Stop describing the URL as "verified live" in `notes`/`curation.gap_notes`.
- Add a `gap_note` documenting the current degraded state and HTTP status.
- Set the affected surface(s) `probe.enabled = false` and add a `rate_limit_notes` explaining why, so the health prober no longer misreports them as up.

The failing hosts are fully down (secondary same-host surfaces — ninja `/swagger`, tensorclaw `/dashboard`, both probe-enabled — return the same errors and were disabled too). The URLs themselves are **left in place** per the issue guidance (the outages may be transient); only the "verified live" claims and probe wiring are corrected. `npm run validate:surface` passes (851 surfaces, 129 files).

Closes #5480