### PR TITLE
docs(backend): fix stale references to deleted staging.mjs in 3 file headers

### DIFF
--- a/src/account-identity-history.mjs
+++ b/src/account-identity-history.mjs
@@ -4,9 +4,10 @@
 // src/subnet-identity-history.mjs's diff-and-append shape (subnet_hyperparams's
 // own D1-side diff-and-append, recordSubnetHyperparamsChanges, was retired
 // alongside its D1 write path -- see src/subnet-hyperparams-history.mjs's
-// header), keyed by account instead of netuid, running as an additional step
-// inside the same staged load rather than a separate pipeline
-// (workers/request-handlers/staging.mjs's loadStagedAccountIdentity).
+// header), keyed by account instead of netuid, and originally run as an
+// additional step inside the retired staged load (loadStagedAccountIdentity,
+// removed in the D1→Postgres cutover #4772 — see workers/api.mjs's
+// staged-loader note) rather than a separate pipeline.
 //
 // Read/format/build functions land here with the serving route (#4328/5.4),
 // mirroring src/subnet-identity-history.mjs's read side exactly (keyed by

--- a/src/account-identity.mjs
+++ b/src/account-identity.mjs
@@ -4,8 +4,9 @@
 // the identity a coldkey attaches to itself. Field mapping documented in
 // scripts/fetch-account-identity.py's docstring and
 // migrations/0039_account_identity.sql. Mirrors NEURON_INSERT_COLUMNS's role
-// in src/metagraph-neurons.mjs — the full column set written by the staged-
-// load path (loadStagedAccountIdentity, workers/request-handlers/staging.mjs).
+// in src/metagraph-neurons.mjs — the full column set once written by the
+// retired staged-load path (loadStagedAccountIdentity, removed in the
+// D1→Postgres cutover #4772 — see workers/api.mjs's staged-loader note).
 //
 // Read/format/build functions land here with the serving route (#4328/5.4).
 

--- a/src/subnet-hyperparams-history.mjs
+++ b/src/subnet-hyperparams-history.mjs
@@ -15,8 +15,8 @@
 // against, so history rows stay hash-identical no matter which tier wrote
 // them. D1's own diff-and-append (recordSubnetHyperparamsChanges) and
 // paginated read (loadSubnetHyperparamsHistory) are retired alongside D1's
-// subnet_hyperparams write path — see workers/request-handlers/staging.mjs's
-// header and workers/request-handlers/entities.mjs's
+// subnet_hyperparams write path — see workers/api.mjs's staged-loader
+// retirement note (#4772) and workers/request-handlers/entities.mjs's
 // handleSubnetHyperparamsHistory.
 
 import { formatSubnetHyperparams } from "./subnet-hyperparams.mjs";


### PR DESCRIPTION
## Summary

`workers/request-handlers/staging.mjs` was deleted in the D1→Postgres migration cutover (#4772), but 3 `src/` file headers still referenced it in the present tense as if it existed. Each now points to `workers/api.mjs`'s staged-loader retirement note (#4772) — the current canonical explanation, matching how `workers/api.mjs`/`entities.mjs` already phrase it.

- `src/account-identity.mjs` — the `loadStagedAccountIdentity` column-set reference
- `src/account-identity-history.mjs` — the staged-load pipeline reference
- `src/subnet-hyperparams-history.mjs` — the retirement "see …" pointer

Comment-only, no behavior change. Verified `git grep staging.mjs` over `src/**` is now empty; prettier + eslint clean.

Closes #5871