### PR TITLE
feat(graphql): add Query.subnet_concentration and subnet_concentration_history

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -54,6 +54,12 @@ import {
 import { buildSubnetYield } from "./subnet-yield.mjs";
 import { buildSubnetPerformance } from "./subnet-performance.mjs";
 import {
+  buildConcentration,
+  buildConcentrationHistory,
+  CONCENTRATION_HISTORY_WINDOWS,
+  DEFAULT_CONCENTRATION_HISTORY_WINDOW,
+} from "./concentration.mjs";
+import {
   analyticsWindow,
   d1Runner,
   loadGlobalIncidentsLedger,
@@ -240,6 +246,10 @@ export const SDL = `
     subnet_yield(netuid: Int!): SubnetYield!
     "Per-subnet reward-distribution and score-spread card over the current neurons snapshot: incentive/dividends concentration plus p10–p90 trust/consensus/validator_trust; a subnet with no neurons resolves to a schema-stable zeroed card (metric blocks null), never null. Mirrors GET /api/v1/subnets/{netuid}/performance."
     subnet_performance(netuid: Int!): SubnetPerformance!
+    "Per-subnet stake and emission concentration over the current neurons snapshot: raw-UID and per-entity Gini/HHI/Nakamoto/top-K share for stake and emission, validator-only stake concentration, and a uids-per-entity Sybil signal; a subnet with no neurons resolves to a schema-stable zeroed card (metric blocks null), never null. Mirrors GET /api/v1/subnets/{netuid}/concentration."
+    subnet_concentration(netuid: Int!): SubnetConcentration!
+    "Per-subnet per-day stake and emission concentration trend from the neuron_daily rollup over a 7d/30d/90d window (default 30d): each day's stake/emission Gini, Nakamoto coefficient, and top-10% share, newest first; a subnet with no daily rollup resolves to a schema-stable empty series (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/concentration/history."
+    subnet_concentration_history(netuid: Int!, window: String): SubnetConcentrationHistory!
     "Append-only on-chain SubnetIdentitiesV3 change timeline for one subnet (name, symbol, description, repo, website, discord, logo), newest first; page with limit/offset or follow next_cursor. A subnet with no matching events resolves to a schema-stable empty timeline (entry_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/identity-history."
     subnet_identity_history(netuid: Int!, limit: Int, offset: Int, cursor: String): SubnetIdentityHistory!
     "Paginated provider/source registry."
@@ -1178,6 +1188,50 @@ export const SDL = `
     validator_trust: ScoreDistribution
   }
 
+  "Per-subnet stake & emission concentration card (#5901) over the current neurons snapshot. Metric blocks are null on a cold/empty subnet. Mirrors GET /api/v1/subnets/{netuid}/concentration."
+  type SubnetConcentration {
+    schema_version: Int!
+    netuid: Int!
+    neuron_count: Int!
+    "Distinct controlling entities (coldkeys) behind the subnet's UIDs."
+    entity_count: Int!
+    "UIDs per controlling entity -- a Sybil/consolidation signal (1.0 = every UID a distinct owner; higher = fewer operators each running many hotkeys). Null on an empty subnet."
+    uids_per_entity: Float
+    captured_at: String
+    "Stake concentration across all UIDs."
+    stake: ConcentrationMetrics
+    "Emission concentration across all UIDs."
+    emission: ConcentrationMetrics
+    "Stake concentration collapsed to one holder per controlling entity."
+    entity_stake: ConcentrationMetrics
+    "Emission concentration collapsed to one holder per controlling entity."
+    entity_emission: ConcentrationMetrics
+    "Stake concentration across permitted validators only."
+    validator_stake: ConcentrationMetrics
+  }
+
+  "One day's point in a subnet's concentration trend (#5901). Flattened (not nested) stake/emission metrics keep the series trivial to plot; each is null on a cold/empty day."
+  type SubnetConcentrationHistoryPoint {
+    snapshot_date: String!
+    neuron_count: Int!
+    stake_gini: Float
+    stake_nakamoto_coefficient: Int
+    stake_top_10pct_share: Float
+    emission_gini: Float
+    emission_nakamoto_coefficient: Int
+    emission_top_10pct_share: Float
+  }
+
+  "Per-subnet per-day concentration trend (#5901) from the neuron_daily rollup, newest first. An empty series (point_count 0) on a cold store, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/concentration/history."
+  type SubnetConcentrationHistory {
+    schema_version: Int!
+    netuid: Int!
+    "The resolved window label (7d/30d/90d)."
+    window: String
+    point_count: Int!
+    points: [SubnetConcentrationHistoryPoint!]!
+  }
+
   "Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope."
   type GlobalIncidents {
     schema_version: Int!
@@ -1910,6 +1964,8 @@ export const FIELD_COMPLEXITY = {
   subnet_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_yield: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_performance: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_concentration: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_concentration_history: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2724,6 +2780,84 @@ const rootValue = {
       trust: data.trust ?? null,
       consensus: data.consensus ?? null,
       validator_trust: data.validator_trust ?? null,
+    };
+  },
+
+  async subnet_concentration({ netuid }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildConcentration([])
+    // cold fallback contract handleSubnetConcentration / MCP get_subnet_concentration
+    // use: a subnet with no neurons is a schema-stable zeroed card (metric blocks
+    // null), never a GraphQL error. No window -- current snapshot only.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/concentration`,
+          new URLSearchParams(),
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildConcentration([], netuid);
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      neuron_count: data.neuron_count ?? 0,
+      entity_count: data.entity_count ?? 0,
+      uids_per_entity: data.uids_per_entity ?? null,
+      captured_at: data.captured_at ?? null,
+      stake: data.stake ?? null,
+      emission: data.emission ?? null,
+      entity_stake: data.entity_stake ?? null,
+      entity_emission: data.entity_emission ?? null,
+      validator_stake: data.validator_stake ?? null,
+    };
+  },
+
+  async subnet_concentration_history({ netuid, window }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same 7d/30d/90d window validation the REST route + MCP
+    // get_subnet_concentration_history use -- an unsupported window is a GraphQL
+    // BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_CONCENTRATION_HISTORY_WINDOW;
+    if (!Object.hasOwn(CONCENTRATION_HISTORY_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, CONCENTRATION_HISTORY_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildConcentrationHistory([])
+    // empty-series fallback the neuron_daily-derived REST route + MCP tool use.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/concentration/history`,
+          params,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ??
+      buildConcentrationHistory([], netuid, {
+        window: windowParam,
+        capped: false,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      point_count: data.point_count ?? 0,
+      points: data.points ?? [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -4208,6 +4208,282 @@ describe("graphql — subnet_performance (#5714, Postgres-tier + zeroed-card fal
   });
 });
 
+describe("graphql — subnet_concentration (#5901, Postgres-tier + zeroed-card fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_concentration(netuid: 5) {
+          schema_version netuid neuron_count entity_count uids_per_entity captured_at
+          stake { holders gini } emission { holders }
+          entity_stake { holders } entity_emission { holders } validator_stake { holders }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_concentration, {
+      schema_version: 1,
+      netuid: 5,
+      neuron_count: 0,
+      entity_count: 0,
+      uids_per_entity: null,
+      captured_at: null,
+      stake: null,
+      emission: null,
+      entity_stake: null,
+      entity_emission: null,
+      validator_stake: null,
+    });
+  });
+
+  test("resolves the Postgres-tier stake + emission concentration blocks", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 7,
+          neuron_count: 4,
+          entity_count: 3,
+          uids_per_entity: 1.3333,
+          captured_at: "2026-07-01T00:00:00.000Z",
+          stake: {
+            holders: 4,
+            total: 1000,
+            gini: 0.4,
+            hhi: 0.5,
+            hhi_normalized: 0.25,
+            nakamoto_coefficient: 1,
+            top_1pct_share: 0.6,
+            top_5pct_share: 0.6,
+            top_10pct_share: 0.6,
+            top_20pct_share: 0.9,
+            entropy: 1.4,
+            entropy_normalized: 0.8,
+          },
+          emission: {
+            holders: 3,
+            total: 12.5,
+            gini: 0.2,
+            hhi: 0.7,
+            hhi_normalized: 0.4,
+            nakamoto_coefficient: 1,
+            top_1pct_share: 0.83,
+            top_5pct_share: 0.83,
+            top_10pct_share: 0.83,
+            top_20pct_share: 1,
+            entropy: 0.9,
+            entropy_normalized: 0.9,
+          },
+          validator_stake: {
+            holders: 2,
+            total: 800,
+            gini: 0.1,
+            hhi: 0.55,
+            hhi_normalized: 0.1,
+            nakamoto_coefficient: 1,
+            top_1pct_share: 0.7,
+            top_5pct_share: 0.7,
+            top_10pct_share: 0.7,
+            top_20pct_share: 1,
+            entropy: 0.8,
+            entropy_normalized: 0.8,
+          },
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_concentration(netuid: 7) {
+          netuid neuron_count entity_count uids_per_entity captured_at
+          stake { holders gini nakamoto_coefficient top_10pct_share }
+          emission { holders total }
+          validator_stake { holders gini }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const c = body.data.subnet_concentration;
+    assert.equal(c.netuid, 7);
+    assert.equal(c.neuron_count, 4);
+    assert.equal(c.entity_count, 3);
+    assert.equal(c.uids_per_entity, 1.3333);
+    assert.equal(c.captured_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(c.stake.holders, 4);
+    assert.equal(c.stake.nakamoto_coefficient, 1);
+    assert.equal(c.stake.top_10pct_share, 0.6);
+    assert.equal(c.emission.holders, 3);
+    assert.equal(c.emission.total, 12.5);
+    assert.equal(c.validator_stake.holders, 2);
+    assert.equal(c.validator_stake.gini, 0.1);
+  });
+
+  test("forwards the concentration path to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql("{ subnet_concentration(netuid: 3) { neuron_count } }", env);
+    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/concentration"));
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ subnet_concentration(netuid: 9) {
+          schema_version netuid neuron_count entity_count uids_per_entity
+          stake { holders } validator_stake { holders }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_concentration, {
+      schema_version: 1,
+      netuid: 9,
+      neuron_count: 0,
+      entity_count: 0,
+      uids_per_entity: null,
+      stake: null,
+      validator_stake: null,
+    });
+  });
+
+  test("a negative netuid is a GraphQL error, not an empty card", async () => {
+    const { body } = await gql(
+      "{ subnet_concentration(netuid: -1) { neuron_count } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/netuid/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_concentration ?? null, null);
+  });
+
+  test("subnet_concentration is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_concentration, 5);
+  });
+});
+
+describe("graphql — subnet_concentration_history (#5901, neuron_daily trend + window validation)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty series, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_concentration_history(netuid: 5) {
+          schema_version netuid window point_count points { snapshot_date stake_gini }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_concentration_history, {
+      schema_version: 1,
+      netuid: 5,
+      window: "30d",
+      point_count: 0,
+      points: [],
+    });
+  });
+
+  test("resolves the Postgres-tier per-day trend points", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 7,
+          window: "7d",
+          point_count: 2,
+          points: [
+            {
+              snapshot_date: "2026-07-02",
+              neuron_count: 4,
+              stake_gini: 0.42,
+              stake_nakamoto_coefficient: 2,
+              stake_top_10pct_share: 0.55,
+              emission_gini: 0.3,
+              emission_nakamoto_coefficient: 1,
+              emission_top_10pct_share: 0.7,
+            },
+            {
+              snapshot_date: "2026-07-01",
+              neuron_count: 3,
+              stake_gini: 0.4,
+              stake_nakamoto_coefficient: 2,
+              stake_top_10pct_share: 0.5,
+              emission_gini: 0.28,
+              emission_nakamoto_coefficient: 1,
+              emission_top_10pct_share: 0.68,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_concentration_history(netuid: 7, window: "7d") {
+          netuid window point_count
+          points { snapshot_date neuron_count stake_gini stake_nakamoto_coefficient emission_top_10pct_share }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const h = body.data.subnet_concentration_history;
+    assert.equal(h.netuid, 7);
+    assert.equal(h.window, "7d");
+    assert.equal(h.point_count, 2);
+    assert.equal(h.points.length, 2);
+    assert.equal(h.points[0].snapshot_date, "2026-07-02");
+    assert.equal(h.points[0].stake_gini, 0.42);
+    assert.equal(h.points[0].stake_nakamoto_coefficient, 2);
+    assert.equal(h.points[1].emission_top_10pct_share, 0.68);
+  });
+
+  test("forwards the window to the concentration/history Postgres path", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(
+      '{ subnet_concentration_history(netuid: 3, window: "90d") { point_count } }',
+      env,
+    );
+    assert.ok(
+      capturedUrl.pathname.endsWith("/subnets/3/concentration/history"),
+    );
+    assert.equal(capturedUrl.searchParams.get("window"), "90d");
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent series", async () => {
+    const { body } = await gql(
+      '{ subnet_concentration_history(netuid: 5, window: "5d") { point_count } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_concentration_history ?? null, null);
+  });
+
+  test("subnet_concentration_history is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_concentration_history, 5);
+  });
+});
+
 describe("graphql — subnet_yield (#5713, Postgres-tier + zeroed-card fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Adds the two missing GraphQL Query fields for subnet concentration, completing the current-snapshot family that already exposes `subnet_performance` and `subnet_yield`:

- `subnet_concentration(netuid: Int!): SubnetConcentration!` — current stake/emission concentration (raw-UID + per-entity Gini/HHI/Nakamoto/top-K share, validator-only stake, and a uids-per-entity Sybil signal).
- `subnet_concentration_history(netuid: Int!, window: String): SubnetConcentrationHistory!` — per-day stake/emission trend (Gini, Nakamoto coefficient, top-10% share) over a 7d/30d/90d window (default 30d).

Both mirror endpoints that already exist at the REST + MCP layers, so no new data path is introduced:
- REST: `workers/data-api.mjs:6410` (`/concentration`), `:6828` (`/concentration/history`)
- MCP: `src/mcp-server.mjs:2792` (`get_subnet_concentration`), `:3594` (`get_subnet_concentration_history`)

## Implementation

Both resolvers reuse the established sibling pattern exactly:
- `subnet_concentration` mirrors `subnet_performance`: `tryPostgresTier(METAGRAPH_NEURONS_SOURCE)` over the same REST path, falling back to `buildConcentration([], netuid)` on a cold store — a subnet with no neurons is a schema-stable zeroed card (metric blocks `null`), never a GraphQL error.
- `subnet_concentration_history` mirrors the window-validated resolvers (`subnet_registrations`) + the daily tier: it validates `window` against `CONCENTRATION_HISTORY_WINDOWS` (unsupported → `BAD_USER_INPUT`), forwards it to the same `METAGRAPH_NEURONS_SOURCE` tier that serves the `neuron_daily`-derived REST route, and falls back to `buildConcentrationHistory([], netuid, { window, capped: false })`.

Both are weighted `RELATIONSHIP_FIELD_COMPLEXITY` in the field-complexity map, matching their siblings. The GraphQL types reuse the existing `ConcentrationMetrics` type; the history point is flattened (matching the REST/MCP shape) so a time series is trivial to plot.

## Tests

11 new tests in `tests/graphql.test.mjs` mirroring the `subnet_performance`/`subnet_yield` conventions: cold-store zeroed card / empty series, Postgres-tier resolution of the metric blocks and trend points, path + window forwarding to the tier, partial-body default degradation, negative-netuid and unsupported-window `BAD_USER_INPUT` errors, and the complexity-weight assertions.

Full `tests/graphql.test.mjs` suite (370 tests) passes; `eslint` and `scripts/validate-schema-enums.mjs` are clean.

Closes #5901
