### PR TITLE
fix(registry): drop redundant bitmind data-artifact duplicating the subnet-api URL (#5736)

### DIFF
--- a/registry/subnets/bitmind.json
+++ b/registry/subnets/bitmind.json
@@ -110,28 +110,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-34-bitmind-data-artifact",
-      "kind": "data-artifact",
-      "name": "BitMind community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "bitmind",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.bitmind.ai/openapi.json"],
-      "url": "https://api.bitmind.ai/health"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-34-bitmind-openapi",
       "kind": "openapi",
       "name": "BitMind community openapi",


### PR DESCRIPTION
## Summary

Closes #5736.

> Scope note: this PR resolves the **bitmind (SN34)** case of #5736. The issue also names allways (SN7) and gradients (SN56); those are separate one-subnet-per-PR changes per the repo's "one subnet = one file = one PR" rule, so they are intentionally not bundled here. If the maintainer wants the issue kept open for the other two, please reopen after merge.

`registry/subnets/bitmind.json` (SN34) registered the exact same URL twice under two surface kinds, both live in the file:

- `sn-34-bitmind-data-artifact` — `kind: data-artifact`
- `sn-34-bitmind-subnet-api` — `kind: subnet-api`

both pointing at `https://api.bitmind.ai/health` (both `authority: community`, submitted by the same contributor).

**Resolution:** `https://api.bitmind.ai/health` returns a live JSON status document — verified `HTTP 200`, body `{"status":"healthy","region":"europe-west1","version":"1.0.0"}` — so **`subnet-api` is the accurate kind** for a queryable status endpoint; `data-artifact` implies a standalone static file, which this is not. I removed the `data-artifact` entry and kept the `subnet-api` one.

The removed entry's only `source_urls` value (`https://api.bitmind.ai/openapi.json`) is already covered by the file's separate `sn-34-bitmind-openapi` surface, so no attribution needed folding into the surviving entry. No other surface and no top-level field (`schema_version`/`curation`/…) is touched.

This follows the single-file model and mirrors the merged #5750 (`fix(registry): drop redundant nodexo source-repo surface`), which removed one redundant surface from exactly one `registry/subnets/*.json` file. This PR resolves only the **bitmind** case in #5736; the allways and gradients cases are separate one-subnet-per-PR changes, per the "one subnet = one file = one PR" rule.

## Template Used

- Backend/code change (`backend-code.md`) — registry data fix.

## Test plan

- [x] Removed the one redundant `data-artifact` surface entry; only `registry/subnets/bitmind.json` is in the diff (22 deletions).
- [x] `npm run validate:surface -- registry/subnets/bitmind.json` — passes (9 surfaces, no duplicate URLs; satisfies the duplicate-URL guard added in #5797).
- [x] `npm run scan:public-safety` — passes.
- [x] `npm run validate` (after `npm run build`) — passes: 129 native subnets, 1614 surfaces, 133 providers.
- [x] `public/metagraph/operational-surfaces.json`, `public/metagraph/r2-manifest.json`, and `public/metagraph/schemas/index.json` are **not** in the diff — all three are build-regenerated / deploy-owned (the freshness gate in `.github/workflows/validate.yml` explicitly excludes `operational-surfaces.json`), reverted against `upstream/main` per the contributor guide.
- [x] The surviving `/health` `subnet-api` surface is live (HTTP 200), so no dead surface is left behind.

## Safety

- [x] No secrets, private/localhost URLs, or credentials. Only a public health endpoint remains registered.
- [x] No generated `public/metagraph/**` artifacts, scripts, workflows, or a second subnet file committed.
