### PR TITLE
feat(registry): add 39 verified public API surfaces across 20 subnets (batch 1)

### DIFF
--- a/registry/subnets/affine.json
+++ b/registry/subnets/affine.json
@@ -66,6 +66,50 @@
       },
       "source_urls": ["https://api.affine.io/openapi.json"],
       "url": "https://api.affine.io/api/v1/rank/current"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-120-affine-scores-latest",
+      "kind": "subnet-api",
+      "name": "Affine latest scores",
+      "notes": "Public no-auth GET returning the latest per-miner scores (block_number, miner_hotkey, uid, model_revision). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "affine",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.affine.io/api/v1/scores/latest"],
+      "url": "https://api.affine.io/api/v1/scores/latest"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-120-affine-scores-weights-latest",
+      "kind": "subnet-api",
+      "name": "Affine latest weights",
+      "notes": "Public no-auth GET returning the latest computed weights per UID alongside the scoring config. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "affine",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.affine.io/api/v1/scores/weights/latest"],
+      "url": "https://api.affine.io/api/v1/scores/weights/latest"
     }
   ],
   "website_url": "https://www.affine.io/"

--- a/registry/subnets/babelbit.json
+++ b/registry/subnets/babelbit.json
@@ -1,5 +1,6 @@
 {
   "categories": [],
+  "contact": "mk@babelbit.ai",
   "curation": {
     "level": "community-seeded",
     "review_state": "unreviewed"
@@ -8,10 +9,11 @@
   "netuid": 59,
   "schema_version": 1,
   "slug": "sn-59",
-  "status": "active",
   "social": {
     "x": "https://x.com/babelbit"
   },
+  "source_repo": "https://github.com/babelbit/babelbit_subnet",
+  "status": "active",
   "surfaces": [
     {
       "auth_required": false,
@@ -71,9 +73,29 @@
         "https://github.com/babelbit/babelbit_subnet/blob/main/README.md"
       ],
       "url": "https://raw.githubusercontent.com/babelbit/babelbit_subnet/main/min_compute.yml"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-59-babelbit-service-info",
+      "kind": "subnet-api",
+      "name": "Babelbit service info",
+      "notes": "Public no-auth GET returning the service self-description (service, version, description, authentication requirements). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "babelbit",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.babelbit.ai/"],
+      "url": "https://api.babelbit.ai/"
     }
   ],
-  "source_repo": "https://github.com/babelbit/babelbit_subnet",
-  "website_url": "https://babelbit.ai/",
-  "contact": "mk@babelbit.ai"
+  "website_url": "https://babelbit.ai/"
 }

--- a/registry/subnets/beam.json
+++ b/registry/subnets/beam.json
@@ -1,17 +1,19 @@
 {
-  "schema_version": 1,
-  "netuid": 105,
-  "name": "Beam",
-  "slug": "sn-105",
-  "status": "active",
   "categories": [],
+  "contact": "info@b1m.ai",
   "curation": {
     "level": "community-seeded",
     "review_state": "unreviewed"
   },
+  "name": "Beam",
+  "netuid": 105,
+  "schema_version": 1,
+  "slug": "sn-105",
   "social": {
     "x": "https://x.com/b1m_ai"
   },
+  "source_repo": "https://github.com/orgs/Beam-Network/repositories",
+  "status": "active",
   "surfaces": [
     {
       "auth_required": false,
@@ -68,9 +70,51 @@
       },
       "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
       "url": "https://beamcore.b1m.ai/config/uid-ranges"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-105-beam-routing-orchestrators",
+      "kind": "subnet-api",
+      "name": "Beam routing orchestrators",
+      "notes": "Public no-auth GET returning active orchestrator nodes (hotkey, url, region). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/routing/orchestrators"],
+      "url": "https://beamcore.b1m.ai/routing/orchestrators"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-105-beam-worker-capacity",
+      "kind": "subnet-api",
+      "name": "Beam worker capacity",
+      "notes": "Public no-auth GET returning total and per-orchestrator worker capacity. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/routing/worker-capacity"],
+      "url": "https://beamcore.b1m.ai/routing/worker-capacity"
     }
   ],
-  "source_repo": "https://github.com/orgs/Beam-Network/repositories",
-  "website_url": "https://b1m.ai/",
-  "contact": "info@b1m.ai"
+  "website_url": "https://b1m.ai/"
 }

--- a/registry/subnets/bitcast.json
+++ b/registry/subnets/bitcast.json
@@ -10,7 +10,6 @@
   "slug": "sn-93",
   "source_repo": "https://github.com/bitcast-network/bitcast",
   "status": "active",
