### PR TITLE
feat(graphql): add Query.neuron and Query.neuron_history

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -98,6 +98,7 @@ import {
   GLOBAL_VALIDATOR_LIMIT_MAX,
   GLOBAL_VALIDATOR_SORTS,
   buildGlobalValidators,
+  buildNeuronDetail,
   buildValidatorDetail,
   overlayFeaturedValidators,
 } from "./metagraph-neurons.mjs";
@@ -154,6 +155,7 @@ import { loadAccountIdentityHistory } from "./account-identity-history.mjs";
 import { KV_HEALTH_META } from "./kv-keys.mjs";
 import { SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
 import {
+  buildNeuronHistory,
   parseHistoryWindow,
   unsupportedWindowMessage,
 } from "./neuron-history.mjs";
@@ -297,6 +299,10 @@ export const SDL = `
     validator_nominators(hotkey: String!, window: String, sort: String): NominatorList!
     "One validator's cross-subnet staked-over-time history: one point per day (window: 7d/30d/90d/1y/all, default 30d), summed across every subnet it validates in, plus a rewards-per-1000-TAO rate. A hotkey with no matching neuron_daily rows resolves to a schema-stable empty-points card, never null. Mirrors GET /api/v1/validators/{hotkey}/history."
     validator_history(hotkey: String!, window: String): ValidatorHistory!
+    "One subnet neuron's latest snapshot by UID: hot/cold keys, stake, rank, trust, consensus, incentive, dividends, emission, validator permit, immunity, take, and axon, wrapped in the subnet's captured_at/block_number. The neuron field is null when that UID is not in the latest snapshot (schema-stable, never a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}."
+    neuron(netuid: Int!, uid: Int!): NeuronDetail!
+    "One subnet neuron's per-day history by UID: one point per snapshot_date (window: 7d/30d/90d/1y/all, default 30d), each a live-shaped neuron row plus that day's snapshot_date/captured_at/block_number, newest first. An unsupported window is a GraphQL error; a UID with no matching neuron_daily rows resolves to a schema-stable empty-points card, never null. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history."
+    neuron_history(netuid: Int!, uid: Int!, window: String): NeuronHistory!
     "Site-wide accounts leaderboard -- every currently-registered hotkey, aggregated cross-subnet from the current neurons snapshot. Mirrors GET /api/v1/accounts."
     accounts(sort: String, limit: Int): AccountList!
     "One account's cross-subnet event-history summary by ss58 address; an address with no matching account_events rows resolves to a schema-stable zero summary, never null. Mirrors GET /api/v1/accounts/{ss58}."
@@ -1540,6 +1546,70 @@ export const SDL = `
     validator_trust: Float
   }
 
