### PR TITLE
feat(registry): add SN99 Leoma scores, rank + weights subnet-api surfaces (#427)

### DIFF
--- a/registry/subnets/leoma.json
+++ b/registry/subnets/leoma.json
@@ -57,14 +57,14 @@
       "kind": "openapi",
       "name": "Leoma validator API OpenAPI schema",
       "notes": "Public no-auth OpenAPI 3.x schema for the SN99 Leoma validator API (title \"Leoma API\", version 0.3.2, 28 paths) on api.leoma.ai. Documents /health, miner listing, samples, scores, and related validator routes; same host as the existing health and scores/stats surfaces.",
-      "provider": "leoma",
-      "public_safe": true,
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 15000
       },
+      "provider": "leoma",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "bohdansolovie"
@@ -77,6 +77,54 @@
         "https://github.com/RendixNetwork/leoma"
       ],
       "url": "https://api.leoma.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-scores",
+      "kind": "subnet-api",
+      "name": "Leoma per-miner aggregated scores",
+      "notes": "Public no-auth GET /scores on api.leoma.ai returning per-miner aggregated evaluation scores (observed per hotkey: avg_score, total_samples, total_passed, pass_rate). Documented as a route in the subnet's own OpenAPI schema (api.leoma.ai/openapi.json, already cited for the existing health and scores/stats surfaces); same api.leoma.ai host.",
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nghetienhiep"
+      },
+      "source_urls": ["https://api.leoma.ai/openapi.json"],
+      "url": "https://api.leoma.ai/scores"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-scores-rank",
+      "kind": "subnet-api",
+      "name": "Leoma miner score ranking",
+      "notes": "Public no-auth GET /scores/rank on api.leoma.ai returning the ranked miner leaderboard (observed per entry: miner_hotkey, uid, rank, passed_count, pass_rate, block, eligible). Documented as a route in the subnet's own OpenAPI schema (api.leoma.ai/openapi.json); same api.leoma.ai host as the existing health and scores/stats surfaces.",
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nghetienhiep"
+      },
+      "source_urls": ["https://api.leoma.ai/openapi.json"],
+      "url": "https://api.leoma.ai/scores/rank"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-weights",
+      "kind": "subnet-api",
+      "name": "Leoma validator weight vector",
+      "notes": "Public no-auth GET /weights on api.leoma.ai returning the current winner UID and the per-miner weight vector the validator sets on chain (observed: winner_uid, miners[] with miner_hotkey, uid, pass_rate, weight). Documented as a route in the subnet's own OpenAPI schema (api.leoma.ai/openapi.json); same api.leoma.ai host as the existing health and scores/stats surfaces.",
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nghetienhiep"
+      },
+      "source_urls": ["https://api.leoma.ai/openapi.json"],
+      "url": "https://api.leoma.ai/weights"
     }
   ],
   "website_url": "https://leoma.ai/"


### PR DESCRIPTION
## Add or update a subnet surface

Closes #427

Enriches **SN99 Leoma** with three previously-unregistered, public, no-auth GET
endpoints of its official validator API (`api.leoma.ai`) — the same host that
already serves the subnet's registered `health`, `scores/stats`, and `openapi`
surfaces. Together they cover the subnet's public scoring pipeline: per-miner
scores → ranked leaderboard → the on-chain weight vector.

## Surfaces (3)

- **subnet-api** — https://api.leoma.ai/scores
  Per-miner aggregated evaluation scores (per hotkey: `avg_score`,
  `total_samples`, `total_passed`, `pass_rate`).
- **subnet-api** — https://api.leoma.ai/scores/rank
  Ranked miner leaderboard (`miner_hotkey`, `uid`, `rank`, `passed_count`,
  `pass_rate`, `block`, `eligible`).
- **subnet-api** — https://api.leoma.ai/weights
  Current winner UID + per-miner weight vector the validator sets on chain
  (`winner_uid`, `miners[]` with `miner_hotkey`, `uid`, `pass_rate`, `weight`).

All `authority: community`, `auth_required: false`, `public_safe: true`.

## Surface

- Netuid: 99
- Kind: `subnet-api` (×3)
- Public URL: `https://api.leoma.ai/scores`, `.../scores/rank`, `.../weights`
- Source URL (proves the claim): `https://api.leoma.ai/openapi.json`
- Provider slug: `leoma` (registered)

## Proof

- All three paths are declared in the subnet's own live OpenAPI schema
  (`https://api.leoma.ai/openapi.json`, title "Leoma API" v0.3.2) with **no
  security requirement** (no global `security`, none per-operation) — the same
  spec already cited as `source_url` for the existing `health` and `scores/stats`
  surfaces on this manifest.
- Same official `api.leoma.ai` host as the subnet's already-registered surfaces
  (provider `leoma`).
- Each URL was verified live: `HTTP 200 application/json`, no auth, returning
  subnet-wide aggregate data only (no account/key material).
- None duplicate the existing Leoma surfaces (`/scores` per-miner aggregates and
  `/scores/rank` leaderboard are distinct from the registered `/scores/stats`
  network counters).

## Checklist

- [x] Changes exactly one `registry/subnets/leoma.json` file (append-only).
- [x] Generated with `npm run surface:add` — `authority: community`,
      `review.state: community-submitted`.
- [x] `url`s are public and safe for read-only probes; `source_url` independently
      proves the subnet publishes them.
- [x] Public-safe: no auth flows, secrets, wallet/PAT data, private URLs, or
      generated `public/metagraph/**` artifacts.
- [x] Does not duplicate an existing Metagraphed surface.
- [x] Links a tracked issue that is still OPEN (`Closes #427`).

## Validation

- [x] `npm run surface:add` — live verification "OK reachable + public-safe" for all 3
- [x] `npm run validate:surface -- registry/subnets/leoma.json` — passed (6 surfaces)
- [x] `npm run scan:public-safety` — passed
- [x] `npm run build && npm run validate` — passed (1618 surfaces)
- [x] `npm run format:check` — passed

Single-file change; no generated artifacts touched.
