### PR TITLE
fix(registry): sweep all 129 subnet files for stale curation.gap_notes

### DIFF
--- a/registry/subnets/8-ball.json
+++ b/registry/subnets/8-ball.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 125,
-  "name": "8 Ball",
-  "slug": "eightball",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
@@ -11,122 +6,125 @@
     "official-website",
     "prediction-market"
   ],
-  "website_url": "https://8ball125.com/",
-  "docs_url": "https://github.com/Barbariandev/8Ball_miner#readme",
-  "source_repo": "https://github.com/Barbariandev/8Ball_miner",
-  "notes": "Reviewed overlay for SN125 8 Ball. The public website is live and the public miner/source repository documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T15:00:00.000Z",
-    "verified_at": "2026-06-08T15:00:00.000Z",
-    "source_count": 7,
     "gap_notes": [
       "Official website and miner/source repository are verified live.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T15:00:00.000Z",
+    "source_count": 7,
+    "verified_at": "2026-06-08T15:00:00.000Z"
   },
+  "docs_url": "https://github.com/Barbariandev/8Ball_miner#readme",
+  "name": "8 Ball",
+  "netuid": 125,
+  "notes": "Reviewed overlay for SN125 8 Ball. The public website is live and the public miner/source repository documents Ethereum wallet binding, reward mechanics, Polygon contracts, and miner setup for netuid 125.",
+  "schema_version": 1,
+  "slug": "eightball",
+  "source_repo": "https://github.com/Barbariandev/8Ball_miner",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-125-eightball-website",
-      "name": "8 Ball website",
-      "kind": "website",
-      "url": "https://8ball125.com/",
-      "provider": "eightball",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-125-eightball-website",
+      "kind": "website",
+      "name": "8 Ball website",
+      "notes": "Official 8 Ball website linked from the public SN125 miner repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "eightball",
       "public_safe": true,
       "source_urls": [
         "https://8ball125.com/",
         "https://github.com/Barbariandev/8Ball_miner"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official 8 Ball website linked from the public SN125 miner repository."
+      "url": "https://8ball125.com/"
     },
     {
-      "id": "sn-125-eightball-source-repo",
-      "name": "8 Ball miner repository",
-      "kind": "source-repo",
-      "url": "https://github.com/Barbariandev/8Ball_miner",
-      "provider": "eightball",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-125-eightball-source-repo",
+      "kind": "source-repo",
+      "name": "8 Ball miner repository",
+      "notes": "Public repository for SN125 miner wallet binding and reward participation.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "eightball",
       "public_safe": true,
       "source_urls": [
         "https://github.com/Barbariandev/8Ball_miner",
         "https://8ball125.com/"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public repository for SN125 miner wallet binding and reward participation."
+      "url": "https://github.com/Barbariandev/8Ball_miner"
     },
     {
-      "id": "sn-125-eightball-docs",
-      "name": "8 Ball miner documentation",
-      "kind": "docs",
-      "url": "https://github.com/Barbariandev/8Ball_miner#readme",
-      "provider": "eightball",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/Barbariandev/8Ball_miner"],
+      "id": "sn-125-eightball-docs",
+      "kind": "docs",
+      "name": "8 Ball miner documentation",
+      "notes": "README documentation covering SN125 wallet binding, R2-hosted binding bundles, reward mechanics, and Polygon contract addresses.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "README documentation covering SN125 wallet binding, R2-hosted binding bundles, reward mechanics, and Polygon contract addresses."
+      "provider": "eightball",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Barbariandev/8Ball_miner"],
+      "url": "https://github.com/Barbariandev/8Ball_miner#readme"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-125-eightball-subnet-api",
-      "name": "8 Ball markets API",
       "kind": "subnet-api",
-      "url": "https://8ball125.com/api/markets",
+      "name": "8 Ball markets API",
+      "notes": "Public no-auth REST API for SN125 prediction markets (markets, market by id, fee, price-history); documented on the official 8ball125.com site. Rate limited per IP.",
       "provider": "eightball",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
-      "source_urls": [
-        "https://8ball125.com/",
-        "https://github.com/Barbariandev/8Ball_miner"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "dev-miro26"
       },
-      "notes": "Public no-auth REST API for SN125 prediction markets (markets, market by id, fee, price-history); documented on the official 8ball125.com site. Rate limited per IP."
+      "source_urls": [
+        "https://8ball125.com/",
+        "https://github.com/Barbariandev/8Ball_miner"
+      ],
+      "url": "https://8ball125.com/api/markets"
     },
     {
-      "id": "sn-125-eightball-data-artifact",
-      "name": "8 Ball deployment manifest",
-      "kind": "data-artifact",
-      "url": "https://8ball125.com/deployment.json",
-      "provider": "eightball",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-125-eightball-data-artifact",
+      "kind": "data-artifact",
+      "name": "8 Ball deployment manifest",
+      "notes": "Static JSON manifest of the SN125 on-chain deployment (Polygon chain 137: USDC/CTF and prediction-market contract addresses); referenced by the public 8ball125.com API docs.",
+      "provider": "eightball",
       "public_safe": true,
-      "source_urls": [
-        "https://8ball125.com/",
-        "https://github.com/Barbariandev/8Ball_miner"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "dev-miro26"
       },
-      "notes": "Static JSON manifest of the SN125 on-chain deployment (Polygon chain 137: USDC/CTF and prediction-market contract addresses); referenced by the public 8ball125.com API docs."
+      "source_urls": [
+        "https://8ball125.com/",
+        "https://github.com/Barbariandev/8Ball_miner"
+      ],
+      "url": "https://8ball125.com/deployment.json"
     }
-  ]
+  ],
+  "website_url": "https://8ball125.com/"
 }

--- a/registry/subnets/actual.json
+++ b/registry/subnets/actual.json
@@ -1,20 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 95,
-  "name": "Actual",
-  "slug": "actual",
-  "status": "active",
-  "categories": [
-    "baseline-curated",
-    "identity-reviewed",
-    "inference",
-    "model-registry",
-    "official-website"
-  ],
-  "website_url": "https://actual.inc/",
-  "docs_url": null,
-  "dashboard_url": "https://backprop.finance/dtao/subnets/95-actual",
-  "source_repo": null,
   "baseline_excluded_surface_ids": [
     "sn-95-taomarketcap-source-repo",
     "sn-95-taomarketcap-website",
@@ -26,58 +10,73 @@
     "sn-95-website-common-swagger-json",
     "sn-95-website-link-actual-inc-website-1"
   ],
-  "notes": "Reviewed overlay for SN95 Actual. The Actual Computer website metadata identifies the project with Bittensor, Subnet 95, decentralized AI, and inference software. The previous GitHub organization candidate currently returns 404 and is not promoted.",
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "inference",
+    "model-registry",
+    "official-website"
+  ],
+  "contact": "subnet@actual.inc",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T18:08:00.000Z",
-    "verified_at": "2026-06-08T18:08:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "Previously discovered GitHub organization/source candidate currently returns 404.",
       "No verified live source repository yet.",
       "Common docs/API/health/OpenAPI/Swagger paths redirect to login and are not promoted as public docs, API, or schema surfaces.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T18:08:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T18:08:00.000Z"
   },
+  "dashboard_url": "https://backprop.finance/dtao/subnets/95-actual",
+  "docs_url": null,
+  "name": "Actual",
+  "netuid": 95,
+  "notes": "Reviewed overlay for SN95 Actual. The Actual Computer website metadata identifies the project with Bittensor, Subnet 95, decentralized AI, and inference software. The previous GitHub organization candidate currently returns 404 and is not promoted.",
+  "schema_version": 1,
+  "slug": "actual",
+  "source_repo": null,
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-95-actual-website",
-      "name": "Actual Computer website",
-      "kind": "website",
-      "url": "https://actual.inc/",
-      "provider": "actual-computer",
       "auth_required": false,
       "authority": "provider-claimed",
+      "id": "sn-95-actual-website",
+      "kind": "website",
+      "name": "Actual Computer website",
+      "notes": "Website metadata identifies Actual Computer with Bittensor, Subnet 95, decentralized AI, and AI inference software.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "actual-computer",
       "public_safe": true,
       "source_urls": ["https://actual.inc/"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Website metadata identifies Actual Computer with Bittensor, Subnet 95, decentralized AI, and AI inference software."
+      "url": "https://actual.inc/"
     },
     {
-      "id": "sn-95-actual-model-registry",
-      "name": "Actual model registry",
-      "kind": "data-artifact",
-      "url": "https://models.actual.inc/",
-      "provider": "actual-computer",
       "auth_required": false,
       "authority": "provider-claimed",
-      "public_safe": true,
-      "source_urls": ["https://actual.inc/", "https://models.actual.inc/"],
+      "id": "sn-95-actual-model-registry",
+      "kind": "data-artifact",
+      "name": "Actual model registry",
+      "notes": "Public Actual GGUF model registry page. The page is browser-facing and served publicly; account-specific Actual docs redirect to login and are not listed as public docs.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Public Actual GGUF model registry page. The page is browser-facing and served publicly; account-specific Actual docs redirect to login and are not listed as public docs."
+      "provider": "actual-computer",
+      "public_safe": true,
+      "source_urls": ["https://actual.inc/", "https://models.actual.inc/"],
+      "url": "https://models.actual.inc/"
     },
     {
       "auth_required": false,
@@ -143,5 +142,5 @@
       "url": "https://actual.inc/llms.txt"
     }
   ],
-  "contact": "subnet@actual.inc"
+  "website_url": "https://actual.inc/"
 }

--- a/registry/subnets/adtao.json
+++ b/registry/subnets/adtao.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 21,
-  "name": "AdTAO",
-  "slug": "sn-21",
-  "status": "active",
   "categories": [
     "advertising",
     "baseline-curated",
@@ -11,134 +6,138 @@
     "official-source-repo",
     "official-website"
   ],
-  "source_repo": "https://github.com/ippcteam/SN21-adtao",
-  "dashboard_url": "https://taomarketcap.com/subnets/21",
-  "website_url": "https://adtao.io/",
-  "notes": "Reviewed overlay for SN21 using the official AdTAO website and source repository.",
+  "contact": "sn21@adtao.io",
   "curation": {
+    "gap_notes": [
+      "No verified official docs URL yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T10:10:00.000Z",
-    "verified_at": "2026-06-08T10:10:00.000Z",
     "source_count": 4,
-    "gap_notes": [
-      "No verified official docs URL yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T10:10:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/21",
+  "name": "AdTAO",
+  "netuid": 21,
+  "notes": "Reviewed overlay for SN21 using the official AdTAO website and source repository.",
+  "schema_version": 1,
+  "slug": "sn-21",
+  "social": {
+    "x": "https://x.com/ppcrebel"
+  },
+  "source_repo": "https://github.com/ippcteam/SN21-adtao",
+  "status": "active",
   "surfaces": [
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-21-adtao-website",
-      "name": "AdTAO website",
       "kind": "website",
-      "url": "https://adtao.io/",
-      "provider": "adtao",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/ippcteam/SN21-adtao"],
+      "name": "AdTAO website",
+      "notes": "Official AdTAO website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official AdTAO website."
-    },
-    {
-      "id": "sn-21-adtao-source",
-      "name": "AdTAO source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/ippcteam/SN21-adtao",
       "provider": "adtao",
-      "auth_required": false,
-      "authority": "official",
       "public_safe": true,
       "source_urls": ["https://github.com/ippcteam/SN21-adtao"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official AdTAO source repository."
+      "url": "https://adtao.io/"
     },
     {
-      "id": "sn-21-adtao-validator-openapi",
-      "name": "AdTAO SN21 Validator OpenAPI schema",
-      "kind": "openapi",
-      "url": "https://validator.adtao.io/openapi.json",
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-21-adtao-source",
+      "kind": "source-repo",
+      "name": "AdTAO source repository",
+      "notes": "Official AdTAO source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "adtao",
+      "public_safe": true,
+      "source_urls": ["https://github.com/ippcteam/SN21-adtao"],
+      "url": "https://github.com/ippcteam/SN21-adtao"
+    },
+    {
       "auth_required": false,
       "authority": "community",
+      "id": "sn-21-adtao-validator-openapi",
+      "kind": "openapi",
+      "name": "AdTAO SN21 Validator OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.1.0 schema (title \"SN21 Validator\", version 0.1.0) served by the official AdTAO validator API on the operator's validator.adtao.io host. Documents the public epoch/episode, prediction, commitment, verification, scores, and training routes plus /health. Unauthenticated GET returns the full paths object.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "adtao",
       "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
       "schema_status": "machine-readable",
       "schema_url": "https://validator.adtao.io/openapi.json",
       "source_urls": [
         "https://github.com/ippcteam/SN21-adtao",
         "https://validator.adtao.io/openapi.json"
       ],
+      "url": "https://validator.adtao.io/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-21-adtao-validator-api",
+      "kind": "subnet-api",
+      "name": "AdTAO SN21 Validator API",
+      "notes": "Official public AdTAO (SN21) validator API on the operator's validator.adtao.io host. An unauthenticated GET on /health returns live JSON service status (service, current epoch label, episodes loaded, submission window, deadline). The /v1/epochs routes are described in the linked OpenAPI schema.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "adtao",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Machine-readable OpenAPI 3.1.0 schema (title \"SN21 Validator\", version 0.1.0) served by the official AdTAO validator API on the operator's validator.adtao.io host. Documents the public epoch/episode, prediction, commitment, verification, scores, and training routes plus /health. Unauthenticated GET returns the full paths object."
-    },
-    {
-      "id": "sn-21-adtao-validator-api",
-      "name": "AdTAO SN21 Validator API",
-      "kind": "subnet-api",
-      "url": "https://validator.adtao.io/health",
-      "provider": "adtao",
-      "auth_required": false,
-      "authority": "community",
-      "public_safe": true,
       "schema_url": "https://validator.adtao.io/openapi.json",
       "source_urls": [
         "https://github.com/ippcteam/SN21-adtao",
         "https://validator.adtao.io/"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "GET",
-        "expect": "json",
-        "timeout_ms": 10000
-      },
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "glorydavid03023"
-      },
-      "notes": "Official public AdTAO (SN21) validator API on the operator's validator.adtao.io host. An unauthenticated GET on /health returns live JSON service status (service, current epoch label, episodes loaded, submission window, deadline). The /v1/epochs routes are described in the linked OpenAPI schema."
+      "url": "https://validator.adtao.io/health"
     },
     {
-      "id": "sn-21-adtao-training-episodes",
-      "name": "AdTAO training episodes sample dataset",
-      "kind": "data-artifact",
-      "url": "https://raw.githubusercontent.com/ippcteam/SN21-adtao/main/data/training/training_episodes.json",
-      "provider": "adtao",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-21-adtao-training-episodes",
+      "kind": "data-artifact",
+      "name": "AdTAO training episodes sample dataset",
+      "notes": "Public no-auth JSON dataset of bundled sample prediction episodes (account state, action context, and known outcomes) published in the official SN21 AdTAO source repository at data/training/. Documented in the repo README as the bundled sample data (10 episodes with known outcomes) and consumed by scripts/train_example_model.py for local baseline-model training.",
+      "provider": "adtao",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/ippcteam/SN21-adtao/blob/main/README.md",
-        "https://github.com/ippcteam/SN21-adtao/blob/main/scripts/train_example_model.py"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "rust-toml"
       },
-      "notes": "Public no-auth JSON dataset of bundled sample prediction episodes (account state, action context, and known outcomes) published in the official SN21 AdTAO source repository at data/training/. Documented in the repo README as the bundled sample data (10 episodes with known outcomes) and consumed by scripts/train_example_model.py for local baseline-model training."
+      "source_urls": [
+        "https://github.com/ippcteam/SN21-adtao/blob/main/README.md",
+        "https://github.com/ippcteam/SN21-adtao/blob/main/scripts/train_example_model.py"
+      ],
+      "url": "https://raw.githubusercontent.com/ippcteam/SN21-adtao/main/data/training/training_episodes.json"
     }
   ],
-  "social": { "x": "https://x.com/ppcrebel" },
-  "contact": "sn21@adtao.io"
+  "website_url": "https://adtao.io/"
 }

--- a/registry/subnets/ain.json
+++ b/registry/subnets/ain.json
@@ -1,21 +1,6 @@
 {
-  "schema_version": 1,
-  "netuid": 69,
-  "name": "ain",
-  "slug": "ain",
-  "status": "active",
   "categories": ["baseline-curated", "identity-reviewed"],
-  "source_repo": null,
-  "website_url": "https://www.heraldmedia.ai/",
-  "docs_url": null,
-  "dashboard_url": null,
-  "notes": "Reviewed overlay for SN69 ain. Public directories and analytics pages list the subnet, but no official team, website, source repository, API, OpenAPI schema, or docs site has been verified.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T15:00:00.000Z",
-    "verified_at": "2026-06-08T15:00:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "No publicly verified team/operator profile yet.",
       "No verified official website yet.",
@@ -23,10 +8,23 @@
       "No verified official docs site yet beyond public directory/community pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T15:00:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T15:00:00.000Z"
   },
+  "dashboard_url": null,
+  "docs_url": null,
+  "name": "ain",
+  "netuid": 69,
+  "notes": "Reviewed overlay for SN69 ain. Public directories and analytics pages list the subnet, but no official team, website, source repository, API, OpenAPI schema, or docs site has been verified.",
+  "schema_version": 1,
+  "slug": "ain",
+  "source_repo": null,
+  "status": "active",
   "surfaces": [
     {
       "auth_required": false,
@@ -85,5 +83,6 @@
       ],
       "url": "https://raw.githubusercontent.com/HeraldMedia/herald/4de1577e82b74807d4081c3f61edffaee9ed718a/min_compute.yml"
     }
-  ]
+  ],
+  "website_url": "https://www.heraldmedia.ai/"
 }

--- a/registry/subnets/ansuz.json
+++ b/registry/subnets/ansuz.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 84,
-  "name": "ansuz",
-  "slug": "sn-84",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "chip-design",
@@ -13,84 +8,87 @@
     "official-source-repo",
     "official-website"
   ],
-  "website_url": "https://www.chipforge.io/",
-  "docs_url": "https://docs.chipforge.io/",
-  "source_repo": "https://github.com/TatsuProject/ChipForge_SN84",
-  "dashboard_url": "https://taomarketcap.com/subnets/84",
-  "notes": "Reviewed overlay for SN84 using the official ChipForge website, docs, and source repository. No machine-readable OpenAPI schema or unauthenticated public subnet API endpoint is promoted yet.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T10:45:00.000Z",
-    "verified_at": "2026-06-08T10:45:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified unauthenticated public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T10:45:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T10:45:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/84",
+  "docs_url": "https://docs.chipforge.io/",
+  "name": "ansuz",
+  "netuid": 84,
+  "notes": "Reviewed overlay for SN84 using the official ChipForge website, docs, and source repository. No machine-readable OpenAPI schema or unauthenticated public subnet API endpoint is promoted yet.",
+  "schema_version": 1,
+  "slug": "sn-84",
+  "source_repo": "https://github.com/TatsuProject/ChipForge_SN84",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-84-chipforge-website",
-      "name": "ChipForge website",
-      "kind": "website",
-      "url": "https://www.chipforge.io/",
-      "provider": "chipforge",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-84-chipforge-website",
+      "kind": "website",
+      "name": "ChipForge website",
+      "notes": "Official ChipForge website from the project source repository homepage.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "chipforge",
       "public_safe": true,
       "source_urls": [
         "https://api.github.com/repos/TatsuProject/ChipForge_SN84",
         "https://www.chipforge.io/"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official ChipForge website from the project source repository homepage."
+      "url": "https://www.chipforge.io/"
     },
     {
-      "id": "sn-84-chipforge-docs",
-      "name": "ChipForge documentation",
-      "kind": "docs",
-      "url": "https://docs.chipforge.io/",
-      "provider": "chipforge",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-84-chipforge-docs",
+      "kind": "docs",
+      "name": "ChipForge documentation",
+      "notes": "Official ChipForge documentation.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "chipforge",
       "public_safe": true,
       "source_urls": ["https://www.chipforge.io/"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official ChipForge documentation."
+      "url": "https://docs.chipforge.io/"
     },
     {
-      "id": "sn-84-chipforge-source",
-      "name": "ChipForge source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/TatsuProject/ChipForge_SN84",
-      "provider": "chipforge",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-84-chipforge-source",
+      "kind": "source-repo",
+      "name": "ChipForge source repository",
+      "notes": "Official ChipForge source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "chipforge",
       "public_safe": true,
       "source_urls": [
         "https://api.github.com/repos/TatsuProject/ChipForge_SN84",
         "https://github.com/TatsuProject/ChipForge_SN84"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official ChipForge source repository."
+      "url": "https://github.com/TatsuProject/ChipForge_SN84"
     },
     {
       "auth_required": false,
@@ -130,5 +128,6 @@
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/84"
     }
-  ]
+  ],
+  "website_url": "https://www.chipforge.io/"
 }

--- a/registry/subnets/basilica.json
+++ b/registry/subnets/basilica.json
@@ -9,11 +9,8 @@
   "curation": {
     "gap_notes": [
       "Native chain name currently reports as deprecated.",
-      "No verified docs site yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "needs-review",

--- a/registry/subnets/bitads.json
+++ b/registry/subnets/bitads.json
@@ -1,20 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 16,
-  "name": "BitAds",
-  "slug": "sn-16",
-  "status": "active",
-  "categories": [
-    "baseline-curated",
-    "identity-reviewed",
-    "official-docs",
-    "official-source-repo",
-    "official-website"
-  ],
-  "website_url": null,
-  "docs_url": null,
-  "source_repo": "https://github.com/study-service/BitAds.ai",
-  "dashboard_url": "https://taomarketcap.com/subnets/16",
   "baseline_excluded_surface_ids": [
     "sn-16-taomarketcap-source-repo",
     "sn-16-taomarketcap-website",
@@ -25,80 +9,97 @@
     "sn-16-website-common-swagger",
     "sn-16-website-common-swagger-json"
   ],
-  "notes": "Reviewed overlay for SN16 BitAds. The former bitads.ai website/docs domain no longer resolves (DNS lame delegation — the domain's own nameservers refuse the query), so website_url/docs_url are nulled until a live domain is confirmed. The operator's active code has moved from FirstTensorLabs/BitAds (now 404) to study-service/BitAds.ai (live), which is now the registered source_repo. Common API/OpenAPI/Swagger paths previously returned website HTML instead of machine-readable API/schema responses, so they are excluded as content mismatches.",
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-docs",
+    "official-source-repo",
+    "official-website"
+  ],
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T20:25:00.000Z",
-    "verified_at": "2026-06-08T20:25:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "The bitads.ai website and docs domain currently fails to resolve (DNS lame delegation) and is nulled until it recovers or a replacement domain is confirmed.",
       "The former FirstTensorLabs/BitAds source repository now returns 404; the live successor repository is study-service/BitAds.ai.",
       "Common API, health, OpenAPI, Swagger JSON, and Swagger UI paths return marketing-site HTML rather than API/schema payloads.",
       "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T20:25:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T20:25:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/16",
+  "docs_url": null,
+  "name": "BitAds",
+  "netuid": 16,
+  "notes": "Reviewed overlay for SN16 BitAds. The former bitads.ai website/docs domain no longer resolves (DNS lame delegation — the domain's own nameservers refuse the query), so website_url/docs_url are nulled until a live domain is confirmed. The operator's active code has moved from FirstTensorLabs/BitAds (now 404) to study-service/BitAds.ai (live), which is now the registered source_repo. Common API/OpenAPI/Swagger paths previously returned website HTML instead of machine-readable API/schema responses, so they are excluded as content mismatches.",
+  "schema_version": 1,
+  "slug": "sn-16",
+  "social": {
+    "x": "https://x.com/bitkoop"
+  },
+  "source_repo": "https://github.com/study-service/BitAds.ai",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-16-bitads-website",
-      "name": "BitAds website",
-      "kind": "website",
-      "url": "https://bitads.ai/",
-      "provider": "bitads",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-16-bitads-website",
+      "kind": "website",
+      "name": "BitAds website",
+      "notes": "Official BitAds website (bitads.ai domain currently unresolvable).",
+      "probe": {
+        "enabled": false,
+        "expect": "html",
+        "method": "HEAD"
+      },
+      "provider": "bitads",
       "public_safe": true,
+      "rate_limit_notes": "Not probe-enabled because bitads.ai currently fails to resolve (DNS lame delegation — the domain's nameservers refuse queries); marked degraded until the domain recovers or a replacement is confirmed.",
       "source_urls": [
         "https://bitads.ai/",
         "https://github.com/FirstTensorLabs/BitAds"
       ],
-      "probe": {
-        "enabled": false,
-        "method": "HEAD",
-        "expect": "html"
-      },
-      "rate_limit_notes": "Not probe-enabled because bitads.ai currently fails to resolve (DNS lame delegation — the domain's nameservers refuse queries); marked degraded until the domain recovers or a replacement is confirmed.",
-      "notes": "Official BitAds website (bitads.ai domain currently unresolvable)."
+      "url": "https://bitads.ai/"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-16-bitads-docs",
-      "name": "BitAds docs",
       "kind": "docs",
-      "url": "https://bitads.ai/docs",
-      "provider": "bitads",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://bitads.ai/docs"],
+      "name": "BitAds docs",
+      "notes": "Official BitAds documentation page (bitads.ai domain currently unresolvable).",
       "probe": {
         "enabled": false,
-        "method": "HEAD",
-        "expect": "html"
+        "expect": "html",
+        "method": "HEAD"
       },
+      "provider": "bitads",
+      "public_safe": true,
       "rate_limit_notes": "Not probe-enabled because the bitads.ai domain currently fails to resolve (DNS lame delegation); marked degraded until it recovers or a replacement is confirmed.",
-      "notes": "Official BitAds documentation page (bitads.ai domain currently unresolvable)."
+      "source_urls": ["https://bitads.ai/docs"],
+      "url": "https://bitads.ai/docs"
     },
     {
-      "id": "sn-16-bitads-source",
-      "name": "BitAds source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/FirstTensorLabs/BitAds",
-      "provider": "bitads",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/FirstTensorLabs/BitAds"],
+      "id": "sn-16-bitads-source",
+      "kind": "source-repo",
+      "name": "BitAds source repository",
+      "notes": "Former BitAds source repository (FirstTensorLabs/BitAds now returns 404; live code has moved to study-service/BitAds.ai).",
       "probe": {
         "enabled": false,
-        "method": "HEAD",
-        "expect": "any"
+        "expect": "any",
+        "method": "HEAD"
       },
+      "provider": "bitads",
+      "public_safe": true,
       "rate_limit_notes": "Not probe-enabled because github.com/FirstTensorLabs/BitAds now returns 404; the operator's live successor repository is study-service/BitAds.ai (the registered top-level source_repo).",
-      "notes": "Former BitAds source repository (FirstTensorLabs/BitAds now returns 404; live code has moved to study-service/BitAds.ai)."
+      "source_urls": ["https://github.com/FirstTensorLabs/BitAds"],
+      "url": "https://github.com/FirstTensorLabs/BitAds"
     },
     {
       "auth_required": false,
@@ -139,7 +140,5 @@
       "url": "https://api.taomarketcap.com/public/v1/subnets/16"
     }
   ],
-  "social": {
-    "x": "https://x.com/bitkoop"
-  }
+  "website_url": null
 }

--- a/registry/subnets/bitmind.json
+++ b/registry/subnets/bitmind.json
@@ -10,12 +10,7 @@
   ],
   "contact": "intern@bitmind.ai",
   "curation": {
-    "gap_notes": [
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified unauthenticated public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ],
+    "gap_notes": ["No verified SSE/event stream yet."],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T10:35:00.000Z",

--- a/registry/subnets/bitrecs.json
+++ b/registry/subnets/bitrecs.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 122,
-  "name": "Bitrecs",
-  "slug": "sn-122",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
@@ -12,81 +7,87 @@
     "official-website",
     "recommendations"
   ],
-  "website_url": "https://www.bitrecs.ai/",
-  "docs_url": "https://bitrecs.gitbook.io/bitrecs-docs/",
-  "source_repo": "https://github.com/bitrecs/bitrecs-subnet",
-  "dashboard_url": "https://taomarketcap.com/subnets/122",
-  "notes": "Reviewed overlay for SN122 using the official Bitrecs website, docs, and source repository. No machine-readable OpenAPI schema or unauthenticated public subnet API endpoint is promoted yet.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T10:35:00.000Z",
-    "verified_at": "2026-06-08T10:35:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified unauthenticated public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T10:35:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T10:35:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/122",
+  "docs_url": "https://bitrecs.gitbook.io/bitrecs-docs/",
+  "name": "Bitrecs",
+  "netuid": 122,
+  "notes": "Reviewed overlay for SN122 using the official Bitrecs website, docs, and source repository. No machine-readable OpenAPI schema or unauthenticated public subnet API endpoint is promoted yet.",
+  "schema_version": 1,
+  "slug": "sn-122",
+  "social": {
+    "x": "https://x.com/cookingtao_"
+  },
+  "source_repo": "https://github.com/bitrecs/bitrecs-subnet",
+  "status": "active",
   "surfaces": [
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-122-bitrecs-website",
-      "name": "Bitrecs website",
       "kind": "website",
-      "url": "https://www.bitrecs.ai/",
-      "provider": "bitrecs",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://www.bitrecs.ai/"],
+      "name": "Bitrecs website",
+      "notes": "Official Bitrecs website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Bitrecs website."
+      "provider": "bitrecs",
+      "public_safe": true,
+      "source_urls": ["https://www.bitrecs.ai/"],
+      "url": "https://www.bitrecs.ai/"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-122-bitrecs-docs",
-      "name": "Bitrecs documentation",
       "kind": "docs",
-      "url": "https://bitrecs.gitbook.io/bitrecs-docs/",
-      "provider": "bitrecs",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://www.bitrecs.ai/"],
+      "name": "Bitrecs documentation",
+      "notes": "Official Bitrecs documentation linked from the official website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Bitrecs documentation linked from the official website."
+      "provider": "bitrecs",
+      "public_safe": true,
+      "source_urls": ["https://www.bitrecs.ai/"],
+      "url": "https://bitrecs.gitbook.io/bitrecs-docs/"
     },
     {
-      "id": "sn-122-bitrecs-source",
-      "name": "Bitrecs source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/bitrecs/bitrecs-subnet",
-      "provider": "bitrecs",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-122-bitrecs-source",
+      "kind": "source-repo",
+      "name": "Bitrecs source repository",
+      "notes": "Official Bitrecs source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "bitrecs",
       "public_safe": true,
       "source_urls": [
         "https://api.github.com/repos/bitrecs/bitrecs-subnet",
         "https://github.com/bitrecs/bitrecs-subnet"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Bitrecs source repository."
+      "url": "https://github.com/bitrecs/bitrecs-subnet"
     },
     {
       "auth_required": false,
@@ -108,26 +109,24 @@
       "url": "https://raw.githubusercontent.com/bitrecs/bitrecs-subnet/main/tests/data/amazon/fashion/amazon_fashion_sample_1000.json"
     },
     {
-      "id": "sn-122-bitrecs-llms-txt",
-      "name": "Bitrecs llms.txt docs index",
-      "kind": "data-artifact",
-      "url": "https://www.bitrecs.ai/llms.txt",
-      "provider": "bitrecs",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-122-bitrecs-llms-txt",
+      "kind": "data-artifact",
+      "name": "Bitrecs llms.txt docs index",
+      "notes": "Machine-readable llms.txt docs index published on the official Bitrecs website; self-identifies as Bittensor subnet 122 and links the homepage, Shopify app, and Taostats subnet page.",
+      "provider": "bitrecs",
       "public_safe": true,
-      "source_urls": [
-        "https://www.bitrecs.ai/llms.txt",
-        "https://www.bitrecs.ai/"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "shin-core"
       },
-      "notes": "Machine-readable llms.txt docs index published on the official Bitrecs website; self-identifies as Bittensor subnet 122 and links the homepage, Shopify app, and Taostats subnet page."
+      "source_urls": [
+        "https://www.bitrecs.ai/llms.txt",
+        "https://www.bitrecs.ai/"
+      ],
+      "url": "https://www.bitrecs.ai/llms.txt"
     }
   ],
-  "social": {
-    "x": "https://x.com/cookingtao_"
-  }
+  "website_url": "https://www.bitrecs.ai/"
 }

--- a/registry/subnets/bitstarter-1.json
+++ b/registry/subnets/bitstarter-1.json
@@ -1,18 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 91,
-  "name": "Bitstarter #1",
-  "slug": "sn-91",
-  "status": "active",
-  "categories": [
-    "baseline-curated",
-    "identity-reviewed",
-    "official-source-repo",
-    "official-website"
-  ],
-  "dashboard_url": "https://taomarketcap.com/subnets/91",
-  "website_url": "https://bitstarter.ai/",
-  "source_repo": "https://github.com/AlphaCoreBittensor/alphacore",
   "baseline_excluded_surface_ids": [
     "sn-91-taomarketcap-website",
     "sn-91-website-common-api",
@@ -27,151 +13,165 @@
     "sn-91-website-link-bitstarter-ai-website-4",
     "sn-91-website-link-bitstarter-ai-website-5"
   ],
