### PR TITLE
fix(registry): Compute Horde (SN12) accuracy pass -- restore missing probes

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 204,
+  "surface_count": 205,
   "surfaces": [
     {
       "auth_required": false,
@@ -1019,6 +1019,24 @@
       "surface_id": "sn-11-trajectoryrl-subnet-api",
       "surface_key": "srf-fb2d84726c2ab7c6",
       "url": "https://trajrl.com/api/stats"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 12,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "compute-horde",
+      "public_safe": true,
+      "subnet_name": "Compute Horde",
+      "subnet_slug": "sn-12",
+      "surface_id": "sn-12-computehorde-collateral-abi",
+      "surface_key": "srf-8b567d64fac472c2",
+      "url": "https://raw.githubusercontent.com/backend-developers-ltd/ComputeHorde/master/validator/app/src/compute_horde_validator/validator/collateral_abi.json"
     },
     {
       "auth_required": false,

--- a/registry/subnets/compute-horde.json
+++ b/registry/subnets/compute-horde.json
@@ -23,7 +23,7 @@
   "dashboard_url": "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12",
   "name": "Compute Horde",
   "netuid": 12,
-  "notes": "Reviewed overlay for SN12 using the official Compute Horde website/source repository and the project-linked Grafana metagraph dashboard. No safe public subnet API/OpenAPI surface is verified yet.",
+  "notes": "Reviewed overlay for SN12 using the official Compute Horde website/source repository and the project-linked Grafana metagraph dashboard. No safe public subnet API/OpenAPI surface is verified yet; no docs subdomain found either (docs.computehorde.io unresolvable, /docs 404s). Two community-submitted surfaces (sdk, collateral-abi) had no probe config at all -- the same registry-wide gap tracked in #5932 -- confirmed live and given probe configs matching sibling conventions elsewhere in the registry.",
   "schema_version": 1,
   "slug": "sn-12",
   "source_repo": "https://github.com/backend-developers-ltd/ComputeHorde",
@@ -100,6 +100,12 @@
       "kind": "sdk",
       "name": "Compute Horde Python SDK",
       "notes": "Official Python SDK (pip install compute-horde-sdk, module compute_horde_sdk.v1) for submitting organic compute jobs to the SN12 Compute Horde subnet, developed and published from the subnet's registered source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "compute-horde",
       "public_safe": true,
       "review": {
@@ -118,6 +124,12 @@
       "kind": "data-artifact",
       "name": "ComputeHorde collateral contract ABI",
       "notes": "Public no-auth machine-readable JSON ABI for ComputeHorde's on-chain collateral smart contract, committed in the official backend-developers-ltd/ComputeHorde source repository (whose README declares \"Subnet 12 of Bittensor\"). The contract carries a NETUID accessor plus the deposit / reclaim / finalizeReclaim / collaterals interface that SN12 miners and validators use for the subnet's economic-security collateral flow — a standalone machine-readable reference artifact the registry did not yet capture.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "compute-horde",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- Two community-submitted surfaces (`sn-12-compute-horde-sdk`, `sn-12-computehorde-collateral-abi`) had no probe config at all -- the same registry-wide gap tracked in #5932 (369 surfaces across 119/129 files). Confirmed both live before adding probe configs matching sibling conventions (HEAD/any for the PyPI SDK page, GET/json for the raw JSON ABI, matching Vanta's own contract-ABI surface).
- Checked for a docs subdomain to address the "No verified official docs URL yet" gap note: `docs.computehorde.io` is unresolvable, `/docs` 404s. Gap note remains accurate.
- All 6 surfaces re-verified live (HTTP 200); no new operational surfaces found in the source repo beyond what's already tracked.

## Test plan

- [x] `npm run validate:schemas` — passes
- [x] `npm run validate:surface` — passes (915 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] Every surface URL live-tested individually before assigning a probe