### PR TITLE
feat(graphql): add Query.rpc_usage mirroring REST /rpc/usage and MCP get_rpc_usage

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -152,7 +152,12 @@ import {
 import { loadAccountIdentity } from "./account-identity.mjs";
 import { loadAccountIdentityHistory } from "./account-identity-history.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
-import { SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
+import {
+  ANALYTICS_WINDOWS,
+  DEFAULT_ANALYTICS_WINDOW,
+  SS58_ADDRESS_PATTERN,
+} from "../workers/config.mjs";
+import { loadRpcUsage } from "./rpc-usage-loader.mjs";
 import {
   parseHistoryWindow,
   unsupportedWindowMessage,
@@ -337,6 +342,8 @@ export const SDL = `
     chain_weight_setters(window: String, limit: Int): ChainWeightSetters!
     "Compact all-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history (probed every ~15 minutes); a cold store still returns both windows, schema-stable and zeroed, never a GraphQL error. Mirrors GET /api/v1/health/trends."
     health_trends: HealthTrends!
+    "RPC reverse-proxy usage analytics over a 7d/30d window (default 7d): total request volume, error + failover rates, cache-hit rate, latency p50/p95/avg, the per-endpoint and per-network request distribution, and bounded time buckets (1h for 7d, 6h for 30d), computed live from the rpc_proxy_events telemetry. A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/rpc/usage."
+    rpc_usage(window: String): RpcUsage!
     "Network-wide reward-distribution & score-spread card across every subnet's neurons: incentive/dividends concentration (who actually captures rewards network-wide) plus the trust/consensus/validator_trust score spread. Current snapshot only (no window/params). Every metric block is null (never a GraphQL error) on a cold store. The network analog of subnet_performance. Mirrors GET /api/v1/chain/performance."
     chain_performance: ChainPerformance!
     "Network-wide emission-yield (return rate) aggregated across every subnet's neurons -- the aggregate network return, the same split by validator vs miner role, and the distribution of the per-neuron return rate. Every aggregate is null (never a GraphQL error) on a cold store. Mirrors GET /api/v1/chain/yield."
@@ -744,6 +751,75 @@ export const SDL = `
     source: String
     "The 7d/30d windows keyed by window label (7d, 30d), each holding days/granularity/subnet_count and the per-subnet daily point series. Opaque JSON: dynamic-keyed by window label, matching the get_health_trends MCP/REST shape."
     windows: JSON!
+  }
+
+  "RPC reverse-proxy usage analytics over a 7d/30d window. Mirrors GET /api/v1/rpc/usage's data envelope."
+  type RpcUsage {
+    schema_version: Int!
+    window: String
+    "Time-bucket granularity for buckets: 1h for the 7d window, 6h for 30d. Null on a cold store."
+    bucket_granularity: String
+    observed_at: String
+    source: String
+    summary: RpcUsageSummary!
+    "Per-endpoint request distribution, ranked by request volume (top 50)."
+    endpoints: [RpcUsageEndpoint!]!
+    "Per-network request breakdown, ordered by request volume."
+    networks: [RpcUsageNetwork!]!
+    "Bounded time buckets over the window for heatmaps, oldest-first."
+    buckets: [RpcUsageBucket!]!
+  }
+
+  "Window-total rollup for RPC reverse-proxy traffic."
+  type RpcUsageSummary {
+    total_requests: Int!
+    ok_requests: Int!
+    error_requests: Int!
+    "Null when there are no requests in the window (no defined rate)."
+    error_rate: Float
+    failover_requests: Int!
+    "Null when there are no requests in the window."
+    failover_rate: Float
+    cache_hits: Int!
+    "Null when there are no requests in the window."
+    cache_hit_rate: Float
+    latency_ms: RpcUsageLatency!
+  }
+
+  "Window latency percentiles + average for RPC reverse-proxy traffic; each is null on a cold store."
+  type RpcUsageLatency {
+    p50: Int
+    p95: Int
+    avg: Int
+  }
+
+  "One endpoint's share of RPC reverse-proxy traffic in the window."
+  type RpcUsageEndpoint {
+    rank: Int!
+    endpoint_id: String
+    provider: String
+    requests: Int!
+    ok_requests: Int!
+    "Null when the endpoint had no requests in the window."
+    error_rate: Float
+    avg_latency_ms: Int
+  }
+
+  "One network's share of RPC reverse-proxy traffic in the window."
+  type RpcUsageNetwork {
+    network: String
+    requests: Int!
+    ok_requests: Int!
+    "Null when the network had no requests in the window."
+    error_rate: Float
+  }
+
+  "One bounded time bucket of RPC reverse-proxy traffic (bucket_granularity wide)."
+  type RpcUsageBucket {
+    ts: Float!
+    requests: Int!
+    errors: Int!
+    avg_latency_ms: Int
   }
 
   "Registry leaderboards over the operational + economic-opportunity boards. Mirrors GET /api/v1/registry/leaderboards."
@@ -2046,6 +2122,7 @@ export const FIELD_COMPLEXITY = {
   chain_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
+  rpc_usage: RELATIONSHIP_FIELD_COMPLEXITY,
   validator_nominators: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_performance: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_yield: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4430,6 +4507,58 @@ const rootValue = {
       observed_at: data.observed_at ?? null,
       source: data.source ?? null,
       windows: data.windows ?? {},
+    };
+  },
+
+  async rpc_usage({ window }, context) {
+    const requestedWindow = window ?? DEFAULT_ANALYTICS_WINDOW;
+    if (!Object.hasOwn(ANALYTICS_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(requestedWindow, ANALYTICS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    // Same tryPostgresTier(METAGRAPH_RPC_USAGE_SOURCE) -> loadRpcUsage fallback
+    // contract REST's handleRpcUsage and the get_rpc_usage MCP tool share -- a
+    // cold store yields a schema-stable zeroed card, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/rpc/usage", params),
+        "METAGRAPH_RPC_USAGE_SOURCE",
+      )) ??
+      (await loadRpcUsage(graphqlD1(context), {
+        window: requestedWindow,
+        observedAt: await loadObservedAt(context),
+      }));
+    const summary = data.summary ?? {};
+    const latency = summary.latency_ms ?? {};
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? requestedWindow,
+      bucket_granularity: data.bucket_granularity ?? null,
+      observed_at: data.observed_at ?? null,
+      source: data.source ?? null,
+      summary: {
+        total_requests: summary.total_requests ?? 0,
+        ok_requests: summary.ok_requests ?? 0,
+        error_requests: summary.error_requests ?? 0,
+        error_rate: summary.error_rate ?? null,
+        failover_requests: summary.failover_requests ?? 0,
+        failover_rate: summary.failover_rate ?? null,
+        cache_hits: summary.cache_hits ?? 0,
+        cache_hit_rate: summary.cache_hit_rate ?? null,
+        latency_ms: {
+          p50: latency.p50 ?? null,
+          p95: latency.p95 ?? null,
+          avg: latency.avg ?? null,
+        },
+      },
+      endpoints: data.endpoints ?? [],
+      networks: data.networks ?? [],
+      buckets: data.buckets ?? [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7502,6 +7502,291 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
   });
 });
 
+describe("graphql — rpc_usage (#5899, Postgres-tier + D1-live fallback)", () => {
+  function usageQuery(argsClause = "") {
+    return `{ rpc_usage${argsClause} {
+      schema_version window bucket_granularity observed_at source
+      summary {
+        total_requests ok_requests error_requests error_rate
+        failover_requests failover_rate cache_hits cache_hit_rate
+        latency_ms { p50 p95 avg }
+      }
+      endpoints { rank endpoint_id provider requests ok_requests error_rate avg_latency_ms }
+      networks { network requests ok_requests error_rate }
+      buckets { ts requests errors avg_latency_ms }
+    } }`;
+  }
+
+  // loadRpcUsage issues five parallel queries over rpc_proxy_events; the D1
+  // runner sees each SQL string, so route rows by the clause unique to each:
+  // the endpoint/network/bucket leaderboards GROUP BY their key, the latency
+  // query is the ROW_NUMBER percentile CTE, and the aggregate totals row has
+  // no GROUP BY at all.
+  function rpcUsageD1({
+    totals,
+    latency,
+    endpoints = [],
+    networks = [],
+    buckets = [],
+  } = {}) {
+    return {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              async all() {
+                if (sql.includes("GROUP BY endpoint_id")) {
+                  return { results: endpoints };
+                }
+                if (sql.includes("GROUP BY network")) {
+                  return { results: networks };
+                }
+                if (sql.includes("GROUP BY ts")) {
+                  return { results: buckets };
+                }
+                if (sql.includes("ROW_NUMBER")) {
+                  return { results: latency ? [latency] : [] };
+                }
+                return { results: totals ? [totals] : [] };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  test("cold store, default args: schema-stable zeroed card", async () => {
+    const { status, body } = await gql(usageQuery());
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.rpc_usage, {
+      schema_version: 1,
+      window: "7d",
+      bucket_granularity: "1h",
+      observed_at: null,
+      source: "rpc-proxy",
+      summary: {
+        total_requests: 0,
+        ok_requests: 0,
+        error_requests: 0,
+        error_rate: null,
+        failover_requests: 0,
+        failover_rate: null,
+        cache_hits: 0,
+        cache_hit_rate: null,
+        latency_ms: { p50: null, p95: null, avg: null },
+      },
+      endpoints: [],
+      networks: [],
+      buckets: [],
+    });
+  });
+
+  test("resolves Postgres-tier data for a valid non-default window, forwarding it as a query param", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_RPC_USAGE_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            bucket_granularity: "6h",
+            observed_at: "2026-07-10T00:00:00.000Z",
+            source: "rpc-proxy",
+            summary: {
+              total_requests: 100,
+              ok_requests: 95,
+              error_requests: 5,
+              error_rate: 0.05,
+              failover_requests: 3,
+              failover_rate: 0.03,
+              cache_hits: 40,
+              cache_hit_rate: 0.4,
+              latency_ms: { p50: 20, p95: 80, avg: 30 },
+            },
+            endpoints: [
+              {
+                rank: 1,
+                endpoint_id: "ep-a",
+                provider: "prov-a",
+                requests: 60,
+                ok_requests: 58,
+                error_rate: 0.0333,
+                avg_latency_ms: 25,
+              },
+            ],
+            networks: [
+              {
+                network: "finney",
+                requests: 100,
+                ok_requests: 95,
+                error_rate: 0.05,
+              },
+            ],
+            buckets: [
+              {
+                ts: 1_750_000_000_000,
+                requests: 10,
+                errors: 1,
+                avg_latency_ms: 22,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(usageQuery('(window: "30d")'), env);
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.pathname, "/api/v1/rpc/usage");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    const usage = body.data.rpc_usage;
+    assert.equal(usage.window, "30d");
+    assert.equal(usage.bucket_granularity, "6h");
+    assert.equal(usage.observed_at, "2026-07-10T00:00:00.000Z");
+    assert.equal(usage.summary.total_requests, 100);
+    assert.equal(usage.summary.error_rate, 0.05);
+    assert.equal(usage.summary.cache_hit_rate, 0.4);
+    assert.equal(usage.summary.latency_ms.p95, 80);
+    assert.equal(usage.endpoints[0].endpoint_id, "ep-a");
+    assert.equal(usage.endpoints[0].error_rate, 0.0333);
+    assert.equal(usage.networks[0].network, "finney");
+    assert.equal(usage.buckets[0].ts, 1_750_000_000_000);
+  });
+
+  test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
+    const env = {
+      METAGRAPH_RPC_USAGE_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(usageQuery(), env);
+    assert.equal(status, 200);
+    const usage = body.data.rpc_usage;
+    assert.equal(usage.schema_version, 1);
+    assert.equal(usage.window, "7d");
+    assert.equal(usage.bucket_granularity, null);
+    assert.equal(usage.observed_at, null);
+    assert.equal(usage.source, null);
+    assert.deepEqual(usage.summary, {
+      total_requests: 0,
+      ok_requests: 0,
+      error_requests: 0,
+      error_rate: null,
+      failover_requests: 0,
+      failover_rate: null,
+      cache_hits: 0,
+      cache_hit_rate: null,
+      latency_ms: { p50: null, p95: null, avg: null },
+    });
+    assert.deepEqual(usage.endpoints, []);
+    assert.deepEqual(usage.networks, []);
+    assert.deepEqual(usage.buckets, []);
+  });
+
+  test("no Postgres tier flag: computes the card straight off the rpc_proxy_events D1 telemetry", async () => {
+    const env = {
+      METAGRAPH_RPC_USAGE_SOURCE: "d1",
+      METAGRAPH_HEALTH_DB: rpcUsageD1({
+        totals: {
+          total: 200,
+          ok_count: 190,
+          failover_count: 8,
+          cache_hits: 120,
+          avg_latency_ms: 27,
+        },
+        latency: { p50: 18, p95: 70 },
+        endpoints: [
+          {
+            endpoint_id: "ep-1",
+            provider: "prov-1",
+            requests: 120,
+            ok_count: 116,
+            avg_latency_ms: 24,
+          },
+        ],
+        networks: [{ network: "finney", requests: 200, ok_count: 190 }],
+        buckets: [
+          {
+            ts: 1_750_000_000_000,
+            requests: 30,
+            errors: 2,
+            avg_latency_ms: 26,
+          },
+        ],
+      }),
+    };
+    const { status, body } = await gql(usageQuery('(window: "7d")'), env);
+    assert.equal(status, 200);
+    const usage = body.data.rpc_usage;
+    assert.equal(usage.window, "7d");
+    assert.equal(usage.bucket_granularity, "1h");
+    assert.equal(usage.source, "rpc-proxy");
+    assert.equal(usage.summary.total_requests, 200);
+    assert.equal(usage.summary.ok_requests, 190);
+    assert.equal(usage.summary.error_requests, 10);
+    assert.equal(usage.summary.error_rate, 0.05);
+    assert.equal(usage.summary.failover_requests, 8);
+    assert.equal(usage.summary.cache_hits, 120);
+    assert.equal(usage.summary.cache_hit_rate, 0.6);
+    assert.equal(usage.summary.latency_ms.p50, 18);
+    assert.equal(usage.summary.latency_ms.p95, 70);
+    assert.equal(usage.summary.latency_ms.avg, 27);
+    assert.equal(usage.endpoints[0].rank, 1);
+    assert.equal(usage.endpoints[0].endpoint_id, "ep-1");
+    assert.equal(usage.endpoints[0].error_rate, 0.0333);
+    assert.equal(usage.networks[0].network, "finney");
+    assert.equal(usage.networks[0].error_rate, 0.05);
+    assert.equal(usage.buckets[0].requests, 30);
+    assert.equal(usage.buckets[0].errors, 2);
+  });
+
+  test("observed_at is stamped from the health:meta KV freshness on the D1-live path", async () => {
+    const env = {
+      METAGRAPH_CONTROL: {
+        async get(key) {
+          return key === KV_HEALTH_META
+            ? { last_run_at: "2026-06-23T00:00:00.000Z" }
+            : null;
+        },
+      },
+      METAGRAPH_HEALTH_DB: rpcUsageD1(),
+    };
+    const { body } = await gql(usageQuery(), env);
+    assert.equal(body.data.rpc_usage.observed_at, "2026-06-23T00:00:00.000Z");
+  });
+
+  test("a D1 query error degrades to a schema-stable zeroed card (no throw)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          throw new Error("db unavailable");
+        },
+      },
+    };
+    const { status, body } = await gql(usageQuery(), env);
+    assert.equal(status, 200);
+    assert.equal(body.data.rpc_usage.summary.total_requests, 0);
+    assert.deepEqual(body.data.rpc_usage.endpoints, []);
+    assert.deepEqual(body.data.rpc_usage.buckets, []);
+  });
+
+  test("an unsupported window is a GraphQL error, not a silently substituted default", async () => {
+    const { status, body } = await gql(usageQuery('(window: "99d")'));
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    const err = body.errors.find(
+      (e) => e.extensions?.code === "BAD_USER_INPUT",
+    );
+    assert.ok(err);
+    assert.match(err.message, /99d/);
+  });
+
+  test("rpc_usage is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.rpc_usage, 5);
+  });
+});
+
 describe("Subscription.chainEvents", () => {
   test("yields a properly-shaped GraphQL execution result for each pushed payload", async () => {
     const hub = fakeChainFirehose((repeater) => {


### PR DESCRIPTION
## What

Adds `Query.rpc_usage` to the GraphQL SDL, closing the REST/GraphQL/MCP parity
gap for RPC reverse-proxy usage analytics. `GET /api/v1/rpc/usage` and the
`get_rpc_usage` MCP tool already exist; GraphQL had no mirror.

## How

The resolver reuses the exact same data path REST's `handleRpcUsage`
(`workers/request-handlers/rpc-proxy.mjs`) and the `get_rpc_usage` MCP tool
already share — no query/aggregation logic is duplicated:

```
tryPostgresTier(METAGRAPH_RPC_USAGE_SOURCE)  ??  loadRpcUsage(d1, { window, observedAt })
```

Both tiers return the same `formatRpcUsage` envelope, so a cold store yields a
schema-stable zeroed card rather than a GraphQL error. `window` is validated
against the module's own `ANALYTICS_WINDOWS` (7d/30d, default 7d) — an
unsupported window is a `BAD_USER_INPUT` error, matching REST's 400 rather than
silently substituting the default. The field follows the same shape as the
sibling `Query.chain_serving` / `Query.health_trends` resolvers and is weighted
as a fan-out field in `FIELD_COMPLEXITY`.

`bucket.ts` is typed `Float!` (epoch-ms exceeds GraphQL's 32-bit `Int`), matching
the underlying `formatRpcUsage` payload.

## Tests

`tests/graphql.test.mjs` gains a `rpc_usage` block covering: cold-store zeroed
card, Postgres-tier resolution with `window` forwarded as a query param, a
malformed Postgres body falling back to schema-stable defaults, the D1-live
rollup with computed rates/percentiles, `observed_at` stamping from the
`health:meta` KV, D1 query-error degradation, and the unsupported-window error.

Closes #5899