-  "notes": "Reviewed overlay for SN91 using the public Bitstarter website, app surface, how-it-works page, project submission page, AlphaCore source repository, and universal TaoMarketCap dashboard. Common docs/API/OpenAPI paths currently return 404 and no verified machine-readable schema, safe public subnet API endpoint, or SSE surface has been found yet.",
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-source-repo",
+    "official-website"
+  ],
+  "contact": "hello@bitstarter.ai",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T09:25:00.000Z",
-    "verified_at": "2026-06-08T09:25:00.000Z",
-    "source_count": 7,
     "gap_notes": [
       "Official website, app, how-it-works, and project submission pages are live and verified.",
       "Common /docs, /api, /health, /openapi.json, and Swagger paths currently return 404 and are explicitly excluded from promoted surfaces.",
       "Generic email-protection and terms-of-service pages are not listed as subnet interfaces.",
       "Bitstarter currently identifies AlphaCore as the project behind this subnet and links its public source repository.",
-      "No verified docs site yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T09:25:00.000Z",
+    "source_count": 7,
+    "verified_at": "2026-06-08T09:25:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/91",
+  "name": "Bitstarter #1",
+  "netuid": 91,
+  "notes": "Reviewed overlay for SN91 using the public Bitstarter website, app surface, how-it-works page, project submission page, AlphaCore source repository, and universal TaoMarketCap dashboard. Common docs/API/OpenAPI paths currently return 404 and no verified machine-readable schema, safe public subnet API endpoint, or SSE surface has been found yet.",
+  "schema_version": 1,
+  "slug": "sn-91",
+  "social": {
+    "x": "https://x.com/bitstarterai"
+  },
+  "source_repo": "https://github.com/AlphaCoreBittensor/alphacore",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-91-bitstarter-website",
-      "name": "Bitstarter website",
-      "kind": "website",
-      "url": "https://bitstarter.ai/",
-      "provider": "bitstarter",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://bitstarter.ai/"],
+      "id": "sn-91-bitstarter-website",
+      "kind": "website",
+      "name": "Bitstarter website",
+      "notes": "Public Bitstarter website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Public Bitstarter website."
+      "provider": "bitstarter",
+      "public_safe": true,
+      "source_urls": ["https://bitstarter.ai/"],
+      "url": "https://bitstarter.ai/"
     },
     {
-      "id": "sn-91-alphacore-source",
-      "name": "AlphaCore source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/AlphaCoreBittensor/alphacore",
-      "provider": "alphacore",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-91-alphacore-source",
+      "kind": "source-repo",
+      "name": "AlphaCore source repository",
+      "notes": "Public AlphaCore repository linked from the live Bitstarter project page for SN91.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "alphacore",
       "public_safe": true,
       "source_urls": [
         "https://bitstarter.ai/",
         "https://github.com/AlphaCoreBittensor/alphacore"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public AlphaCore repository linked from the live Bitstarter project page for SN91."
+      "url": "https://github.com/AlphaCoreBittensor/alphacore"
     },
     {
-      "id": "sn-91-bitstarter-app",
-      "name": "Bitstarter app",
-      "kind": "dashboard",
-      "url": "https://app.bitstarter.ai/",
-      "provider": "bitstarter",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-91-bitstarter-app",
+      "kind": "dashboard",
+      "name": "Bitstarter app",
+      "notes": "Public Bitstarter app surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "bitstarter",
       "public_safe": true,
       "source_urls": ["https://app.bitstarter.ai/"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Public Bitstarter app surface."
+      "url": "https://app.bitstarter.ai/"
     },
     {
-      "id": "sn-91-bitstarter-how-it-works",
-      "name": "Bitstarter how it works",
-      "kind": "docs",
-      "url": "https://app.bitstarter.ai/how-it-works/",
-      "provider": "bitstarter",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-91-bitstarter-how-it-works",
+      "kind": "docs",
+      "name": "Bitstarter how it works",
+      "notes": "Public Bitstarter app information page.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "bitstarter",
       "public_safe": true,
       "source_urls": [
         "https://app.bitstarter.ai/",
         "https://app.bitstarter.ai/how-it-works/"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Public Bitstarter app information page."
+      "url": "https://app.bitstarter.ai/how-it-works/"
     },
     {
-      "id": "sn-91-bitstarter-submit-project",
-      "name": "Bitstarter project submission",
-      "kind": "dashboard",
-      "url": "https://app.bitstarter.ai/submit-a-project/incubator/",
-      "provider": "bitstarter",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-91-bitstarter-submit-project",
+      "kind": "dashboard",
+      "name": "Bitstarter project submission",
+      "notes": "Public Bitstarter app workflow for incubator project submissions.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "bitstarter",
       "public_safe": true,
       "source_urls": [
         "https://app.bitstarter.ai/",
         "https://app.bitstarter.ai/submit-a-project/incubator/"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Public Bitstarter app workflow for incubator project submissions."
+      "url": "https://app.bitstarter.ai/submit-a-project/incubator/"
     },
     {
-      "id": "sn-91-bitstarter-updates-health-api",
-      "name": "Bitstarter updates platform health API",
-      "kind": "subnet-api",
-      "url": "https://updates.bitstarter.ai/api/health",
-      "provider": "bitstarter",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-91-bitstarter-updates-health-api",
+      "kind": "subnet-api",
+      "name": "Bitstarter updates platform health API",
+      "notes": "Public no-auth GET returning operational status JSON on the official Bitstarter updates/crowdfund host linked from app.bitstarter.ai project pages.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 15000
+      },
+      "provider": "bitstarter",
       "public_safe": true,
+      "review": {
+        "confidence": "medium",
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
       "source_urls": [
         "https://bitstarter.ai/",
         "https://app.bitstarter.ai/",
         "https://updates.bitstarter.ai/api/health"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "GET",
-        "expect": "json",
-        "timeout_ms": 15000
-      },
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "bohdansolovie",
-        "confidence": "medium"
-      },
-      "notes": "Public no-auth GET returning operational status JSON on the official Bitstarter updates/crowdfund host linked from app.bitstarter.ai project pages."
+      "url": "https://updates.bitstarter.ai/api/health"
     },
     {
       "auth_required": false,
@@ -192,8 +192,5 @@
       "url": "https://raw.githubusercontent.com/AlphaCoreBittensor/alphacore/main/modules/task_config.yaml"
     }
   ],
-  "social": {
-    "x": "https://x.com/bitstarterai"
-  },
-  "contact": "hello@bitstarter.ai"
+  "website_url": "https://bitstarter.ai/"
 }

--- a/registry/subnets/brainplay.json
+++ b/registry/subnets/brainplay.json
@@ -1,77 +1,74 @@
 {
-  "schema_version": 1,
-  "netuid": 117,
-  "name": "BrainPlay",
-  "slug": "sn-117",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-dispute",
     "identity-reviewed",
     "official-source-repo"
   ],
-  "source_repo": "https://github.com/shiftlayer-llc/brainplay-subnet",
-  "dashboard_url": "https://taomarketcap.com/subnets/117",
-  "website_url": "https://play.shiftlayer.ai/",
-  "notes": "Reviewed overlay for SN117 using the BrainPlay repository, whose metadata identifies it as BrainPlay SN117. Public directory evidence is conflicting: TaoMarketCap points to a Chi repository while Tensorplex points to BrainPlay, and the native chain name is currently a placeholder. The BrainPlay surfaces are promoted as reviewed public evidence, but the identity conflict remains explicit.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "needs-review",
-    "reviewed_at": "2026-06-08T10:50:00.000Z",
-    "verified_at": "2026-06-08T10:50:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "Native chain name is a placeholder.",
       "TaoMarketCap and Tensorplex currently disagree on the SN117 source repository.",
       "No verified docs site yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "needs-review",
+    "reviewed_at": "2026-06-08T10:50:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T10:50:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/117",
+  "name": "BrainPlay",
+  "netuid": 117,
+  "notes": "Reviewed overlay for SN117 using the BrainPlay repository, whose metadata identifies it as BrainPlay SN117. Public directory evidence is conflicting: TaoMarketCap points to a Chi repository while Tensorplex points to BrainPlay, and the native chain name is currently a placeholder. The BrainPlay surfaces are promoted as reviewed public evidence, but the identity conflict remains explicit.",
+  "schema_version": 1,
+  "slug": "sn-117",
+  "source_repo": "https://github.com/shiftlayer-llc/brainplay-subnet",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-117-brainplay-source",
-      "name": "BrainPlay source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/shiftlayer-llc/brainplay-subnet",
-      "provider": "shiftlayer",
       "auth_required": false,
       "authority": "provider-claimed",
+      "id": "sn-117-brainplay-source",
+      "kind": "source-repo",
+      "name": "BrainPlay source repository",
+      "notes": "BrainPlay repository metadata identifies this as SN117, but public directory sources conflict.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "shiftlayer",
       "public_safe": true,
       "source_urls": [
         "https://github.com/shiftlayer-llc/brainplay-subnet",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/117/subnet.json"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "BrainPlay repository metadata identifies this as SN117, but public directory sources conflict."
+      "url": "https://github.com/shiftlayer-llc/brainplay-subnet"
     },
     {
-      "id": "sn-117-brainplay-app",
-      "name": "BrainPlay public app",
-      "kind": "website",
-      "url": "https://play.shiftlayer.ai/",
-      "provider": "shiftlayer",
       "auth_required": false,
       "authority": "provider-claimed",
+      "id": "sn-117-brainplay-app",
+      "kind": "website",
+      "name": "BrainPlay public app",
+      "notes": "Public BrainPlay app URL from repository homepage metadata.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "shiftlayer",
       "public_safe": true,
       "source_urls": [
         "https://github.com/shiftlayer-llc/brainplay-subnet",
         "https://play.shiftlayer.ai/"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public BrainPlay app URL from repository homepage metadata."
+      "url": "https://play.shiftlayer.ai/"
     },
     {
       "auth_required": false,
@@ -130,5 +127,6 @@
       ],
       "url": "https://play.shiftlayer.ai/leaderboard"
     }
-  ]
+  ],
+  "website_url": "https://play.shiftlayer.ai/"
 }

--- a/registry/subnets/byzantium.json
+++ b/registry/subnets/byzantium.json
@@ -3,11 +3,8 @@
   "curation": {
     "gap_notes": [
       "No verified docs site yet.",
-      "No verified source repository yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",

--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -12,9 +12,7 @@
     "gap_notes": [
       "Official website, docs, source repository, and miner API contract documentation are verified live.",
       "The miner API contract describes required miner-hosted endpoints rather than a shared hosted public subnet API endpoint.",
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",

--- a/registry/subnets/chunking.json
+++ b/registry/subnets/chunking.json
@@ -11,11 +11,9 @@
     "gap_notes": [
       "subnet.chunking.com appears to be the official Chunking website, but its TLS certificate is currently expired and probe-derived status should be degraded.",
       "Previously discovered VectorChat/chunking_subnet source repository currently returns 404.",
-      "No verified live source repository yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -122,6 +120,12 @@
       "kind": "data-artifact",
       "name": "Chunking subnet protocol definition",
       "notes": "Public no-auth machine-readable protocol module (chunking/protocol.py) committed in the official salahawk/chunking_subnet repository, defining the Bittensor synapse schema SN40 Chunking miners and validators communicate over — the document/chunk request and response contract for the subnet's text-chunking task. Pinned to an immutable commit. Verified 200, SS58-clean, no keys or secrets. Distinct from the min_compute spec already registered.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "vectorchat",
       "public_safe": true,
       "review": {
@@ -132,12 +136,6 @@
         "https://github.com/salahawk/chunking_subnet/blob/29ed38c60aac356717d3e1dfc3e7c3627158bff4/chunking/protocol.py",
         "https://github.com/salahawk/chunking_subnet"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "GET",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
       "url": "https://raw.githubusercontent.com/salahawk/chunking_subnet/29ed38c60aac356717d3e1dfc3e7c3627158bff4/chunking/protocol.py"
     }
   ],

--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -11,10 +11,7 @@
   ],
   "contact": "support@chutes.ai",
   "curation": {
-    "gap_notes": [
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet."
-    ],
+    "gap_notes": [],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T07:45:00.000Z",

--- a/registry/subnets/coldint.json
+++ b/registry/subnets/coldint.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 29,
-  "name": "Coldint",
-  "slug": "sn-29",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "data",
@@ -13,168 +8,174 @@
     "official-source-repo",
     "official-website"
   ],
-  "docs_url": "https://github.com/coldint/coldint_validator/blob/main/README.md",
-  "source_repo": "https://github.com/coldint/coldint_validator",
-  "dashboard_url": "https://taostats.io/subnets/netuid-29",
-  "website_url": "https://coldint.io/",
-  "notes": "Reviewed overlay for SN29 using the official Coldint website, validator repository, dynamic configuration repository, README documentation, and referenced training dataset.",
   "curation": {
+    "gap_notes": [
+      "No verified machine-readable OpenAPI/Swagger schema yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T08:35:00.000Z",
-    "verified_at": "2026-06-08T08:35:00.000Z",
     "source_count": 9,
-    "gap_notes": [
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet."
-    ]
+    "verified_at": "2026-06-08T08:35:00.000Z"
   },
+  "dashboard_url": "https://taostats.io/subnets/netuid-29",
+  "docs_url": "https://github.com/coldint/coldint_validator/blob/main/README.md",
+  "name": "Coldint",
+  "netuid": 29,
+  "notes": "Reviewed overlay for SN29 using the official Coldint website, validator repository, dynamic configuration repository, README documentation, and referenced training dataset.",
+  "schema_version": 1,
+  "slug": "sn-29",
+  "social": {
+    "x": "https://x.com/cacheon_ai"
+  },
+  "source_repo": "https://github.com/coldint/coldint_validator",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-29-coldint-website",
-      "name": "Coldint website",
-      "kind": "website",
-      "url": "https://coldint.io/",
-      "provider": "coldint",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-29-coldint-website",
+      "kind": "website",
+      "name": "Coldint website",
+      "notes": "Official Coldint website.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "coldint",
       "public_safe": true,
       "source_urls": [
         "https://github.com/coldint/coldint_validator",
         "https://coldint.io/"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Coldint website."
+      "url": "https://coldint.io/"
     },
     {
-      "id": "sn-29-coldint-validator-source",
-      "name": "Coldint validator source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/coldint/coldint_validator",
-      "provider": "coldint",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-29-coldint-validator-source",
+      "kind": "source-repo",
+      "name": "Coldint validator source repository",
+      "notes": "Official Coldint validator repository for SN29.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "coldint",
       "public_safe": true,
       "source_urls": ["https://github.com/coldint/coldint_validator"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Coldint validator repository for SN29."
+      "url": "https://github.com/coldint/coldint_validator"
     },
     {
-      "id": "sn-29-coldint-config-source",
-      "name": "Coldint dynamic configuration repository",
-      "kind": "source-repo",
-      "url": "https://github.com/coldint/sn29",
-      "provider": "coldint",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-29-coldint-config-source",
+      "kind": "source-repo",
+      "name": "Coldint dynamic configuration repository",
+      "notes": "Official dynamic configuration repository for SN29 validators.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "coldint",
       "public_safe": true,
       "source_urls": [
         "https://github.com/coldint/coldint_validator",
         "https://github.com/coldint/sn29"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official dynamic configuration repository for SN29 validators."
+      "url": "https://github.com/coldint/sn29"
     },
     {
-      "id": "sn-29-coldint-readme-docs",
-      "name": "Coldint README",
-      "kind": "docs",
-      "url": "https://github.com/coldint/coldint_validator/blob/main/README.md",
-      "provider": "coldint",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-29-coldint-readme-docs",
+      "kind": "docs",
+      "name": "Coldint README",
+      "notes": "Official Coldint README for SN29.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "coldint",
       "public_safe": true,
       "source_urls": ["https://github.com/coldint/coldint_validator"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Coldint README for SN29."
+      "url": "https://github.com/coldint/coldint_validator/blob/main/README.md"
     },
     {
-      "id": "sn-29-coldint-fineweb-dataset",
-      "name": "FineWeb Edu score 2 dataset",
-      "kind": "data-artifact",
-      "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu-score-2",
-      "provider": "coldint",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-29-coldint-fineweb-dataset",
+      "kind": "data-artifact",
+      "name": "FineWeb Edu score 2 dataset",
+      "notes": "Public Hugging Face dataset referenced by the Coldint README.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "coldint",
       "public_safe": true,
       "source_urls": [
         "https://github.com/coldint/coldint_validator",
         "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu-score-2"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Public Hugging Face dataset referenced by the Coldint README."
+      "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu-score-2"
     },
     {
-      "id": "sn-29-coldint-taostats-dashboard",
-      "name": "Coldint TaoStats dashboard",
-      "kind": "dashboard",
-      "url": "https://taostats.io/subnets/netuid-29",
-      "provider": "taostats",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-29-coldint-taostats-dashboard",
+      "kind": "dashboard",
+      "name": "Coldint TaoStats dashboard",
+      "notes": "TaoStats subnet dashboard linked by the Coldint README.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
       "public_safe": true,
       "source_urls": [
         "https://github.com/coldint/coldint_validator",
         "https://taostats.io/subnets/netuid-29"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "TaoStats subnet dashboard linked by the Coldint README."
+      "url": "https://taostats.io/subnets/netuid-29"
     },
     {
-      "id": "sn-29-coldint-competitions-api",
-      "name": "Coldint competitions configuration API",
-      "kind": "subnet-api",
-      "url": "https://github.com/coldint/sn29/raw/main/competitions.json",
-      "provider": "coldint",
       "auth_required": false,
       "authority": "community",
-      "public_safe": true,
-      "source_urls": [
-        "https://github.com/coldint/coldint_validator/blob/main/constants/__init__.py",
-        "https://github.com/coldint/sn29/blob/main/README.md"
-      ],
+      "id": "sn-29-coldint-competitions-api",
+      "kind": "subnet-api",
+      "name": "Coldint competitions configuration API",
+      "notes": "Public no-auth GET competitions.json on the official SN29 dynamic-configuration repository (github.com/coldint/sn29). Validators poll this URL on COMPETITIONS_URL in constants/__init__.py via requests.get to load live competition parameters without restart.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "coldint",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "jimcody1995"
       },
-      "notes": "Public no-auth GET competitions.json on the official SN29 dynamic-configuration repository (github.com/coldint/sn29). Validators poll this URL on COMPETITIONS_URL in constants/__init__.py via requests.get to load live competition parameters without restart."
+      "source_urls": [
+        "https://github.com/coldint/coldint_validator/blob/main/constants/__init__.py",
+        "https://github.com/coldint/sn29/blob/main/README.md"
+      ],
+      "url": "https://github.com/coldint/sn29/raw/main/competitions.json"
     },
     {
       "auth_required": false,
@@ -196,7 +197,5 @@
       "url": "https://raw.githubusercontent.com/coldint/coldint_validator/a5860df87847173842772a2c234dad8a4ff87727/min_compute.yml"
     }
   ],
-  "social": {
-    "x": "https://x.com/cacheon_ai"
-  }
+  "website_url": "https://coldint.io/"
 }

--- a/registry/subnets/compelle.json
+++ b/registry/subnets/compelle.json
@@ -1,69 +1,66 @@
 {
-  "schema_version": 1,
-  "netuid": 82,
-  "name": "Compelle",
-  "slug": "sn-82",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "official-source-repo",
     "official-website"
   ],
-  "source_repo": "https://github.com/compelle/compelle-validator",
-  "dashboard_url": "https://taomarketcap.com/subnets/82",
-  "website_url": "https://compelle.com/",
-  "notes": "Reviewed overlay for SN82 using the official Compelle website and validator repository.",
   "curation": {
+    "gap_notes": [
+      "No verified official docs URL yet.",
+      "No verified OpenAPI/Swagger schema yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T10:10:00.000Z",
-    "verified_at": "2026-06-08T10:10:00.000Z",
     "source_count": 4,
-    "gap_notes": [
-      "No verified official docs URL yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T10:10:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/82",
+  "name": "Compelle",
+  "netuid": 82,
+  "notes": "Reviewed overlay for SN82 using the official Compelle website and validator repository.",
+  "schema_version": 1,
+  "slug": "sn-82",
+  "source_repo": "https://github.com/compelle/compelle-validator",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-82-compelle-website",
-      "name": "Compelle website",
-      "kind": "website",
-      "url": "https://compelle.com/",
-      "provider": "compelle",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/compelle/compelle-validator"],
+      "id": "sn-82-compelle-website",
+      "kind": "website",
+      "name": "Compelle website",
+      "notes": "Official Compelle website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Compelle website."
+      "provider": "compelle",
+      "public_safe": true,
+      "source_urls": ["https://github.com/compelle/compelle-validator"],
+      "url": "https://compelle.com/"
     },
     {
-      "id": "sn-82-compelle-source",
-      "name": "Compelle validator repository",
-      "kind": "source-repo",
-      "url": "https://github.com/compelle/compelle-validator",
-      "provider": "compelle",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/compelle/compelle-validator"],
+      "id": "sn-82-compelle-source",
+      "kind": "source-repo",
+      "name": "Compelle validator repository",
+      "notes": "Official Compelle validator repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Compelle validator repository."
+      "provider": "compelle",
+      "public_safe": true,
+      "source_urls": ["https://github.com/compelle/compelle-validator"],
+      "url": "https://github.com/compelle/compelle-validator"
     },
     {
       "auth_required": false,
@@ -119,5 +116,6 @@
       "source_urls": ["https://compelle.com/status", "https://compelle.com/"],
       "url": "https://compelle.com/status"
     }
-  ]
+  ],
+  "website_url": "https://compelle.com/"
 }

--- a/registry/subnets/compute-horde.json
+++ b/registry/subnets/compute-horde.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 12,
-  "name": "Compute Horde",
-  "slug": "sn-12",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "compute",
@@ -12,107 +7,109 @@
     "official-website",
     "official-source-repo"
   ],
-  "website_url": "https://computehorde.io/",
-  "source_repo": "https://github.com/backend-developers-ltd/ComputeHorde",
-  "dashboard_url": "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12",
-  "notes": "Reviewed overlay for SN12 using the official Compute Horde website/source repository and the project-linked Grafana metagraph dashboard. No safe public subnet API/OpenAPI surface is verified yet.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T15:45:00.000Z",
-    "verified_at": "2026-06-08T15:45:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "Project-linked Grafana metagraph dashboard is verified live.",
       "No verified official docs URL yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T15:45:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T15:45:00.000Z"
   },
+  "dashboard_url": "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12",
+  "name": "Compute Horde",
+  "netuid": 12,
+  "notes": "Reviewed overlay for SN12 using the official Compute Horde website/source repository and the project-linked Grafana metagraph dashboard. No safe public subnet API/OpenAPI surface is verified yet.",
+  "schema_version": 1,
+  "slug": "sn-12",
+  "source_repo": "https://github.com/backend-developers-ltd/ComputeHorde",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-12-compute-horde-website",
-      "name": "Compute Horde website",
-      "kind": "website",
-      "url": "https://computehorde.io/",
-      "provider": "compute-horde",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-12-compute-horde-website",
+      "kind": "website",
+      "name": "Compute Horde website",
+      "notes": "Official Compute Horde website linked from Learn Bittensor.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "compute-horde",
       "public_safe": true,
       "source_urls": [
         "https://learnbittensor.org/subnets/12",
         "https://computehorde.io/"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Compute Horde website linked from Learn Bittensor."
+      "url": "https://computehorde.io/"
     },
     {
-      "id": "sn-12-compute-horde-source",
-      "name": "Compute Horde source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/backend-developers-ltd/ComputeHorde",
-      "provider": "compute-horde",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-12-compute-horde-source",
+      "kind": "source-repo",
+      "name": "Compute Horde source repository",
+      "notes": "Official Compute Horde source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "compute-horde",
       "public_safe": true,
       "source_urls": [
         "https://learnbittensor.org/subnets/12",
         "https://github.com/backend-developers-ltd/ComputeHorde"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Compute Horde source repository."
+      "url": "https://github.com/backend-developers-ltd/ComputeHorde"
     },
     {
-      "id": "sn-12-compute-horde-grafana",
-      "name": "Compute Horde Grafana dashboard",
-      "kind": "dashboard",
-      "url": "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12",
-      "provider": "compute-horde",
       "auth_required": false,
       "authority": "provider-claimed",
+      "id": "sn-12-compute-horde-grafana",
+      "kind": "dashboard",
+      "name": "Compute Horde Grafana dashboard",
+      "notes": "Project-linked public Grafana metagraph dashboard. The originally discovered bactensor.io URL redirects to bittensor.church.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "compute-horde",
       "public_safe": true,
       "source_urls": [
         "https://github.com/backend-developers-ltd/ComputeHorde",
         "https://grafana.bactensor.io/d/subnet/metagraph-subnet?var-subnet=12",
         "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Project-linked public Grafana metagraph dashboard. The originally discovered bactensor.io URL redirects to bittensor.church."
+      "url": "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12"
     },
     {
-      "id": "sn-12-compute-horde-sdk",
-      "name": "Compute Horde Python SDK",
-      "kind": "sdk",
-      "url": "https://pypi.org/project/compute-horde-sdk/",
-      "provider": "compute-horde",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-12-compute-horde-sdk",
+      "kind": "sdk",
+      "name": "Compute Horde Python SDK",
+      "notes": "Official Python SDK (pip install compute-horde-sdk, module compute_horde_sdk.v1) for submitting organic compute jobs to the SN12 Compute Horde subnet, developed and published from the subnet's registered source repository.",
+      "provider": "compute-horde",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/backend-developers-ltd/ComputeHorde/tree/master/compute_horde_sdk"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "devmixa702"
       },
-      "notes": "Official Python SDK (pip install compute-horde-sdk, module compute_horde_sdk.v1) for submitting organic compute jobs to the SN12 Compute Horde subnet, developed and published from the subnet's registered source repository."
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/ComputeHorde/tree/master/compute_horde_sdk"
+      ],
+      "url": "https://pypi.org/project/compute-horde-sdk/"
     },
     {
       "auth_required": false,
@@ -140,25 +137,26 @@
       "kind": "openapi",
       "name": "Compute Horde Grafana HTTP API OpenAPI",
       "notes": "Public no-auth OpenAPI 3.0.3 schema (title \"Grafana HTTP API.\", 215 paths) at grafana.bittensor.church/public/openapi3.json. Served on the same Grafana host already registered as this file's dashboard surface (metagraph subnet dashboard for var-subnet=12; bactensor.io redirects here). Same publish convention already accepted for Templar (SN3) and Grail (SN81) Grafana OpenAPI surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 15000
+      },
       "provider": "compute-horde",
       "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
       "schema_status": "machine-readable",
       "schema_url": "https://grafana.bittensor.church/public/openapi3.json",
       "source_urls": [
         "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12",
         "https://github.com/backend-developers-ltd/ComputeHorde"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "GET",
-        "expect": "json",
-        "timeout_ms": 15000
-      },
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "bohdansolovie"
-      },
       "url": "https://grafana.bittensor.church/public/openapi3.json"
     }
-  ]
+  ],
+  "website_url": "https://computehorde.io/"
 }

--- a/registry/subnets/connitoai.json
+++ b/registry/subnets/connitoai.json
@@ -1,69 +1,69 @@
 {
-  "schema_version": 1,
-  "netuid": 102,
-  "name": "ConnitoAI",
-  "slug": "sn-102",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "official-source-repo",
     "official-website"
   ],
-  "source_repo": "https://github.com/Connito-AI/Connito",
-  "dashboard_url": "https://taomarketcap.com/subnets/102",
-  "website_url": "https://connito.ai/",
-  "notes": "Reviewed overlay for SN102 using the official ConnitoAI website and source repository. The previously discovered miner docs URL currently returns 404 and is not promoted.",
+  "contact": "isabella@connito.ai",
   "curation": {
+    "gap_notes": [
+      "Previously discovered Connito miner docs URL currently returns 404.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T09:50:00.000Z",
-    "verified_at": "2026-06-08T09:50:00.000Z",
     "source_count": 4,
-    "gap_notes": [
-      "Previously discovered Connito miner docs URL currently returns 404.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T09:50:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/102",
+  "name": "ConnitoAI",
+  "netuid": 102,
+  "notes": "Reviewed overlay for SN102 using the official ConnitoAI website and source repository. The previously discovered miner docs URL currently returns 404 and is not promoted.",
+  "schema_version": 1,
+  "slug": "sn-102",
+  "social": {
+    "x": "https://x.com/connitoai"
+  },
+  "source_repo": "https://github.com/Connito-AI/Connito",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-102-connito-website",
-      "name": "ConnitoAI website",
-      "kind": "website",
-      "url": "https://connito.ai/",
-      "provider": "connito",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/Connito-AI/Connito"],
+      "id": "sn-102-connito-website",
+      "kind": "website",
+      "name": "ConnitoAI website",
+      "notes": "Official ConnitoAI website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official ConnitoAI website."
+      "provider": "connito",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Connito-AI/Connito"],
+      "url": "https://connito.ai/"
     },
     {
-      "id": "sn-102-connito-source",
-      "name": "ConnitoAI source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/Connito-AI/Connito",
-      "provider": "connito",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/Connito-AI/Connito"],
+      "id": "sn-102-connito-source",
+      "kind": "source-repo",
+      "name": "ConnitoAI source repository",
+      "notes": "Official ConnitoAI source repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official ConnitoAI source repository."
+      "provider": "connito",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Connito-AI/Connito"],
+      "url": "https://github.com/Connito-AI/Connito"
     },
     {
       "auth_required": false,
@@ -127,8 +127,5 @@
       "url": "https://cycle-api.connito.ai/previous_phase_blocks"
     }
   ],
-  "social": {
-    "x": "https://x.com/connitoai"
-  },
-  "contact": "isabella@connito.ai"
+  "website_url": "https://connito.ai/"
 }

--- a/registry/subnets/data-universe.json
+++ b/registry/subnets/data-universe.json
@@ -10,12 +10,7 @@
   ],
   "contact": "support@macrocosmos.ai",
   "curation": {
-    "gap_notes": [
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ],
+    "gap_notes": ["No verified SSE/event stream yet."],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T08:35:00.000Z",
@@ -310,8 +305,8 @@
       "notes": "Machine-readable OpenAPI 3.1.0 schema (title \"Data Universe Validator API\", version 1.0.0) served by the SN13 validator API on the macrocosmos-hosted sn13.api.macrocosmos.ai host. Documents the on-demand data-query, bucket, label-size, age-size, and desirability routes. Unauthenticated GET returns the full paths object.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
       "provider": "macrocosmos",
@@ -335,22 +330,22 @@
       "kind": "data-artifact",
       "name": "Data Universe default desirability list",
       "notes": "Public no-auth JSON default dynamic-desirability list (per-source label weights used to value Reddit and X data) published at dynamic_desirability/default.json in the official macrocosm-os/data-universe repository. Documents the SN13 baseline data-scoring configuration.",
-      "provider": "macrocosmos",
-      "public_safe": true,
-      "source_urls": [
-        "https://github.com/macrocosm-os/data-universe/blob/main/dynamic_desirability/default.json",
-        "https://github.com/macrocosm-os/data-universe"
-      ],
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "macrocosmos",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "davion-knight"
       },
+      "source_urls": [
+        "https://github.com/macrocosm-os/data-universe/blob/main/dynamic_desirability/default.json",
+        "https://github.com/macrocosm-os/data-universe"
+      ],
       "url": "https://raw.githubusercontent.com/macrocosm-os/data-universe/main/dynamic_desirability/default.json"
     }
   ],

--- a/registry/subnets/degenbrain.json
+++ b/registry/subnets/degenbrain.json
@@ -11,10 +11,7 @@
       "Native chain name currently reports as ogham while the project website identifies SN90 as DegenBrain/Brain.",
       "The GitHub repository linked from the project website currently returns 404 and is not promoted.",
       "No verified source repository yet.",
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",

--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -12,10 +12,7 @@
   ],
   "contact": "giga@desearch.ai",
   "curation": {
-    "gap_notes": [
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ],
+    "gap_notes": ["No verified SSE/event stream yet."],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T07:45:00.000Z",

--- a/registry/subnets/ditto.json
+++ b/registry/subnets/ditto.json
@@ -22,9 +22,7 @@
       "Common API, health, OpenAPI, Swagger JSON, and Swagger UI paths currently return 404.",
       "Canonical source repository verified: ditto-assistant/dittobench-starter-kit self-declares \"Official DittoBench miner starter kit for Bittensor subnet 118\" (not a fork, ditto-assistant org).",
       "No verified safe public subnet API endpoint yet.",
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",

--- a/registry/subnets/djinn.json
+++ b/registry/subnets/djinn.json
@@ -1,69 +1,70 @@
 {
-  "schema_version": 1,
-  "netuid": 103,
-  "name": "Djinn",
-  "slug": "sn-103",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "official-source-repo",
     "official-website"
   ],
-  "source_repo": "https://github.com/Djinn-Inc/djinn",
-  "dashboard_url": "https://taomarketcap.com/subnets/103",
-  "website_url": "https://www.djinn.gg/",
-  "notes": "Reviewed overlay for SN103 using the official Djinn website and source repository.",
+  "contact": "info@djinn.gg",
   "curation": {
+    "gap_notes": [
+      "No verified official docs URL yet.",
+      "No verified OpenAPI/Swagger schema yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T10:10:00.000Z",
-    "verified_at": "2026-06-08T10:10:00.000Z",
     "source_count": 4,
-    "gap_notes": [
-      "No verified official docs URL yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T10:10:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/103",
+  "name": "Djinn",
+  "netuid": 103,
+  "notes": "Reviewed overlay for SN103 using the official Djinn website and source repository.",
+  "schema_version": 1,
+  "slug": "sn-103",
+  "social": {
+    "x": "https://x.com/djinn_gg"
+  },
+  "source_repo": "https://github.com/Djinn-Inc/djinn",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-103-djinn-website",
-      "name": "Djinn website",
-      "kind": "website",
-      "url": "https://www.djinn.gg/",
-      "provider": "djinn",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/Djinn-Inc/djinn"],
+      "id": "sn-103-djinn-website",
+      "kind": "website",
+      "name": "Djinn website",
+      "notes": "Official Djinn website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Djinn website."
+      "provider": "djinn",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Djinn-Inc/djinn"],
+      "url": "https://www.djinn.gg/"
     },
     {
-      "id": "sn-103-djinn-source",
-      "name": "Djinn source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/Djinn-Inc/djinn",
-      "provider": "djinn",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/Djinn-Inc/djinn"],
+      "id": "sn-103-djinn-source",
+      "kind": "source-repo",
+      "name": "Djinn source repository",
+      "notes": "Official Djinn source repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Djinn source repository."
+      "provider": "djinn",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Djinn-Inc/djinn"],
+      "url": "https://github.com/Djinn-Inc/djinn"
     },
     {
       "auth_required": false,
@@ -120,8 +121,5 @@
       "url": "https://www.djinn.gg/api/leaderboard"
     }
   ],
-  "social": {
-    "x": "https://x.com/djinn_gg"
-  },
-  "contact": "info@djinn.gg"
+  "website_url": "https://www.djinn.gg/"
 }

--- a/registry/subnets/dojo.json
+++ b/registry/subnets/dojo.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 52,
-  "name": "Dojo",
-  "slug": "sn-52",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
@@ -12,157 +7,160 @@
     "official-website",
     "tensorplex"
   ],
