### PR TITLE
feat(graphql): add Query.account_events mirroring REST + MCP account events

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -110,6 +110,7 @@ import {
   buildAccountsList,
 } from "./accounts-list.mjs";
 import {
+  buildAccountEvents,
   buildAccountSummary,
   buildAccountTransfers,
 } from "./account-events.mjs";
@@ -339,6 +340,8 @@ export const SDL = `
     account_identity_history(ss58: String!, limit: Int, offset: Int, cursor: String): AccountIdentityHistory!
     "Rank who one account transacts native TAO with, by total transfer volume, from the Balances.Transfer feed: per counterparty the sent/received/net TAO, transfer count, and last block, plus scan totals. Pass counterparty=<ss58> (must differ from ss58) to drill into a single relationship instead -- its fund-flow totals plus direction-aware transfer evidence under relationship, newest first. limit caps the ranked list (default 20) or the relationship's transfer evidence (default 50); 1-100. An address with no transfers resolves to a schema-stable zero card, never null. Mirrors GET /api/v1/accounts/{ss58}/counterparties."
     account_counterparties(ss58: String!, counterparty: String, limit: Int): AccountCounterparties!
+    "One account's first-party chain-event history (hotkey or coldkey), newest first -- each event's kind, block/index, hotkey/coldkey, netuid/uid, amount_tao/alpha_amount, and observed_at. kind filters to one ingested event kind (e.g. StakeAdded, NeuronRegistered); netuid scopes to one subnet; block_start/block_end bound the block-height range; page with limit/offset or cursor (opaque keyset from a prior response's next_cursor). An address with no matching events resolves to a schema-stable empty feed, never null. Mirrors GET /api/v1/accounts/{ss58}/events."
+    account_events(ss58: String!, kind: String, netuid: Int, limit: Int, offset: Int, cursor: String, block_start: Int, block_end: Int): AccountEvents!
     "One account's native-TAO transfer feed from the Balances.Transfer event stream, newest first -- each event's block/index, from/to, amount_tao, a direction relative to the queried address (sent = it paid, received = it was paid), and observed_at. direction narrows to sent | received only (default both); block_start/block_end bound the block-height range; page with limit/offset or cursor (opaque keyset from a prior response's next_cursor). An address with no transfers resolves to a schema-stable empty feed, never null. Mirrors GET /api/v1/accounts/{ss58}/transfers."
     account_transfers(ss58: String!, limit: Int, offset: Int, cursor: String, direction: String, block_start: Int, block_end: Int): AccountTransfers!
     "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
@@ -1901,6 +1904,17 @@ export const SDL = `
     extrinsic_index: Int
   }
 
+  "One account's first-party chain-event feed, keyset-paginated newest-first. Mirrors GET /api/v1/accounts/{ss58}/events' data envelope."
+  type AccountEvents {
+    schema_version: Int!
+    ss58: String!
+    event_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    events: [AccountEvent!]!
+  }
+
   "Signing-activity aggregate from the extrinsics tier, matched by signer only -- an account queried by a key that did not sign returns tx_count 0, other fields null/empty."
   type AccountActivity {
     tx_count: Int!
@@ -2183,6 +2197,7 @@ export const FIELD_COMPLEXITY = {
   account_identity: RELATIONSHIP_FIELD_COMPLEXITY,
   account_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   account_counterparties: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_events: RELATIONSHIP_FIELD_COMPLEXITY,
   account_transfers: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   // A single latest-only row -- but it fans out into the full hyperparameter
@@ -4465,6 +4480,73 @@ const rootValue = {
             })),
           }
         : null,
