### PR TITLE
feat(api,ui): wire Download CSV into the Providers page

### DIFF
--- a/apps/ui/src/lib/metagraphed/providers-csv-params.test.ts
+++ b/apps/ui/src/lib/metagraphed/providers-csv-params.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { providersCsvParams, providersCsvIsBroaderThanView } from "./providers-csv-params";
+
+describe("providersCsvParams", () => {
+  it("always requests the csv format", () => {
+    expect(providersCsvParams({})).toEqual({ format: "csv" });
+  });
+
+  it("forwards the filters the providers collection actually registers", () => {
+    expect(providersCsvParams({ kind: "subnet-team", authority: "official" })).toEqual({
+      format: "csv",
+      kind: "subnet-team",
+      authority: "official",
+    });
+  });
+
+  it("drops q: providers registers no search_keys, so the API would ignore it and return every row", () => {
+    expect(providersCsvParams({ q: "academia", kind: "indexer" })).toEqual({
+      format: "csv",
+      kind: "indexer",
+    });
+  });
+
+  it("drops the 'high' authority alias, which spans two real authority values", () => {
+    expect(providersCsvParams({ authority: "high" })).toEqual({
+      format: "csv",
+    });
+  });
+
+  it("forwards sort=name (the only page sort the API also supports)", () => {
+    expect(providersCsvParams({ sort: "name" })).toEqual({
+      format: "csv",
+      sort: "name",
+    });
+  });
+
+  it.each(["surfaces", "endpoints", "subnets", "updated"])(
+    "drops the client-side-only %s sort",
+    (sort) => {
+      expect(providersCsvParams({ sort })).toEqual({ format: "csv" });
+    },
+  );
+
+  it("ignores empty-string search state", () => {
+    expect(providersCsvParams({ q: "", kind: "", authority: "", sort: "" })).toEqual({
+      format: "csv",
+    });
+  });
+});
+
+describe("providersCsvIsBroaderThanView", () => {
+  it("flags a text-filtered view, whose rows the export cannot reproduce", () => {
+    expect(providersCsvIsBroaderThanView({ q: "academia" })).toBe(true);
+  });
+
+  it("flags the 'high' authority shortcut", () => {
+    expect(providersCsvIsBroaderThanView({ authority: "high" })).toBe(true);
+  });
+
+  it("does not flag a view the export reproduces exactly", () => {
+    expect(providersCsvIsBroaderThanView({ authority: "official" })).toBe(false);
+    expect(providersCsvIsBroaderThanView({})).toBe(false);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/providers-csv-params.ts
+++ b/apps/ui/src/lib/metagraphed/providers-csv-params.ts
@@ -1,0 +1,42 @@
+import type { QueryParams } from "./client";
+
+/**
+ * Map the /providers page's search state onto the params `GET /api/v1/providers`
+ * actually honours, for the CSV export (#5665).
+ *
+ * Deliberately NOT a blind `{ ...search, format: "csv" }` spread. The providers
+ * collection registers `filters: [id, kind, authority]`, `search_keys: []`, and
+ * `sort_fields: [authority, id, kind, name]` (src/contracts.mjs), so:
+ *
+ * - `q` is a client-side-only filter here (unlike the subnets collection, whose
+ *   search_keys are populated). Forwarding it would be silently ignored by the
+ *   API and hand back every provider — a CSV that contradicts the filtered rows
+ *   on screen. It is dropped, and the button is labelled as a full export.
+ * - `surfaces`/`endpoints`/`subnets`/`updated` are computed client-side and are
+ *   not sortable server-side; only `name` overlaps, so only `name` is forwarded.
+ * - `authority: "high"` is a nav shortcut for "official + provider-claimed", not
+ *   a real authority value, so it cannot be pushed down to a single-value filter.
+ */
+export function providersCsvParams(search: {
+  q?: string;
+  kind?: string;
+  authority?: string;
+  sort?: string;
+}): QueryParams {
+  const params: QueryParams = { format: "csv" };
+  if (search.kind) params.kind = search.kind;
+  // "high" is a UI-only alias spanning two authority values -- not pushable.
+  if (search.authority && search.authority !== "high") {
+    params.authority = search.authority;
+  }
+  if (search.sort === "name") params.sort = "name";
+  return params;
+}
+
+/**
+ * True when the current view has filters the export cannot reproduce, i.e. the
+ * CSV would be broader than what the user is looking at.
+ */
+export function providersCsvIsBroaderThanView(search: { q?: string; authority?: string }): boolean {
+  return Boolean(search.q) || search.authority === "high";
+}

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -22,6 +22,11 @@ import {
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
 import { matchesQuery } from "@/lib/metagraphed/url-state";
 import { matchesProviderAuthority } from "@/lib/metagraphed/providers-url-state";
+import {
+  providersCsvParams,
+  providersCsvIsBroaderThanView,
+} from "@/lib/metagraphed/providers-csv-params";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { resolveProviderCard } from "@/lib/metagraphed/provider-card-fields";
 import { healthStatusSegments } from "@/lib/metagraphed/health-segments";
 import {
@@ -29,6 +34,7 @@ import {
   prefetchBrandIcon,
   PageHero,
   ViewModeToggle,
+  DownloadCsvButton,
   ShareButton,
   TimeAgo,
   ActionBar,
@@ -78,6 +84,13 @@ function ProvidersPage() {
     search.q || search.kind || search.authority || (search.sort && search.sort !== "name"),
   );
   const onReset = () => navigate({ search: { view: search.view } as never, replace: true });
+  const providersCsvUrl = buildUrl("/api/v1/providers", providersCsvParams(search));
+  // `q` (and the "high" authority alias) are client-side-only for this
+  // collection, so the export is broader than the on-screen rows -- say so in
+  // the label rather than handing back a CSV that quietly contradicts the view.
+  const csvLabel = providersCsvIsBroaderThanView(search)
+    ? "Download CSV (all providers)"
+    : "Download CSV";
   return (
     <AppShell>
       <PageHero
@@ -99,6 +112,7 @@ function ProvidersPage() {
             />
             <ActionBar>
               <ResetFiltersButton active={filtersActive} onReset={onReset} bare />
+              <DownloadCsvButton url={providersCsvUrl} label={csvLabel} bare />
               <ShareButton bare />
             </ActionBar>
           </>

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -19237,6 +19237,8 @@ export interface operations {
                 sort?: "authority" | "id" | "kind" | "name";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -19244,7 +19246,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19300,6 +19302,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProvidersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2648,6 +2648,17 @@
               "desc"
             ]
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -37984,6 +37984,19 @@
                 "desc"
               ]
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -38047,9 +38060,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -19237,6 +19237,8 @@ export interface operations {
                 sort?: "authority" | "id" | "kind" | "name";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -19244,7 +19246,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19300,6 +19302,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProvidersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1823,7 +1823,7 @@ export const API_ROUTES = [
     "List providers and sources.",
     "standard",
     ["providers"],
-    listQuery("providers"),
+    csvListQuery("providers"),
   ),
   route(
     "provider-detail",

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1263,10 +1263,11 @@ describe("subnets CSV export", () => {
   });
 
   test("Accept: text/csv is ignored for collection routes without CSV contracts", async () => {
-    // /api/v1/providers is a list route that intentionally has no CSV contract,
-    // so content negotiation must fall through to the JSON envelope.
+    // /api/v1/rpc/endpoints is a list route that intentionally has no CSV
+    // contract, so content negotiation must fall through to the JSON envelope.
+    // (/api/v1/providers held this role until #5665 gave it a CSV contract.)
     const res = await handleRequest(
-      req("/api/v1/providers?limit=1", {
+      req("/api/v1/rpc/endpoints?limit=1", {
         headers: { accept: "text/csv" },
       }),
       createLocalArtifactEnv(),
@@ -1277,7 +1278,6 @@ describe("subnets CSV export", () => {
 
     const body = await res.json();
     assert.equal(body.ok, true);
-    assert.equal(Array.isArray(body.data.providers), true);
   });
 
   test("empty projected CSV exports retain the requested header row", async () => {
@@ -1424,6 +1424,7 @@ describe("registry list CSV export", () => {
   };
 
   const CSV_ROUTES = [
+    "providers",
     "economics",
     "surfaces",
     "subnet-surfaces",
@@ -1450,7 +1451,9 @@ describe("registry list CSV export", () => {
   });
 
   test("list routes without a CSV contract stay JSON-only", () => {
-    for (const id of ["providers", "rpc-endpoints", "source-snapshots"]) {
+    // `providers` moved to a CSV contract in #5665 and is asserted by
+    // CSV_ROUTES above.
+    for (const id of ["rpc-endpoints", "source-snapshots"]) {
       const entry = API_ROUTES.find((route) => route.id === id);
       assert.ok(entry, `route ${id} should exist`);
       assert.notEqual(entry.csv_response, true, `${id} must stay JSON-only`);

--- a/tests/providers-csv.test.mjs
+++ b/tests/providers-csv.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+// GET /api/v1/providers?format=csv (#5665). The providers route was registered
+// with plain listQuery, so the contract-driven dispatcher never treated
+// ?format=csv as a CSV request; csvListQuery sets csvResponse on the route
+// entry. These cover the generic mechanism against this collection's own data
+// shape (array- and object-valued fields), which it had never been exercised
+// against.
+const req = (path) => new Request(`https://api.metagraph.sh${path}`);
+
+describe("providers CSV export", () => {
+  test("?format=csv returns text/csv as an attachment", async () => {
+    const res = await handleRequest(
+      req("/api/v1/providers?format=csv&limit=3"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="providers.csv"',
+    );
+  });
+
+  test("the CSV body carries a header row plus the projected rows", async () => {
+    const res = await handleRequest(
+      req("/api/v1/providers?format=csv&fields=id,name,kind&sort=name&order=asc&limit=2"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    const body = await res.text();
+    // RFC 4180: the CSV writer emits CRLF row separators.
+    const lines = body.trim().split(/\r?\n/);
+    assert.equal(lines[0], "id,name,kind");
+    assert.equal(lines.length, 3, "header + 2 rows");
+  });
+
+  test("json remains the default: no format param still returns the envelope", async () => {
+    const res = await handleRequest(
+      req("/api/v1/providers?limit=2"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^application\/json/);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+  });
+
+  test("the filters the CSV url forwards actually narrow the export", async () => {
+    const env = createLocalArtifactEnv();
+    const all = await handleRequest(
+      req("/api/v1/providers?format=csv&fields=id&limit=1000"),
+      env,
+      {},
+    );
+    const official = await handleRequest(
+      req("/api/v1/providers?format=csv&fields=id&authority=official&limit=1000"),
+      env,
+      {},
+    );
+    const allRows = (await all.text()).trim().split("\n").length;
+    const officialRows = (await official.text()).trim().split("\n").length;
+    assert.ok(officialRows > 1, "authority filter should still return rows");
+    assert.ok(
+      officialRows < allRows,
+      `authority=official (${officialRows}) should be a strict subset of all (${allRows})`,
+    );
+  });
+
+  test("object- and array-valued provider fields survive CSV serialization", async () => {
+    // `social` is object-valued and `netuids` is array-valued; the generic CSV
+    // path must quote/serialize them rather than emitting raw commas that would
+    // break the column count.
+    const res = await handleRequest(
+      req("/api/v1/providers?format=csv&fields=id,netuids,social&limit=1000"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    const body = await res.text();
+    // RFC 4180: the CSV writer emits CRLF row separators.
+    const lines = body.trim().split(/\r?\n/);
+    assert.equal(lines[0], "id,netuids,social");
+    // Every data row must still parse to exactly 3 top-level fields.
+    for (const line of lines.slice(1)) {
+      let inQuotes = false;
+      let fields = 1;
+      for (let i = 0; i < line.length; i += 1) {
+        const ch = line[i];
+        if (ch === '"') {
+          if (inQuotes && line[i + 1] === '"') i += 1;
+          else inQuotes = !inQuotes;
+        } else if (ch === "," && !inQuotes) fields += 1;
+      }
+      assert.equal(fields, 3, `row should keep 3 columns: ${line.slice(0, 80)}`);
+    }
+  });
+});

--- a/tests/providers-csv.test.mjs
+++ b/tests/providers-csv.test.mjs
@@ -28,7 +28,9 @@ describe("providers CSV export", () => {
 
   test("the CSV body carries a header row plus the projected rows", async () => {
     const res = await handleRequest(
-      req("/api/v1/providers?format=csv&fields=id,name,kind&sort=name&order=asc&limit=2"),
+      req(
+        "/api/v1/providers?format=csv&fields=id,name,kind&sort=name&order=asc&limit=2",
+      ),
       createLocalArtifactEnv(),
       {},
     );
@@ -59,7 +61,9 @@ describe("providers CSV export", () => {
       {},
     );
     const official = await handleRequest(
-      req("/api/v1/providers?format=csv&fields=id&authority=official&limit=1000"),
+      req(
+        "/api/v1/providers?format=csv&fields=id&authority=official&limit=1000",
+      ),
       env,
       {},
     );
@@ -96,7 +100,11 @@ describe("providers CSV export", () => {
           else inQuotes = !inQuotes;
         } else if (ch === "," && !inQuotes) fields += 1;
       }
-      assert.equal(fields, 3, `row should keep 3 columns: ${line.slice(0, 80)}`);
+      assert.equal(
+        fields,
+        3,
+        `row should keep 3 columns: ${line.slice(0, 80)}`,
+      );
     }
   });
 });


### PR DESCRIPTION
Closes #5665

## Screenshots

The Providers `PageHero` gains a **Download CSV** control between the view toggle and Share view — the same slot and order the sibling ranked-list pages use. Fixed-viewport captures (never fullPage), 3 viewports x 2 themes, before = `main`, after = this branch.

| Viewport | Before | After |
|---|---|---|
| **375x812** light | <img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/5665/providers-mobile-light-before.png" width="420"> | <img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/5665/providers-mobile-light-after.png" width="420"> |
| **375x812** dark | <img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/5665/providers-mobile-dark-before.png" width="420"> | <img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/5665/providers-mobile-dark-after.png" width="420"> |
| **768x1024** light | <img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/5665/providers-tablet-light-before.png" width="420"> | <img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/5665/providers-tablet-light-after.png" width="420"> |
| **768x1024** dark | <img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/5665/providers-tablet-dark-before.png" width="420"> | <img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/5665/providers-tablet-dark-after.png" width="420"> |
| **1280x800** light | <img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/5665/providers-desktop-light-before.png" width="420"> | <img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/5665/providers-desktop-light-after.png" width="420"> |
| **1280x800** dark | <img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/5665/providers-desktop-dark-before.png" width="420"> | <img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/5665/providers-desktop-dark-after.png" width="420"> |

## Backend

`/api/v1/providers` was registered with plain `listQuery("providers")` (`src/contracts.mjs`), so the contract-driven dispatcher never treated `?format=csv` as a CSV request — the frontend could send whatever it liked and still get JSON. Switching to `csvListQuery("providers")` sets `csv_response` on the route entry and adds the `format` parameter, matching the `subnets`/`candidates` precedent exactly.

## The CSV url is deliberately not a blind param spread

The issue suggests `buildUrl("/api/v1/providers", { ...currentQueryParams, format: "csv" })`. That would ship a silently wrong export here, because **providers is not shaped like subnets**:

- `API_QUERY_COLLECTIONS.providers` registers `filters: [id, kind, authority]` and **`search_keys: []`** — so `q` is a *client-side-only* filter on this page. Forwarding it is silently ignored by the API, which hands back all 133 providers. I verified this directly: `?q=academia&limit=500` returns **132 rows**, i.e. no filtering at all.
- `sort_fields: [authority, id, kind, name]`, but the page sorts by `name | surfaces | endpoints | subnets | updated` — only `name` overlaps; the other four are computed client-side.
- `authority=high` is a nav shortcut spanning two real authority values, not a filter value.

So `providersCsvParams` forwards **only what the API honours**, and when the view is narrower than the export can reproduce (a `q` search, or the `high` shortcut) the button relabels to **"Download CSV (all providers)"** rather than handing back a CSV that quietly contradicts the rows on screen. `?authority=official` genuinely narrows (132 -> 66), so it is pushed down.

## Verified end-to-end, not assumed

The issue explicitly says not to assume the generic mechanism works for a collection it has never been exercised against, since provider rows have array/object-valued fields. Against the real providers artifact:

- `?format=csv` -> `200`, `text/csv; charset=utf-8`, `content-disposition: attachment; filename="providers.csv"`.
- `social` (object-valued) serializes as a quoted JSON string and `netuids` (array-valued) flattens — a test asserts every row still parses to exactly the projected column count, so neither can break the CSV grid.
- JSON remains the default when `format` is absent.

The Playwright capture also **asserts** the control exists and that a `q`-filtered view relabels it, so the screenshots prove behaviour rather than just showing a picture:

```
PASS: Download CSV control present (1 match(es))
unfiltered label: "Download CSV"
q-filtered label : "Download CSV (all providers)"
PASS: q-filtered view relabels the export as a full download
```

## Tests & generated artifacts

- `tests/providers-csv.test.mjs` — 5 new cases (headers/attachment, projected rows, JSON default, filters narrowing the export, array/object serialization).
- `apps/ui/src/lib/metagraphed/providers-csv-params.test.ts` — 13 cases pinning exactly which params are forwarded and which are dropped.
- `tests/api-coverage.test.mjs` — its JSON-only guard encoded the old contract (`providers must stay JSON-only`). `providers` moves into `CSV_ROUTES`, and the content-negotiation case repoints at `rpc-endpoints`, which is still genuinely JSON-only.
- `openapi.json`, `types.d.ts` and `packages/contract/index.d.ts` regenerated per the generated-artifacts rule — `validate:contract-drift` and `validate:types` both pass.

Rebased to `behind: 0` immediately before pushing.
