### PR TITLE
feat(graphql): add Query.account_transfers mirroring REST + MCP account transfers

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -109,7 +109,10 @@ import {
   DEFAULT_ACCOUNTS_LIST_SORT,
   buildAccountsList,
 } from "./accounts-list.mjs";
-import { buildAccountSummary } from "./account-events.mjs";
+import {
+  buildAccountSummary,
+  buildAccountTransfers,
+} from "./account-events.mjs";
 import {
   DEFAULT_PROMETHEUS_WINDOW,
   PROMETHEUS_WINDOWS,
@@ -335,6 +338,8 @@ export const SDL = `
     account_identity_history(ss58: String!, limit: Int, offset: Int, cursor: String): AccountIdentityHistory!
     "Rank who one account transacts native TAO with, by total transfer volume, from the Balances.Transfer feed: per counterparty the sent/received/net TAO, transfer count, and last block, plus scan totals. Pass counterparty=<ss58> (must differ from ss58) to drill into a single relationship instead -- its fund-flow totals plus direction-aware transfer evidence under relationship, newest first. limit caps the ranked list (default 20) or the relationship's transfer evidence (default 50); 1-100. An address with no transfers resolves to a schema-stable zero card, never null. Mirrors GET /api/v1/accounts/{ss58}/counterparties."
     account_counterparties(ss58: String!, counterparty: String, limit: Int): AccountCounterparties!
+    "One account's native-TAO transfer feed from the Balances.Transfer event stream, newest first -- each event's block/index, from/to, amount_tao, a direction relative to the queried address (sent = it paid, received = it was paid), and observed_at. direction narrows to sent | received only (default both); block_start/block_end bound the block-height range; page with limit/offset or cursor (opaque keyset from a prior response's next_cursor). An address with no transfers resolves to a schema-stable empty feed, never null. Mirrors GET /api/v1/accounts/{ss58}/transfers."
+    account_transfers(ss58: String!, limit: Int, offset: Int, cursor: String, direction: String, block_start: Int, block_end: Int): AccountTransfers!
     "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
     economics_trends(window: String): EconomicsTrends!
     "Registry leaderboards: the operational boards (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable) and the economic-opportunity boards (open-slots, cheapest-registration, highest-emission, validator-headroom), composed live from the registry profiles projection plus D1 health/rpc/growth/reliability rows and the economics tier. Pass board to return just that board (default: every board); limit caps each board's entries (default 20, max 100). An unknown board is a BAD_USER_INPUT error, matching REST's invalid_query 400. Mirrors GET /api/v1/registry/leaderboards."
@@ -1837,6 +1842,28 @@ export const SDL = `
     relationship: AccountCounterpartyRelationship
   }
 
+  "One native-TAO Balances.Transfer event on an account's feed. direction is relative to the queried address (sent = it paid, received = it was paid)."
+  type AccountTransfer {
+    block_number: Int
+    event_index: Int
+    from: String
+    to: String
+    amount_tao: Float
+    direction: String
+    observed_at: String
+  }
+
+  "One account's native-TAO transfer feed, keyset-paginated newest-first. Mirrors GET /api/v1/accounts/{ss58}/transfers' data envelope."
+  type AccountTransfers {
+    schema_version: Int!
+    ss58: String!
+    transfer_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    transfers: [AccountTransfer!]!
+  }
+
   type AccountEvent {
     block_number: Int
     event_index: Int
@@ -2133,6 +2160,7 @@ export const FIELD_COMPLEXITY = {
   account_identity: RELATIONSHIP_FIELD_COMPLEXITY,
   account_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   account_counterparties: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_transfers: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   // A single latest-only row -- but it fans out into the full hyperparameter
   // block, so it is priced with the other per-subnet relationship fields.
@@ -4413,6 +4441,68 @@ const rootValue = {
             })),
           }
         : null,
