### PR TITLE
feat(graphql): add Query.governance_config_changes mirroring REST + MCP (#5897)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -284,6 +284,8 @@ export const SDL = `
     extrinsics(limit: Int, offset: Int, cursor: String, block: Int, signer: String, call_module: String, call_function: String, success: Boolean): ExtrinsicList!
     "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}."
     extrinsic(ref: String!): ExtrinsicDetail
+    "Subtensor's root-origin hyperparameter/network-config change feed (newest first) -- the extrinsics feed fixed to call_module=AdminUtils, so it takes no signer/call_module filter. Same ExtrinsicList shape as extrinsics. Mirrors GET /api/v1/governance/config-changes."
+    governance_config_changes(limit: Int, offset: Int, cursor: String, block: Int, call_function: String, success: Boolean): ExtrinsicList!
     "Recent-block feed (newest first). Mirrors GET /api/v1/blocks."
     blocks(limit: Int, offset: Int, cursor: String): BlockList!
     "One block by numeric height or 0x block hash; block is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/{ref}."
@@ -2025,6 +2027,7 @@ export const FIELD_COMPLEXITY = {
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
   extrinsic: RELATIONSHIP_FIELD_COMPLEXITY,
+  governance_config_changes: RELATIONSHIP_FIELD_COMPLEXITY,
   validators: RELATIONSHIP_FIELD_COMPLEXITY,
   validator: RELATIONSHIP_FIELD_COMPLEXITY,
   validator_history: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3357,6 +3360,50 @@ const rootValue = {
     return {
       ref: data.ref ?? ref,
       extrinsic: extrinsicNode(data.extrinsic),
+    };
+  },
+
+  async governance_config_changes(
+    { limit, offset, cursor, block, call_function: callFunction, success },
+    context,
+  ) {
+    if (block != null && (!Number.isInteger(block) || block < 0)) {
+      throw new GraphQLError("block must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const safeLimit = clampLimit(limit, BLOCK_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    if (cursor) params.set("cursor", cursor);
+    if (block != null) params.set("block", String(block));
+    if (callFunction) params.set("call_function", callFunction);
+    if (success != null) params.set("success", String(success));
+    // Same DATA_API extrinsics tier as Query.extrinsics, hitting the
+    // /governance/config-changes path so the worker fixes call_module=AdminUtils
+    // itself (see SUDO_GOVERNANCE_ROUTES in workers/data-api.mjs) -- no filter
+    // logic duplicated here; the REST route and MCP tool share this exact path.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          "/api/v1/governance/config-changes",
+          params,
+        ),
+        "METAGRAPH_EXTRINSICS_SOURCE",
+      )) ??
+      buildExtrinsicFeed([], {
+        limit: safeLimit,
+        offset: safeOffset,
+        nextCursor: null,
+      });
+    return {
+      items: (data.extrinsics || []).map(extrinsicNode),
+      total: data.extrinsic_count ?? 0,
+      next_cursor: data.next_cursor ?? null,
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1988,6 +1988,139 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
   });
 });
 
+describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("governance_config_changes: cold/no-tier store returns a schema-stable empty page (fallback builder)", async () => {
+    const { status, body } = await gql(
+      "{ governance_config_changes { items { call_module } total next_cursor } }",
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.governance_config_changes, {
+      items: [],
+      total: 0,
+      next_cursor: null,
+    });
+  });
+
+  test("governance_config_changes: resolves Postgres-tier AdminUtils rows", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          extrinsic_count: 1,
+          limit: 20,
+          offset: 0,
+          next_cursor: "cursor-1",
+          extrinsics: [
+            {
+              block_number: 5,
+              extrinsic_index: 0,
+              extrinsic_hash: `0x${"a".repeat(64)}`,
+              signer: null,
+              call_module: "AdminUtils",
+              call_function: "sudo_set_weights_set_rate_limit",
+              call_args: [{ name: "netuid", value: 1 }],
+              success: true,
+              fee_tao: 0,
+              tip_tao: 0,
+              observed_at: "2026-07-14T00:00:00.000Z",
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      "{ governance_config_changes { items { block_number call_module call_function call_args success } total next_cursor } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.governance_config_changes.total, 1);
+    assert.equal(body.data.governance_config_changes.next_cursor, "cursor-1");
+    const item = body.data.governance_config_changes.items[0];
+    assert.equal(item.call_module, "AdminUtils");
+    assert.equal(item.call_function, "sudo_set_weights_set_rate_limit");
+    assert.equal(item.success, true);
+    assert.equal(
+      item.call_args,
+      JSON.stringify([{ name: "netuid", value: 1 }]),
+    );
+  });
+
+  test("governance_config_changes: filter args are forwarded to the /governance/config-changes path (loader reuse, no signer/call_module)", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            extrinsic_count: 0,
+            limit: 5,
+            offset: 0,
+            next_cursor: null,
+            extrinsics: [],
+          });
+        },
+      },
+    };
+    await gql(
+      `{ governance_config_changes(limit: 5, block: 42, call_function: "sudo_set_tempo", success: true) { total } }`,
+      env,
+    );
+    // The worker fixes call_module=AdminUtils by path, so the resolver hits the
+    // governance route (not /extrinsics) and never forwards signer/call_module.
+    assert.equal(capturedUrl.pathname, "/api/v1/governance/config-changes");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl.searchParams.get("block"), "42");
+    assert.equal(
+      capturedUrl.searchParams.get("call_function"),
+      "sudo_set_tempo",
+    );
+    assert.equal(capturedUrl.searchParams.get("success"), "true");
+    assert.equal(capturedUrl.searchParams.get("signer"), null);
+    assert.equal(capturedUrl.searchParams.get("call_module"), null);
+  });
+
+  test("governance_config_changes: a cursor arg is forwarded as a query param", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            extrinsic_count: 0,
+            limit: 20,
+            offset: 0,
+            next_cursor: null,
+            extrinsics: [],
+          });
+        },
+      },
+    };
+    await gql(`{ governance_config_changes(cursor: "abc123") { total } }`, env);
+    assert.equal(capturedUrl.searchParams.get("cursor"), "abc123");
+  });
+
+  test("governance_config_changes: rejects a negative block with BAD_USER_INPUT", async () => {
+    const { status, body } = await gql(
+      "{ governance_config_changes(block: -1) { total } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("governance_config_changes is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.governance_config_changes, 5);
+  });
+});
+
 describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Closes the last REST/GraphQL/MCP parity gap on the governance surface. The root-origin hyperparameter/network-config change feed already ships as `GET /api/v1/governance/config-changes` and MCP `get_governance_config_changes`, but had no GraphQL mirror.

Adds `Query.governance_config_changes(limit, offset, cursor, block, call_function, success)` returning the shared `ExtrinsicList` shape. The resolver mirrors `Query.extrinsics` but hits the `/api/v1/governance/config-changes` path, so the DATA_API extrinsics tier fixes `call_module=AdminUtils` itself (`SUDO_GOVERNANCE_ROUTES` in `workers/data-api.mjs`) — **no filter/aggregation logic duplicated**, and it takes no `signer`/`call_module` arg since those are fixed. Priced at `RELATIONSHIP_FIELD_COMPLEXITY` like the other fan-out feeds.

Entirely within `src/graphql.mjs` + its test — no registry/schema/contract change.

## Testing

- `tests/graphql.test.mjs` — 6 new tests: cold-store fallback, AdminUtils row resolution, arg→query-param forwarding on the governance path (asserts `signer`/`call_module` are never forwarded), cursor forwarding, negative-block `BAD_USER_INPUT`, complexity weight. **Full graphql suite: 391 pass.**
- `eslint` + `prettier` clean; new resolver lines 100% covered.

Closes #5897