+  "One neuron (UID) in a subnet's metagraph: hot/cold keys, stake, rank, trust, consensus, incentive, dividends, emission, validator permit, immunity, and axon (host:port or null). trust/validator_trust/consensus/incentive/dividends are 0..1 ratios; take is the global 0..1 per-hotkey validator commission."
+  type Neuron {
+    uid: Int
+    hotkey: String
+    coldkey: String
+    active: Boolean
+    validator_permit: Boolean
+    rank: Float
+    trust: Float
+    validator_trust: Float
+    consensus: Float
+    incentive: Float
+    dividends: Float
+    emission_tao: Float
+    stake_tao: Float
+    registered_at_block: Int
+    is_immunity_period: Boolean
+    axon: String
+    take: Float
+  }
+
+  "One subnet neuron's latest snapshot by UID, wrapped in the subnet's captured_at/block_number. The neuron field is null when that UID is not in the latest snapshot. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}."
+  type NeuronDetail {
+    schema_version: Int!
+    netuid: Int!
+    captured_at: String
+    block_number: Int
+    neuron: Neuron
+  }
+
+  "One subnet neuron's per-day time series by UID. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history."
+  type NeuronHistory {
+    schema_version: Int!
+    netuid: Int!
+    uid: Int!
+    window: String
+    point_count: Int!
+    points: [NeuronHistoryPoint!]!
+  }
+
+  "One day's snapshot for a neuron UID: the live-shaped neuron row (same fields as Neuron) plus that day's snapshot_date/captured_at/block_number."
+  type NeuronHistoryPoint {
+    snapshot_date: String!
+    captured_at: String
+    block_number: Int
+    uid: Int
+    hotkey: String
+    coldkey: String
+    active: Boolean
+    validator_permit: Boolean
+    rank: Float
+    trust: Float
+    validator_trust: Float
+    consensus: Float
+    incentive: Float
+    dividends: Float
+    emission_tao: Float
+    stake_tao: Float
+    registered_at_block: Int
+    is_immunity_period: Boolean
+    axon: String
+    take: Float
+  }
+
   "Self-reported on-chain identity (SubtensorModule::set_identity) for a coldkey."
   type Identity {
     has_identity: Boolean!
@@ -2008,6 +2078,10 @@ export const FIELD_COMPLEXITY = {
   validators: RELATIONSHIP_FIELD_COMPLEXITY,
   validator: RELATIONSHIP_FIELD_COMPLEXITY,
   validator_history: RELATIONSHIP_FIELD_COMPLEXITY,
+  // A single latest-only detail row, priced with the other per-subnet reads.
+  neuron: RELATIONSHIP_FIELD_COMPLEXITY,
+  // Paginated fan-out: one neuron row per recorded snapshot_date.
+  neuron_history: RELATIONSHIP_FIELD_COMPLEXITY,
   accounts: RELATIONSHIP_FIELD_COMPLEXITY,
   account: RELATIONSHIP_FIELD_COMPLEXITY,
   account_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3542,6 +3616,67 @@ const rootValue = {
     return {
       schema_version: data.schema_version ?? 1,
       hotkey: data.hotkey ?? hotkey,
+      window: data.window ?? label,
+      point_count: data.point_count ?? 0,
+      points: data.points || [],
+    };
+  },
+
+  async neuron({ netuid, uid }, context) {
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildNeuronDetail(null, ...)
+    // fallback contract handleNeuron / the get_neuron MCP tool use: a UID absent
+    // from the latest snapshot (or a cold tier) is a schema-stable envelope with
+    // neuron:null, never a GraphQL error. A malformed tier body degrades to the
+    // same zeroed envelope the same way validator_history's `?? 1` guards degrade
+    // a partial upstream body.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/neurons/${uid}`,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildNeuronDetail(null, netuid);
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      captured_at: data.captured_at ?? null,
+      block_number: data.block_number ?? null,
+      neuron: data.neuron ?? null,
+    };
+  },
+
+  async neuron_history({ netuid, uid, window }, context) {
+    // Same parseHistoryWindow REST's handleNeuronHistory / the get_neuron_history
+    // MCP tool use, so accepted window labels (7d/30d/90d/1y/all, default 30d)
+    // match exactly; an unsupported window is a GraphQL error, never a silently
+    // substituted default.
+    const { label, error } = parseHistoryWindow(window);
+    if (error) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const params = new URLSearchParams();
+    params.set("window", label);
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildNeuronHistory([])
+    // fallback contract handleNeuronHistory uses; a UID with no neuron_daily rows
+    // in the window is a schema-stable empty-points card, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/neurons/${uid}/history`,
+          params,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildNeuronHistory([], netuid, uid, { window: label });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      uid: data.uid ?? uid,
       window: data.window ?? label,
       point_count: data.point_count ?? 0,
       points: data.points || [],

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -2554,6 +2554,296 @@ describe("graphql — validator_history (#5710, Postgres-tier + empty-points fal
   });
 });
 