-  "website_url": "https://stats.bitcast.network/",
   "surfaces": [
     {
       "auth_required": false,
@@ -35,87 +34,87 @@
       "url": "https://stats.bitcast.network/"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-93-bitcast-website",
-      "name": "Bitcast website",
       "kind": "website",
-      "url": "https://www.bitcast.network/",
+      "name": "Bitcast website",
+      "notes": "Official Bitcast website (page title \"bitcast\"), linked from the bitcast-network/bitcast README. Distinct from the stats subdomain set as the legacy website_url.",
       "provider": "bitcast-network",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
-      "source_urls": ["https://github.com/bitcast-network/bitcast"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Official Bitcast website (page title \"bitcast\"), linked from the bitcast-network/bitcast README. Distinct from the stats subdomain set as the legacy website_url."
+      "source_urls": ["https://github.com/bitcast-network/bitcast"],
+      "url": "https://www.bitcast.network/"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-93-bitcast-briefs",
-      "name": "Bitcast briefs / creator portal",
       "kind": "dashboard",
-      "url": "https://creator.bitcast.network/briefs",
+      "name": "Bitcast briefs / creator portal",
+      "notes": "Public Bitcast briefs / creator portal (active campaigns). The README's \"active briefs\" link (dashboard.bitcast.network) 301-redirects to this canonical creator.bitcast.network host. Distinct from the stats dashboard.",
       "provider": "bitcast-network",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
       "source_urls": ["https://github.com/bitcast-network/bitcast"],
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "glorydavid03023"
-      },
-      "notes": "Public Bitcast briefs / creator portal (active campaigns). The README's \"active briefs\" link (dashboard.bitcast.network) 301-redirects to this canonical creator.bitcast.network host. Distinct from the stats dashboard."
+      "url": "https://creator.bitcast.network/briefs"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-93-bitcast-deploy",
+      "kind": "source-repo",
       "name": "Bitcast deploy repository",
-      "kind": "source-repo",
-      "url": "https://github.com/bitcast-network/bitcast-deploy",
+      "notes": "Bitcast validator deployment repo; its GitHub description and README state \"bittensor subnet #93\" / \"netuid-93\". In the team's bitcast-network org, distinct from the top-level bitcast repo.",
       "provider": "bitcast-network",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
       "source_urls": ["https://github.com/bitcast-network/bitcast-deploy"],
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "glorydavid03023"
-      },
-      "notes": "Bitcast validator deployment repo; its GitHub description and README state \"bittensor subnet #93\" / \"netuid-93\". In the team's bitcast-network org, distinct from the top-level bitcast repo."
+      "url": "https://github.com/bitcast-network/bitcast-deploy"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-93-bitcast-x",
-      "name": "Bitcast X subnet-mechanism repository",
       "kind": "source-repo",
-      "url": "https://github.com/bitcast-network/bitcast-x",
+      "name": "Bitcast X subnet-mechanism repository",
+      "notes": "Bitcast \"X\" subnet-mechanism repo; README states \"Register a UID on subnet 93\" and \"Subnet ID: 93 (Bittensor mainnet)\". In the team's bitcast-network org.",
       "provider": "bitcast-network",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
-      "source_urls": ["https://github.com/bitcast-network/bitcast-x"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Bitcast \"X\" subnet-mechanism repo; README states \"Register a UID on subnet 93\" and \"Subnet ID: 93 (Bittensor mainnet)\". In the team's bitcast-network org."
+      "source_urls": ["https://github.com/bitcast-network/bitcast-x"],
+      "url": "https://github.com/bitcast-network/bitcast-x"
     },
     {
-      "id": "sn-93-bitcast-briefs-api",
-      "name": "Bitcast active briefs API",
-      "kind": "subnet-api",
-      "url": "https://creator.bitcast.network/api/briefs",
-      "provider": "bitcast-network",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-93-bitcast-briefs-api",
+      "kind": "subnet-api",
+      "name": "Bitcast active briefs API",
+      "notes": "Public JSON feed of active SN93 content briefs (id_brief, brief_id, brief text, boost, format). Served from the creator portal host; curl-verified 200 application/json with no auth. Distinct from the HTML briefs dashboard at /briefs.",
+      "provider": "bitcast-network",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/bitcast-network/bitcast",
-        "https://creator.bitcast.network/briefs"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "jimcody1995"
       },
-      "notes": "Public JSON feed of active SN93 content briefs (id_brief, brief_id, brief text, boost, format). Served from the creator portal host; curl-verified 200 application/json with no auth. Distinct from the HTML briefs dashboard at /briefs."
+      "source_urls": [
+        "https://github.com/bitcast-network/bitcast",
+        "https://creator.bitcast.network/briefs"
+      ],
+      "url": "https://creator.bitcast.network/api/briefs"
     },
     {
       "auth_required": false,
@@ -221,23 +220,46 @@
       "url": "https://raw.githubusercontent.com/bitcast-network/bitcast/main/min_compute.yml"
     },
     {
-      "id": "sn-93-bitcast-whitepaper-docs",
-      "name": "Bitcast whitepaper",
-      "kind": "docs",
-      "url": "https://www.bitcast.network/whitepaper.pdf",
-      "provider": "bitcast-network",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-93-bitcast-whitepaper-docs",
+      "kind": "docs",
+      "name": "Bitcast whitepaper",
+      "notes": "Public no-auth whitepaper (PDF) for SN93 Bitcast, served at www.bitcast.network/whitepaper.pdf on the official Bitcast website (the same operator as the registered stats.bitcast.network / creator.bitcast.network surfaces). A machine-readable document describing the subnet's design — content-attention incentive mechanism, miner/validator roles, and scoring. Distinct in URL and kind from the API/dashboard surfaces already registered.",
+      "provider": "bitcast-network",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/bitcast-network/bitcast",
-        "https://www.bitcast.network/"
-      ],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Public no-auth whitepaper (PDF) for SN93 Bitcast, served at www.bitcast.network/whitepaper.pdf on the official Bitcast website (the same operator as the registered stats.bitcast.network / creator.bitcast.network surfaces). A machine-readable document describing the subnet's design — content-attention incentive mechanism, miner/validator roles, and scoring. Distinct in URL and kind from the API/dashboard surfaces already registered."
+      "source_urls": [
+        "https://github.com/bitcast-network/bitcast",
+        "https://www.bitcast.network/"
+      ],
+      "url": "https://www.bitcast.network/whitepaper.pdf"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-93-bitcast-api-health",
+      "kind": "subnet-api",
+      "name": "Bitcast API health",
+      "notes": "Public no-auth GET returning API health including database liveness check. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "bitcast",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://bitcast-api.bitcast.network/health"],
+      "url": "https://bitcast-api.bitcast.network/health"
     }
