### PR TITLE
chore(backend): remove unused IDENTITY_HISTORY_COLUMNS constant

### DIFF
--- a/src/subnet-identity-history.mjs
+++ b/src/subnet-identity-history.mjs
@@ -15,9 +15,6 @@ import {
 
 const D1_STATEMENTS_PER_BATCH = 100;
 
-export const IDENTITY_HISTORY_COLUMNS =
-  "id, netuid, block_number, observed_at, subnet_name, symbol, description, github_repo, subnet_url, discord, logo_url, identity_hash";
-
 const READ_COLUMNS =
   "id, block_number, observed_at, subnet_name, symbol, description, github_repo, subnet_url, discord, logo_url, identity_hash";
 


### PR DESCRIPTION
## Summary

Removes the dead `IDENTITY_HISTORY_COLUMNS` export from `src/subnet-identity-history.mjs`. It has **zero import sites** — the module's own `READ_COLUMNS` (which omits the `netuid` column) is the constant actually used for the identity-history timeline read, so `IDENTITY_HISTORY_COLUMNS` was a dead, shadowing declaration.

Verified zero references across the repo (`grep -rn IDENTITY_HISTORY_COLUMNS` matches only the removed definition). `tests/subnet-identity-history.test.mjs` (67 tests) passes, eslint + prettier clean.

Closes #5870