### PR TITLE
fix(registry): dedupe subnet files registering the same URL under two surface kinds

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -276,28 +276,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-7-allways-data-artifact",
-      "kind": "data-artifact",
-      "name": "Allways community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "allways",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.all-ways.io/swagger-json"],
-      "url": "https://api.all-ways.io/miners/leaderboard"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-7-allways-subnet-api",
       "kind": "subnet-api",
       "name": "Allways swaps API",

--- a/registry/subnets/bitmind.json
+++ b/registry/subnets/bitmind.json
@@ -110,28 +110,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-34-bitmind-data-artifact",
-      "kind": "data-artifact",
-      "name": "BitMind community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "bitmind",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.bitmind.ai/openapi.json"],
-      "url": "https://api.bitmind.ai/health"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-34-bitmind-openapi",
       "kind": "openapi",
       "name": "BitMind community openapi",

--- a/registry/subnets/gradients.json
+++ b/registry/subnets/gradients.json
@@ -199,28 +199,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-56-gradients-data-artifact",
-      "kind": "data-artifact",
-      "name": "Gradients community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "gradients",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.gradients.io/docs"],
-      "url": "https://api.gradients.io/v1/network/status"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-56-gradients-subnet-api",
       "kind": "subnet-api",
       "name": "Gradients network status API",


### PR DESCRIPTION
## Summary

Each of the three files registered **one URL twice** under two different surface `kind`s, double-counting the same endpoint in surface-count/coverage aggregates. This removes the redundant entry in each, keeping the `kind` that accurately describes the endpoint.

| File | Duplicated URL | Kept | Removed |
|---|---|---|---|
| `allways.json` (SN7) | `https://api.all-ways.io/miners/leaderboard` | `allways-miners-leaderboard` (`subnet-api`) | `sn-7-allways-data-artifact` |
| `bitmind.json` (SN34) | `https://api.bitmind.ai/health` | `sn-34-bitmind-subnet-api` | `sn-34-bitmind-data-artifact` |
| `gradients.json` (SN56) | `https://api.gradients.io/v1/network/status` | `sn-56-gradients-subnet-api` | `sn-56-gradients-data-artifact` |

## Why `subnet-api` survives in all three

All three URLs are **callable, no-auth REST endpoints** — a leaderboard query, a health probe, and a network-status read. The `subnet-api` kind describes that accurately; `data-artifact` does not (an artifact is a standalone static payload, not a live endpoint). Two additional tie-breakers point the same way:

- **allways**: the kept `subnet-api` carries the stronger `provider-claimed` authority, vs a `community` data-artifact.
- **gradients**: the kept `subnet-api` carries the descriptive `notes` documenting the live response shape; the removed entry had none.

No `notes`/attribution data was lost that needed folding into the survivors (the removed entries had no `notes`).

## Scope

- **Deletions only** (`3 files changed, 66 deletions(-)`, zero additions) — no other surface touched, no `schema_version`/`curation`/top-level field altered, no reordering.

## Deliverables

- [x] `registry/subnets/allways.json`: dedupe `allways-miners-leaderboard` / `sn-7-allways-data-artifact`
- [x] `registry/subnets/bitmind.json`: dedupe `sn-34-bitmind-data-artifact` / `sn-34-bitmind-subnet-api`
- [x] `registry/subnets/gradients.json`: dedupe `sn-56-gradients-data-artifact` / `sn-56-gradients-subnet-api`
- [x] `npm run validate:surface` passes for all 3 files — *Surface validation passed: 40 surface(s) across 3 subnet file(s).*

## Test plan

- [x] `npm run validate:surface -- registry/subnets/{allways,bitmind,gradients}.json` → passed (40 surfaces / 3 files)
- [x] `npm run scan:public-safety -- ` same 3 files → passed
- [x] Re-checked each file post-change: **no URL is registered more than once** (allways 18 surfaces, bitmind 9, gradients 13 — all with zero duplicate URLs)
- [x] `git diff` is deletions-only

Closes #5736
