### PR TITLE
feat(registry): iota (SN9) accuracy pass -- add metrics + run-info surfaces

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 201,
+  "surface_count": 204,
   "surfaces": [
     {
       "auth_required": false,
@@ -950,6 +950,42 @@
     },
     {
       "auth_required": false,
+      "authority": "official",
+      "kind": "subnet-api",
+      "netuid": 9,
+      "probe": {
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "subnet_name": "iota",
+      "subnet_slug": "sn-9",
+      "surface_id": "sn-9-iota-metrics",
+      "surface_key": "srf-08b192cbe61bfd12",
+      "url": "https://iota.api.macrocosmos.ai/metrics"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subnet-api",
+      "netuid": 9,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "subnet_name": "iota",
+      "subnet_slug": "sn-9",
+      "surface_id": "sn-9-iota-run-info",
+      "surface_key": "srf-6ec629d96674b06d",
+      "url": "https://iota.api.macrocosmos.ai/common/get_run_info"
+    },
+    {
+      "auth_required": false,
       "authority": "community",
       "kind": "subnet-api",
       "netuid": 10,
@@ -1703,6 +1739,24 @@
       "surface_id": "sn-45-alpharidge-price-tao-usd",
       "surface_key": "srf-cf17396684e450d9",
       "url": "https://api.alpharidge.ai/price/tao-usd"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 46,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zipcode",
+      "public_safe": true,
+      "subnet_name": "Zipcode",
+      "subnet_slug": "sn-46",
+      "surface_id": "sn-46-zipcode-real-estate-validation-set",
+      "surface_key": "srf-be800cb48c735c6f",
+      "url": "https://zipcode.ai/api/dashboard/validation-set/real_estate/download"
     },
     {
       "auth_required": false,

--- a/registry/subnets/iota.json
+++ b/registry/subnets/iota.json
@@ -22,7 +22,7 @@
   "dashboard_url": "https://iota.macrocosmos.ai/dashboard/mainnet",
   "name": "iota",
   "netuid": 9,
-  "notes": "Reviewed overlay for SN9 using the official IOTA website, public dashboard, and source repository. The previously discovered Macrocosmos IOTA mining setup URL currently returns 404 and is intentionally not promoted.",
+  "notes": "Reviewed overlay for SN9 using the official IOTA website, public dashboard, and source repository. The previously discovered Macrocosmos IOTA mining setup URL currently returns 404 and is intentionally not promoted. The orchestrator OpenAPI schema documents 35 total paths; 5 are tracked here (healthcheck, openapi.json, metrics, run info) plus the codeparrot dataset. Of the rest: most are miner/validator protocol endpoints (register, submit_weights, heartbeat, and similar) meant for a specific registered hotkey, not public dashboard consumption -- global_miner_scores returned HTTP 400 unsigned, consistent with requiring Epistula request signing despite no OpenAPI-declared security scheme. get_run_epoch needs a specific run_id and isn't tracked for the same staleness reason as Numinous's (#5914) per-miner endpoints; get_run_info (tracked, zero params) is how a client discovers the current run_id instead.",
   "schema_version": 1,
   "slug": "sn-9",
   "source_repo": "https://github.com/macrocosm-os/iota",
@@ -136,6 +136,42 @@
       },
       "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
       "url": "https://iota.api.macrocosmos.ai/healthcheck"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-9-iota-metrics",
+      "kind": "subnet-api",
+      "name": "IOTA orchestrator Prometheus metrics",
+      "notes": "Public no-auth GET returning Prometheus text-exposition-format process/runtime metrics (python_gc_objects_collected_total and similar). Documented in the subnet's own OpenAPI schema (path /metrics); plain-text response, not JSON, so tracked with expect: any. Same pattern as the SN1 Apex orchestrator's own /metrics surface (same macrocosm-os org).",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
+      "url": "https://iota.api.macrocosmos.ai/metrics"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-9-iota-run-info",
+      "kind": "subnet-api",
+      "name": "IOTA training run info",
+      "notes": "Public no-auth GET /common/get_run_info on the IOTA orchestrator, returning the current decentralized pre-training run's configuration (run_id, num_miners, incentive_perc, run_flags) with no parameters required. Distinct from /common/get_run_epoch, which needs a specific run_id and is not tracked here since the current run_id changes over time (this endpoint is how a client discovers it).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "source_urls": ["https://iota.api.macrocosmos.ai/openapi.json"],
+      "url": "https://iota.api.macrocosmos.ai/common/get_run_info"
     }
   ],
   "website_url": "https://iota.macrocosmos.ai/"


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- Fetched and diffed the tracked orchestrator OpenAPI schema against tracked surfaces: 35 total paths, only `healthcheck` + `openapi.json` were tracked.
- Added **`/metrics`** (Prometheus text-exposition process metrics) -- exact precedent from the sibling SN1 Apex orchestrator's own `/metrics` surface (same macrocosm-os org, same orchestrator pattern).
- Added **`/common/get_run_info`** (current training run config: run_id, num_miners, incentive_perc, run_flags) -- zero parameters, stable.
- Reviewed the remaining ~30 paths: almost all are miner/validator protocol endpoints (register, submit_weights, heartbeat, submit_activation, and similar) meant for a specific registered hotkey, not public consumption. `global_miner_scores` returned HTTP 400 unsigned -- consistent with requiring Epistula request signing despite no OpenAPI-declared security scheme (none of these 35 paths declare one). `get_run_epoch` needs a specific `run_id` and isn't tracked for the same staleness reason as Numinous's (#5914) per-miner query params -- `get_run_info` (tracked) is how a client discovers the current run_id instead.
- All 5 pre-existing surfaces re-verified live (HTTP 200); the previously-404 docs URL gap note re-tested and still accurate.

## Test plan

- [x] `npm run validate:schemas` — passes
- [x] `npm run validate:surface` — passes (915 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] Every existing + new surface URL live-tested individually
- [x] All 35 OpenAPI paths individually reviewed for auth requirements and parameter fitness