### PR TITLE
fix(chutes): probe 3 data-artifact surfaces with GET, not HEAD

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -308,8 +308,8 @@
       "name": "Chutes community data-artifact",
       "probe": {
         "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
+        "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
       "provider": "chutes",
@@ -330,8 +330,8 @@
       "name": "Chutes community boosted data-artifact",
       "probe": {
         "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
+        "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
       "provider": "chutes",
@@ -352,8 +352,8 @@
       "name": "Chutes utilization data-artifact",
       "probe": {
         "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
+        "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
       "provider": "chutes",


### PR DESCRIPTION
## Summary

Found while triage-scanning subnet API hosts as part of the root->128 accuracy audit: `api.chutes.ai`'s FastAPI backend 404s on a bare HEAD to GET-only routes, even though the routes work fine.

Confirmed live:
- `HEAD https://api.chutes.ai/chutes/gpu_count_history` -> 404
- `GET https://api.chutes.ai/chutes/gpu_count_history` -> 200 with real data

Same for `/chutes/boosted` and `/chutes/utilization`. All three are documented in chutes' own `openapi.json` and return valid JSON on GET.

The registry's `probe.method: "HEAD"` config for these three surfaces meant the live health prober was almost certainly getting the same false 404 -- these were likely showing as unhealthy in production despite working correctly. Switched to `GET` / `expect: json`.

## Test plan

- [x] `npm run validate:schemas` — passes
- [x] `npm run validate:surface` — passes (867 surfaces across 129 subnet files)
- [x] Verified all three endpoints return 200 + valid JSON via GET, and confirmed the HEAD-404 behavior is consistent (not transient) across 3 repeated checks