### PR TITLE
feat(registry): Numinous (SN6) accuracy pass -- document untracked API scope

### DIFF
--- a/registry/subnets/numinous.json
+++ b/registry/subnets/numinous.json
@@ -24,7 +24,7 @@
   "docs_url": "https://api.numinouslabs.io/api/docs",
   "name": "Numinous",
   "netuid": 6,
-  "notes": "Reviewed overlay for SN6 Numinous. The public API exposes Swagger UI, a machine-readable OpenAPI 3.1 schema, and a read-only health endpoint.",
+  "notes": "Reviewed overlay for SN6 Numinous. The public API exposes Swagger UI, a machine-readable OpenAPI 3.1 schema, and a read-only health endpoint. The OpenAPI schema documents 20 total paths; 3 are tracked here (health, leaderboard, benchmarks/baseline). Of the remaining 17: 3 explicitly require an API key (forecasters/predictions, internal/liveuamap/events, internal/liveuamap/regions) and are correctly gated; the other 14 are per-miner (miner_uid + miner_hotkey, sometimes also event_id/version_id/run_id) or per-query (free-text \"question\") lookups with no stable canonical parameter value to probe against -- unlike this file's leaderboard/benchmarks endpoints, which need none. Not tracked as surfaces: a hardcoded miner_uid would silently go stale the moment that specific miner deregisters, misrepresenting an API problem that doesn't exist.",
   "schema_version": 1,
   "slug": "numinous",
   "social": {
@@ -169,6 +169,7 @@
       "id": "sn-6-numinous-data-artifact",
       "kind": "data-artifact",
       "name": "Numinous community data-artifact",
+      "notes": "Public no-auth GET returning a daily time series comparing baseline vs. top-miner forecasting performance (Brier score, 7-day moving average, accuracy) split by track (main/signal). Documented as 'Get Baseline Benchmark' in the Numinous OpenAPI schema.",
       "probe": {
         "enabled": true,
         "expect": "any",


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- Fetched and diffed the tracked OpenAPI schema (`api.numinouslabs.io/api/openapi.json`) against tracked surfaces: 20 total paths, 3 already tracked (health, leaderboard, benchmarks/baseline).
- Of the remaining 17: **3 explicitly require an API key** per the schema's own per-endpoint security override (`forecasters/predictions`, `internal/liveuamap/events`, `internal/liveuamap/regions`) -- correctly excluded, not a gap. The other **14 are per-miner or per-query lookups** with no stable canonical parameter value to probe against -- confirmed live with a real miner_uid/hotkey pulled from the leaderboard, unlike this file's existing leaderboard/benchmarks endpoints, which need zero parameters. Not tracked as surfaces: a hardcoded `miner_uid` would silently go stale the moment that specific miner deregisters, misrepresenting an API problem that doesn't exist.
- Documented this investigation in `notes` so a future audit pass doesn't redo it from scratch.
- Added a missing `notes` field to the `benchmarks/baseline` data-artifact surface (had none, unlike its siblings) describing what it actually returns.
- All 7 pre-existing surface URLs re-verified live (HTTP 200) before this pass -- none needed fixing. `gap_notes` were already accurate, no changes needed.

## Test plan

- [x] `npm run validate:schemas` — passes
- [x] `npm run validate:surface` — passes (869 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] Every existing surface URL live-tested individually
- [x] All 17 untracked OpenAPI paths individually reviewed for auth requirements and parameter stability