### PR TITLE
fix(ninja): migrate SN66 from unarbos/ninja.arbos.life to ninja-subnet/ninja66.ai

### DIFF
--- a/registry/providers/unarbos.json
+++ b/registry/providers/unarbos.json
@@ -1,12 +1,12 @@
 {
   "authority": "official",
-  "docs_url": "https://github.com/unarbos/tau/blob/main/README.md",
-  "github_url": "https://github.com/unarbos/tau",
+  "docs_url": "https://github.com/ninja-subnet/ninja/blob/main/README.md",
+  "github_url": "https://github.com/ninja-subnet/ninja",
   "id": "unarbos",
   "kind": "subnet-team",
   "logo_url": "https://metagraph.sh/logos/unarbos.png",
   "name": "Unarbos",
-  "notes": "Provider entry for Unarbos Ninja SN66 website, source repositories, public health surface, and Swagger UI.",
+  "notes": "Provider entry for Unarbos Ninja SN66 website, source repositories, and public health surface. Migrated from unarbos/ninja.arbos.life to the ninja-subnet org / ninja66.ai domain -- verified live 2026-07-15.",
   "schema_version": 1,
-  "website_url": "https://ninja.arbos.life/"
+  "website_url": "https://ninja66.ai/"
 }

--- a/registry/subnets/ninja.json
+++ b/registry/subnets/ninja.json
@@ -21,21 +21,21 @@
     "source_count": 7,
     "verified_at": "2026-06-08T07:45:00.000Z"
   },
-  "dashboard_url": "https://ninja.arbos.life/",
-  "docs_url": "https://github.com/unarbos/tau/blob/main/README.md",
+  "dashboard_url": "https://ninja66.ai/",
+  "docs_url": "https://github.com/ninja-subnet/ninja/blob/main/README.md",
   "links": [
     {
       "label": "Miner harness",
-      "source_url": "https://github.com/unarbos/tau",
-      "url": "https://github.com/unarbos/ninja"
+      "source_url": "https://github.com/ninja-subnet/ninja",
+      "url": "https://github.com/ninja-subnet/katana-cli"
     }
   ],
   "name": "ninja",
   "netuid": 66,
-  "notes": "Reviewed overlay for SN66 using the official Ninja/Unarbos website, tau workflow repository, miner harness repository, health endpoint, and Swagger UI. The obvious OpenAPI JSON paths currently serve HTML, so schema-backed status remains a gap.",
+  "notes": "Reviewed overlay for SN66. Migrated from the unarbos/ninja.arbos.life identity to the ninja-subnet org / ninja66.ai domain -- verified live 2026-07-15 (ninja.arbos.life now 404s site-wide; ninja66.ai's own page links to github.com/ninja-subnet/ninja and ninja-validator, both actively pushed the same day). Official website, source repositories, and health endpoint verified live under the new identity. The obvious OpenAPI JSON paths currently serve HTML or 404, so schema-backed status remains a gap.",
   "schema_version": 1,
   "slug": "sn-66",
