### PR TITLE
feat(graphql): add Query.sudo mirroring REST /api/v1/sudo + MCP get_sudo (#5895)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -351,6 +351,8 @@ export const SDL = `
     account_balance(ss58: String!): AccountBalance
     "The network's on-chain sudo (superuser) key hotkey, read live from chain via RPC (not the Postgres tier). hotkey is null on RPC failure or a renounced sudo, schema-stable, never a GraphQL error. Mirrors GET /api/v1/sudo/key."
     sudo_key: SudoKey
+    "Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Mirrors GET /api/v1/sudo."
+    sudo(limit: Int, offset: Int, cursor: String, block: Int, call_function: String, success: Boolean): ExtrinsicList!
   }
 
   type SubnetList {
@@ -2004,6 +2006,7 @@ export const FIELD_COMPLEXITY = {
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
+  sudo: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
   validators: RELATIONSHIP_FIELD_COMPLEXITY,
   validator: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3309,6 +3312,45 @@ const rootValue = {
       (await tryPostgresTier(
         context.env,
         postgresTierRequest(context, "/api/v1/extrinsics", params),
+        "METAGRAPH_EXTRINSICS_SOURCE",
+      )) ??
+      buildExtrinsicFeed([], {
+        limit: safeLimit,
+        offset: safeOffset,
+        nextCursor: null,
+      });
+    return {
+      items: (data.extrinsics || []).map(extrinsicNode),
+      total: data.extrinsic_count ?? 0,
+      next_cursor: data.next_cursor ?? null,
+    };
+  },
+
+  async sudo(
+    { limit, offset, cursor, block, call_function: callFunction, success },
+    context,
+  ) {
+    // The Sudo governance feed is the /extrinsics feed with call_module fixed
+    // to Sudo by the route itself, so it takes no signer/call_module args and
+    // reuses the identical extrinsics source + ExtrinsicList shape.
+    if (block != null && (!Number.isInteger(block) || block < 0)) {
+      throw new GraphQLError("block must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const safeLimit = clampLimit(limit, BLOCK_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    if (cursor) params.set("cursor", cursor);
+    if (block != null) params.set("block", String(block));
+    if (callFunction) params.set("call_function", callFunction);
+    if (success != null) params.set("success", String(success));
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/sudo", params),
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) ??
       buildExtrinsicFeed([], {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1766,6 +1766,158 @@ describe("graphql — compare (reuse the shared compare loader)", () => {
   });
 });
 
+describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("sudo: cold/no-tier store returns a schema-stable empty page (fallback builder)", async () => {
+    const { status, body } = await gql(
+      "{ sudo { items { call_module } total next_cursor } }",
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.sudo, {
+      items: [],
+      total: 0,
+      next_cursor: null,
+    });
+  });
+
+  test("sudo: resolves Postgres-tier rows from the Sudo feed, JSON-encoding call_args", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          extrinsic_count: 1,
+          limit: 20,
+          offset: 0,
+          next_cursor: "cursor-1",
+          extrinsics: [
+            {
+              block_number: 9,
+              extrinsic_index: 0,
+              extrinsic_hash: `0x${"b".repeat(64)}`,
+              signer: "5Sudo",
+              call_module: "Sudo",
+              call_function: "sudo",
+              call_args: [{ name: "call", value: "setWeights" }],
+              success: true,
+              fee_tao: 0,
+              tip_tao: 0,
+              observed_at: "2026-07-15T00:00:00.000Z",
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      "{ sudo { items { block_number call_module call_args success } total next_cursor } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.sudo.total, 1);
+    assert.equal(body.data.sudo.next_cursor, "cursor-1");
+    const item = body.data.sudo.items[0];
+    assert.equal(item.call_module, "Sudo");
+    assert.equal(item.success, true);
+    assert.equal(
+      item.call_args,
+      JSON.stringify([{ name: "call", value: "setWeights" }]),
+    );
+  });
+
+  test("sudo: hits /api/v1/sudo and forwards filters, never signer/call_module", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            extrinsic_count: 0,
+            limit: 5,
+            offset: 0,
+            next_cursor: null,
+            extrinsics: [],
+          });
+        },
+      },
+    };
+    await gql(
+      `{ sudo(limit: 5, offset: 2, block: 42, call_function: "sudo", success: true) { total } }`,
+      env,
+    );
+    assert.equal(capturedUrl.pathname, "/api/v1/sudo");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl.searchParams.get("offset"), "2");
+    assert.equal(capturedUrl.searchParams.get("block"), "42");
+    assert.equal(capturedUrl.searchParams.get("call_function"), "sudo");
+    assert.equal(capturedUrl.searchParams.get("success"), "true");
+    // The route fixes call_module=Sudo, so the field exposes neither arg.
+    assert.equal(capturedUrl.searchParams.get("call_module"), null);
+    assert.equal(capturedUrl.searchParams.get("signer"), null);
+  });
+
+  test("sudo: a cursor arg is forwarded as a query param to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            extrinsic_count: 0,
+            limit: 20,
+            offset: 0,
+            next_cursor: null,
+            extrinsics: [],
+          });
+        },
+      },
+    };
+    await gql(`{ sudo(cursor: "abc123") { total } }`, env);
+    assert.equal(capturedUrl.searchParams.get("cursor"), "abc123");
+  });
+
+  test("sudo: a negative block filter is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql("{ sudo(block: -1) { total } }", env);
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("sudo: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      "{ sudo { items { call_module } total next_cursor } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.sudo, {
+      items: [],
+      total: 0,
+      next_cursor: null,
+    });
+  });
+});
+
 describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
Closes the chain-governance parity gap: `GET /api/v1/sudo` and the `get_sudo` MCP tool both expose the Sudo-pallet extrinsic feed, but GraphQL had no mirror — matching the repo's growing REST/GraphQL/MCP parity convention (`Query.blocks`/`Query.validators`/`Query.account_*`).

## What

- Adds `Query.sudo(limit, offset, cursor, block, call_function, success): ExtrinsicList!` to `src/graphql.mjs`.
- `/api/v1/sudo` is the `/extrinsics` feed with `call_module` **fixed to `Sudo`** by the route itself, so the field exposes **no `signer`/`call_module` args** and reuses the identical Postgres-tier source (`METAGRAPH_EXTRINSICS_SOURCE`), `ExtrinsicList` shape, and cold-store fallback as `Query.extrinsics`.
- The resolver **proxies to `/api/v1/sudo`** exactly as the sibling feed fields proxy to their REST routes — no query/aggregation logic is duplicated.

## Test coverage

`tests/graphql.test.mjs` — a new `sudo` describe block mirroring the `extrinsics` feed tests:
- cold/no-tier store → schema-stable empty page (fallback builder)
- resolves Postgres-tier rows, JSON-encoding `call_args`
- hits `/api/v1/sudo` and forwards `limit/offset/cursor/block/call_function/success` — and asserts `call_module`/`signer` are **never** forwarded
- negative `block` → `BAD_USER_INPUT`, never reaching the tier
- malformed tier body → schema-stable empty page

`npm run test -- graphql` green (391 tests); new resolver at 100% patch coverage; `lint` + `format:check` clean.

Closes #5895