+    };
+  },
+
+  async account_transfers(
+    { ss58, limit, offset, cursor, direction, block_start, block_end },
+    context,
+  ) {
+    // Same SS58 validation every account_* resolver uses -- a malformed address
+    // is a GraphQL BAD_USER_INPUT error, not a silent empty feed.
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same FEED_PAGINATION bounds parsePagination applies for REST, so a GraphQL
+    // caller cannot request a wider page than the /transfers route allows;
+    // direction/cursor/block_start/block_end are forwarded verbatim for the
+    // route to re-parse, matching the sibling feed resolvers.
+    const safeLimit = clampLimit(limit, FEED_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    if (cursor != null) params.set("cursor", cursor);
+    if (direction != null) params.set("direction", direction);
+    if (block_start != null) params.set("block_start", String(block_start));
+    if (block_end != null) params.set("block_end", String(block_end));
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) the REST handler and
+    // MCP get_account_transfers tool use. The account_events D1 write path is
+    // retired (#4772), so a tier miss resolves through buildAccountTransfers over
+    // an empty scan -- a schema-stable empty feed, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}/transfers`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      buildAccountTransfers([], ss58, {
+        limit: safeLimit,
+        offset: safeOffset,
+        nextCursor: null,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      ss58: data.ss58 ?? ss58,
+      transfer_count: data.transfer_count ?? 0,
+      limit: data.limit ?? safeLimit,
+      offset: data.offset ?? safeOffset,
+      next_cursor: data.next_cursor ?? null,
+      transfers: (data.transfers ?? []).map((t) => ({
+        block_number: t.block_number ?? null,
+        event_index: t.event_index ?? null,
+        from: t.from ?? null,
+        to: t.to ?? null,
+        amount_tao: t.amount_tao ?? null,
+        direction: t.direction ?? null,
+        observed_at: t.observed_at ?? null,
+      })),
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -6748,6 +6748,231 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
   });
 });
 
+describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () => {
+  const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+  const OTHER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  function dataApi(response, capture) {
+    return {
+      fetch: async (req) => {
+        if (capture) capture.url = new URL(req.url);
+        return response;
+      },
+    };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty feed, never null", async () => {
+    const { status, body } = await gql(
+      `{ account_transfers(ss58: "${SS58}") {
+          schema_version ss58 transfer_count limit offset next_cursor
+          transfers { block_number event_index from to amount_tao direction observed_at }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_transfers, {
+      schema_version: 1,
+      ss58: SS58,
+      transfer_count: 0,
+      limit: 100,
+      offset: 0,
+      next_cursor: null,
+      transfers: [],
+    });
+  });
+
+  test("resolves the flat Postgres-tier envelope, mapping each transfer's fields", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          transfer_count: 1,
+          limit: 50,
+          offset: 0,
+          next_cursor: "b:1200:3",
+          transfers: [
+            {
+              block_number: 1200,
+              event_index: 3,
+              from: SS58,
+              to: OTHER,
+              amount_tao: 1.5,
+              direction: "sent",
+              observed_at: "2026-07-15T00:00:00.000Z",
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ account_transfers(ss58: "${SS58}") {
+          schema_version ss58 transfer_count limit offset next_cursor
+          transfers { block_number event_index from to amount_tao direction observed_at }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_transfers, {
+      schema_version: 1,
+      ss58: SS58,
+      transfer_count: 1,
+      limit: 50,
+      offset: 0,
+      next_cursor: "b:1200:3",
+      transfers: [
+        {
+          block_number: 1200,
+          event_index: 3,
+          from: SS58,
+          to: OTHER,
+          amount_tao: 1.5,
+          direction: "sent",
+          observed_at: "2026-07-15T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  test("hits /api/v1/accounts/{ss58}/transfers and forwards every filter", async () => {
+    const capture = {};
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          transfer_count: 0,
+          limit: 5,
+          offset: 2,
+          next_cursor: null,
+          transfers: [],
+        }),
+        capture,
+      ),
+    };
+    const { status } = await gql(
+      `{ account_transfers(ss58: "${SS58}", limit: 5, offset: 2, cursor: "c:9:1", direction: "received", block_start: 10, block_end: 20) { transfer_count } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(capture.url.pathname, `/api/v1/accounts/${SS58}/transfers`);
+    assert.equal(capture.url.searchParams.get("limit"), "5");
+    assert.equal(capture.url.searchParams.get("offset"), "2");
+    assert.equal(capture.url.searchParams.get("cursor"), "c:9:1");
+    assert.equal(capture.url.searchParams.get("direction"), "received");
+    assert.equal(capture.url.searchParams.get("block_start"), "10");
+    assert.equal(capture.url.searchParams.get("block_end"), "20");
+  });
+
+  test("clamps limit/offset to FEED_PAGINATION bounds before forwarding", async () => {
+    const capture = {};
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({}), capture),
+    };
+    await gql(
+      `{ account_transfers(ss58: "${SS58}", limit: 100000, offset: -5) { transfer_count } }`,
+      env,
+    );
+    const forwardedLimit = Number(capture.url.searchParams.get("limit"));
+    const forwardedOffset = Number(capture.url.searchParams.get("offset"));
+    assert.ok(forwardedLimit > 0 && forwardedLimit < 100000);
+    assert.equal(forwardedOffset, 0);
+    // No filter params were supplied, so none are forwarded.
+    assert.equal(capture.url.searchParams.get("cursor"), null);
+    assert.equal(capture.url.searchParams.get("direction"), null);
+    assert.equal(capture.url.searchParams.get("block_start"), null);
+    assert.equal(capture.url.searchParams.get("block_end"), null);
+  });
+
+  test("a partial tier envelope degrades missing scalars to schema-stable defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ account_transfers(ss58: "${SS58}") {
+          schema_version ss58 transfer_count limit offset next_cursor transfers { from }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_transfers, {
+      schema_version: 1,
+      ss58: SS58,
+      transfer_count: 0,
+      limit: 100,
+      offset: 0,
+      next_cursor: null,
+      transfers: [],
+    });
+  });
+
+  test("a transfer row with missing fields degrades each to null", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          transfer_count: 1,
+          next_cursor: null,
+          transfers: [{}],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ account_transfers(ss58: "${SS58}") {
+          transfers { block_number event_index from to amount_tao direction observed_at }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_transfers.transfers, [
+      {
+        block_number: null,
+        event_index: null,
+        from: null,
+        to: null,
+        amount_tao: null,
+        direction: null,
+        observed_at: null,
+      },
+    ]);
+  });
+
+  test("an invalid ss58 is a GraphQL error and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { body } = await gql(
+      '{ account_transfers(ss58: "not-an-address") { transfer_count } }',
+      env,
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/ss58/i.test(body.errors[0].message));
+    assert.equal(body.data?.account_transfers ?? null, null);
+    assert.equal(called, false);
+  });
+
+  test("account_transfers is weighted as a relationship field", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.account_transfers,
+      FIELD_COMPLEXITY.account_identity_history,
+    );
+  });
+});
+
 describe("graphql — account_identity_history (#5709, Postgres-tier + D1-live fallback)", () => {
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 


### PR DESCRIPTION
## What

Adds `Query.account_transfers` to `src/graphql.mjs`, mirroring the existing REST route `GET /api/v1/accounts/{ss58}/transfers` (`workers/data-api.mjs`) and the MCP `get_account_transfers` tool. This closes the last REST/GraphQL/MCP parity gap for the native-TAO transfer feed — the same gap-closure category as the recently merged `Query.account_counterparties` (#5940) and `Query.account_position_history` (#5939).

## How

- New SDL types `AccountTransfer` / `AccountTransfers` and the `account_transfers(ss58: String!, limit: Int, offset: Int, cursor: String, direction: String, block_start: Int, block_end: Int): AccountTransfers!` field, weighted as a `RELATIONSHIP_FIELD_COMPLEXITY` field like its siblings.
- The resolver reuses the same `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` path the REST handler and MCP tool already use — no query/aggregation logic is duplicated. `limit`/`offset` are clamped to `FEED_PAGINATION` (matching `parsePagination`'s REST bounds) and `cursor`/`direction`/`block_start`/`block_end` are forwarded verbatim for the route to re-parse.
- On a tier miss the resolver falls back to `buildAccountTransfers([], ss58, …)` for a schema-stable empty feed (the `account_events` D1 write path is retired, #4772), never a GraphQL error.
- A malformed `ss58` is a `BAD_USER_INPUT` error and never reaches the Postgres tier, matching every sibling `account_*` resolver.

## Tests

`tests/graphql.test.mjs` — a new `account_transfers` describe block (8 tests): cold-store empty feed, full tier envelope mapping, filter forwarding, limit/offset clamping, partial-envelope scalar defaults, per-row null defaults, invalid-ss58 guard (tier never called), and field-complexity weighting.

- `npx vitest run tests/graphql.test.mjs` → 416 passed
- `vitest --coverage` on `src/graphql.mjs` → 100% statements / 100% lines / 100% functions on the changed file; every added line and branch is covered.
- `npm run lint` and `npm run format:check` → clean.
- `node scripts/worker-bundle-budget.mjs` → passes (1001.3 KiB, under the 1008 KiB fail budget).

Closes #5892