-  "docs_url": "https://docs.tensorplex.ai/tensorplex-docs/tensorplex-dojo-bittensor-subnet/subnet-mechanism",
-  "source_repo": "https://github.com/tensorplex-labs/dojo",
-  "dashboard_url": "https://taomarketcap.com/subnets/52",
-  "website_url": "https://www.tensorplex.ai/",
-  "notes": "Reviewed overlay for SN52 using the official Tensorplex website, Dojo docs, source repository, UI repository, and worker API repository. The older dojo-synthetic-api repository candidate currently 404s and is intentionally not promoted.",
+  "contact": "jarvis@tensorplex.ai",
   "curation": {
+    "gap_notes": [
+      "No verified safe public subnet API endpoint yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T09:25:00.000Z",
-    "verified_at": "2026-06-08T09:25:00.000Z",
     "source_count": 8,
-    "gap_notes": [
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T09:25:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/52",
+  "docs_url": "https://docs.tensorplex.ai/tensorplex-docs/tensorplex-dojo-bittensor-subnet/subnet-mechanism",
+  "name": "Dojo",
+  "netuid": 52,
+  "notes": "Reviewed overlay for SN52 using the official Tensorplex website, Dojo docs, source repository, UI repository, and worker API repository. The older dojo-synthetic-api repository candidate currently 404s and is intentionally not promoted.",
+  "schema_version": 1,
+  "slug": "sn-52",
+  "source_repo": "https://github.com/tensorplex-labs/dojo",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-52-tensorplex-website",
-      "name": "Tensorplex website",
-      "kind": "website",
-      "url": "https://www.tensorplex.ai/",
-      "provider": "tensorplex",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-52-tensorplex-website",
+      "kind": "website",
+      "name": "Tensorplex website",
+      "notes": "Official Tensorplex website.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorplex",
       "public_safe": true,
       "source_urls": [
         "https://www.tensorplex.ai/",
         "https://github.com/tensorplex-labs/dojo"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Tensorplex website."
+      "url": "https://www.tensorplex.ai/"
     },
     {
-      "id": "sn-52-dojo-docs",
-      "name": "Dojo subnet mechanism docs",
-      "kind": "docs",
-      "url": "https://docs.tensorplex.ai/tensorplex-docs/tensorplex-dojo-bittensor-subnet/subnet-mechanism",
-      "provider": "tensorplex",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-52-dojo-docs",
+      "kind": "docs",
+      "name": "Dojo subnet mechanism docs",
+      "notes": "Official Tensorplex Dojo subnet mechanism documentation.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorplex",
       "public_safe": true,
       "source_urls": [
         "https://docs.tensorplex.ai/tensorplex-docs/tensorplex-dojo-bittensor-subnet/subnet-mechanism"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Tensorplex Dojo subnet mechanism documentation."
+      "url": "https://docs.tensorplex.ai/tensorplex-docs/tensorplex-dojo-bittensor-subnet/subnet-mechanism"
     },
     {
-      "id": "sn-52-dojo-source",
-      "name": "Dojo source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/tensorplex-labs/dojo",
-      "provider": "tensorplex",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-52-dojo-source",
+      "kind": "source-repo",
+      "name": "Dojo source repository",
+      "notes": "Official Dojo source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorplex",
       "public_safe": true,
       "source_urls": ["https://github.com/tensorplex-labs/dojo"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Dojo source repository."
+      "url": "https://github.com/tensorplex-labs/dojo"
     },
     {
-      "id": "sn-52-dojo-ui-source",
-      "name": "Dojo UI repository",
-      "kind": "source-repo",
-      "url": "https://github.com/tensorplex-labs/dojo-ui",
-      "provider": "tensorplex",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-52-dojo-ui-source",
+      "kind": "source-repo",
+      "name": "Dojo UI repository",
+      "notes": "Official Dojo UI repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorplex",
       "public_safe": true,
       "source_urls": ["https://github.com/tensorplex-labs/dojo-ui"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Dojo UI repository."
+      "url": "https://github.com/tensorplex-labs/dojo-ui"
     },
     {
-      "id": "sn-52-dojo-worker-api-source",
-      "name": "Dojo worker API repository",
-      "kind": "source-repo",
-      "url": "https://github.com/tensorplex-labs/dojo-worker-api",
-      "provider": "tensorplex",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/tensorplex-labs/dojo-worker-api"],
+      "id": "sn-52-dojo-worker-api-source",
+      "kind": "source-repo",
+      "name": "Dojo worker API repository",
+      "notes": "Official Dojo worker API repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Dojo worker API repository."
+      "provider": "tensorplex",
+      "public_safe": true,
+      "source_urls": ["https://github.com/tensorplex-labs/dojo-worker-api"],
+      "url": "https://github.com/tensorplex-labs/dojo-worker-api"
     },
     {
-      "id": "sn-52-dojo-synthetic-sft-dataset",
-      "name": "Dojo synthetic SFT dataset",
-      "kind": "data-artifact",
-      "url": "https://huggingface.co/datasets/tensorplex-labs/Dojo-Synthetic-SFT",
-      "provider": "tensorplex",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-52-dojo-synthetic-sft-dataset",
+      "kind": "data-artifact",
+      "name": "Dojo synthetic SFT dataset",
+      "notes": "Public Tensorplex Dojo (SN52) HuggingFace dataset of 12.5k synthetic HTML/CSS/JS interface-generation Q&A pairs (id + messages columns), used to train the subnet's DOJO-INTERFACE-CODER model; not gated. The dojo repo README (source) declares the Bittensor subnet (--netuid 52) and the tensorplex-labs HF org owns the dataset.",
+      "provider": "tensorplex",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/tensorplex-labs/dojo",
-        "https://huggingface.co/tensorplex-labs"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Public Tensorplex Dojo (SN52) HuggingFace dataset of 12.5k synthetic HTML/CSS/JS interface-generation Q&A pairs (id + messages columns), used to train the subnet's DOJO-INTERFACE-CODER model; not gated. The dojo repo README (source) declares the Bittensor subnet (--netuid 52) and the tensorplex-labs HF org owns the dataset."
-    },
-    {
-      "id": "sn-52-dojo-humanfeedback-dpo",
-      "name": "Dojo Human Feedback DPO dataset",
-      "kind": "data-artifact",
-      "url": "https://huggingface.co/datasets/tensorplex-labs/Dojo-HumanFeedback-DPO",
-      "provider": "tensorplex",
-      "auth_required": false,
-      "authority": "community",
-      "public_safe": true,
       "source_urls": [
         "https://github.com/tensorplex-labs/dojo",
         "https://huggingface.co/tensorplex-labs"
       ],
+      "url": "https://huggingface.co/datasets/tensorplex-labs/Dojo-Synthetic-SFT"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-52-dojo-humanfeedback-dpo",
+      "kind": "data-artifact",
+      "name": "Dojo Human Feedback DPO dataset",
+      "notes": "Public Tensorplex Dojo (SN52) HuggingFace DPO dataset of human-feedback preference pairs collected through the subnet's Dojo human-feedback-loop platform; not gated. The dojo repo README (source) declares the Bittensor subnet (--netuid 52) and the tensorplex-labs HF org owns the dataset. Distinct from the subnet's registered Dojo-Synthetic-SFT dataset.",
+      "provider": "tensorplex",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "davion-knight"
       },
-      "notes": "Public Tensorplex Dojo (SN52) HuggingFace DPO dataset of human-feedback preference pairs collected through the subnet's Dojo human-feedback-loop platform; not gated. The dojo repo README (source) declares the Bittensor subnet (--netuid 52) and the tensorplex-labs HF org owns the dataset. Distinct from the subnet's registered Dojo-Synthetic-SFT dataset."
+      "source_urls": [
+        "https://github.com/tensorplex-labs/dojo",
+        "https://huggingface.co/tensorplex-labs"
+      ],
+      "url": "https://huggingface.co/datasets/tensorplex-labs/Dojo-HumanFeedback-DPO"
     },
     {
       "auth_required": false,
@@ -211,5 +209,5 @@
       "url": "https://api.taomarketcap.com/public/v1/subnets/52"
     }
   ],
-  "contact": "jarvis@tensorplex.ai"
+  "website_url": "https://www.tensorplex.ai/"
 }

--- a/registry/subnets/dsperse.json
+++ b/registry/subnets/dsperse.json
@@ -16,10 +16,7 @@
     "gap_notes": [
       "Official website, docs, and source repository are verified live.",
       "Common `/api`, `/health`, `/swagger`, and `/openapi.json` paths currently serve the public SPA shell, not API/schema data.",
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
@@ -193,8 +190,19 @@
       "kind": "openapi",
       "name": "DSperse circuit repository OpenAPI",
       "notes": "Public no-auth OpenAPI 3.1 schema for the SN2 circuit repository API (title \"Circuit Repository API\", 11 paths) on repository.inferencelabs.com. Validators and miners fetch active ZK circuits from this host; the official subnet-2 client sets CIRCUIT_API_URL to https://repository.inferencelabs.com in crates/sn2-types/src/constants.rs.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 15000
+      },
       "provider": "inference-labs",
       "public_safe": true,
+      "review": {
+        "confidence": "medium",
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
       "schema_status": "machine-readable",
       "schema_url": "https://repository.inferencelabs.com/openapi.json",
       "source_urls": [
@@ -202,17 +210,6 @@
         "https://sn2-docs.inferencelabs.com/technical-roadmap.md",
         "https://repository.inferencelabs.com/docs"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "GET",
-        "expect": "json",
-        "timeout_ms": 15000
-      },
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "bohdansolovie",
-        "confidence": "medium"
-      },
       "url": "https://repository.inferencelabs.com/openapi.json"
     }
   ],

--- a/registry/subnets/efficientfrontier.json
+++ b/registry/subnets/efficientfrontier.json
@@ -13,11 +13,9 @@
       "SignalPlus website is live and is tracked as the team/project website.",
       "The subnet mining app currently returns a 403/auth-challenge response to simple probes and is expected to appear degraded rather than healthy.",
       "Previously discovered GitHub source repository currently returns 404.",
-      "No verified live source repository yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",

--- a/registry/subnets/eni.json
+++ b/registry/subnets/eni.json
@@ -1,31 +1,29 @@
 {
-  "schema_version": 1,
-  "netuid": 101,
-  "name": "eni",
-  "slug": "eni",
-  "status": "active",
   "categories": ["baseline-curated", "identity-reviewed"],
-  "source_repo": "https://github.com/tag101-ai/tag101",
-  "website_url": "http://tag101.ai/",
-  "docs_url": null,
-  "dashboard_url": null,
-  "notes": "Reviewed overlay for SN101 eni. Public directories list the subnet, but no official website, source repository, API, OpenAPI schema, or docs site has been verified.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T15:00:00.000Z",
-    "verified_at": "2026-06-08T15:00:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "No verified official website yet.",
       "No verified live source repository yet.",
       "No verified official docs site yet beyond public directory/community pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T15:00:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T15:00:00.000Z"
   },
+  "dashboard_url": null,
+  "docs_url": null,
+  "name": "eni",
+  "netuid": 101,
+  "notes": "Reviewed overlay for SN101 eni. Public directories list the subnet, but no official website, source repository, API, OpenAPI schema, or docs site has been verified.",
+  "schema_version": 1,
+  "slug": "eni",
+  "source_repo": "https://github.com/tag101-ai/tag101",
+  "status": "active",
   "surfaces": [
     {
       "auth_required": false,
@@ -71,5 +69,6 @@
       ],
       "url": "https://raw.githubusercontent.com/tag101-ai/tag101/115f36da7c483d16018d4c16a14f8fb8d0433306/min_compute.yml"
     }
-  ]
+  ],
+  "website_url": "http://tag101.ai/"
 }

--- a/registry/subnets/enigma.json
+++ b/registry/subnets/enigma.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 63,
-  "name": "Enigma",
-  "slug": "sn-63",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
@@ -11,60 +6,66 @@
     "official-website",
     "quantum"
   ],
-  "source_repo": "https://github.com/qbittensor-labs/enigma",
-  "dashboard_url": "https://taomarketcap.com/subnets/63",
-  "website_url": "https://www.qbittensorlabs.com/",
-  "notes": "Reviewed overlay for SN63 using the official qBittensor Labs website and Enigma source repository.",
+  "contact": "qbittensorlabs@gmail.com",
   "curation": {
+    "gap_notes": [
+      "No verified official docs URL yet.",
+      "No verified OpenAPI/Swagger schema yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T10:10:00.000Z",
-    "verified_at": "2026-06-08T10:10:00.000Z",
     "source_count": 4,
-    "gap_notes": [
-      "No verified official docs URL yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T10:10:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/63",
+  "name": "Enigma",
+  "netuid": 63,
+  "notes": "Reviewed overlay for SN63 using the official qBittensor Labs website and Enigma source repository.",
+  "schema_version": 1,
+  "slug": "sn-63",
+  "social": {
+    "x": "https://x.com/qbittensorlabs"
+  },
+  "source_repo": "https://github.com/qbittensor-labs/enigma",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-63-enigma-website",
-      "name": "qBittensor Labs website",
-      "kind": "website",
-      "url": "https://www.qbittensorlabs.com/",
-      "provider": "qbittensor-labs",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/qbittensor-labs/enigma"],
+      "id": "sn-63-enigma-website",
+      "kind": "website",
+      "name": "qBittensor Labs website",
+      "notes": "Official qBittensor Labs website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official qBittensor Labs website."
+      "provider": "qbittensor-labs",
+      "public_safe": true,
+      "source_urls": ["https://github.com/qbittensor-labs/enigma"],
+      "url": "https://www.qbittensorlabs.com/"
     },
     {
-      "id": "sn-63-enigma-source",
-      "name": "Enigma source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/qbittensor-labs/enigma",
-      "provider": "qbittensor-labs",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/qbittensor-labs/enigma"],
+      "id": "sn-63-enigma-source",
+      "kind": "source-repo",
+      "name": "Enigma source repository",
+      "notes": "Official Enigma source repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Enigma source repository."
+      "provider": "qbittensor-labs",
+      "public_safe": true,
+      "source_urls": ["https://github.com/qbittensor-labs/enigma"],
+      "url": "https://github.com/qbittensor-labs/enigma"
     },
     {
       "auth_required": false,
@@ -113,8 +114,8 @@
       "notes": "Public no-auth machine-readable constants module (qbittensor/constants.py) published in the official qbittensor-labs/enigma repository, defining the SN63 Enigma validator/miner operational parameters: cross-check timeout and max batch size, solution-container manager scheduling, max concurrent solutions, and related tuning values the subnet software runs against. Pinned to an immutable commit. Verified 200, SS58-clean (no keys or secrets). Distinct from the min_compute hardware spec already registered.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "any",
+        "method": "GET",
         "timeout_ms": 10000
       },
       "provider": "qbittensor-labs",
@@ -130,8 +131,5 @@
       "url": "https://raw.githubusercontent.com/qbittensor-labs/enigma/c4f9082ea09d5bb3e834e856501a92ee47a65632/qbittensor/constants.py"
     }
   ],
-  "social": {
-    "x": "https://x.com/qbittensorlabs"
-  },
-  "contact": "qbittensorlabs@gmail.com"
+  "website_url": "https://www.qbittensorlabs.com/"
 }

--- a/registry/subnets/evolai.json
+++ b/registry/subnets/evolai.json
@@ -7,10 +7,8 @@
   ],
   "curation": {
     "gap_notes": [
-      "No verified official website yet.",
       "No verified docs site yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
@@ -122,17 +120,17 @@
       "kind": "data-artifact",
       "name": "EvolAI validator configuration",
       "notes": "Public no-auth machine-readable validator-configuration module (evolai/validator/config.py) committed in the official openevolai/evolai repository, defining the SN47 EvolAI evaluation parameters the validator runs against: reference tokenizer/model, per-stage generation token budgets (think/KL/side-quest max-new-tokens), fast-transformer and Mamba2 evaluation toggles, and CUDA memory settings. Pinned to an immutable commit. Verified 200, SS58-clean and contains no secret values (the one API-key field reads an env var with a locally-generated default). Distinct from the universal_qa dataset already registered.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "evolai",
       "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "ultrahighsuper"
-      },
-      "probe": {
-        "enabled": true,
-        "method": "GET",
-        "expect": "any",
-        "timeout_ms": 10000
       },
       "source_urls": [
         "https://github.com/openevolai/evolai/blob/4cc0040eca74e3541178661ce8b5dd29fa2d343a/evolai/validator/config.py",

--- a/registry/subnets/forevermoney.json
+++ b/registry/subnets/forevermoney.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 98,
-  "name": "ForeverMoney",
-  "slug": "sn-98",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "finance",
@@ -11,141 +6,144 @@
     "official-source-repo",
     "official-website"
   ],
-  "source_repo": "https://github.com/SN98-ForeverMoney/forever-money",
-  "dashboard_url": "https://taomarketcap.com/subnets/98",
-  "website_url": "https://forevermoney.ai/",
-  "notes": "Reviewed overlay for SN98 using the official ForeverMoney website and source repository.",
+  "contact": "gm@forevermoney.ai",
   "curation": {
+    "gap_notes": [
+      "No verified official docs URL yet.",
+      "No verified OpenAPI/Swagger schema yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T10:10:00.000Z",
-    "verified_at": "2026-06-08T10:10:00.000Z",
     "source_count": 4,
-    "gap_notes": [
-      "No verified official docs URL yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T10:10:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/98",
+  "name": "ForeverMoney",
+  "netuid": 98,
+  "notes": "Reviewed overlay for SN98 using the official ForeverMoney website and source repository.",
+  "schema_version": 1,
+  "slug": "sn-98",
+  "social": {
+    "x": "https://x.com/forevermoney_ai"
+  },
+  "source_repo": "https://github.com/SN98-ForeverMoney/forever-money",
+  "status": "active",
   "surfaces": [
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-98-forevermoney-website",
-      "name": "ForeverMoney website",
       "kind": "website",
-      "url": "https://forevermoney.ai/",
-      "provider": "forevermoney",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/SN98-ForeverMoney/forever-money"],
+      "name": "ForeverMoney website",
+      "notes": "Official ForeverMoney website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official ForeverMoney website."
-    },
-    {
-      "id": "sn-98-forevermoney-source",
-      "name": "ForeverMoney source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/SN98-ForeverMoney/forever-money",
       "provider": "forevermoney",
-      "auth_required": false,
-      "authority": "official",
       "public_safe": true,
       "source_urls": ["https://github.com/SN98-ForeverMoney/forever-money"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official ForeverMoney source repository."
+      "url": "https://forevermoney.ai/"
     },
     {
-      "id": "sn-98-forevermoney-vaults-tvl-api",
-      "name": "ForeverMoney vault TVL API",
-      "kind": "subnet-api",
-      "url": "https://dashboard.forevermoney.ai/api/vaults/tvl",
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-98-forevermoney-source",
+      "kind": "source-repo",
+      "name": "ForeverMoney source repository",
+      "notes": "Official ForeverMoney source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "forevermoney",
+      "public_safe": true,
+      "source_urls": ["https://github.com/SN98-ForeverMoney/forever-money"],
+      "url": "https://github.com/SN98-ForeverMoney/forever-money"
+    },
+    {
       "auth_required": false,
       "authority": "community",
+      "id": "sn-98-forevermoney-vaults-tvl-api",
+      "kind": "subnet-api",
+      "name": "ForeverMoney vault TVL API",
+      "notes": "Public no-auth GET returning vault TVL aggregates grouped by trading pair on the official ForeverMoney Insights dashboard API host.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 15000
+      },
+      "provider": "forevermoney",
       "public_safe": true,
+      "review": {
+        "confidence": "medium",
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
       "source_urls": [
         "https://forevermoney.ai/",
         "https://dashboard.forevermoney.ai/api/vaults/tvl"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "GET",
-        "expect": "json",
-        "timeout_ms": 15000
-      },
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "bohdansolovie",
-        "confidence": "medium"
-      },
-      "notes": "Public no-auth GET returning vault TVL aggregates grouped by trading pair on the official ForeverMoney Insights dashboard API host."
+      "url": "https://dashboard.forevermoney.ai/api/vaults/tvl"
     },
     {
-      "id": "sn-98-forevermoney-min-compute-spec",
-      "name": "ForeverMoney minimum compute requirements",
-      "kind": "data-artifact",
-      "url": "https://raw.githubusercontent.com/SN98-ForeverMoney/forever-money/main/min_compute.yml",
-      "provider": "forevermoney",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-98-forevermoney-min-compute-spec",
+      "kind": "data-artifact",
+      "name": "ForeverMoney minimum compute requirements",
+      "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official SN98-ForeverMoney/forever-money repository as min_compute.yml. Documents baseline CPU, memory, storage, and network bandwidth requirements for SN98 ForeverMoney miners and validators.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 15000
+      },
+      "provider": "forevermoney",
       "public_safe": true,
+      "review": {
+        "confidence": "medium",
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
       "source_urls": [
         "https://github.com/SN98-ForeverMoney/forever-money/blob/main/min_compute.yml",
         "https://github.com/SN98-ForeverMoney/forever-money/blob/main/setup.py"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "GET",
-        "expect": "any",
-        "timeout_ms": 15000
-      },
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "davion-knight",
-        "confidence": "medium"
-      },
-      "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official SN98-ForeverMoney/forever-money repository as min_compute.yml. Documents baseline CPU, memory, storage, and network bandwidth requirements for SN98 ForeverMoney miners and validators."
+      "url": "https://raw.githubusercontent.com/SN98-ForeverMoney/forever-money/main/min_compute.yml"
     },
     {
-      "id": "sn-98-forevermoney-liquidity-manager-abi",
-      "name": "ForeverMoney LiquidityManager contract ABI",
-      "kind": "data-artifact",
-      "url": "https://raw.githubusercontent.com/SN98-ForeverMoney/forever-money/7acfc5422a4e1714670275bf8dc2b32c1f815756/validator/utils/abis/LiquidityManager.json",
-      "provider": "forevermoney",
       "auth_required": false,
       "authority": "community",
-      "public_safe": true,
-      "source_urls": [
-        "https://github.com/SN98-ForeverMoney/forever-money/blob/7acfc5422a4e1714670275bf8dc2b32c1f815756/validator/utils/abis/LiquidityManager.json",
-        "https://github.com/SN98-ForeverMoney/forever-money"
-      ],
+      "id": "sn-98-forevermoney-liquidity-manager-abi",
+      "kind": "data-artifact",
+      "name": "ForeverMoney LiquidityManager contract ABI",
+      "notes": "Public no-auth machine-readable JSON ABI for the on-chain LiquidityManager smart contract loaded by the SN98 ForeverMoney validator, committed in the official SN98-ForeverMoney/forever-money repository at validator/utils/abis/LiquidityManager.json. Describes the constructor, functions, and events of the core liquidity-management contract the subnet's validator interacts with. Pinned to an immutable commit. Distinct from the min_compute hardware spec already registered.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 15000
       },
+      "provider": "forevermoney",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "ultrahighsuper"
       },
-      "notes": "Public no-auth machine-readable JSON ABI for the on-chain LiquidityManager smart contract loaded by the SN98 ForeverMoney validator, committed in the official SN98-ForeverMoney/forever-money repository at validator/utils/abis/LiquidityManager.json. Describes the constructor, functions, and events of the core liquidity-management contract the subnet's validator interacts with. Pinned to an immutable commit. Distinct from the min_compute hardware spec already registered."
+      "source_urls": [
+        "https://github.com/SN98-ForeverMoney/forever-money/blob/7acfc5422a4e1714670275bf8dc2b32c1f815756/validator/utils/abis/LiquidityManager.json",
+        "https://github.com/SN98-ForeverMoney/forever-money"
+      ],
+      "url": "https://raw.githubusercontent.com/SN98-ForeverMoney/forever-money/7acfc5422a4e1714670275bf8dc2b32c1f815756/validator/utils/abis/LiquidityManager.json"
     }
   ],
-  "social": {
-    "x": "https://x.com/forevermoney_ai"
-  },
-  "contact": "gm@forevermoney.ai"
+  "website_url": "https://forevermoney.ai/"
 }

--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -2,8 +2,6 @@
   "categories": ["developer-tools", "repositories", "pilot"],
   "curation": {
     "gap_notes": [
-      "No verified dashboard surface yet.",
-      "No verified OpenAPI/Swagger surface yet.",
       "No verified SSE/event stream yet.",
       "Bounty state is documented through public CLI flows, but no unauthenticated public API has been verified yet."
     ],

--- a/registry/subnets/gm.json
+++ b/registry/subnets/gm.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 28,
-  "name": "gm",
-  "slug": "gm",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
@@ -11,28 +6,33 @@
     "marketplace",
     "tee"
   ],
-  "source_repo": "https://github.com/taostat/gm-miner",
-  "website_url": "https://saygm.com/",
-  "docs_url": null,
-  "dashboard_url": null,
-  "notes": "Reviewed overlay for SN28 gm. Public news/directory sources describe a TEE-enabled LLM inference marketplace, but no official public website, source repository, API, OpenAPI schema, or docs site has been verified.",
+  "contact": "hi@saygm.com",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T15:00:00.000Z",
-    "verified_at": "2026-06-08T15:00:00.000Z",
-    "source_count": 6,
     "gap_notes": [
       "No verified official website yet.",
       "No verified live source repository yet.",
       "No verified official docs site yet beyond public directory/community pages.",
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet.",
       "SubnetRadar published Discord-derived news about a TEE-enabled model routing marketplace, but that is not treated as an official operational interface."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T15:00:00.000Z",
+    "source_count": 6,
+    "verified_at": "2026-06-08T15:00:00.000Z"
   },
+  "dashboard_url": null,
+  "docs_url": null,
+  "name": "gm",
+  "netuid": 28,
+  "notes": "Reviewed overlay for SN28 gm. Public news/directory sources describe a TEE-enabled LLM inference marketplace, but no official public website, source repository, API, OpenAPI schema, or docs site has been verified.",
+  "schema_version": 1,
+  "slug": "gm",
+  "social": {
+    "x": "https://x.com/say_gm_"
+  },
+  "source_repo": "https://github.com/taostat/gm-miner",
+  "status": "active",
   "surfaces": [
     {
       "auth_required": false,
@@ -102,8 +102,5 @@
       "url": "https://raw.githubusercontent.com/taostat/gm-miner/refs/heads/main/image/envoy.yaml"
     }
   ],
-  "social": {
-    "x": "https://x.com/say_gm_"
-  },
-  "contact": "hi@saygm.com"
+  "website_url": "https://saygm.com/"
 }

--- a/registry/subnets/gopher.json
+++ b/registry/subnets/gopher.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 42,
-  "name": "Gopher",
-  "slug": "sn-42",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "data",
@@ -14,176 +9,178 @@
     "official-website",
     "tee"
   ],
-  "docs_url": "https://developers.gopher-ai.com/docs/subnet/intro",
-  "source_repo": "https://github.com/gopher-lab/subnet-42",
-  "dashboard_url": "https://taomarketcap.com/subnets/42",
-  "website_url": "https://developers.gopher-ai.com/",
-  "notes": "Reviewed overlay for SN42 using the live Gopher developer portal, subnet documentation, miner documentation, and source repository. Native chain identity currently reports a placeholder name, so this remains an explicit identity-drift entry rather than a silent rename.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T20:15:00.000Z",
-    "verified_at": "2026-06-08T20:15:00.000Z",
-    "source_count": 7,
     "gap_notes": [
       "Native chain name currently reports as a placeholder.",
       "Official developer portal, subnet docs, miner docs, and source repository are verified live.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T20:15:00.000Z",
+    "source_count": 7,
+    "verified_at": "2026-06-08T20:15:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/42",
+  "docs_url": "https://developers.gopher-ai.com/docs/subnet/intro",
+  "name": "Gopher",
+  "netuid": 42,
+  "notes": "Reviewed overlay for SN42 using the live Gopher developer portal, subnet documentation, miner documentation, and source repository. Native chain identity currently reports a placeholder name, so this remains an explicit identity-drift entry rather than a silent rename.",
+  "schema_version": 1,
+  "slug": "sn-42",
+  "source_repo": "https://github.com/gopher-lab/subnet-42",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-42-gopher-developer-portal",
-      "name": "Gopher developer portal",
-      "kind": "website",
-      "url": "https://developers.gopher-ai.com/",
-      "provider": "gopher-ai",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-42-gopher-developer-portal",
+      "kind": "website",
+      "name": "Gopher developer portal",
+      "notes": "Official Gopher developer portal.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "gopher-ai",
       "public_safe": true,
       "source_urls": [
         "https://developers.gopher-ai.com/",
         "https://developers.gopher-ai.com/docs/subnet/intro"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Gopher developer portal."
+      "url": "https://developers.gopher-ai.com/"
     },
     {
-      "id": "sn-42-gopher-docs",
-      "name": "Gopher subnet documentation",
-      "kind": "docs",
-      "url": "https://developers.gopher-ai.com/docs/subnet/intro",
-      "provider": "gopher-ai",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-42-gopher-docs",
+      "kind": "docs",
+      "name": "Gopher subnet documentation",
+      "notes": "Public Gopher subnet documentation. The docs identify the subnet as mainnet netuid 42 and link miner setup to the subnet source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "gopher-ai",
       "public_safe": true,
       "source_urls": [
         "https://developers.gopher-ai.com/docs/subnet/intro",
         "https://developers.gopher-ai.com/docs/subnet/miners",
         "https://github.com/gopher-lab/subnet-42"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Public Gopher subnet documentation. The docs identify the subnet as mainnet netuid 42 and link miner setup to the subnet source repository."
+      "url": "https://developers.gopher-ai.com/docs/subnet/intro"
     },
     {
-      "id": "sn-42-gopher-miner-docs",
-      "name": "Gopher miner documentation",
-      "kind": "docs",
-      "url": "https://developers.gopher-ai.com/docs/subnet/miners",
-      "provider": "gopher-ai",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-42-gopher-miner-docs",
+      "kind": "docs",
+      "name": "Gopher miner documentation",
+      "notes": "Official Gopher miner documentation for Subnet 42.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "gopher-ai",
       "public_safe": true,
       "source_urls": [
         "https://developers.gopher-ai.com/docs/subnet/miners",
         "https://github.com/gopher-lab/subnet-42"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Gopher miner documentation for Subnet 42."
+      "url": "https://developers.gopher-ai.com/docs/subnet/miners"
     },
     {
-      "id": "sn-42-gopher-source",
-      "name": "Gopher subnet source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/gopher-lab/subnet-42",
-      "provider": "gopher-ai",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-42-gopher-source",
+      "kind": "source-repo",
+      "name": "Gopher subnet source repository",
+      "notes": "Public source repository for Gopher Subnet 42 neuron logic.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "gopher-ai",
       "public_safe": true,
       "source_urls": [
         "https://github.com/gopher-lab/subnet-42",
         "https://developers.gopher-ai.com/docs/subnet/miners"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public source repository for Gopher Subnet 42 neuron logic."
+      "url": "https://github.com/gopher-lab/subnet-42"
     },
     {
-      "id": "sn-42-gopher-ai-subnet-api",
-      "name": "Gopher Data API live search",
-      "kind": "subnet-api",
-      "url": "https://data.gopher-ai.com/api/v1/search/live",
-      "provider": "gopher-ai",
-      "authority": "community",
       "auth_required": true,
+      "authority": "community",
+      "id": "sn-42-gopher-ai-subnet-api",
+      "kind": "subnet-api",
+      "name": "Gopher Data API live search",
+      "notes": "Official SN42 Gopher Data API live search (POST data.gopher-ai.com/api/v1/search/live). gopher-client defines jobEndpoint /v1/search/live on default base https://data.gopher-ai.com/api; gopher-mcp-server posts to /search/live on https://data.gopher-ai.com/api/v1.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "HEAD"
+      },
+      "provider": "gopher-ai",
       "public_safe": true,
       "rate_limit_notes": "Bearer API key required (GOPHER_CLIENT_TOKEN). POST-only credentialed endpoint; recurring read probes are intentionally disabled.",
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "claytonlin1110"
+      },
       "source_urls": [
         "https://github.com/gopher-lab/gopher-client/blob/main/client/client.go#L15-L16",
         "https://github.com/gopher-lab/gopher-client/blob/main/config/config.go#L15-L16",
         "https://github.com/gopher-lab/gopher-mcp-server/blob/main/data/internal/client/client.go#L22-L23",
         "https://github.com/gopher-lab/gopher-mcp-server/blob/main/data/internal/client/client.go#L75-L76"
       ],
-      "probe": {
-        "enabled": false,
-        "expect": "json",
-        "method": "HEAD"
-      },
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "claytonlin1110"
-      },
-      "notes": "Official SN42 Gopher Data API live search (POST data.gopher-ai.com/api/v1/search/live). gopher-client defines jobEndpoint /v1/search/live on default base https://data.gopher-ai.com/api; gopher-mcp-server posts to /search/live on https://data.gopher-ai.com/api/v1."
+      "url": "https://data.gopher-ai.com/api/v1/search/live"
     },
     {
-      "id": "sn-42-gopher-webscrape-example",
-      "name": "Gopher web-scrape example dataset",
-      "kind": "data-artifact",
-      "url": "https://huggingface.co/datasets/Gopher-Lab/Bittensor_Whitepaper_Webscrape_Example",
-      "provider": "gopher-ai",
-      "authority": "community",
       "auth_required": false,
+      "authority": "community",
+      "id": "sn-42-gopher-webscrape-example",
+      "kind": "data-artifact",
+      "name": "Gopher web-scrape example dataset",
+      "notes": "Public Gopher-Lab HuggingFace example of the SN42 web-scraper output (title/url/description/content columns of cleaned, structured page text; tagged Bittensor / Subnet / Masa), MIT-licensed and not gated. The subnet-42 repo (source) and developer portal declare the Bittensor subnet, and the Gopher-Lab HF org matches the operator's gopher-lab GitHub org.",
+      "provider": "gopher-ai",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/gopher-lab/subnet-42",
-        "https://huggingface.co/Gopher-Lab"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Public Gopher-Lab HuggingFace example of the SN42 web-scraper output (title/url/description/content columns of cleaned, structured page text; tagged Bittensor / Subnet / Masa), MIT-licensed and not gated. The subnet-42 repo (source) and developer portal declare the Bittensor subnet, and the Gopher-Lab HF org matches the operator's gopher-lab GitHub org."
-    },
-    {
-      "id": "sn-42-gopher-x-trending-topics",
-      "name": "Gopher X/Twitter trending-topics dataset",
-      "kind": "data-artifact",
-      "url": "https://huggingface.co/datasets/Gopher-Lab/X_Twitter_Trending_Topics_August2025",
-      "provider": "gopher-ai",
-      "authority": "community",
-      "auth_required": false,
-      "public_safe": true,
       "source_urls": [
         "https://github.com/gopher-lab/subnet-42",
         "https://huggingface.co/Gopher-Lab"
       ],
+      "url": "https://huggingface.co/datasets/Gopher-Lab/Bittensor_Whitepaper_Webscrape_Example"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-42-gopher-x-trending-topics",
+      "kind": "data-artifact",
+      "name": "Gopher X/Twitter trending-topics dataset",
+      "notes": "Public Gopher-Lab HuggingFace dataset of X/Twitter trending-topics scraped by the SN42 Gopher data network, not gated. The subnet-42 repo (source) declares the Bittensor subnet and the Gopher-Lab HF org matches the operator's gopher-lab GitHub org. Distinct from the subnet's registered web-scrape example dataset.",
+      "provider": "gopher-ai",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "davion-knight"
       },
-      "notes": "Public Gopher-Lab HuggingFace dataset of X/Twitter trending-topics scraped by the SN42 Gopher data network, not gated. The subnet-42 repo (source) declares the Bittensor subnet and the Gopher-Lab HF org matches the operator's gopher-lab GitHub org. Distinct from the subnet's registered web-scrape example dataset."
+      "source_urls": [
+        "https://github.com/gopher-lab/subnet-42",
+        "https://huggingface.co/Gopher-Lab"
+      ],
+      "url": "https://huggingface.co/datasets/Gopher-Lab/X_Twitter_Trending_Topics_August2025"
     },
     {
       "auth_required": false,
@@ -204,5 +201,6 @@
       ],
       "url": "https://huggingface.co/datasets/Gopher-Lab/TikTok_Most_Shared_Video_Transcription_Example"
     }
