### PR TITLE
fix(registry): make reviewed-tier verified_at/source_urls convention non-silent (#5739)

### DIFF
--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -49,6 +49,32 @@ const GRANDFATHERED_DUPLICATE_URLS = new Set([
   "gradients.json|https://api.gradients.io/v1/network/status",
 ]);
 
+// Reviewed-tier authorship convention + its acknowledged exemptions (#5739).
+// Files at the `maintainer-reviewed` / `adapter-backed` curation tier normally
+// pair a non-null `curation.verified_at` with their `reviewed_at` and carry a
+// proving `source_urls` on every surface. Exactly three entries deviate — and
+// they are a recognized class of specially-seeded, self-referential / pilot
+// manifests, recognizable by structural fields (never a filename allowlist):
+//   - the netuid-0 root/base-layer overlay, whose surfaces ARE the canonical
+//     Bittensor properties (a source_url "proving" bittensor.com is official
+//     would be circular) and whose RPC/WSS/archive kinds are maintainer-curated
+//     infrastructure rather than contributor surfaces; and
+//   - `partnership.tier: "pilot"` manifests (metagraphed's own dogfood subnet
+//     plus pilot partners), hand-seeded ahead of the automated review pipeline.
+// Those are exempt. ANY OTHER reviewed-tier entry that drops `verified_at` or a
+// surface's `source_urls` is surfaced as a non-blocking advisory below, so a
+// real future data gap is flagged rather than sitting silently ambiguous.
+const REVIEWED_AUTHORSHIP_TIERS = new Set([
+  "maintainer-reviewed",
+  "adapter-backed",
+]);
+
+function conventionExemption(document) {
+  if (document.netuid === 0) return "netuid-0 base-layer overlay";
+  if (document.partnership?.tier === "pilot") return "pilot manifest";
+  return null;
+}
+
 // Build the set of (netuid, normalized-url) keys for native-chain candidates that
 // are already machine-promoted (classification live or redirected). A community
 // surface duplicating one of these adds no signal — the build pipeline injects it
@@ -91,6 +117,8 @@ const files =
     : await listJsonFiles(path.join(repoRoot, "registry/subnets"));
 
 const errors = [];
+const conventionAdvisories = [];
+const conventionExemptions = [];
 let surfaceCount = 0;
 for (const file of files) {
   let document;
@@ -187,6 +215,36 @@ for (const file of files) {
       );
     }
   }
