### PR TITLE
feat(graphql): add Query.chain_serving mirroring REST /chain/serving and MCP get_chain_serving

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -168,6 +168,13 @@ import {
   loadChainWeights,
 } from "./chain-weights.mjs";
 import {
+  CHAIN_SERVING_LIMIT_DEFAULT,
+  CHAIN_SERVING_LIMIT_MAX,
+  CHAIN_SERVING_WINDOWS,
+  DEFAULT_CHAIN_SERVING_WINDOW,
+  loadChainServing,
+} from "./chain-serving.mjs";
+import {
   buildChainTurnover,
   CHAIN_TURNOVER_LIMIT_DEFAULT,
   CHAIN_TURNOVER_LIMIT_MAX,
@@ -312,6 +319,8 @@ export const SDL = `
     chain_turnover(window: String, limit: Int): ChainTurnover!
     "Network-wide validator weight-setting activity leaderboard over a 7d/30d window (default 7d): subnets ranked by WeightsSet events with each's distinct-setter count and sets-per-setter update intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. Mirrors GET /api/v1/chain/weights."
     chain_weights(window: String, limit: Int): ChainWeights!
+    "Network-wide axon-serving announcement leaderboard over a 7d/30d window (default 7d): subnets ranked by AxonServed announcements with each's distinct-server count and announcements-per-server re-announcement intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The network-wide counterpart of subnet_serving. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/serving."
+    chain_serving(window: String, limit: Int): ChainServing!
     "Network-wide weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators driving consensus network-wide, each with its total WeightsSet count, share of the network total, and first/last set times, ranked by activity. The setter-level drill-in behind chain_weights. Mirrors GET /api/v1/chain/weights/setters."
     chain_weight_setters(window: String, limit: Int): ChainWeightSetters!
     "Compact all-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history (probed every ~15 minutes); a cold store still returns both windows, schema-stable and zeroed, never a GraphQL error. Mirrors GET /api/v1/health/trends."
@@ -583,6 +592,45 @@ export const SDL = `
     distinct_setters: Int!
     weight_sets: Int!
     sets_per_setter: Float
+  }
+
+  "Network-wide axon-serving announcement leaderboard (#5873). The network-wide counterpart of subnet_serving. Mirrors GET /api/v1/chain/serving's data envelope."
+  type ChainServing {
+    schema_version: Int!
+    window: String
+    observed_at: String
+    subnet_count: Int!
+    network: ChainServingNetwork!
+    intensity_distribution: ChainServingIntensityDistribution
+    subnets: [ChainServingSubnet!]!
+  }
+
+  "Network-wide axon-serving rollup: every subnet with AxonServed announcements in the window, combined."
+  type ChainServingNetwork {
+    distinct_servers: Int!
+    announcements: Int!
+    "Null when distinct_servers is 0 (no defined intensity without servers)."
+    announcements_per_server: Float
+  }
+
+  "Spread of per-subnet re-announcement intensity (AxonServed events per server) across EVERY subnet with announcements in the window -- network-wide even when limit truncates the leaderboard."
+  type ChainServingIntensityDistribution {
+    count: Int!
+    mean: Float!
+    min: Float!
+    p25: Float!
+    median: Float!
+    p75: Float!
+    p90: Float!
+    max: Float!
+  }
+
+  "One subnet's axon-serving activity in the window, ranked by announcements."
+  type ChainServingSubnet {
+    netuid: Int!
+    distinct_servers: Int!
+    announcements: Int!
+    announcements_per_server: Float
   }
 
   "Network-wide rolling 24h buy/sell alpha-volume leaderboard, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/alpha-volume's data envelope."