-  ]
+  ],
+  "website_url": "https://developers.gopher-ai.com/"
 }

--- a/registry/subnets/grail.json
+++ b/registry/subnets/grail.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 81,
-  "name": "Grail",
-  "slug": "sn-81",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "decentralized-training",
@@ -12,87 +7,88 @@
     "official-docs",
     "official-source-repo"
   ],
-  "source_repo": "https://github.com/one-covenant/grail",
-  "docs_url": "https://github.com/one-covenant/grail/tree/main/docs",
-  "dashboard_url": "https://grail-grafana.tplr.ai/",
-  "website_url": null,
-  "notes": "Reviewed overlay for SN81 using the live One Covenant Grail repository, repository documentation, and public dashboards. Native chain identity currently reports a deprecated placeholder, so this remains an explicit identity-drift entry rather than a silent rename.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "needs-review",
-    "reviewed_at": "2026-06-08T11:05:00.000Z",
-    "verified_at": "2026-06-08T11:05:00.000Z",
-    "source_count": 6,
     "gap_notes": [
       "Native chain name currently reports as deprecated.",
       "No verified standalone website yet.",
       "Official miner, validator, FAQ, incentive, and operational docs are maintained inside the public source repository.",
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "needs-review",
+    "reviewed_at": "2026-06-08T11:05:00.000Z",
+    "source_count": 6,
+    "verified_at": "2026-06-08T11:05:00.000Z"
   },
+  "dashboard_url": "https://grail-grafana.tplr.ai/",
+  "docs_url": "https://github.com/one-covenant/grail/tree/main/docs",
+  "name": "Grail",
+  "netuid": 81,
+  "notes": "Reviewed overlay for SN81 using the live One Covenant Grail repository, repository documentation, and public dashboards. Native chain identity currently reports a deprecated placeholder, so this remains an explicit identity-drift entry rather than a silent rename.",
+  "schema_version": 1,
+  "slug": "sn-81",
+  "source_repo": "https://github.com/one-covenant/grail",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-81-grail-source",
-      "name": "Grail source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/one-covenant/grail",
-      "provider": "one-covenant",
       "auth_required": false,
       "authority": "provider-claimed",
+      "id": "sn-81-grail-source",
+      "kind": "source-repo",
+      "name": "Grail source repository",
+      "notes": "Public Grail source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "one-covenant",
       "public_safe": true,
       "source_urls": [
         "https://github.com/one-covenant/grail",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/81/subnet.json"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public Grail source repository."
+      "url": "https://github.com/one-covenant/grail"
     },
     {
-      "id": "sn-81-grail-docs",
-      "name": "Grail repository documentation",
-      "kind": "docs",
-      "url": "https://github.com/one-covenant/grail/tree/main/docs",
-      "provider": "one-covenant",
       "auth_required": false,
       "authority": "provider-claimed",
+      "id": "sn-81-grail-docs",
+      "kind": "docs",
+      "name": "Grail repository documentation",
+      "notes": "Public Grail docs directory with miner, validator, FAQ, incentive, and operational setup documentation.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "one-covenant",
       "public_safe": true,
       "source_urls": [
         "https://github.com/one-covenant/grail/tree/main/docs",
         "https://github.com/one-covenant/grail"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public Grail docs directory with miner, validator, FAQ, incentive, and operational setup documentation."
+      "url": "https://github.com/one-covenant/grail/tree/main/docs"
     },
     {
-      "id": "sn-81-grail-grafana",
-      "name": "Grail Grafana dashboard",
-      "kind": "dashboard",
-      "url": "https://grail-grafana.tplr.ai/",
-      "provider": "one-covenant",
       "auth_required": false,
       "authority": "provider-claimed",
-      "public_safe": true,
-      "source_urls": ["https://github.com/one-covenant/grail"],
+      "id": "sn-81-grail-grafana",
+      "kind": "dashboard",
+      "name": "Grail Grafana dashboard",
+      "notes": "Public Grafana dashboard linked from the Grail repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Public Grafana dashboard linked from the Grail repository."
+      "provider": "one-covenant",
+      "public_safe": true,
+      "source_urls": ["https://github.com/one-covenant/grail"],
+      "url": "https://grail-grafana.tplr.ai/"
     },
     {
       "auth_required": false,
@@ -114,22 +110,22 @@
       "url": "https://grail-grafana.tplr.ai/api/health"
     },
     {
-      "id": "sn-81-grail-wandb",
-      "name": "Grail W&B dashboard",
-      "kind": "dashboard",
-      "url": "https://wandb.ai/tplr/grail",
-      "provider": "one-covenant",
       "auth_required": false,
       "authority": "provider-claimed",
-      "public_safe": true,
-      "source_urls": ["https://github.com/one-covenant/grail"],
+      "id": "sn-81-grail-wandb",
+      "kind": "dashboard",
+      "name": "Grail W&B dashboard",
+      "notes": "Public W&B dashboard linked from the Grail repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Public W&B dashboard linked from the Grail repository."
+      "provider": "one-covenant",
+      "public_safe": true,
+      "source_urls": ["https://github.com/one-covenant/grail"],
+      "url": "https://wandb.ai/tplr/grail"
     },
     {
       "auth_required": false,
@@ -157,25 +153,26 @@
       "kind": "openapi",
       "name": "Grail Grafana HTTP API OpenAPI",
       "notes": "Public no-auth OpenAPI 3 schema (title \"Grafana HTTP API.\") served at grail-grafana.tplr.ai/public/openapi3.json — the same host already registered as this file's dashboard and subnet-api (health) surfaces. Same operator (one-covenant / tplr.ai) and identical publish convention already accepted for the sibling Templar (SN3) subnet's Grafana OpenAPI surface (grafana.tplr.ai/public/openapi3.json).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 15000
+      },
       "provider": "one-covenant",
       "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "galuis116"
+      },
       "schema_status": "machine-readable",
       "schema_url": "https://grail-grafana.tplr.ai/public/openapi3.json",
       "source_urls": [
         "https://grail-grafana.tplr.ai/",
         "https://github.com/one-covenant/grail"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "GET",
-        "expect": "json",
-        "timeout_ms": 15000
-      },
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "galuis116"
-      },
       "url": "https://grail-grafana.tplr.ai/public/openapi3.json"
     }
-  ]
+  ],
+  "website_url": null
 }

--- a/registry/subnets/graphite.json
+++ b/registry/subnets/graphite.json
@@ -11,10 +11,7 @@
   "curation": {
     "gap_notes": [
       "No verified official docs URL yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",

--- a/registry/subnets/green-compute.json
+++ b/registry/subnets/green-compute.json
@@ -9,7 +9,6 @@
   "curation": {
     "gap_notes": [
       "No verified source repository has been promoted as official because the discovered repository identifies a different Rich Kids of TAO subnet identity.",
-      "No verified OpenAPI/Swagger surface yet.",
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
@@ -26,6 +25,9 @@
   "notes": "Reviewed overlay for SN110. The official Green Compute website advertises a public model directory and API host; the discovered Rich Kids of TAO repository is retained only as registry-observed evidence pending identity review.",
   "schema_version": 1,
   "slug": "sn-110",
+  "social": {
+    "x": "https://x.com/vocence_bt"
+  },
   "source_repo": "https://github.com/Rich-Kids-of-TAO/rkt-subnet",
   "status": "active",
   "surfaces": [
@@ -217,8 +219,5 @@
       "url": "https://api.green-compute.com/platform/billing/bonus-rates"
     }
   ],
-  "social": {
-    "x": "https://x.com/vocence_bt"
-  },
   "website_url": "https://www.green-compute.com/"
 }

--- a/registry/subnets/groundlayer.json
+++ b/registry/subnets/groundlayer.json
@@ -1,13 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 20,
-  "name": "GroundLayer",
-  "slug": "sn-20",
-  "status": "active",
-  "categories": ["baseline-curated", "capital-markets", "identity-reviewed"],
-  "source_repo": null,
-  "dashboard_url": "https://taomarketcap.com/subnets/20",
-  "website_url": "https://www.groundlayer.xyz/",
   "baseline_excluded_surface_ids": [
     "sn-20-taomarketcap-source-repo",
     "sn-20-taomarketcap-website",
@@ -20,13 +11,9 @@
     "sn-20-website-link-groundlayer-xyz-website-1",
     "sn-20-website-link-groundlayer-xyz-website-2"
   ],
-  "notes": "Reviewed overlay for SN20 using the live GroundLayer website, subnet page, and roadmap. Previously discovered source repository candidates are not live and common API/docs/OpenAPI paths currently return 404.",
+  "categories": ["baseline-curated", "capital-markets", "identity-reviewed"],
+  "contact": "groundlayer@rizzo.network",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T11:15:00.000Z",
-    "verified_at": "2026-06-08T11:15:00.000Z",
-    "source_count": 6,
     "gap_notes": [
       "Official website, subnet, and roadmap pages are live and verified.",
       "Common /docs, /api, /health, /openapi.json, and Swagger paths currently return 404 and are explicitly excluded from promoted surfaces.",
@@ -35,73 +22,88 @@
       "No verified docs site yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T11:15:00.000Z",
+    "source_count": 6,
+    "verified_at": "2026-06-08T11:15:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/20",
+  "name": "GroundLayer",
+  "netuid": 20,
+  "notes": "Reviewed overlay for SN20 using the live GroundLayer website, subnet page, and roadmap. Previously discovered source repository candidates are not live and common API/docs/OpenAPI paths currently return 404.",
+  "schema_version": 1,
+  "slug": "sn-20",
+  "social": {
+    "x": "https://x.com/groundlayerhq"
+  },
+  "source_repo": null,
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-20-groundlayer-website",
-      "name": "GroundLayer website",
-      "kind": "website",
-      "url": "https://www.groundlayer.xyz/",
-      "provider": "groundlayer",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-20-groundlayer-website",
+      "kind": "website",
+      "name": "GroundLayer website",
+      "notes": "Official GroundLayer website.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "groundlayer",
       "public_safe": true,
       "source_urls": [
         "https://www.groundlayer.xyz/",
         "https://api.taomarketcap.com/public/v1/subnets/20"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official GroundLayer website."
+      "url": "https://www.groundlayer.xyz/"
     },
     {
-      "id": "sn-20-groundlayer-subnet-page",
-      "name": "GroundLayer subnet page",
-      "kind": "website",
-      "url": "https://www.groundlayer.xyz/subnet",
-      "provider": "groundlayer",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-20-groundlayer-subnet-page",
+      "kind": "website",
+      "name": "GroundLayer subnet page",
+      "notes": "Official GroundLayer subnet information page.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "groundlayer",
       "public_safe": true,
       "source_urls": [
         "https://www.groundlayer.xyz/",
         "https://www.groundlayer.xyz/subnet"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official GroundLayer subnet information page."
+      "url": "https://www.groundlayer.xyz/subnet"
     },
     {
-      "id": "sn-20-groundlayer-roadmap",
-      "name": "GroundLayer roadmap",
-      "kind": "website",
-      "url": "https://www.groundlayer.xyz/roadmap",
-      "provider": "groundlayer",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-20-groundlayer-roadmap",
+      "kind": "website",
+      "name": "GroundLayer roadmap",
+      "notes": "Official GroundLayer roadmap page.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "groundlayer",
       "public_safe": true,
       "source_urls": [
         "https://www.groundlayer.xyz/",
         "https://www.groundlayer.xyz/roadmap"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official GroundLayer roadmap page."
+      "url": "https://www.groundlayer.xyz/roadmap"
     },
     {
       "auth_required": false,
@@ -142,6 +144,5 @@
       "url": "https://api.taomarketcap.com/public/v1/subnets/20"
     }
   ],
-  "social": { "x": "https://x.com/groundlayerhq" },
-  "contact": "groundlayer@rizzo.network"
+  "website_url": "https://www.groundlayer.xyz/"
 }

--- a/registry/subnets/handshake58.json
+++ b/registry/subnets/handshake58.json
@@ -10,10 +10,7 @@
     "payments"
   ],
   "curation": {
-    "gap_notes": [
-      "No verified SSE/event stream yet.",
-      "No verified static data artifact yet."
-    ],
+    "gap_notes": ["No verified SSE/event stream yet."],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T07:12:52.000Z",
@@ -39,6 +36,9 @@
   "notes": "Reviewed identity overlay because the official repositories and website identify Bittensor SN58 as Handshake58 while native chain metadata currently displays Pending.",
   "schema_version": 1,
   "slug": "sn-58",
+  "social": {
+    "x": "https://x.com/greevils_ai"
+  },
   "source_repo": "https://github.com/Handshake58/HS58-subnet",
   "status": "active",
   "surfaces": [
@@ -308,8 +308,5 @@
       "url": "https://handshake58.com/api/validator/registry"
     }
   ],
-  "website_url": "https://handshake58.com",
-  "social": {
-    "x": "https://x.com/greevils_ai"
-  }
+  "website_url": "https://handshake58.com"
 }

--- a/registry/subnets/hashichain.json
+++ b/registry/subnets/hashichain.json
@@ -1,54 +1,53 @@
 {
-  "schema_version": 1,
-  "netuid": 115,
-  "name": "HashiChain",
-  "slug": "sn-115",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "official-source-repo"
   ],
-  "source_repo": "https://github.com/hashi115/hashichain",
-  "dashboard_url": "https://taomarketcap.com/subnets/115",
-  "website_url": null,
-  "notes": "Reviewed overlay for SN115 using the live HashiChain source repository. No standalone website, docs site, API, OpenAPI, SSE, or data artifact has been verified yet.",
+  "contact": "hashichain@outlook.com",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T10:50:00.000Z",
-    "verified_at": "2026-06-08T10:50:00.000Z",
-    "source_count": 4,
     "gap_notes": [
       "No verified standalone website yet.",
       "No verified docs site yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T10:50:00.000Z",
+    "source_count": 4,
+    "verified_at": "2026-06-08T10:50:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/115",
+  "name": "HashiChain",
+  "netuid": 115,
+  "notes": "Reviewed overlay for SN115 using the live HashiChain source repository. No standalone website, docs site, API, OpenAPI, SSE, or data artifact has been verified yet.",
+  "schema_version": 1,
+  "slug": "sn-115",
+  "source_repo": "https://github.com/hashi115/hashichain",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-115-hashichain-source",
-      "name": "HashiChain source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/hashi115/hashichain",
-      "provider": "hashichain",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-115-hashichain-source",
+      "kind": "source-repo",
+      "name": "HashiChain source repository",
+      "notes": "Public HashiChain source repository for SN115.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "hashichain",
       "public_safe": true,
       "source_urls": [
         "https://github.com/hashi115/hashichain",
         "https://api.taomarketcap.com/public/v1/subnets/115"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public HashiChain source repository for SN115."
+      "url": "https://github.com/hashi115/hashichain"
     },
     {
       "auth_required": false,
@@ -89,5 +88,5 @@
       "url": "https://raw.githubusercontent.com/hashi115/hashichain/e4a0280c0d29cc858795b84a7cac932baae43088/assets/intro.png"
     }
   ],
-  "contact": "hashichain@outlook.com"
+  "website_url": null
 }

--- a/registry/subnets/hippius.json
+++ b/registry/subnets/hippius.json
@@ -10,12 +10,7 @@
   ],
   "contact": "hello@hippius.com",
   "curation": {
-    "gap_notes": [
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ],
+    "gap_notes": ["No verified SSE/event stream yet."],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T09:25:00.000Z",

--- a/registry/subnets/hone.json
+++ b/registry/subnets/hone.json
@@ -1,18 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 5,
-  "name": "Hone",
-  "slug": "sn-5",
-  "status": "active",
-  "categories": [
-    "baseline-curated",
-    "identity-reviewed",
-    "official-source-repo",
-    "official-website"
-  ],
-  "website_url": "https://www.hone.training/",
-  "source_repo": "https://github.com/manifold-inc/hone",
-  "dashboard_url": "https://taomarketcap.com/subnets/5",
   "baseline_excluded_surface_ids": [
     "sn-5-taomarketcap-source-repo",
     "sn-5-taomarketcap-website",
@@ -27,163 +13,175 @@
     "sn-5-website-link-www-hone-training-website-3",
     "sn-5-website-subdomain-docs-docs-hone-training"
   ],
-  "notes": "Reviewed overlay for SN5 Hone using the official Hone website, source repository, and public network pages. Common docs/API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational interfaces.",
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-source-repo",
+    "official-website"
+  ],
+  "contact": "devs@manifold.inc",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T20:25:00.000Z",
-    "verified_at": "2026-06-08T20:25:00.000Z",
-    "source_count": 6,
     "gap_notes": [
       "Official website, network pages, and source repository are verified live.",
       "Common /docs, /api, /health, /openapi.json, and Swagger paths currently return 404.",
       "No verified docs site yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T20:25:00.000Z",
+    "source_count": 6,
+    "verified_at": "2026-06-08T20:25:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/5",
+  "name": "Hone",
+  "netuid": 5,
+  "notes": "Reviewed overlay for SN5 Hone using the official Hone website, source repository, and public network pages. Common docs/API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational interfaces.",
+  "schema_version": 1,
+  "slug": "sn-5",
+  "source_repo": "https://github.com/manifold-inc/hone",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-5-hone-website",
-      "name": "Hone website",
-      "kind": "website",
-      "url": "https://www.hone.training/",
-      "provider": "hone",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-5-hone-website",
+      "kind": "website",
+      "name": "Hone website",
+      "notes": "Official Hone website.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "hone",
       "public_safe": true,
       "source_urls": [
         "https://www.hone.training/",
         "https://github.com/manifold-inc/hone"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Hone website."
+      "url": "https://www.hone.training/"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-5-hone-network",
+      "kind": "dashboard",
       "name": "Hone network",
-      "kind": "dashboard",
-      "url": "https://www.hone.training/network",
-      "provider": "hone",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://www.hone.training/"],
+      "notes": "Official Hone public network page.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Hone public network page."
+      "provider": "hone",
+      "public_safe": true,
+      "source_urls": ["https://www.hone.training/"],
+      "url": "https://www.hone.training/network"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-5-hone-nodes",
+      "kind": "dashboard",
       "name": "Hone nodes",
-      "kind": "dashboard",
-      "url": "https://www.hone.training/nodes",
-      "provider": "hone",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://www.hone.training/"],
+      "notes": "Official Hone public nodes page.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Hone public nodes page."
+      "provider": "hone",
+      "public_safe": true,
+      "source_urls": ["https://www.hone.training/"],
+      "url": "https://www.hone.training/nodes"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-5-hone-projects",
-      "name": "Hone projects",
       "kind": "dashboard",
-      "url": "https://www.hone.training/projects",
-      "provider": "hone",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://www.hone.training/"],
+      "name": "Hone projects",
+      "notes": "Official Hone public projects page.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Hone public projects page."
+      "provider": "hone",
+      "public_safe": true,
+      "source_urls": ["https://www.hone.training/"],
+      "url": "https://www.hone.training/projects"
     },
     {
-      "id": "sn-5-hone-source",
-      "name": "Hone source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/manifold-inc/hone",
-      "provider": "hone",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-5-hone-source",
+      "kind": "source-repo",
+      "name": "Hone source repository",
+      "notes": "Official Hone source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "hone",
       "public_safe": true,
       "source_urls": ["https://github.com/manifold-inc/hone"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Hone source repository."
+      "url": "https://github.com/manifold-inc/hone"
     },
     {
-      "id": "sn-5-hone-subnet-api",
-      "name": "Hone API health",
-      "kind": "subnet-api",
-      "url": "https://api.hone.training/health",
-      "provider": "hone",
       "auth_required": false,
       "authority": "community",
-      "public_safe": true,
-      "source_urls": ["https://www.hone.training/"],
+      "id": "sn-5-hone-subnet-api",
+      "kind": "subnet-api",
+      "name": "Hone API health",
+      "notes": "Public no-auth GET returning the Hone (SN5) backend API health as JSON ({\"status\":\"ok\"}). Served on the api.hone.training subdomain of the subnet's registered website hone.training — a live API host distinct from the website-host /health path noted as 404 in this file. Fills the noted missing public-API-endpoint gap.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "hone",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "nickmopen"
       },
-      "notes": "Public no-auth GET returning the Hone (SN5) backend API health as JSON ({\"status\":\"ok\"}). Served on the api.hone.training subdomain of the subnet's registered website hone.training — a live API host distinct from the website-host /health path noted as 404 in this file. Fills the noted missing public-API-endpoint gap."
+      "source_urls": ["https://www.hone.training/"],
+      "url": "https://api.hone.training/health"
     },
     {
-      "id": "sn-5-hone-projects-json",
-      "name": "Hone training projects data",
-      "kind": "data-artifact",
-      "url": "https://www.hone.training/api/proxy/runs/projects",
-      "provider": "hone",
       "auth_required": false,
       "authority": "community",
-      "public_safe": true,
-      "source_urls": [
-        "https://www.hone.training/projects",
-        "https://github.com/manifold-inc/hone"
-      ],
+      "id": "sn-5-hone-projects-json",
+      "kind": "data-artifact",
+      "name": "Hone training projects data",
+      "notes": "Public no-auth GET returning the Hone (SN5) training projects catalog as JSON (project, version, modelSize, runCount, lastSeen fields; 46 release entries observed at submission time). This is the machine-readable feed behind the registered hone.training /projects dashboard surface, served from the same first-party hone.training host as the subnet's registered website.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "hone",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "dalledajay-coder"
       },
-      "notes": "Public no-auth GET returning the Hone (SN5) training projects catalog as JSON (project, version, modelSize, runCount, lastSeen fields; 46 release entries observed at submission time). This is the machine-readable feed behind the registered hone.training /projects dashboard surface, served from the same first-party hone.training host as the subnet's registered website."
+      "source_urls": [
+        "https://www.hone.training/projects",
+        "https://github.com/manifold-inc/hone"
+      ],
+      "url": "https://www.hone.training/api/proxy/runs/projects"
     },
     {
       "auth_required": false,
@@ -205,5 +203,5 @@
       "url": "https://raw.githubusercontent.com/manifold-inc/hone/786d1d457b30319080885ce742c94b21185eaafc/sandbox_runner/config.yaml"
     }
   ],
-  "contact": "devs@manifold.inc"
+  "website_url": "https://www.hone.training/"
 }

--- a/registry/subnets/infinitehash.json
+++ b/registry/subnets/infinitehash.json
@@ -1,73 +1,73 @@
 {
-  "schema_version": 1,
-  "netuid": 89,
-  "name": "InfiniteHash",
-  "slug": "sn-89",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "official-docs",
     "official-source-repo"
   ],
-  "source_repo": "https://github.com/backend-developers-ltd/InfiniteHash",
-  "docs_url": "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md",
-  "dashboard_url": "https://taomarketcap.com/subnets/89",
-  "notes": "Reviewed overlay for SN89 using the official InfiniteHash source repository, repository documentation, and universal TaoMarketCap dashboard. The repository homepage points to infinitehash.xyz, but that deployment currently returns HTTP 402 and is not promoted as a monitored website/API surface.",
+  "contact": "btc@infinitehash.xyz",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T09:25:00.000Z",
-    "verified_at": "2026-06-08T09:25:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "Project homepage currently returns HTTP 402.",
       "The subnet auction incentive mechanism is documented in the public source repository.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T09:25:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T09:25:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/89",
+  "docs_url": "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md",
+  "name": "InfiniteHash",
+  "netuid": 89,
+  "notes": "Reviewed overlay for SN89 using the official InfiniteHash source repository, repository documentation, and universal TaoMarketCap dashboard. The repository homepage points to infinitehash.xyz, but that deployment currently returns HTTP 402 and is not promoted as a monitored website/API surface.",
+  "schema_version": 1,
+  "slug": "sn-89",
+  "source_repo": "https://github.com/backend-developers-ltd/InfiniteHash",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-89-infinitehash-source",
-      "name": "InfiniteHash source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/backend-developers-ltd/InfiniteHash",
-      "provider": "infinitehash",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/backend-developers-ltd/InfiniteHash"],
+      "id": "sn-89-infinitehash-source",
+      "kind": "source-repo",
+      "name": "InfiniteHash source repository",
+      "notes": "Official InfiniteHash source repository for SN89.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official InfiniteHash source repository for SN89."
+      "provider": "infinitehash",
+      "public_safe": true,
+      "source_urls": ["https://github.com/backend-developers-ltd/InfiniteHash"],
+      "url": "https://github.com/backend-developers-ltd/InfiniteHash"
     },
     {
-      "id": "sn-89-infinitehash-auction-docs",
-      "name": "InfiniteHash auction incentive documentation",
-      "kind": "docs",
-      "url": "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md",
-      "provider": "infinitehash",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-89-infinitehash-auction-docs",
+      "kind": "docs",
+      "name": "InfiniteHash auction incentive documentation",
+      "notes": "Public InfiniteHash documentation for the subnet auction incentive mechanism.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "infinitehash",
       "public_safe": true,
       "source_urls": [
         "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md",
         "https://github.com/backend-developers-ltd/InfiniteHash"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public InfiniteHash documentation for the subnet auction incentive mechanism."
+      "url": "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md"
     },
     {
       "auth_required": false,
@@ -95,22 +95,22 @@
       "kind": "data-artifact",
       "name": "InfiniteHash validator runtime version spec",
       "notes": "Public no-auth JSON runtime-version specification (node-subtensor spec/impl names, spec version, transaction/apis versions) used by the InfiniteHash SN89 validator/consensus simulator, published in the official backend-developers-ltd/InfiniteHash repository. Documents the on-chain runtime version the subnet's consensus targets.",
-      "provider": "infinitehash",
-      "public_safe": true,
-      "source_urls": [
-        "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/app/src/infinite_hashes/testutils/simulator/runtime_version_318.json",
-        "https://github.com/backend-developers-ltd/InfiniteHash"
-      ],
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "infinitehash",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "davion-knight"
       },
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/app/src/infinite_hashes/testutils/simulator/runtime_version_318.json",
+        "https://github.com/backend-developers-ltd/InfiniteHash"
+      ],
       "url": "https://raw.githubusercontent.com/backend-developers-ltd/InfiniteHash/b0313ed2edc8c07c8312effb108e9cadd580e314/app/src/infinite_hashes/testutils/simulator/runtime_version_318.json"
     },
     {
@@ -120,25 +120,24 @@
       "kind": "data-artifact",
       "name": "InfiniteHash miner system constants",
       "notes": "Public no-auth machine-readable system-constants module (app/src/infinite_hashes/aps_miner/constants.py) published in the official backend-developers-ltd/InfiniteHash repository, defining SN89 InfiniteHash miner operational parameters: block time, auction ILP/CBC max nodes and max price multiplier, scheduler intervals (commitment/auction/job timeouts), and window-transition thresholds. These are the non-user-configurable system-level values the miner runs against. Pinned to an immutable commit. Verified 200, SS58-clean, no keys or secrets. Distinct from the validator runtime-version spec already registered.",
-      "provider": "infinitehash",
-      "public_safe": true,
-      "source_urls": [
-        "https://github.com/backend-developers-ltd/InfiniteHash/blob/b0313ed2edc8c07c8312effb108e9cadd580e314/app/src/infinite_hashes/aps_miner/constants.py",
-        "https://github.com/backend-developers-ltd/InfiniteHash"
-      ],
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "any",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "infinitehash",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "ultrahighsuper"
       },
+      "source_urls": [
+        "https://github.com/backend-developers-ltd/InfiniteHash/blob/b0313ed2edc8c07c8312effb108e9cadd580e314/app/src/infinite_hashes/aps_miner/constants.py",
+        "https://github.com/backend-developers-ltd/InfiniteHash"
+      ],
       "url": "https://raw.githubusercontent.com/backend-developers-ltd/InfiniteHash/b0313ed2edc8c07c8312effb108e9cadd580e314/app/src/infinite_hashes/aps_miner/constants.py"
     }
   ],
-  "website_url": "https://infinitehash.xyz/",
-  "contact": "btc@infinitehash.xyz"
+  "website_url": "https://infinitehash.xyz/"
 }

--- a/registry/subnets/iota.json
+++ b/registry/subnets/iota.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 9,
-  "name": "iota",
-  "slug": "sn-9",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
@@ -12,134 +7,136 @@
     "official-source-repo",
     "official-website"
   ],
