### PR TITLE
feat(graphql): add Query.account_subnets mirroring REST + MCP account subnets

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -110,6 +110,7 @@ import {
   buildAccountsList,
 } from "./accounts-list.mjs";
 import {
+  buildAccountSubnets,
   buildAccountSummary,
   buildAccountTransfers,
 } from "./account-events.mjs";
@@ -327,6 +328,8 @@ export const SDL = `
     account_position_history(ss58: String!, netuid: Int!, window: String): AccountPositionHistory!
     "One wallet's cross-subnet neuron portfolio: every subnet where the hotkey is a registered neuron, each position's economics (stake, emission, rank, trust, incentive, dividends, role) and emission/stake yield, plus wallet-level aggregates (totals, counts, overall return, stake concentration). Richer than account.registrations (registration footprint only). An address with no registered neurons resolves to a schema-stable empty card, never null. Mirrors GET /api/v1/accounts/{ss58}/portfolio."
     account_portfolio(ss58: String!): AccountPortfolio!
+    "One account's live cross-subnet footprint: every subnet where the hotkey is currently registered as a neuron, each with its netuid, uid, stake, validator-permit and active flag, plus a subnet_count. The registration snapshot only (netuid/uid/stake/permit/active) -- account_portfolio is the richer economics view over the same neurons. An unregistered or never-seen address resolves to a schema-stable empty footprint (subnet_count 0, subnets []), never null. Mirrors GET /api/v1/accounts/{ss58}/subnets."
+    account_subnets(ss58: String!): AccountSubnets!
     "One account's per-subnet axon-serving footprint over a 7d/30d/90d window (default 30d): AxonServed announcement count and first/last timestamps per subnet, an HHI concentration of where its serving activity is focused, and the dominant subnet; an address with no announcements in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/serving."
     account_serving(ss58: String!, window: String): AccountServing!
     "One account's per-subnet axon-removal footprint over a 7d/30d/90d window (default 30d): AxonInfoRemoved count and first/last timestamps per subnet, an HHI concentration of where its teardown activity is focused, and the dominant subnet; an address with no removals in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/axon-removals."
@@ -1998,6 +2001,15 @@ export const SDL = `
     yield: Float
   }
 
