### PR TITLE
feat(mcp): add query_graphql bridge tool for /api/v1/graphql

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -40,6 +40,7 @@ import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { d1TimeoutMs, withTimeout } from "../workers/storage.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 import { handleRpcProxyRequest } from "../workers/request-handlers/rpc-proxy.mjs";
+import { handleGraphQLRequest } from "./graphql.mjs";
 import {
   isValidSubscriptionId,
   subscriptionStorageKey,
@@ -9111,6 +9112,93 @@ export const MCP_TOOLS = [
         endpoint_id: response.headers.get("x-metagraph-rpc-endpoint-id"),
         provider: response.headers.get("x-metagraph-rpc-provider"),
         cache: response.headers.get("x-metagraph-rpc-cache"),
+      };
+    },
+  },
+  {
+    name: "query_graphql",
+    title: "Run a GraphQL query",
+    description:
+      "Execute an arbitrary read-only GraphQL query against the metagraph " +
+      "GraphQL API (POST /api/v1/graphql) and return its { data, errors } " +
+      "result. Prefer this over the individual REST-mirrored tools (get_subnet, " +
+      "list_subnets, etc.) when you need arbitrary field selection or nested " +
+      "relations resolved in ONE round-trip; prefer a dedicated tool for a " +
+      "single well-known lookup. The endpoint is query-only (no mutations) and " +
+      "enforces the same depth (max 7) and complexity (max 50) limits as the " +
+      "REST GraphQL endpoint -- a query that exceeds them is rejected. Pass the " +
+      "query string in `query` and any GraphQL variables as an object in " +
+      "`variables`.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description:
+            "The GraphQL query document, e.g. '{ subnet(netuid: 1) { name } }'.",
+        },
+        variables: {
+          type: "object",
+          description:
+            "Optional GraphQL variables keyed by name, e.g. { netuid: 1 }.",
+          additionalProperties: true,
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        data: {
+          type: "object",
+          description: "The query result, or null when the query errored.",
+          additionalProperties: true,
+          nullable: true,
+        },
+        errors: {
+          type: "array",
+          description:
+            "GraphQL errors (validation, depth/complexity, or resolver), when any.",
+          items: { type: "object", additionalProperties: true },
+        },
+      },
+      additionalProperties: true,
+    },
+    async handler(args, ctx) {
+      const query = requireString(args, "query");
+      if (
+        args?.variables !== undefined &&
+        (typeof args.variables !== "object" ||
+          args.variables === null ||
+          Array.isArray(args.variables))
+      ) {
+        throw toolError(
+          "invalid_params",
+          "Argument `variables`, when present, must be an object.",
+        );
+      }
+      // Forward through the SAME handler REST callers hit, so the depth and
+      // complexity validation rules (and any other GraphQL-side protection)
+      // apply identically -- this tool cannot bypass them. The MCP path already
+      // ran enforceMcpRateLimit before dispatch, so no extra limiter is needed.
+      const gqlRequest = new Request("https://d/api/v1/graphql", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query, variables: args?.variables }),
+      });
+      const response = await handleGraphQLRequest(gqlRequest, ctx.env);
+      // The POST path of handleGraphQLRequest always returns a JSON body -- the
+      // execution result on success, or an errors[] envelope on a parse /
+      // validation / depth-complexity failure -- so no non-JSON guard is needed.
+      const payload = await response.json();
+      // A malformed/oversized query is a non-2xx with a populated errors[]; a
+      // valid query that resolves to GraphQL-level errors is a 200 with errors[].
+      // Both are surfaced to the agent as { data, errors } rather than thrown,
+      // so it can read partial data and the error detail together.
+      return {
+        data: payload?.data ?? null,
+        errors: payload?.errors ?? [],
       };
     },
   },

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -39,7 +39,10 @@ import { DAY_PATTERN } from "../workers/request-params.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { d1TimeoutMs, withTimeout } from "../workers/storage.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
-import { handleRpcProxyRequest } from "../workers/request-handlers/rpc-proxy.mjs";
+import {
+  handleRpcProxyRequest,
+  graphqlRateLimited,
+} from "../workers/request-handlers/rpc-proxy.mjs";
 import { handleGraphQLRequest } from "./graphql.mjs";
 import {
   isValidSubscriptionId,
@@ -9180,13 +9183,28 @@ export const MCP_TOOLS = [
       }
       // Forward through the SAME handler REST callers hit, so the depth and
       // complexity validation rules (and any other GraphQL-side protection)
-      // apply identically -- this tool cannot bypass them. The MCP path already
-      // ran enforceMcpRateLimit before dispatch, so no extra limiter is needed.
+      // apply identically -- this tool cannot bypass them. cf-connecting-ip is
+      // forged from ctx.clientIp (the real inbound caller) so the GraphQL rate
+      // limiter below keys on that caller, not this synthetic request.
       const gqlRequest = new Request("https://d/api/v1/graphql", {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          "cf-connecting-ip": ctx.clientIp,
+        },
         body: JSON.stringify({ query, variables: args?.variables }),
       });