-  "source_repo": "https://github.com/macrocosm-os/iota",
-  "dashboard_url": "https://iota.macrocosmos.ai/dashboard/mainnet",
-  "website_url": "https://iota.macrocosmos.ai/",
-  "notes": "Reviewed overlay for SN9 using the official IOTA website, public dashboard, and source repository. The previously discovered Macrocosmos IOTA mining setup URL currently returns 404 and is intentionally not promoted.",
+  "contact": "support@macrocosmos.ai",
   "curation": {
+    "gap_notes": [
+      "Previously discovered IOTA docs URL currently returns 404.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T09:50:00.000Z",
-    "verified_at": "2026-06-08T09:50:00.000Z",
     "source_count": 5,
-    "gap_notes": [
-      "Previously discovered IOTA docs URL currently returns 404.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T09:50:00.000Z"
   },
+  "dashboard_url": "https://iota.macrocosmos.ai/dashboard/mainnet",
+  "name": "iota",
+  "netuid": 9,
+  "notes": "Reviewed overlay for SN9 using the official IOTA website, public dashboard, and source repository. The previously discovered Macrocosmos IOTA mining setup URL currently returns 404 and is intentionally not promoted.",
+  "schema_version": 1,
+  "slug": "sn-9",
+  "source_repo": "https://github.com/macrocosm-os/iota",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-9-iota-website",
-      "name": "IOTA website",
-      "kind": "website",
-      "url": "https://iota.macrocosmos.ai/",
-      "provider": "macrocosmos",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/macrocosm-os/iota"],
+      "id": "sn-9-iota-website",
+      "kind": "website",
+      "name": "IOTA website",
+      "notes": "Official IOTA website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official IOTA website."
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "source_urls": ["https://github.com/macrocosm-os/iota"],
+      "url": "https://iota.macrocosmos.ai/"
     },
     {
-      "id": "sn-9-iota-dashboard",
-      "name": "IOTA dashboard",
-      "kind": "dashboard",
-      "url": "https://iota.macrocosmos.ai/dashboard/mainnet",
-      "provider": "macrocosmos",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-9-iota-dashboard",
+      "kind": "dashboard",
+      "name": "IOTA dashboard",
+      "notes": "Official public IOTA dashboard linked from the source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
       "public_safe": true,
       "source_urls": [
         "https://github.com/macrocosm-os/iota/blob/main/README.md"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official public IOTA dashboard linked from the source repository."
+      "url": "https://iota.macrocosmos.ai/dashboard/mainnet"
     },
     {
-      "id": "sn-9-iota-source",
-      "name": "IOTA source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/macrocosm-os/iota",
-      "provider": "macrocosmos",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/macrocosm-os/iota"],
+      "id": "sn-9-iota-source",
+      "kind": "source-repo",
+      "name": "IOTA source repository",
+      "notes": "Official IOTA source repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official IOTA source repository."
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "source_urls": ["https://github.com/macrocosm-os/iota"],
+      "url": "https://github.com/macrocosm-os/iota"
     },
     {
-      "id": "sn-9-iota-codeparrot-dataset",
-      "name": "IOTA code pretraining dataset",
-      "kind": "data-artifact",
-      "url": "https://huggingface.co/datasets/macrocosm-os/code-parrot-github-code",
-      "provider": "macrocosmos",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-9-iota-codeparrot-dataset",
+      "kind": "data-artifact",
+      "name": "IOTA code pretraining dataset",
+      "notes": "Public Macrocosmos HuggingFace GitHub-code corpus (repo_name/path/size/content/license columns; 32 languages) in the macrocosm-os org, a pretraining-data source fit for the IOTA (SN9) LLM-pretraining subnet; not gated. The IOTA repo README (source) declares Macrocosmos operates subnet 9 and links docs.macrocosmos.ai/subnets/subnet-9-pre-training.",
+      "provider": "macrocosmos",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/macrocosm-os/iota",
-        "https://huggingface.co/macrocosm-os"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Public Macrocosmos HuggingFace GitHub-code corpus (repo_name/path/size/content/license columns; 32 languages) in the macrocosm-os org, a pretraining-data source fit for the IOTA (SN9) LLM-pretraining subnet; not gated. The IOTA repo README (source) declares Macrocosmos operates subnet 9 and links docs.macrocosmos.ai/subnets/subnet-9-pre-training."
+      "source_urls": [
+        "https://github.com/macrocosm-os/iota",
+        "https://huggingface.co/macrocosm-os"
+      ],
+      "url": "https://huggingface.co/datasets/macrocosm-os/code-parrot-github-code"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-9-iota-openapi",
-      "name": "IOTA orchestrator API OpenAPI schema",
       "kind": "openapi",
-      "url": "https://iota.api.macrocosmos.ai/openapi.json",
+      "name": "IOTA orchestrator API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI 3.1 schema (title: FastAPI) for the IOTA SN9 orchestrator, served publicly at iota.api.macrocosmos.ai — documents the miner registration/activation/weight-submission routes and GET /healthcheck. The SN9 companion to the merged SN1 apex.api.macrocosmos.ai orchestrator API; Macrocosmos operates subnet 9 per the official IOTA source repo.",
       "provider": "macrocosmos",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
-      "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
-      "schema_url": "https://iota.api.macrocosmos.ai/openapi.json",
-      "schema_status": "machine-readable",
       "review": {
         "state": "community-submitted",
         "submitted_by": "codevector96"
       },
-      "notes": "Machine-readable OpenAPI 3.1 schema (title: FastAPI) for the IOTA SN9 orchestrator, served publicly at iota.api.macrocosmos.ai — documents the miner registration/activation/weight-submission routes and GET /healthcheck. The SN9 companion to the merged SN1 apex.api.macrocosmos.ai orchestrator API; Macrocosmos operates subnet 9 per the official IOTA source repo."
+      "schema_status": "machine-readable",
+      "schema_url": "https://iota.api.macrocosmos.ai/openapi.json",
+      "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
+      "url": "https://iota.api.macrocosmos.ai/openapi.json"
     },
     {
-      "id": "sn-9-iota-healthcheck",
-      "name": "IOTA orchestrator healthcheck",
-      "kind": "subnet-api",
-      "url": "https://iota.api.macrocosmos.ai/healthcheck",
-      "provider": "macrocosmos",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-9-iota-healthcheck",
+      "kind": "subnet-api",
+      "name": "IOTA orchestrator healthcheck",
+      "notes": "Public no-auth GET /healthcheck on the IOTA SN9 orchestrator returning liveness JSON (observed: {\"status\":\"healthy\"}); documented as GET /healthcheck in the subnet OpenAPI spec.",
+      "provider": "macrocosmos",
       "public_safe": true,
-      "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "codevector96"
       },
-      "notes": "Public no-auth GET /healthcheck on the IOTA SN9 orchestrator returning liveness JSON (observed: {\"status\":\"healthy\"}); documented as GET /healthcheck in the subnet OpenAPI spec."
+      "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
+      "url": "https://iota.api.macrocosmos.ai/healthcheck"
     }
   ],
-  "contact": "support@macrocosmos.ai"
+  "website_url": "https://iota.macrocosmos.ai/"
 }

--- a/registry/subnets/itsai.json
+++ b/registry/subnets/itsai.json
@@ -1,157 +1,157 @@
 {
-  "schema_version": 1,
-  "netuid": 32,
-  "name": "ItsAI",
-  "slug": "sn-32",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "official-source-repo",
     "official-website"
   ],
-  "source_repo": "https://github.com/It-s-AI/llm-detection",
-  "dashboard_url": "https://taomarketcap.com/subnets/32",
-  "website_url": "https://its-ai.org/en",
-  "notes": "Reviewed overlay for SN32 using the official ItsAI website and LLM-detection source repository.",
+  "contact": "support@its-ai.org",
   "curation": {
+    "gap_notes": [
+      "No verified OpenAPI/Swagger schema yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T10:10:00.000Z",
-    "verified_at": "2026-06-08T10:10:00.000Z",
     "source_count": 4,
-    "gap_notes": [
-      "No verified official docs URL yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T10:10:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/32",
+  "name": "ItsAI",
+  "netuid": 32,
+  "notes": "Reviewed overlay for SN32 using the official ItsAI website and LLM-detection source repository.",
+  "schema_version": 1,
+  "slug": "sn-32",
+  "social": {
+    "x": "https://x.com/ai_detection"
+  },
+  "source_repo": "https://github.com/It-s-AI/llm-detection",
+  "status": "active",
   "surfaces": [
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-32-itsai-website",
-      "name": "ItsAI website",
       "kind": "website",
-      "url": "https://its-ai.org/en",
-      "provider": "its-ai",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/It-s-AI/llm-detection"],
+      "name": "ItsAI website",
+      "notes": "Official ItsAI website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official ItsAI website."
-    },
-    {
-      "id": "sn-32-itsai-source",
-      "name": "ItsAI source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/It-s-AI/llm-detection",
       "provider": "its-ai",
-      "auth_required": false,
-      "authority": "official",
       "public_safe": true,
       "source_urls": ["https://github.com/It-s-AI/llm-detection"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official ItsAI source repository."
+      "url": "https://its-ai.org/en"
     },
     {
-      "id": "sn-32-itsai-sdk",
-      "name": "ItsAI Python SDK (PyPI)",
-      "kind": "sdk",
-      "url": "https://pypi.org/project/its-ai/",
-      "provider": "its-ai",
       "auth_required": false,
-      "authority": "community",
-      "public_safe": true,
-      "source_urls": ["https://its-ai.org/en"],
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "glorydavid03023"
-      },
-      "notes": "Published PyPI package `its-ai` (\"Typed Python SDK client for ITS-AI API\", author ITS AI <support@its-ai.org>), linked as the \"Python SDK\" from the official homepage."
-    },
-    {
-      "id": "sn-32-itsai-docs",
-      "name": "ItsAI API documentation",
-      "kind": "docs",
-      "url": "https://docs.its-ai.org/",
-      "provider": "its-ai",
-      "auth_required": false,
-      "authority": "community",
-      "public_safe": true,
-      "source_urls": ["https://its-ai.org/en"],
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "glorydavid03023"
-      },
-      "notes": "Official ItsAI documentation (page title \"AI content detection API\") on the team's docs.its-ai.org subdomain, linked from the homepage. Fills the file's noted missing-docs gap."
-    },
-    {
-      "id": "sn-32-itsai-api-repo",
-      "name": "ItsAI API repository",
+      "authority": "official",
+      "id": "sn-32-itsai-source",
       "kind": "source-repo",
-      "url": "https://github.com/It-s-AI/api",
+      "name": "ItsAI source repository",
+      "notes": "Official ItsAI source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "its-ai",
+      "public_safe": true,
+      "source_urls": ["https://github.com/It-s-AI/llm-detection"],
+      "url": "https://github.com/It-s-AI/llm-detection"
+    },
+    {
       "auth_required": false,
       "authority": "community",
+      "id": "sn-32-itsai-sdk",
+      "kind": "sdk",
+      "name": "ItsAI Python SDK (PyPI)",
+      "notes": "Published PyPI package `its-ai` (\"Typed Python SDK client for ITS-AI API\", author ITS AI <support@its-ai.org>), linked as the \"Python SDK\" from the official homepage.",
+      "provider": "its-ai",
       "public_safe": true,
-      "source_urls": ["https://github.com/It-s-AI/api"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "ItsAI API repository in the team's It-s-AI org; its README describes a FastAPI app that queries miners in \"Subnet32: It's AI\". Distinct from the registered llm-detection repo."
+      "source_urls": ["https://its-ai.org/en"],
+      "url": "https://pypi.org/project/its-ai/"
     },
     {
-      "id": "sn-32-itsai-subnet-api",
-      "name": "ItsAI API health",
-      "kind": "subnet-api",
-      "url": "https://api.its-ai.org/api/health",
-      "provider": "its-ai",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-32-itsai-docs",
+      "kind": "docs",
+      "name": "ItsAI API documentation",
+      "notes": "Official ItsAI documentation (page title \"AI content detection API\") on the team's docs.its-ai.org subdomain, linked from the homepage. Fills the file's noted missing-docs gap.",
+      "provider": "its-ai",
       "public_safe": true,
-      "source_urls": ["https://its-ai.org/en", "https://docs.its-ai.org/"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": ["https://its-ai.org/en"],
+      "url": "https://docs.its-ai.org/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-32-itsai-api-repo",
+      "kind": "source-repo",
+      "name": "ItsAI API repository",
+      "notes": "ItsAI API repository in the team's It-s-AI org; its README describes a FastAPI app that queries miners in \"Subnet32: It's AI\". Distinct from the registered llm-detection repo.",
+      "provider": "its-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
+      "source_urls": ["https://github.com/It-s-AI/api"],
+      "url": "https://github.com/It-s-AI/api"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-32-itsai-subnet-api",
+      "kind": "subnet-api",
+      "name": "ItsAI API health",
+      "notes": "Public no-auth GET returning the ItsAI (SN32) content-detection API health as JSON. Hosted on api.its-ai.org, the API subdomain of the registered website its-ai.org; the API is documented at docs.its-ai.org and implemented in the team's It-s-AI/api FastAPI repo. Fills the file's noted missing public-API-endpoint gap.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "its-ai",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "nickmopen"
       },
-      "notes": "Public no-auth GET returning the ItsAI (SN32) content-detection API health as JSON. Hosted on api.its-ai.org, the API subdomain of the registered website its-ai.org; the API is documented at docs.its-ai.org and implemented in the team's It-s-AI/api FastAPI repo. Fills the file's noted missing public-API-endpoint gap."
+      "source_urls": ["https://its-ai.org/en", "https://docs.its-ai.org/"],
+      "url": "https://api.its-ai.org/api/health"
     },
     {
-      "id": "sn-32-its-ai-data-artifact",
-      "name": "ItsAI SN32 leaderboard (Hugging Face Space)",
-      "kind": "data-artifact",
-      "url": "https://huggingface.co/spaces/sergak0/ai-detection-leaderboard",
-      "provider": "its-ai",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-32-its-ai-data-artifact",
+      "kind": "data-artifact",
+      "name": "ItsAI SN32 leaderboard (Hugging Face Space)",
+      "notes": "Live SN32 miner leaderboard (UID/incentive/emission plus F1, false-positive, and average-precision scores from the Yuma validator) hosted as a public, no-auth Hugging Face Space. Explicitly named as the team's own leaderboard in docs/FAQ.md (\"Yes, we do have a leaderboard based on OTF scores\"); the app itself titles the page \"Subnet 32 Leaderboard\" and links back to github.com/It-s-AI/llm-detection. Fills the file's noted missing standalone-data-artifact gap.",
+      "provider": "its-ai",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/It-s-AI/llm-detection/blob/main/docs/FAQ.md"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "galuis116"
       },
-      "notes": "Live SN32 miner leaderboard (UID/incentive/emission plus F1, false-positive, and average-precision scores from the Yuma validator) hosted as a public, no-auth Hugging Face Space. Explicitly named as the team's own leaderboard in docs/FAQ.md (\"Yes, we do have a leaderboard based on OTF scores\"); the app itself titles the page \"Subnet 32 Leaderboard\" and links back to github.com/It-s-AI/llm-detection. Fills the file's noted missing standalone-data-artifact gap."
+      "source_urls": [
+        "https://github.com/It-s-AI/llm-detection/blob/main/docs/FAQ.md"
+      ],
+      "url": "https://huggingface.co/spaces/sergak0/ai-detection-leaderboard"
     },
     {
       "auth_required": false,
@@ -172,6 +172,5 @@
       "url": "https://wandb.ai/itsai-dev/subnet32"
     }
   ],
-  "social": { "x": "https://x.com/ai_detection" },
-  "contact": "support@its-ai.org"
+  "website_url": "https://its-ai.org/en"
 }

--- a/registry/subnets/luminar-network.json
+++ b/registry/subnets/luminar-network.json
@@ -9,11 +9,8 @@
   ],
   "curation": {
     "gap_notes": [
-      "No verified source repository yet.",
       "No verified OpenAPI/Swagger surface yet.",
-      "No verified subnet API surface yet.",
-      "No verified SSE/event stream yet.",
-      "No verified data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",

--- a/registry/subnets/mainframe.json
+++ b/registry/subnets/mainframe.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 25,
-  "name": "Mainframe",
-  "slug": "sn-25",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "compute",
@@ -11,53 +6,65 @@
     "macrocosmos",
     "official-source-repo"
   ],
-  "source_repo": "https://github.com/macrocosm-os/mainframe",
-  "dashboard_url": "https://taomarketcap.com/subnets/25",
-  "website_url": "https://macrocosmos.ai/sn25",
-  "notes": "Reviewed overlay for SN25 using the official Mainframe source repository. Previously discovered Mainframe docs/API URLs currently return 404 and the old dashboard URL redirects to the general Macrocosmos homepage, so they are not promoted.",
+  "contact": "brian@macrocosmos.ai",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T09:50:00.000Z",
-    "verified_at": "2026-06-08T09:50:00.000Z",
-    "source_count": 4,
     "gap_notes": [
       "Previously discovered Mainframe docs URL currently returns 404.",
       "Previously discovered Mainframe API documentation URL currently returns 404.",
       "Previously discovered dashboard URL redirects to the general Macrocosmos homepage.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T09:50:00.000Z",
+    "source_count": 4,
+    "verified_at": "2026-06-08T09:50:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/25",
+  "name": "Mainframe",
+  "netuid": 25,
+  "notes": "Reviewed overlay for SN25 using the official Mainframe source repository. Previously discovered Mainframe docs/API URLs currently return 404 and the old dashboard URL redirects to the general Macrocosmos homepage, so they are not promoted.",
+  "schema_version": 1,
+  "slug": "sn-25",
+  "social": {
+    "x": "https://x.com/macrocosmosai"
+  },
+  "source_repo": "https://github.com/macrocosm-os/mainframe",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-25-mainframe-source",
-      "name": "Mainframe source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/macrocosm-os/mainframe",
-      "provider": "macrocosmos",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/macrocosm-os/mainframe"],
+      "id": "sn-25-mainframe-source",
+      "kind": "source-repo",
+      "name": "Mainframe source repository",
+      "notes": "Official Mainframe source repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Mainframe source repository."
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "source_urls": ["https://github.com/macrocosm-os/mainframe"],
+      "url": "https://github.com/macrocosm-os/mainframe"
     },
     {
-      "id": "sn-25-macrocosm-os-macrobench-benchmark-dataset",
-      "name": "Macrocosmos Macrobench benchmark dataset",
-      "kind": "data-artifact",
-      "url": "https://huggingface.co/datasets/macrocosm-os/macrobench-bittensor-01",
-      "provider": "macrocosmos",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-25-macrocosm-os-macrobench-benchmark-dataset",
+      "kind": "data-artifact",
+      "name": "Macrocosmos Macrobench benchmark dataset",
+      "notes": "Public MIT-licensed benchmark data artifact published under the Macrocosmos (macrocosm-os) Hugging Face organization, the operator of SN25 Mainframe (github.com/macrocosm-os/mainframe, macrocosmos.ai). Daily parquet snapshots of a multiple-choice question benchmark with per-miner evaluation and voting records, spanning October 2024 through August 2025 in the 100K-1M row range.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
       "public_safe": true,
       "review": {
         "state": "community-submitted",
@@ -67,40 +74,34 @@
         "https://huggingface.co/datasets/macrocosm-os/macrobench-bittensor-01",
         "https://huggingface.co/macrocosm-os"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public MIT-licensed benchmark data artifact published under the Macrocosmos (macrocosm-os) Hugging Face organization, the operator of SN25 Mainframe (github.com/macrocosm-os/mainframe, macrocosmos.ai). Daily parquet snapshots of a multiple-choice question benchmark with per-miner evaluation and voting records, spanning October 2024 through August 2025 in the 100K-1M row range."
+      "url": "https://huggingface.co/datasets/macrocosm-os/macrobench-bittensor-01"
     },
     {
-      "id": "sn-25-mainframe-pdb-file-api",
-      "name": "Mainframe PDB structure file API",
-      "kind": "subnet-api",
-      "url": "https://sn25.nyc3.digitaloceanspaces.com/pdb_files/1ubq.pdb",
-      "provider": "macrocosmos",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-25-mainframe-pdb-file-api",
+      "kind": "subnet-api",
+      "name": "Mainframe PDB structure file API",
+      "notes": "Public no-auth GET returning PDB structure text from the official SN25 DigitalOcean Spaces bucket. The folding API utility route checks this host first before falling back to RCSB/PDBe mirrors.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 15000
+      },
+      "provider": "macrocosmos",
       "public_safe": true,
+      "review": {
+        "confidence": "medium",
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
       "source_urls": [
         "https://github.com/macrocosm-os/mainframe/blob/main/folding_api/utility_endpoints.py",
         "https://github.com/macrocosm-os/mainframe/blob/main/README.md",
         "https://sn25.nyc3.digitaloceanspaces.com/pdb_files/1ubq.pdb"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "GET",
-        "expect": "any",
-        "timeout_ms": 15000
-      },
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "bohdansolovie",
-        "confidence": "medium"
-      },
-      "notes": "Public no-auth GET returning PDB structure text from the official SN25 DigitalOcean Spaces bucket. The folding API utility route checks this host first before falling back to RCSB/PDBe mirrors."
+      "url": "https://sn25.nyc3.digitaloceanspaces.com/pdb_files/1ubq.pdb"
     },
     {
       "auth_required": false,
@@ -121,8 +122,5 @@
       "url": "https://wandb.ai/macrocosmos/folding-openmm"
     }
   ],
-  "social": {
-    "x": "https://x.com/macrocosmosai"
-  },
-  "contact": "brian@macrocosmos.ai"
+  "website_url": "https://macrocosmos.ai/sn25"
 }

--- a/registry/subnets/mantis.json
+++ b/registry/subnets/mantis.json
@@ -1,112 +1,110 @@
 {
-  "schema_version": 1,
-  "netuid": 123,
-  "name": "MANTIS",
-  "slug": "sn-123",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "sdk",
     "official-source-repo"
   ],
-  "source_repo": "https://github.com/Barbariandev/MANTIS",
-  "dashboard_url": "https://taomarketcap.com/subnets/123",
-  "website_url": null,
-  "notes": "Reviewed overlay for SN123 using the live MANTIS source repository and linked model-iteration SDK/tooling repository. No standalone website, docs site, public API, OpenAPI, SSE, or data artifact has been verified yet.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T10:50:00.000Z",
-    "verified_at": "2026-06-08T10:50:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "No verified standalone website yet.",
       "The linked model iteration tool repository includes SDK and API guide references for builder workflows.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T10:50:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T10:50:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/123",
+  "name": "MANTIS",
+  "netuid": 123,
+  "notes": "Reviewed overlay for SN123 using the live MANTIS source repository and linked model-iteration SDK/tooling repository. No standalone website, docs site, public API, OpenAPI, SSE, or data artifact has been verified yet.",
+  "schema_version": 1,
+  "slug": "sn-123",
+  "source_repo": "https://github.com/Barbariandev/MANTIS",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-123-mantis-source",
-      "name": "MANTIS source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/Barbariandev/MANTIS",
-      "provider": "mantis",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-123-mantis-source",
+      "kind": "source-repo",
+      "name": "MANTIS source repository",
+      "notes": "Public MANTIS source repository for SN123.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "mantis",
       "public_safe": true,
       "source_urls": [
         "https://github.com/Barbariandev/MANTIS",
         "https://api.taomarketcap.com/public/v1/subnets/123"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public MANTIS source repository for SN123."
+      "url": "https://github.com/Barbariandev/MANTIS"
     },
     {
-      "id": "sn-123-mantis-model-iteration-tool",
-      "name": "MANTIS model iteration tool",
-      "kind": "sdk",
-      "url": "https://github.com/Barbariandev/mantis_model_iteration_tool",
-      "provider": "mantis",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-123-mantis-model-iteration-tool",
+      "kind": "sdk",
+      "name": "MANTIS model iteration tool",
+      "notes": "Public SDK/tooling repository linked from the MANTIS source README for strategy iteration, GUI workflows, and local evaluation helpers.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "mantis",
       "public_safe": true,
       "source_urls": [
         "https://github.com/Barbariandev/MANTIS",
         "https://github.com/Barbariandev/mantis_model_iteration_tool"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public SDK/tooling repository linked from the MANTIS source README for strategy iteration, GUI workflows, and local evaluation helpers."
+      "url": "https://github.com/Barbariandev/mantis_model_iteration_tool"
     },
     {
-      "id": "sn-123-mantis-price-feed",
-      "name": "MANTIS price & funding data artifact",
-      "kind": "data-artifact",
-      "url": "https://pub-ba8c1b8edb8046edaccecbd26b5ca7f8.r2.dev/latest_prices.json",
-      "provider": "mantis",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-123-mantis-price-feed",
+      "kind": "data-artifact",
+      "name": "MANTIS price & funding data artifact",
+      "notes": "Public no-auth JSON data artifact of asset prices and funding rates published by the SN123 MANTIS validator — the PRICE_DATA_URL declared in the official repo's config.py (line 63). Freshness/uptime are probe-derived and not asserted here.",
+      "provider": "mantis",
       "public_safe": true,
-      "source_urls": [
-        "https://raw.githubusercontent.com/Barbariandev/MANTIS/main/config.py"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "dev-miro26"
       },
-      "notes": "Public no-auth JSON data artifact of asset prices and funding rates published by the SN123 MANTIS validator — the PRICE_DATA_URL declared in the official repo's config.py (line 63). Freshness/uptime are probe-derived and not asserted here."
-    },
-    {
-      "id": "sn-123-mantis-datalog-archive",
-      "name": "MANTIS historical datalog archive",
-      "kind": "data-artifact",
-      "url": "https://pub-879ad825983e43529792665f4f510cd6.r2.dev/datalog.db",
-      "provider": "mantis",
-      "auth_required": false,
-      "authority": "community",
-      "public_safe": true,
       "source_urls": [
         "https://raw.githubusercontent.com/Barbariandev/MANTIS/main/config.py"
       ],
+      "url": "https://pub-ba8c1b8edb8046edaccecbd26b5ca7f8.r2.dev/latest_prices.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-123-mantis-datalog-archive",
+      "kind": "data-artifact",
+      "name": "MANTIS historical datalog archive",
+      "notes": "Public no-auth downloadable SQLite datalog of the SN123 MANTIS validator's full historical multi-asset signal/price time series — the DATALOG_ARCHIVE_URL declared in the official repo's config.py, distinct from and complementary to the latest_prices.json snapshot (this is the complete historical archive, served as a SQLite database file). Verified as a live SQLite artifact (magic bytes 'SQLite format 3'). Freshness/size are probe-derived and not asserted here.",
+      "provider": "mantis",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Public no-auth downloadable SQLite datalog of the SN123 MANTIS validator's full historical multi-asset signal/price time series — the DATALOG_ARCHIVE_URL declared in the official repo's config.py, distinct from and complementary to the latest_prices.json snapshot (this is the complete historical archive, served as a SQLite database file). Verified as a live SQLite artifact (magic bytes 'SQLite format 3'). Freshness/size are probe-derived and not asserted here."
+      "source_urls": [
+        "https://raw.githubusercontent.com/Barbariandev/MANTIS/main/config.py"
+      ],
+      "url": "https://pub-879ad825983e43529792665f4f510cd6.r2.dev/datalog.db"
     },
     {
       "auth_required": false,
@@ -127,5 +125,6 @@
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/123/candle-chart"
     }
-  ]
+  ],
+  "website_url": null
 }

--- a/registry/subnets/mvtrx.json
+++ b/registry/subnets/mvtrx.json
@@ -1,87 +1,89 @@
 {
-  "schema_version": 1,
-  "netuid": 79,
-  "name": "MVTRX",
-  "slug": "sn-79",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "official-source-repo",
     "official-website"
   ],
-  "docs_url": "https://simulate.trading/taos-im-paper",
-  "source_repo": "https://github.com/taos-im/sn-79",
-  "dashboard_url": "https://taomarketcap.com/subnets/79",
-  "website_url": "https://taos.im/",
-  "notes": "Reviewed overlay for SN79 using the TAOS IM website, source repository, and public paper link. The paper URL redirects to a public Proton Drive document, so it is tracked as a data artifact rather than a docs site.",
+  "contact": "to@mvtrx.fi",
   "curation": {
+    "gap_notes": [
+      "Public paper link redirects to Proton Drive and is not a documentation site.",
+      "No verified OpenAPI/Swagger schema yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T09:50:00.000Z",
-    "verified_at": "2026-06-08T09:50:00.000Z",
     "source_count": 5,
-    "gap_notes": [
-      "Public paper link redirects to Proton Drive and is not a documentation site.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet."
-    ]
+    "verified_at": "2026-06-08T09:50:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/79",
+  "docs_url": "https://simulate.trading/taos-im-paper",
+  "name": "MVTRX",
+  "netuid": 79,
+  "notes": "Reviewed overlay for SN79 using the TAOS IM website, source repository, and public paper link. The paper URL redirects to a public Proton Drive document, so it is tracked as a data artifact rather than a docs site.",
+  "schema_version": 1,
+  "slug": "sn-79",
+  "social": {
+    "x": "https://x.com/taos_im"
+  },
+  "source_repo": "https://github.com/taos-im/sn-79",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-79-mvtrx-website",
-      "name": "TAOS IM website",
-      "kind": "website",
-      "url": "https://taos.im/",
-      "provider": "taos-im",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/taos-im/sn-79"],
+      "id": "sn-79-mvtrx-website",
+      "kind": "website",
+      "name": "TAOS IM website",
+      "notes": "Official TAOS IM website for SN79.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official TAOS IM website for SN79."
+      "provider": "taos-im",
+      "public_safe": true,
+      "source_urls": ["https://github.com/taos-im/sn-79"],
+      "url": "https://taos.im/"
     },
     {
-      "id": "sn-79-mvtrx-paper",
-      "name": "TAOS IM paper",
-      "kind": "data-artifact",
-      "url": "https://simulate.trading/taos-im-paper",
-      "provider": "taos-im",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-79-mvtrx-paper",
+      "kind": "data-artifact",
+      "name": "TAOS IM paper",
+      "notes": "Public TAOS IM paper link. The URL currently redirects to a public Proton Drive document.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taos-im",
       "public_safe": true,
       "source_urls": ["https://github.com/taos-im/sn-79/blob/main/README.md"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public TAOS IM paper link. The URL currently redirects to a public Proton Drive document."
+      "url": "https://simulate.trading/taos-im-paper"
     },
     {
-      "id": "sn-79-mvtrx-source",
-      "name": "MVTRX source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/taos-im/sn-79",
-      "provider": "taos-im",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/taos-im/sn-79"],
+      "id": "sn-79-mvtrx-source",
+      "kind": "source-repo",
+      "name": "MVTRX source repository",
+      "notes": "Official MVTRX source repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official MVTRX source repository."
+      "provider": "taos-im",
+      "public_safe": true,
+      "source_urls": ["https://github.com/taos-im/sn-79"],
+      "url": "https://github.com/taos-im/sn-79"
     },
     {
       "auth_required": false,
@@ -116,8 +118,5 @@
       "url": "https://taos.simulate.trading/"
     }
   ],
-  "social": {
-    "x": "https://x.com/taos_im"
-  },
-  "contact": "to@mvtrx.fi"
+  "website_url": "https://taos.im/"
 }

--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -12,10 +12,7 @@
   ],
   "contact": "contact@nepher.ai",
   "curation": {
-    "gap_notes": [
-      "No verified SSE/event stream yet.",
-      "No verified standalone data artifact yet."
-    ],
+    "gap_notes": ["No verified SSE/event stream yet."],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T07:12:52.000Z",

--- a/registry/subnets/ninja.json
+++ b/registry/subnets/ninja.json
@@ -13,8 +13,7 @@
   "curation": {
     "gap_notes": [
       "Swagger/OpenAPI routes currently serve HTML UI only; no verified machine-readable schema URL yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",

--- a/registry/subnets/nodexo.json
+++ b/registry/subnets/nodexo.json
@@ -1,21 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 106,
-  "name": "Nodexo",
-  "slug": "nodexo",
-  "status": "active",
-  "categories": [
-    "baseline-curated",
-    "compute",
-    "gpu",
-    "identity-reviewed",
-    "official-docs",
-    "official-website"
-  ],
-  "website_url": "https://nodexo.ai/",
-  "docs_url": "https://docs.nodexo.ai/",
-  "dashboard_url": "https://console.nodexo.ai/",
-  "source_repo": "https://github.com/nodexo-ai/nodexo",
   "baseline_excluded_surface_ids": [
     "sn-106-taomarketcap-source-repo",
     "sn-106-taomarketcap-website",
@@ -26,80 +9,96 @@
     "sn-106-website-common-swagger",
     "sn-106-website-common-swagger-json"
   ],
-  "notes": "Reviewed overlay for SN106 Nodexo Compute (on-chain SubnetIdentitiesV3 netuid 106 = subnet_name \"Nodexo\", subnet_url nodexo.ai; re-keyed from netuid 27, which on-chain is \"Team TBC\"). Official browser-facing website, docs, and console surfaces are known, but simple Node/HEAD probes currently receive connection resets. The previously discovered source repository candidate currently returns 404 and is not promoted.",
+  "categories": [
+    "baseline-curated",
+    "compute",
+    "gpu",
+    "identity-reviewed",
+    "official-docs",
+    "official-website"
+  ],
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T14:15:00.000Z",
-    "verified_at": "2026-06-08T14:15:00.000Z",
-    "source_count": 6,
     "gap_notes": [
       "Official website/docs/console are browser-facing but currently reject simple machine probes with connection resets, so these surfaces are listed without recurring probe monitoring.",
       "Common /docs, /api, /health, /openapi.json, and Swagger paths on nodexo.ai are not promoted because the origin rejects simple machine probes.",
       "Previously discovered GitHub source repository candidates currently return 404.",
       "No verified live source repository yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T14:15:00.000Z",
+    "source_count": 6,
+    "verified_at": "2026-06-08T14:15:00.000Z"
   },
-  "social": { "x": "https://x.com/nodex0_" },
+  "dashboard_url": "https://console.nodexo.ai/",
+  "docs_url": "https://docs.nodexo.ai/",
+  "name": "Nodexo",
+  "netuid": 106,
+  "notes": "Reviewed overlay for SN106 Nodexo Compute (on-chain SubnetIdentitiesV3 netuid 106 = subnet_name \"Nodexo\", subnet_url nodexo.ai; re-keyed from netuid 27, which on-chain is \"Team TBC\"). Official browser-facing website, docs, and console surfaces are known, but simple Node/HEAD probes currently receive connection resets. The previously discovered source repository candidate currently returns 404 and is not promoted.",
+  "schema_version": 1,
+  "slug": "nodexo",
+  "social": {
+    "x": "https://x.com/nodex0_"
+  },
+  "source_repo": "https://github.com/nodexo-ai/nodexo",
+  "status": "active",
   "surfaces": [
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-106-nodexo-website",
-      "name": "Nodexo website",
       "kind": "website",
-      "url": "https://nodexo.ai/",
+      "name": "Nodexo website",
+      "notes": "Official Nodexo Compute website.",
       "provider": "nodexo",
-      "auth_required": false,
-      "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://nodexo.ai/", "https://docs.nodexo.ai/"],
       "rate_limit_notes": "Not probe-enabled because simple Node/HEAD probes currently receive connection resets from the origin.",
-      "notes": "Official Nodexo Compute website."
+      "source_urls": ["https://nodexo.ai/", "https://docs.nodexo.ai/"],
+      "url": "https://nodexo.ai/"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-106-nodexo-docs",
-      "name": "Nodexo docs",
       "kind": "docs",
-      "url": "https://docs.nodexo.ai/",
+      "name": "Nodexo docs",
+      "notes": "Official Nodexo Compute documentation.",
       "provider": "nodexo",
-      "auth_required": false,
-      "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://nodexo.ai/", "https://docs.nodexo.ai/"],
       "rate_limit_notes": "Not probe-enabled because simple Node/HEAD probes currently receive connection resets from the origin.",
-      "notes": "Official Nodexo Compute documentation."
+      "source_urls": ["https://nodexo.ai/", "https://docs.nodexo.ai/"],
+      "url": "https://docs.nodexo.ai/"
     },
     {
-      "id": "sn-106-nodexo-console",
-      "name": "Nodexo console",
-      "kind": "dashboard",
-      "url": "https://console.nodexo.ai/",
-      "provider": "nodexo",
       "auth_required": true,
       "authority": "official",
+      "id": "sn-106-nodexo-console",
+      "kind": "dashboard",
+      "name": "Nodexo console",
+      "notes": "Official Nodexo console surface. Authentication may be required for account-specific workflows.",
+      "provider": "nodexo",
       "public_safe": true,
-      "source_urls": ["https://nodexo.ai/", "https://docs.nodexo.ai/"],
       "rate_limit_notes": "Not probe-enabled because simple Node/HEAD probes currently receive connection resets from the origin.",
-      "notes": "Official Nodexo console surface. Authentication may be required for account-specific workflows."
+      "source_urls": ["https://nodexo.ai/", "https://docs.nodexo.ai/"],
+      "url": "https://console.nodexo.ai/"
     },
     {
-      "id": "sn-106-nodexo-subnet-api",
-      "name": "Nodexo inventory API",
-      "kind": "subnet-api",
-      "url": "https://nodexo.ai/api/inventory",
-      "provider": "nodexo",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-106-nodexo-subnet-api",
+      "kind": "subnet-api",
+      "name": "Nodexo inventory API",
+      "notes": "Public Nodexo (SN106) GPU marketplace inventory API. Returns live JSON offers with GPU model, VRAM, pricing (USDC/hour), availability, and reliability metrics. No auth required.",
+      "provider": "nodexo",
       "public_safe": true,
-      "source_urls": ["https://nodexo.ai/"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "seekmistar01"
       },
-      "notes": "Public Nodexo (SN106) GPU marketplace inventory API. Returns live JSON offers with GPU model, VRAM, pricing (USDC/hour), availability, and reliability metrics. No auth required."
+      "source_urls": ["https://nodexo.ai/"],
+      "url": "https://nodexo.ai/api/inventory"
     },
     {
       "auth_required": false,
@@ -189,5 +188,6 @@
       ],
       "url": "https://raw.githubusercontent.com/nodexo-ai/nodexo/f104f2fa848da6bc7d02b7ac00a2c9a7f1a5af73/abis/SubnetConfig.json"
     }
