### PR TITLE
feat(registry): Templar (SN3) accuracy pass -- Crusades pivot, review_state fix

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 141,
+  "surface_count": 158,
   "surfaces": [
     {
       "auth_required": false,
@@ -191,6 +191,96 @@
       "surface_id": "opentensor-lite-wss",
       "surface_key": "srf-dcf48d017826dc4b",
       "url": "wss://lite.chain.opentensor.ai:443"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 1,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "subnet_name": "Apex",
+      "subnet_slug": "sn-1",
+      "surface_id": "sn-1-apex-healthcheck-ready",
+      "surface_key": "srf-fcd390d4676aeddd",
+      "url": "https://apex.api.macrocosmos.ai/healthcheck/ready"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 1,
+      "probe": {
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "subnet_name": "Apex",
+      "subnet_slug": "sn-1",
+      "surface_id": "sn-1-apex-metrics",
+      "surface_key": "srf-efc1590639bd9f16",
+      "url": "https://apex.api.macrocosmos.ai/metrics"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 2,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "inference-labs",
+      "public_safe": true,
+      "subnet_name": "DSperse",
+      "subnet_slug": "dsperse",
+      "surface_id": "sn-2-dsperse-circuit-list",
+      "surface_key": "srf-06434934e964a608",
+      "url": "https://repository.inferencelabs.com/circuits"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 2,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "inference-labs",
+      "public_safe": true,
+      "subnet_name": "DSperse",
+      "subnet_slug": "dsperse",
+      "surface_id": "sn-2-dsperse-component-list",
+      "surface_key": "srf-342e021c20c4d950",
+      "url": "https://repository.inferencelabs.com/components"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 2,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "inference-labs",
+      "public_safe": true,
+      "subnet_name": "DSperse",
+      "subnet_slug": "dsperse",
+      "surface_id": "sn-2-dsperse-model-list",
+      "surface_key": "srf-43ce8d499d2a4e28",
+      "url": "https://repository.inferencelabs.com/models"
     },
     {
       "auth_required": false,
@@ -386,9 +476,99 @@
       "public_safe": true,
       "subnet_name": "Allways",
       "subnet_slug": "allways",
+      "surface_id": "allways-crown-history",
+      "surface_key": "srf-1c507e95e9b90ef3",
+      "url": "https://api.all-ways.io/crown/history?direction=SOL-BTC"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-crown-rate-history",
+      "surface_key": "srf-7d2a3a092e2f4288",
+      "url": "https://api.all-ways.io/crown/rate-history?direction=SOL-BTC"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-crown-time",
+      "surface_key": "srf-565238052b5d145d",
+      "url": "https://api.all-ways.io/crown/time?direction=SOL-BTC"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-events",
+      "surface_key": "srf-9f537fe97d9e4b4b",
+      "url": "https://api.all-ways.io/events"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": null
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
       "surface_id": "allways-events-latest",
       "surface_key": "srf-cc1a1ad8cf1170b7",
       "url": "https://api.all-ways.io/events/latest"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-history-rate",
+      "surface_key": "srf-b12a1b63c48a3b03",
+      "url": "https://api.all-ways.io/history/rate?direction=SOL-BTC"
     },
     {
       "auth_required": false,
@@ -446,6 +626,24 @@
     },
     {
       "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-network-halt-state",
+      "surface_key": "srf-f0a104b03ec0cb95",
+      "url": "https://api.all-ways.io/network/halt-state"
+    },
+    {
+      "auth_required": false,
       "authority": "provider-claimed",
       "kind": "subnet-api",
       "netuid": 7,
@@ -461,6 +659,42 @@
       "surface_id": "allways-network-overview",
       "surface_key": "srf-3517b995dfdb719a",
       "url": "https://api.all-ways.io/network/overview"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-network-scoring-state",
+      "surface_key": "srf-1c7162d58d41d2ac",
+      "url": "https://api.all-ways.io/network/scoring-state"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-network-stats",
+      "surface_key": "srf-be707e5c5525070f",
+      "url": "https://api.all-ways.io/stats"
     },
     {
       "auth_required": false,
@@ -500,6 +734,42 @@
     },
     {
       "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-reservations",
+      "surface_key": "srf-22ad2af21ecd6626",
+      "url": "https://api.all-ways.io/reservations"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-reservations-active",
+      "surface_key": "srf-c81433df18ed23d4",
+      "url": "https://api.all-ways.io/reservations/active"
+    },
+    {
+      "auth_required": false,
       "authority": "provider-claimed",
       "kind": "sse",
       "netuid": 7,
@@ -515,6 +785,42 @@
       "surface_id": "allways-sse",
       "surface_key": "srf-9a3013f8b54338b4",
       "url": "https://api.all-ways.io/sse"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-swaps-active",
+      "surface_key": "srf-abf0965c49081975",
+      "url": "https://api.all-ways.io/swaps/active"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-swaps-count",
+      "surface_key": "srf-b1738ebcc631a0d2",
+      "url": "https://api.all-ways.io/swaps/count"
     },
     {
       "auth_required": false,
@@ -1530,8 +1836,8 @@
       "kind": "data-artifact",
       "netuid": 64,
       "probe": {
-        "expect": "any",
-        "method": "HEAD",
+        "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
       "provider": "chutes",
@@ -1548,8 +1854,8 @@
       "kind": "data-artifact",
       "netuid": 64,
       "probe": {
-        "expect": "any",
-        "method": "HEAD",
+        "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
       "provider": "chutes",
@@ -1566,8 +1872,8 @@
       "kind": "data-artifact",
       "netuid": 64,
       "probe": {
-        "expect": "any",
-        "method": "HEAD",
+        "expect": "json",
+        "method": "GET",
         "timeout_ms": 10000
       },
       "provider": "chutes",

--- a/registry/subnets/templar.json
+++ b/registry/subnets/templar.json
@@ -4,7 +4,8 @@
     "decentralized-training",
     "identity-drift",
     "identity-reviewed",
-    "official-source-repo"
+    "official-source-repo",
+    "tournament"
   ],
   "curation": {
     "gap_notes": [
@@ -12,7 +13,7 @@
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
-    "review_state": "needs-review",
+    "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T11:05:00.000Z",
     "source_count": 6,
     "verified_at": "2026-06-08T11:05:00.000Z"
@@ -21,7 +22,7 @@
   "docs_url": "https://docs.tplr.ai/",
   "name": "Templar",
   "netuid": 3,
-  "notes": "Reviewed overlay for SN3 using the live One Covenant Templar repository, website, docs, and public dashboards. Native chain identity currently reports a deprecated placeholder, so this remains an explicit identity-drift entry rather than a silent rename.",
+  "notes": "Reviewed overlay for SN3 using the live One Covenant Templar repository, website, docs, and public dashboards. Native chain identity currently reports a deprecated placeholder, matching the source repository's own dormancy notice: the original Covenant-72B decentralized training run is complete and not currently active. Subnet 3 now runs Crusades, an MFU (Model FLOPs Utilization) optimization tournament by the same one-covenant team on the same netuid, tracked via a separate source-repo surface. The existing website/docs/dashboards remain live and serve both the dormant Templar protocol's history and Crusades' current activity (the Grafana eval-metrics dashboard doubles as the tournament leaderboard).",
   "schema_version": 1,
   "slug": "sn-3",
   "social": {
@@ -50,6 +51,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/3/subnet.json"
       ],
       "url": "https://github.com/one-covenant/templar"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "id": "sn-3-templar-crusades-source",
+      "kind": "source-repo",
+      "name": "Templar Crusades source repository",
+      "notes": "Public source repository for Crusades, the MFU (Model FLOPs Utilization) optimization tournament currently running on SN3 -- a distinct mechanism from the original (now dormant) Templar decentralized-training protocol, run by the same one-covenant team on the same netuid.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "one-covenant",
+      "public_safe": true,
+      "source_urls": ["https://github.com/one-covenant/crusades"],
+      "url": "https://github.com/one-covenant/crusades"
     },
     {
       "auth_required": false,
@@ -180,7 +199,7 @@
       "id": "sn-3-templar-min-compute-spec",
       "kind": "data-artifact",
       "name": "Templar minimum compute requirements",
-      "notes": "Public no-auth YAML miner and validator hardware specification (CPU, memory, storage, OS, and bandwidth) published at the root of the official one-covenant/templar repository as min_compute.yml. Documents SN3 Templar operator requirements for the decentralized pre-training run.",
+      "notes": "Public no-auth YAML miner and validator hardware specification (CPU, memory, storage, OS, and bandwidth) published at the root of the official one-covenant/templar repository as min_compute.yml. Documents requirements for the original (now dormant) Templar decentralized pre-training run -- substantially heavier than the currently-active Crusades tournament, which the Crusades README documents as needing 2x A100 80GB GPUs, not this file's 8x B200s.",
       "probe": {
         "enabled": true,
         "expect": "any",


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903), following the pattern from #5815 (SN7 pilot), #5849 (SN1), #5851 (SN2).

- **Major finding**: Templar's own source repository README now carries an explicit dormancy notice -- the Covenant-72B decentralized training run is complete and the protocol is not currently active. **Subnet 3 now runs Crusades**, an MFU (Model FLOPs Utilization) optimization tournament by the same one-covenant team on the same netuid. Confirmed live and added as a new `source-repo` surface (`github.com/one-covenant/crusades`).
- Confirmed the existing `"Native chain name currently reports as deprecated"` gap note is **accurate, not stale**: queried SN3's live on-chain identity via `api.metagraph.sh` -- `native_name` literally is the string `"deprecated"`, consistent with the repo's own dormancy notice. No fix needed there.
- Rewrote `notes` to describe the actual current state (Crusades tournament) instead of only the dormant protocol. The existing Grafana eval-metrics dashboard now also doubles as the Crusades tournament leaderboard.
- Added the `"tournament"` category (existing precedent: `nepher-robotics.json`).
- Clarified the tracked `min_compute.yml` describes the *dormant* protocol's much heavier hardware requirements (8x B200 GPUs) -- Crusades' own README documents a lighter 2x A100 80GB requirement instead. Same upstream file, not updated by the team; flagged in this surface's `notes` so a reader isn't misled.
- Fixed a `review_state`/`level` inconsistency: `review_state` was `"needs-review"` while `level` was already `"maintainer-reviewed"`.
- All 7 pre-existing surface URLs re-verified live (HTTP 200) before this pass -- none needed fixing.

## Test plan

- [x] `npm run validate:schemas` — passes
- [x] `npm run validate:surface` — passes (868 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] Crusades repo confirmed public and live (HTTP 200) before adding as a surface
- [x] Every existing + new surface URL live-tested individually, not assumed