### PR TITLE
fix(registry): backfill verified_at + source_urls on root/gittensor/a…

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -9,7 +9,7 @@
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-06T00:00:00.000Z",
     "source_count": 3,
-    "verified_at": null
+    "verified_at": "2026-06-06T00:00:00.000Z"
   },
   "dashboard_url": null,
   "docs_url": "https://docs.all-ways.io/how-it-works.html",
@@ -57,6 +57,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://docs.all-ways.io/how-it-works.html"],
       "url": "https://docs.all-ways.io/how-it-works.html"
     },
     {
@@ -72,6 +73,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://all-ways.io/"],
       "url": "https://all-ways.io/"
     },
     {
@@ -87,6 +89,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://docs.all-ways.io/how-it-works.html",
+        "https://github.com/entrius/allways"
+      ],
       "url": "https://github.com/entrius/allways"
     },
     {
@@ -104,6 +110,10 @@
       "public_safe": true,
       "schema_status": "machine-readable",
       "schema_url": "https://api.all-ways.io/swagger-json",
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://github.com/entrius/allways"
+      ],
       "url": "https://api.all-ways.io/swagger"
     },
     {
@@ -119,6 +129,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/health"
     },
     {
@@ -134,6 +148,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/protocol/constants"
     },
     {
@@ -149,6 +167,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/protocol/chain-state"
     },
     {
@@ -164,6 +186,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/network/overview"
     },
     {
@@ -179,6 +205,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/miners"
     },
     {
@@ -194,6 +224,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/miners/leaderboard"
     },
     {
@@ -209,6 +243,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/miners/reliability"
     },
     {
@@ -224,6 +262,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/events/latest"
     },
     {
@@ -239,6 +281,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/crown"
     },
     {
@@ -255,6 +301,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/crown/history"
     },
     {
@@ -271,6 +321,10 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": [
+        "https://api.all-ways.io/swagger-json",
+        "https://api.all-ways.io/swagger"
+      ],
       "url": "https://api.all-ways.io/sse"
     },
     {

--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -11,7 +11,7 @@
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-06T00:00:00.000Z",
     "source_count": 5,
-    "verified_at": null
+    "verified_at": "2026-06-06T00:00:00.000Z"
   },
   "dashboard_url": null,
   "docs_url": "https://docs.gittensor.io/",
@@ -63,6 +63,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://docs.gittensor.io/"],
       "url": "https://docs.gittensor.io/"
     },
     {
@@ -78,6 +79,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://gittensor.io/"],
       "url": "https://gittensor.io/"
     },
     {
@@ -93,6 +95,10 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": [
+        "https://docs.gittensor.io/",
+        "https://github.com/entrius/gittensor"
+      ],
       "url": "https://github.com/entrius/gittensor"
     },
     {
@@ -108,6 +114,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://docs.gittensor.io/register-repository.html"],
       "url": "https://docs.gittensor.io/register-repository.html"
     },
     {
@@ -123,6 +130,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://docs.gittensor.io/repository-hyperparameters"],
       "url": "https://docs.gittensor.io/repository-hyperparameters"
     },
     {
@@ -207,6 +215,7 @@
       },
       "provider": "gittensory",
       "public_safe": true,
+      "source_urls": ["https://gittensory.aethereal.dev/"],
       "url": "https://gittensory.aethereal.dev/"
     },
     {

--- a/registry/subnets/root.json
+++ b/registry/subnets/root.json
@@ -9,7 +9,7 @@
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-06T00:00:00.000Z",
     "source_count": 6,
-    "verified_at": null
+    "verified_at": "2026-06-06T00:00:00.000Z"
   },
   "dashboard_url": "https://taomarketcap.com/subnets/0",
   "docs_url": "https://docs.learnbittensor.org/concepts/bittensor-networks",
@@ -35,6 +35,9 @@
       },
       "provider": "opentensor",
       "public_safe": true,
+      "source_urls": [
+        "https://docs.learnbittensor.org/concepts/bittensor-networks"
+      ],
       "url": "https://docs.learnbittensor.org/concepts/bittensor-networks"
     },
     {
@@ -50,6 +53,7 @@
       },
       "provider": "opentensor",
       "public_safe": true,
+      "source_urls": ["https://docs.learnbittensor.org/subtensor-nodes"],
       "url": "https://docs.learnbittensor.org/subtensor-nodes"
     },
     {
@@ -65,6 +69,7 @@
       },
       "provider": "opentensor",
       "public_safe": true,
+      "source_urls": ["https://bittensor.com"],
       "url": "https://bittensor.com"
     },
     {
@@ -80,6 +85,10 @@
       },
       "provider": "opentensor",
       "public_safe": true,
+      "source_urls": [
+        "https://docs.learnbittensor.org/concepts/bittensor-networks",
+        "https://github.com/opentensor/subtensor"
+      ],
       "url": "https://github.com/opentensor/subtensor"
     },
     {


### PR DESCRIPTION
## Summary

Backfills `curation.verified_at` and per-surface `source_urls` on `registry/subnets/root.json`, `gittensor.json`, and `allways.json` — the only 3 of 90 maintainer-reviewed/adapter-backed subnet files in the registry with a null `verified_at`, and the only ones whose official/provider-claimed surfaces lacked `source_urls` (25 surfaces total: 4 on root.json, 6 on gittensor.json, 15 on allways.json).

Closes #5739

## What Changed

- Verified this is accidental drift, not an intentional exemption: all 3 files share an identical, unusually-formatted `reviewed_at` (`2026-06-06T00:00:00.000Z`, exact midnight vs. the specific time-of-day stamps every other reviewed file uses), indicating a manual pilot-onboarding seed rather than the automated review pipeline. Every other maintainer-reviewed/adapter-backed file in the corpus pairs `verified_at` with `reviewed_at`, and the reference shape for a normal reviewed-tier file (`chutes.json`) shows even self-referential official surfaces (website/docs/source-repo) carry `source_urls` — so there's no established exemption category for these 3 files to fall into.
- `curation.verified_at` backfilled to match `curation.reviewed_at` in all 3 files.
- `source_urls` added to each of the 25 affected surfaces, following the established convention: a self-proving URL for docs/website surfaces, a citing doc page for source-repo surfaces, and the swagger/OpenAPI doc pages for API endpoints on the same host.
- `curation.gap_notes` deliberately left untouched (out of scope per the issue).
- No other fields touched: no surfaces added/removed, no changes to `status`, `categories`, `social`, `contact`, or generated `public/metagraph/**` artifacts.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #5739`)
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state
- [x] No generated artifacts touched (data-only change to 3 `registry/subnets/*.json` files)
- [x] No R2-only/high-churn detail artifacts committed
- [x] No public API/OpenAPI/schema changes

## Validation

Ran locally against the 3 changed files:

- [x] `npm run validate:surface -- registry/subnets/root.json registry/subnets/gittensor.json registry/subnets/allways.json` — passed (57 surfaces across 3 files)
- [x] `npm run validate` — passed (129 native subnets, 129 curated overlays, 1615 surfaces, 133 providers, 2037 candidates)
- [x] `npm run scan:public-safety` — passed (no findings in the changed files)
- [x] `npx prettier --check` on the 3 files — clean
- [x] `git diff --check` — clean