### PR TITLE
feat(graphql): add Query.runtime mirroring REST /api/v1/runtime

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -59,6 +59,7 @@ import {
   CONCENTRATION_HISTORY_WINDOWS,
   DEFAULT_CONCENTRATION_HISTORY_WINDOW,
 } from "./concentration.mjs";
+import { buildRuntimeVersionHistory } from "./runtime-versions.mjs";
 import {
   analyticsWindow,
   d1Runner,
@@ -289,6 +290,8 @@ export const SDL = `
     block(ref: String!): BlockDetail
     "Block-production summary over the recent-block window -- counts, inter-block timing, throughput, and author-concentration. Every aggregate is null (never a GraphQL error) when the retired-D1 store is cold. Mirrors GET /api/v1/blocks/summary."
     blocks_summary: BlocksSummary!
+    "Site-wide runtime spec-version transition timeline: every distinct spec_version with the earliest block that carried it, the current (latest-known) spec_version, and the coverage start. Empty/null (never a GraphQL error) when the retired-D1 blocks store is cold. Mirrors GET /api/v1/runtime."
+    runtime: Runtime!
     "Network-wide validator/operator leaderboard, grouped by hotkey across every subnet it operates in. Mirrors GET /api/v1/validators."
     validators(sort: String, limit: Int): ValidatorList!
     "One validator's cross-subnet aggregate by hotkey; a hotkey with no validator_permit=1 rows resolves to a schema-stable zeroed aggregate, never null. Mirrors GET /api/v1/validators/{hotkey}."
@@ -1438,6 +1441,25 @@ export const SDL = `
     latest_spec_version: Int
   }
 
+  "One runtime spec-version transition (#5898): the earliest block that carried a given spec_version reading."
+  type RuntimeTransition {
+    spec_version: Int!
+    block_number: Int!
+    observed_at: String
+  }
+
+  "Site-wide runtime spec-version transition timeline (#5898), ascending by block. Empty (transition_count 0) on a cold/retired-D1 blocks store, never a GraphQL error. Mirrors GET /api/v1/runtime."
+  type Runtime {
+    schema_version: Int!
+    transitions: [RuntimeTransition!]!
+    transition_count: Int!
+    "Latest KNOWN spec_version by block height (not the last transitions entry — see the REST route). Null on a cold store."
+    current_spec_version: Int
+    "Earliest block this timeline can see a reading at. Null on a cold store."
+    coverage_from_block: Int
+    coverage_from_at: String
+  }
+
   "Inter-block interval distribution in milliseconds, over genuinely consecutive in-window blocks."
   type BlockTimeDistribution {
     count: Int!
@@ -2038,6 +2060,7 @@ export const FIELD_COMPLEXITY = {
   subnet_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
+  runtime: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
   economics_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_movers: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3392,6 +3415,28 @@ const rootValue = {
       author_concentration: data.author_concentration ?? null,
       distinct_spec_versions: data.distinct_spec_versions ?? 0,
       latest_spec_version: data.latest_spec_version ?? null,
+    };
+  },
+
+  async runtime(_args, context) {
+    // Same tryPostgresTier(METAGRAPH_BLOCKS_SOURCE) -> buildRuntimeVersionHistory([])
+    // fallback contract handleRuntime / MCP get_runtime use. blocks' D1 write path
+    // is retired (#4909) so a cold Postgres tier is the steady state -- the empty
+    // builder shape (transition_count 0, current_spec_version null) satisfies the
+    // non-null Runtime! contract, never a GraphQL error. No params -- site-wide.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/runtime"),
+        "METAGRAPH_BLOCKS_SOURCE",
+      )) ?? buildRuntimeVersionHistory([]);
+    return {
+      schema_version: data.schema_version ?? 1,
+      transitions: data.transitions ?? [],
+      transition_count: data.transition_count ?? 0,
+      current_spec_version: data.current_spec_version ?? null,
+      coverage_from_block: data.coverage_from_block ?? null,
+      coverage_from_at: data.coverage_from_at ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3819,6 +3819,119 @@ describe("graphql — blocks_summary (#5664, Postgres-tier + retired-D1 fallback
   });
 });
 
