### PR TITLE
feat(graphql): add Query.account_transfers mirroring REST + MCP get_account_transfers (#5892)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -109,7 +109,10 @@ import {
   DEFAULT_ACCOUNTS_LIST_SORT,
   buildAccountsList,
 } from "./accounts-list.mjs";
-import { buildAccountSummary } from "./account-events.mjs";
+import {
+  buildAccountSummary,
+  buildAccountTransfers,
+} from "./account-events.mjs";
 import {
   DEFAULT_PROMETHEUS_WINDOW,
   PROMETHEUS_WINDOWS,
@@ -310,6 +313,8 @@ export const SDL = `
     account_registrations(ss58: String!, window: String): AccountRegistrations!
     "One account's per-subnet deregistration footprint over a 7d/30d/90d window (default 30d): NeuronDeregistered count and first/last timestamps per subnet, an HHI concentration of where its deregistration activity is focused, and the dominant subnet; an address with no deregistrations in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/deregistrations."
     account_deregistrations(ss58: String!, window: String): AccountDeregistrations!
+    "One account's native-TAO transfer feed by ss58 (newest first): each Transfer event where the address is sender and/or recipient, with from/to/amount_tao/direction/observed_at, keyset-paginated. direction filters to sent | received (default both); block_start/block_end bound the height range. A malformed ss58 is a GraphQL error; an address with no transfers resolves to a schema-stable empty feed, never null. Mirrors GET /api/v1/accounts/{ss58}/transfers."
+    account_transfers(ss58: String!, limit: Int, offset: Int, cursor: String, direction: String, block_start: Int, block_end: Int): AccountTransfers!
     "One account's StakeAdded/StakeRemoved flow per subnet over a 7d/30d/90d window (default 30d) -- net + gross flow, a direction label (accumulating/exiting/churning/idle), and an HHI concentration of where its flow is focused. direction narrows to inflow (in) or outflow (out) only; all (default) reports both sides. An address with no flow in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/stake-flow."
     account_stake_flow(ss58: String!, window: String, direction: String): AccountStakeFlow!
     "One wallet's cross-subnet neuron portfolio: every subnet where the hotkey is a registered neuron, each position's economics (stake, emission, rank, trust, incentive, dividends, role) and emission/stake yield, plus wallet-level aggregates (totals, counts, overall return, stake concentration). Richer than account.registrations (registration footprint only). An address with no registered neurons resolves to a schema-stable empty card, never null. Mirrors GET /api/v1/accounts/{ss58}/portfolio."
@@ -1673,6 +1678,28 @@ export const SDL = `
     subnets: [AccountDeregistrationSubnet!]!
   }
 
