### PR TITLE
feat(registry): Targon (SN4) accuracy pass -- add version API surface

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 158,
+  "surface_count": 159,
   "surfaces": [
     {
       "auth_required": false,
@@ -335,6 +335,24 @@
       "surface_id": "sn-4-targon-subnet-api",
       "surface_key": "srf-40be5162d95eb737",
       "url": "https://api.targon.com/tha/v2/inventory"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subnet-api",
+      "netuid": 4,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "targon",
+      "public_safe": true,
+      "subnet_name": "Targon",
+      "subnet_slug": "sn-4",
+      "surface_id": "sn-4-targon-version-api",
+      "surface_key": "srf-d5daaf19626ba91f",
+      "url": "https://api.targon.com/tha/v2/version"
     },
     {
       "auth_required": false,

--- a/registry/subnets/targon.json
+++ b/registry/subnets/targon.json
@@ -24,7 +24,7 @@
   "docs_url": "https://docs.targon.com/",
   "name": "Targon",
   "netuid": 4,
-  "notes": "Reviewed overlay for SN4 using the official Targon website, docs, Intel whitepaper, and source repository. No public API, OpenAPI schema, SSE stream, or standalone data artifact is verified yet.",
+  "notes": "Reviewed overlay for SN4 using the official Targon website, docs, Intel whitepaper, and source repository. The docs site's own sitemap lists 10 API categories (compute, health, heim, inventory, ssh-keys, templates, user, version, volumes, workloads); all but inventory and version are personal compute-rental account actions requiring a Bearer API key (create/manage workloads, templates, ssh keys, volumes), not eligible for public surface tracking. The documented no-auth health endpoints (/tha/v2/healthz, /tha/v2/readyz) currently 500 in production despite the docs describing them as working liveness/readiness checks -- not tracked as a surface since it would only generate false-unhealthy noise. No OpenAPI/Swagger schema, SSE stream, or standalone data artifact is verified yet.",
   "schema_version": 1,
   "slug": "sn-4",
   "social": {
@@ -128,6 +128,24 @@
       },
       "source_urls": ["https://docs.targon.com/api/inventory"],
       "url": "https://api.targon.com/tha/v2/inventory"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-4-targon-version-api",
+      "kind": "subnet-api",
+      "name": "Targon Hub API version",
+      "notes": "Public no-auth GET /tha/v2/version on api.targon.com returning the Targon Hub API's own release metadata (name, version, gitHash, buildDate). Documented in the official Targon API docs.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "targon",
+      "public_safe": true,
+      "source_urls": ["https://docs.targon.com/api/version"],
+      "url": "https://api.targon.com/tha/v2/version"
     },
     {
       "auth_required": false,


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- `docs.targon.com`'s own sitemap lists 10 API categories (compute, health, heim, inventory, ssh-keys, templates, user, version, volumes, workloads); only `inventory` was tracked. Checked each doc page individually: `compute`/`heim`/`templates`/`ssh-keys`/`user`/`volumes`/`workloads` are personal compute-rental account actions requiring a Bearer API key (create/manage workloads, templates, ssh keys) -- not eligible for public surface tracking. `health` and `version` are documented as no-auth.
- Added the **version** endpoint (`GET /tha/v2/version`, confirmed live, returns API release metadata: name/version/gitHash/buildDate) as a new `subnet-api` surface.
- The documented **health** endpoints (`/tha/v2/healthz`, `/tha/v2/readyz`) 500 in production on every attempt (5 repeated checks, with and without explicit headers) despite the docs describing them as working liveness/readiness checks -- a real bug on Targon's own side. Not tracked as a surface: a permanently-broken probe would only generate false-unhealthy noise in operational tracking.
- All 8 pre-existing surface URLs re-verified live (HTTP 200) before this pass -- none needed fixing. `gap_notes` were already accurate, no changes needed there.

## Test plan

- [x] `npm run validate:schemas` — passes
- [x] `npm run validate:surface` — passes (869 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] Every existing + new surface URL live-tested individually
- [x] Health endpoint 500 confirmed non-transient (5 attempts, varied headers, not a one-off blip)