### PR TITLE
fix(registry): dedupe same-URL surfaces registered under two kinds

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -276,28 +276,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-7-allways-data-artifact",
-      "kind": "data-artifact",
-      "name": "Allways community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "allways",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.all-ways.io/swagger-json"],
-      "url": "https://api.all-ways.io/miners/leaderboard"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-7-allways-subnet-api",
       "kind": "subnet-api",
       "name": "Allways swaps API",

--- a/registry/subnets/bitmind.json
+++ b/registry/subnets/bitmind.json
@@ -110,28 +110,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-34-bitmind-data-artifact",
-      "kind": "data-artifact",
-      "name": "BitMind community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "bitmind",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.bitmind.ai/openapi.json"],
-      "url": "https://api.bitmind.ai/health"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-34-bitmind-openapi",
       "kind": "openapi",
       "name": "BitMind community openapi",

--- a/registry/subnets/gradients.json
+++ b/registry/subnets/gradients.json
@@ -199,28 +199,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-56-gradients-data-artifact",
-      "kind": "data-artifact",
-      "name": "Gradients community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "gradients",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.gradients.io/docs"],
-      "url": "https://api.gradients.io/v1/network/status"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-56-gradients-subnet-api",
       "kind": "subnet-api",
       "name": "Gradients network status API",


### PR DESCRIPTION
## Summary

Three subnet files each registered the **same URL twice** under two different surface `kind`s. In every case the URL is a live API path (`/health`, `/status`, `/miners/leaderboard`), so the accurate `kind` is `subnet-api`; the redundant `data-artifact` entry is removed. The surviving `subnet-api` entry is also the better-described / canonical one in each file.

| File | URL | Removed (redundant) | Kept |
| --- | --- | --- | --- |
| `allways.json` (SN7) | `https://api.all-ways.io/miners/leaderboard` | `sn-7-allways-data-artifact` (data-artifact) | `allways-miners-leaderboard` (subnet-api) |
| `bitmind.json` (SN34) | `https://api.bitmind.ai/health` | `sn-34-bitmind-data-artifact` (data-artifact) | `sn-34-bitmind-subnet-api` (subnet-api) |
| `gradients.json` (SN56) | `https://api.gradients.io/v1/network/status` | `sn-56-gradients-data-artifact` (data-artifact) | `sn-56-gradients-subnet-api` (subnet-api) |

No other surface or top-level field is touched. After the change each URL is registered exactly once, so surface-count/coverage aggregates no longer double-count it. `npm run validate:surface` passes (848 surfaces, 129 files).

Closes #5736