### PR TITLE
feat(ui): StateBlock wrapper enforcing the empty-state decision rule (#5341)

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/drift-activity.tsx
@@ -4,7 +4,7 @@ import { ArrowUpRight, ChevronRight } from "lucide-react";
 import type { SchemaInfo } from "@/lib/metagraphed/types";
 import { classNames } from "@/lib/metagraphed/format";
 import { TimeAgo } from "@jsonbored/ui-kit";
-import { RegistryEmpty } from "@/components/metagraphed/states/registry-empty";
+import { StateBlock } from "@/components/metagraphed/states/state-block";
 
 interface Props {
   schemas: SchemaInfo[];
@@ -46,7 +46,8 @@ export function DriftActivity({ schemas, fromPath }: Props) {
 
   if (total === 0) {
     return (
-      <RegistryEmpty
+      <StateBlock
+        kind="registry"
         variant="empty"
         title="No schemas tracked yet"
         description="Drift activity appears once the registry has two snapshots of a schema to compare."
@@ -116,7 +117,8 @@ export function DriftActivity({ schemas, fromPath }: Props) {
       {/* Drifting list */}
       {drifting.length === 0 ? (
         <div className="p-6">
-          <RegistryEmpty
+          <StateBlock
+            kind="registry"
             variant="empty"
             title="No drift detected"
             description="All tracked schemas match their previous snapshot. New activity will appear here as soon as a published schema changes."

--- a/apps/ui/src/components/metagraphed/states/state-block.tsx
+++ b/apps/ui/src/components/metagraphed/states/state-block.tsx
@@ -1,0 +1,56 @@
+import type { ComponentProps } from "react";
+import { TableState } from "@jsonbored/ui-kit";
+import { EmptyState, ErrorState } from "../states";
+import { RegistryEmpty } from "./registry-empty";
+
+/**
+ * Mechanical enforcement of the empty/error/stale-state decision rule (#3962,
+ * #5341), documented in prose above `EmptyState` in `../states.tsx`.
+ *
+ * The app has three deliberately-distinct "nothing here" primitives —
+ * `EmptyState` (subtle dashed list / card-grid / section card), `TableState`
+ * (solid query-backed table block with a shared retry CTA), and `RegistryEmpty`
+ * (registry provenance with a variant badge + freshness row + evidence link).
+ * Their visual differences are intentional and context-driven, so this wrapper
+ * deliberately does NOT collapse them into one look — that would regress every
+ * established surface and discard the decision rule's rationale. Instead it
+ * makes the rule *executable*: a caller declares the CONTEXT via `kind`, and the
+ * wrapper renders exactly the sanctioned primitive for it. Reaching for the
+ * wrong treatment now requires deliberately passing the wrong `kind` rather than
+ * silently importing whichever primitive is closest to hand — the failure mode
+ * the prose rule and the `states.tsx:102-121` guard were written to catch.
+ *
+ * Each `kind`'s props are the underlying primitive's own props (via
+ * `ComponentProps`), so this stays automatically in sync with them:
+ *
+ *  - `kind="list"`       → `EmptyState`    — general list / card-grid / section emptiness
+ *  - `kind="list-error"` → `ErrorState`    — the error partner for a `list` context
+ *  - `kind="table"`      → `TableState`    — paginated / query-backed table empty/stale/error
+ *  - `kind="registry"`   → `RegistryEmpty` — registry-provenance surfaces
+ */
+export type StateBlockProps =
+  | ({ kind: "list" } & ComponentProps<typeof EmptyState>)
+  | ({ kind: "list-error" } & ComponentProps<typeof ErrorState>)
+  | ({ kind: "table" } & ComponentProps<typeof TableState>)
+  | ({ kind: "registry" } & ComponentProps<typeof RegistryEmpty>);
+
+export function StateBlock(props: StateBlockProps) {
+  switch (props.kind) {
+    case "list": {
+      const { kind: _kind, ...rest } = props;
+      return <EmptyState {...rest} />;
+    }
+    case "list-error": {
+      const { kind: _kind, ...rest } = props;
+      return <ErrorState {...rest} />;
+    }
+    case "table": {
+      const { kind: _kind, ...rest } = props;
+      return <TableState {...rest} />;
+    }
+    case "registry": {
+      const { kind: _kind, ...rest } = props;
+      return <RegistryEmpty {...rest} />;
+    }
+  }
+}

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -8,7 +8,7 @@ import { Search, X } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton, StaleBanner } from "@/components/metagraphed/states";
-import { RegistryEmpty } from "@/components/metagraphed/states/registry-empty";
+import { StateBlock } from "@/components/metagraphed/states/state-block";
 import {
   TimeAgo,
   HealthPill,
@@ -791,7 +791,8 @@ function EndpointsTable() {
 
   if (rows.length === 0)
     return (
-      <RegistryEmpty
+      <StateBlock
+        kind="registry"
         variant="empty"
         title="No endpoints in the registry"
         description="The endpoints artifact returned no rows. The source may be temporarily unavailable — inspect the raw API response or try again shortly."
@@ -922,7 +923,8 @@ function EndpointsTable() {
       </div>
 
       {sorted.length === 0 ? (
-        <RegistryEmpty
+        <StateBlock
+          kind="registry"
           variant="empty"
           title="No endpoints match these filters"
           description="Remove one filter at a time, or reset to see the full list. Eligibility and category chips have the biggest effect on row count."

--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -38,7 +38,7 @@ import {
 } from "@/lib/metagraphed/queries";
 import { GITHUB_REPO } from "@/lib/metagraphed/config";
 import { classNames } from "@/lib/metagraphed/format";
-import { RegistryEmpty } from "@/components/metagraphed/states/registry-empty";
+import { StateBlock } from "@/components/metagraphed/states/state-block";
 import type { CurationLevel, Gap, Subnet } from "@/lib/metagraphed/types";
 
 const STATUS_OPTIONS = ["all", "open", "in-review", "resolved", "wont-fix"] as const;
@@ -664,7 +664,8 @@ function OpenGapsSection() {
 
       {sorted.length === 0 ? (
         <div className="mt-6">
-          <RegistryEmpty
+          <StateBlock
+            kind="registry"
             variant="empty"
             title={rows.length === 0 ? "No open gaps" : "No gaps match these filters"}
             description={

--- a/apps/ui/src/routes/surfaces.tsx
+++ b/apps/ui/src/routes/surfaces.tsx
@@ -4,7 +4,7 @@ import { Suspense, useMemo } from "react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
-import { RegistryEmpty } from "@/components/metagraphed/states/registry-empty";
+import { StateBlock } from "@/components/metagraphed/states/state-block";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { EvidencePanel } from "@/components/metagraphed/evidence-panel";
 import {
@@ -278,7 +278,8 @@ function SurfacesTable({ view }: { view: "table" | "grid" }) {
   );
 
   const emptyNode = (
-    <RegistryEmpty
+    <StateBlock
+      kind="registry"
       variant="empty"
       title={filtersActive ? "No surfaces match these filters" : "No surfaces yet"}
       description={


### PR DESCRIPTION
## What

Implements #5341 via the issue's option (b) — **enforce the existing empty-state decision rule (#3962) via a shared wrapper** — rather than collapsing the three primitives into one look.

The app has three deliberately-distinct "nothing here" primitives:
- `EmptyState` (`apps/ui/.../states.tsx`) — subtle dashed list / card-grid / section card
- `TableState` (`@jsonbored/ui-kit`) — solid query-backed table block with a shared retry CTA
- `RegistryEmpty` (`apps/ui/.../states/registry-empty.tsx`) — registry provenance with a variant badge + freshness row + evidence link

Their visual differences are **intentional and context-driven** — the decision rule in `states.tsx:102-121` documents which to use where. Collapsing them would regress every established surface and discard that rationale, so this makes the rule *executable* instead.

## How

- **New `StateBlock` wrapper** (`apps/ui/src/components/metagraphed/states/state-block.tsx`): a typed component with a `kind` discriminated union — `"list"` → `EmptyState`, `"list-error"` → `ErrorState`, `"table"` → `TableState`, `"registry"` → `RegistryEmpty`. Each kind's props are the underlying primitive's own props (via `ComponentProps`), so it stays in sync automatically. A caller declares the **context** via `kind` and gets exactly the sanctioned primitive.
- **Reference adoption**: migrated the registry-provenance cluster — `endpoints`, `gaps`, `surfaces`, `drift-activity` (6 call sites) — to `StateBlock kind="registry"`.

## Screenshots

Pure-delegation refactor — **zero visual change** (before/after are pixel-identical by construction). Captured on `/endpoints` (a migrated route) across the full viewport × theme matrix to confirm no regression:

| View | Before | After |
|------|--------|-------|
| Desktop · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5341-states-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5341-states-after-desktop-light.png) |
| Desktop · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5341-states-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5341-states-after-desktop-dark.png) |
| Tablet · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5341-states-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5341-states-after-tablet-light.png) |
| Tablet · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5341-states-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5341-states-after-tablet-dark.png) |
| Mobile · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5341-states-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5341-states-after-mobile-light.png) |
| Mobile · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5341-states-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5341-states-after-mobile-dark.png) |

## Scope / follow-ups

Kept reviewable: broader adoption of the `list`/`table` clusters + an optional `no-restricted-imports` lint guard steering direct primitive imports to `StateBlock` are the natural next steps to make enforcement total.

Closes #5341.