+      // Apply the SAME per-client GraphQL rate limiter the REST route runs
+      // before handleGraphQLRequest, so this bridge is throttled identically
+      // and cannot bypass GraphQL-specific limits (in addition to the MCP-path
+      // enforceMcpRateLimit that already ran before dispatch).
+      const limited = await graphqlRateLimited(gqlRequest, ctx.env);
+      if (limited) {
+        throw toolError(
+          "graphql_rate_limited",
+          "Too many GraphQL requests from this client; slow down.",
+        );
+      }
       const response = await handleGraphQLRequest(gqlRequest, ctx.env);
       // The POST path of handleGraphQLRequest always returns a JSON body -- the
       // execution result on success, or an errors[] envelope on a parse /

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5860,6 +5860,26 @@ describe("MCP query_graphql (#5591 — GraphQL bridge tool)", () => {
     assert.ok(/too large/i.test(JSON.stringify(out.errors)));
   });
 
+  test("applies the GraphQL rate limiter, surfacing a throttle as an error (never bypassing it)", async () => {
+    // A saturated RPC_RATE_LIMITER makes graphqlRateLimited return its 429, so
+    // the bridge is throttled identically to the REST route rather than
+    // bypassing the GraphQL-specific per-client limit.
+    // Saturate only the GraphQL bucket (key `gql:*`); the MCP-dispatch limiter
+    // uses a different key and must still pass so the request reaches the tool.
+    const env = {
+      RPC_RATE_LIMITER: {
+        limit: async ({ key }) => ({ success: !key.startsWith("gql:") }),
+      },
+    };
+    const res = await callTool(
+      "query_graphql",
+      { query: "{ __typename }" },
+      { env },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.ok(/too many|rate/i.test(res.body.result.content[0].text));
+  });
+
   test("requires a non-empty query string", async () => {
     const res = await callTool("query_graphql", { query: "   " });
     assert.equal(res.body.result.isError, true);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -5797,6 +5797,85 @@ describe("MCP call_rpc", () => {
   });
 });
 
+describe("MCP query_graphql (#5591 — GraphQL bridge tool)", () => {
+  test("executes a query and returns { data, errors }", async () => {
+    const res = await callTool("query_graphql", { query: "{ __typename }" });
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError ?? false, false);
+    assert.deepEqual(out, { data: { __typename: "Query" }, errors: [] });
+  });
+
+  test("passes GraphQL variables through to the query", async () => {
+    const res = await callTool("query_graphql", {
+      query:
+        "query Q($netuid: Int!) { subnet_serving(netuid: $netuid) { netuid schema_version } }",
+      variables: { netuid: 7 },
+    });
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError ?? false, false);
+    assert.deepEqual(out.errors, []);
+    // Cold env (no Postgres flag) -> the resolver's schema-stable zeroed card.
+    assert.equal(out.data.subnet_serving.netuid, 7);
+    assert.equal(out.data.subnet_serving.schema_version, 1);
+  });
+
+  test("surfaces GraphQL validation errors as a populated errors[] (never bypassing the schema)", async () => {
+    const res = await callTool("query_graphql", {
+      query: "{ definitely_not_a_real_field }",
+    });
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError ?? false, false);
+    assert.equal(out.data, null);
+    assert.ok(Array.isArray(out.errors) && out.errors.length > 0);
+  });
+
+  test("a query that exceeds the complexity cap is rejected, proving the cap is reused", async () => {
+    // 11 aliased relationship fields (weight 5 each = 55) trip
+    // GRAPHQL_MAX_COMPLEXITY (50); the shared handler's maxComplexityRule
+    // rejects it, so the bridge can't bypass the GraphQL-side protection.
+    const aliases = Array.from(
+      { length: 11 },
+      (_unused, i) => `a${i}: subnet_serving(netuid: ${i}) { netuid }`,
+    ).join(" ");
+    const res = await callTool("query_graphql", { query: `{ ${aliases} }` });
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError ?? false, false);
+    assert.ok(Array.isArray(out.errors) && out.errors.length > 0);
+    assert.ok(/complex/i.test(JSON.stringify(out.errors)));
+  });
+
+  test("surfaces a non-2xx handler response (oversized query -> 413) as { data: null, errors[] }, never thrown", async () => {
+    // Pins the invariant the handler relies on: every handleGraphQLRequest path,
+    // including the non-2xx query-too-large (>16KB) response, returns a JSON
+    // errors[] body -- so the bridge shapes it into { data, errors } rather than
+    // throwing or dropping the error detail.
+    // Padded with a GraphQL comment (non-whitespace, so requireString's trim
+    // leaves it) to exceed GRAPHQL_MAX_QUERY_BYTES (16KB) -> the handler's 413.
+    const oversized = `{ __typename }\n#${"x".repeat(17000)}`;
+    const res = await callTool("query_graphql", { query: oversized });
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError ?? false, false);
+    assert.equal(out.data, null);
+    assert.ok(Array.isArray(out.errors) && out.errors.length > 0);
+    assert.ok(/too large/i.test(JSON.stringify(out.errors)));
+  });
+
+  test("requires a non-empty query string", async () => {
+    const res = await callTool("query_graphql", { query: "   " });
+    assert.equal(res.body.result.isError, true);
+    assert.ok(res.body.result.content[0].text.includes("query"));
+  });
+
+  test("rejects a non-object variables argument", async () => {
+    const res = await callTool("query_graphql", {
+      query: "{ __typename }",
+      variables: [1, 2, 3],
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.ok(res.body.result.content[0].text.includes("variables"));
+  });
+});
+
 describe("MCP get_account_counterparties", () => {
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
   const CP = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy";


### PR DESCRIPTION
Adds a read-only \`query_graphql\` MCP tool that bridges the GraphQL endpoint into MCP: an agent can run an arbitrary GraphQL query (with optional variables) and get the \`{ data, errors }\` result, covering what the individual REST-mirrored tools cannot express (arbitrary field selection, nested relations in one round-trip).

Closes #5591.

> Resubmit of #5804 (closed for a Superagent P2). **Fixed:** the tool now applies the GraphQL-specific per-client rate limiter — it forwards \`ctx.clientIp\` as \`cf-connecting-ip\` and runs the same \`graphqlRateLimited\` guard the REST route applies before \`handleGraphQLRequest\`, so the bridge can no longer bypass GraphQL-side throttling. A test covers the throttle path.

## What
- New \`query_graphql\` tool in \`src/mcp-server.mjs\` (\`inputSchema\`: required \`query\` string + optional \`variables\` object; \`outputSchema\`: \`{ data, errors }\`).
- Forwards a synthetic \`POST /api/v1/graphql\` request to the same \`handleGraphQLRequest\` the REST route uses, so the endpoint's **depth (max 7)** and **complexity (max 50)** validation rules apply identically. Read-only (no mutations).
- **Rate limiting:** forwards \`ctx.clientIp\` and applies \`graphqlRateLimited\` before dispatch to the handler — the GraphQL-specific per-client throttle is enforced exactly as on the REST path (on top of the MCP-path \`enforceMcpRateLimit\`).
- Read-only annotations + untrusted-data note applied automatically; tool-count/spec-projection assertions track \`MCP_TOOLS.length\`. No version bumps (handled by \`sync-mcp-version\` post-merge).

## Tests
Eight cases in \`tests/mcp-server.test.mjs\`: successful query, variable passthrough, GraphQL validation error surfaced as \`errors[]\`, the complexity cap rejecting an 11-relationship-field query, the non-2xx (413 oversized) path surfaced as \`{ data: null, errors[] }\`, the **GraphQL rate limiter throttling the bridge**, and the malformed-query / non-object-variables guards. Full MCP suite green (1062 tests); \`scripts/validate-mcp.mjs\` passes (173 tools); new handler 100% covered (statements + branches).