-  "source_repo": "https://github.com/unarbos/tau",
+  "source_repo": "https://github.com/ninja-subnet/ninja",
   "status": "active",
   "surfaces": [
     {
@@ -44,7 +44,7 @@
       "id": "sn-66-ninja-website",
       "kind": "website",
       "name": "Ninja website",
-      "notes": "Official Ninja SN66 public website.",
+      "notes": "Official Ninja SN66 public website. Migrated from ninja.arbos.life (now 404) to ninja66.ai -- verified live 2026-07-15.",
       "probe": {
         "enabled": true,
         "expect": "html",
@@ -53,16 +53,16 @@
       },
       "provider": "unarbos",
       "public_safe": true,
-      "source_urls": ["https://ninja.arbos.life/"],
-      "url": "https://ninja.arbos.life/"
+      "source_urls": ["https://ninja66.ai/"],
+      "url": "https://ninja66.ai/"
     },
     {
       "auth_required": false,
       "authority": "official",
       "id": "sn-66-ninja-tau-source",
       "kind": "source-repo",
-      "name": "Ninja tau source repository",
-      "notes": "Official staged workflow repository for Ninja SN66.",
+      "name": "Ninja agent source repository",
+      "notes": "Official published-agent repository for Ninja SN66. Migrated from unarbos/tau to the ninja-subnet org's \"ninja\" repo (description: \"Subnet 66 published ninja king agent\") -- verified live 2026-07-15, pushed same day.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -72,18 +72,18 @@
       "provider": "unarbos",
       "public_safe": true,
       "source_urls": [
-        "https://github.com/unarbos/tau",
-        "https://github.com/unarbos/tau/blob/main/README.md"
+        "https://github.com/ninja-subnet/ninja",
+        "https://ninja66.ai/"
       ],
-      "url": "https://github.com/unarbos/tau"
+      "url": "https://github.com/ninja-subnet/ninja"
     },
     {
       "auth_required": false,
       "authority": "official",
       "id": "sn-66-ninja-harness-source",
       "kind": "source-repo",
-      "name": "Ninja miner harness source repository",
-      "notes": "Official SN66 miner starter harness repository referenced by the tau README.",
+      "name": "Ninja CLI harness source repository",
+      "notes": "Official SN66 miner CLI harness repository. Migrated from unarbos/ninja to the ninja-subnet org's \"katana-cli\" repo (description: \"Claude Code-style CLI harness for the Subnet 66 ninja agent\") -- verified live 2026-07-15.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -93,10 +93,10 @@
       "provider": "unarbos",
       "public_safe": true,
       "source_urls": [
-        "https://github.com/unarbos/tau",
-        "https://github.com/unarbos/ninja"
+        "https://github.com/ninja-subnet/ninja",
+        "https://github.com/ninja-subnet/katana-cli"
       ],
-      "url": "https://github.com/unarbos/ninja"
+      "url": "https://github.com/ninja-subnet/katana-cli"
     },
     {
       "auth_required": false,
@@ -104,7 +104,7 @@
       "id": "sn-66-ninja-readme-docs",
       "kind": "docs",
       "name": "Ninja README docs",
-      "notes": "Official tau README documentation for Ninja task generation, execution, validation, and scoring workflow.",
+      "notes": "Official README documentation for Ninja task generation, execution, validation, and scoring workflow. Migrated from unarbos/tau to ninja-subnet/ninja -- verified live 2026-07-15.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -114,10 +114,10 @@
       "provider": "unarbos",
       "public_safe": true,
       "source_urls": [
-        "https://github.com/unarbos/tau",
-        "https://github.com/unarbos/tau/blob/main/README.md"
+        "https://github.com/ninja-subnet/ninja",
+        "https://github.com/ninja-subnet/ninja/blob/main/README.md"
       ],
-      "url": "https://github.com/unarbos/tau/blob/main/README.md"
+      "url": "https://github.com/ninja-subnet/ninja/blob/main/README.md"
     },
     {
       "auth_required": false,
@@ -125,36 +125,35 @@
       "id": "sn-66-ninja-health",
       "kind": "subnet-api",
       "name": "Ninja health endpoint",
-      "notes": "Health path returns HTTP 404 (the host is up; the /health route does not exist) — verified 2026-06-15. Probe disabled pending a valid health URL.",
+      "notes": "Public no-auth GET returning HTTP 200 on the new ninja66.ai host -- verified live 2026-07-15 (the old ninja.arbos.life/health always 404'd; that whole domain is now dead). Re-enabled probing under the migrated identity.",
       "probe": {
-        "enabled": false,
+        "enabled": true,
         "expect": "any",
         "method": "GET",
         "timeout_ms": 10000
       },
       "provider": "unarbos",
       "public_safe": true,
-      "source_urls": ["https://ninja.arbos.life/health"],
-      "url": "https://ninja.arbos.life/health"
+      "source_urls": ["https://ninja66.ai/"],
+      "url": "https://ninja66.ai/health"
     },
     {
       "auth_required": false,
       "authority": "official",
-      "id": "sn-66-ninja-swagger-ui",
-      "kind": "docs",
-      "name": "Ninja Swagger UI",
-      "notes": "Swagger UI route for Ninja. Obvious JSON schema paths currently serve HTML and are not treated as machine-readable OpenAPI.",
+      "id": "sn-66-ninja-validator-source",
+      "kind": "source-repo",
+      "name": "Ninja validator source repository",
+      "notes": "Official validator/task code repository for Ninja SN66, under the same ninja-subnet org as the migrated agent/harness repos -- verified live 2026-07-15, pushed same day.",
       "probe": {
         "enabled": true,
-        "expect": "html",
+        "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
       "provider": "unarbos",
       "public_safe": true,
-      "schema_status": "ui-only",
-      "source_urls": ["https://ninja.arbos.life/swagger"],
-      "url": "https://ninja.arbos.life/swagger"
+      "source_urls": ["https://github.com/ninja-subnet/ninja"],
+      "url": "https://github.com/ninja-subnet/ninja-validator"
     },
     {
       "auth_required": false,
@@ -220,16 +219,18 @@
       "id": "sn-66-unarbos-data-artifact",
       "kind": "data-artifact",
       "name": "Ninja accepted private-submission metadata dataset",
-      "notes": "Public no-auth GET https://ninja66.ai/api/submissions returning application/json with an updated_at timestamp and the accepted public submission metadata ledger (submission_id, uid, hotkey, submitted_block, submitted_at, status) for SN66 private miner harness submissions. The official unarbos/ninja miner harness README documents this route as the public visibility endpoint for accepted submission metadata and explicitly states it does not expose agent.py contents or hotkey signatures.",
+      "notes": "Public no-auth GET https://ninja66.ai/api/submissions returning application/json with an updated_at timestamp and the accepted public submission metadata ledger (submission_id, uid, hotkey, submitted_block, submitted_at, status) for SN66 private miner harness submissions. The official miner CLI harness README (migrated from unarbos/ninja to ninja-subnet/katana-cli) documents this route as the public visibility endpoint for accepted submission metadata and explicitly states it does not expose agent.py contents or hotkey signatures.",
       "provider": "unarbos",
       "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "jimcody1995"
       },
-      "source_urls": ["https://github.com/unarbos/ninja/blob/main/README.md"],
+      "source_urls": [
+        "https://github.com/ninja-subnet/katana-cli/blob/main/README.md"
+      ],
       "url": "https://ninja66.ai/api/submissions"
     }
   ],
