### PR TITLE
fix(registry): TrajectoryRL (SN11) accuracy pass -- restore missing probes

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 203,
+  "surface_count": 204,
   "surfaces": [
     {
       "auth_required": false,
@@ -1001,6 +1001,24 @@
       "surface_id": "sn-11-trajectoryrl-miners",
       "surface_key": "srf-e752617b3d782a38",
       "url": "https://trajrl.com/api/miners"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 11,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "trajectoryrl",
+      "public_safe": true,
+      "subnet_name": "TrajectoryRL",
+      "subnet_slug": "sn-11",
+      "surface_id": "sn-11-trajectoryrl-subnet-api",
+      "surface_key": "srf-fb2d84726c2ab7c6",
+      "url": "https://trajrl.com/api/stats"
     },
     {
       "auth_required": false,

--- a/registry/subnets/trajectoryrl.json
+++ b/registry/subnets/trajectoryrl.json
@@ -38,7 +38,7 @@
   "docs_url": "https://trajrl.com/docs",
   "name": "TrajectoryRL",
   "netuid": 11,
-  "notes": "Reviewed overlay for SN11 TrajectoryRL using the official website, docs, leaderboard, live, winners, benchmark pages, and source repository. Common API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces.",
+  "notes": "Reviewed overlay for SN11 TrajectoryRL using the official website, docs, leaderboard, live, winners, benchmark pages, and source repository. Common API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces. Two community-submitted surfaces (api-docs, subnet-api) had no probe config at all -- not disabled, just absent, meaning they were silently excluded from operational-surfaces.json / live health tracking despite being valid public endpoints (see #5932 for the registry-wide scope of this class of gap). Both confirmed live and given probe configs matching their sibling surfaces' conventions.",
   "schema_version": 1,
   "slug": "sn-11",
   "social": {
@@ -183,6 +183,12 @@
       "kind": "docs",
       "name": "TrajectoryRL API documentation",
       "notes": "Public request/response API specification for TrajectoryRL validator and miner integration, covering the web-submit channel, pre-eval checks, score submission, winner lookup, heartbeat, and log-upload flows.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "trajectoryrl",
       "public_safe": true,
       "review": {
@@ -202,6 +208,12 @@
       "kind": "subnet-api",
       "name": "TrajectoryRL network stats API",
       "notes": "Public read-only REST JSON endpoint reporting SN11 network totals (reports, LLM calls, tokens, cost); no auth. Documented in the official trajrl API client.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "trajectoryrl",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- Two community-submitted surfaces (`sn-11-trajectoryrl-api-docs`, `sn-11-trajectoryrl-subnet-api`) had no `probe` config at all -- not `probe.enabled: false`, the whole object was absent. `build-artifacts.mjs`'s operational-surfaces filter checks `surface.probe?.enabled` (truthy), so a missing field is indistinguishable from a disabled one: both were silently excluded from all live health tracking despite the network stats API being a genuinely live, public, no-auth JSON endpoint. Confirmed live before adding probe configs matching their sibling surfaces' conventions (HEAD/html for the docs page, GET/json for the stats API).
- Filed #5932 to track this as a **registry-wide pattern -- 369 surfaces across 119/129 subnet files** are missing probe config the same way. Not fixed in bulk here: blindly assigning probe configs without individually live-testing each URL risks the same failure mode #5928 (SN10) found (a wrong method/expect silently reporting healthy endpoints as down).
- All 8 remaining surfaces re-verified live (HTTP 200); the common API/health/OpenAPI 404 gap notes re-tested and still accurate.

## Test plan

- [x] `npm run validate:schemas` — passes
- [x] `npm run validate:surface` — passes (915 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] Every surface URL live-tested individually before assigning a probe