+describe("graphql — runtime (#5898, Postgres-tier + retired-D1 fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty timeline, never null", async () => {
+    const { status, body } = await gql(
+      `{ runtime {
+          schema_version transition_count current_spec_version
+          coverage_from_block coverage_from_at
+          transitions { spec_version block_number observed_at }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.runtime, {
+      schema_version: 1,
+      transition_count: 0,
+      current_spec_version: null,
+      coverage_from_block: null,
+      coverage_from_at: null,
+      transitions: [],
+    });
+  });
+
+  test("resolves the Postgres-tier timeline, including the per-version transitions", async () => {
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          transition_count: 2,
+          current_spec_version: 201,
+          coverage_from_block: 100,
+          coverage_from_at: "2026-07-01T00:00:00.000Z",
+          transitions: [
+            {
+              spec_version: 199,
+              block_number: 100,
+              observed_at: "2026-07-01T00:00:00.000Z",
+            },
+            {
+              spec_version: 201,
+              block_number: 250,
+              observed_at: "2026-07-02T00:00:00.000Z",
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ runtime {
+          transition_count current_spec_version coverage_from_block coverage_from_at
+          transitions { spec_version block_number observed_at }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.runtime;
+    assert.equal(r.transition_count, 2);
+    assert.equal(r.current_spec_version, 201);
+    assert.equal(r.coverage_from_block, 100);
+    assert.equal(r.coverage_from_at, "2026-07-01T00:00:00.000Z");
+    assert.equal(r.transitions.length, 2);
+    assert.equal(r.transitions[0].spec_version, 199);
+    assert.equal(r.transitions[1].block_number, 250);
+  });
+
+  test("forwards to /api/v1/runtime with no query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({ schema_version: 1, transition_count: 0 });
+        },
+      },
+    };
+    await gql("{ runtime { transition_count } }", env);
+    assert.equal(capturedUrl.pathname, "/api/v1/runtime");
+    assert.equal(capturedUrl.search, "");
+  });
+
+  test("a partial Postgres-tier body degrades to the schema-stable defaults, never null", async () => {
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ runtime {
+          schema_version transition_count current_spec_version
+          coverage_from_block coverage_from_at transitions { spec_version }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.runtime, {
+      schema_version: 1,
+      transition_count: 0,
+      current_spec_version: null,
+      coverage_from_block: null,
+      coverage_from_at: null,
+      transitions: [],
+    });
+  });
+
+  test("runtime is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.runtime, 5);
+  });
+});
+
 describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledger)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Adds `Query.runtime` to close the REST/GraphQL/MCP parity gap for the site-wide runtime spec-version transition timeline — the REST route (`workers/data-api.mjs`) and MCP `get_runtime` already exist, GraphQL was the only surface missing it.

`runtime: Runtime!` returns every distinct `spec_version` with the earliest block that carried it (ascending), the current latest-known `spec_version`, and the coverage start.

## Implementation

Mirrors the no-arg global sibling `blocks_summary` exactly: the resolver calls `tryPostgresTier(METAGRAPH_BLOCKS_SOURCE)` over the same `/api/v1/runtime` path and falls back to `buildRuntimeVersionHistory([])` on a cold store. Since blocks' D1 write path is retired (#4909), a cold Postgres tier is the steady state — the empty builder shape (`transition_count` 0, `current_spec_version` null) satisfies the non-null `Runtime!` contract, never a GraphQL error. Weighted `RELATIONSHIP_FIELD_COMPLEXITY` like its siblings.

## Tests

5 new tests in `tests/graphql.test.mjs` mirroring the `blocks_summary` conventions: cold-store empty timeline, Postgres-tier resolution with per-version transitions, path forwarding (no query params), partial-body default degradation, and the complexity-weight assertion. Patch coverage of the new `src/graphql.mjs` lines is 100%; full `tests/graphql.test.mjs` suite (390) passes; eslint + prettier + `scripts/validate-schema-enums.mjs` clean.

Closes #5898