### PR TITLE
fix(ui): pair the top-active-account ss58 with a copy button

### DIFF
--- a/apps/ui/src/components/metagraphed/top-active-account-row.tsx
+++ b/apps/ui/src/components/metagraphed/top-active-account-row.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 import {
@@ -13,26 +14,33 @@ type TopActiveAccountRowLinkProps = {
 };
 
 /**
- * Single ranked account row — account short-hash link + tx count + cohort share.
- * Replaces the duplicated BarMini + pill list pair on `/accounts` (#5315).
+ * Single ranked account row — account short-hash link + copy button + tx count +
+ * cohort share. The ss58 address is paired with a `CopyButton` (matching the
+ * shared `AccountCell` idiom) so the full address can be copied without a
+ * hover-only tooltip, which is unusable on touch/mobile (#5856). Replaces the
+ * duplicated BarMini + pill list pair on `/accounts` (#5315).
  */
 export function TopActiveAccountRowLink({ row }: TopActiveAccountRowLinkProps) {
   const label = shortHash(row.ss58) ?? row.ss58;
   return (
-    <Link
-      to="/accounts/$ss58"
-      params={{ ss58: row.ss58 }}
-      title={row.ss58}
-      className={TOP_ACTIVE_ACCOUNT_LINK_CLASS}
-      data-testid="top-active-account-row"
-      preload="intent"
-    >
-      <span className="min-w-0 truncate">{label}</span>
+    <div className={TOP_ACTIVE_ACCOUNT_LINK_CLASS} data-testid="top-active-account-row">
+      <span className="inline-flex min-w-0 items-center gap-1">
+        <Link
+          to="/accounts/$ss58"
+          params={{ ss58: row.ss58 }}
+          title={row.ss58}
+          className="min-w-0 truncate rounded-sm hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 group-hover:text-accent"
+          preload="intent"
+        >
+          {label}
+        </Link>
+        <CopyButton value={row.ss58} label="account" />
+      </span>
       <span className="shrink-0 tabular-nums text-ink-muted">
         {formatNumber(row.txCount)} tx
         <span className="ml-2 text-ink-muted/70">{formatTopActiveShare(row.shareOfTop)}</span>
       </span>
-    </Link>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Closes #5856

The "Most active accounts" row on `/accounts` (`top-active-account-row.tsx`) rendered each account's ss58 address as a plain `<Link title={row.ss58}>` — the full address was only reachable via a hover tooltip, so it was uncopyable on touch/mobile where there is no hover. This pairs the address with the same `<CopyButton value={row.ss58} label="account" />` the shared `AccountCell` already uses on `/blocks` and `/extrinsics`, so the full ss58 can be copied on any device.

## What Changed

- `apps/ui/src/components/metagraphed/top-active-account-row.tsx`: the row is now a container that holds the account `<Link>` and a sibling `<CopyButton>` (the `AccountCell` idiom), instead of a single `<Link>` wrapping the whole row. A `<button>` cannot be nested inside an `<a>`, and the copy click must not trigger navigation, so the link now wraps only the address label; the copy button sits beside it.
- Link destination (`/accounts/$ss58`), `preload="intent"`, the tx-count / cohort-share column, and the ranking/sort logic are all unchanged. The row shell class, group-hover accent, and `min-h-11` touch target are preserved.
- Scoped to a single file under `apps/ui/`.

## Gates

`eslint .` OK (0 errors) · prettier `--check` OK · `tsc --noEmit` OK · unit tests OK (132 files / 1027 tests) · `vite build` OK · rebased on latest `main`.

## Screenshots

Playwright, fixed-viewport (375×812 / 768×1024 / 1280×800) × light/dark, scrolled to the "Most active accounts" list, real `api.metagraph.sh` data. The copy button appears on every account row in **after**; **before** has no copy affordance. The change is identical across breakpoints.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/5856-after-mobile-dark.png)<br><sub>after</sub> |
