### PR TITLE
feat(graphql): add Query.account_position_history, mirroring REST /api/v1/accounts/{ss58}/subnets/{netuid}/history

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -120,6 +120,7 @@ import {
   STAKE_FLOW_WINDOWS,
   buildAccountStakeFlow,
 } from "./account-stake-flow.mjs";
+import { buildAccountPositionHistory } from "./account-position-history.mjs";
 import {
   DEFAULT_STAKE_FLOW_DIRECTION,
   STAKE_FLOW_DIRECTIONS,
@@ -312,6 +313,8 @@ export const SDL = `
     account_deregistrations(ss58: String!, window: String): AccountDeregistrations!
     "One account's StakeAdded/StakeRemoved flow per subnet over a 7d/30d/90d window (default 30d) -- net + gross flow, a direction label (accumulating/exiting/churning/idle), and an HHI concentration of where its flow is focused. direction narrows to inflow (in) or outflow (out) only; all (default) reports both sides. An address with no flow in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/stake-flow."
     account_stake_flow(ss58: String!, window: String, direction: String): AccountStakeFlow!
+    "One account's per-subnet position (uid/role/active plus stake/emission/rank/trust/incentive/dividends/yield) day-by-day over a 7d/30d/90d/1y/all window (default 30d), newest first, one point per neuron_daily snapshot. An account with no rows for the subnet in the window resolves to a schema-stable empty-points card, never null. Mirrors GET /api/v1/accounts/{ss58}/subnets/{netuid}/history."
+    account_position_history(ss58: String!, netuid: Int!, window: String): AccountPositionHistory!
     "One wallet's cross-subnet neuron portfolio: every subnet where the hotkey is a registered neuron, each position's economics (stake, emission, rank, trust, incentive, dividends, role) and emission/stake yield, plus wallet-level aggregates (totals, counts, overall return, stake concentration). Richer than account.registrations (registration footprint only). An address with no registered neurons resolves to a schema-stable empty card, never null. Mirrors GET /api/v1/accounts/{ss58}/portfolio."
     account_portfolio(ss58: String!): AccountPortfolio!
     "One account's per-subnet axon-serving footprint over a 7d/30d/90d window (default 30d): AxonServed announcement count and first/last timestamps per subnet, an HHI concentration of where its serving activity is focused, and the dominant subnet; an address with no announcements in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/serving."
@@ -1854,6 +1857,33 @@ export const SDL = `
     unstake_events: Int!
   }
 
