### PR TITLE
fix(backend): consolidate compare-parsing to src/analytics-live.mjs (#5868)

### DIFF
--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -35,7 +35,12 @@ import {
   unsupportedWindowMessage,
 } from "../../src/neuron-history.mjs";
 import { loadEconomicsTrends } from "../../src/economics-trends.mjs";
-import { growthRowsFromSamples } from "../../src/analytics-live.mjs";
+import {
+  COMPARE_DIMENSIONS,
+  growthRowsFromSamples,
+  parseCompareDimensions,
+  parseCompareNetuids,
+} from "../../src/analytics-live.mjs";
 import {
   formatLeaderboards,
   formatTrajectory,
@@ -159,9 +164,6 @@ export function configureAnalyticsRoutes(deps) {
 
 const LEADERBOARD_PROFILES_TTL_MS = 300_000;
 let leaderboardProfilesCache = null; // { subnetMeta, mostComplete, builtAt }
-
-const COMPARE_DIMENSIONS = ["structure", "economics", "health"];
-const COMPARE_NETUIDS_PATTERN = /^\d{1,5}(,\d{1,5}){0,127}$/;
 
 async function envelopeWithD1Fallback(request, payload, cacheProfile, rowSets) {
   const response = await envelopeResponse(request, payload, cacheProfile);
@@ -634,37 +636,11 @@ export async function handleLeaderboards(request, env, url) {
   );
 }
 
-function compareNetuids(netuidsRaw) {
-  if (!netuidsRaw || !COMPARE_NETUIDS_PATTERN.test(netuidsRaw)) return null;
-  const requestedNetuids = [];
-  const seenNetuids = new Set();
-  for (const part of netuidsRaw.split(",")) {
-    const netuid = Number(part);
-    if (seenNetuids.has(netuid)) continue;
-    seenNetuids.add(netuid);
-    requestedNetuids.push(netuid);
-  }
-  return requestedNetuids;
-}
-
-function compareDimensions(dimensionsRaw) {
-  if (dimensionsRaw === null) return COMPARE_DIMENSIONS;
-  const requested = [];
-  for (const part of dimensionsRaw.split(",")) {
-    const trimmed = part.trim();
-    if (trimmed === "") return null;
-    requested.push(trimmed);
-  }
-  const unknown = requested.find((d) => !COMPARE_DIMENSIONS.includes(d));
-  if (unknown !== undefined) return null;
-  return COMPARE_DIMENSIONS.filter((d) => requested.includes(d));
-}
-
 export function canonicalCompareCachePath(url) {
   if (validateQueryParams(url, ["netuids", "dimensions"])) return null;
-  const requestedNetuids = compareNetuids(url.searchParams.get("netuids"));
+  const requestedNetuids = parseCompareNetuids(url.searchParams.get("netuids"));
   if (!requestedNetuids) return null;
-  const dimensions = compareDimensions(url.searchParams.get("dimensions"));
+  const dimensions = parseCompareDimensions(url.searchParams.get("dimensions"));
   if (!dimensions) return null;
   const params = [`netuids=${encodeURIComponent(requestedNetuids.join(","))}`];
   if (dimensions.length !== COMPARE_DIMENSIONS.length) {
@@ -776,7 +752,7 @@ export async function handleCompare(request, env, url) {
   if (validationError) return analyticsQueryError(validationError);
 
   const netuidsRaw = url.searchParams.get("netuids");
-  const requestedNetuids = compareNetuids(netuidsRaw);
+  const requestedNetuids = parseCompareNetuids(netuidsRaw);
   if (!requestedNetuids) {
     return errorResponse(
       "invalid_query",
@@ -787,7 +763,7 @@ export async function handleCompare(request, env, url) {
   }
 
   const dimensionsRaw = url.searchParams.get("dimensions");
-  const dimensions = compareDimensions(dimensionsRaw);
+  const dimensions = parseCompareDimensions(dimensionsRaw);
   if (!dimensions) {
     const tokens = dimensionsRaw.split(",").map((d) => d.trim());
     const unknown =


### PR DESCRIPTION
`analytics-routes.mjs` carried its own `COMPARE_NETUIDS_PATTERN`, `compareNetuids()`, and `compareDimensions()` — byte-for-byte duplicates of `src/analytics-live.mjs`'s canonical `parseCompareNetuids()` / `parseCompareDimensions()` (which previously had no callers). Two copies of the same parse rules is a divergence risk.

## Change
- Import the canonical parsers (plus the shared `COMPARE_DIMENSIONS` constant, also duplicated) from `src/analytics-live.mjs`; delete the local copies and the now-unused `COMPARE_NETUIDS_PATTERN`.
- The compare route call sites only ever pass `url.searchParams.get(...)` (`string | null`), for which the two implementations are behaviourally identical — a pure de-duplication, **no behaviour change**.
- The `List`-variant parsers (`parseCompareNetuidList` / `parseCompareDimensionList`) keep their graphql/mcp callers and are untouched, so nothing in `analytics-live.mjs` is removed.

## Testing
- `npm run test` — analytics-routes (84) + analytics-live + mcp-server suites green (**1201 passing**).
- `lint` + `format:check` clean.
- Net **−24 lines** of Worker code (bundle shrinks).

Closes #5868