+describe("graphql — neuron (#5900, Postgres-tier + neuron:null fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable envelope with neuron:null, never a GraphQL error", async () => {
+    const { status, body } = await gql(
+      "{ neuron(netuid: 5, uid: 999) { schema_version netuid captured_at block_number neuron { uid } } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.neuron, {
+      schema_version: 1,
+      netuid: 5,
+      captured_at: null,
+      block_number: null,
+      neuron: null,
+    });
+  });
+
+  test("resolves the Postgres-tier detail envelope, reading every Neuron field off the row", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          captured_at: "2026-07-14T02:00:00.000Z",
+          block_number: 300,
+          neuron: {
+            uid: 12,
+            hotkey: "5Hot",
+            coldkey: "5Cold",
+            active: true,
+            validator_permit: false,
+            rank: 0.5,
+            trust: 0.6,
+            validator_trust: 0.7,
+            consensus: 0.4,
+            incentive: 0.3,
+            dividends: 0.2,
+            emission_tao: 1.5,
+            stake_tao: 100,
+            registered_at_block: 250,
+            is_immunity_period: false,
+            axon: "1.2.3.4:8091",
+            take: 0.18,
+          },
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ neuron(netuid: 5, uid: 12) {
+          schema_version netuid captured_at block_number
+          neuron {
+            uid hotkey coldkey active validator_permit rank trust validator_trust
+            consensus incentive dividends emission_tao stake_tao registered_at_block
+            is_immunity_period axon take
+          }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.neuron, {
+      schema_version: 1,
+      netuid: 5,
+      captured_at: "2026-07-14T02:00:00.000Z",
+      block_number: 300,
+      neuron: {
+        uid: 12,
+        hotkey: "5Hot",
+        coldkey: "5Cold",
+        active: true,
+        validator_permit: false,
+        rank: 0.5,
+        trust: 0.6,
+        validator_trust: 0.7,
+        consensus: 0.4,
+        incentive: 0.3,
+        dividends: 0.2,
+        emission_tao: 1.5,
+        stake_tao: 100,
+        registered_at_block: 250,
+        is_immunity_period: false,
+        axon: "1.2.3.4:8091",
+        take: 0.18,
+      },
+    });
+  });
+
+  test("netuid and uid are forwarded into the Postgres-tier path", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql("{ neuron(netuid: 7, uid: 42) { netuid } }", env);
+    assert.equal(capturedUrl.pathname, "/api/v1/subnets/7/neurons/42");
+  });
+
+  test("a malformed Postgres-tier body degrades to the resolver's schema-stable defaults", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      "{ neuron(netuid: 5, uid: 12) { schema_version netuid captured_at block_number neuron { uid } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.neuron, {
+      schema_version: 1,
+      netuid: 5,
+      captured_at: null,
+      block_number: null,
+      neuron: null,
+    });
+  });
+
+  test("neuron is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.neuron, 5);
+  });
+});
+
+describe("graphql — neuron_history (#5900, Postgres-tier + empty-points fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag / no neuron_daily rows returns a schema-stable empty-points card, never null", async () => {
+    const { status, body } = await gql(
+      `{ neuron_history(netuid: 5, uid: 12) {
+          schema_version netuid uid window point_count points { snapshot_date }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.neuron_history, {
+      schema_version: 1,
+      netuid: 5,
+      uid: 12,
+      window: "30d",
+      point_count: 0,
+      points: [],
+    });
+  });
+
+  test("resolves the Postgres-tier points for the requested window", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          uid: 12,
+          window: "90d",
+          point_count: 1,
+          points: [
+            {
+              snapshot_date: "2026-07-01",
+              captured_at: "2026-07-01T00:00:00.000Z",
+              block_number: 280,
+              uid: 12,
+              hotkey: "5Hot",
+              coldkey: "5Cold",
+              active: true,
+              validator_permit: false,
+              rank: 0.5,
+              trust: 0.6,
+              validator_trust: 0.7,
+              consensus: 0.4,
+              incentive: 0.3,
+              dividends: 0.2,
+              emission_tao: 1.5,
+              stake_tao: 100,
+              registered_at_block: 250,
+              is_immunity_period: false,
+              axon: "1.2.3.4:8091",
+              take: 0.18,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ neuron_history(netuid: 5, uid: 12, window: "90d") {
+          netuid uid window point_count
+          points {
+            snapshot_date captured_at block_number uid hotkey coldkey active
+            validator_permit rank trust validator_trust consensus incentive
+            dividends emission_tao stake_tao registered_at_block is_immunity_period
+            axon take
+          }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.neuron_history;
+    assert.equal(r.netuid, 5);
+    assert.equal(r.uid, 12);
+    assert.equal(r.window, "90d");
+    assert.equal(r.point_count, 1);
+    assert.deepEqual(r.points, [
+      {
+        snapshot_date: "2026-07-01",
+        captured_at: "2026-07-01T00:00:00.000Z",
+        block_number: 280,
+        uid: 12,
+        hotkey: "5Hot",
+        coldkey: "5Cold",
+        active: true,
+        validator_permit: false,
+        rank: 0.5,
+        trust: 0.6,
+        validator_trust: 0.7,
+        consensus: 0.4,
+        incentive: 0.3,
+        dividends: 0.2,
+        emission_tao: 1.5,
+        stake_tao: 100,
+        registered_at_block: 250,
+        is_immunity_period: false,
+        axon: "1.2.3.4:8091",
+        take: 0.18,
+      },
+    ]);
+  });
+
+  test("netuid, uid, and window are forwarded to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(
+      '{ neuron_history(netuid: 7, uid: 42, window: "7d") { window } }',
+      env,
+    );
+    assert.equal(capturedUrl.pathname, "/api/v1/subnets/7/neurons/42/history");
+    assert.equal(capturedUrl.searchParams.get("window"), "7d");
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ neuron_history(netuid: 5, uid: 12, window: "30d") {
+          schema_version netuid uid window point_count points { snapshot_date }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.neuron_history, {
+      schema_version: 1,
+      netuid: 5,
+      uid: 12,
+      window: "30d",
+      point_count: 0,
+      points: [],
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ neuron_history(netuid: 5, uid: 12, window: "99d") { point_count } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window|30d/i.test(body.errors[0].message));
+    assert.equal(body.data?.neuron_history ?? null, null);
+  });
+
+  test("neuron_history is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.neuron_history, 5);
+  });
+});
+
 describe("graphql — subnet_identity_history (#5721, Postgres-tier + empty timeline fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## What

Add `Query.neuron` and `Query.neuron_history` to the GraphQL SDL in `src/graphql.mjs`, mirroring the existing REST routes and MCP tools so single-neuron drill-in is reachable from GraphQL like every other neuron/subnet aggregate already is.

- `neuron(netuid: Int!, uid: Int!): NeuronDetail!` — one UID's latest metagraph snapshot, mirroring `GET /api/v1/subnets/{netuid}/neurons/{uid}` (`neuronDetail`, `workers/data-api.mjs`) and the `get_neuron` MCP tool.
- `neuron_history(netuid: Int!, uid: Int!, window: String): NeuronHistory!` — one UID's per-day time series (window `7d`/`30d`/`90d`/`1y`/`all`, default `30d`), mirroring `GET /api/v1/subnets/{netuid}/neurons/{uid}/history` (`neuronHistoryMatch`) and the `get_neuron_history` MCP tool.

## How

Both resolvers follow the existing `validator` / `validator_history` convention exactly: they call `tryPostgresTier(..., "METAGRAPH_NEURONS_SOURCE")` against the same REST path the routes and MCP tools already forward to, and fall back to the shared `buildNeuronDetail(null, netuid)` / `buildNeuronHistory([], netuid, uid, { window })` builders — no query logic is duplicated. A cold tier or an absent UID resolves to a schema-stable envelope (`neuron: null` / empty-points card), never a GraphQL error; `neuron_history` reuses `parseHistoryWindow`, so an unsupported window is a `BAD_USER_INPUT` error just like `validator_history`.

New SDL types `Neuron`, `NeuronDetail`, `NeuronHistory`, and `NeuronHistoryPoint` match the shared `Neuron` JSON-schema shape field-for-field. Both fields are registered in `FIELD_COMPLEXITY` as fan-out reads.

## Tests

`tests/graphql.test.mjs` adds cover for both fields matching the `validator`/`validator_history` test suites: cold-store fallback, Postgres-tier resolution reading every field off the row, path/param forwarding, malformed-body degradation, unsupported-window error, and the complexity weighting. Full suite green (8782 tests); patch lines in `src/graphql.mjs` are fully covered.

Closes #5900
