### PR TITLE
feat(graphql): add Query.runtime mirroring GET /api/v1/runtime

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -88,6 +88,7 @@ import {
 import { buildExtrinsic, buildExtrinsicFeed } from "./extrinsics.mjs";
 import { buildBlock, buildBlockFeed } from "./blocks.mjs";
 import { buildBlocksSummary } from "./blocks-summary.mjs";
+import { buildRuntimeVersionHistory } from "./runtime-versions.mjs";
 import { buildChainYield } from "./chain-yield.mjs";
 import { loadSubnetRecycled, isU16Netuid } from "./subnet-recycled.mjs";
 import { loadAccountBalance, isFinneySs58Address } from "./account-balance.mjs";
@@ -289,6 +290,8 @@ export const SDL = `
     block(ref: String!): BlockDetail
     "Block-production summary over the recent-block window -- counts, inter-block timing, throughput, and author-concentration. Every aggregate is null (never a GraphQL error) when the retired-D1 store is cold. Mirrors GET /api/v1/blocks/summary."
     blocks_summary: BlocksSummary!
+    "Site-wide runtime spec-version transition timeline: the earliest known block at each distinct spec_version observed (ascending), the current spec_version, and where coverage starts. The empty shape (transition_count 0, current_spec_version null) is schema-stable, never a GraphQL error, when the store has no reading yet. Mirrors GET /api/v1/runtime."
+    runtime: RuntimeVersionHistory!
     "Network-wide validator/operator leaderboard, grouped by hotkey across every subnet it operates in. Mirrors GET /api/v1/validators."
     validators(sort: String, limit: Int): ValidatorList!
     "One validator's cross-subnet aggregate by hotkey; a hotkey with no validator_permit=1 rows resolves to a schema-stable zeroed aggregate, never null. Mirrors GET /api/v1/validators/{hotkey}."
@@ -1438,6 +1441,23 @@ export const SDL = `
     latest_spec_version: Int
   }
 
+  "Site-wide runtime spec-version transition timeline. Mirrors GET /api/v1/runtime."
+  type RuntimeVersionHistory {
+    schema_version: Int!
+    transitions: [RuntimeTransition!]!
+    transition_count: Int!
+    current_spec_version: Int
+    coverage_from_block: Int
+    coverage_from_at: String
+  }
+
+  "One runtime spec-version's first-seen block in the transition timeline."
+  type RuntimeTransition {
+    spec_version: Int!
+    block_number: Int!
+    observed_at: String
+  }
+
   "Inter-block interval distribution in milliseconds, over genuinely consecutive in-window blocks."
   type BlockTimeDistribution {
     count: Int!
@@ -2038,6 +2058,7 @@ export const FIELD_COMPLEXITY = {
   subnet_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
+  runtime: RELATIONSHIP_FIELD_COMPLEXITY,
   block: RELATIONSHIP_FIELD_COMPLEXITY,
   economics_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_movers: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3392,6 +3413,28 @@ const rootValue = {
       author_concentration: data.author_concentration ?? null,
       distinct_spec_versions: data.distinct_spec_versions ?? 0,
       latest_spec_version: data.latest_spec_version ?? null,
+    };
+  },
+
+  async runtime(_args, context) {
+    // Same tryPostgresTier(METAGRAPH_BLOCKS_SOURCE) -> buildRuntimeVersionHistory([])
+    // fallback contract GET /api/v1/runtime and the get_runtime MCP tool use; blocks'
+    // D1 write path is retired (#4909) so a cold Postgres tier is the steady state --
+    // the empty builder shape (transition_count 0, current_spec_version null) satisfies
+    // the non-null RuntimeVersionHistory! contract, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/runtime"),
+        "METAGRAPH_BLOCKS_SOURCE",
+      )) ?? buildRuntimeVersionHistory([]);
+    return {
+      schema_version: data.schema_version ?? 1,
+      transitions: data.transitions || [],
+      transition_count: data.transition_count ?? 0,
+      current_spec_version: data.current_spec_version ?? null,
+      coverage_from_block: data.coverage_from_block ?? null,
+      coverage_from_at: data.coverage_from_at ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3819,6 +3819,126 @@ describe("graphql — blocks_summary (#5664, Postgres-tier + retired-D1 fallback
   });
 });
 