+
+  // Reviewed-tier verified_at/source_urls convention (#5739). Advisory, never a
+  // hard error: exempt entries (root / pilot manifests) are acknowledged, and
+  // any other reviewed-tier entry that deviates is flagged rather than silent.
+  if (REVIEWED_AUTHORSHIP_TIERS.has(document.curation?.level)) {
+    const missingSourceUrls = (document.surfaces || []).filter(
+      (surface) =>
+        !Array.isArray(surface.source_urls) || surface.source_urls.length === 0,
+    ).length;
+    const verifiedAtNull = document.curation?.verified_at == null;
+    if (verifiedAtNull || missingSourceUrls > 0) {
+      const label = path.basename(file);
+      const exemption = conventionExemption(document);
+      if (exemption) {
+        conventionExemptions.push(`${label} (${exemption})`);
+      } else {
+        const gaps = [];
+        if (verifiedAtNull) gaps.push("curation.verified_at is null");
+        if (missingSourceUrls > 0) {
+          gaps.push(`${missingSourceUrls} surface(s) lack source_urls`);
+        }
+        conventionAdvisories.push(
+          `${label}: ${document.curation.level} entry deviates from the ` +
+            `reviewed-tier convention (${gaps.join("; ")}). Backfill to match ` +
+            "the reviewed-tier shape, or mark it exempt if it is a " +
+            "self-referential/pilot manifest.",
+        );
+      }
+    }
+  }
 }
 
 if (errors.length > 0) {
@@ -200,6 +258,21 @@ if (errors.length > 0) {
 console.log(
   `Surface validation passed: ${surfaceCount} surface(s) across ${files.length} subnet file(s).`,
 );
+
+// #5739 — make the reviewed-tier convention non-silent: name the acknowledged
+// exemptions, and loudly flag any non-exempt deviation as a real data gap.
+if (conventionExemptions.length > 0) {
+  console.log(
+    `Reviewed-tier convention: ${conventionExemptions.length} acknowledged exemption(s) ` +
+      `(self-referential / pilot manifests) — ${conventionExemptions.join(", ")}.`,
+  );
+}
+if (conventionAdvisories.length > 0) {
+  console.warn(
+    `\nReviewed-tier convention advisory (${conventionAdvisories.length} — not blocking):`,
+  );
+  for (const advisory of conventionAdvisories) console.warn(`- ${advisory}`);
+}
 
 // ajv.errorsText() collapses every error to its bare `message`, which for an
 // `enum` keyword is the unhelpful "must be equal to one of the allowed

--- a/tests/validate-surface-reviewed-convention.test.mjs
+++ b/tests/validate-surface-reviewed-convention.test.mjs
@@ -1,0 +1,173 @@
+// Coverage for #5739: validate-surface.mjs now makes the reviewed-tier
+// verified_at/source_urls convention non-silent. Reviewed-tier
+// (maintainer-reviewed / adapter-backed) entries that drop verified_at or a
+// surface's source_urls are surfaced as a NON-BLOCKING advisory, EXCEPT the
+// acknowledged self-referential exemptions (netuid-0 base-layer overlay and
+// partnership.tier "pilot" manifests), which are named instead of flagged.
+// Mirrors validate-surface-duplicate-url.test.mjs's subprocess-fixture pattern.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, test } from "vitest";
+import { repoRoot } from "../scripts/lib.mjs";
+
+// spawnSync (not execFileSync) so stderr is captured even on a passing run —
+// the non-blocking convention advisory is written to stderr via console.warn.
+function runNode(args) {
+  const result = spawnSync(process.execPath, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  return {
+    status: result.status ?? 1,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+describe("validate-surface.mjs reviewed-tier convention (#5739)", () => {
+  let tempDir;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  function writeFixture(document) {
+    tempDir = mkdtempSync(`${tmpdir()}/metagraphed-validate-surface-conv-`);
+    const fixturePath = path.join(tempDir, "fixture.json");
+    writeFileSync(fixturePath, JSON.stringify(document, null, 2));
+    return fixturePath;
+  }
+
+  const base = {
+    schema_version: 1,
+    netuid: 999,
+    slug: "fixture",
+    name: "Fixture Subnet",
+    status: "active",
+    categories: [],
+    links: [],
+    surfaces: [],
+  };
+
+  test("flags (advisory, not failing) a non-exempt reviewed-tier entry with null verified_at", () => {
+    const fixturePath = writeFixture({
+      ...base,
+      curation: {
+        level: "maintainer-reviewed",
+        review_state: "maintainer-reviewed",
+        verified_at: null,
+      },
+    });
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    // Advisory only — the entry is still valid, so the run must pass.
+    assert.equal(status, 0, output);
+    assert.match(output, /convention advisory/i);
+    assert.match(output, /curation\.verified_at is null/);
+  });
+
+  test("flags a non-exempt reviewed-tier surface missing source_urls", () => {
+    const fixturePath = writeFixture({
+      ...base,
+      curation: {
+        level: "adapter-backed",
+        review_state: "maintainer-reviewed",
+        verified_at: "2026-06-06T00:00:00.000Z",
+      },
+      surfaces: [
+        {
+          id: "fixture-api",
+          kind: "subnet-api",
+          name: "Fixture API",
+          url: "https://api.fixture.example/v1",
+          provider: "academia",
+          authority: "community",
+          auth_required: false,
+          public_safe: true,
+          review: { state: "community-submitted" },
+        },
+      ],
+    });
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 0, output);
+    assert.match(output, /convention advisory/i);
+    assert.match(output, /lack source_urls/);
+  });
+
+  test("acknowledges (does not flag) a pilot manifest with the same gap", () => {
+    const fixturePath = writeFixture({
+      ...base,
+      partnership: { tier: "pilot", since: "2026-07-04" },
+      curation: {
+        level: "adapter-backed",
+        review_state: "maintainer-reviewed",
+        verified_at: null,
+      },
+    });
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 0, output);
+    assert.match(output, /acknowledged exemption/i);
+    assert.match(output, /pilot manifest/);
+    assert.doesNotMatch(output, /convention advisory/i);
+  });
+
+  test("acknowledges the netuid-0 base-layer overlay as exempt", () => {
+    const fixturePath = writeFixture({
+      ...base,
+      netuid: 0,
+      name: "root",
+      slug: "root",
+      curation: {
+        level: "maintainer-reviewed",
+        review_state: "maintainer-reviewed",
+        verified_at: null,
+      },
+    });
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 0, output);
+    assert.match(output, /base-layer overlay/);
+    assert.doesNotMatch(output, /convention advisory/i);
+  });
+
+  test("the three live exempt files are acknowledged, not flagged", () => {
+    // Pin to the three named files rather than a no-args full-corpus scan:
+    // other tests (validate-error-messages) mutate registry/subnets/*.json
+    // in place under parallel vitest, which races a full-corpus run.
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      "registry/subnets/root.json",
+      "registry/subnets/gittensor.json",
+      "registry/subnets/allways.json",
+    ]);
+    assert.equal(status, 0, output);
+    assert.match(output, /acknowledged exemption/i);
+    assert.match(output, /root\.json/);
+    assert.match(output, /gittensor\.json/);
+    assert.match(output, /allways\.json/);
+    assert.doesNotMatch(output, /convention advisory/i);
+  });
+});