+    };
+  },
+
+  async account_events(
+    { ss58, kind, netuid, limit, offset, cursor, block_start, block_end },
+    context,
+  ) {
+    // Same SS58 validation every account_* resolver uses -- a malformed address
+    // is a GraphQL BAD_USER_INPUT error, not a silent empty feed.
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same FEED_PAGINATION bounds parsePagination applies for REST, so a GraphQL
+    // caller cannot request a wider page than the /events route allows;
+    // kind/netuid/cursor/block_start/block_end are forwarded verbatim for the
+    // route to re-parse, matching the sibling feed resolvers.
+    const safeLimit = clampLimit(limit, FEED_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    if (kind != null) params.set("kind", kind);
+    if (netuid != null) params.set("netuid", String(netuid));
+    if (cursor != null) params.set("cursor", cursor);
+    if (block_start != null) params.set("block_start", String(block_start));
+    if (block_end != null) params.set("block_end", String(block_end));
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) the REST handler and
+    // MCP get_account_events tool use. The account_events D1 write path is
+    // retired (#4772), so a tier miss resolves through buildAccountEvents over
+    // an empty scan -- a schema-stable empty feed, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}/events`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      buildAccountEvents([], ss58, {
+        limit: safeLimit,
+        offset: safeOffset,
+        nextCursor: null,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      ss58: data.ss58 ?? ss58,
+      event_count: data.event_count ?? 0,
+      limit: data.limit ?? safeLimit,
+      offset: data.offset ?? safeOffset,
+      next_cursor: data.next_cursor ?? null,
+      events: (data.events ?? []).map((e) => ({
+        block_number: e.block_number ?? null,
+        event_index: e.event_index ?? null,
+        event_kind: e.event_kind ?? null,
+        hotkey: e.hotkey ?? null,
+        coldkey: e.coldkey ?? null,
+        netuid: e.netuid ?? null,
+        uid: e.uid ?? null,
+        amount_tao: e.amount_tao ?? null,
+        alpha_amount: e.alpha_amount ?? null,
+        observed_at: e.observed_at ?? null,
+        extrinsic_index: e.extrinsic_index ?? null,
+      })),
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7095,6 +7095,254 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
   });
 });
 
