### PR TITLE
feat(graphql): add Query.chain_calls mirroring REST + MCP (#5880)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -199,6 +199,7 @@ import {
   DEFAULT_CHAIN_TURNOVER_WINDOW,
 } from "./chain-turnover.mjs";
 import { buildTurnover } from "./turnover.mjs";
+import { buildChainCalls } from "./chain-analytics.mjs";
 import { buildChainPerformance } from "./chain-performance.mjs";
 import { buildChainConcentration } from "./concentration.mjs";
 import {
@@ -353,6 +354,8 @@ export const SDL = `
     chain_weights(window: String, limit: Int): ChainWeights!
     "Network-wide axon-serving announcement leaderboard over a 7d/30d window (default 7d): subnets ranked by AxonServed announcements with each's distinct-server count and announcements-per-server re-announcement intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The network-wide counterpart of subnet_serving. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/serving."
     chain_serving(window: String, limit: Int): ChainServing!
+    "Extrinsic call-mix breakdown over a 7d/30d window (default 7d): the extrinsic count and share per call_module, or per call_module+call_function when group_by is module_function (default module), optionally scoped to a single call_module, ranked by count (limit default 50, max 100). Computed live from the extrinsics tier; a cold store yields a schema-stable empty breakdown, never a GraphQL error. Mirrors GET /api/v1/chain/calls."
+    chain_calls(window: String, group_by: String, limit: Int, call_module: String): ChainCalls!
     "Network-wide weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators driving consensus network-wide, each with its total WeightsSet count, share of the network total, and first/last set times, ranked by activity. The setter-level drill-in behind chain_weights. Mirrors GET /api/v1/chain/weights/setters."
     chain_weight_setters(window: String, limit: Int): ChainWeightSetters!
     "Compact all-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history (probed every ~15 minutes); a cold store still returns both windows, schema-stable and zeroed, never a GraphQL error. Mirrors GET /api/v1/health/trends."
@@ -539,6 +542,25 @@ export const SDL = `
     neurons_start: Int!
     neurons_end: Int!
     neurons_delta: Int!
+  }
+
+  "One row of the extrinsic call-mix breakdown -- a call_module (plus call_function when group_by=module_function), its extrinsic count over the window, and its share of the window total (null when the window has no extrinsics)."
+  type ChainCall {
+    call_module: String!
+    call_function: String
+    count: Int!
+    share: Float
+  }
+
+  "Extrinsic call-mix breakdown over the window. Mirrors GET /api/v1/chain/calls's data envelope."
+  type ChainCalls {
+    schema_version: Int!
+    window: String!
+    group_by: String!
+    observed_at: String
+    total_extrinsics: Int!
+    call_count: Int!
+    calls: [ChainCall!]!
   }
 
   "Network-wide validator-set churn across all subnets (#5686). Mirrors GET /api/v1/chain/turnover's data envelope."
@@ -2211,6 +2233,7 @@ export const FIELD_COMPLEXITY = {
   subnet_movers: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_turnover: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_turnover: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_calls: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4690,6 +4713,68 @@ const rootValue = {
       },
       stability_distribution: data.stability_distribution ?? null,
       subnets: data.subnets || [],
+    };
+  },
+
+  async chain_calls(
+    { window, group_by: groupBy, limit, call_module: callModule },
+    context,
+  ) {
+    // Reuse the exact analyticsWindow parse/validate REST's handleChainCalls
+    // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL
+    // BAD_USER_INPUT error, not a silent empty result.
+    const windowUrl = new URL(context.request.url);
+    windowUrl.search = "";
+    if (window != null) windowUrl.searchParams.set("window", window);
+    const { label, error } = analyticsWindow(windowUrl);
+    if (error) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const requestedGroupBy = groupBy ?? "module";
+    if (
+      requestedGroupBy !== "module" &&
+      requestedGroupBy !== "module_function"
+    ) {
+      throw new GraphQLError(
+        "group_by must be one of: module, module_function.",
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    if (callModule != null && callModule.length > 100) {
+      throw new GraphQLError("call_module must be at most 100 characters.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const safeLimit = clampLimit(limit, { defaultLimit: 50, maxLimit: 100 });
+    const params = new URLSearchParams();
+    params.set("window", label);
+    params.set("group_by", requestedGroupBy);
+    params.set("limit", String(safeLimit));
+    if (callModule != null) params.set("call_module", callModule);
+    // Same tryPostgresTier(METAGRAPH_EXTRINSICS_SOURCE) -> buildChainCalls fallback
+    // handleChainCalls uses; the tier owns the call-mix aggregation (no logic
+    // duplicated here), and a cold store yields a schema-stable empty breakdown.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/calls", params),
+        "METAGRAPH_EXTRINSICS_SOURCE",
+      )) ?? buildChainCalls({ window: label, groupBy: requestedGroupBy });
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? label,
+      group_by: data.group_by ?? requestedGroupBy,
+      observed_at: data.observed_at ?? null,
+      total_extrinsics: data.total_extrinsics ?? 0,
+      call_count: data.call_count ?? 0,
+      calls: (data.calls ?? []).map((c) => ({
+        call_module: c.call_module,
+        call_function: c.call_function ?? null,
+        count: c.count ?? 0,
+        share: c.share ?? null,
+      })),
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7935,6 +7935,168 @@ describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", 
   });
 });
 
+describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fallback)", () => {
+  function callsQuery(argsClause) {
+    return `{ chain_calls${argsClause} {
+      schema_version window group_by observed_at total_extrinsics call_count
+      calls { call_module call_function count share }
+    } }`;
+  }
+
+  test("cold store, default args: schema-stable empty breakdown (7d/module)", async () => {
+    const { status, body } = await gql(callsQuery(""));
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_calls, {
+      schema_version: 1,
+      window: "7d",
+      group_by: "module",
+      observed_at: null,
+      total_extrinsics: 0,
+      call_count: 0,
+      calls: [],
+    });
+  });
+
+  test("resolves Postgres-tier call-mix rows", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "30d",
+            group_by: "module_function",
+            observed_at: "2026-07-14T00:00:00.000Z",
+            total_extrinsics: 8,
+            call_count: 1,
+            calls: [
+              {
+                call_module: "SubtensorModule",
+                call_function: "set_weights",
+                count: 6,
+                share: 0.75,
+              },
+            ],
+          }),
+      },
+    };
+    const { status, body } = await gql(
+      callsQuery(`(window: "30d", group_by: "module_function")`),
+      env,
+    );
+    assert.equal(status, 200);
+    const d = body.data.chain_calls;
+    assert.equal(d.window, "30d");
+    assert.equal(d.group_by, "module_function");
+    assert.equal(d.total_extrinsics, 8);
+    assert.equal(d.call_count, 1);
+    const c = d.calls[0];
+    assert.equal(c.call_module, "SubtensorModule");
+    assert.equal(c.call_function, "set_weights");
+    assert.equal(c.count, 6);
+    assert.equal(c.share, 0.75);
+  });
+
+  test("a partial Postgres-tier body degrades every missing field to its schema-stable default", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      // Only a row's call_module present; envelope + row omit the rest, so
+      // every ?? default fallback must fire (not surface undefined).
+      DATA_API: {
+        fetch: async () =>
+          Response.json({ calls: [{ call_module: "Balances" }] }),
+      },
+    };
+    const { status, body } = await gql(callsQuery(""), env);
+    assert.equal(status, 200);
+    const d = body.data.chain_calls;
+    assert.equal(d.schema_version, 1);
+    assert.equal(d.window, "7d");
+    assert.equal(d.group_by, "module");
+    assert.equal(d.observed_at, null);
+    assert.equal(d.total_extrinsics, 0);
+    assert.equal(d.call_count, 0);
+    const c = d.calls[0];
+    assert.equal(c.call_module, "Balances");
+    assert.equal(c.call_function, null);
+    assert.equal(c.count, 0);
+    assert.equal(c.share, null);
+  });
+
+  test("an empty Postgres-tier body (no calls key) degrades to a schema-stable empty breakdown", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(callsQuery(""), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_calls, {
+      schema_version: 1,
+      window: "7d",
+      group_by: "module",
+      observed_at: null,
+      total_extrinsics: 0,
+      call_count: 0,
+      calls: [],
+    });
+  });
+
+  test("window/group_by/limit/call_module args are forwarded to the /chain/calls path", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            group_by: "module",
+            total_extrinsics: 0,
+            call_count: 0,
+            calls: [],
+          });
+        },
+      },
+    };
+    await gql(
+      callsQuery(
+        `(window: "30d", group_by: "module", limit: 5, call_module: "SubtensorModule")`,
+      ),
+      env,
+    );
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/calls");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl.searchParams.get("group_by"), "module");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(
+      capturedUrl.searchParams.get("call_module"),
+      "SubtensorModule",
+    );
+  });
+
+  test("rejects an unsupported window with BAD_USER_INPUT", async () => {
+    const { body } = await gql(callsQuery(`(window: "99d")`));
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("rejects an unsupported group_by with BAD_USER_INPUT", async () => {
+    const { body } = await gql(callsQuery(`(group_by: "signer")`));
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("rejects an over-long call_module with BAD_USER_INPUT", async () => {
+    const { body } = await gql(
+      callsQuery(`(call_module: "${"x".repeat(101)}")`),
+    );
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("chain_calls is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.chain_calls, 5);
+  });
+});
+
 describe("graphql — chain_serving (#5873, Postgres-tier + D1-live fallback)", () => {
   function servingQuery(argsClause) {
     return `{ chain_serving${argsClause} {


### PR DESCRIPTION
## Summary

Closes the REST/GraphQL/MCP parity gap on the extrinsic call-mix surface. `GET /api/v1/chain/calls` and MCP `get_chain_calls` already ship, but had no GraphQL mirror.

Adds `Query.chain_calls(window, group_by, limit, call_module)` returning a new `ChainCalls` type (`schema_version`, `window`, `group_by`, `observed_at`, `total_extrinsics`, `call_count`, `calls[]`) with a `ChainCall` item (`call_module`, `call_function`, `count`, `share`). The resolver reuses the exact `analyticsWindow` validation (7d/30d, default 7d) and hits the same DATA_API extrinsics-tier path `/api/v1/chain/calls` the REST route uses — so the tier owns the call-mix aggregation, no logic duplicated. `group_by` (module | module_function), an over-long `call_module`, and an unsupported window are each `BAD_USER_INPUT`; a cold tier falls back to `buildChainCalls`'s schema-stable empty breakdown. Priced at `RELATIONSHIP_FIELD_COMPLEXITY`.

Entirely within `src/graphql.mjs` + its test.

## Testing

- `tests/graphql.test.mjs` — 9 new tests: cold-store empty card, Postgres row resolution, **a partial body and an empty body (exercising every `?? default` / `|| []` fallback branch)**, arg forwarding to the `/chain/calls` path, the three `BAD_USER_INPUT` rejections (window / group_by / call_module length), and the complexity weight. **Full graphql suite: 424 pass.**
- eslint + prettier clean; resolver verified **at the branch level** — all statements *and* branches covered (100% patch).

Closes #5880