### PR DESCRIPTION
Closes #5739

## Template Used

backend-code

## Summary

Resolves the silent ambiguity in #5739. Reviewed-tier (`maintainer-reviewed` / `adapter-backed`) entries normally pair a non-null `curation.verified_at` with `reviewed_at` and carry proving `source_urls` on every surface. Exactly three files deviate — `root.json` (SN0), `gittensor.json` (SN74), `allways.json` (SN7) — and `validate:surface` said nothing.

## Decision: intentional exemption (documented), not a silent data gap

These three are a recognized class of specially-seeded, self-referential / pilot manifests:

- **root.json** — netuid-0 base-layer overlay. Its surfaces are the canonical Bittensor properties; RPC/WSS/archive kinds are maintainer-curated infrastructure, not contributor surfaces.
- **gittensor.json + allways.json** — both `partnership.tier: "pilot"` (dogfood + pilot partner), hand-seeded with the same midnight `reviewed_at` ahead of the automated review pipeline.

A contributor data backfill against these curated manifests is the wrong lane (see closed #5818 — Registry surface review hard-close). The issue explicitly allows documenting an intentional exemption instead; that is what this PR does.

Partial `source_urls` already present on some surfaces in these files does not undermine the exemption: later community additions filled some surfaces, while the hand-seeded core still carries null `verified_at` + remaining gaps. Treating the *authoring class* as exempt ends the silent ambiguity without inventing provenance.

`curation.gap_notes` is untouched per the issue scope.

## What Changed

- `scripts/validate-surface.mjs` — enforces the convention as a **non-blocking advisory**, keyed on structural fields (`netuid === 0` OR `partnership.tier === "pilot"`), never a filename allowlist. Exempt entries are named on every run; any other reviewed-tier deviation is flagged.
- `tests/validate-surface-reviewed-convention.test.mjs` — 5 cases (advisory on non-exempt `verified_at` / `source_urls` gaps; pilot + netuid-0 fixtures acknowledged; the three live files validated and acknowledged without a flaky full-corpus scan).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5739`)
- [x] No secrets / private URLs
- [x] No generated artifacts hand-edited
- [x] No registry data touched (gap_notes left alone)

## Validation

- [x] `node scripts/validate-surface.mjs registry/subnets/root.json registry/subnets/gittensor.json registry/subnets/allways.json` — pass, 3 acknowledged exemptions
- [x] `node scripts/validate-surface.mjs` — pass (851 surfaces / 129 files), 3 exemptions, 0 advisories
- [x] `npx vitest run tests/validate-surface-reviewed-convention.test.mjs` — 5/5
- [x] `npx vitest run tests/validate-surface-duplicate-url.test.mjs` — 5/5
- [x] `npx eslint` + `npx prettier --check` on touched files
- [x] `git diff --check`