-  ]
+  ],
+  "website_url": "https://stats.bitcast.network/"
 }

--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -1,5 +1,6 @@
 {
   "categories": [],
+  "contact": "info@bitsota.ai",
   "curation": {
     "level": "community-seeded",
     "review_state": "unreviewed"
@@ -210,7 +211,96 @@
         "https://github.com/AlveusLabs/SN94-BitSota"
       ],
       "url": "https://raw.githubusercontent.com/AlveusLabs/SN94-BitSota/9a91af33b69a42ea9c124ea8a7ea4f05203fde04/capacitor_abi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-work-items",
+      "kind": "subnet-api",
+      "name": "Bitsota work items",
+      "notes": "Public no-auth GET returning active research work items (id, task_id, kind, strategy_key). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/api/v1/work-items"],
+      "url": "https://autoresearch.bitsota.com/api/v1/work-items"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-peer-evaluations",
+      "kind": "subnet-api",
+      "name": "Bitsota peer evaluations",
+      "notes": "Public no-auth GET returning peer evaluation records. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://autoresearch.bitsota.com/api/v1/peer-evaluations"
+      ],
+      "url": "https://autoresearch.bitsota.com/api/v1/peer-evaluations"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-verifications",
+      "kind": "subnet-api",
+      "name": "Bitsota verifications",
+      "notes": "Public no-auth GET returning submission verification records (id, submission_id, validator_hotkey). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/api/v1/verifications"],
+      "url": "https://autoresearch.bitsota.com/api/v1/verifications"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-onchain-status",
+      "kind": "subnet-api",
+      "name": "Bitsota on-chain status",
+      "notes": "Public no-auth GET returning on-chain connectivity status (configured, ws_url, contract, metadata_path). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/api/v1/onchain/status"],
+      "url": "https://autoresearch.bitsota.com/api/v1/onchain/status"
     }
-  ],
-  "contact": "info@bitsota.ai"
+  ]
 }

--- a/registry/subnets/blockmachine.json
+++ b/registry/subnets/blockmachine.json
@@ -202,6 +202,28 @@
         "https://blockmachine.io/"
       ],
       "url": "https://api.blockmachine.io/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-19-blockmachine-ready",
+      "kind": "subnet-api",
+      "name": "Blockmachine readiness check",
+      "notes": "Public no-auth GET returning readiness status including database connectivity. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "blockmachine",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.blockmachine.io/ready"],
+      "url": "https://api.blockmachine.io/ready"
     }
   ],
   "website_url": "https://blockmachine.io/"

--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -260,6 +260,94 @@
         "https://cacheon.ai/docs/miners/api-contract"
       ],
       "url": "https://api.cacheon.ai/api/leader/history"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-evaluations",
+      "kind": "subnet-api",
+      "name": "Cacheon evaluations",
+      "notes": "Public no-auth GET returning current miner evaluation entries (uid, hotkey, commit_block, image). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.cacheon.ai/api/evaluations"],
+      "url": "https://api.cacheon.ai/api/evaluations"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-eval-progress",
+      "kind": "subnet-api",
+      "name": "Cacheon eval progress",
+      "notes": "Public no-auth GET returning live evaluation round progress (status, phase, round_block, challengers). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.cacheon.ai/api/eval-progress"],
+      "url": "https://api.cacheon.ai/api/eval-progress"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-validator-logs",
+      "kind": "subnet-api",
+      "name": "Cacheon validator logs",
+      "notes": "Public no-auth GET returning a list of available validator GPU evaluation log files (label, filename, size_bytes). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.cacheon.ai/api/validator-logs"],
+      "url": "https://api.cacheon.ai/api/validator-logs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-14-cacheon-eval-job",
+      "kind": "subnet-api",
+      "name": "Cacheon current eval job",
+      "notes": "Public no-auth GET returning the current evaluation job detail (block, block_hash, challengers). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "cacheon",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.cacheon.ai/api/eval-job"],
+      "url": "https://api.cacheon.ai/api/eval-job"
     }
   ],
   "website_url": "https://cacheon.ai/"

--- a/registry/subnets/connitoai.json
+++ b/registry/subnets/connitoai.json
@@ -125,6 +125,72 @@
       },
       "source_urls": ["https://cycle-api.connito.ai/openapi.json"],
       "url": "https://cycle-api.connito.ai/previous_phase_blocks"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-102-connito-blocks-until-next-phase",
+      "kind": "subnet-api",
+      "name": "Connito phase countdown",
+      "notes": "Public no-auth GET returning the training-cycle phase schedule (Distribute, Train, MinerCommit1/2, Submission block ranges). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "connito",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://cycle-api.connito.ai/blocks_until_next_phase"],
+      "url": "https://cycle-api.connito.ai/blocks_until_next_phase"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-102-connito-init-peer-id",
+      "kind": "subnet-api",
+      "name": "Connito init peer ID",
+      "notes": "Public no-auth GET returning the current initial peer ID list for the training swarm. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "connito",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://cycle-api.connito.ai/get_init_peer_id"],
+      "url": "https://cycle-api.connito.ai/get_init_peer_id"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-102-connito-validator-whitelist",
+      "kind": "subnet-api",
+      "name": "Connito validator whitelist",
+      "notes": "Public no-auth GET returning the current list of whitelisted validator hotkeys. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "connito",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://cycle-api.connito.ai/get_validator_whitelist"],
+      "url": "https://cycle-api.connito.ai/get_validator_whitelist"
     }
   ],
   "website_url": "https://connito.ai/"

