### PR TITLE
feat(ui): align Settings page visual weight with utility siblings

### DIFF
--- a/apps/ui/src/components/metagraphed/settings-summary-strip.test.ts
+++ b/apps/ui/src/components/metagraphed/settings-summary-strip.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { SettingsSummaryStrip } from "./settings-summary-strip";
+import { buildSettingsSummaryTiles } from "@/lib/metagraphed/settings-summary";
+
+describe("SettingsSummaryStrip", () => {
+  it("exports a renderable component", () => {
+    expect(typeof SettingsSummaryStrip).toBe("function");
+  });
+
+  it("defaults to the three self-service action tiles", () => {
+    const tiles = buildSettingsSummaryTiles();
+    expect(tiles.map((t) => t.id)).toEqual(["create", "lookup", "delete"]);
+  });
+});

--- a/apps/ui/src/components/metagraphed/settings-summary-strip.tsx
+++ b/apps/ui/src/components/metagraphed/settings-summary-strip.tsx
@@ -1,0 +1,47 @@
+import { Webhook, Search, Trash2, type LucideIcon } from "lucide-react";
+import { StatTile } from "@jsonbored/ui-kit";
+import {
+  buildSettingsSummaryTiles,
+  type SettingsSummaryAction,
+  type SettingsSummaryTile,
+} from "@/lib/metagraphed/settings-summary";
+
+const ACTION_ICONS: Record<SettingsSummaryAction["id"], LucideIcon> = {
+  create: Webhook,
+  lookup: Search,
+  delete: Trash2,
+};
+
+export interface SettingsSummaryStripProps {
+  /** Optional override for tests / previews — defaults to the live API surface. */
+  tiles?: SettingsSummaryTile[];
+}
+
+/**
+ * Light KPI/status strip above the webhook forms (#5346) so Settings opens with
+ * the same visual weight as sibling utility pages (health / status / endpoints).
+ */
+export function SettingsSummaryStrip({ tiles }: SettingsSummaryStripProps = {}) {
+  const rows = tiles ?? buildSettingsSummaryTiles();
+  return (
+    <div
+      className="mb-8 grid grid-cols-1 gap-3 sm:grid-cols-3"
+      data-testid="settings-summary-strip"
+      aria-label="Webhook subscription actions at a glance"
+    >
+      {rows.map((tile) => {
+        const Icon = ACTION_ICONS[tile.id];
+        return (
+          <StatTile
+            key={tile.id}
+            icon={Icon}
+            eyebrow={tile.eyebrow}
+            value={tile.value}
+            hint={tile.hint}
+            tone={tile.tone}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/settings-summary-strip.tsx
+++ b/apps/ui/src/components/metagraphed/settings-summary-strip.tsx
@@ -25,7 +25,7 @@ export function SettingsSummaryStrip({ tiles }: SettingsSummaryStripProps = {}) 
   const rows = tiles ?? buildSettingsSummaryTiles();
   return (
     <div
-      className="mb-8 grid grid-cols-1 gap-3 sm:grid-cols-3"
+      className="mb-8 grid grid-cols-1 gap-3 sm:grid-cols-3 min-w-0"
       data-testid="settings-summary-strip"
       aria-label="Webhook subscription actions at a glance"
     >
@@ -39,6 +39,7 @@ export function SettingsSummaryStrip({ tiles }: SettingsSummaryStripProps = {}) 
             value={tile.value}
             hint={tile.hint}
             tone={tile.tone}
+            className="min-w-0 overflow-hidden"
           />
         );
       })}

--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
@@ -4,6 +4,7 @@ import { apiFetch, ApiError } from "@/lib/metagraphed/client";
 import { classNames } from "@/lib/metagraphed/format";
 import { CopyableCode, SectionHeading } from "@jsonbored/ui-kit";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
+import { SettingsSummaryStrip } from "@/components/metagraphed/settings-summary-strip";
 import type {
   WebhookDeliveryStatus,
   WebhookSubscriptionCreated,
@@ -52,6 +53,8 @@ function describeApiError(error: unknown): string {
 export function WebhookSubscriptionManager() {
   return (
     <div className="space-y-8">
+      {/* #5346: KPI/status strip so Settings matches sibling utility-page weight. */}
+      <SettingsSummaryStrip />
       <CreateSubscriptionSection />
       <LookupSubscriptionSection />
       <DeleteSubscriptionSection />

--- a/apps/ui/src/lib/metagraphed/settings-summary.test.ts
+++ b/apps/ui/src/lib/metagraphed/settings-summary.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  SETTINGS_CHANGE_KINDS,
+  SETTINGS_SUMMARY_ACTIONS,
+  buildSettingsHeroKpis,
+  buildSettingsSummaryTiles,
+} from "./settings-summary";
+
+describe("settings-summary", () => {
+  it("exposes the three self-service webhook actions", () => {
+    expect(SETTINGS_SUMMARY_ACTIONS).toHaveLength(3);
+    expect(SETTINGS_SUMMARY_ACTIONS.map((a) => a.id)).toEqual(["create", "lookup", "delete"]);
+    expect(SETTINGS_SUMMARY_ACTIONS.map((a) => a.method)).toEqual(["POST", "GET", "DELETE"]);
+  });
+
+  it("exposes the change-feed kinds the forms can filter on", () => {
+    expect(SETTINGS_CHANGE_KINDS).toEqual(["subnets", "artifacts"]);
+  });
+
+  it("builds PageHero KPIs with action / kind / auth / endpoint cells", () => {
+    const kpis = buildSettingsHeroKpis();
+    expect(kpis).toHaveLength(4);
+    expect(kpis[0]).toEqual({
+      label: "Actions",
+      value: "3",
+      hint: "create · look up · delete",
+    });
+    expect(kpis[1]).toEqual({
+      label: "Change kinds",
+      value: "2",
+      hint: "subnets · artifacts",
+    });
+    expect(kpis[2]).toEqual({
+      label: "Auth",
+      value: "token + secret",
+      hint: "no account model",
+    });
+    expect(kpis[3]).toEqual({
+      label: "Endpoint",
+      value: "/webhooks/subscriptions",
+      hint: "public API",
+    });
+  });
+
+  it("honors custom action and kind lists when building hero KPIs", () => {
+    const kpis = buildSettingsHeroKpis(
+      [{ id: "create", label: "Create", method: "POST", hint: "token-gated" }],
+      ["subnets"],
+    );
+    expect(kpis[0]).toMatchObject({ value: "1", hint: "create" });
+    expect(kpis[1]).toMatchObject({ value: "1", hint: "subnets" });
+  });
+
+  it("builds StatTile rows with an accent create tile", () => {
+    const tiles = buildSettingsSummaryTiles();
+    expect(tiles).toHaveLength(3);
+    expect(tiles[0]).toEqual({
+      id: "create",
+      eyebrow: "Create",
+      value: "POST",
+      hint: "token-gated",
+      tone: "accent",
+    });
+    expect(tiles[1]).toMatchObject({
+      id: "lookup",
+      eyebrow: "Look up",
+      value: "GET",
+      tone: "default",
+    });
+    expect(tiles[2]).toMatchObject({
+      id: "delete",
+      eyebrow: "Delete",
+      value: "DELETE",
+      tone: "default",
+    });
+  });
+
+  it("marks only the first tile as accent when given a custom action list", () => {
+    const tiles = buildSettingsSummaryTiles([
+      { id: "lookup", label: "Look up", method: "GET", hint: "by id" },
+      { id: "delete", label: "Delete", method: "DELETE", hint: "secret" },
+    ]);
+    expect(tiles[0].tone).toBe("accent");
+    expect(tiles[1].tone).toBe("default");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/settings-summary.test.ts
+++ b/apps/ui/src/lib/metagraphed/settings-summary.test.ts
@@ -17,38 +17,38 @@ describe("settings-summary", () => {
     expect(SETTINGS_CHANGE_KINDS).toEqual(["subnets", "artifacts"]);
   });
 
-  it("builds PageHero KPIs with action / kind / auth / endpoint cells", () => {
+  it("builds PageHero KPIs with short action / kind / auth / API cells", () => {
     const kpis = buildSettingsHeroKpis();
     expect(kpis).toHaveLength(4);
     expect(kpis[0]).toEqual({
       label: "Actions",
       value: "3",
-      hint: "create · look up · delete",
+      hint: "forms",
     });
     expect(kpis[1]).toEqual({
-      label: "Change kinds",
+      label: "Kinds",
       value: "2",
-      hint: "subnets · artifacts",
+      hint: "feeds",
     });
     expect(kpis[2]).toEqual({
       label: "Auth",
-      value: "token + secret",
-      hint: "no account model",
+      value: "2",
+      hint: "keys",
     });
     expect(kpis[3]).toEqual({
-      label: "Endpoint",
-      value: "/webhooks/subscriptions",
-      hint: "public API",
+      label: "API",
+      value: "live",
+      hint: "public",
     });
   });
 
-  it("honors custom action and kind lists when building hero KPIs", () => {
+  it("honors custom action and kind list lengths when building hero KPIs", () => {
     const kpis = buildSettingsHeroKpis(
       [{ id: "create", label: "Create", method: "POST", hint: "token-gated" }],
       ["subnets"],
     );
-    expect(kpis[0]).toMatchObject({ value: "1", hint: "create" });
-    expect(kpis[1]).toMatchObject({ value: "1", hint: "subnets" });
+    expect(kpis[0]).toMatchObject({ value: "1", hint: "forms" });
+    expect(kpis[1]).toMatchObject({ value: "1", hint: "feeds" });
   });
 
   it("builds StatTile rows with an accent create tile", () => {

--- a/apps/ui/src/lib/metagraphed/settings-summary.ts
+++ b/apps/ui/src/lib/metagraphed/settings-summary.ts
@@ -55,7 +55,12 @@ export interface SettingsSummaryTile {
   tone: "default" | "accent";
 }
 
-/** PageHero KPI cells — hairline strip under the hero copy. */
+/** PageHero KPI cells — hairline strip under the hero copy.
+ * Keep value/hint short: the KPI strip lays value+hint on one flex row and
+ * long strings (e.g. `/webhooks/subscriptions`) escape the viewport at ≤1280px,
+ * which fails the responsive-overflow e2e gate. Detailed method labels live in
+ * the StatTile strip below instead.
+ */
 export function buildSettingsHeroKpis(
   actions: readonly SettingsSummaryActionInput[] = SETTINGS_SUMMARY_ACTIONS,
   kinds: readonly string[] = SETTINGS_CHANGE_KINDS,
@@ -64,22 +69,22 @@ export function buildSettingsHeroKpis(
     {
       label: "Actions",
       value: String(actions.length),
-      hint: actions.map((a) => a.label.toLowerCase()).join(" · "),
+      hint: "forms",
     },
     {
-      label: "Change kinds",
+      label: "Kinds",
       value: String(kinds.length),
-      hint: kinds.join(" · "),
+      hint: "feeds",
     },
     {
       label: "Auth",
-      value: "token + secret",
-      hint: "no account model",
+      value: "2",
+      hint: "keys",
     },
     {
-      label: "Endpoint",
-      value: "/webhooks/subscriptions",
-      hint: "public API",
+      label: "API",
+      value: "live",
+      hint: "public",
     },
   ];
 }

--- a/apps/ui/src/lib/metagraphed/settings-summary.ts
+++ b/apps/ui/src/lib/metagraphed/settings-summary.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure view-models for the Settings page summary strip (#5346).
+ *
+ * There is no subscription list API and no account model — the strip reports
+ * the self-service webhook surface (actions / kinds / auth) so `/settings`
+ * opens with the same KPI visual weight as sibling utility pages.
+ */
+
+export const SETTINGS_CHANGE_KINDS = ["subnets", "artifacts"] as const;
+
+export type SettingsChangeKind = (typeof SETTINGS_CHANGE_KINDS)[number];
+
+export const SETTINGS_SUMMARY_ACTIONS = [
+  {
+    id: "create",
+    label: "Create",
+    method: "POST",
+    hint: "token-gated",
+  },
+  {
+    id: "lookup",
+    label: "Look up",
+    method: "GET",
+    hint: "by subscription id",
+  },
+  {
+    id: "delete",
+    label: "Delete",
+    method: "DELETE",
+    hint: "secret-gated",
+  },
+] as const;
+
+export type SettingsSummaryAction = (typeof SETTINGS_SUMMARY_ACTIONS)[number];
+
+export interface SettingsHeroKpi {
+  label: string;
+  value: string;
+  hint: string;
+}
+
+export interface SettingsSummaryTile {
+  id: SettingsSummaryAction["id"];
+  eyebrow: string;
+  value: string;
+  hint: string;
+  tone: "default" | "accent";
+}
+
+/** PageHero KPI cells — hairline strip under the hero copy. */
+export function buildSettingsHeroKpis(
+  actions: readonly SettingsSummaryAction[] = SETTINGS_SUMMARY_ACTIONS,
+  kinds: readonly SettingsChangeKind[] = SETTINGS_CHANGE_KINDS,
+): SettingsHeroKpi[] {
+  return [
+    {
+      label: "Actions",
+      value: String(actions.length),
+      hint: actions.map((a) => a.label.toLowerCase()).join(" · "),
+    },
+    {
+      label: "Change kinds",
+      value: String(kinds.length),
+      hint: kinds.join(" · "),
+    },
+    {
+      label: "Auth",
+      value: "token + secret",
+      hint: "no account model",
+    },
+    {
+      label: "Endpoint",
+      value: "/webhooks/subscriptions",
+      hint: "public API",
+    },
+  ];
+}
+
+/** Compact StatTile row between the hero and the subscription forms. */
+export function buildSettingsSummaryTiles(
+  actions: readonly SettingsSummaryAction[] = SETTINGS_SUMMARY_ACTIONS,
+): SettingsSummaryTile[] {
+  return actions.map((action, index) => ({
+    id: action.id,
+    eyebrow: action.label,
+    value: action.method,
+    hint: action.hint,
+    tone: index === 0 ? "accent" : "default",
+  }));
+}

--- a/apps/ui/src/lib/metagraphed/settings-summary.ts
+++ b/apps/ui/src/lib/metagraphed/settings-summary.ts
@@ -33,6 +33,14 @@ export const SETTINGS_SUMMARY_ACTIONS = [
 
 export type SettingsSummaryAction = (typeof SETTINGS_SUMMARY_ACTIONS)[number];
 
+/** Loose input shape so callers/tests can pass custom action lists. */
+export interface SettingsSummaryActionInput {
+  id: SettingsSummaryAction["id"];
+  label: string;
+  method: string;
+  hint: string;
+}
+
 export interface SettingsHeroKpi {
   label: string;
   value: string;
@@ -49,8 +57,8 @@ export interface SettingsSummaryTile {
 
 /** PageHero KPI cells — hairline strip under the hero copy. */
 export function buildSettingsHeroKpis(
-  actions: readonly SettingsSummaryAction[] = SETTINGS_SUMMARY_ACTIONS,
-  kinds: readonly SettingsChangeKind[] = SETTINGS_CHANGE_KINDS,
+  actions: readonly SettingsSummaryActionInput[] = SETTINGS_SUMMARY_ACTIONS,
+  kinds: readonly string[] = SETTINGS_CHANGE_KINDS,
 ): SettingsHeroKpi[] {
   return [
     {
@@ -78,7 +86,7 @@ export function buildSettingsHeroKpis(
 
 /** Compact StatTile row between the hero and the subscription forms. */
 export function buildSettingsSummaryTiles(
-  actions: readonly SettingsSummaryAction[] = SETTINGS_SUMMARY_ACTIONS,
+  actions: readonly SettingsSummaryActionInput[] = SETTINGS_SUMMARY_ACTIONS,
 ): SettingsSummaryTile[] {
   return actions.map((action, index) => ({
     id: action.id,

--- a/apps/ui/src/routes/settings.tsx
+++ b/apps/ui/src/routes/settings.tsx
@@ -3,6 +3,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { PageHero } from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { WebhookSubscriptionManager } from "@/components/metagraphed/webhook-subscription-manager";
+import { buildSettingsHeroKpis } from "@/lib/metagraphed/settings-summary";
 
 export const Route = createFileRoute("/settings")({
   head: () => ({
@@ -23,12 +24,16 @@ export const Route = createFileRoute("/settings")({
 });
 
 function SettingsPage() {
+  const kpis = buildSettingsHeroKpis();
   return (
     <AppShell>
       <PageHero
         eyebrow="Developer"
+        live
         title="Developer settings"
         description="Self-service webhook subscription management against the public subscription API. Nothing here is stored server-side beyond the subscription record itself — there is no account model."
+        caption={<>webhooks / v1</>}
+        kpis={kpis}
       />
       <WebhookSubscriptionManager />
       <ApiSourceFooter paths={["/api/v1/webhooks/subscriptions"]} />


### PR DESCRIPTION
## Summary

Closes #5346.

Give `/settings` the same PageHero KPI + StatTile visual weight as sibling utility pages. Webhook create / look up / delete forms are unchanged.

Fresh PR after #5846 was closed on a responsive-overflow e2e fail — hero KPI value/hint pairs were too long and escaped the viewport. KPI cells are now compact; method detail stays in the StatTile strip.

## What Changed

- `settings-summary.ts` (+ tests): builders for short hero KPIs + summary tiles
- `settings-summary-strip.tsx` (+ tests): StatTile strip above the forms (`min-w-0` / overflow-safe)
- `settings.tsx`: PageHero `live` + KPI strip
- `webhook-subscription-manager.tsx`: renders the strip above unchanged forms

## Template Used

Frontend / `apps/ui` visual change (Path C screenshot contract).

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-after-desktop-light.png)<br><sub>after — KPIs + action strip</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/kiannidev/metagraphed/6ed29d2a/5346-settings-after-mobile-dark.png)<br><sub>after</sub> |

## Registry Safety

- [x] Links open issue (`Closes #5346`)
- [x] No secrets / private URLs
- [x] UI-only; no hand-edited generated artifacts
- [x] Forms functionally unchanged

## Validation

- [x] `npm test --workspace=apps/ui` (settings-summary unit tests)
- [x] Hero KPIs shortened to satisfy responsive-overflow e2e (the #5846 fail)
- [x] Fresh 12-image before/after screenshot matrix

## Test plan

- [ ] `/settings` shows compact hero KPIs + Create/Look up/Delete StatTiles
- [ ] Forms still create/lookup/delete as before
- [ ] Responsive-overflow e2e green for `/settings` at 375/768/1024/1280