-  ]
+  ],
+  "website_url": "https://nodexo.ai/"
 }

--- a/registry/subnets/numinous.json
+++ b/registry/subnets/numinous.json
@@ -12,8 +12,7 @@
   "curation": {
     "gap_notes": [
       "Official website, source repository, Swagger UI, OpenAPI schema, and health endpoint are verified live.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",

--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 111,
-  "name": "oneoneone",
-  "slug": "sn-111",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "data",
@@ -12,63 +7,67 @@
     "official-website",
     "ugc"
   ],
-  "website_url": "https://oneoneone.io/",
-  "source_repo": "https://github.com/oneoneone-io/subnet-111",
-  "dashboard_url": "https://taomarketcap.com/subnets/111",
-  "notes": "Reviewed overlay for SN111 using the official oneoneone website and source repository. No official docs/API/OpenAPI surface is verified yet.",
+  "contact": "support@oneoneone.io",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T10:35:00.000Z",
-    "verified_at": "2026-06-08T10:35:00.000Z",
-    "source_count": 4,
     "gap_notes": [
       "No verified official docs URL yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T10:35:00.000Z",
+    "source_count": 4,
+    "verified_at": "2026-06-08T10:35:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/111",
+  "name": "oneoneone",
+  "netuid": 111,
+  "notes": "Reviewed overlay for SN111 using the official oneoneone website and source repository. No official docs/API/OpenAPI surface is verified yet.",
+  "schema_version": 1,
+  "slug": "sn-111",
+  "source_repo": "https://github.com/oneoneone-io/subnet-111",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-111-oneoneone-website",
-      "name": "oneoneone website",
-      "kind": "website",
-      "url": "https://oneoneone.io/",
-      "provider": "oneoneone",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://oneoneone.io/"],
+      "id": "sn-111-oneoneone-website",
+      "kind": "website",
+      "name": "oneoneone website",
+      "notes": "Official oneoneone website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official oneoneone website."
+      "provider": "oneoneone",
+      "public_safe": true,
+      "source_urls": ["https://oneoneone.io/"],
+      "url": "https://oneoneone.io/"
     },
     {
-      "id": "sn-111-oneoneone-source",
-      "name": "oneoneone source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/oneoneone-io/subnet-111",
-      "provider": "oneoneone",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-111-oneoneone-source",
+      "kind": "source-repo",
+      "name": "oneoneone source repository",
+      "notes": "Official oneoneone source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "oneoneone",
       "public_safe": true,
       "source_urls": [
         "https://api.github.com/repos/oneoneone-io/subnet-111",
         "https://github.com/oneoneone-io/subnet-111"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official oneoneone source repository."
+      "url": "https://github.com/oneoneone-io/subnet-111"
     },
     {
       "auth_required": false,
@@ -148,5 +147,5 @@
       "url": "https://api.taomarketcap.com/public/v1/subnets/111"
     }
   ],
-  "contact": "support@oneoneone.io"
+  "website_url": "https://oneoneone.io/"
 }

--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -8,12 +8,7 @@
   ],
   "contact": "team@oroagents.com",
   "curation": {
-    "gap_notes": [
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ],
+    "gap_notes": ["No verified SSE/event stream yet."],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T09:50:00.000Z",

--- a/registry/subnets/pla-form.json
+++ b/registry/subnets/pla-form.json
@@ -1,9 +1,11 @@
 {
-  "schema_version": 1,
-  "netuid": 100,
-  "name": "Plaτform",
-  "slug": "sn-100",
-  "status": "active",
+  "baseline_excluded_surface_ids": [
+    "sn-100-taomarketcap-source-repo",
+    "sn-100-taomarketcap-website",
+    "sn-100-tensorplex-source-repo-1",
+    "sn-100-tensorplex-source-repo-2",
+    "sn-100-website-common-docs"
+  ],
   "categories": [
     "ai-research",
     "baseline-curated",
@@ -12,95 +14,93 @@
     "official-source-repo",
     "official-website"
   ],
-  "website_url": "https://www.platform.network/",
-  "docs_url": "https://www.platform.network/docs",
-  "source_repo": "https://github.com/PlatformNetwork/platform",
-  "dashboard_url": "https://taomarketcap.com/subnets/100",
-  "baseline_excluded_surface_ids": [
-    "sn-100-taomarketcap-source-repo",
-    "sn-100-taomarketcap-website",
-    "sn-100-tensorplex-source-repo-1",
-    "sn-100-tensorplex-source-repo-2",
-    "sn-100-website-common-docs"
-  ],
-  "notes": "Reviewed overlay for SN100 Plaτform using the official Platform Network website, docs, and source repository. Common API, health, OpenAPI, and Swagger probe paths currently return 404 and are not promoted as public operational API surfaces.",
+  "contact": "platform@cortex.foundation",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T19:30:00.000Z",
-    "verified_at": "2026-06-08T19:30:00.000Z",
-    "source_count": 7,
     "gap_notes": [
       "Official website, docs, and source repository are verified.",
       "Common API, health, OpenAPI, Swagger JSON, and Swagger UI paths currently return 404.",
       "CortexLM/platform redirects to PlatformNetwork/platform and is excluded as duplicate source evidence.",
       "The PlatformNetwork GitHub organization page is not promoted as a source repository.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T19:30:00.000Z",
+    "source_count": 7,
+    "verified_at": "2026-06-08T19:30:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/100",
+  "docs_url": "https://www.platform.network/docs",
+  "name": "Plaτform",
+  "netuid": 100,
+  "notes": "Reviewed overlay for SN100 Plaτform using the official Platform Network website, docs, and source repository. Common API, health, OpenAPI, and Swagger probe paths currently return 404 and are not promoted as public operational API surfaces.",
+  "schema_version": 1,
+  "slug": "sn-100",
+  "social": {
+    "x": "https://x.com/platformnet"
+  },
+  "source_repo": "https://github.com/PlatformNetwork/platform",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-100-platform-website",
-      "name": "Platform Network website",
-      "kind": "website",
-      "url": "https://www.platform.network/",
-      "provider": "platform-network",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-100-platform-website",
+      "kind": "website",
+      "name": "Platform Network website",
+      "notes": "Official Platform Network website for SN100 Plaτform.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "platform-network",
       "public_safe": true,
       "source_urls": [
         "https://www.platform.network/",
         "https://github.com/PlatformNetwork/platform"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Platform Network website for SN100 Plaτform."
+      "url": "https://www.platform.network/"
     },
     {
-      "id": "sn-100-platform-docs",
-      "name": "Platform Network docs",
-      "kind": "docs",
-      "url": "https://www.platform.network/docs",
-      "provider": "platform-network",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-100-platform-docs",
+      "kind": "docs",
+      "name": "Platform Network docs",
+      "notes": "Official Platform Network documentation.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "platform-network",
       "public_safe": true,
       "source_urls": [
         "https://www.platform.network/docs",
         "https://github.com/PlatformNetwork/platform"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Platform Network documentation."
+      "url": "https://www.platform.network/docs"
     },
     {
-      "id": "sn-100-platform-source",
-      "name": "Platform Network source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/PlatformNetwork/platform",
-      "provider": "platform-network",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/PlatformNetwork/platform"],
+      "id": "sn-100-platform-source",
+      "kind": "source-repo",
+      "name": "Platform Network source repository",
+      "notes": "Official Platform Network source repository. The repository describes Platform as a Bittensor subnet for decentralized collaborative AI research.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Platform Network source repository. The repository describes Platform as a Bittensor subnet for decentralized collaborative AI research."
+      "provider": "platform-network",
+      "public_safe": true,
+      "source_urls": ["https://github.com/PlatformNetwork/platform"],
+      "url": "https://github.com/PlatformNetwork/platform"
     },
     {
       "auth_required": false,
@@ -167,8 +167,5 @@
       "url": "https://chain.joinbase.ai/v1/challenges/dashboard.svg"
     }
   ],
-  "social": {
-    "x": "https://x.com/platformnet"
-  },
-  "contact": "platform@cortex.foundation"
+  "website_url": "https://www.platform.network/"
 }

--- a/registry/subnets/quantum-compute.json
+++ b/registry/subnets/quantum-compute.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 48,
-  "name": "Quantum Compute",
-  "slug": "sn-48",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "compute",
@@ -12,60 +7,65 @@
     "official-website",
     "quantum"
   ],
-  "source_repo": "https://github.com/qbittensor-labs/quantum-compute",
-  "dashboard_url": "https://taomarketcap.com/subnets/48",
-  "website_url": "https://www.qbittensorlabs.com/",
-  "notes": "Reviewed overlay for SN48 using the official qBittensor Labs website and Quantum Compute source repository.",
+  "contact": "qbittensorlabs@gmail.com",
   "curation": {
+    "gap_notes": [
+      "No verified OpenAPI/Swagger schema yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T10:10:00.000Z",
-    "verified_at": "2026-06-08T10:10:00.000Z",
     "source_count": 4,
-    "gap_notes": [
-      "No verified official docs URL yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T10:10:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/48",
+  "name": "Quantum Compute",
+  "netuid": 48,
+  "notes": "Reviewed overlay for SN48 using the official qBittensor Labs website and Quantum Compute source repository.",
+  "schema_version": 1,
+  "slug": "sn-48",
+  "social": {
+    "x": "https://x.com/qbittensorlabs"
+  },
+  "source_repo": "https://github.com/qbittensor-labs/quantum-compute",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-48-quantum-compute-website",
-      "name": "qBittensor Labs website",
-      "kind": "website",
-      "url": "https://www.qbittensorlabs.com/",
-      "provider": "qbittensor-labs",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/qbittensor-labs/quantum-compute"],
+      "id": "sn-48-quantum-compute-website",
+      "kind": "website",
+      "name": "qBittensor Labs website",
+      "notes": "Official qBittensor Labs website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official qBittensor Labs website."
+      "provider": "qbittensor-labs",
+      "public_safe": true,
+      "source_urls": ["https://github.com/qbittensor-labs/quantum-compute"],
+      "url": "https://www.qbittensorlabs.com/"
     },
     {
-      "id": "sn-48-quantum-compute-source",
-      "name": "Quantum Compute source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/qbittensor-labs/quantum-compute",
-      "provider": "qbittensor-labs",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/qbittensor-labs/quantum-compute"],
+      "id": "sn-48-quantum-compute-source",
+      "kind": "source-repo",
+      "name": "Quantum Compute source repository",
+      "notes": "Official Quantum Compute source repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Quantum Compute source repository."
+      "provider": "qbittensor-labs",
+      "public_safe": true,
+      "source_urls": ["https://github.com/qbittensor-labs/quantum-compute"],
+      "url": "https://github.com/qbittensor-labs/quantum-compute"
     },
     {
       "auth_required": false,
@@ -125,8 +125,5 @@
       "url": "https://docs.openquantum.com/"
     }
   ],
-  "social": {
-    "x": "https://x.com/qbittensorlabs"
-  },
-  "contact": "qbittensorlabs@gmail.com"
+  "website_url": "https://www.qbittensorlabs.com/"
 }

--- a/registry/subnets/readyai.json
+++ b/registry/subnets/readyai.json
@@ -10,11 +10,7 @@
   ],
   "contact": "david@readyai.ai",
   "curation": {
-    "gap_notes": [
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet."
-    ],
+    "gap_notes": ["No verified SSE/event stream yet."],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T08:35:00.000Z",
@@ -193,29 +189,29 @@
       "url": "https://huggingface.co/datasets/ReadyAi/organic_query_results_dataset"
     },
     {
-      "id": "sn-33-readyai-priorityqueue-request-api",
-      "name": "ReadyAI priority queue domain request API",
-      "kind": "subnet-api",
-      "url": "https://api.readyai.ai/api/v1/priorityqueue/request",
-      "provider": "readyai",
       "auth_required": false,
       "authority": "community",
-      "public_safe": true,
-      "source_urls": [
-        "https://api.readyai.ai/openapi.json",
-        "https://github.com/afterpartyai/bittensor-conversation-genome-project/blob/main/README.md"
-      ],
+      "id": "sn-33-readyai-priorityqueue-request-api",
+      "kind": "subnet-api",
+      "name": "ReadyAI priority queue domain request API",
+      "notes": "Public no-auth PUT /api/v1/priorityqueue/request on api.readyai.ai for users to request a domain for priority Common Crawl processing (upserts requested_domains). Documented in the subnet OpenAPI spec with no security requirement on PUT; GET on the same path is admin-authenticated, so recurring read probes are intentionally disabled.",
       "probe": {
         "enabled": false,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "readyai",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "carlh7777"
       },
-      "notes": "Public no-auth PUT /api/v1/priorityqueue/request on api.readyai.ai for users to request a domain for priority Common Crawl processing (upserts requested_domains). Documented in the subnet OpenAPI spec with no security requirement on PUT; GET on the same path is admin-authenticated, so recurring read probes are intentionally disabled."
+      "source_urls": [
+        "https://api.readyai.ai/openapi.json",
+        "https://github.com/afterpartyai/bittensor-conversation-genome-project/blob/main/README.md"
+      ],
+      "url": "https://api.readyai.ai/api/v1/priorityqueue/request"
     }
   ],
   "website_url": "https://readyai.ai/"

--- a/registry/subnets/redteam.json
+++ b/registry/subnets/redteam.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 61,
-  "name": "RedTeam",
-  "slug": "sn-61",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "cybersecurity",
@@ -13,100 +8,100 @@
     "official-source-repo",
     "official-website"
   ],
-  "docs_url": "https://docs.theredteam.io/",
-  "source_repo": "https://github.com/RedTeamSubnet/RedTeam",
-  "dashboard_url": "https://dashboard.theredteam.io/",
-  "website_url": "https://www.theredteam.io/",
-  "notes": "Reviewed overlay for SN61 using the official RedTeam website, dashboard, documentation, and source repository.",
+  "contact": "oscar@theredteam.io",
   "curation": {
+    "gap_notes": ["No verified SSE/event stream yet."],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T09:50:00.000Z",
-    "verified_at": "2026-06-08T09:50:00.000Z",
     "source_count": 6,
-    "gap_notes": [
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T09:50:00.000Z"
   },
+  "dashboard_url": "https://dashboard.theredteam.io/",
+  "docs_url": "https://docs.theredteam.io/",
+  "name": "RedTeam",
+  "netuid": 61,
+  "notes": "Reviewed overlay for SN61 using the official RedTeam website, dashboard, documentation, and source repository.",
+  "schema_version": 1,
+  "slug": "sn-61",
+  "source_repo": "https://github.com/RedTeamSubnet/RedTeam",
+  "status": "active",
   "surfaces": [
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-61-redteam-website",
-      "name": "RedTeam website",
       "kind": "website",
-      "url": "https://www.theredteam.io/",
-      "provider": "redteam",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/RedTeamSubnet/RedTeam"],
+      "name": "RedTeam website",
+      "notes": "Official RedTeam website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official RedTeam website."
+      "provider": "redteam",
+      "public_safe": true,
+      "source_urls": ["https://github.com/RedTeamSubnet/RedTeam"],
+      "url": "https://www.theredteam.io/"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-61-redteam-dashboard",
-      "name": "RedTeam dashboard",
       "kind": "dashboard",
-      "url": "https://dashboard.theredteam.io/",
+      "name": "RedTeam dashboard",
+      "notes": "Official RedTeam dashboard.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "redteam",
-      "auth_required": false,
-      "authority": "official",
       "public_safe": true,
       "source_urls": [
         "https://github.com/RedTeamSubnet/RedTeam/blob/main/README.md"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official RedTeam dashboard."
+      "url": "https://dashboard.theredteam.io/"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-61-redteam-docs",
-      "name": "RedTeam docs",
       "kind": "docs",
-      "url": "https://docs.theredteam.io/",
+      "name": "RedTeam docs",
+      "notes": "Official RedTeam documentation.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "redteam",
-      "auth_required": false,
-      "authority": "official",
       "public_safe": true,
       "source_urls": [
         "https://github.com/RedTeamSubnet/RedTeam/blob/main/README.md"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official RedTeam documentation."
+      "url": "https://docs.theredteam.io/"
     },
     {
-      "id": "sn-61-redteam-source",
-      "name": "RedTeam source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/RedTeamSubnet/RedTeam",
-      "provider": "redteam",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-61-redteam-source",
+      "kind": "source-repo",
+      "name": "RedTeam source repository",
+      "notes": "Official RedTeam source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "redteam",
       "public_safe": true,
       "source_urls": ["https://github.com/RedTeamSubnet/RedTeam"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official RedTeam source repository."
+      "url": "https://github.com/RedTeamSubnet/RedTeam"
     },
     {
       "auth_required": false,
@@ -168,5 +163,5 @@
       "url": "https://cdn.jsdelivr.net/gh/RedTeamSubnet/rest-dfp-proxy@main/docs/pages/api-docs/openapi.json"
     }
   ],
-  "contact": "oscar@theredteam.io"
+  "website_url": "https://www.theredteam.io/"
 }

--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -1,75 +1,73 @@
 {
-  "schema_version": 1,
-  "netuid": 62,
-  "name": "Ridges",
-  "slug": "sn-62",
-  "status": "active",
   "categories": [
     "agents",
     "baseline-curated",
     "identity-reviewed",
     "official-source-repo"
   ],
-  "source_repo": "https://github.com/ridgesai/ridges",
-  "dashboard_url": "https://taomarketcap.com/subnets/62",
-  "website_url": "https://www.ridges.ai/",
-  "notes": "Reviewed overlay for SN62 using the official Ridges source repository and public website identity. The website and common API/docs paths currently rate-limit simple probes, so they are not promoted as monitored operational surfaces.",
+  "contact": "hello@ridges.ai",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T09:25:00.000Z",
-    "verified_at": "2026-06-08T09:25:00.000Z",
-    "source_count": 4,
     "gap_notes": [
       "Website exists but currently rate-limits simple probes.",
       "No verified docs site yet.",
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T09:25:00.000Z",
+    "source_count": 4,
+    "verified_at": "2026-06-08T09:25:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/62",
+  "name": "Ridges",
+  "netuid": 62,
+  "notes": "Reviewed overlay for SN62 using the official Ridges source repository and public website identity. The website and common API/docs paths currently rate-limit simple probes, so they are not promoted as monitored operational surfaces.",
+  "schema_version": 1,
+  "slug": "sn-62",
+  "source_repo": "https://github.com/ridgesai/ridges",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-62-ridges-source",
-      "name": "Ridges source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/ridgesai/ridges",
-      "provider": "ridges",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/ridgesai/ridges"],
+      "id": "sn-62-ridges-source",
+      "kind": "source-repo",
+      "name": "Ridges source repository",
+      "notes": "Official Ridges source repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Ridges source repository."
+      "provider": "ridges",
+      "public_safe": true,
+      "source_urls": ["https://github.com/ridgesai/ridges"],
+      "url": "https://github.com/ridgesai/ridges"
     },
     {
-      "id": "sn-62-ridges-subnet-api",
-      "name": "Ridges API — top agents leaderboard (retrieval)",
-      "kind": "subnet-api",
-      "url": "https://agent-upload.ridges.ai/retrieval/top-agents",
-      "provider": "ridges",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-62-ridges-subnet-api",
+      "kind": "subnet-api",
+      "name": "Ridges API — top agents leaderboard (retrieval)",
+      "notes": "Public, unauthenticated read endpoint on the Ridges backend API: the live leaderboard of top-scored SWE agents (miner_hotkey, name, version_num, final_score). agent-upload.ridges.ai is the DEFAULT_API_BASE_URL the official CLI uses (ridgesai/ridges miners/cli/commands/upload.py) and serves the platform's read routes; /retrieval/top-agents is defined in api/endpoints/retrieval.py (no auth) and mounted at /retrieval in api/src/main.py. OpenAPI 3.1.0 spec at /openapi.json.",
+      "provider": "ridges",
       "public_safe": true,
-      "schema_url": "https://agent-upload.ridges.ai/openapi.json",
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "dexterity104"
+      },
       "schema_status": "machine-readable",
+      "schema_url": "https://agent-upload.ridges.ai/openapi.json",
       "source_urls": [
         "https://github.com/ridgesai/ridges/blob/main/miners/cli/commands/upload.py",
         "https://raw.githubusercontent.com/ridgesai/ridges/main/miners/cli/commands/upload.py",
         "https://github.com/ridgesai/ridges/blob/main/api/endpoints/retrieval.py",
         "https://raw.githubusercontent.com/ridgesai/ridges/main/api/endpoints/retrieval.py"
       ],
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "dexterity104"
-      },
-      "notes": "Public, unauthenticated read endpoint on the Ridges backend API: the live leaderboard of top-scored SWE agents (miner_hotkey, name, version_num, final_score). agent-upload.ridges.ai is the DEFAULT_API_BASE_URL the official CLI uses (ridgesai/ridges miners/cli/commands/upload.py) and serves the platform's read routes; /retrieval/top-agents is defined in api/endpoints/retrieval.py (no auth) and mounted at /retrieval in api/src/main.py. OpenAPI 3.1.0 spec at /openapi.json."
+      "url": "https://agent-upload.ridges.ai/retrieval/top-agents"
     },
     {
       "auth_required": false,
@@ -93,5 +91,5 @@
       "url": "https://agent-upload.ridges.ai/openapi.json"
     }
   ],
-  "contact": "hello@ridges.ai"
+  "website_url": "https://www.ridges.ai/"
 }

--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -18,8 +18,6 @@
       "Level114/level114-subnet is live from Tensorplex evidence but is not promoted as the primary source repository.",
       "Common docs, health, OpenAPI, Swagger JSON, and Swagger UI paths currently return 404.",
       "The /api path currently fails simple safe fetch probes and is not promoted.",
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",

--- a/registry/subnets/sparket.json
+++ b/registry/subnets/sparket.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 57,
-  "name": "Sparket",
-  "slug": "sn-57",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
@@ -12,107 +7,109 @@
     "prediction-market",
     "sports"
   ],
-  "website_url": "https://sparket.ai/",
-  "source_repo": "https://github.com/sparket-ai/sparket-ai",
-  "dashboard_url": "https://taomarketcap.com/subnets/57",
-  "notes": "Reviewed overlay for SN57 using the official Sparket website and source repository. No official docs/API/OpenAPI surface is verified yet.",
   "curation": {
+    "gap_notes": [
+      "No verified official docs URL yet.",
+      "No verified OpenAPI/Swagger schema yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T10:35:00.000Z",
-    "verified_at": "2026-06-08T10:35:00.000Z",
     "source_count": 4,
-    "gap_notes": [
-      "No verified official docs URL yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T10:35:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/57",
+  "name": "Sparket",
+  "netuid": 57,
+  "notes": "Reviewed overlay for SN57 using the official Sparket website and source repository. No official docs/API/OpenAPI surface is verified yet.",
+  "schema_version": 1,
+  "slug": "sn-57",
+  "source_repo": "https://github.com/sparket-ai/sparket-ai",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-57-sparket-website",
-      "name": "Sparket website",
-      "kind": "website",
-      "url": "https://sparket.ai/",
-      "provider": "sparket",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://sparket.ai/"],
+      "id": "sn-57-sparket-website",
+      "kind": "website",
+      "name": "Sparket website",
+      "notes": "Official Sparket website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Sparket website."
+      "provider": "sparket",
+      "public_safe": true,
+      "source_urls": ["https://sparket.ai/"],
+      "url": "https://sparket.ai/"
     },
     {
-      "id": "sn-57-sparket-source",
-      "name": "Sparket source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/sparket-ai/sparket-ai",
-      "provider": "sparket",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-57-sparket-source",
+      "kind": "source-repo",
+      "name": "Sparket source repository",
+      "notes": "Official Sparket source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "sparket",
       "public_safe": true,
       "source_urls": [
         "https://api.github.com/repos/sparket-ai/sparket-ai",
         "https://github.com/sparket-ai/sparket-ai"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Sparket source repository."
+      "url": "https://github.com/sparket-ai/sparket-ai"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-57-sparket-subnet-api",
-      "name": "Sparket API health",
       "kind": "subnet-api",
-      "url": "https://sparket.ai/api/v1/health",
-      "provider": "sparket",
-      "auth_required": false,
-      "authority": "community",
-      "public_safe": true,
-      "source_urls": ["https://sparket.ai/"],
+      "name": "Sparket API health",
+      "notes": "Public no-auth GET returning the Sparket (SN57) backend API health as JSON (status, db connectivity, version, and sync lag). Served on the subnet's own registered website domain sparket.ai under /api/v1/. Fills the file's noted missing public-API-endpoint gap.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "sparket",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "nickmopen"
       },
-      "notes": "Public no-auth GET returning the Sparket (SN57) backend API health as JSON (status, db connectivity, version, and sync lag). Served on the subnet's own registered website domain sparket.ai under /api/v1/. Fills the file's noted missing public-API-endpoint gap."
+      "source_urls": ["https://sparket.ai/"],
+      "url": "https://sparket.ai/api/v1/health"
     },
     {
-      "id": "sn-57-sparket-leaderboard",
-      "name": "Sparket miner leaderboard",
-      "kind": "data-artifact",
-      "url": "https://sparket.ai/api/v1/leaderboard",
-      "provider": "sparket",
       "auth_required": false,
       "authority": "community",
-      "public_safe": true,
-      "source_urls": ["https://sparket.ai/"],
+      "id": "sn-57-sparket-leaderboard",
+      "kind": "data-artifact",
+      "name": "Sparket miner leaderboard",
+      "notes": "Public no-auth GET returning the Sparket (SN57) miner leaderboard as JSON — per-miner rank, uid, component scores (skill/accuracy/edge/timeliness/uniqueness), incentive, and weight (25 ranked rows plus a meta block). Served on the subnet's own registered domain sparket.ai under /api/v1/; all fields are public scoreboard and ranking data. Fills the file's noted missing standalone-data-artifact gap.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "sparket",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "nickmopen"
       },
-      "notes": "Public no-auth GET returning the Sparket (SN57) miner leaderboard as JSON — per-miner rank, uid, component scores (skill/accuracy/edge/timeliness/uniqueness), incentive, and weight (25 ranked rows plus a meta block). Served on the subnet's own registered domain sparket.ai under /api/v1/; all fields are public scoreboard and ranking data. Fills the file's noted missing standalone-data-artifact gap."
+      "source_urls": ["https://sparket.ai/"],
+      "url": "https://sparket.ai/api/v1/leaderboard"
     },
     {
       "auth_required": false,
@@ -133,5 +130,6 @@
       ],
       "url": "https://dashboard.sparket.ai/leaderboard"
     }
-  ]
+  ],
+  "website_url": "https://sparket.ai/"
 }

--- a/registry/subnets/sundae-bar.json
+++ b/registry/subnets/sundae-bar.json
@@ -1,69 +1,70 @@
 {
-  "schema_version": 1,
-  "netuid": 121,
-  "name": "sundae_bar",
-  "slug": "sn-121",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "official-source-repo",
     "official-website"
   ],
-  "source_repo": "https://github.com/sundae-bar/bittensor-subnet",
-  "dashboard_url": "https://taomarketcap.com/subnets/121",
-  "website_url": "https://www.sundaebar.ai/",
-  "notes": "Reviewed overlay for SN121 using the official Sundae Bar website and source repository.",
+  "contact": "hello@sundaebar.ai",
   "curation": {
+    "gap_notes": [
+      "No verified official docs URL yet.",
+      "No verified OpenAPI/Swagger schema yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T10:10:00.000Z",
-    "verified_at": "2026-06-08T10:10:00.000Z",
     "source_count": 4,
-    "gap_notes": [
-      "No verified official docs URL yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T10:10:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/121",
+  "name": "sundae_bar",
+  "netuid": 121,
+  "notes": "Reviewed overlay for SN121 using the official Sundae Bar website and source repository.",
+  "schema_version": 1,
+  "slug": "sn-121",
+  "social": {
+    "x": "https://x.com/sundae_bar_"
+  },
+  "source_repo": "https://github.com/sundae-bar/bittensor-subnet",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-121-sundae-bar-website",
-      "name": "Sundae Bar website",
-      "kind": "website",
-      "url": "https://www.sundaebar.ai/",
-      "provider": "sundae-bar",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/sundae-bar/bittensor-subnet"],
+      "id": "sn-121-sundae-bar-website",
+      "kind": "website",
+      "name": "Sundae Bar website",
+      "notes": "Official Sundae Bar website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Sundae Bar website."
+      "provider": "sundae-bar",
+      "public_safe": true,
+      "source_urls": ["https://github.com/sundae-bar/bittensor-subnet"],
+      "url": "https://www.sundaebar.ai/"
     },
     {
-      "id": "sn-121-sundae-bar-source",
-      "name": "Sundae Bar source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/sundae-bar/bittensor-subnet",
-      "provider": "sundae-bar",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/sundae-bar/bittensor-subnet"],
+      "id": "sn-121-sundae-bar-source",
+      "kind": "source-repo",
+      "name": "Sundae Bar source repository",
+      "notes": "Official Sundae Bar source repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Sundae Bar source repository."
+      "provider": "sundae-bar",
+      "public_safe": true,
+      "source_urls": ["https://github.com/sundae-bar/bittensor-subnet"],
+      "url": "https://github.com/sundae-bar/bittensor-subnet"
     },
     {
       "auth_required": false,
@@ -153,8 +154,5 @@
       "url": "https://www.sundaebar.ai/api/products"
     }
   ],
-  "social": {
-    "x": "https://x.com/sundae_bar_"
-  },
-  "contact": "hello@sundaebar.ai"
+  "website_url": "https://www.sundaebar.ai/"
 }

--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -1,20 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 10,
-  "name": "Swap",
-  "slug": "sn-10",
-  "status": "active",
-  "categories": [
-    "baseline-curated",
-    "identity-reviewed",
-    "official-docs",
-    "official-source-repo",
-    "official-website"
-  ],
-  "website_url": "https://www.taofi.com/pool",
-  "docs_url": "https://docs.taofi.com/",
-  "source_repo": "https://github.com/Swap-Subnet/swap-subnet",
-  "dashboard_url": "https://taomarketcap.com/subnets/10",
   "baseline_excluded_surface_ids": [
     "sn-10-taomarketcap-source-repo",
     "sn-10-taomarketcap-website",
@@ -26,151 +10,164 @@
     "sn-10-website-common-swagger-json",
     "sn-10-website-subdomain-docs-docs-taofi-com"
   ],