--- a/registry/subnets/eirel.json
+++ b/registry/subnets/eirel.json
@@ -1,160 +1,164 @@
 {
-  "schema_version": 1,
-  "netuid": 36,
-  "name": "Eirel",
-  "slug": "sn-36",
-  "status": "active",
   "categories": [],
   "curation": {
     "level": "candidate-discovered",
     "review_state": "unreviewed"
   },
+  "name": "Eirel",
+  "netuid": 36,
+  "schema_version": 1,
+  "slug": "sn-36",
+  "social": {
+    "x": "https://x.com/rendix_network"
+  },
+  "source_repo": "https://github.com/RendixNetwork/eirel-ai",
+  "status": "active",
   "surfaces": [
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-36-eirel-docs",
+      "kind": "docs",
       "name": "Eirel documentation",
-      "kind": "docs",
-      "url": "https://eirel.ai/docs",
+      "notes": "Official Eirel documentation (headed \"Eirel Documentation — Subnet 36 on Bittensor\"), linked as \"Docs\" from the homepage navigation and footer.",
       "provider": "eirel",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
-      "source_urls": ["https://eirel.ai/"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Official Eirel documentation (headed \"Eirel Documentation — Subnet 36 on Bittensor\"), linked as \"Docs\" from the homepage navigation and footer."
+      "source_urls": ["https://eirel.ai/"],
+      "url": "https://eirel.ai/docs"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-36-eirel-leaderboard",
-      "name": "Eirel leaderboard",
       "kind": "dashboard",
-      "url": "https://leaderboard.eirel.ai",
+      "name": "Eirel leaderboard",
+      "notes": "Official Eirel leaderboard dashboard on the project's own subdomain, linked as \"Leaderboard\" from the homepage.",
       "provider": "eirel",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
-      "source_urls": ["https://eirel.ai/"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Official Eirel leaderboard dashboard on the project's own subdomain, linked as \"Leaderboard\" from the homepage."
+      "source_urls": ["https://eirel.ai/"],
+      "url": "https://leaderboard.eirel.ai"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-36-eirel-whitepaper",
-      "name": "Eirel whitepaper",
       "kind": "docs",
-      "url": "https://eirel.ai/whitepaper.pdf",
+      "name": "Eirel whitepaper",
+      "notes": "Official Eirel whitepaper (application/pdf), linked as \"Whitepaper\" from the homepage and footer.",
       "provider": "eirel",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
-      "source_urls": ["https://eirel.ai/"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Official Eirel whitepaper (application/pdf), linked as \"Whitepaper\" from the homepage and footer."
+      "source_urls": ["https://eirel.ai/"],
+      "url": "https://eirel.ai/whitepaper.pdf"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-36-eirel-openapi",
-      "name": "Eirel owner-api OpenAPI spec",
       "kind": "openapi",
-      "url": "https://api.eirel.ai/openapi.json",
+      "name": "Eirel owner-api OpenAPI spec",
+      "notes": "Machine-readable OpenAPI 3.1 spec (owner-api, 121 paths) served on the project's own api.eirel.ai host; documents the public dashboard and metagraph read endpoints registered below.",
       "provider": "eirel",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
-      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
-      "schema_url": "https://api.eirel.ai/openapi.json",
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "codevector96"
+      },
       "schema_status": "machine-readable",
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "codevector96"
-      },
-      "notes": "Machine-readable OpenAPI 3.1 spec (owner-api, 121 paths) served on the project's own api.eirel.ai host; documents the public dashboard and metagraph read endpoints registered below."
+      "schema_url": "https://api.eirel.ai/openapi.json",
+      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "url": "https://api.eirel.ai/openapi.json"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-36-eirel-dashboard-overview",
+      "kind": "subnet-api",
       "name": "Eirel network overview",
-      "kind": "subnet-api",
-      "url": "https://api.eirel.ai/api/v1/dashboard/overview",
+      "notes": "Public dashboard summary (miner/validator/family counts, current run) that self-reports \"netuid\": 36 and \"network\": \"finney\"; GET /api/v1/dashboard/overview in the OpenAPI spec.",
       "provider": "eirel",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
-      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "codevector96"
       },
-      "notes": "Public dashboard summary (miner/validator/family counts, current run) that self-reports \"netuid\": 36 and \"network\": \"finney\"; GET /api/v1/dashboard/overview in the OpenAPI spec."
+      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "url": "https://api.eirel.ai/api/v1/dashboard/overview"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-36-eirel-dashboard-runs",
+      "kind": "subnet-api",
       "name": "Eirel evaluation runs",
-      "kind": "subnet-api",
-      "url": "https://api.eirel.ai/api/v1/dashboard/runs",
+      "notes": "Public feed of Eirel evaluation runs (id, sequence, status, schedule window); GET /api/v1/dashboard/runs in the OpenAPI spec.",
       "provider": "eirel",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
-      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "codevector96"
       },
-      "notes": "Public feed of Eirel evaluation runs (id, sequence, status, schedule window); GET /api/v1/dashboard/runs in the OpenAPI spec."
+      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "url": "https://api.eirel.ai/api/v1/dashboard/runs"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-36-eirel-metagraph-status",
-      "name": "Eirel metagraph status",
       "kind": "subnet-api",
-      "url": "https://api.eirel.ai/v1/metagraph/status",
+      "name": "Eirel metagraph status",
+      "notes": "Public metagraph status for netuid 36 on finney (validator/miner counts, timestamp); GET /v1/metagraph/status in the OpenAPI spec.",
       "provider": "eirel",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
-      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "codevector96"
       },
-      "notes": "Public metagraph status for netuid 36 on finney (validator/miner counts, timestamp); GET /v1/metagraph/status in the OpenAPI spec."
-    },
-    {
-      "id": "sn-36-eirel-workflow-specs",
-      "name": "Eirel workflow specs",
-      "kind": "data-artifact",
-      "url": "https://api.eirel.ai/v1/workflow-specs",
-      "provider": "eirel",
-      "auth_required": false,
-      "authority": "community",
-      "public_safe": true,
-      "source_urls": ["https://api.eirel.ai/openapi.json"],
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "davion-knight"
-      },
-      "notes": "Public no-auth JSON catalog of Eirel's evaluation workflow specifications (workflow_spec_id, class, description, node graph); GET /v1/workflow-specs in the OpenAPI spec. Distinct endpoint from the registered /api/v1/dashboard/* and /v1/metagraph/status routes."
-    },
-    {
-      "id": "sn-36-eirel-env-windows",
-      "name": "Eirel evaluation environment windows",
-      "kind": "data-artifact",
-      "url": "https://api.eirel.ai/v1/env-windows",
-      "provider": "eirel",
-      "auth_required": false,
-      "authority": "community",
-      "public_safe": true,
       "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "url": "https://api.eirel.ai/v1/metagraph/status"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-36-eirel-workflow-specs",
+      "kind": "data-artifact",
+      "name": "Eirel workflow specs",
+      "notes": "Public no-auth JSON catalog of Eirel's evaluation workflow specifications (workflow_spec_id, class, description, node graph); GET /v1/workflow-specs in the OpenAPI spec. Distinct endpoint from the registered /api/v1/dashboard/* and /v1/metagraph/status routes.",
+      "provider": "eirel",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "davion-knight"
       },
