### PR TITLE
feat(registry): Zeus (SN18) full first accuracy pass

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 221,
+  "surface_count": 224,
   "surfaces": [
     {
       "auth_required": false,
@@ -1581,6 +1581,42 @@
     {
       "auth_required": false,
       "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 18,
+      "probe": {
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zeus",
+      "public_safe": true,
+      "subnet_name": "Zeus",
+      "subnet_slug": "sn-18",
+      "surface_id": "sn-18-zeus-data-artifact",
+      "surface_key": "srf-b2b48c1a1208f787",
+      "url": "https://raw.githubusercontent.com/Orpheus-AI/Zeus/8b79e8ea117d085f959decd6fea9ae17da1b1494/zeus/data/weights/latitude_weights_for_rmse.npy"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 18,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zeus",
+      "public_safe": true,
+      "subnet_name": "Zeus",
+      "subnet_slug": "sn-18",
+      "surface_id": "sn-18-zeus-health",
+      "surface_key": "srf-65e3740b96a293dc",
+      "url": "https://api.zeussubnet.com/v1/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
       "kind": "subnet-api",
       "netuid": 18,
       "probe": {
@@ -1595,6 +1631,24 @@
       "surface_id": "sn-18-zeus-ready",
       "surface_key": "srf-4911085047e7584f",
       "url": "https://api.zeussubnet.com/v1/ready"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 18,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "zeus",
+      "public_safe": true,
+      "subnet_name": "Zeus",
+      "subnet_slug": "sn-18",
+      "surface_id": "sn-18-zeus-subnet-api",
+      "surface_key": "srf-f1ec4a119075ec61",
+      "url": "https://api.zeussubnet.com/v1/meta"
     },
     {
       "auth_required": false,

--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -260,6 +260,20 @@
       "notes": "First maintainer review for this subnet (previously candidate-discovered/unreviewed, categories empty, no website/source-repo surfaces despite the top-level fields already being set). Verified the official website, source repository, and the separate live 404-active-competition state repository; confirmed the gateway API's task-submission endpoints require x-api-key and the portal's docs/OpenAPI routes are deliberately disabled in production (HTTP 200, empty body) rather than missing."
     },
     {
+      "netuid": 18,
+      "slug": "sn-18",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-07-15T22:50:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.zeussubnet.com/",
+        "https://github.com/Orpheus-AI/Zeus",
+        "https://docs.zeussubnet.com/docs/introduction",
+        "https://api.zeussubnet.com/openapi.json"
+      ],
+      "notes": "First maintainer review for this subnet (previously candidate-discovered/unreviewed, categories empty, no website/source-repo/docs surfaces despite the top-level fields already being set). Verified the official website, source repository, and docs; confirmed the BOREAS Edge API's forecast endpoints require a real API key (401 Invalid API key, live-tested) despite the OpenAPI schema marking the key optional, and /metrics is WAF-blocked."
+    },
+    {
       "netuid": 19,
       "slug": "sn-19",
       "decision": "maintainer-reviewed",

--- a/registry/subnets/zeus.json
+++ b/registry/subnets/zeus.json
@@ -1,11 +1,25 @@
 {
-  "categories": [],
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-docs",
+    "official-source-repo",
+    "official-website",
+    "weather-forecasting"
+  ],
   "curation": {
-    "level": "candidate-discovered",
-    "review_state": "unreviewed"
+    "gap_notes": ["No verified SSE/event stream yet."],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-07-15T22:50:00.000Z",
+    "source_count": 6,
+    "verified_at": "2026-07-15T22:50:00.000Z"
   },
+  "dashboard_url": null,
+  "docs_url": "https://docs.zeussubnet.com/docs/introduction",
   "name": "Zeus",
   "netuid": 18,
+  "notes": "First maintainer-reviewed pass for SN18 (previously unreviewed, categories empty, no website/source-repo/docs surfaces despite website_url and source_repo already being set at the top level). Zeus (by Orpheus AI) forecasts environmental variables (temperature, wind, solar radiation) from ERA5 reanalysis data using on-chain commit-reveal validation. Added the missing website, source-repo, and docs surfaces. Diffed the tracked OpenAPI schema (8 paths) against tracked surfaces: /v1/forecast/point and /v1/forecast/area both confirmed live-tested to require a real API key (401 \"Invalid API key\" despite the schema marking X-API-Key optional); the two /v1/billing/* routes are payment endpoints; /metrics is WAF-blocked (403, HTML challenge page, not the API). None are new public surfaces. 4 of the 5 pre-existing community-submitted surfaces had no probe config at all -- the registry-wide gap tracked in #5932 -- fixed.",
   "schema_version": 1,
   "slug": "sn-18",
   "social": {
@@ -16,10 +30,70 @@
   "surfaces": [
     {
       "auth_required": false,
+      "authority": "official",
+      "id": "sn-18-zeus-website",
+      "kind": "website",
+      "name": "Zeus website",
+      "notes": "Official Zeus website.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "zeus",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Orpheus-AI/Zeus"],
+      "url": "https://www.zeussubnet.com/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-18-zeus-source-repo",
+      "kind": "source-repo",
+      "name": "Zeus source repository",
+      "notes": "Official Zeus environmental forecasting subnet source repository (SN18, per the README's own title).",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "zeus",
+      "public_safe": true,
+      "source_urls": ["https://www.zeussubnet.com/"],
+      "url": "https://github.com/Orpheus-AI/Zeus"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-18-zeus-docs",
+      "kind": "docs",
+      "name": "Zeus docs",
+      "notes": "Official Zeus documentation.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "zeus",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Orpheus-AI/Zeus"],
+      "url": "https://docs.zeussubnet.com/docs/introduction"
+    },
+    {
+      "auth_required": false,
       "authority": "community",
       "id": "sn-18-zeus-subnet-api",
       "kind": "subnet-api",
       "name": "Zeus subnet-api",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "zeus",
       "public_safe": true,
       "review": {
@@ -36,6 +110,12 @@
       "kind": "openapi",
       "name": "Zeus BOREAS Edge API (public)",
       "notes": "Machine-readable spec for the public BOREAS Edge API documented by Zeus.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "zeus",
       "public_safe": true,
       "review": {
@@ -57,6 +137,12 @@
       "kind": "subnet-api",
       "name": "Zeus BOREAS Edge API health",
       "notes": "Public no-auth health probe for the Zeus BOREAS Edge API; GET /v1/health returns {\"status\":\"ok\"} per the machine-readable OpenAPI spec on the same host as the existing /v1/meta subnet-api surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "zeus",
       "public_safe": true,
       "review": {
@@ -76,6 +162,12 @@
       "kind": "data-artifact",
       "name": "Zeus latitude-weighting array for RMSE scoring",
       "notes": "Public NumPy (.npy) array of per-latitude weights that SN18 Zeus applies to compute area-weighted RMSE when scoring miner weather/climate forecasts (correcting for grid-cell area shrinking toward the poles). Committed in the validator repository alongside its generator script. No-auth static file, pinned to an immutable commit.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "zeus",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

Same situation as SN17 (#5952): **never had a maintainer review at all** -- `categories` was an empty array, `curation.level` was "candidate-discovered", `review_state` was "unreviewed" -- and despite `website_url` and `source_repo` already being set at the top level, neither had a corresponding surface.

- Added the missing website, source-repo, and docs surfaces.
- Diffed the tracked OpenAPI schema (8 paths) against tracked surfaces: `/v1/forecast/point` and `/v1/forecast/area` both confirmed live-tested to require a real API key (401 "Invalid API key") despite the schema marking `X-API-Key` optional -- correctly excluded, not a gap. The two `/v1/billing/*` routes are payment endpoints. `/metrics` is WAF-blocked (403, HTML challenge page, not the actual API response).
- 4 of the 5 pre-existing community-submitted surfaces had no probe config at all -- the registry-wide gap tracked in #5932 -- fixed.
- Filled in `categories` (added `weather-forecasting`, no prior registry precedent for this subnet type), `gap_notes`, and top-level `notes`.
- Added the required backing decision to `registry/reviews/maintainer-reviewed.json` (learned from #5952's CI failure) for this first-time promotion to maintainer-reviewed.

## Test plan

- [x] `npm run validate` — passes (includes the maintainer-reviewed decision-backing check that caught #5952's mistake)
- [x] `npm run validate:surface` — passes (922 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] Every surface URL live-tested individually, including confirming the forecast endpoints genuinely require an API key rather than assuming