### PR TITLE
feat(graphql): add Query.sudo_key, mirroring REST /api/v1/sudo/key

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -85,6 +85,7 @@ import { buildBlocksSummary } from "./blocks-summary.mjs";
 import { buildChainYield } from "./chain-yield.mjs";
 import { loadSubnetRecycled, isU16Netuid } from "./subnet-recycled.mjs";
 import { loadAccountBalance, isFinneySs58Address } from "./account-balance.mjs";
+import { loadSudoKey } from "./sudo-key.mjs";
 import {
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
@@ -329,6 +330,8 @@ export const SDL = `
     subnet_recycled(netuid: Int!): SubnetRecycled
     "Live free+reserved balance in TAO for one Finney ss58 account, read directly from chain via RPC (KV-cached, not the Postgres tier). balance_tao is null on RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/accounts/{ss58}/balance."
     account_balance(ss58: String!): AccountBalance
+    "The network's on-chain sudo (superuser) key hotkey, read live from chain via RPC (not the Postgres tier). hotkey is null on RPC failure or a renounced sudo, schema-stable, never a GraphQL error. Mirrors GET /api/v1/sudo/key."
+    sudo_key: SudoKey
   }
 
   type SubnetList {
@@ -1310,6 +1313,13 @@ export const SDL = `
     queried_at: String!
   }
 
+  "The network's on-chain sudo (superuser) key, read live from chain via RPC. hotkey is null on RPC failure or a renounced sudo (schema-stable). Mirrors GET /api/v1/sudo/key's data envelope."
+  type SudoKey {
+    schema_version: Int!
+    hotkey: String
+    queried_at: String!
+  }
+
   "Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary."
   type BlocksSummary {
     schema_version: Int!
@@ -1944,6 +1954,7 @@ export const FIELD_COMPLEXITY = {
   registry_leaderboards: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_recycled: LIVE_RPC_FIELD_COMPLEXITY,
   account_balance: LIVE_RPC_FIELD_COMPLEXITY,
+  sudo_key: LIVE_RPC_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -4360,6 +4371,15 @@ const rootValue = {
     // loadAccountBalance always sets schema_version/ss58/queried_at
     // unconditionally, so no `??` fallback is needed for those.
     return loadAccountBalance(context.env, ss58);
+  },
+
+  async sudo_key(_args, context) {
+    // Live chain RPC, not the Postgres tier -- reuses loadSudoKey's own KV
+    // cache/TTL, matching REST's sudo/key handler exactly. hotkey stays null
+    // on RPC failure or a renounced sudo (schema-stable), never a GraphQL
+    // error. loadSudoKey always sets schema_version/queried_at
+    // unconditionally, so no `??` fallback is needed for those.
+    return loadSudoKey(context.env);
   },
 };
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7758,6 +7758,74 @@ describe("graphql — chain_yield (Postgres-tier + cold-store fallback)", () => 
   });
 });
 
+describe("graphql — sudo_key (#5896, live chain RPC via sudo-key.mjs)", () => {
+  // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
+  // in tests/sudo-key.test.mjs.
+  function withFetchStub(stub, fn) {
+    const orig = globalThis.fetch;
+    globalThis.fetch = stub;
+    return Promise.resolve(fn()).finally(() => {
+      globalThis.fetch = orig;
+    });
+  }
+
+  test("resolves the sudo hotkey from a live RPC hit", async () => {
+    await withFetchStub(
+      async () => ({
+        ok: true,
+        json: async () => ({
+          jsonrpc: "2.0",
+          id: 1,
+          result: "0x" + "11".repeat(32), // a valid 32-byte AccountId32
+        }),
+      }),
+      async () => {
+        const { status, body } = await gql(
+          "{ sudo_key { schema_version hotkey queried_at } }",
+        );
+        assert.equal(status, 200);
+        assert.equal(body.errors, undefined);
+        const r = body.data.sudo_key;
+        assert.equal(r.schema_version, 1);
+        assert.equal(typeof r.hotkey, "string");
+        assert.ok(r.hotkey.length > 0);
+        assert.ok(r.queried_at);
+      },
+    );
+  });
+
+  test("RPC failure degrades hotkey to null, never a GraphQL error", async () => {
+    await withFetchStub(
+      async () => {
+        throw new Error("network unreachable");
+      },
+      async () => {
+        const { status, body } = await gql(
+          "{ sudo_key { schema_version hotkey queried_at } }",
+        );
+        assert.equal(status, 200);
+        assert.equal(body.errors, undefined);
+        const r = body.data.sudo_key;
+        assert.equal(r.schema_version, 1);
+        assert.equal(r.hotkey, null);
+        assert.ok(r.queried_at);
+      },
+    );
+  });
+
+  test("a renounced sudo (null storage) resolves hotkey to null without error", async () => {
+    await withFetchStub(
+      async () => ({ ok: true, json: async () => ({ result: null }) }),
+      async () => {
+        const { status, body } = await gql("{ sudo_key { hotkey } }");
+        assert.equal(status, 200);
+        assert.equal(body.errors, undefined);
+        assert.equal(body.data.sudo_key.hotkey, null);
+      },
+    );
+  });
+});
+
 describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled.mjs)", () => {
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
   // in tests/subnet-recycled.test.mjs.


### PR DESCRIPTION
Closes #5896

Adds `Query.sudo_key` to the GraphQL SDL, mirroring the existing `GET /api/v1/sudo/key` REST route (`workers/data-api.mjs`) and the `get_sudo_key` MCP tool.

- Reuses the existing `loadSudoKey` from `src/sudo-key.mjs` — the same live-chain-RPC loader (with its own KV cache/TTL) the REST handler uses — so the field is a faithful mirror with no new data path.
- `sudo_key: SudoKey` takes no arguments (network-wide). The `SudoKey` type mirrors the loader's envelope: `schema_version: Int!`, `hotkey: String` (the sudo superuser key ss58; null on RPC failure or a renounced sudo — schema-stable, never a GraphQL error), and `queried_at: String!`.
- Registered under `LIVE_RPC_FIELD_COMPLEXITY`, matching the sibling live-RPC field `subnet_recycled`.

Tests cover a live RPC hit, an RPC failure (`hotkey` → null, no GraphQL error), and a renounced sudo (null storage → `hotkey` null).