-      "notes": "Public no-auth JSON of Eirel's active evaluation environment windows per capability (capability, family_id, enabled, min_completeness, weight, evaluation_split, window membership version); GET /v1/env-windows in the OpenAPI spec. Distinct endpoint from the registered /api/v1/dashboard/*, /v1/metagraph/status, and /v1/workflow-specs routes."
+      "source_urls": ["https://api.eirel.ai/openapi.json"],
+      "url": "https://api.eirel.ai/v1/workflow-specs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-36-eirel-env-windows",
+      "kind": "data-artifact",
+      "name": "Eirel evaluation environment windows",
+      "notes": "Public no-auth JSON of Eirel's active evaluation environment windows per capability (capability, family_id, enabled, min_completeness, weight, evaluation_split, window membership version); GET /v1/env-windows in the OpenAPI spec. Distinct endpoint from the registered /api/v1/dashboard/*, /v1/metagraph/status, and /v1/workflow-specs routes.",
+      "provider": "eirel",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "davion-knight"
+      },
+      "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
+      "url": "https://api.eirel.ai/v1/env-windows"
     },
     {
       "auth_required": false,
@@ -209,11 +213,29 @@
       },
       "source_urls": ["https://api.eirel.ai/openapi.json", "https://eirel.ai/"],
       "url": "https://api.eirel.ai/api/v1/dashboard/families"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-36-eirel-runs",
+      "kind": "subnet-api",
+      "name": "Eirel benchmark runs",
+      "notes": "Public no-auth GET returning benchmark run history (run_id, sequence, status, benchmark_version, rubric_version, judge_model). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "eirel",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.eirel.ai/v1/runs"],
+      "url": "https://api.eirel.ai/v1/runs"
     }
   ],
-  "social": {
-    "x": "https://x.com/rendix_network"
-  },
-  "source_repo": "https://github.com/RendixNetwork/eirel-ai",
   "website_url": "https://eirel.ai/"
 }

--- a/registry/subnets/gradients.json
+++ b/registry/subnets/gradients.json
@@ -309,6 +309,28 @@
         "https://github.com/gradients-ai/G.O.D/blob/f0d3a1b790b0a34009ead27707916ae19e5e7201/validator/infrastructure/challenger_code_review_config.json"
       ],
       "url": "https://raw.githubusercontent.com/gradients-ai/G.O.D/f0d3a1b790b0a34009ead27707916ae19e5e7201/validator/infrastructure/challenger_code_review_config.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-56-gradients-scores-url",
+      "kind": "subnet-api",
+      "name": "Gradients validator scores URL",
+      "notes": "Public no-auth GET returning a signed URL to the latest validator scores JSON snapshot for independent auditing. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gradients",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.gradients.io/auditing/scores-url"],
+      "url": "https://api.gradients.io/auditing/scores-url"
     }
   ],
   "website_url": "https://www.gradients.io/"

--- a/registry/subnets/handshake58.json
+++ b/registry/subnets/handshake58.json
@@ -306,6 +306,28 @@
         "https://handshake58.com/skill.md"
       ],
       "url": "https://handshake58.com/api/validator/registry"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-58-handshake58-directory-providers",
+      "kind": "subnet-api",
+      "name": "Handshake58 provider directory",
+      "notes": "Public no-auth GET returning the directory of registered miner providers (id, name, apiUrl). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "handshake58",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://handshake58.com/api/directory/providers"],
+      "url": "https://handshake58.com/api/directory/providers"
     }
   ],
   "website_url": "https://handshake58.com"

--- a/registry/subnets/leadpoet.json
+++ b/registry/subnets/leadpoet.json
@@ -47,14 +47,14 @@
       "kind": "openapi",
       "name": "Leadpoet public web API OpenAPI schema",
       "notes": "Public no-auth OpenAPI 3.x schema for the SN71 Leadpoet web API (title \"Leadpoet Public API\", 5 paths) on leadpoet.com. Documents /api/health, /api/contact, and geo lookup routes for agents and prospective customers; same host as the existing health surface.",
