### PR TITLE
fix(ui): enlarge incident-strip dismiss button to a size-8 tap target

### DIFF
--- a/apps/ui/src/components/metagraphed/incident-strip.tsx
+++ b/apps/ui/src/components/metagraphed/incident-strip.tsx
@@ -131,9 +131,9 @@ export function IncidentStrip() {
             });
           }}
           aria-label="Dismiss incident"
-          className="shrink-0 inline-flex size-5 items-center justify-center rounded text-ink-muted hover:text-ink-strong hover:bg-surface"
+          className="shrink-0 -my-1 inline-flex size-8 items-center justify-center rounded text-ink-muted hover:text-ink-strong hover:bg-surface"
         >
-          <X className="size-3" />
+          <X className="size-4" />
         </button>
       </div>
     </div>


### PR DESCRIPTION
## What

The incident banner's dismiss button was a `size-5` (20×20px) hit target with a `size-3` icon — an easy mis-tap on a dense single-row strip that sits above the fold on `/endpoints` and `/subnets`, right next to truncating text.

Bump it to a `size-8` (32×32px) target with a `size-4` icon. A `-my-1` keeps the taller target from inflating the strip's compact `py-1.5` row, so the tap area grows without changing the banner's height or breaking the single-row flex layout on mobile.

## Changes

- `apps/ui/src/components/metagraphed/incident-strip.tsx` — dismiss button `size-5` → `size-8`, icon `size-3` → `size-4`, add `-my-1` to preserve row height.

## Verification

- `npm run lint --workspace=apps/ui` / `npm run format:check` — clean
- `npm run typecheck --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 1027 passing
- `npm run test:e2e --workspace=apps/ui` (responsive-overflow) — 24 passing, no new overflow at `/endpoints` on any viewport
- `npm run build --workspace=apps/ui` — success

## Screenshots

Captured at the three Phase C2 viewports (375×812 / 768×1024 / 1280×800), both themes, fixed-viewport (never full-page). The incident feed is identical in every cell, so the dismiss button's size is the only thing that changes between the before and after columns.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5334-after-mobile-dark.png)<br><sub>after</sub> |

Closes #5334