@@ -1918,6 +1966,7 @@ export const FIELD_COMPLEXITY = {
   subnet_movers: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_turnover: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weights: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   validator_nominators: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4073,6 +4122,50 @@ const rootValue = {
         distinct_setters: 0,
         weight_sets: 0,
         sets_per_setter: null,
+      },
+      intensity_distribution: data.intensity_distribution ?? null,
+      subnets: data.subnets || [],
+    };
+  },
+
+  async chain_serving({ window, limit }, context) {
+    const requestedWindow = window ?? DEFAULT_CHAIN_SERVING_WINDOW;
+    if (!Object.hasOwn(CHAIN_SERVING_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(requestedWindow, CHAIN_SERVING_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: CHAIN_SERVING_LIMIT_DEFAULT,
+      maxLimit: CHAIN_SERVING_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    params.set("limit", String(safeLimit));
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> loadChainServing
+    // fallback contract REST's chainServing route uses -- a cold store yields a
+    // schema-stable zeroed card, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/serving", params),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      (await loadChainServing(graphqlD1(context), {
+        windowLabel: requestedWindow,
+        windowDays: CHAIN_SERVING_WINDOWS[requestedWindow],
+        limit: safeLimit,
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? requestedWindow,
+      observed_at: data.observed_at ?? null,
+      subnet_count: data.subnet_count ?? 0,
+      network: data.network ?? {
+        distinct_servers: 0,
+        announcements: 0,
+        announcements_per_server: null,
       },
       intensity_distribution: data.intensity_distribution ?? null,
       subnets: data.subnets || [],

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -6502,6 +6502,182 @@ describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", 
   });
 });
 
