### PR TITLE
feat(verathos): add validator-proxy OpenAPI host + 2 new surfaces

### DIFF
--- a/registry/subnets/verathos.json
+++ b/registry/subnets/verathos.json
@@ -306,6 +306,74 @@
         "https://verathos.ai/docs"
       ],
       "url": "https://api.verathos.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-validator-proxy-openapi",
+      "kind": "openapi",
+      "name": "Verathos validator proxy OpenAPI schema",
+      "notes": "Public no-auth machine-readable OpenAPI 3.x schema (title \"Verathos Validator Proxy\") for api.verathos.ai -- a distinct host/API from the already-tracked verathos.ai/openapi.json protocol schema, covering validator proxy network stats, supply, and TEE-inference routes.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "schema_status": "machine-readable",
+      "schema_url": "https://api.verathos.ai/openapi.json",
+      "source_urls": ["https://api.verathos.ai/openapi.json"],
+      "url": "https://api.verathos.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-network-stats",
+      "kind": "subnet-api",
+      "name": "Verathos network stats",
+      "notes": "Public no-auth GET returning live per-miner network stats (address, ss58_address, uid, endpoint, model_id). Documented in the validator proxy's own OpenAPI schema (path /v1/network/stats).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.verathos.ai/openapi.json"],
+      "url": "https://api.verathos.ai/v1/network/stats"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-supply-info",
+      "kind": "subnet-api",
+      "name": "Verathos supply info",
+      "notes": "Public no-auth GET returning full token supply info (circulating, total, max, minted_total, alpha_in_pool, alpha_staked, price_tao, volume_tao) in one call -- a superset of the already-tracked /v1/supply/circulating. Documented in the validator proxy's own OpenAPI schema (path /v1/supply/info).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.verathos.ai/openapi.json"],
+      "url": "https://api.verathos.ai/v1/supply/info"
     }
   ],
   "website_url": "https://verathos.ai/"


### PR DESCRIPTION
## Summary

Found via the root->128 surface-completeness sweep: `api.verathos.ai` runs a separate, distinct API (title: "Verathos Validator Proxy", 35 paths) from the already-tracked `verathos.ai/openapi.json` protocol schema -- covers network stats, supply, and TEE-inference routes, not documented anywhere in the registry yet.

Added the schema itself plus two verified public endpoints:
- `/v1/network/stats` -- live per-miner data (address, uid, endpoint, model_id)
- `/v1/supply/info` -- a superset of the already-tracked `/v1/supply/circulating`

## Test plan

- [x] Both new endpoints fetched live and confirmed real JSON data before adding
- [x] `npm run validate:schemas` / `validate:surface` — pass (870 surfaces across 129 files)
- [x] `npm run build` — full clean build passes