+  "One account's live cross-subnet registration footprint (the neurons snapshot), backing account_subnets. The lightweight sibling of AccountPortfolio -- registration facts only, no economics rollup."
+  type AccountSubnets {
+    schema_version: Int!
+    ss58: String!
+    subnet_count: Int!
+    "Where this hotkey is currently registered, ordered by netuid -- each an AccountRegistration (netuid/uid/stake/validator_permit/active)."
+    subnets: [AccountRegistration!]!
+  }
+
   "One wallet's cross-subnet neuron portfolio (#5702): every subnet where the hotkey is a registered neuron, plus wallet-level aggregates. Mirrors GET /api/v1/accounts/{ss58}/portfolio."
   type AccountPortfolio {
     schema_version: Int!
@@ -2224,6 +2236,7 @@ export const FIELD_COMPLEXITY = {
   account_stake_flow: RELATIONSHIP_FIELD_COMPLEXITY,
   account_position_history: RELATIONSHIP_FIELD_COMPLEXITY,
   account_portfolio: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_subnets: RELATIONSHIP_FIELD_COMPLEXITY,
   // Fans out into leaderboardProfilesProjection plus several D1 reads and the
   // economics tier -- same cost class as the other relationship fields.
   registry_leaderboards: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4014,6 +4027,34 @@ const rootValue = {
       overall_yield: data.overall_yield ?? null,
       stake_concentration: data.stake_concentration ?? null,
       positions: data.positions || [],
+    };
+  },
+
+  async account_subnets({ ss58 }, context) {
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildAccountSubnets([])
+    // fallback contract the REST route (/accounts/{ss58}/subnets) and the
+    // get_account_subnets MCP tool use -- a flat body (like account_portfolio's),
+    // not the { data, generatedAt } envelope the account-event footprint family
+    // uses. An unregistered address is a schema-stable empty card, never null.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}/subnets`,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildAccountSubnets([], ss58);
+    return {
+      schema_version: data.schema_version ?? 1,
+      ss58: data.ss58 ?? ss58,
+      subnet_count: data.subnet_count ?? 0,
+      subnets: data.subnets || [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -4019,6 +4019,129 @@ describe("graphql — account_portfolio (#5702, Postgres-tier flat body + zeroed
   });
 });
 
+describe("graphql — account_subnets (#5894, Postgres-tier flat body + empty-card fallback)", () => {
+  const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  function query(argsClause) {
+    return `{ account_subnets${argsClause} {
+      schema_version ss58 subnet_count
+      subnets { netuid uid stake_tao validator_permit active }
+    } }`;
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty footprint, never null", async () => {
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`));
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_subnets, {
+      schema_version: 1,
+      ss58: SS58,
+      subnet_count: 0,
+      subnets: [],
+    });
+  });
+
+  test("resolves the Postgres-tier footprint (flat body, unlike the account-event footprint family)", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            ss58: SS58,
+            subnet_count: 2,
+            subnets: [
+              {
+                netuid: 3,
+                uid: 5,
+                stake_tao: 1000,
+                validator_permit: true,
+                active: true,
+              },
+              {
+                netuid: 7,
+                uid: 9,
+                stake_tao: 500,
+                validator_permit: false,
+                active: false,
+              },
+            ],
+          }),
+      },
+    };
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    const s = body.data.account_subnets;
+    assert.equal(s.subnet_count, 2);
+    assert.equal(s.subnets[0].netuid, 3);
+    assert.equal(s.subnets[0].validator_permit, true);
+    assert.equal(s.subnets[0].active, true);
+    assert.equal(s.subnets[1].netuid, 7);
+    assert.equal(s.subnets[1].validator_permit, false);
+    assert.equal(s.subnets[1].active, false);
+  });
+
+  test("ss58 is forwarded on the Postgres-tier request path", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            ss58: SS58,
+            subnet_count: 0,
+            subnets: [],
+          });
+        },
+      },
+    };
+    await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(capturedUrl.pathname, `/api/v1/accounts/${SS58}/subnets`);
+  });
+
+  test("a malformed Postgres-tier body degrades to a schema-stable empty footprint", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_subnets, {
+      schema_version: 1,
+      ss58: SS58,
+      subnet_count: 0,
+      subnets: [],
+    });
+  });
+
+  test("an invalid ss58 is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      query('(ss58: "not-a-valid-address")'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("account_subnets is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.account_subnets, 5);
+  });
+});
+
 // --- Subscription.chainEvents (#4983, ADR 0015) ---------------------------------
 //
 // The DO-runtime side of this wiring (ChainFirehoseHub.subscribeChainEvents,


### PR DESCRIPTION
## Summary

Closes the REST/GraphQL/MCP parity gap for a wallet's live cross-subnet registration footprint. `GET /api/v1/accounts/{ss58}/subnets` (`workers/data-api.mjs`) and the `get_account_subnets` MCP tool (`src/mcp-server.mjs`) already expose it — this adds the missing GraphQL mirror.

Adds `account_subnets(ss58: String!): AccountSubnets!` — every subnet where the hotkey is currently a registered neuron, each with its `netuid`, `uid`, `stake_tao`, `validator_permit`, and `active` flag, plus a `subnet_count`.

## Implementation

- **Same data path, no duplication.** The resolver reuses exactly the loader contract the REST route and MCP tool use: `tryPostgresTier(env, /api/v1/accounts/{ss58}/subnets, "METAGRAPH_NEURONS_SOURCE")`, falling back to `buildAccountSubnets([], ss58)` (`src/account-events.mjs`). The empty footprint (`subnet_count: 0`, `subnets: []`) is schema-stable — never a GraphQL error — matching the `account_portfolio` sibling it sits beside.
- Invalid SS58 input is rejected with a `BAD_USER_INPUT` error, exactly as the other `account_*` fields do.
- The `subnets` list reuses the existing `AccountRegistration` SDL type (the exact `formatRegistration` shape); only a thin `AccountSubnets` envelope type + a `FIELD_COMPLEXITY` weight are added.
- Scoped entirely to `src/graphql.mjs` (+ tests) — no registry/schema/openapi change (GraphQL SDL is inline; `npm run build` regenerates nothing here).

## Tests

`tests/graphql.test.mjs`, mirroring the `account_portfolio` sibling: cold-store empty fallback, Postgres-tier hit, `ss58` path forwarding, malformed-body default fill, and invalid-`ss58` rejection, plus the field-complexity weight. Full `graphql.test.mjs` green (429 tests); full suite green (8827 tests). 100% line coverage on the new resolver (patch coverage clean).

Closes #5894