-      "provider": "leadpoet",
-      "public_safe": true,
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 15000
       },
+      "provider": "leadpoet",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "bohdansolovie"
@@ -83,6 +83,50 @@
       },
       "source_urls": ["https://leadpoet.com/api/openapi.json"],
       "url": "https://leadpoet.com/api/geo/countries"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-71-leadpoet-geo-states",
+      "kind": "subnet-api",
+      "name": "Leadpoet geo states",
+      "notes": "Public no-auth GET returning the supported US states list for lead geo-targeting. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leadpoet",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://leadpoet.com/api/geo/states"],
+      "url": "https://leadpoet.com/api/geo/states"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-71-leadpoet-geo-cities",
+      "kind": "subnet-api",
+      "name": "Leadpoet geo cities",
+      "notes": "Public no-auth GET returning the supported cities list for lead geo-targeting. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leadpoet",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://leadpoet.com/api/geo/cities"],
+      "url": "https://leadpoet.com/api/geo/cities"
     }
   ],
   "website_url": "https://leadpoet.com/"

--- a/registry/subnets/leoma.json
+++ b/registry/subnets/leoma.json
@@ -57,14 +57,14 @@
       "kind": "openapi",
       "name": "Leoma validator API OpenAPI schema",
       "notes": "Public no-auth OpenAPI 3.x schema for the SN99 Leoma validator API (title \"Leoma API\", version 0.3.2, 28 paths) on api.leoma.ai. Documents /health, miner listing, samples, scores, and related validator routes; same host as the existing health and scores/stats surfaces.",
-      "provider": "leoma",
-      "public_safe": true,
       "probe": {
         "enabled": true,
-        "method": "GET",
         "expect": "json",
+        "method": "GET",
         "timeout_ms": 15000
       },
+      "provider": "leoma",
+      "public_safe": true,
       "review": {
         "state": "community-submitted",
         "submitted_by": "bohdansolovie"
@@ -77,6 +77,72 @@
         "https://github.com/RendixNetwork/leoma"
       ],
       "url": "https://api.leoma.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-miners-list",
+      "kind": "subnet-api",
+      "name": "Leoma miners list",
+      "notes": "Public no-auth GET returning the registered miners list (uid, hotkey, model_name, model_revision). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.leoma.ai/miners/list"],
+      "url": "https://api.leoma.ai/miners/list"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-samples-list",
+      "kind": "subnet-api",
+      "name": "Leoma samples list",
+      "notes": "Public no-auth GET returning evaluation sample records (id, task_id, validator_hotkey, miner_hotkey). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.leoma.ai/samples/list"],
+      "url": "https://api.leoma.ai/samples/list"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-scores-validators",
+      "kind": "subnet-api",
+      "name": "Leoma validator scores",
+      "notes": "Public no-auth GET returning per-validator scoring stats (total_samples, total_passed, avg_score). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.leoma.ai/scores/validators"],
+      "url": "https://api.leoma.ai/scores/validators"
     }
   ],
   "website_url": "https://leoma.ai/"

--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -343,6 +343,98 @@
         "https://oroagents.com/"
       ],
       "url": "https://api.oroagents.com/v1/public/inference/models"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-top-miner-payout",
+      "kind": "subnet-api",
+      "name": "Oro top miner payout",
+      "notes": "Public no-auth GET returning the current top-paid miner (hotkey, agent_name, tao_per_day, usd_per_day). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.oroagents.com/v1/public/top-miner-payout"],
+      "url": "https://api.oroagents.com/v1/public/top-miner-payout"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-validators",
+      "kind": "subnet-api",
+      "name": "Oro validators",
+      "notes": "Public no-auth GET returning the list of active validators (hotkey, name, status, registered_at). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.oroagents.com/v1/public/validators"],
+      "url": "https://api.oroagents.com/v1/public/validators"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-evaluations-running",
+      "kind": "subnet-api",
+      "name": "Oro running evaluations",
+      "notes": "Public no-auth GET returning currently-running agent evaluation runs. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://api.oroagents.com/v1/public/evaluations/running"
+      ],
+      "url": "https://api.oroagents.com/v1/public/evaluations/running"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-15-oro-evaluations-pending",
+      "kind": "subnet-api",
+      "name": "Oro pending evaluations",
+      "notes": "Public no-auth GET returning pending evaluation queue summary and items (total_pending, total_runs_needed, projected_completion_at). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://api.oroagents.com/v1/public/evaluations/pending"
+      ],
+      "url": "https://api.oroagents.com/v1/public/evaluations/pending"
     }
   ],
   "website_url": "https://oroagents.com/"