+  "One account's per-subnet position history over a lookback window, one point per neuron_daily snapshot. Mirrors GET /api/v1/accounts/{ss58}/subnets/{netuid}/history."
+  type AccountPositionHistory {
+    schema_version: Int!
+    ss58: String!
+    netuid: Int!
+    window: String
+    point_count: Int!
+    points: [AccountPositionHistoryPoint!]!
+  }
+
+  "One day's position for an account in one subnet: the neuron's uid/role/active plus stake/emission and its rank/trust/incentive/dividends scores and emission-per-stake yield."
+  type AccountPositionHistoryPoint {
+    snapshot_date: String!
+    captured_at: String
+    uid: Int
+    coldkey: String
+    role: String!
+    active: Boolean!
+    stake_tao: Float
+    emission_tao: Float
+    rank: Float
+    trust: Float
+    incentive: Float
+    dividends: Float
+    yield: Float
+  }
+
   "One wallet's cross-subnet neuron portfolio (#5702): every subnet where the hotkey is a registered neuron, plus wallet-level aggregates. Mirrors GET /api/v1/accounts/{ss58}/portfolio."
   type AccountPortfolio {
     schema_version: Int!
@@ -2074,6 +2104,7 @@ export const FIELD_COMPLEXITY = {
   chain_alpha_volume: RELATIONSHIP_FIELD_COMPLEXITY,
   account_prometheus: RELATIONSHIP_FIELD_COMPLEXITY,
   account_stake_flow: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_position_history: RELATIONSHIP_FIELD_COMPLEXITY,
   account_portfolio: RELATIONSHIP_FIELD_COMPLEXITY,
   // Fans out into leaderboardProfilesProjection plus several D1 reads and the
   // economics tier -- same cost class as the other relationship fields.
@@ -3585,6 +3616,51 @@ const rootValue = {
     return {
       schema_version: data.schema_version ?? 1,
       hotkey: data.hotkey ?? hotkey,
+      window: data.window ?? label,
+      point_count: data.point_count ?? 0,
+      points: data.points || [],
+    };
+  },
+
+  async account_position_history({ ss58, netuid, window }, context) {
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    if (!isU16Netuid(netuid)) {
+      throw new GraphQLError("netuid must be a u16 subnet id (0-65535).", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same parseHistoryWindow the REST position-history handler uses, so
+    // accepted window labels (7d/30d/90d/1y/all, default 30d) match exactly.
+    const { label, error } = parseHistoryWindow(window);
+    if (error) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const params = new URLSearchParams();
+    params.set("window", label);
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildAccountPositionHistory
+    // fallback contract the REST handler uses; an account with no neuron_daily
+    // rows for the subnet in the window is a schema-stable empty-points card,
+    // never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}/subnets/${netuid}/history`,
+          params,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildAccountPositionHistory([], ss58, netuid, { window: label });
+    return {
+      schema_version: data.schema_version ?? 1,
+      ss58: data.ss58 ?? ss58,
+      netuid: data.netuid ?? netuid,
       window: data.window ?? label,
       point_count: data.point_count ?? 0,
       points: data.points || [],

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -2434,6 +2434,97 @@ describe("graphql — validators / validator (#5573, Postgres-tier leaderboard)"
   });
 });
 
+describe("graphql — account_position_history (#5889, Postgres-tier + empty-points fallback)", () => {
+  const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty-points card, never null", async () => {
+    const { status, body } = await gql(
+      `{ account_position_history(ss58: "${SS58}", netuid: 1) {
+          schema_version ss58 netuid window point_count points { snapshot_date }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_position_history, {
+      schema_version: 1,
+      ss58: SS58,
+      netuid: 1,
+      window: "30d",
+      point_count: 0,
+      points: [],
+    });
+  });
+
+  test("resolves the Postgres-tier points for the requested window", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          netuid: 5,
+          window: "90d",
+          point_count: 1,
+          points: [
+            {
+              snapshot_date: "2026-07-01",
+              captured_at: "2026-07-01T00:00:00.000Z",
+              uid: 3,
+              coldkey: "5Cold",
+              role: "validator",
+              active: true,
+              stake_tao: 1000,
+              emission_tao: 4,
+              rank: 0.1,
+              trust: 0.2,
+              incentive: 0.3,
+              dividends: 0.4,
+              yield: 0.004,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ account_position_history(ss58: "${SS58}", netuid: 5, window: "90d") {
+          ss58 netuid window point_count
+          points { snapshot_date captured_at uid coldkey role active stake_tao emission_tao rank trust incentive dividends yield }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.account_position_history;
+    assert.equal(r.netuid, 5);
+    assert.equal(r.window, "90d");
+    assert.equal(r.point_count, 1);
+    assert.equal(r.points[0].role, "validator");
+    assert.equal(r.points[0].stake_tao, 1000);
+    assert.equal(r.points[0].yield, 0.004);
+  });
+
+  test("an invalid ss58 is BAD_USER_INPUT and never reaches the tier", async () => {
+    const { status, body } = await gql(
+      `{ account_position_history(ss58: "not-an-ss58", netuid: 1) { point_count } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+  });
+
+  test("an out-of-range netuid is BAD_USER_INPUT", async () => {
+    const { status, body } = await gql(
+      `{ account_position_history(ss58: "${SS58}", netuid: 99999) { point_count } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data, null);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+  });
+});
+
 describe("graphql — validator_history (#5710, Postgres-tier + empty-points fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
Closes #5889

Adds `Query.account_position_history` to the GraphQL SDL, mirroring the existing `GET /api/v1/accounts/{ss58}/subnets/{netuid}/history` REST route and the `get_account_position_history` MCP tool.

- Reuses the existing `buildAccountPositionHistory` from `src/account-position-history.mjs` (the response builder this issue names) and the shared `parseHistoryWindow` history-window vocabulary from `src/neuron-history.mjs`, so the field is a faithful mirror with no new data path.
- `account_position_history(ss58: String!, netuid: Int!, window: String): AccountPositionHistory!` validates `ss58` (SS58_ADDRESS_PATTERN) and `netuid` (isU16Netuid), then reads the Postgres tier via `tryPostgresTier(METAGRAPH_NEURONS_SOURCE)` — the same source and empty-points fallback contract the REST handler uses. An account with no neuron_daily rows for the subnet in the window resolves to a schema-stable empty-points card, never a GraphQL error.
- Mirrors the `validator_history` resolver/type shape (the repo's neuron_daily history convention). `AccountPositionHistoryPoint` carries each day's uid/role/active plus stake/emission and rank/trust/incentive/dividends scores and emission-per-stake yield.

Tests cover a cold-store empty-points card, a live Postgres-tier hit with a full point, an invalid `ss58` → BAD_USER_INPUT, and an out-of-range `netuid` → BAD_USER_INPUT.