+describe("graphql — chain_serving (#5873, Postgres-tier + D1-live fallback)", () => {
+  function servingQuery(argsClause) {
+    return `{ chain_serving${argsClause} {
+      schema_version window observed_at subnet_count
+      network { distinct_servers announcements announcements_per_server }
+      intensity_distribution { count mean min p25 median p75 p90 max }
+      subnets { netuid distinct_servers announcements announcements_per_server }
+    } }`;
+  }
+
+  // The network aggregate (COUNT DISTINCT hotkey / MAX(observed_at)) has no
+  // GROUP BY; the per-subnet leaderboard is GROUP BY netuid -- same two-query
+  // shape loadChainServing always issues. The subnet query only fires when the
+  // network row carries a non-null newest_observed.
+  function chainServingD1({ network, subnets = [] } = {}) {
+    return {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              async all() {
+                if (sql.includes("GROUP BY netuid")) {
+                  return { results: subnets };
+                }
+                return { results: network ? [network] : [] };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  test("cold store, default args: schema-stable empty leaderboard", async () => {
+    const { status, body } = await gql(servingQuery(""));
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_serving, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_servers: 0,
+        announcements: 0,
+        announcements_per_server: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            observed_at: "2026-07-10T00:00:00.000Z",
+            subnet_count: 1,
+            network: {
+              distinct_servers: 4,
+              announcements: 40,
+              announcements_per_server: 10,
+            },
+            intensity_distribution: {
+              count: 1,
+              mean: 10,
+              min: 10,
+              p25: 10,
+              median: 10,
+              p75: 10,
+              p90: 10,
+              max: 10,
+            },
+            subnets: [
+              {
+                netuid: 3,
+                distinct_servers: 4,
+                announcements: 40,
+                announcements_per_server: 10,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      servingQuery('(window: "30d", limit: 5)'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/serving");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(body.data.chain_serving.window, "30d");
+    assert.equal(body.data.chain_serving.subnet_count, 1);
+    assert.equal(body.data.chain_serving.network.distinct_servers, 4);
+    assert.equal(body.data.chain_serving.network.announcements_per_server, 10);
+    assert.equal(body.data.chain_serving.intensity_distribution.median, 10);
+    assert.equal(body.data.chain_serving.subnets[0].netuid, 3);
+  });
+
+  test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(servingQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.chain_serving.window, "7d");
+    assert.equal(body.data.chain_serving.subnet_count, 0);
+    assert.equal(body.data.chain_serving.network.announcements, 0);
+    assert.equal(
+      body.data.chain_serving.network.announcements_per_server,
+      null,
+    );
+    assert.equal(body.data.chain_serving.intensity_distribution, null);
+    assert.deepEqual(body.data.chain_serving.subnets, []);
+  });
+
+  test("no Postgres tier flag: rolls up the account_events AxonServed stream straight off D1", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: chainServingD1({
+        network: {
+          distinct_servers: 4,
+          newest_observed: 1_750_000_000_000,
+        },
+        subnets: [{ netuid: 3, announcements: 40, distinct_servers: 4 }],
+      }),
+    };
+    const { status, body } = await gql(servingQuery('(window: "7d")'), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.chain_serving.window, "7d");
+    assert.equal(body.data.chain_serving.subnet_count, 1);
+    assert.equal(body.data.chain_serving.network.distinct_servers, 4);
+    assert.equal(body.data.chain_serving.network.announcements, 40);
+    assert.equal(body.data.chain_serving.network.announcements_per_server, 10);
+    assert.equal(body.data.chain_serving.subnets[0].netuid, 3);
+    assert.equal(body.data.chain_serving.intensity_distribution.count, 1);
+    assert.ok(body.data.chain_serving.observed_at);
+  });
+
+  test("a D1 query error degrades to a schema-stable empty leaderboard (no throw)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          throw new Error("db unavailable");
+        },
+      },
+    };
+    const { status, body } = await gql(servingQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.chain_serving.subnet_count, 0);
+    assert.deepEqual(body.data.chain_serving.subnets, []);
+  });
+
+  test("an unsupported window is a GraphQL error, not a silently substituted default", async () => {
+    const { status, body } = await gql(servingQuery('(window: "99d")'));
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    const err = body.errors.find(
+      (e) => e.extensions?.code === "BAD_USER_INPUT",
+    );
+    assert.ok(err);
+    assert.match(err.message, /99d/);
+  });
+
+  test("chain_serving is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.chain_serving, 5);
+  });
+});
+
 describe("graphql — chain_weight_setters (#5689, Postgres-tier + D1-live fallback)", () => {
   function weightSettersQuery(argsClause) {
     return `{ chain_weight_setters${argsClause} {


### PR DESCRIPTION
`subnet_serving` already exists in GraphQL (`src/graphql.mjs:221`) — the network-wide counterpart didn't.

## What

Adds `Query.chain_serving` to `src/graphql.mjs`, mirroring the live `GET /api/v1/chain/serving` route (`workers/data-api.mjs:4506`) and the existing MCP `get_chain_serving` tool.

## How

Follows the `chain_weights` sibling convention exactly — the `{window, limit}` + D1-loader family:

- Resolves through the same `tryPostgresTier(..., "METAGRAPH_ACCOUNT_EVENTS_SOURCE") ?? loadChainServing(graphqlD1(context), ...)` fallback contract the REST route uses — no query/aggregation logic is duplicated; `src/chain-serving.mjs`'s `loadChainServing`/`buildChainServing` remain the single source of truth.
- Validates `window` against the module's own `CHAIN_SERVING_WINDOWS` (7d/30d, default 7d); an unsupported window is a `BAD_USER_INPUT` GraphQL error rather than a silently substituted default.
- Clamps `limit` via `clampLimit` to `CHAIN_SERVING_LIMIT_DEFAULT`/`CHAIN_SERVING_LIMIT_MAX` (20/100).
- A cold store yields a schema-stable zeroed card, never a GraphQL error.

`intensity_distribution` is computed over **every** subnet with announcements in the window, not just the returned page, so the spread stays network-wide even when `limit` truncates the leaderboard (matching the builder's existing behaviour).

## Tests

Seven cases in `tests/graphql.test.mjs`, mirroring the `chain_weights` block:

- cold store, default args → schema-stable empty leaderboard
- Postgres-tier hit on a non-default `window`/`limit` → asserts `capturedUrl.pathname` and that both are forwarded as query params
- malformed tier body → degrades to schema-stable defaults without throwing
- no Postgres flag → rolls the `account_events` AxonServed stream straight off D1 (two-query stub: network aggregate + `GROUP BY netuid`)
- D1 query error → schema-stable empty leaderboard, no throw
- unsupported window → `BAD_USER_INPUT`
- `FIELD_COMPLEXITY.chain_serving` fan-out weighting

Full `tests/graphql.test.mjs` suite green (366 passed). `prettier --check`, `eslint`, `validate:contract-drift` and `validate:docs` all pass. Patch coverage verified locally at 100% of the changed range (0 uncovered statements, 0 partial branches). Rebased onto current `main`.

Closes #5873