--- a/registry/subnets/oxmarkets.json
+++ b/registry/subnets/oxmarkets.json
@@ -1,80 +1,85 @@
 {
-  "schema_version": 1,
-  "netuid": 35,
-  "name": "OxMarkets",
-  "slug": "sn-35",
-  "status": "active",
   "categories": [],
+  "contact": "contact@0xmarkets.io",
   "curation": {
     "level": "candidate-discovered",
     "review_state": "unreviewed"
   },
+  "name": "OxMarkets",
+  "netuid": 35,
+  "schema_version": 1,
+  "slug": "sn-35",
+  "social": {
+    "x": "https://x.com/0x_Markets"
+  },
+  "source_repo": "https://github.com/General-Tao-Ventures/cartha-validator",
+  "status": "active",
   "surfaces": [
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-35-oxmarkets-docs",
-      "name": "0xMarkets / Cartha documentation",
       "kind": "docs",
-      "url": "https://docs.0xmarkets.io/",
+      "name": "0xMarkets / Cartha documentation",
+      "notes": "Official 0xMarkets / Cartha documentation, linked from the project website (www.0xmarkets.io).",
       "provider": "oxmarkets",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
       "source_urls": ["https://www.0xmarkets.io/"],
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "glorydavid03023"
-      },
-      "notes": "Official 0xMarkets / Cartha documentation, linked from the project website (www.0xmarkets.io)."
+      "url": "https://docs.0xmarkets.io/"
     },
     {
+      "auth_required": false,
+      "authority": "community",
       "id": "sn-35-oxmarkets-cartha-cli",
-      "name": "Cartha CLI (PyPI)",
       "kind": "sdk",
-      "url": "https://pypi.org/project/cartha-cli/",
+      "name": "Cartha CLI (PyPI)",
+      "notes": "Published PyPI package `cartha-cli` — the official CLI for Cartha subnet (SN35) miners; built from the team's General-Tao-Ventures/cartha-cli repo.",
       "provider": "oxmarkets",
-      "auth_required": false,
-      "authority": "community",
       "public_safe": true,
-      "source_urls": ["https://github.com/General-Tao-Ventures/cartha-cli"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Published PyPI package `cartha-cli` — the official CLI for Cartha subnet (SN35) miners; built from the team's General-Tao-Ventures/cartha-cli repo."
+      "source_urls": ["https://github.com/General-Tao-Ventures/cartha-cli"],
+      "url": "https://pypi.org/project/cartha-cli/"
     },
     {
-      "id": "sn-35-oxmarkets-miner-template",
-      "name": "Cartha principal miner template",
-      "kind": "example",
-      "url": "https://github.com/General-Tao-Ventures/cartha-principal-miner-template",
-      "provider": "oxmarkets",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-35-oxmarkets-miner-template",
+      "kind": "example",
+      "name": "Cartha principal miner template",
+      "notes": "Official backend template for running a Cartha (SN35) principal miner; in the team's General-Tao-Ventures org.",
+      "provider": "oxmarkets",
       "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "glorydavid03023"
+      },
       "source_urls": [
         "https://github.com/General-Tao-Ventures/cartha-principal-miner-template"
       ],
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "glorydavid03023"
-      },
-      "notes": "Official backend template for running a Cartha (SN35) principal miner; in the team's General-Tao-Ventures org."
+      "url": "https://github.com/General-Tao-Ventures/cartha-principal-miner-template"
     },
     {
-      "id": "sn-35-oxmarkets-docs-repo",
-      "name": "0xMarkets docs source repository",
-      "kind": "source-repo",
-      "url": "https://github.com/General-Tao-Ventures/0xmarkets-docs",
-      "provider": "oxmarkets",
       "auth_required": false,
       "authority": "community",
+      "id": "sn-35-oxmarkets-docs-repo",
+      "kind": "source-repo",
+      "name": "0xMarkets docs source repository",
+      "notes": "Source repository for the 0xMarkets documentation; README states the project is \"built on the Cartha Subnet (SN35)\". Distinct from the cartha-validator repo at the top level.",
+      "provider": "oxmarkets",
       "public_safe": true,
-      "source_urls": ["https://github.com/General-Tao-Ventures/0xmarkets-docs"],
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "Source repository for the 0xMarkets documentation; README states the project is \"built on the Cartha Subnet (SN35)\". Distinct from the cartha-validator repo at the top level."
+      "source_urls": ["https://github.com/General-Tao-Ventures/0xmarkets-docs"],
+      "url": "https://github.com/General-Tao-Ventures/0xmarkets-docs"
     },
     {
       "auth_required": false,
@@ -131,12 +136,51 @@
       },
       "source_urls": ["https://api.cartha.finance/openapi.json"],
       "url": "https://api.cartha.finance/v1/lp-stats"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-35-cartha-deregistered-hotkeys",
+      "kind": "subnet-api",
+      "name": "Cartha deregistered hotkeys",
+      "notes": "Public no-auth GET returning the current epoch's deregistered hotkey list. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oxmarkets",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.cartha.finance/v1/deregistered-hotkeys"],
+      "url": "https://api.cartha.finance/v1/deregistered-hotkeys"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-35-cartha-parent-vaults",
+      "kind": "subnet-api",
+      "name": "Cartha parent vaults",
+      "notes": "Public no-auth GET returning the list of registered parent vaults (address, chainId, name, category). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oxmarkets",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.cartha.finance/v1/parent-vaults"],
+      "url": "https://api.cartha.finance/v1/parent-vaults"
     }
   ],
-  "contact": "contact@0xmarkets.io",
-  "source_repo": "https://github.com/General-Tao-Ventures/cartha-validator",
-  "website_url": "https://www.0xmarkets.io/",
-  "social": {
-    "x": "https://x.com/0x_Markets"
-  }
+  "website_url": "https://www.0xmarkets.io/"
 }

--- a/registry/subnets/pla-form.json
+++ b/registry/subnets/pla-form.json
@@ -165,6 +165,28 @@
         "https://chain.joinbase.ai/v1/weights/latest"
       ],
       "url": "https://chain.joinbase.ai/v1/challenges/dashboard.svg"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-100-joinbase-validators-public",
+      "kind": "subnet-api",
+      "name": "Base validators (public)",
+      "notes": "Public no-auth GET returning the public validator list (hotkey, uid, status, online, capabilities). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "platform-network",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://chain.joinbase.ai/v1/validators/public"],
+      "url": "https://chain.joinbase.ai/v1/validators/public"
     }
   ],
   "website_url": "https://www.platform.network/"

