### PR TITLE
feat(graphql): add Query.chain_prometheus mirroring REST

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -9,6 +9,13 @@ import {
 import { readArtifact, readHealthKv } from "../workers/storage.mjs";
 import { contractVersion } from "../workers/responses.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
+import {
+  loadChainPrometheus,
+  CHAIN_PROMETHEUS_WINDOWS,
+  DEFAULT_CHAIN_PROMETHEUS_WINDOW,
+  CHAIN_PROMETHEUS_LIMIT_DEFAULT,
+  CHAIN_PROMETHEUS_LIMIT_MAX,
+} from "./chain-prometheus.mjs";
 import { buildSubnetHyperparams } from "./subnet-hyperparams.mjs";
 import { buildSubnetHyperparamsHistory } from "./subnet-hyperparams-history.mjs";
 import {
@@ -356,6 +363,8 @@ export const SDL = `
     chain_serving(window: String, limit: Int): ChainServing!
     "Extrinsic call-mix breakdown over a 7d/30d window (default 7d): the extrinsic count and share per call_module, or per call_module+call_function when group_by is module_function (default module), optionally scoped to a single call_module, ranked by count (limit default 50, max 100). Computed live from the extrinsics tier; a cold store yields a schema-stable empty breakdown, never a GraphQL error. Mirrors GET /api/v1/chain/calls."
     chain_calls(window: String, group_by: String, limit: Int, call_module: String): ChainCalls!
+    "Network-wide Prometheus telemetry-endpoint announcement leaderboard over a 7d/30d window (default 7d): subnets ranked by PrometheusServed announcements with each's distinct-exporter count and announcements-per-exporter re-announcement intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The telemetry-endpoint companion to chain_serving's axon endpoints -- which subnets run observability infrastructure. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/prometheus."
+    chain_prometheus(window: String, limit: Int): ChainPrometheus!
     "Network-wide weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators driving consensus network-wide, each with its total WeightsSet count, share of the network total, and first/last set times, ranked by activity. The setter-level drill-in behind chain_weights. Mirrors GET /api/v1/chain/weights/setters."
     chain_weight_setters(window: String, limit: Int): ChainWeightSetters!
     "Compact all-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history (probed every ~15 minutes); a cold store still returns both windows, schema-stable and zeroed, never a GraphQL error. Mirrors GET /api/v1/health/trends."
@@ -691,6 +700,44 @@ export const SDL = `
     distinct_servers: Int!
     announcements: Int!
     announcements_per_server: Float
+  }
+
+  type ChainPrometheus {
+    schema_version: Int!
+    window: String
+    observed_at: String
+    subnet_count: Int!
+    network: ChainPrometheusNetwork!
+    intensity_distribution: ChainPrometheusIntensityDistribution
+    subnets: [ChainPrometheusSubnet!]!
+  }
+
+  "Network-wide Prometheus-serving rollup: every subnet with PrometheusServed announcements in the window, combined. distinct_exporters counts a hotkey once even when it announces on several subnets, so it is NOT the sum of the per-subnet counts."
+  type ChainPrometheusNetwork {
+    distinct_exporters: Int!
+    announcements: Int!
+    "Null when distinct_exporters is 0 (no defined intensity without exporters)."
+    announcements_per_exporter: Float
+  }
+
+  "Spread of per-subnet re-announcement intensity (PrometheusServed events per exporter) across EVERY subnet with announcements in the window -- network-wide even when limit truncates the leaderboard."
+  type ChainPrometheusIntensityDistribution {
+    count: Int!
+    mean: Float!
+    min: Float!
+    p25: Float!
+    median: Float!
+    p75: Float!
+    p90: Float!
+    max: Float!
+  }
+
+  "One subnet's Prometheus telemetry-serving activity in the window, ranked by announcements."
+  type ChainPrometheusSubnet {
+    netuid: Int!
+    distinct_exporters: Int!
+    announcements: Int!
+    announcements_per_exporter: Float
   }
 
   "Network-wide rolling 24h buy/sell alpha-volume leaderboard, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/alpha-volume's data envelope."
@@ -2236,6 +2283,7 @@ export const FIELD_COMPLEXITY = {
   chain_calls: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_serving: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_prometheus: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   validator_nominators: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4860,6 +4908,50 @@ const rootValue = {
         distinct_servers: 0,
         announcements: 0,
         announcements_per_server: null,
+      },
+      intensity_distribution: data.intensity_distribution ?? null,
+      subnets: data.subnets || [],
+    };
+  },
+
+  async chain_prometheus({ window, limit }, context) {
+    const requestedWindow = window ?? DEFAULT_CHAIN_PROMETHEUS_WINDOW;
+    if (!Object.hasOwn(CHAIN_PROMETHEUS_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(requestedWindow, CHAIN_PROMETHEUS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: CHAIN_PROMETHEUS_LIMIT_DEFAULT,
+      maxLimit: CHAIN_PROMETHEUS_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    params.set("limit", String(safeLimit));
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> loadChainPrometheus
+    // fallback contract REST's handleChainPrometheus uses -- a cold store yields a
+    // schema-stable zeroed card, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/prometheus", params),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      (await loadChainPrometheus(graphqlD1(context), {
+        windowLabel: requestedWindow,
+        windowDays: CHAIN_PROMETHEUS_WINDOWS[requestedWindow],
+        limit: safeLimit,
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? requestedWindow,
+      observed_at: data.observed_at ?? null,
+      subnet_count: data.subnet_count ?? 0,
+      network: data.network ?? {
+        distinct_exporters: 0,
+        announcements: 0,
+        announcements_per_exporter: null,
       },
       intensity_distribution: data.intensity_distribution ?? null,
       subnets: data.subnets || [],

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -22,6 +22,7 @@ import {
   schema as chainEventsSchema,
 } from "../src/graphql.mjs";
 import { LEADERBOARD_BOARDS } from "../src/health-serving.mjs";
+import { CHAIN_PROMETHEUS_WINDOWS } from "../src/chain-prometheus.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { resolveClientIp } from "../workers/config.mjs";
 import {
@@ -10258,6 +10259,228 @@ describe("Query.account_identity", () => {
     assert.equal(
       FIELD_COMPLEXITY.account_identity,
       FIELD_COMPLEXITY.account_identity_history,
+    );
+  });
+});
+
+describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)", () => {
+  function prometheusQuery(argsClause) {
+    return `{ chain_prometheus${argsClause} {
+      schema_version window observed_at subnet_count
+      network { distinct_exporters announcements announcements_per_exporter }
+      intensity_distribution { count mean min p25 median p75 p90 max }
+      subnets { netuid distinct_exporters announcements announcements_per_exporter }
+    } }`;
+  }
+
+  // Mirrors chainServingD1: loadChainPrometheus issues the network aggregate
+  // (COUNT DISTINCT hotkey / MAX(observed_at), no GROUP BY) and only then the
+  // GROUP BY netuid leaderboard, and only when newest_observed is non-null.
+  function chainPrometheusD1({ network, subnets = [] } = {}) {
+    return {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              async all() {
+                if (sql.includes("GROUP BY netuid")) {
+                  return { results: subnets };
+                }
+                return { results: network ? [network] : [] };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  test("cold store, default args: schema-stable empty leaderboard, never an error", async () => {
+    const { status, body } = await gql(prometheusQuery(""));
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_prometheus, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_exporters: 0,
+        announcements: 0,
+        announcements_per_exporter: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("resolves the D1-live tier: per-subnet leaderboard + network rollup", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: chainPrometheusD1({
+        network: { distinct_exporters: 3, newest_observed: 1780000000000 },
+        subnets: [
+          { netuid: 1, announcements: 10, distinct_exporters: 2 },
+          { netuid: 7, announcements: 4, distinct_exporters: 2 },
+        ],
+      }),
+    };
+    const { status, body } = await gql(prometheusQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const got = body.data.chain_prometheus;
+    assert.equal(got.subnet_count, 2);
+    assert.equal(got.observed_at, new Date(1780000000000).toISOString());
+    // The network rollup is the true distinct count, not the sum of per-subnet
+    // exporters (a hotkey announcing on several subnets counts once).
+    assert.deepEqual(got.network, {
+      distinct_exporters: 3,
+      announcements: 14,
+      // 14 announcements / 3 distinct exporters, rounded to the builder's 2dp.
+      announcements_per_exporter: 4.67,
+    });
+    assert.deepEqual(got.subnets, [
+      {
+        netuid: 1,
+        distinct_exporters: 2,
+        announcements: 10,
+        announcements_per_exporter: 5,
+      },
+      {
+        netuid: 7,
+        distinct_exporters: 2,
+        announcements: 4,
+        announcements_per_exporter: 2,
+      },
+    ]);
+    assert.equal(got.intensity_distribution.count, 2);
+  });
+
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            observed_at: "2026-07-01T00:00:00.000Z",
+            subnet_count: 1,
+            network: {
+              distinct_exporters: 5,
+              announcements: 20,
+              announcements_per_exporter: 4,
+            },
+            intensity_distribution: {
+              count: 1,
+              mean: 4,
+              min: 4,
+              p25: 4,
+              median: 4,
+              p75: 4,
+              p90: 4,
+              max: 4,
+            },
+            subnets: [
+              {
+                netuid: 3,
+                distinct_exporters: 5,
+                announcements: 20,
+                announcements_per_exporter: 4,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      prometheusQuery('(window: "30d", limit: 5)'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/prometheus");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(body.data.chain_prometheus.window, "30d");
+    assert.equal(body.data.chain_prometheus.subnet_count, 1);
+    assert.equal(body.data.chain_prometheus.network.distinct_exporters, 5);
+  });
+
+  test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
+    // The tier's shape is upstream-controlled, so every field falls back rather
+    // than surfacing null through a non-null SDL field.
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(prometheusQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_prometheus, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_exporters: 0,
+        announcements: 0,
+        announcements_per_exporter: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("clamps an over-max limit to the route's own ceiling", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(prometheusQuery("(limit: 99999)"), env);
+    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+  });
+
+  test("every documented window is accepted", async () => {
+    for (const window of Object.keys(CHAIN_PROMETHEUS_WINDOWS)) {
+      const { status, body } = await gql(
+        prometheusQuery(`(window: "${window}")`),
+      );
+      assert.equal(status, 200, window);
+      assert.equal(body.errors, undefined);
+      assert.equal(body.data.chain_prometheus.window, window);
+    }
+  });
+
+  test("an unsupported window is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(prometheusQuery('(window: "1y")'), env);
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("is priced at the relationship-field complexity weight", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.chain_prometheus,
+      FIELD_COMPLEXITY.chain_serving,
     );
   });
 });


### PR DESCRIPTION
Closes #5874

## What

Adds `Query.chain_prometheus`, mirroring `GET /api/v1/chain/prometheus` and MCP `get_chain_prometheus`: the network-wide Prometheus telemetry-endpoint announcement leaderboard — which subnets actually run observability infrastructure.

It is the telemetry-endpoint companion to the already-shipped `Query.chain_serving` (axon endpoints); both read the same `account_events` `[netuid, hotkey]` tuple, one for `PrometheusServed` and one for `AxonServed`.

## How

**No query/aggregation logic is duplicated.** The resolver reuses `chain-prometheus.mjs`'s `loadChainPrometheus` through the same `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` → D1-live fallback that `handleChainPrometheus` takes, so the GraphQL, REST and MCP shapes cannot drift apart.

- **`window`** is validated against the route's own `CHAIN_PROMETHEUS_WINDOWS` (`7d`/`30d`, default `7d`) and raises `BAD_USER_INPUT` rather than silently defaulting — matching the sibling `chain_serving`/`chain_turnover` resolvers.
- **`limit`** is clamped with the route's own `CHAIN_PROMETHEUS_LIMIT_DEFAULT`/`MAX` (20/100), so a GraphQL caller cannot request a wider leaderboard than REST allows.
- A cold store yields a schema-stable zeroed card, never a GraphQL error.

**Types** mirror the `ChainServing` family field-for-field, keyed on *exporters* rather than *servers* (`ChainPrometheus`, `ChainPrometheusNetwork`, `ChainPrometheusIntensityDistribution`, `ChainPrometheusSubnet`). The doc-comments record the two contracts worth knowing: `network.distinct_exporters` counts a hotkey once even when it announces on several subnets (so it is **not** the sum of the per-subnet counts), and `intensity_distribution` spans every subnet in the window even when `limit` truncates the leaderboard.

`FIELD_COMPLEXITY` entry at `RELATIONSHIP_FIELD_COMPLEXITY`, matching `chain_serving`.

## Tests

8 new cases in `tests/graphql.test.mjs`, following the `chain_serving` (#5873) suite's conventions including its two-query D1 stub:

- cold store → schema-stable empty leaderboard, never an error
- D1-live tier → per-subnet leaderboard + network rollup, asserting the rollup uses the *true* distinct count (3) rather than the sum of per-subnet exporters (4)
- Postgres tier for a non-default `window`/`limit`, asserting both are forwarded as query params
- sparse upstream payload → every field falls back rather than surfacing null through a non-null SDL field
- over-max `limit` clamped to the route ceiling (99999 → 100)
- every documented window accepted
- unsupported window → `BAD_USER_INPUT`, never reaching the tier
- complexity weight matches `chain_serving`

```
tests/graphql.test.mjs        passed
tests/chain-prometheus.test.mjs   passed   (loader unregressed)
tests/analytics.test.mjs      passed   (REST unregressed)
```

Patch coverage measured locally the way codecov measures it — every added line mapped against `coverage-final.json`'s `statementMap`/`branchMap`: **29/29 covered statements and branch arms = 100%** (target 99%), no partials. `eslint` clean, `prettier --check` clean.

Rebased onto `chain_calls` (#5951, which landed mid-work) and pushed at `behind: 0`.
