### PR TITLE
feat(providers): wire Download CSV into Providers page

### DIFF
--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/lib/metagraphed/queries";
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
 import { matchesQuery } from "@/lib/metagraphed/url-state";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { matchesProviderAuthority } from "@/lib/metagraphed/providers-url-state";
 import { resolveProviderCard } from "@/lib/metagraphed/provider-card-fields";
 import { healthStatusSegments } from "@/lib/metagraphed/health-segments";
@@ -30,6 +31,7 @@ import {
   PageHero,
   ViewModeToggle,
   ShareButton,
+  DownloadCsvButton,
   TimeAgo,
   ActionBar,
   Donut,
@@ -70,6 +72,19 @@ export const Route = createFileRoute("/providers/")({
   component: ProvidersPage,
 });
 
+type ProvidersSearch = z.infer<typeof providersSearchSchema>;
+
+/** Server-backed params for CSV export — client-only filters (q, high, count sorts) stay UI-side. */
+function providersQueryParams(search: ProvidersSearch) {
+  const authority =
+    search.authority && search.authority !== "high" ? search.authority : undefined;
+  return {
+    kind: search.kind || undefined,
+    authority,
+    sort: search.sort === "name" ? "name" : undefined,
+  };
+}
+
 function ProvidersPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
@@ -78,6 +93,7 @@ function ProvidersPage() {
     search.q || search.kind || search.authority || (search.sort && search.sort !== "name"),
   );
   const onReset = () => navigate({ search: { view: search.view } as never, replace: true });
+  const providersCsvUrl = buildUrl("/api/v1/providers", providersQueryParams(search));
   return (
     <AppShell>
       <PageHero
@@ -99,6 +115,7 @@ function ProvidersPage() {
             />
             <ActionBar>
               <ResetFiltersButton active={filtersActive} onReset={onReset} bare />
+              <DownloadCsvButton url={providersCsvUrl} bare />
               <ShareButton bare />
             </ActionBar>
           </>

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -76,8 +76,7 @@ type ProvidersSearch = z.infer<typeof providersSearchSchema>;
 
 /** Server-backed params for CSV export — client-only filters (q, high, count sorts) stay UI-side. */
 function providersQueryParams(search: ProvidersSearch) {
-  const authority =
-    search.authority && search.authority !== "high" ? search.authority : undefined;
+  const authority = search.authority && search.authority !== "high" ? search.authority : undefined;
   return {
     kind: search.kind || undefined,
     authority,

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -19237,6 +19237,8 @@ export interface operations {
                 sort?: "authority" | "id" | "kind" | "name";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -19244,7 +19246,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19300,6 +19302,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProvidersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2648,6 +2648,17 @@
               "desc"
             ]
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -37984,6 +37984,19 @@
                 "desc"
               ]
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -38047,9 +38060,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -19237,6 +19237,8 @@ export interface operations {
                 sort?: "authority" | "id" | "kind" | "name";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -19244,7 +19246,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19300,6 +19302,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProvidersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1823,7 +1823,7 @@ export const API_ROUTES = [
     "List providers and sources.",
     "standard",
     ["providers"],
-    listQuery("providers"),
+    csvListQuery("providers"),
   ),
   route(
     "provider-detail",

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1263,10 +1263,10 @@ describe("subnets CSV export", () => {
   });
 
   test("Accept: text/csv is ignored for collection routes without CSV contracts", async () => {
-    // /api/v1/providers is a list route that intentionally has no CSV contract,
-    // so content negotiation must fall through to the JSON envelope.
+    // /api/v1/source-snapshots is a list route with no CSV contract, so content
+    // negotiation must fall through to the JSON envelope.
     const res = await handleRequest(
-      req("/api/v1/providers?limit=1", {
+      req("/api/v1/source-snapshots?limit=1", {
         headers: { accept: "text/csv" },
       }),
       createLocalArtifactEnv(),
@@ -1277,7 +1277,7 @@ describe("subnets CSV export", () => {
 
     const body = await res.json();
     assert.equal(body.ok, true);
-    assert.equal(Array.isArray(body.data.providers), true);
+    assert.equal(Array.isArray(body.data.sources), true);
   });
 
   test("empty projected CSV exports retain the requested header row", async () => {
@@ -1425,6 +1425,7 @@ describe("registry list CSV export", () => {
 
   const CSV_ROUTES = [
     "economics",
+    "providers",
     "surfaces",
     "subnet-surfaces",
     "endpoints",
@@ -1450,7 +1451,7 @@ describe("registry list CSV export", () => {
   });
 
   test("list routes without a CSV contract stay JSON-only", () => {
-    for (const id of ["providers", "rpc-endpoints", "source-snapshots"]) {
+    for (const id of ["rpc-endpoints", "source-snapshots"]) {
       const entry = API_ROUTES.find((route) => route.id === id);
       assert.ok(entry, `route ${id} should exist`);
       assert.notEqual(entry.csv_response, true, `${id} must stay JSON-only`);
@@ -1461,6 +1462,7 @@ describe("registry list CSV export", () => {
   // a text/csv attachment named after the route id with a header row.
   for (const [path, filename] of [
     ["/api/v1/economics", "economics.csv"],
+    ["/api/v1/providers", "providers.csv"],
     ["/api/v1/surfaces", "surfaces.csv"],
     ["/api/v1/endpoints", "endpoints.csv"],
     ["/api/v1/candidates", "candidates.csv"],


### PR DESCRIPTION
## Summary

Closes #5665.

Wires CSV export for the Providers ranked-list page end-to-end: enable `csvListQuery` on `GET /api/v1/providers`, regenerate OpenAPI so `format=json|csv` is advertised, and add `DownloadCsvButton` to the Providers `PageHero` actions (matching Subnets / Surfaces / Validators).

## What Changed

- `src/contracts.mjs`: `providers` route uses `csvListQuery("providers")` (no `exclude` needed — arrays/objects flatten via the generic CSV serializer).
- `public/metagraph/openapi.json`: regenerated (`npm run openapi:generate`) — `/api/v1/providers` now exposes `format` and a `text/csv` response.
- `apps/ui/src/routes/providers.index.tsx`: `DownloadCsvButton` in `ActionBar` beside `ShareButton`, URL built with `buildUrl("/api/v1/providers", …)` for server-backed kind/authority/sort params.
- `tests/api-coverage.test.mjs`: providers added to CSV contract + named `text/csv` download coverage; the "JSON-only list routes" fixture now uses `source-snapshots` instead of providers.

## Template Used

Backend/code change (`backend-code.md`) + frontend visual evidence (Path C screenshot table).

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-after-desktop-light.png)<br><sub>after — Download CSV in hero</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/screenshots/5665-providers-after-mobile-dark.png)<br><sub>after</sub> |

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5665`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (`npm run openapi:generate`).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (providers list gains optional `format=csv`).

## Validation

- [x] `npm run validate:openapi`
- [x] `npm test -- tests/api-coverage.test.mjs -t "…providers…/CSV…"` (includes `GET /api/v1/providers?format=csv` → `text/csv` + `providers.csv` disposition)
- [x] `npm test -- tests/contracts.test.mjs`
- [x] `git diff --check`
- [ ] Full `npm run check` / `worker:test` / `test:coverage` suite left to CI (focused local run above covers the changed surface)

## Test plan

- [ ] Open `/providers` — hero shows **Download CSV** beside Share.
- [ ] Click Download CSV — browser receives `text/csv` attachment `providers.csv` (post-deploy; currently live API still rejects `format=csv` until this merges).
- [ ] OpenAPI at `/api/v1/openapi.json` lists `format` on `/api/v1/providers`.
- [ ] Filters: `kind` / `authority` (non-`high`) / `sort=name` are forwarded on the CSV URL; client-only `q` / `high` / count sorts remain UI-side.

Made with [Cursor](https://cursor.com)