+describe("graphql — runtime (#5898, Postgres-tier spec-version timeline + retired-D1 fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty timeline, never null", async () => {
+    const { status, body } = await gql(
+      `{ runtime {
+          schema_version transition_count current_spec_version
+          coverage_from_block coverage_from_at
+          transitions { spec_version block_number observed_at }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.runtime, {
+      schema_version: 1,
+      transition_count: 0,
+      current_spec_version: null,
+      coverage_from_block: null,
+      coverage_from_at: null,
+      transitions: [],
+    });
+  });
+
+  test("resolves the Postgres-tier spec-version transition timeline", async () => {
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          transitions: [
+            {
+              spec_version: 200,
+              block_number: 100,
+              observed_at: "2026-06-25T00:00:00.000Z",
+            },
+            {
+              spec_version: 201,
+              block_number: 500,
+              observed_at: "2026-07-01T00:00:00.000Z",
+            },
+          ],
+          transition_count: 2,
+          current_spec_version: 201,
+          coverage_from_block: 100,
+          coverage_from_at: "2026-06-25T00:00:00.000Z",
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ runtime {
+          schema_version transition_count current_spec_version
+          coverage_from_block coverage_from_at
+          transitions { spec_version block_number observed_at }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.runtime, {
+      schema_version: 1,
+      transition_count: 2,
+      current_spec_version: 201,
+      coverage_from_block: 100,
+      coverage_from_at: "2026-06-25T00:00:00.000Z",
+      transitions: [
+        {
+          spec_version: 200,
+          block_number: 100,
+          observed_at: "2026-06-25T00:00:00.000Z",
+        },
+        {
+          spec_version: 201,
+          block_number: 500,
+          observed_at: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  test("forwards to /api/v1/runtime with no query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({ schema_version: 1, transition_count: 0 });
+        },
+      },
+    };
+    await gql("{ runtime { transition_count } }", env);
+    assert.equal(capturedUrl.pathname, "/api/v1/runtime");
+    assert.equal(capturedUrl.search, "");
+  });
+
+  test("a partial Postgres-tier body degrades to the schema-stable defaults, never null", async () => {
+    const env = {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      // Every field absent -- the resolver's own ?? / || defaults must fill them in.
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ runtime {
+          schema_version transition_count current_spec_version
+          coverage_from_block coverage_from_at transitions { spec_version }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.runtime, {
+      schema_version: 1,
+      transition_count: 0,
+      current_spec_version: null,
+      coverage_from_block: null,
+      coverage_from_at: null,
+      transitions: [],
+    });
+  });
+});
+
 describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledger)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Closes the REST/GraphQL/MCP parity gap for the runtime spec-version timeline: `GET /api/v1/runtime` and the `get_runtime` MCP tool already expose it, but there was no GraphQL mirror.

Adds a `runtime: RuntimeVersionHistory!` field to the `Query` type returning the site-wide spec-version transition timeline — the earliest known block at each distinct `spec_version` (ascending), the `current_spec_version`, and where coverage starts.

## Implementation

- **Same data path, no duplication.** The resolver reuses the exact loader the REST route and MCP tool use: `tryPostgresTier(env, /api/v1/runtime, "METAGRAPH_BLOCKS_SOURCE")`, falling back to `buildRuntimeVersionHistory([])` (`src/runtime-versions.mjs`) for the retired-D1 / cold-store case. The empty shape (`transition_count: 0`, `current_spec_version: null`) satisfies the non-null `RuntimeVersionHistory!` contract — schema-stable, never a GraphQL error — mirroring the `blocks_summary` convention this sits next to.
- `RuntimeVersionHistory` + `RuntimeTransition` SDL types added; snake_case fields read straight off the loader output by the default resolver.
- `FIELD_COMPLEXITY` weight added for the new field.
- Scoped entirely to `src/graphql.mjs` (+ tests) — no registry/schema/openapi change.

## Tests

`tests/graphql.test.mjs` — mirroring the `blocks_summary` sibling: the Postgres-tier hit, the cold-store empty fallback, path-forwarding with no params, and a partial-body default fill. 100% line + branch coverage on the new resolver locally; full `graphql.test.mjs` green.

Closes #5898