+  "One native-TAO Transfer event on the account's feed. direction is relative to the queried address (sent = it paid, received = it was paid)."
+  type AccountTransfer {
+    block_number: Int
+    event_index: Int
+    from: String
+    to: String
+    amount_tao: Float
+    direction: String
+    observed_at: String
+  }
+
+  "One account's native-TAO transfer feed, keyset-paginated newest-first. Mirrors GET /api/v1/accounts/{ss58}/transfers' data envelope."
+  type AccountTransfers {
+    schema_version: Int!
+    address: String!
+    transfer_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    transfers: [AccountTransfer!]!
+  }
+
   "One subnet's slice of an account's axon-serving footprint over the window."
   type AccountServingSubnet {
     netuid: Int!
@@ -2031,6 +2058,7 @@ export const FIELD_COMPLEXITY = {
   accounts: RELATIONSHIP_FIELD_COMPLEXITY,
   account: RELATIONSHIP_FIELD_COMPLEXITY,
   account_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_transfers: RELATIONSHIP_FIELD_COMPLEXITY,
   account_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
   account_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   account_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3826,6 +3854,63 @@ const rootValue = {
         registrations: s.registrations,
         first_registered_at: s.first_registered_at ?? null,
         last_registered_at: s.last_registered_at ?? null,
+      })),
+    };
+  },
+
+  async account_transfers(
+    { ss58, limit, offset, cursor, direction, block_start, block_end },
+    context,
+  ) {
+    // Same SS58 validation the REST transfers handler enforces -- a malformed
+    // address is a GraphQL BAD_USER_INPUT error, not a silent empty feed.
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const safeLimit = clampLimit(limit, FEED_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    if (cursor) params.set("cursor", cursor);
+    if (direction) params.set("direction", direction);
+    if (block_start != null) params.set("block_start", String(block_start));
+    if (block_end != null) params.set("block_end", String(block_end));
+    // Same flat tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) envelope the
+    // REST transfers handler returns; a cold store / an address with no Transfer
+    // events is a schema-stable empty feed via buildAccountTransfers([], ...).
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}/transfers`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      buildAccountTransfers([], ss58, {
+        limit: safeLimit,
+        offset: safeOffset,
+        nextCursor: null,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      address: data.ss58 ?? ss58,
+      transfer_count: data.transfer_count ?? 0,
+      limit: data.limit ?? safeLimit,
+      offset: data.offset ?? safeOffset,
+      next_cursor: data.next_cursor ?? null,
+      transfers: (data.transfers ?? []).map((t) => ({
+        block_number: t.block_number,
+        event_index: t.event_index,
+        from: t.from,
+        to: t.to,
+        amount_tao: t.amount_tao,
+        direction: t.direction,
+        observed_at: t.observed_at,
       })),
     };
   },

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3220,6 +3220,143 @@ describe("graphql — account_prometheus (#5703, Postgres-tier { data, generated
   });
 });
 
+describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () => {
+  const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("account_transfers: a valid ss58 on a cold store returns a schema-stable empty feed", async () => {
+    const { status, body } = await gql(
+      `{ account_transfers(ss58: "${SS58}") { address transfer_count next_cursor transfers { from } } }`,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_transfers, {
+      address: SS58,
+      transfer_count: 0,
+      next_cursor: null,
+      transfers: [],
+    });
+  });
+
+  test("account_transfers: an invalid ss58 is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      '{ account_transfers(ss58: "not-a-valid-address") { address } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("account_transfers: resolves the flat Postgres-tier envelope, mapping ss58 -> address", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          transfer_count: 1,
+          limit: 50,
+          offset: 0,
+          next_cursor: "cursor-1",
+          transfers: [
+            {
+              block_number: 12,
+              event_index: 3,
+              from: SS58,
+              to: "5Recipient",
+              amount_tao: 1.5,
+              direction: "sent",
+              observed_at: "2026-07-15T00:00:00.000Z",
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ account_transfers(ss58: "${SS58}") { address transfer_count next_cursor transfers { block_number event_index from to amount_tao direction observed_at } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.account_transfers.address, SS58);
+    assert.equal(body.data.account_transfers.transfer_count, 1);
+    assert.equal(body.data.account_transfers.next_cursor, "cursor-1");
+    const t = body.data.account_transfers.transfers[0];
+    assert.equal(t.block_number, 12);
+    assert.equal(t.from, SS58);
+    assert.equal(t.to, "5Recipient");
+    assert.equal(t.amount_tao, 1.5);
+    assert.equal(t.direction, "sent");
+  });
+
+  test("account_transfers: hits /api/v1/accounts/{ss58}/transfers and forwards every filter", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            ss58: SS58,
+            transfer_count: 0,
+            limit: 5,
+            offset: 2,
+            next_cursor: null,
+            transfers: [],
+          });
+        },
+      },
+    };
+    await gql(
+      `{ account_transfers(ss58: "${SS58}", limit: 5, offset: 2, cursor: "abc", direction: "received", block_start: 10, block_end: 20) { transfer_count } }`,
+      env,
+    );
+    assert.equal(capturedUrl.pathname, `/api/v1/accounts/${SS58}/transfers`);
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl.searchParams.get("offset"), "2");
+    assert.equal(capturedUrl.searchParams.get("cursor"), "abc");
+    assert.equal(capturedUrl.searchParams.get("direction"), "received");
+    assert.equal(capturedUrl.searchParams.get("block_start"), "10");
+    assert.equal(capturedUrl.searchParams.get("block_end"), "20");
+  });
+
+  test("account_transfers: a partial tier body degrades missing fields to schema-stable defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      `{ account_transfers(ss58: "${SS58}") { address transfer_count next_cursor transfers { from } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_transfers, {
+      address: SS58,
+      transfer_count: 0,
+      next_cursor: null,
+      transfers: [],
+    });
+  });
+
+  test("account_transfers is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.account_transfers, 5);
+  });
+});
+
 describe("graphql — account_stake_flow (#5706, Postgres-tier { data, generatedAt } + zeroed-card fallback)", () => {
   const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 


### PR DESCRIPTION
Closes the account transfer-feed parity gap: `GET /api/v1/accounts/{ss58}/transfers` and the `get_account_transfers` MCP tool both expose an account's native-TAO transfer feed, but GraphQL had no mirror — extending the repo's REST/GraphQL/MCP parity convention (`Query.account_registrations`/`Query.account_balance`).

## What

- Adds `Query.account_transfers(ss58: String!, limit, offset, cursor, direction, block_start, block_end): AccountTransfers!` to `src/graphql.mjs`, plus `AccountTransfer` / `AccountTransfers` types.
- The resolver **proxies to `/api/v1/accounts/{ss58}/transfers`** via the same `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` path the sibling account fields use, reuses the REST handler's flat envelope, and falls back to `buildAccountTransfers([], ss58, …)` on a cold store — **no query/aggregation logic duplicated**.
- SS58 validation matches the REST handler: a malformed address is a GraphQL `BAD_USER_INPUT` error (never reaching the tier); an address with no transfers is a schema-stable empty feed, never null.
- `direction` filters `sent | received` (default both); `block_start`/`block_end` bound the height range — forwarded to the route exactly as REST accepts them.

## Test coverage

`tests/graphql.test.mjs` — a new `account_transfers` describe block mirroring the account-feed test convention: cold-store empty feed, invalid-ss58 `BAD_USER_INPUT` (tier never called), flat-envelope resolution (`ss58`→`address`), all filters forwarded to `/api/v1/accounts/{ss58}/transfers`, partial-body degradation to defaults, and the fan-out complexity weight.

`npm run test -- graphql` green (395 tests); new resolver at 100% patch coverage; `lint` + `format:check` clean.

Closes #5892
