### PR TITLE
fix(registry): dedupe same-URL surfaces under two kinds (#5736)

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -276,28 +276,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-7-allways-data-artifact",
-      "kind": "data-artifact",
-      "name": "Allways community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "allways",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.all-ways.io/swagger-json"],
-      "url": "https://api.all-ways.io/miners/leaderboard"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-7-allways-subnet-api",
       "kind": "subnet-api",
       "name": "Allways swaps API",

--- a/registry/subnets/bitmind.json
+++ b/registry/subnets/bitmind.json
@@ -110,28 +110,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-34-bitmind-data-artifact",
-      "kind": "data-artifact",
-      "name": "BitMind community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "bitmind",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.bitmind.ai/openapi.json"],
-      "url": "https://api.bitmind.ai/health"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-34-bitmind-openapi",
       "kind": "openapi",
       "name": "BitMind community openapi",

--- a/registry/subnets/gradients.json
+++ b/registry/subnets/gradients.json
@@ -199,28 +199,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-56-gradients-data-artifact",
-      "kind": "data-artifact",
-      "name": "Gradients community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "gradients",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.gradients.io/docs"],
-      "url": "https://api.gradients.io/v1/network/status"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-56-gradients-subnet-api",
       "kind": "subnet-api",
       "name": "Gradients network status API",

--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -43,10 +43,10 @@ const BASE_LAYER_KINDS = new Set(["subtensor-rpc", "subtensor-wss", "archive"]);
 // 4th instance this check additionally surfaced. Remove an entry here once
 // its underlying duplicate is actually resolved in the registry file.
 const GRANDFATHERED_DUPLICATE_URLS = new Set([
+  // 8-ball still has a same-URL website/source-repo pair; leave listed until that
+  // case is resolved separately. The allways/bitmind/gradients triples from #5736
+  // were removed, so they are no longer grandfathered.
   "8-ball.json|https://github.com/Barbariandev/8Ball_miner",
-  "allways.json|https://api.all-ways.io/miners/leaderboard",
-  "bitmind.json|https://api.bitmind.ai/health",
-  "gradients.json|https://api.gradients.io/v1/network/status",
 ]);
 
 // Build the set of (netuid, normalized-url) keys for native-chain candidates that


### PR DESCRIPTION
## Summary

Closes #5736.

Three subnet files each registered the same URL twice under `data-artifact` and `subnet-api`. Removed the redundant `data-artifact` entry in each file and kept the `subnet-api` surface (live queryable JSON endpoints, not static artifacts).

Also dropped the three resolved URLs from `GRANDFATHERED_DUPLICATE_URLS` in `scripts/validate-surface.mjs` so the duplicate-URL guard stays honest (the `8-ball` grandfather remains).

## What Changed

- `registry/subnets/allways.json` — remove `sn-7-allways-data-artifact`
- `registry/subnets/bitmind.json` — remove `sn-34-bitmind-data-artifact`
- `registry/subnets/gradients.json` — remove `sn-56-gradients-data-artifact`
- `scripts/validate-surface.mjs` — remove the three resolved grandfather allowlist entries

No other surfaces or top-level fields touched. No generated `public/metagraph/**` artifacts.

## Validation

- [x] `npm run validate:surface -- registry/subnets/allways.json registry/subnets/bitmind.json registry/subnets/gradients.json`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`

Closes #5736.