### PR TITLE
fix(registry): Cacheon (SN14) accuracy pass -- source repo renamed/archived

### DIFF
--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -24,13 +24,13 @@
   "docs_url": "https://cacheon.ai/docs",
   "name": "Cacheon",
   "netuid": 14,
-  "notes": "Reviewed overlay for SN14 Cacheon. The public docs include miner API contract documentation for OpenAI-compatible inference endpoints, but no shared hosted public subnet API endpoint is promoted from that contract.",
+  "notes": "Reviewed overlay for SN14 Cacheon. The public docs include miner API contract documentation for OpenAI-compatible inference endpoints, but no shared hosted public subnet API endpoint is promoted from that contract. The team renamed and archived their GitHub repo from latent-to/cacheon to latent-to/cacheon-old (2026-07-07); source_repo updated to the canonical location. Confirmed NOT a subnet rebrand: live on-chain native_name for SN14 is still \"Cacheon\", and the archived repo's own content still matches the on-chain description exactly. The org's separate 'optima' repo (very recently active) is an unrelated testnet-only project, not SN14's successor.",
   "schema_version": 1,
   "slug": "cacheon",
   "social": {
     "x": "https://x.com/cacheon_ai"
   },
-  "source_repo": "https://github.com/latent-to/cacheon",
+  "source_repo": "https://github.com/latent-to/cacheon-old",
   "status": "active",
   "surfaces": [
     {
@@ -50,7 +50,7 @@
       "public_safe": true,
       "source_urls": [
         "https://cacheon.ai/",
-        "https://github.com/latent-to/cacheon"
+        "https://github.com/latent-to/cacheon-old"
       ],
       "url": "https://cacheon.ai/"
     },
@@ -71,7 +71,7 @@
       "public_safe": true,
       "source_urls": [
         "https://cacheon.ai/docs",
-        "https://github.com/latent-to/cacheon"
+        "https://github.com/latent-to/cacheon-old"
       ],
       "url": "https://cacheon.ai/docs"
     },
@@ -81,7 +81,7 @@
       "id": "sn-14-cacheon-source-repo",
       "kind": "source-repo",
       "name": "Cacheon source repository",
-      "notes": "Public Cacheon source repository.",
+      "notes": "Public Cacheon source repository. The team renamed and archived the repo from latent-to/cacheon to latent-to/cacheon-old (2026-07-07); the old URL still 301-redirects here, but this is the canonical, non-redirecting location. Content unchanged and still matches the live on-chain SN14 description -- confirmed this is NOT a subnet rebrand: the org's separate 'optima' repo is an unrelated testnet-only project (mentions testnet netuid 307), and the live on-chain native_name for SN14 is still 'Cacheon'.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -91,10 +91,10 @@
       "provider": "cacheon",
       "public_safe": true,
       "source_urls": [
-        "https://github.com/latent-to/cacheon",
+        "https://github.com/latent-to/cacheon-old",
         "https://cacheon.ai/"
       ],
-      "url": "https://github.com/latent-to/cacheon"
+      "url": "https://github.com/latent-to/cacheon-old"
     },
     {
       "auth_required": false,
@@ -113,7 +113,7 @@
       "public_safe": true,
       "source_urls": [
         "https://cacheon.ai/docs/miners/api-contract",
-        "https://github.com/latent-to/cacheon"
+        "https://github.com/latent-to/cacheon-old"
       ],
       "url": "https://cacheon.ai/docs/miners/api-contract"
     },
@@ -122,7 +122,8 @@
       "authority": "community",
       "id": "sn-14-cacheon-data-artifact",
       "kind": "data-artifact",
-      "name": "Cacheon community data-artifact",
+      "name": "Cacheon container logs listing",
+      "notes": "Public no-auth GET returning the list of available validator container evaluation log files (label, filename, size_bytes). Documented in the subnet's own OpenAPI schema; same host as the other api.cacheon.ai subnet-api surfaces.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -144,7 +145,8 @@
       "authority": "community",
       "id": "sn-14-cacheon-openapi",
       "kind": "openapi",
-      "name": "Cacheon community openapi",
+      "name": "Cacheon monitoring API OpenAPI schema",
+      "notes": "Machine-readable OpenAPI schema (title \"Cacheon Monitoring API\") for the SN14 coordinator/monitoring API on api.cacheon.ai, documenting the health, status, leader, evaluations, rounds, and log-listing endpoints tracked elsewhere in this file.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -168,7 +170,8 @@
       "authority": "community",
       "id": "sn-14-cacheon-subnet-api",
       "kind": "subnet-api",
-      "name": "Cacheon community subnet-api",
+      "name": "Cacheon coordinator status API",
+      "notes": "Public no-auth GET returning current coordinator status (leader UID/score/image, evaluated/active/disqualified miner counts, last evaluation/weights-set block). Documented in the subnet's own OpenAPI schema; same host as the other api.cacheon.ai subnet-api surfaces.",
       "probe": {
         "enabled": true,
         "expect": "any",


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- Discovered the tracked source repo (`github.com/latent-to/cacheon`) now 301-redirects: the team renamed it to `latent-to/cacheon-old` and archived it (2026-07-07). **Confirmed this is NOT a subnet rebrand before touching anything** -- queried the live on-chain identity via `api.metagraph.sh`: `native_name` for SN14 is still "Cacheon", matching the archived repo's own README content word-for-word (same containerized-inference-server competition description). The org's separate `optima` repo (updated today, very recently active) mentions a testnet netuid and is an unrelated new project by the same team, not SN14's successor.
- Updated `source_repo` and the source-repo surface's `url`/`source_urls` to the canonical non-redirecting `cacheon-old` location, rather than depending indefinitely on a redirect GitHub or the team could remove.
- Gave 3 generically-named community surfaces (data-artifact, openapi, subnet-api -- all literally named "Cacheon community `<kind>`" with no `notes`) descriptive names and notes matching their better-documented siblings, after confirming what each actually returns.
- All 15 surfaces re-verified live; diffed the tracked OpenAPI schema against tracked surfaces -- the only 4 undocumented paths are per-hotkey/per-uid/per-label parameterized lookups, not tracked for the same staleness reason established in prior passes (#5914, #5934).

## Test plan

- [x] `npm run validate:schemas` — passes
- [x] `npm run validate:surface` — passes (915 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] Confirmed the repo rename is not a subnet rebrand via live on-chain identity, not just GitHub metadata
- [x] Every surface URL live-tested individually