### PR TITLE
chore(enrich): taostats identity gap-fills

### DIFF
--- a/registry/subnets/ain.json
+++ b/registry/subnets/ain.json
@@ -5,7 +5,7 @@
   "slug": "ain",
   "status": "active",
   "categories": ["baseline-curated", "identity-reviewed"],
-  "source_repo": null,
+  "source_repo": "https://github.com/HeraldMedia/herald",
   "website_url": "https://www.heraldmedia.ai/",
   "docs_url": null,
   "dashboard_url": null,

--- a/registry/subnets/bitsec.json
+++ b/registry/subnets/bitsec.json
@@ -70,6 +70,9 @@
       "url": "https://bitsec.ai/api/projects/known-solutions"
     }
   ],
+  "social": {
+    "x": "https://x.com/bitsecai"
+  },
   "source_repo": "https://github.com/Bitsec-AI/sandbox",
   "website_url": "https://bitsec.ai/"
 }

--- a/registry/subnets/mantis.json
+++ b/registry/subnets/mantis.json
@@ -12,7 +12,7 @@
   ],
   "source_repo": "https://github.com/Barbariandev/MANTIS",
   "dashboard_url": "https://taomarketcap.com/subnets/123",
-  "website_url": null,
+  "website_url": "https://mantis123.com",
   "notes": "Reviewed overlay for SN123 using the live MANTIS source repository and linked model-iteration SDK/tooling repository. No standalone website, docs site, public API, OpenAPI, SSE, or data artifact has been verified yet.",
   "curation": {
     "level": "maintainer-reviewed",


### PR DESCRIPTION
## Source

Third-party identity gap-fills sourced from the **taostats** `GET /api/subnet/identity/v1` endpoint. These are community-provenance fills for human review — not chain-authoritative.

## Fills

| Subnet | Field | Value |
|--------|-------|-------|
| SN69 ain (Herald) | `source_repo` | https://github.com/HeraldMedia/herald |
| SN60 Bitsec | `social.x` | https://x.com/bitsecai |
| SN123 MANTIS | `website_url` | https://mantis123.com |

## Methodology

- Only fields that were **null/missing** in the registry were filled (no overwrites)
- URLs verified live (HTTP 200) before inclusion
- Dropped 10 raw candidates: name mismatches (subnet changed owners), placeholder repos (`comingsoon`), generic opentensor resources, 404 repos, and junk values (`pending...`)
- Twitter handle `@bitsecai` converted to full URL via `socialAccounts()`
- All 3 files pass `validate:schemas` and `lint`
- Only `registry/subnets/*.json` modified — no generated artifact churn committed