### PR TITLE
fix(registry): backfill verified_at + source_urls on root/gittensor/a…

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -9,7 +9,7 @@
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-06T00:00:00.000Z",
     "source_count": 3,
-    "verified_at": null
+    "verified_at": "2026-06-06T00:00:00.000Z"
   },
   "dashboard_url": null,
   "docs_url": "https://docs.all-ways.io/how-it-works.html",
@@ -57,6 +57,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://docs.all-ways.io/how-it-works.html"],
       "url": "https://docs.all-ways.io/how-it-works.html"
     },
     {
@@ -72,6 +73,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://all-ways.io/"],
       "url": "https://all-ways.io/"
     },
     {
@@ -87,6 +89,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://docs.all-ways.io/how-it-works.html",
+        "https://github.com/entrius/allways"
+      ],
       "url": "https://github.com/entrius/allways"
     },
     {
@@ -104,6 +110,10 @@
       "public_safe": true,
       "schema_status": "machine-readable",
       "schema_url": "https://api.all-ways.io/swagger-json",
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://github.com/entrius/allways"
+      ],
       "url": "https://api.all-ways.io/swagger"
     },
     {
@@ -119,6 +129,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/health"
     },
     {
@@ -134,6 +148,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/protocol/constants"
     },
     {
@@ -149,6 +167,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/protocol/chain-state"
     },
     {
@@ -164,6 +186,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/network/overview"
     },
     {
@@ -179,6 +205,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/miners"
     },
     {
@@ -194,6 +224,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/miners/leaderboard"
     },
     {
@@ -209,6 +243,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/miners/reliability"
     },
     {
@@ -224,6 +262,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/events/latest"
     },
     {
@@ -239,6 +281,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/crown"
     },
     {
@@ -255,6 +301,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/crown/history"
     },
     {
@@ -271,6 +321,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/sse"
     },
     {

--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -11,7 +11,7 @@
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-06T00:00:00.000Z",
     "source_count": 5,
-    "verified_at": null
+    "verified_at": "2026-06-06T00:00:00.000Z"
   },
   "dashboard_url": null,
   "docs_url": "https://docs.gittensor.io/",
@@ -63,6 +63,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://docs.gittensor.io/"],
       "url": "https://docs.gittensor.io/"
     },
     {
@@ -78,6 +79,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://gittensor.io/"],
       "url": "https://gittensor.io/"
     },
     {
@@ -93,6 +95,10 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": [
+        "https://docs.gittensor.io/",
+        "https://github.com/entrius/gittensor"
+      ],
       "url": "https://github.com/entrius/gittensor"
     },
     {
@@ -108,6 +114,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://docs.gittensor.io/register-repository.html"],
       "url": "https://docs.gittensor.io/register-repository.html"
     },
     {
@@ -123,6 +130,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://docs.gittensor.io/repository-hyperparameters"],
       "url": "https://docs.gittensor.io/repository-hyperparameters"
     },
     {
@@ -207,6 +215,7 @@
       },
       "provider": "gittensory",
       "public_safe": true,
+      "source_urls": ["https://gittensory.aethereal.dev/"],
       "url": "https://gittensory.aethereal.dev/"
     },
     {

--- a/registry/subnets/root.json
+++ b/registry/subnets/root.json
@@ -9,7 +9,7 @@
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-06T00:00:00.000Z",
     "source_count": 6,
-    "verified_at": null
+    "verified_at": "2026-06-06T00:00:00.000Z"
   },
   "dashboard_url": "https://taomarketcap.com/subnets/0",
   "docs_url": "https://docs.learnbittensor.org/concepts/bittensor-networks",
@@ -35,6 +35,9 @@
       },
       "provider": "opentensor",
       "public_safe": true,
+      "source_urls": [
+        "https://docs.learnbittensor.org/concepts/bittensor-networks"
+      ],
       "url": "https://docs.learnbittensor.org/concepts/bittensor-networks"
     },
     {
@@ -50,6 +53,7 @@
       },
       "provider": "opentensor",
       "public_safe": true,
+      "source_urls": ["https://docs.learnbittensor.org/subtensor-nodes"],
       "url": "https://docs.learnbittensor.org/subtensor-nodes"
     },
     {
@@ -65,6 +69,7 @@
       },
       "provider": "opentensor",
       "public_safe": true,
+      "source_urls": ["https://bittensor.com"],
       "url": "https://bittensor.com"
     },
     {
@@ -80,6 +85,10 @@
       },
       "provider": "opentensor",
       "public_safe": true,
+      "source_urls": [
+        "https://docs.learnbittensor.org/concepts/bittensor-networks",
+        "https://github.com/opentensor/subtensor"
+      ],
       "url": "https://github.com/opentensor/subtensor"
     },
     {


### PR DESCRIPTION
Closes (#5739)

root.json, gittensor.json, and allways.json were seeded via a manual pilot-onboarding pass rather than the automated review pipeline, so they were the only 3 of 90 maintainer-reviewed/adapter-backed subnet files with a null curation.verified_at, and the only ones whose official/provider-claimed surfaces lacked source_urls (25 surfaces across the 3 files). Every other reviewed-tier file, including self-referential official surfaces (see chutes.json), pairs verified_at with reviewed_at and carries source_urls on every surface, so this is accidental drift rather than an intentional exemption.

Backfill verified_at to match reviewed_at, and add source_urls to each affected surface following the established convention: a self-proving URL for docs/website surfaces, and a citing doc page for source-repo/ subnet-api surfaces on the same host.

## Pick The Right Template

Use the matching PR template so the submission gate can classify your PR
correctly:

- [Subnet surface](?template=surface.md): one `registry/subnets/<slug>.json`
  file — a community surface added with `npm run surface:add`; for a missing
  subnet manifest, scaffold it first with `npm run subnet:new` in the same file
  (optionally plus one `registry/providers/*.json` for a debut provider).
- [Provider/operator profile](?template=provider-profile.md): one
  `registry/providers/*.json` file only.
- [Backend/code change](?template=backend-code.md): scripts, schemas,
  contracts, workflows, or registry generator logic.
- [Docs-only change](?template=docs-only.md): README or docs edits only.

For data submissions, do not edit generated `public/metagraph/**` artifacts,
native snapshots, scripts, workflows, or package files.