+describe("graphql — account_events (#5890, Postgres-tier flat feed)", () => {
+  const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+  const OTHER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  function dataApi(response, capture) {
+    return {
+      fetch: async (req) => {
+        if (capture) capture.url = new URL(req.url);
+        return response;
+      },
+    };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty feed, never null", async () => {
+    const { status, body } = await gql(
+      `{ account_events(ss58: "${SS58}") {
+          schema_version ss58 event_count limit offset next_cursor
+          events {
+            block_number event_index event_kind hotkey coldkey
+            netuid uid amount_tao alpha_amount observed_at extrinsic_index
+          }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_events, {
+      schema_version: 1,
+      ss58: SS58,
+      event_count: 0,
+      limit: 100,
+      offset: 0,
+      next_cursor: null,
+      events: [],
+    });
+  });
+
+  test("resolves the flat Postgres-tier envelope, mapping each event's fields", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          event_count: 1,
+          limit: 50,
+          offset: 0,
+          next_cursor: "b:1200:3",
+          events: [
+            {
+              block_number: 1200,
+              event_index: 3,
+              event_kind: "StakeAdded",
+              hotkey: SS58,
+              coldkey: OTHER,
+              netuid: 1,
+              uid: 7,
+              amount_tao: 1.5,
+              alpha_amount: 2.25,
+              observed_at: "2026-07-15T00:00:00.000Z",
+              extrinsic_index: 4,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ account_events(ss58: "${SS58}") {
+          schema_version ss58 event_count limit offset next_cursor
+          events {
+            block_number event_index event_kind hotkey coldkey
+            netuid uid amount_tao alpha_amount observed_at extrinsic_index
+          }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_events, {
+      schema_version: 1,
+      ss58: SS58,
+      event_count: 1,
+      limit: 50,
+      offset: 0,
+      next_cursor: "b:1200:3",
+      events: [
+        {
+          block_number: 1200,
+          event_index: 3,
+          event_kind: "StakeAdded",
+          hotkey: SS58,
+          coldkey: OTHER,
+          netuid: 1,
+          uid: 7,
+          amount_tao: 1.5,
+          alpha_amount: 2.25,
+          observed_at: "2026-07-15T00:00:00.000Z",
+          extrinsic_index: 4,
+        },
+      ],
+    });
+  });
+
+  test("hits /api/v1/accounts/{ss58}/events and forwards every filter", async () => {
+    const capture = {};
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          event_count: 0,
+          limit: 5,
+          offset: 2,
+          next_cursor: null,
+          events: [],
+        }),
+        capture,
+      ),
+    };
+    const { status } = await gql(
+      `{ account_events(ss58: "${SS58}", kind: "StakeAdded", netuid: 1, limit: 5, offset: 2, cursor: "c:9:1", block_start: 10, block_end: 20) { event_count } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(capture.url.pathname, `/api/v1/accounts/${SS58}/events`);
+    assert.equal(capture.url.searchParams.get("kind"), "StakeAdded");
+    assert.equal(capture.url.searchParams.get("netuid"), "1");
+    assert.equal(capture.url.searchParams.get("limit"), "5");
+    assert.equal(capture.url.searchParams.get("offset"), "2");
+    assert.equal(capture.url.searchParams.get("cursor"), "c:9:1");
+    assert.equal(capture.url.searchParams.get("block_start"), "10");
+    assert.equal(capture.url.searchParams.get("block_end"), "20");
+  });
+
+  test("clamps limit/offset to FEED_PAGINATION bounds before forwarding", async () => {
+    const capture = {};
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({}), capture),
+    };
+    await gql(
+      `{ account_events(ss58: "${SS58}", limit: 100000, offset: -5) { event_count } }`,
+      env,
+    );
+    const forwardedLimit = Number(capture.url.searchParams.get("limit"));
+    const forwardedOffset = Number(capture.url.searchParams.get("offset"));
+    assert.ok(forwardedLimit > 0 && forwardedLimit < 100000);
+    assert.equal(forwardedOffset, 0);
+    // No filter params were supplied, so none are forwarded.
+    assert.equal(capture.url.searchParams.get("kind"), null);
+    assert.equal(capture.url.searchParams.get("netuid"), null);
+    assert.equal(capture.url.searchParams.get("cursor"), null);
+    assert.equal(capture.url.searchParams.get("block_start"), null);
+    assert.equal(capture.url.searchParams.get("block_end"), null);
+  });
+
+  test("a partial tier envelope degrades missing scalars to schema-stable defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ account_events(ss58: "${SS58}") {
+          schema_version ss58 event_count limit offset next_cursor events { event_kind }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_events, {
+      schema_version: 1,
+      ss58: SS58,
+      event_count: 0,
+      limit: 100,
+      offset: 0,
+      next_cursor: null,
+      events: [],
+    });
+  });
+
+  test("an event row with missing fields degrades each to null", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          event_count: 1,
+          next_cursor: null,
+          events: [{}],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ account_events(ss58: "${SS58}") {
+          events {
+            block_number event_index event_kind hotkey coldkey
+            netuid uid amount_tao alpha_amount observed_at extrinsic_index
+          }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_events.events, [
+      {
+        block_number: null,
+        event_index: null,
+        event_kind: null,
+        hotkey: null,
+        coldkey: null,
+        netuid: null,
+        uid: null,
+        amount_tao: null,
+        alpha_amount: null,
+        observed_at: null,
+        extrinsic_index: null,
+      },
+    ]);
+  });
+
+  test("an invalid ss58 is a GraphQL error and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { body } = await gql(
+      '{ account_events(ss58: "not-an-address") { event_count } }',
+      env,
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/ss58/i.test(body.errors[0].message));
+    assert.equal(body.data?.account_events ?? null, null);
+    assert.equal(called, false);
+  });
+
+  test("account_events is weighted as a relationship field", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.account_events,
+      FIELD_COMPLEXITY.account_identity_history,
+    );
+  });
+});
+
 describe("graphql — account_identity_history (#5709, Postgres-tier + D1-live fallback)", () => {
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 


### PR DESCRIPTION
## What

Adds `Query.account_events` to `src/graphql.mjs`, mirroring the existing REST route `GET /api/v1/accounts/{ss58}/events` (`workers/data-api.mjs`) and the MCP `get_account_events` tool. This closes the REST/GraphQL/MCP parity gap for the plain account event feed — the same gap-closure category as `Query.account_transfers` (#5892 / #5947) and the other `account_*` GraphQL mirrors.

## How

- New SDL type `AccountEvents` (reuses the existing `AccountEvent` row type) and the field `account_events(ss58: String!, kind: String, netuid: Int, limit: Int, offset: Int, cursor: String, block_start: Int, block_end: Int): AccountEvents!`, weighted as a `RELATIONSHIP_FIELD_COMPLEXITY` field like its siblings.
- The resolver reuses the same `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` path the REST handler and MCP tool already use — no query/aggregation logic is duplicated. `limit`/`offset` are clamped to `FEED_PAGINATION` (matching REST bounds) and `kind`/`netuid`/`cursor`/`block_start`/`block_end` are forwarded verbatim for the route to re-parse.
- On a tier miss the resolver falls back to `buildAccountEvents([], ss58, …)` for a schema-stable empty feed (the `account_events` D1 write path is retired, #4772), never a GraphQL error.
- A malformed `ss58` is a `BAD_USER_INPUT` error and never reaches the Postgres tier, matching every sibling `account_*` resolver.

## Tests

`tests/graphql.test.mjs` — a new `account_events` describe block (8 tests): cold-store empty feed, full tier envelope mapping, filter forwarding, limit/offset clamping, partial-envelope scalar defaults, per-row null defaults, invalid-ss58 guard (tier never called), and field-complexity weighting.

- `npx vitest run tests/graphql.test.mjs -t "account_events"` → passed

Closes #5890