-  "notes": "Reviewed overlay for SN10 Swap using the TaoFi pool page, TaoFi docs, and Swap source repository. Common www.taofi.com API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-docs",
+    "official-source-repo",
+    "official-website"
+  ],
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T20:25:00.000Z",
-    "verified_at": "2026-06-08T20:25:00.000Z",
-    "source_count": 5,
     "gap_notes": [
       "Official TaoFi pool page, docs, and Swap source repository are verified live.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T20:25:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-06-08T20:25:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/10",
+  "docs_url": "https://docs.taofi.com/",
+  "name": "Swap",
+  "netuid": 10,
+  "notes": "Reviewed overlay for SN10 Swap using the TaoFi pool page, TaoFi docs, and Swap source repository. Common www.taofi.com API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
+  "schema_version": 1,
+  "slug": "sn-10",
+  "source_repo": "https://github.com/Swap-Subnet/swap-subnet",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-10-taofi-pool",
-      "name": "TaoFi pool",
-      "kind": "website",
-      "url": "https://www.taofi.com/pool",
-      "provider": "taofi",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-10-taofi-pool",
+      "kind": "website",
+      "name": "TaoFi pool",
+      "notes": "Official TaoFi pool page for SN10 Swap.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taofi",
       "public_safe": true,
       "source_urls": [
         "https://www.taofi.com/pool",
         "https://github.com/Swap-Subnet/swap-subnet"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official TaoFi pool page for SN10 Swap."
+      "url": "https://www.taofi.com/pool"
     },
     {
-      "id": "sn-10-taofi-docs",
-      "name": "TaoFi docs",
-      "kind": "docs",
-      "url": "https://docs.taofi.com/",
-      "provider": "taofi",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-10-taofi-docs",
+      "kind": "docs",
+      "name": "TaoFi docs",
+      "notes": "Official TaoFi documentation.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taofi",
       "public_safe": true,
       "source_urls": ["https://docs.taofi.com/"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official TaoFi documentation."
+      "url": "https://docs.taofi.com/"
     },
     {
-      "id": "sn-10-swap-source",
-      "name": "Swap source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/Swap-Subnet/swap-subnet",
-      "provider": "taofi",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/Swap-Subnet/swap-subnet"],
+      "id": "sn-10-swap-source",
+      "kind": "source-repo",
+      "name": "Swap source repository",
+      "notes": "Official Swap subnet source repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Swap subnet source repository."
+      "provider": "taofi",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Swap-Subnet/swap-subnet"],
+      "url": "https://github.com/Swap-Subnet/swap-subnet"
     },
     {
-      "id": "sn-10-taofi-openapi",
-      "name": "TaoFi API OpenAPI schema",
-      "kind": "openapi",
-      "url": "https://taofi-doc.web.app/openapi.yaml",
-      "provider": "taofi",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-10-taofi-openapi",
+      "kind": "openapi",
+      "name": "TaoFi API OpenAPI schema",
+      "notes": "Official TaoFi (SN10 Swap) OpenAPI 3.0.4 schema (title \"TaoFi - OpenAPI 3.0\", servers host https://taofi-api.web.app/) served behind the public Swagger UI at taofi-doc.web.app. Documents the swap/bridge quote-and-call endpoints (getBuyQuote, getSellQuote, getBalance, getNativeTaoQuote, etc.); no authentication scheme is defined. The taofi-api.web.app host is referenced in TaoFi's own repository (TaoFi-0x/taofi-swap).",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taofi",
       "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
       "schema_status": "machine-readable",
       "schema_url": "https://taofi-doc.web.app/openapi.yaml",
       "source_urls": [
         "https://docs.taofi.com/",
         "https://taofi-doc.web.app/openapi.yaml"
       ],
+      "url": "https://taofi-doc.web.app/openapi.yaml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-10-taofi-api",
+      "kind": "subnet-api",
+      "name": "TaoFi swap API",
+      "notes": "Public unauthenticated TaoFi (SN10 Swap) API — the servers host declared in the TaoFi OpenAPI schema. POST endpoints return live swap/bridge quotes and transaction call data (verified: getBuyQuote returned an HTTP 200 JSON quote). Documented at taofi-doc.web.app.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "any",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "taofi",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Official TaoFi (SN10 Swap) OpenAPI 3.0.4 schema (title \"TaoFi - OpenAPI 3.0\", servers host https://taofi-api.web.app/) served behind the public Swagger UI at taofi-doc.web.app. Documents the swap/bridge quote-and-call endpoints (getBuyQuote, getSellQuote, getBalance, getNativeTaoQuote, etc.); no authentication scheme is defined. The taofi-api.web.app host is referenced in TaoFi's own repository (TaoFi-0x/taofi-swap)."
-    },
-    {
-      "id": "sn-10-taofi-api",
-      "name": "TaoFi swap API",
-      "kind": "subnet-api",
-      "url": "https://taofi-api.web.app/",
-      "provider": "taofi",
-      "auth_required": false,
-      "authority": "community",
-      "public_safe": true,
       "schema_url": "https://taofi-doc.web.app/openapi.yaml",
       "source_urls": [
         "https://docs.taofi.com/",
         "https://taofi-doc.web.app/openapi.yaml"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "GET",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "glorydavid03023"
-      },
-      "notes": "Public unauthenticated TaoFi (SN10 Swap) API — the servers host declared in the TaoFi OpenAPI schema. POST endpoints return live swap/bridge quotes and transaction call data (verified: getBuyQuote returned an HTTP 200 JSON quote). Documented at taofi-doc.web.app."
+      "url": "https://taofi-api.web.app/"
     },
     {
-      "id": "sn-10-swap-nfpm-abi",
-      "name": "Swap NonfungiblePositionManager contract ABI",
-      "kind": "data-artifact",
-      "url": "https://raw.githubusercontent.com/Swap-Subnet/swap-subnet/main/swap/abi/NonfungiblePositionManager.json",
-      "provider": "taofi",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-10-swap-nfpm-abi",
+      "kind": "data-artifact",
+      "name": "Swap NonfungiblePositionManager contract ABI",
+      "notes": "Public no-auth Uniswap-V3-style NonfungiblePositionManager contract ABI (46 entries) published in the official Swap-Subnet/swap-subnet repository at swap/abi/NonfungiblePositionManager.json. Used by SN10 Swap's on-chain liquidity-position logic; the same repo is already this file's registered source_repo.",
+      "provider": "taofi",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/Swap-Subnet/swap-subnet/blob/main/swap/abi/NonfungiblePositionManager.json",
-        "https://github.com/Swap-Subnet/swap-subnet"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "galuis116"
       },
-      "notes": "Public no-auth Uniswap-V3-style NonfungiblePositionManager contract ABI (46 entries) published in the official Swap-Subnet/swap-subnet repository at swap/abi/NonfungiblePositionManager.json. Used by SN10 Swap's on-chain liquidity-position logic; the same repo is already this file's registered source_repo."
+      "source_urls": [
+        "https://github.com/Swap-Subnet/swap-subnet/blob/main/swap/abi/NonfungiblePositionManager.json",
+        "https://github.com/Swap-Subnet/swap-subnet"
+      ],
+      "url": "https://raw.githubusercontent.com/Swap-Subnet/swap-subnet/main/swap/abi/NonfungiblePositionManager.json"
     }
-  ]
+  ],
+  "website_url": "https://www.taofi.com/pool"
 }

--- a/registry/subnets/talisman-ai.json
+++ b/registry/subnets/talisman-ai.json
@@ -1,69 +1,69 @@
 {
-  "schema_version": 1,
-  "netuid": 45,
-  "name": "Talisman AI",
-  "slug": "sn-45",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
     "official-source-repo",
     "official-website"
   ],
-  "source_repo": "https://github.com/Team-Rizzo/talisman-ai",
-  "dashboard_url": "https://taomarketcap.com/subnets/45",
-  "website_url": "https://ai.talisman.xyz/",
-  "notes": "Reviewed overlay for SN45 using the official Talisman AI website and source repository.",
+  "contact": "tai@rizzo.network",
   "curation": {
+    "gap_notes": [
+      "No verified official docs URL yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T10:10:00.000Z",
-    "verified_at": "2026-06-08T10:10:00.000Z",
     "source_count": 4,
-    "gap_notes": [
-      "No verified official docs URL yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T10:10:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/45",
+  "name": "Talisman AI",
+  "netuid": 45,
+  "notes": "Reviewed overlay for SN45 using the official Talisman AI website and source repository.",
+  "schema_version": 1,
+  "slug": "sn-45",
+  "social": {
+    "x": "https://x.com/wearetalisman"
+  },
+  "source_repo": "https://github.com/Team-Rizzo/talisman-ai",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-45-talisman-ai-website",
-      "name": "Talisman AI website",
-      "kind": "website",
-      "url": "https://ai.talisman.xyz/",
-      "provider": "talisman-ai",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/Team-Rizzo/talisman-ai"],
+      "id": "sn-45-talisman-ai-website",
+      "kind": "website",
+      "name": "Talisman AI website",
+      "notes": "Official Talisman AI website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Talisman AI website."
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Team-Rizzo/talisman-ai"],
+      "url": "https://ai.talisman.xyz/"
     },
     {
-      "id": "sn-45-talisman-ai-source",
-      "name": "Talisman AI source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/Team-Rizzo/talisman-ai",
-      "provider": "talisman-ai",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/Team-Rizzo/talisman-ai"],
+      "id": "sn-45-talisman-ai-source",
+      "kind": "source-repo",
+      "name": "Talisman AI source repository",
+      "notes": "Official Talisman AI source repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Talisman AI source repository."
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Team-Rizzo/talisman-ai"],
+      "url": "https://github.com/Team-Rizzo/talisman-ai"
     },
     {
       "auth_required": false,
@@ -125,6 +125,5 @@
       "url": "https://api.alpharidge.ai/dashboard/stats"
     }
   ],
-  "social": { "x": "https://x.com/wearetalisman" },
-  "contact": "tai@rizzo.network"
+  "website_url": "https://ai.talisman.xyz/"
 }

--- a/registry/subnets/taolend.json
+++ b/registry/subnets/taolend.json
@@ -12,11 +12,9 @@
       "Native chain name currently reports as hard_sign; public directories identify SN116 as TaoLend.",
       "Official website currently returns 500/server-error responses to simple probes and should appear degraded until it recovers.",
       "Previously discovered GitHub source repository currently returns 404.",
-      "No verified live source repository yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",

--- a/registry/subnets/targon.json
+++ b/registry/subnets/targon.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 4,
-  "name": "Targon",
-  "slug": "sn-4",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
@@ -11,191 +6,200 @@
     "official-source-repo",
     "official-website"
   ],
-  "source_repo": "https://github.com/manifold-inc/targon",
-  "docs_url": "https://docs.targon.com/",
-  "dashboard_url": null,
-  "website_url": "https://targon.com/",
-  "notes": "Reviewed overlay for SN4 using the official Targon website, docs, Intel whitepaper, and source repository. No public API, OpenAPI schema, SSE stream, or standalone data artifact is verified yet.",
+  "contact": "devs@manifold.inc",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T16:10:00.000Z",
-    "verified_at": "2026-06-08T16:10:00.000Z",
-    "source_count": 6,
     "gap_notes": [
       "Official website, docs, Intel whitepaper, and source repository are verified live.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified OpenAPI/Swagger schema yet.",
       "No verified SSE/event stream yet.",
       "No verified standalone static data artifact yet."
-    ]
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T16:10:00.000Z",
+    "source_count": 6,
+    "verified_at": "2026-06-08T16:10:00.000Z"
   },
+  "dashboard_url": null,
+  "docs_url": "https://docs.targon.com/",
+  "name": "Targon",
+  "netuid": 4,
+  "notes": "Reviewed overlay for SN4 using the official Targon website, docs, Intel whitepaper, and source repository. No public API, OpenAPI schema, SSE stream, or standalone data artifact is verified yet.",
+  "schema_version": 1,
+  "slug": "sn-4",
+  "social": {
+    "x": "https://x.com/targoncompute"
+  },
+  "source_repo": "https://github.com/manifold-inc/targon",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-4-targon-website",
-      "name": "Targon website",
-      "kind": "website",
-      "url": "https://targon.com/",
-      "provider": "targon",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-4-targon-website",
+      "kind": "website",
+      "name": "Targon website",
+      "notes": "Official Targon website.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "targon",
       "public_safe": true,
       "source_urls": ["https://github.com/manifold-inc/targon"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Targon website."
+      "url": "https://targon.com/"
     },
     {
-      "id": "sn-4-targon-docs",
-      "name": "Targon docs",
-      "kind": "docs",
-      "url": "https://docs.targon.com/",
-      "provider": "targon",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-4-targon-docs",
+      "kind": "docs",
+      "name": "Targon docs",
+      "notes": "Official Targon documentation.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "targon",
       "public_safe": true,
       "source_urls": ["https://targon.com/", "https://docs.targon.com/"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Targon documentation."
+      "url": "https://docs.targon.com/"
     },
     {
-      "id": "sn-4-targon-intel-whitepaper",
-      "name": "Targon Intel whitepaper",
-      "kind": "docs",
-      "url": "https://targon.com/releases/intel-whitepaper",
-      "provider": "targon",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-4-targon-intel-whitepaper",
+      "kind": "docs",
+      "name": "Targon Intel whitepaper",
+      "notes": "Official Targon Intel whitepaper / release page.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "targon",
       "public_safe": true,
       "source_urls": [
         "https://targon.com/",
         "https://targon.com/releases/intel-whitepaper"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Targon Intel whitepaper / release page."
+      "url": "https://targon.com/releases/intel-whitepaper"
     },
     {
-      "id": "sn-4-targon-source",
-      "name": "Targon source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/manifold-inc/targon",
-      "provider": "targon",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-4-targon-source",
+      "kind": "source-repo",
+      "name": "Targon source repository",
+      "notes": "Official Targon source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "targon",
       "public_safe": true,
       "source_urls": ["https://github.com/manifold-inc/targon"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Targon source repository."
+      "url": "https://github.com/manifold-inc/targon"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-4-targon-subnet-api",
-      "name": "Targon inventory API",
       "kind": "subnet-api",
-      "url": "https://api.targon.com/tha/v2/inventory",
-      "provider": "targon",
-      "authority": "community",
-      "auth_required": false,
-      "public_safe": true,
-      "source_urls": ["https://docs.targon.com/api/inventory"],
+      "name": "Targon inventory API",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
-      "review": { "state": "community-submitted", "submitted_by": "nickmopen" }
+      "provider": "targon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "nickmopen"
+      },
+      "source_urls": ["https://docs.targon.com/api/inventory"],
+      "url": "https://api.targon.com/tha/v2/inventory"
     },
     {
-      "id": "sn-4-targon-sdk",
-      "name": "Targon Python SDK",
-      "kind": "sdk",
-      "url": "https://github.com/manifold-inc/targon-sdk",
-      "provider": "targon",
-      "authority": "community",
       "auth_required": false,
+      "authority": "community",
+      "id": "sn-4-targon-sdk",
+      "kind": "sdk",
+      "name": "Targon Python SDK",
+      "notes": "Official Targon Python SDK (PyPI: targon-sdk) by manifold-inc for interacting with Targon rentals and serverless. Same manifold-inc org as the registered official source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "targon",
       "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
       "source_urls": [
         "https://pypi.org/project/targon-sdk/",
         "https://github.com/manifold-inc/targon-sdk/blob/main/README.md"
       ],
+      "url": "https://github.com/manifold-inc/targon-sdk"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-4-targon-stats-dashboard",
+      "kind": "dashboard",
+      "name": "Targon Stats dashboard",
+      "notes": "Official Targon Stats dashboard (page title \"Targon Stats\"). Its first-party ownership is proven by the official manifold-inc/targon CLI source, which names https://stats.targon.com as a default endpoint host.",
       "probe": {
         "enabled": true,
+        "expect": "html",
         "method": "HEAD",
-        "expect": "any",
         "timeout_ms": 10000
       },
+      "provider": "targon",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Official Targon Python SDK (PyPI: targon-sdk) by manifold-inc for interacting with Targon rentals and serverless. Same manifold-inc org as the registered official source repository."
-    },
-    {
-      "id": "sn-4-targon-stats-dashboard",
-      "name": "Targon Stats dashboard",
-      "kind": "dashboard",
-      "url": "https://stats.targon.com/",
-      "provider": "targon",
-      "authority": "community",
-      "auth_required": false,
-      "public_safe": true,
       "source_urls": [
         "https://github.com/manifold-inc/targon/blob/main/targon/cli/get/errors.go"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "glorydavid03023"
-      },
-      "notes": "Official Targon Stats dashboard (page title \"Targon Stats\"). Its first-party ownership is proven by the official manifold-inc/targon CLI source, which names https://stats.targon.com as a default endpoint host."
+      "url": "https://stats.targon.com/"
     },
     {
-      "id": "sn-4-targon-miner-stats-api",
-      "name": "Targon miner stats API",
-      "kind": "subnet-api",
-      "url": "https://stats.targon.com/api/miners",
-      "provider": "targon",
-      "authority": "community",
       "auth_required": false,
-      "public_safe": true,
-      "source_urls": ["https://stats.targon.com/docs"],
+      "authority": "community",
+      "id": "sn-4-targon-miner-stats-api",
+      "kind": "subnet-api",
+      "name": "Targon miner stats API",
+      "notes": "Public no-auth JSON endpoint returning live SN4 per-miner stats (uid, payout, GPU card count, confidential-compute type), documented as 'Get All Miners' in the official Targon Stats HTTP API docs.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "targon",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "reyanthony062001-ops"
       },
-      "notes": "Public no-auth JSON endpoint returning live SN4 per-miner stats (uid, payout, GPU card count, confidential-compute type), documented as 'Get All Miners' in the official Targon Stats HTTP API docs."
+      "source_urls": ["https://stats.targon.com/docs"],
+      "url": "https://stats.targon.com/api/miners"
     }
   ],
-  "social": { "x": "https://x.com/targoncompute" },
-  "contact": "devs@manifold.inc"
+  "website_url": "https://targon.com/"
 }

--- a/registry/subnets/templar.json
+++ b/registry/subnets/templar.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 3,
-  "name": "Templar",
-  "slug": "sn-3",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "decentralized-training",
@@ -11,121 +6,125 @@
     "identity-reviewed",
     "official-source-repo"
   ],
-  "docs_url": "https://docs.tplr.ai/",
-  "source_repo": "https://github.com/one-covenant/templar",
-  "dashboard_url": "https://wandb.ai/tplr/templar",
-  "website_url": "https://www.tplr.ai/",
-  "notes": "Reviewed overlay for SN3 using the live One Covenant Templar repository, website, docs, and public dashboards. Native chain identity currently reports a deprecated placeholder, so this remains an explicit identity-drift entry rather than a silent rename.",
   "curation": {
+    "gap_notes": [
+      "Native chain name currently reports as deprecated.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "needs-review",
     "reviewed_at": "2026-06-08T11:05:00.000Z",
-    "verified_at": "2026-06-08T11:05:00.000Z",
     "source_count": 6,
-    "gap_notes": [
-      "Native chain name currently reports as deprecated.",
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T11:05:00.000Z"
   },
+  "dashboard_url": "https://wandb.ai/tplr/templar",
+  "docs_url": "https://docs.tplr.ai/",
+  "name": "Templar",
+  "netuid": 3,
+  "notes": "Reviewed overlay for SN3 using the live One Covenant Templar repository, website, docs, and public dashboards. Native chain identity currently reports a deprecated placeholder, so this remains an explicit identity-drift entry rather than a silent rename.",
+  "schema_version": 1,
+  "slug": "sn-3",
+  "social": {
+    "x": "https://x.com/tplr_ai"
+  },
+  "source_repo": "https://github.com/one-covenant/templar",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-3-templar-source",
-      "name": "Templar source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/one-covenant/templar",
-      "provider": "one-covenant",
       "auth_required": false,
       "authority": "provider-claimed",
+      "id": "sn-3-templar-source",
+      "kind": "source-repo",
+      "name": "Templar source repository",
+      "notes": "Public Templar source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "one-covenant",
       "public_safe": true,
       "source_urls": [
         "https://github.com/one-covenant/templar",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/3/subnet.json"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public Templar source repository."
+      "url": "https://github.com/one-covenant/templar"
     },
     {
-      "id": "sn-3-templar-website",
-      "name": "Templar website",
-      "kind": "website",
-      "url": "https://www.tplr.ai/",
-      "provider": "one-covenant",
       "auth_required": false,
       "authority": "provider-claimed",
+      "id": "sn-3-templar-website",
+      "kind": "website",
+      "name": "Templar website",
+      "notes": "Website linked from the Templar repository homepage.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "one-covenant",
       "public_safe": true,
       "source_urls": ["https://github.com/one-covenant/templar"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Website linked from the Templar repository homepage."
+      "url": "https://www.tplr.ai/"
     },
     {
-      "id": "sn-3-templar-docs",
-      "name": "Templar docs",
-      "kind": "docs",
-      "url": "https://docs.tplr.ai/",
-      "provider": "one-covenant",
       "auth_required": false,
       "authority": "provider-claimed",
+      "id": "sn-3-templar-docs",
+      "kind": "docs",
+      "name": "Templar docs",
+      "notes": "Public Templar documentation.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "one-covenant",
       "public_safe": true,
       "source_urls": [
         "https://docs.tplr.ai/",
         "https://github.com/one-covenant/templar"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public Templar documentation."
+      "url": "https://docs.tplr.ai/"
     },
     {
+      "auth_required": false,
+      "authority": "provider-claimed",
       "id": "sn-3-templar-wandb",
-      "name": "Templar W&B dashboard",
       "kind": "dashboard",
-      "url": "https://wandb.ai/tplr/templar",
-      "provider": "one-covenant",
-      "auth_required": false,
-      "authority": "provider-claimed",
-      "public_safe": true,
-      "source_urls": ["https://github.com/one-covenant/templar"],
+      "name": "Templar W&B dashboard",
+      "notes": "Public W&B dashboard linked from the Templar repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Public W&B dashboard linked from the Templar repository."
+      "provider": "one-covenant",
+      "public_safe": true,
+      "source_urls": ["https://github.com/one-covenant/templar"],
+      "url": "https://wandb.ai/tplr/templar"
     },
     {
-      "id": "sn-3-templar-grafana",
-      "name": "Templar Grafana dashboard",
-      "kind": "dashboard",
-      "url": "https://grafana.tplr.ai/d/ceia6bwlwn8qof/eval-metrics",
-      "provider": "one-covenant",
       "auth_required": false,
       "authority": "provider-claimed",
-      "public_safe": true,
-      "source_urls": ["https://github.com/one-covenant/templar"],
+      "id": "sn-3-templar-grafana",
+      "kind": "dashboard",
+      "name": "Templar Grafana dashboard",
+      "notes": "Public Grafana evaluation dashboard linked from the Templar repository.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Public Grafana evaluation dashboard linked from the Templar repository."
+      "provider": "one-covenant",
+      "public_safe": true,
+      "source_urls": ["https://github.com/one-covenant/templar"],
+      "url": "https://grafana.tplr.ai/d/ceia6bwlwn8qof/eval-metrics"
     },
     {
       "auth_required": false,
@@ -153,8 +152,19 @@
       "kind": "openapi",
       "name": "Templar Grafana HTTP API OpenAPI",
       "notes": "Public no-auth OpenAPI 3.0.3 schema (title \"Grafana HTTP API.\", 208 paths) on grafana.tplr.ai/public/openapi3.json. Served on the Templar Grafana host registered as a dashboard surface and linked from the Templar source repository README; the built-in Swagger UI at grafana.tplr.ai/swagger loads this spec alongside the legacy v2 merge at public/api-merged.json.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 15000
+      },
       "provider": "one-covenant",
       "public_safe": true,
+      "review": {
+        "confidence": "medium",
+        "state": "community-submitted",
+        "submitted_by": "bohdansolovie"
+      },
       "schema_status": "machine-readable",
       "schema_url": "https://grafana.tplr.ai/public/openapi3.json",
       "source_urls": [
@@ -162,17 +172,6 @@
         "https://github.com/one-covenant/templar",
         "https://github.com/one-covenant/crusades/blob/main/src/crusades/logging.py"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "GET",
-        "expect": "json",
-        "timeout_ms": 15000
-      },
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "bohdansolovie",
-        "confidence": "medium"
-      },
       "url": "https://grafana.tplr.ai/public/openapi3.json"
     },
     {
@@ -182,26 +181,24 @@
       "kind": "data-artifact",
       "name": "Templar minimum compute requirements",
       "notes": "Public no-auth YAML miner and validator hardware specification (CPU, memory, storage, OS, and bandwidth) published at the root of the official one-covenant/templar repository as min_compute.yml. Documents SN3 Templar operator requirements for the decentralized pre-training run.",
-      "provider": "one-covenant",
-      "public_safe": true,
-      "source_urls": [
-        "https://github.com/one-covenant/templar/blob/main/min_compute.yml",
-        "https://github.com/one-covenant/templar"
-      ],
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "any",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "one-covenant",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "davion-knight"
       },
+      "source_urls": [
+        "https://github.com/one-covenant/templar/blob/main/min_compute.yml",
+        "https://github.com/one-covenant/templar"
+      ],
       "url": "https://raw.githubusercontent.com/one-covenant/templar/main/min_compute.yml"
     }
   ],
-  "social": {
-    "x": "https://x.com/tplr_ai"
-  }
+  "website_url": "https://www.tplr.ai/"
 }

--- a/registry/subnets/tensorclaw.json
+++ b/registry/subnets/tensorclaw.json
@@ -1,9 +1,5 @@
 {
-  "schema_version": 1,
-  "netuid": 92,
-  "name": "Tensorclaw",
-  "slug": "sn-92",
-  "status": "active",
+  "baseline_excluded_surface_ids": ["sn-92-taomarketcap-website"],
   "categories": [
     "baseline-curated",
     "inference",
@@ -13,122 +9,124 @@
     "official-website",
     "stale-source-restored"
   ],
-  "source_repo": "https://github.com/tensorclaw/tensorclaw",
-  "dashboard_url": "https://www.tensorclaw.ai/dashboard",
-  "website_url": "https://www.tensorclaw.ai/",
-  "baseline_excluded_surface_ids": ["sn-92-taomarketcap-website"],
-  "notes": "Reviewed overlay for SN92 using the live Tensorclaw Network website, dashboard, and source repository. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The website links https://github.com/tensorclaw/tensorclaw and the repository README identifies it as Bittensor Tensorclaw Subnet 92.",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-09T12:25:00.000Z",
-    "verified_at": "2026-06-09T12:25:00.000Z",
-    "source_count": 6,
     "gap_notes": [
       "Native chain name currently reports as luis while the public website identifies the project as Tensorclaw Network / Subnet 92.",
       "Official website, dashboard, and source repository are verified live.",
       "No verified docs site yet beyond directory pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-09T12:25:00.000Z",
+    "source_count": 6,
+    "verified_at": "2026-06-09T12:25:00.000Z"
   },
+  "dashboard_url": "https://www.tensorclaw.ai/dashboard",
+  "name": "Tensorclaw",
+  "netuid": 92,
+  "notes": "Reviewed overlay for SN92 using the live Tensorclaw Network website, dashboard, and source repository. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The website links https://github.com/tensorclaw/tensorclaw and the repository README identifies it as Bittensor Tensorclaw Subnet 92.",
+  "schema_version": 1,
+  "slug": "sn-92",
+  "source_repo": "https://github.com/tensorclaw/tensorclaw",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-92-taomarketcap-dashboard",
-      "name": "SN92 TaoMarketCap dashboard",
-      "kind": "dashboard",
-      "url": "https://taomarketcap.com/subnets/92",
-      "provider": "taomarketcap",
       "auth_required": false,
       "authority": "registry-observed",
-      "public_safe": true,
-      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/92"],
+      "id": "sn-92-taomarketcap-dashboard",
+      "kind": "dashboard",
+      "name": "SN92 TaoMarketCap dashboard",
+      "notes": "Directory dashboard retained while stale source evidence is excluded.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "any",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Directory dashboard retained while stale source evidence is excluded."
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/92"],
+      "url": "https://taomarketcap.com/subnets/92"
     },
     {
-      "id": "sn-92-tensorplex-docs",
-      "name": "SN92 Tensorplex metadata",
-      "kind": "docs",
-      "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/92",
-      "provider": "tensorplex-subnet-docs",
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-92-tensorplex-docs",
+      "kind": "docs",
+      "name": "SN92 Tensorplex metadata",
+      "notes": "Directory metadata retained as registry-observed provenance; the stale Tensorclaw source URL is excluded.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "source_urls": [
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/92/subnet.json"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Directory metadata retained as registry-observed provenance; the stale Tensorclaw source URL is excluded."
+      "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/92"
     },
     {
-      "id": "sn-92-tensorclaw-website",
-      "name": "Tensorclaw website",
-      "kind": "website",
-      "url": "https://www.tensorclaw.ai/",
-      "provider": "tensorclaw",
       "auth_required": false,
       "authority": "provider-claimed",
+      "id": "sn-92-tensorclaw-website",
+      "kind": "website",
+      "name": "Tensorclaw website",
+      "notes": "Website identifies Tensorclaw Network as Bittensor Mainnet Subnet 92 and describes a decentralized LLM inference subnet for autonomous agents.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorclaw",
       "public_safe": true,
       "source_urls": ["https://www.tensorclaw.ai/"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Website identifies Tensorclaw Network as Bittensor Mainnet Subnet 92 and describes a decentralized LLM inference subnet for autonomous agents."
+      "url": "https://www.tensorclaw.ai/"
     },
     {
-      "id": "sn-92-tensorclaw-source-repo",
-      "name": "Tensorclaw source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/tensorclaw/tensorclaw",
-      "provider": "tensorclaw",
       "auth_required": false,
       "authority": "provider-claimed",
+      "id": "sn-92-tensorclaw-source-repo",
+      "kind": "source-repo",
+      "name": "Tensorclaw source repository",
+      "notes": "The official Tensorclaw website links this public repository, and the README identifies it as Bittensor Tensorclaw Subnet 92.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorclaw",
       "public_safe": true,
       "source_urls": [
         "https://www.tensorclaw.ai/",
         "https://github.com/tensorclaw/tensorclaw"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "The official Tensorclaw website links this public repository, and the README identifies it as Bittensor Tensorclaw Subnet 92."
+      "url": "https://github.com/tensorclaw/tensorclaw"
     },
     {
-      "id": "sn-92-tensorclaw-dashboard",
-      "name": "Tensorclaw live demo",
-      "kind": "dashboard",
-      "url": "https://www.tensorclaw.ai/dashboard",
-      "provider": "tensorclaw",
       "auth_required": true,
       "authority": "provider-claimed",
-      "public_safe": true,
-      "source_urls": ["https://www.tensorclaw.ai/"],
+      "id": "sn-92-tensorclaw-dashboard",
+      "kind": "dashboard",
+      "name": "Tensorclaw live demo",
+      "notes": "Public live-demo page for SN92. The page uses Cloudflare Turnstile to unlock trial requests, so it is listed as an auth-gated dashboard surface rather than a public API.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Public live-demo page for SN92. The page uses Cloudflare Turnstile to unlock trial requests, so it is listed as an auth-gated dashboard surface rather than a public API."
+      "provider": "tensorclaw",
+      "public_safe": true,
+      "source_urls": ["https://www.tensorclaw.ai/"],
+      "url": "https://www.tensorclaw.ai/dashboard"
     },
     {
       "auth_required": false,
@@ -169,5 +167,6 @@
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/92"
     }
-  ]
+  ],
+  "website_url": "https://www.tensorclaw.ai/"
 }

--- a/registry/subnets/tensorusd.json
+++ b/registry/subnets/tensorusd.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 113,
-  "name": "TensorUSD",
-  "slug": "sn-113",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
@@ -12,102 +7,108 @@
     "official-website",
     "stablecoin"
   ],
-  "docs_url": "https://docs.tensorusd.com/components/subnet",
-  "source_repo": "https://github.com/TensorUSD/subnet",
-  "dashboard_url": "https://taomarketcap.com/subnets/113",
-  "website_url": "https://tensorusd.com/",
-  "notes": "Reviewed overlay for SN113 using the official TensorUSD website, subnet docs, and source repository.",
+  "contact": "admin@tensorusd.com",
   "curation": {
+    "gap_notes": [
+      "No verified OpenAPI/Swagger schema yet.",
+      "No verified SSE/event stream yet."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T09:50:00.000Z",
-    "verified_at": "2026-06-08T09:50:00.000Z",
     "source_count": 5,
-    "gap_notes": [
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+    "verified_at": "2026-06-08T09:50:00.000Z"
   },
+  "dashboard_url": "https://taomarketcap.com/subnets/113",
+  "docs_url": "https://docs.tensorusd.com/components/subnet",
+  "name": "TensorUSD",
+  "netuid": 113,
+  "notes": "Reviewed overlay for SN113 using the official TensorUSD website, subnet docs, and source repository.",
+  "schema_version": 1,
+  "slug": "sn-113",
+  "social": {
+    "x": "https://x.com/tensorusd"
+  },
+  "source_repo": "https://github.com/TensorUSD/subnet",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-113-tensorusd-website",
-      "name": "TensorUSD website",
-      "kind": "website",
-      "url": "https://tensorusd.com/",
-      "provider": "tensorusd",
       "auth_required": false,
       "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://github.com/TensorUSD/subnet"],
+      "id": "sn-113-tensorusd-website",
+      "kind": "website",
+      "name": "TensorUSD website",
+      "notes": "Official TensorUSD website.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official TensorUSD website."
+      "provider": "tensorusd",
+      "public_safe": true,
+      "source_urls": ["https://github.com/TensorUSD/subnet"],
+      "url": "https://tensorusd.com/"
     },
     {
-      "id": "sn-113-tensorusd-docs",
-      "name": "TensorUSD subnet docs",
-      "kind": "docs",
-      "url": "https://docs.tensorusd.com/components/subnet",
-      "provider": "tensorusd",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-113-tensorusd-docs",
+      "kind": "docs",
+      "name": "TensorUSD subnet docs",
+      "notes": "Official TensorUSD subnet documentation.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorusd",
       "public_safe": true,
       "source_urls": [
         "https://github.com/TensorUSD/subnet/blob/main/README.md"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official TensorUSD subnet documentation."
+      "url": "https://docs.tensorusd.com/components/subnet"
     },
     {
-      "id": "sn-113-tensorusd-source",
-      "name": "TensorUSD source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/TensorUSD/subnet",
-      "provider": "tensorusd",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-113-tensorusd-source",
+      "kind": "source-repo",
+      "name": "TensorUSD source repository",
+      "notes": "Official TensorUSD source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorusd",
       "public_safe": true,
       "source_urls": ["https://github.com/TensorUSD/subnet"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official TensorUSD source repository."
+      "url": "https://github.com/TensorUSD/subnet"
     },
     {
-      "id": "sn-113-tensorusd-subnet-api",
-      "name": "TensorUSD API health",
-      "kind": "subnet-api",
-      "url": "https://api.tensorusd.com/health",
-      "provider": "tensorusd",
       "auth_required": false,
       "authority": "community",
-      "public_safe": true,
-      "source_urls": ["https://tensorusd.com/"],
+      "id": "sn-113-tensorusd-subnet-api",
+      "kind": "subnet-api",
+      "name": "TensorUSD API health",
+      "notes": "Public no-auth GET returning the TensorUSD (SN113) backend API health (status + component/database connectivity). Hosted on api.tensorusd.com, the API subdomain of the subnet's registered website tensorusd.com.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "tensorusd",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "nickmopen"
       },
-      "notes": "Public no-auth GET returning the TensorUSD (SN113) backend API health (status + component/database connectivity). Hosted on api.tensorusd.com, the API subdomain of the subnet's registered website tensorusd.com."
+      "source_urls": ["https://tensorusd.com/"],
+      "url": "https://api.tensorusd.com/health"
     },
     {
       "auth_required": false,
@@ -148,8 +149,5 @@
       "url": "https://docs.tensorusd.com/llms.txt"
     }
   ],