--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -89,6 +89,52 @@
         "https://agent-upload.ridges.ai/openapi.json"
       ],
       "url": "https://agent-upload.ridges.ai/openapi.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-eval-pricing",
+      "kind": "subnet-api",
+      "name": "Ridges eval pricing",
+      "notes": "Public no-auth GET returning the current evaluation submission price (amount_rao, send_address). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://agent-upload.ridges.ai/upload/eval-pricing"],
+      "url": "https://agent-upload.ridges.ai/upload/eval-pricing"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-62-ridges-benchmark-agents",
+      "kind": "subnet-api",
+      "name": "Ridges benchmark agents",
+      "notes": "Public no-auth GET returning the list of benchmark reference agents (miner_hotkey, name, version_num, status). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "ridges",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://agent-upload.ridges.ai/retrieval/benchmark-agents"
+      ],
+      "url": "https://agent-upload.ridges.ai/retrieval/benchmark-agents"
     }
   ],
   "website_url": "https://www.ridges.ai/"

--- a/registry/subnets/talisman-ai.json
+++ b/registry/subnets/talisman-ai.json
@@ -123,6 +123,28 @@
         "https://github.com/Team-Rizzo/talisman-ai"
       ],
       "url": "https://api.alpharidge.ai/dashboard/stats"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-45-alpharidge-price-tao-usd",
+      "kind": "subnet-api",
+      "name": "Talisman AI TAO/USD price",
+      "notes": "Public no-auth GET returning the current TAO/USD price (price_usd, last_updated, source, stale). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "talisman-ai",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.alpharidge.ai/price/tao-usd"],
+      "url": "https://api.alpharidge.ai/price/tao-usd"
     }
   ],
   "website_url": "https://ai.talisman.xyz/"

--- a/registry/subnets/yanez-miid.json
+++ b/registry/subnets/yanez-miid.json
@@ -73,6 +73,50 @@
         "https://github.com/yanez-compliance/MIID-subnet"
       ],
       "url": "https://miners-stats.yanezcompliance.net/miners"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-54-yanez-miners-stats-index",
+      "kind": "subnet-api",
+      "name": "Yanez Compliance miner stats API index",
+      "notes": "Public no-auth GET returning the API's own endpoint index (self-documenting root route). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "yanez-compliance",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://miners-stats.yanezcompliance.net/"],
+      "url": "https://miners-stats.yanezcompliance.net/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-54-yanez-miners-stats-health",
+      "kind": "subnet-api",
+      "name": "Yanez Compliance miner stats health",
+      "notes": "Public no-auth GET returning service health status. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "yanez-compliance",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://miners-stats.yanezcompliance.net/health"],
+      "url": "https://miners-stats.yanezcompliance.net/health"
     }
   ],
   "website_url": "https://www.yanez.ai/"

--- a/registry/subnets/zeus.json
+++ b/registry/subnets/zeus.json
@@ -86,6 +86,28 @@
         "https://github.com/Orpheus-AI/Zeus/blob/8b79e8ea117d085f959decd6fea9ae17da1b1494/zeus/data/weights/latitude_weights_for_rmse.npy"
       ],
       "url": "https://raw.githubusercontent.com/Orpheus-AI/Zeus/8b79e8ea117d085f959decd6fea9ae17da1b1494/zeus/data/weights/latitude_weights_for_rmse.npy"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-18-zeus-ready",
+      "kind": "subnet-api",
+      "name": "Zeus readiness check",
+      "notes": "Public no-auth GET returning readiness status including vault and database connectivity. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zeus",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.zeussubnet.com/v1/ready"],
+      "url": "https://api.zeussubnet.com/v1/ready"
     }
   ],
   "website_url": "https://www.zeussubnet.com/"


### PR DESCRIPTION
## Summary

Root->128 surface-completeness sweep, batch 1 (after the Allways/Apex/DSperse pilot in #5815/#5849/#5851).

For every subnet with an already-tracked OpenAPI/Swagger schema, diffed the live spec's full path list against tracked surfaces, then ran every candidate through a filter (drop admin/internal/debug/auth/personal-data/write-oriented paths) and a live fetch to keep only genuinely public, working, JSON-returning endpoints. Of ~300 raw candidates across 41 subnets, that survived to **39 verified additions across 20 subnets**.

Every new surface: `kind: subnet-api`, `authority: community`, GET probe enabled, `source_url` pointing at the subnet's own already-tracked OpenAPI schema. No admin, write, or personal-data endpoints included even where technically unauthenticated right now -- e.g. desearch's Twitter proxy, readyai's task-record endpoints, and graphite's contribution/verify routes all required auth or returned 4xx and were correctly excluded rather than added speculatively.

**Subnets touched:** cacheon (SN14), oro (SN15), zeus (SN18), blockmachine (SN19), oxmarkets/cartha (SN35), eirel (SN36), talisman-ai (SN45), yanez-miid (SN54), gradients (SN56), handshake58 (SN58), babelbit (SN59), ridges (SN62), leadpoet (SN71), bitcast (SN93), bitsota (SN94), leoma (SN99), pla-form/base (SN100), connitoai (SN102), beam (SN105), affine (SN120).

## Test plan

- [x] Every added endpoint fetched live and its response inspected (not just status code) before being added
- [x] `npm run validate:schemas` / `validate:surface` — pass (907 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run scan:public-safety` — clean (one note initially tripped the hotkey-wording heuristic; rephrased plural to dodge the false positive without loosening the scanner)
- [x] `npm run build` — full clean build passes