### PR TITLE
fix(registry): Swap (SN10) accuracy pass -- disable POST-only API probe

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 204,
+  "surface_count": 203,
   "surfaces": [
     {
       "auth_required": false,
@@ -983,24 +983,6 @@
       "surface_id": "sn-9-iota-run-info",
       "surface_key": "srf-6ec629d96674b06d",
       "url": "https://iota.api.macrocosmos.ai/common/get_run_info"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 10,
-      "probe": {
-        "expect": "any",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "taofi",
-      "public_safe": true,
-      "subnet_name": "Swap",
-      "subnet_slug": "sn-10",
-      "surface_id": "sn-10-taofi-api",
-      "surface_key": "srf-6bf50fe9203db27c",
-      "url": "https://taofi-api.web.app/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -33,7 +33,7 @@
   "docs_url": "https://docs.taofi.com/",
   "name": "Swap",
   "netuid": 10,
-  "notes": "Reviewed overlay for SN10 Swap using the TaoFi pool page, TaoFi docs, and Swap source repository. Common www.taofi.com API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
+  "notes": "Reviewed overlay for SN10 Swap using the TaoFi pool page, TaoFi docs, and Swap source repository. Common www.taofi.com API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces. As of this pass, the entire www.taofi.com domain (the registered website, including /pool) returns HTTP 402 with header x-vercel-error: DEPLOYMENT_DISABLED -- the team's Vercel deployment appears disabled (likely a billing lapse, not a code issue). docs.taofi.com is unaffected (separate host/platform, still live). Not a registry misconfiguration -- the website surface is correctly probed and the live health tracker will reflect this outage; left as-is rather than disabling the probe, since this looks recoverable rather than permanently broken.",
   "schema_version": 1,
   "slug": "sn-10",
   "source_repo": "https://github.com/Swap-Subnet/swap-subnet",
@@ -129,9 +129,9 @@
       "id": "sn-10-taofi-api",
       "kind": "subnet-api",
       "name": "TaoFi swap API",
-      "notes": "Public unauthenticated TaoFi (SN10 Swap) API — the servers host declared in the TaoFi OpenAPI schema. POST endpoints return live swap/bridge quotes and transaction call data (verified: getBuyQuote returned an HTTP 200 JSON quote). Documented at taofi-doc.web.app.",
+      "notes": "Public unauthenticated TaoFi (SN10 Swap) API — the servers host declared in the TaoFi OpenAPI schema. All 8 documented paths (getBuyQuote, getBuyCall, getSellQuote, getSellCall, getRefundCall, getBalance, getNativeTaoQuote, getNativeTaoCall) are POST-only; GET/HEAD to any of them returns 405, and the bare host root returns 404 (confirmed live). The registry's probe schema only supports GET/HEAD, so recurring read probes are intentionally disabled -- same pattern as gittensor.json's POST-only MCP surface. Documented at taofi-doc.web.app.",
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "expect": "any",
         "method": "GET",
         "timeout_ms": 10000


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- The tracked TaoFi swap API surface probed GET on the bare host root, which actually returns 404 -- and `src/health-probe-core.mjs:247` gates health purely on `response.ok` (HTTP 2xx), so this surface has been reporting unhealthy on every single live probe regardless of the registry's own "verified: getBuyQuote returned 200" claim in its old notes. Confirmed live: all 8 documented paths are POST-only (GET/HEAD return 405 on real endpoints, OPTIONS 404s the root too). The registry's probe schema only supports GET/HEAD (`schemas/components/04-surfaces.schema.json`), so there is no way to configure a working probe for a POST-only API -- **disabled recurring probing**, same established pattern as `gittensor.json`'s own POST-only MCP surface.
- Separately (informational, no registry change): the entire `www.taofi.com` domain -- the subnet's registered website, including `/pool` -- currently returns **HTTP 402 with header `x-vercel-error: DEPLOYMENT_DISABLED`**, a real live outage (likely a Vercel billing lapse, not a code issue). `docs.taofi.com` is unaffected. Left the website surface's probe untouched: it's correctly configured and the live health tracker will reflect this outage on its own -- that's what it's for, and this looks recoverable rather than permanently broken (documented in `notes` for context).
- The remaining 4 surfaces (docs, source-repo, OpenAPI schema, NFPM ABI) re-verified live (HTTP 200); `gap_notes` were already accurate, no changes needed there.

## Test plan

- [x] `npm run validate:schemas` — passes
- [x] `npm run validate:surface` — passes (915 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] Confirmed all 8 OpenAPI paths are POST-only (405 on GET) individually
- [x] Confirmed the www.taofi.com outage is non-transient (repeated checks, root + /pool, explicit HEAD)