-  "social": {
-    "x": "https://x.com/tensorusd"
-  },
-  "contact": "admin@tensorusd.com"
+  "website_url": "https://tensorusd.com/"
 }

--- a/registry/subnets/trajectoryrl.json
+++ b/registry/subnets/trajectoryrl.json
@@ -1,20 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 11,
-  "name": "TrajectoryRL",
-  "slug": "sn-11",
-  "status": "active",
-  "categories": [
-    "baseline-curated",
-    "identity-reviewed",
-    "official-docs",
-    "official-source-repo",
-    "official-website"
-  ],
-  "website_url": "https://trajrl.com/",
-  "docs_url": "https://trajrl.com/docs",
-  "source_repo": "https://github.com/trajectoryRL/trajectoryRL",
-  "dashboard_url": "https://trajrl.com/leaderboard",
   "baseline_excluded_surface_ids": [
     "sn-11-taomarketcap-source-repo",
     "sn-11-taomarketcap-website",
@@ -29,212 +13,228 @@
     "sn-11-website-link-trajrl-com-website-2",
     "sn-11-website-link-trajrl-com-website-4"
   ],
-  "notes": "Reviewed overlay for SN11 TrajectoryRL using the official website, docs, leaderboard, live, winners, benchmark pages, and source repository. Common API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-docs",
+    "official-source-repo",
+    "official-website"
+  ],
+  "contact": "trajectoryrl@gmail.com",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T20:25:00.000Z",
-    "verified_at": "2026-06-08T20:25:00.000Z",
-    "source_count": 8,
     "gap_notes": [
       "Official website, docs, leaderboard, live, winners, benchmark pages, and source repository are verified live.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T20:25:00.000Z",
+    "source_count": 8,
+    "verified_at": "2026-06-08T20:25:00.000Z"
   },
+  "dashboard_url": "https://trajrl.com/leaderboard",
+  "docs_url": "https://trajrl.com/docs",
+  "name": "TrajectoryRL",
+  "netuid": 11,
+  "notes": "Reviewed overlay for SN11 TrajectoryRL using the official website, docs, leaderboard, live, winners, benchmark pages, and source repository. Common API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
+  "schema_version": 1,
+  "slug": "sn-11",
+  "social": {
+    "x": "https://x.com/trajectoryrl"
+  },
+  "source_repo": "https://github.com/trajectoryRL/trajectoryRL",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-11-trajectoryrl-website",
-      "name": "TrajectoryRL website",
-      "kind": "website",
-      "url": "https://trajrl.com/",
-      "provider": "trajectoryrl",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-11-trajectoryrl-website",
+      "kind": "website",
+      "name": "TrajectoryRL website",
+      "notes": "Official TrajectoryRL website.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "trajectoryrl",
       "public_safe": true,
       "source_urls": [
         "https://trajrl.com/",
         "https://github.com/trajectoryRL/trajectoryRL"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official TrajectoryRL website."
+      "url": "https://trajrl.com/"
     },
     {
-      "id": "sn-11-trajectoryrl-docs",
-      "name": "TrajectoryRL docs",
-      "kind": "docs",
-      "url": "https://trajrl.com/docs",
-      "provider": "trajectoryrl",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-11-trajectoryrl-docs",
+      "kind": "docs",
+      "name": "TrajectoryRL docs",
+      "notes": "Official TrajectoryRL documentation.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "trajectoryrl",
       "public_safe": true,
       "source_urls": ["https://trajrl.com/docs"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official TrajectoryRL documentation."
+      "url": "https://trajrl.com/docs"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-11-trajectoryrl-leaderboard",
+      "kind": "dashboard",
       "name": "TrajectoryRL leaderboard",
-      "kind": "dashboard",
-      "url": "https://trajrl.com/leaderboard",
-      "provider": "trajectoryrl",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://trajrl.com/"],
+      "notes": "Official TrajectoryRL leaderboard.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official TrajectoryRL leaderboard."
+      "provider": "trajectoryrl",
+      "public_safe": true,
+      "source_urls": ["https://trajrl.com/"],
+      "url": "https://trajrl.com/leaderboard"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-11-trajectoryrl-live",
+      "kind": "dashboard",
       "name": "TrajectoryRL live",
-      "kind": "dashboard",
-      "url": "https://trajrl.com/live",
-      "provider": "trajectoryrl",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://trajrl.com/"],
+      "notes": "Official TrajectoryRL live page.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official TrajectoryRL live page."
+      "provider": "trajectoryrl",
+      "public_safe": true,
+      "source_urls": ["https://trajrl.com/"],
+      "url": "https://trajrl.com/live"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-11-trajectoryrl-winners",
+      "kind": "dashboard",
       "name": "TrajectoryRL winners",
-      "kind": "dashboard",
-      "url": "https://trajrl.com/winners",
-      "provider": "trajectoryrl",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://trajrl.com/"],
+      "notes": "Official TrajectoryRL winners page.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official TrajectoryRL winners page."
+      "provider": "trajectoryrl",
+      "public_safe": true,
+      "source_urls": ["https://trajrl.com/"],
+      "url": "https://trajrl.com/winners"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-11-trajectoryrl-bench",
-      "name": "TrajectoryRL benchmark",
       "kind": "dashboard",
-      "url": "https://trajrl.com/bench",
-      "provider": "trajectoryrl",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://trajrl.com/"],
+      "name": "TrajectoryRL benchmark",
+      "notes": "Official TrajectoryRL benchmark page.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official TrajectoryRL benchmark page."
+      "provider": "trajectoryrl",
+      "public_safe": true,
+      "source_urls": ["https://trajrl.com/"],
+      "url": "https://trajrl.com/bench"
     },
     {
-      "id": "sn-11-trajectoryrl-source",
-      "name": "TrajectoryRL source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/trajectoryRL/trajectoryRL",
-      "provider": "trajectoryrl",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-11-trajectoryrl-source",
+      "kind": "source-repo",
+      "name": "TrajectoryRL source repository",
+      "notes": "Official TrajectoryRL source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "trajectoryrl",
       "public_safe": true,
       "source_urls": ["https://github.com/trajectoryRL/trajectoryRL"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official TrajectoryRL source repository."
+      "url": "https://github.com/trajectoryRL/trajectoryRL"
     },
     {
-      "id": "sn-11-trajectoryrl-api-docs",
-      "name": "TrajectoryRL API documentation",
-      "kind": "docs",
-      "url": "https://github.com/trajectoryRL/trajectoryRL/blob/main/docs/API.md",
-      "provider": "trajectoryrl",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-11-trajectoryrl-api-docs",
+      "kind": "docs",
+      "name": "TrajectoryRL API documentation",
+      "notes": "Public request/response API specification for TrajectoryRL validator and miner integration, covering the web-submit channel, pre-eval checks, score submission, winner lookup, heartbeat, and log-upload flows.",
+      "provider": "trajectoryrl",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/trajectoryRL/trajectoryRL/blob/main/docs/VALIDATOR_OPERATIONS.md",
-        "https://github.com/trajectoryRL/trajectoryRL/blob/main/docs/MINER_OPERATIONS.md"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "jakearmstrong59"
       },
-      "notes": "Public request/response API specification for TrajectoryRL validator and miner integration, covering the web-submit channel, pre-eval checks, score submission, winner lookup, heartbeat, and log-upload flows."
+      "source_urls": [
+        "https://github.com/trajectoryRL/trajectoryRL/blob/main/docs/VALIDATOR_OPERATIONS.md",
+        "https://github.com/trajectoryRL/trajectoryRL/blob/main/docs/MINER_OPERATIONS.md"
+      ],
+      "url": "https://github.com/trajectoryRL/trajectoryRL/blob/main/docs/API.md"
     },
     {
-      "id": "sn-11-trajectoryrl-subnet-api",
-      "name": "TrajectoryRL network stats API",
-      "kind": "subnet-api",
-      "url": "https://trajrl.com/api/stats",
-      "provider": "trajectoryrl",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-11-trajectoryrl-subnet-api",
+      "kind": "subnet-api",
+      "name": "TrajectoryRL network stats API",
+      "notes": "Public read-only REST JSON endpoint reporting SN11 network totals (reports, LLM calls, tokens, cost); no auth. Documented in the official trajrl API client.",
+      "provider": "trajectoryrl",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/trajectoryRL/trajrl/blob/main/trajrl/subnet/api.py"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "boskodev790"
       },
-      "notes": "Public read-only REST JSON endpoint reporting SN11 network totals (reports, LLM calls, tokens, cost); no auth. Documented in the official trajrl API client."
+      "source_urls": [
+        "https://github.com/trajectoryRL/trajrl/blob/main/trajrl/subnet/api.py"
+      ],
+      "url": "https://trajrl.com/api/stats"
     },
     {
-      "id": "sn-11-trajectoryrl-miners",
-      "name": "TrajectoryRL miner directory",
-      "kind": "data-artifact",
-      "url": "https://trajrl.com/api/miners",
-      "provider": "trajectoryrl",
       "auth_required": false,
       "authority": "community",
-      "public_safe": true,
-      "source_urls": ["https://trajrl.com/"],
+      "id": "sn-11-trajectoryrl-miners",
+      "kind": "data-artifact",
+      "name": "TrajectoryRL miner directory",
+      "notes": "Public no-auth GET returning the TrajectoryRL (SN11) miner directory as JSON — aggregate counters (total / active / qualified miner counts, validator count) plus a per-miner array of 256 rows carrying uid, name, incentive, score, rank, activity flags, and latest-model fields. Served on trajrl.com, the subnet's own registered domain (same host as the existing website and /api/stats subnet-api), and distinct from that aggregate-only stats surface.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "trajectoryrl",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "nickmopen"
       },
-      "notes": "Public no-auth GET returning the TrajectoryRL (SN11) miner directory as JSON — aggregate counters (total / active / qualified miner counts, validator count) plus a per-miner array of 256 rows carrying uid, name, incentive, score, rank, activity flags, and latest-model fields. Served on trajrl.com, the subnet's own registered domain (same host as the existing website and /api/stats subnet-api), and distinct from that aggregate-only stats surface."
+      "source_urls": ["https://trajrl.com/"],
+      "url": "https://trajrl.com/api/miners"
     }
   ],
-  "social": { "x": "https://x.com/trajectoryrl" },
-  "contact": "trajectoryrl@gmail.com"
+  "website_url": "https://trajrl.com/"
 }

--- a/registry/subnets/trishool.json
+++ b/registry/subnets/trishool.json
@@ -1,9 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 23,
-  "name": "Trishool",
-  "slug": "sn-23",
-  "status": "active",
   "categories": [
     "baseline-curated",
     "identity-reviewed",
@@ -11,97 +6,104 @@
     "official-source-repo",
     "subnet-api-observed"
   ],
-  "source_repo": "https://github.com/TrishoolAI/trishool-phase2",
-  "dashboard_url": "https://trishool.ai/dashboard",
-  "website_url": "https://trishool.ai/",
-  "notes": "Reviewed overlay for SN23 using the official Trishool dashboard, phase-two source repository, and public API landing URL. The API root returns a public landing response, but OpenAPI and docs paths currently require auth or return 404, so no schema-backed API is promoted.",
+  "contact": "nav@astroware.ai",
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T09:50:00.000Z",
-    "verified_at": "2026-06-08T09:50:00.000Z",
-    "source_count": 6,
     "gap_notes": [
       "Trishool API root is public, but `/openapi.json` and `/docs` currently return 401 and `/swagger.json` returns 404.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T09:50:00.000Z",
+    "source_count": 6,
+    "verified_at": "2026-06-08T09:50:00.000Z"
   },
+  "dashboard_url": "https://trishool.ai/dashboard",
+  "name": "Trishool",
+  "netuid": 23,
+  "notes": "Reviewed overlay for SN23 using the official Trishool dashboard, phase-two source repository, and public API landing URL. The API root returns a public landing response, but OpenAPI and docs paths currently require auth or return 404, so no schema-backed API is promoted.",
+  "schema_version": 1,
+  "slug": "sn-23",
+  "social": {
+    "x": "https://x.com/trishoolai"
+  },
+  "source_repo": "https://github.com/TrishoolAI/trishool-phase2",
+  "status": "active",
   "surfaces": [
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-23-trishool-dashboard",
-      "name": "Trishool dashboard",
       "kind": "dashboard",
-      "url": "https://trishool.ai/dashboard",
-      "provider": "trishool",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": [
-        "https://github.com/TrishoolAI/trishool-phase2/blob/main/README.md"
-      ],
+      "name": "Trishool dashboard",
+      "notes": "Official Trishool dashboard.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Trishool dashboard."
-    },
-    {
-      "id": "sn-23-trishool-api-root",
-      "name": "Trishool API landing",
-      "kind": "subnet-api",
-      "url": "https://api.trishool.ai/",
       "provider": "trishool",
-      "auth_required": false,
-      "authority": "official",
       "public_safe": true,
       "source_urls": [
         "https://github.com/TrishoolAI/trishool-phase2/blob/main/README.md"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "GET",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Public Trishool API landing surface. This is not schema-backed and should not be treated as an OpenAPI surface."
+      "url": "https://trishool.ai/dashboard"
     },
     {
-      "id": "sn-23-trishool-source",
-      "name": "Trishool phase two source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/TrishoolAI/trishool-phase2",
-      "provider": "trishool",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-23-trishool-api-root",
+      "kind": "subnet-api",
+      "name": "Trishool API landing",
+      "notes": "Public Trishool API landing surface. This is not schema-backed and should not be treated as an OpenAPI surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "trishool",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/TrishoolAI/trishool-phase2/blob/main/README.md"
+      ],
+      "url": "https://api.trishool.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-23-trishool-source",
+      "kind": "source-repo",
+      "name": "Trishool phase two source repository",
+      "notes": "Official Trishool phase two source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "trishool",
       "public_safe": true,
       "source_urls": ["https://github.com/TrishoolAI/trishool-phase2"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Trishool phase two source repository."
+      "url": "https://github.com/TrishoolAI/trishool-phase2"
     },
     {
-      "id": "sn-23-trishool-docs",
-      "name": "Trishool documentation",
-      "kind": "docs",
-      "url": "https://docs.trishool.ai",
-      "provider": "trishool",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-23-trishool-docs",
+      "kind": "docs",
+      "name": "Trishool documentation",
+      "notes": "Official Trishool documentation site (docs.trishool.ai), hosted on the subnet's own domain and linked from the official website trishool.ai.",
+      "provider": "trishool",
       "public_safe": true,
-      "source_urls": ["https://trishool.ai/"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "devmixa702"
       },
-      "notes": "Official Trishool documentation site (docs.trishool.ai), hosted on the subnet's own domain and linked from the official website trishool.ai."
+      "source_urls": ["https://trishool.ai/"],
+      "url": "https://docs.trishool.ai"
     },
     {
       "auth_required": false,
@@ -123,27 +125,24 @@
       "url": "https://raw.githubusercontent.com/TrishoolAI/trishool-phase2/main/tri-check/data/submission_schema.json"
     },
     {
-      "id": "sn-23-trishool-litepaper-docs",
-      "name": "Trishool litepaper",
-      "kind": "docs",
-      "url": "https://litepaper.trishool.ai/",
-      "provider": "trishool",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-23-trishool-litepaper-docs",
+      "kind": "docs",
+      "name": "Trishool litepaper",
+      "notes": "Public no-auth Trishool litepaper (PDF) for SN23, served at litepaper.trishool.ai — a dedicated subdomain of the registered official website trishool.ai (same operator as the api.trishool.ai and docs.trishool.ai surfaces). A machine-readable primary-source document describing the subnet's design, mechanism, and roles. Distinct in URL from the docs.trishool.ai API documentation already registered.",
+      "provider": "trishool",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/TrishoolAI/trishool-phase2",
-        "https://trishool.ai/"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Public no-auth Trishool litepaper (PDF) for SN23, served at litepaper.trishool.ai — a dedicated subdomain of the registered official website trishool.ai (same operator as the api.trishool.ai and docs.trishool.ai surfaces). A machine-readable primary-source document describing the subnet's design, mechanism, and roles. Distinct in URL from the docs.trishool.ai API documentation already registered."
+      "source_urls": [
+        "https://github.com/TrishoolAI/trishool-phase2",
+        "https://trishool.ai/"
+      ],
+      "url": "https://litepaper.trishool.ai/"
     }
   ],
-  "social": {
-    "x": "https://x.com/trishoolai"
-  },
-  "contact": "nav@astroware.ai"
+  "website_url": "https://trishool.ai/"
 }

--- a/registry/subnets/vanta.json
+++ b/registry/subnets/vanta.json
@@ -1,18 +1,4 @@
 {
-  "schema_version": 1,
-  "netuid": 8,
-  "name": "Vanta",
-  "slug": "sn-8",
-  "status": "active",
-  "categories": [
-    "baseline-curated",
-    "identity-reviewed",
-    "official-source-repo",
-    "official-website"
-  ],
-  "website_url": "https://www.vantanetwork.io/",
-  "source_repo": "https://github.com/taoshidev/vanta-network",
-  "dashboard_url": "https://www.vantanetwork.io/dashboard",
   "baseline_excluded_surface_ids": [
     "sn-8-taomarketcap-source-repo",
     "sn-8-taomarketcap-website",
@@ -26,166 +12,179 @@
     "sn-8-website-link-www-vantanetwork-io-website-2",
     "sn-8-website-link-www-vantanetwork-io-website-3"
   ],
-  "notes": "Reviewed overlay for SN8 Vanta using the official Vanta Network website, dashboard, transparency, tokenomics, and source repository. Common docs/API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-source-repo",
+    "official-website"
+  ],
   "curation": {
-    "level": "maintainer-reviewed",
-    "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T20:25:00.000Z",
-    "verified_at": "2026-06-08T20:25:00.000Z",
-    "source_count": 6,
     "gap_notes": [
       "Official website, dashboard, transparency page, tokenomics page, and source repository are verified live.",
       "Common /docs, /api, /health, /openapi.json, and Swagger paths currently return 404.",
-      "No verified docs site yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ]
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T20:25:00.000Z",
+    "source_count": 6,
+    "verified_at": "2026-06-08T20:25:00.000Z"
   },
+  "dashboard_url": "https://www.vantanetwork.io/dashboard",
+  "name": "Vanta",
+  "netuid": 8,
+  "notes": "Reviewed overlay for SN8 Vanta using the official Vanta Network website, dashboard, transparency, tokenomics, and source repository. Common docs/API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
+  "schema_version": 1,
+  "slug": "sn-8",
+  "social": {
+    "x": "https://x.com/taoshiio"
+  },
+  "source_repo": "https://github.com/taoshidev/vanta-network",
+  "status": "active",
   "surfaces": [
     {
-      "id": "sn-8-vanta-website",
-      "name": "Vanta Network website",
-      "kind": "website",
-      "url": "https://www.vantanetwork.io/",
-      "provider": "vanta",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-8-vanta-website",
+      "kind": "website",
+      "name": "Vanta Network website",
+      "notes": "Official Vanta Network website.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "vanta",
       "public_safe": true,
       "source_urls": [
         "https://www.vantanetwork.io/",
         "https://github.com/taoshidev/vanta-network"
       ],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "html",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Vanta Network website."
+      "url": "https://www.vantanetwork.io/"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-8-vanta-dashboard",
-      "name": "Vanta dashboard",
       "kind": "dashboard",
-      "url": "https://www.vantanetwork.io/dashboard",
-      "provider": "vanta",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://www.vantanetwork.io/"],
+      "name": "Vanta dashboard",
+      "notes": "Official Vanta dashboard page.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Vanta dashboard page."
+      "provider": "vanta",
+      "public_safe": true,
+      "source_urls": ["https://www.vantanetwork.io/"],
+      "url": "https://www.vantanetwork.io/dashboard"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-8-vanta-tokenomics",
+      "kind": "docs",
       "name": "Vanta tokenomics",
-      "kind": "docs",
-      "url": "https://www.vantanetwork.io/tokenomics",
-      "provider": "vanta",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://www.vantanetwork.io/"],
+      "notes": "Official Vanta tokenomics information page.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Vanta tokenomics information page."
+      "provider": "vanta",
+      "public_safe": true,
+      "source_urls": ["https://www.vantanetwork.io/"],
+      "url": "https://www.vantanetwork.io/tokenomics"
     },
     {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-8-vanta-transparency",
-      "name": "Vanta transparency",
       "kind": "docs",
-      "url": "https://www.vantanetwork.io/transparency",
-      "provider": "vanta",
-      "auth_required": false,
-      "authority": "official",
-      "public_safe": true,
-      "source_urls": ["https://www.vantanetwork.io/"],
+      "name": "Vanta transparency",
+      "notes": "Official Vanta transparency page for open-source scoring rules.",
       "probe": {
         "enabled": true,
-        "method": "HEAD",
         "expect": "html",
+        "method": "HEAD",
         "timeout_ms": 10000
       },
-      "notes": "Official Vanta transparency page for open-source scoring rules."
+      "provider": "vanta",
+      "public_safe": true,
+      "source_urls": ["https://www.vantanetwork.io/"],
+      "url": "https://www.vantanetwork.io/transparency"
     },
     {
-      "id": "sn-8-vanta-source",
-      "name": "Vanta Network source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/taoshidev/vanta-network",
-      "provider": "vanta",
       "auth_required": false,
       "authority": "official",
+      "id": "sn-8-vanta-source",
+      "kind": "source-repo",
+      "name": "Vanta Network source repository",
+      "notes": "Official Vanta Network source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "vanta",
       "public_safe": true,
       "source_urls": ["https://github.com/taoshidev/vanta-network"],
-      "probe": {
-        "enabled": true,
-        "method": "HEAD",
-        "expect": "any",
-        "timeout_ms": 10000
-      },
-      "notes": "Official Vanta Network source repository."
+      "url": "https://github.com/taoshidev/vanta-network"
     },
     {
-      "id": "sn-8-vanta-model-parameters",
-      "name": "Vanta scoring model parameters",
-      "kind": "subnet-api",
-      "url": "https://github.com/taoshidev/vanta-network/raw/main/vali_objects/utils/model_parameters/all_model_parameters.json",
-      "provider": "vanta",
       "auth_required": false,
       "authority": "community",
-      "public_safe": true,
-      "source_urls": [
-        "https://github.com/taoshidev/vanta-network/blob/main/vali_objects/utils/vali_bkp_utils.py",
-        "https://github.com/taoshidev/vanta-network/blob/main/vali_objects/utils/model_parameters/all_model_parameters.json"
-      ],
+      "id": "sn-8-vanta-model-parameters",
+      "kind": "subnet-api",
+      "name": "Vanta scoring model parameters",
+      "notes": "Public no-auth GET all_model_parameters.json on the official SN8 Vanta Network repository (github.com/taoshidev/vanta-network). Provides the per-asset buy/sell slippage model parameters (intercept and coefficients) that the validator loads via vali_objects/utils/vali_bkp_utils.py to score miner positions.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "vanta",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "davion-knight"
       },
-      "notes": "Public no-auth GET all_model_parameters.json on the official SN8 Vanta Network repository (github.com/taoshidev/vanta-network). Provides the per-asset buy/sell slippage model parameters (intercept and coefficients) that the validator loads via vali_objects/utils/vali_bkp_utils.py to score miner positions."
-    },
-    {
-      "id": "sn-8-vanta-slippage-estimates",
-      "name": "Vanta empirical slippage estimates dataset",
-      "kind": "data-artifact",
-      "url": "https://github.com/taoshidev/vanta-network/raw/main/vali_objects/utils/model_parameters/slippage_estimates.json",
-      "provider": "vanta",
-      "auth_required": false,
-      "authority": "community",
-      "public_safe": true,
       "source_urls": [
         "https://github.com/taoshidev/vanta-network/blob/main/vali_objects/utils/vali_bkp_utils.py",
-        "https://github.com/taoshidev/vanta-network/blob/main/vali_objects/utils/price_slippage_model.py"
+        "https://github.com/taoshidev/vanta-network/blob/main/vali_objects/utils/model_parameters/all_model_parameters.json"
       ],
+      "url": "https://github.com/taoshidev/vanta-network/raw/main/vali_objects/utils/model_parameters/all_model_parameters.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-8-vanta-slippage-estimates",
+      "kind": "data-artifact",
+      "name": "Vanta empirical slippage estimates dataset",
+      "notes": "Public no-auth static JSON dataset slippage_estimates.json committed in the official SN8 Vanta Network repository (github.com/taoshidev/vanta-network). Distinct from the model-coefficients surface: this is the precomputed per-asset, per-trade-size empirical slippage lookup table (e.g. crypto BTCUSDC/ETHUSDC long/short across notional buckets). The path is resolved in vali_objects/utils/vali_bkp_utils.py and loaded by the PriceSlippageModel in vali_objects/utils/price_slippage_model.py to estimate execution slippage when scoring miner positions. Whitelisted for commit in .gitignore, so it is intentionally published.",
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
+      "provider": "vanta",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "rust-toml"
       },
-      "notes": "Public no-auth static JSON dataset slippage_estimates.json committed in the official SN8 Vanta Network repository (github.com/taoshidev/vanta-network). Distinct from the model-coefficients surface: this is the precomputed per-asset, per-trade-size empirical slippage lookup table (e.g. crypto BTCUSDC/ETHUSDC long/short across notional buckets). The path is resolved in vali_objects/utils/vali_bkp_utils.py and loaded by the PriceSlippageModel in vali_objects/utils/price_slippage_model.py to estimate execution slippage when scoring miner positions. Whitelisted for commit in .gitignore, so it is intentionally published."
+      "source_urls": [
+        "https://github.com/taoshidev/vanta-network/blob/main/vali_objects/utils/vali_bkp_utils.py",
+        "https://github.com/taoshidev/vanta-network/blob/main/vali_objects/utils/price_slippage_model.py"
+      ],
+      "url": "https://github.com/taoshidev/vanta-network/raw/main/vali_objects/utils/model_parameters/slippage_estimates.json"
     },
     {
       "auth_required": false,
@@ -207,7 +206,5 @@
       "url": "https://www.vantanetwork.io/llms.txt"
     }
   ],
-  "social": {
-    "x": "https://x.com/taoshiio"
-  }
+  "website_url": "https://www.vantanetwork.io/"
 }

--- a/registry/subnets/verathos.json
+++ b/registry/subnets/verathos.json
@@ -12,10 +12,7 @@
   ],
   "contact": "info@verathos.ai",
   "curation": {
-    "gap_notes": [
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ],
+    "gap_notes": ["No verified SSE/event stream yet."],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T07:45:00.000Z",

--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -12,10 +12,7 @@
   "curation": {
     "gap_notes": [
       "Website docs and dashboard paths currently redirect to sign-in.",
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",

--- a/tests/stale-gap-notes.test.mjs
+++ b/tests/stale-gap-notes.test.mjs
@@ -149,24 +149,68 @@ describe("findStaleGapNotes", () => {
   });
 });
 
-describe("collectStaleGapNotes (real registry)", () => {
-  test("reproduces the documented chutes.json and gittensor.json findings", async () => {
-    const report = await collectStaleGapNotes();
-    assert.ok(report.subnet_count > 0);
-    assert.ok(report.stale_note_count >= report.subnet_count);
+describe("findStaleGapNotes (fixtures reproducing real registry bugs)", () => {
+  const providersById = new Map([
+    ["chutes", { id: "chutes", kind: "subnet-team" }],
+    ["gittensor", { id: "gittensor", kind: "subnet-team" }],
+  ]);
 
-    const chutes = report.subnets.find((s) => s.file === "chutes.json");
-    assert.ok(chutes, "chutes.json should have stale notes");
-    const chutesKinds = chutes.stale_notes.map((n) => n.kind).sort();
-    assert.deepEqual(chutesKinds, ["openapi", "sse"]);
-
-    const gittensor = report.subnets.find((s) => s.file === "gittensor.json");
-    assert.ok(gittensor, "gittensor.json should have stale notes");
-    const gittensorKinds = gittensor.stale_notes.map((n) => n.kind).sort();
-    assert.ok(gittensorKinds.includes("dashboard"));
-    assert.ok(gittensorKinds.includes("openapi"));
+  // Frozen snapshots of the exact real chutes.json/gittensor.json shapes that
+  // motivated this script (both fixed in the same PR that added this
+  // regression case -- see #5815/#5849/#5851 and onward for the wider
+  // stale-note sweep). Synthetic on purpose: a live-registry read here would
+  // make this test fail the moment someone fixes the real file, which is
+  // exactly the outcome this tool exists to produce.
+  test("reproduces the documented chutes.json finding", () => {
+    const document = {
+      curation: {
+        gap_notes: [
+          "No verified machine-readable OpenAPI/Swagger schema yet.",
+          "No verified SSE/event stream yet.",
+        ],
+      },
+      surfaces: [
+        { id: "sn-64-chutes-openapi", kind: "openapi", provider: "chutes" },
+        { id: "sn-64-chutes-sse", kind: "sse", provider: "chutes" },
+      ],
+    };
+    const kinds = findStaleGapNotes(document, providersById)
+      .map((n) => n.kind)
+      .sort();
+    assert.deepEqual(kinds, ["openapi", "sse"]);
   });
 
+  test("reproduces the documented gittensor.json finding", () => {
+    const document = {
+      curation: {
+        gap_notes: [
+          "No verified dashboard surface yet.",
+          "No verified OpenAPI/Swagger surface yet.",
+          "No verified SSE/event stream yet.",
+          "Bounty state is documented through public CLI flows, but no unauthenticated public API has been verified yet.",
+        ],
+      },
+      surfaces: [
+        {
+          id: "sn-74-gittensor-dashboard",
+          kind: "dashboard",
+          provider: "gittensor",
+        },
+        {
+          id: "sn-74-gittensor-openapi",
+          kind: "openapi",
+          provider: "gittensor",
+        },
+      ],
+    };
+    const kinds = findStaleGapNotes(document, providersById)
+      .map((n) => n.kind)
+      .sort();
+    assert.deepEqual(kinds, ["dashboard", "openapi"]);
+  });
+});
+
+describe("collectStaleGapNotes (real registry)", () => {
   test("does not flag oneoneone.json's third-party subnet-api note", async () => {
     const report = await collectStaleGapNotes();
     const oneoneone = report.subnets.find((s) => s.file === "oneoneone.json");


### PR DESCRIPTION
## Summary

Registry-wide version of the same bug found and fixed one subnet at a time in the root->128 accuracy audit so far (#5815, #5849, #5851): `curation.gap_notes` claims a surface kind is still missing after a later PR added exactly that surface, because adding a surface has no reason to also touch the unrelated `gap_notes` array.

Ran the project's own existing (already-tested, apparently never actually run) `scripts/stale-gap-notes.mjs` / `npm run curation:stale-notes` across the full registry via its `collectStaleGapNotes()` -- the correct, first-party-surface-aware detector, not a fresh reimplementation.

**An earlier draft of this fix used an ad-hoc regex scanner that lacked the `isFirstPartySurface` check** documented in that script (the exact distinction #5738 exists to enforce: a third-party aggregator wrapping a subnet's data, e.g. TaoMarketCap's generic per-subnet API, is not the same claim as "the subnet publishes its own API"). Diffing that draft's removals against `collectStaleGapNotes()`'s authoritative output caught **26 would-be false-positive removals** across ~24 files before they were committed. This PR uses the real tool's output directly instead of my own reimplementation.

**75 of 129 subnet files had at least one stale note; 152 stale entries removed total.** `npm run curation:stale-notes` now reports zero across the whole registry.

Also fixes `tests/stale-gap-notes.test.mjs`'s one real-registry integration test, which hardcoded `chutes.json` and `gittensor.json` as permanently-broken fixtures and started failing the moment this PR fixed them (ironic, given the tool's whole purpose). Replaced with synthetic fixtures reproducing the same two real bug shapes, so the regression coverage survives fixing the underlying files.

## Test plan

- [x] `npm run curation:stale-notes` — zero stale notes remaining (was 152 across 75 files)
- [x] `npm run validate:schemas` — passes
- [x] `npm run validate:surface` — passes (864 surfaces across 129 subnet files)
- [x] `npm run build` — full clean build passes
- [x] `npx vitest run tests/artifacts.test.mjs tests/stale-gap-notes.test.mjs` — 36/36 pass
- [x] `npx eslint tests/stale-gap-notes.test.mjs` — clean
- [x] Verified every removal against the authoritative `collectStaleGapNotes()` output, not against my own logic