-  "website_url": "https://ninja.arbos.life/"
+  "website_url": "https://ninja66.ai/"
 }


### PR DESCRIPTION
## Summary

Found via the root->128 dead-link triage pass: `ninja.arbos.life` returned 404 site-wide (website, `/health`, `/swagger` all dead), and `github.com/unarbos/tau` and `unarbos/ninja` were both stale/unreachable.

Confirmed this is a genuine migration, not just downtime: `ninja66.ai` resolves with real dashboard content and links directly to `github.com/ninja-subnet/ninja` and `ninja-subnet/ninja-validator`, both actively pushed the same day as this fix. Verified the new repo mapping via the org's full repo list:
- `ninja` = published agent (old "tau" role)
- `katana-cli` = CLI harness (old "miner harness" concept -- description literally says "Claude Code-style CLI harness for the Subnet 66 ninja agent")
- `ninja-validator` = validator/task code, **not previously tracked at all** under the old org

## Changes

- website/dashboard/docs/source-repo/health surfaces all repointed to the new domain+org, health probing re-enabled (was disabled: a 2026-06-15 note documented `ninja.arbos.life/health` 404ing on that specific path -- now the whole domain is gone, not just that route)
- `swagger-ui` surface removed (no working equivalent found on the new site) and replaced with the newly-discovered `ninja-validator` repo
- `unarbos.json` provider profile updated to match

## Test plan

- [x] Every new URL fetched live and confirmed 200 before being added
- [x] `npm run validate:schemas` — passes
- [x] `npm run validate:surface` — passes (867 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full clean build passes