### PR TITLE
fix(registry): ORO (SN15) accuracy pass -- restore 10 missing probes

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 205,
+  "surface_count": 215,
   "surfaces": [
     {
       "auth_required": false,
@@ -1178,6 +1178,42 @@
       "public_safe": true,
       "subnet_name": "ORO",
       "subnet_slug": "sn-15",
+      "surface_id": "sn-15-oro-current-suite-api",
+      "surface_key": "srf-6e0db30048e9f1f5",
+      "url": "https://api.oroagents.com/v1/public/suites/current"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 15,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "subnet_name": "ORO",
+      "subnet_slug": "sn-15",
+      "surface_id": "sn-15-oro-data-artifact",
+      "surface_key": "srf-b6237bb2eb9a7851",
+      "url": "https://api.oroagents.com/v1/public/top"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 15,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "subnet_name": "ORO",
+      "subnet_slug": "sn-15",
       "surface_id": "sn-15-oro-evaluations-pending",
       "surface_key": "srf-23133a11c7c7087d",
       "url": "https://api.oroagents.com/v1/public/evaluations/pending"
@@ -1214,6 +1250,42 @@
       "public_safe": true,
       "subnet_name": "ORO",
       "subnet_slug": "sn-15",
+      "surface_id": "sn-15-oro-health",
+      "surface_key": "srf-81be83ff67a2d74b",
+      "url": "https://api.oroagents.com/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 15,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "subnet_name": "ORO",
+      "subnet_slug": "sn-15",
+      "surface_id": "sn-15-oro-health-deep",
+      "surface_key": "srf-ef67e23327810f35",
+      "url": "https://api.oroagents.com/health/deep"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 15,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "subnet_name": "ORO",
+      "subnet_slug": "sn-15",
       "surface_id": "sn-15-oro-public-inference-models",
       "surface_key": "srf-1d9e3afff1f4f5a7",
       "url": "https://api.oroagents.com/v1/public/inference/models"
@@ -1235,6 +1307,114 @@
       "surface_id": "sn-15-oro-public-top-history",
       "surface_key": "srf-57ea439895d9faf9",
       "url": "https://api.oroagents.com/v1/public/top/history"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 15,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "subnet_name": "ORO",
+      "subnet_slug": "sn-15",
+      "surface_id": "sn-15-oro-races-current-api",
+      "surface_key": "srf-788c7b31d899d584",
+      "url": "https://api.oroagents.com/v1/public/races/current"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 15,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "subnet_name": "ORO",
+      "subnet_slug": "sn-15",
+      "surface_id": "sn-15-oro-races-history-api",
+      "surface_key": "srf-2a7242a1a6718a88",
+      "url": "https://api.oroagents.com/v1/public/races/history"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 15,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "subnet_name": "ORO",
+      "subnet_slug": "sn-15",
+      "surface_id": "sn-15-oro-shoppingbench-sft",
+      "surface_key": "srf-969ab12e56ca1aa2",
+      "url": "https://huggingface.co/datasets/oro-ai/sn15-shoppingbench-sft-15k"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 15,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "subnet_name": "ORO",
+      "subnet_slug": "sn-15",
+      "surface_id": "sn-15-oro-shoppingbench-traces",
+      "surface_key": "srf-b76c17ff20f5711a",
+      "url": "https://huggingface.co/datasets/oro-ai/sn15-shoppingbench-traces-18k"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 15,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "subnet_name": "ORO",
+      "subnet_slug": "sn-15",
+      "surface_id": "sn-15-oro-subnet-api",
+      "surface_key": "srf-e47c4ed311daea8f",
+      "url": "https://api.oroagents.com/v1/public/leaderboard"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 15,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "oro",
+      "public_safe": true,
+      "subnet_name": "ORO",
+      "subnet_slug": "sn-15",
+      "surface_id": "sn-15-oro-subnet-api-api-oroagents-com",
+      "surface_key": "srf-4210ffeab337cec8",
+      "url": "https://api.oroagents.com/v1/public/suites"
     },
     {
       "auth_required": false,

--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -19,7 +19,7 @@
   "docs_url": "https://docs.oroagents.com/docs/miners/quick-start",
   "name": "ORO",
   "netuid": 15,
-  "notes": "Reviewed overlay for SN15 using the official ORO website, miner quick-start docs, and source repository. No safe public API or machine-readable schema is verified yet.",
+  "notes": "Reviewed overlay for SN15 using the official ORO website, miner quick-start docs, and source repository. 10 community-submitted surfaces had no probe config at all -- the same registry-wide gap tracked in #5932 -- confirmed all 10 live and given probe configs matching sibling conventions. The OpenAPI schema documents 75 total paths; everything under /v1/admin, /v1/validator, /v1/miner, and /v1/auth is privileged and correctly untracked, and the remaining untracked /v1/public/* paths are either parameterized per-entity lookups (agent_version_id, eval_run_id, race_id, suite_id -- no stable canonical value, same reasoning as #5914/#5934) or POST write actions (download-url generation, waitlist signup), not GET-able data reads.",
   "schema_version": 1,
   "slug": "sn-15",
   "social": {
@@ -112,6 +112,13 @@
       "id": "sn-15-oro-subnet-api",
       "kind": "subnet-api",
       "name": "ORO public leaderboard API",
+      "notes": "Public no-auth GET returning the current ORO leaderboard (rank, agent, suite). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "oro",
       "public_safe": true,
       "review": {
@@ -130,6 +137,13 @@
       "id": "sn-15-oro-data-artifact",
       "kind": "data-artifact",
       "name": "ORO top-miner snapshot",
+      "notes": "Public no-auth GET returning a snapshot of the current top-ranked ORO miner. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "oro",
       "public_safe": true,
       "review": {
@@ -149,6 +163,12 @@
       "kind": "subnet-api",
       "name": "ORO public evaluation-suites API",
       "notes": "Public no-auth GET returning the ORO evaluation-suite catalog. Documented in the subnet's own OpenAPI (api.oroagents.com/openapi.json); same host as the existing openapi + subnet-api + data-artifact surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "oro",
       "public_safe": true,
       "review": {
@@ -168,6 +188,12 @@
       "kind": "data-artifact",
       "name": "ORO SN15 ShoppingBench traces dataset",
       "notes": "Public ORO (SN15) HuggingFace dataset of 18,043 multi-turn agentic shopping trajectories (messages/tools/task_name columns) harvested from the subnet's ShoppingBench agentic-commerce benchmark; CC BY 4.0, not gated. The dataset card names \"ORO Subnet 15 (SN15), the Bittensor deployment\" and the ORO repo README (source) declares the subnet; the oro-ai HF org matches the operator's ORO-AI GitHub org.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "oro",
       "public_safe": true,
       "review": {
@@ -187,6 +213,12 @@
       "kind": "data-artifact",
       "name": "ORO SN15 ShoppingBench SFT dataset",
       "notes": "Public ORO (SN15) Hugging Face supervised-fine-tuning dataset of ~15k agentic-commerce instruction/response pairs distilled from the subnet's ShoppingBench benchmark; CC BY 4.0, not gated. The dataset card names ORO Subnet 15 and the oro-ai HF org matches the operator's ORO-AI GitHub org (the ORO repo README declares the subnet). Distinct from the subnet's registered ShoppingBench traces dataset.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "oro",
       "public_safe": true,
       "review": {
@@ -206,6 +238,12 @@
       "kind": "subnet-api",
       "name": "ORO API health",
       "notes": "Public no-auth GET /health returning ORO API status and version. Documented in the subnet's OpenAPI spec on the same host as the existing leaderboard, suites, and snapshot surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "oro",
       "public_safe": true,
       "review": {
@@ -225,6 +263,12 @@
       "kind": "subnet-api",
       "name": "ORO current active suite API",
       "notes": "Public no-auth GET returning the currently active ORO evaluation problem suite (suite_id, suite_version, is_active). Documented in the subnet's own OpenAPI (api.oroagents.com/openapi.json, path /v1/public/suites/current); same host as the existing suites catalog and leaderboard surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "oro",
       "public_safe": true,
       "review": {
@@ -244,6 +288,12 @@
       "kind": "subnet-api",
       "name": "ORO current race API",
       "notes": "Public no-auth GET /v1/public/races/current on api.oroagents.com returning the active evaluation race for the current suite. Documented in the subnet OpenAPI on the same host as existing ORO public API surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "oro",
       "public_safe": true,
       "review": {
@@ -263,6 +313,12 @@
       "kind": "subnet-api",
       "name": "ORO race history API",
       "notes": "Public no-auth GET /v1/public/races/history on api.oroagents.com returning paginated completed and cancelled evaluation races (most recent first). Documented in the subnet OpenAPI on the same host as existing ORO public API surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "oro",
       "public_safe": true,
       "review": {
@@ -282,6 +338,12 @@
       "kind": "subnet-api",
       "name": "ORO API deep health",
       "notes": "Public no-auth GET /health/deep returning deep readiness JSON (status, version) that exercises the SQLAlchemy connection pool. Documented in the subnet's own OpenAPI (api.oroagents.com/openapi.json, path /health/deep); same host as the existing /health and public API surfaces. Distinct from the lightweight /health liveness endpoint.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "oro",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- **10 of 20** community-submitted surfaces had no probe config at all -- the same registry-wide gap tracked in #5932 (369 surfaces across 119/129 files). Confirmed all 10 live before adding probe configs matching sibling conventions (GET/json for the api.oroagents.com JSON endpoints, HEAD/html for the two HuggingFace dataset pages).
- Diffed the tracked OpenAPI schema (75 total paths) against tracked surfaces: everything under `/v1/admin`, `/v1/validator`, `/v1/miner`, and `/v1/auth` is privileged and correctly untracked. The remaining untracked `/v1/public/*` paths are either parameterized per-entity lookups (agent_version_id, eval_run_id, race_id, suite_id -- no stable canonical value, same reasoning as #5914/#5934) or POST write actions (download-url generation, waitlist signup), not GET-able data reads.
- All 20 surfaces re-verified live; `gap_notes` were already accurate, no changes needed there.

## Test plan

- [x] `npm run validate:schemas` — passes
- [x] `npm run validate:surface` — passes (915 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] Every surface URL live-tested individually before assigning a probe
- [x] All 75 OpenAPI paths individually reviewed for auth requirements and parameter fitness