### PR TITLE
feat(graphql): add Query.chain_fees mirroring REST + MCP (#5881)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -207,7 +207,7 @@ import {
   DEFAULT_CHAIN_TURNOVER_WINDOW,
 } from "./chain-turnover.mjs";
 import { buildTurnover } from "./turnover.mjs";
-import { buildChainCalls } from "./chain-analytics.mjs";
+import { buildChainCalls, buildChainFees } from "./chain-analytics.mjs";
 import { buildChainPerformance } from "./chain-performance.mjs";
 import { buildChainConcentration } from "./concentration.mjs";
 import {
@@ -368,6 +368,8 @@ export const SDL = `
     chain_calls(window: String, group_by: String, limit: Int, call_module: String): ChainCalls!
     "Network-wide Prometheus telemetry-endpoint announcement leaderboard over a 7d/30d window (default 7d): subnets ranked by PrometheusServed announcements with each's distinct-exporter count and announcements-per-exporter re-announcement intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The telemetry-endpoint companion to chain_serving's axon endpoints -- which subnets run observability infrastructure. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/prometheus."
     chain_prometheus(window: String, limit: Int): ChainPrometheus!
+    "Per-UTC-day network fee/tip series over a 7d/30d window (default 7d): each day's extrinsic count and total/avg/median fee + tip in TAO, plus the top fee-paying signers (limit default 25, max 100), optionally scoped to a single call_module. Computed live from the extrinsics tier; a cold store yields a schema-stable empty series, never a GraphQL error. Mirrors GET /api/v1/chain/fees."
+    chain_fees(window: String, limit: Int, call_module: String): ChainFees!
     "Network-wide weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators driving consensus network-wide, each with its total WeightsSet count, share of the network total, and first/last set times, ranked by activity. The setter-level drill-in behind chain_weights. Mirrors GET /api/v1/chain/weights/setters."
     chain_weight_setters(window: String, limit: Int): ChainWeightSetters!
     "Compact all-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history (probed every ~15 minutes); a cold store still returns both windows, schema-stable and zeroed, never a GraphQL error. Mirrors GET /api/v1/health/trends."
@@ -573,6 +575,36 @@ export const SDL = `
     total_extrinsics: Int!
     call_count: Int!
     calls: [ChainCall!]!
+  }
+
+  "One UTC day's fee/tip aggregate: extrinsic count, total/avg/median fee and tip in TAO (avg/median are null on a zero-extrinsic day)."
+  type ChainFeesDay {
+    day: String!
+    extrinsic_count: Int!
+    total_fee_tao: Float
+    avg_fee_tao: Float
+    median_fee_tao: Float
+    total_tip_tao: Float
+    avg_tip_tao: Float
+    median_tip_tao: Float
+  }
+
+  "One top fee-paying signer over the window, with its total fee/tip and extrinsic count."
+  type ChainFeePayer {
+    signer: String!
+    total_fee_tao: Float
+    total_tip_tao: Float
+    extrinsic_count: Int!
+  }
+
+  "Per-UTC-day network fee/tip series plus the top fee payers over the window. Mirrors GET /api/v1/chain/fees's data envelope."
+  type ChainFees {
+    schema_version: Int!
+    window: String!
+    observed_at: String
+    day_count: Int!
+    daily: [ChainFeesDay!]!
+    top_fee_payers: [ChainFeePayer!]!
   }
 
   "Network-wide validator-set churn across all subnets (#5686). Mirrors GET /api/v1/chain/turnover's data envelope."
@@ -2293,6 +2325,7 @@ export const FIELD_COMPLEXITY = {
   chain_turnover: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_turnover: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_calls: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_fees: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_prometheus: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4863,6 +4896,62 @@ const rootValue = {
         call_function: c.call_function ?? null,
         count: c.count ?? 0,
         share: c.share ?? null,
+      })),
+    };
+  },
+
+  async chain_fees({ window, limit, call_module: callModule }, context) {
+    // Reuse the exact analyticsWindow parse/validate REST's handleChainFees
+    // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL
+    // BAD_USER_INPUT error, not a silent empty result.
+    const windowUrl = new URL(context.request.url);
+    windowUrl.search = "";
+    if (window != null) windowUrl.searchParams.set("window", window);
+    const { label, error } = analyticsWindow(windowUrl);
+    if (error) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    if (callModule != null && callModule.length > 100) {
+      throw new GraphQLError("call_module must be at most 100 characters.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const safeLimit = clampLimit(limit, { defaultLimit: 25, maxLimit: 100 });
+    const params = new URLSearchParams();
+    params.set("window", label);
+    params.set("limit", String(safeLimit));
+    if (callModule != null) params.set("call_module", callModule);
+    // Same tryPostgresTier(METAGRAPH_EXTRINSICS_SOURCE) -> buildChainFees fallback
+    // handleChainFees uses; the tier owns the daily/median/payer aggregation (no
+    // logic duplicated here), and a cold store yields a schema-stable empty series.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/fees", params),
+        "METAGRAPH_EXTRINSICS_SOURCE",
+      )) ?? buildChainFees({ window: label });
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? label,
+      observed_at: data.observed_at ?? null,
+      day_count: data.day_count ?? 0,
+      daily: (data.daily ?? []).map((d) => ({
+        day: d.day,
+        extrinsic_count: d.extrinsic_count ?? 0,
+        total_fee_tao: d.total_fee_tao ?? null,
+        avg_fee_tao: d.avg_fee_tao ?? null,
+        median_fee_tao: d.median_fee_tao ?? null,
+        total_tip_tao: d.total_tip_tao ?? null,
+        avg_tip_tao: d.avg_tip_tao ?? null,
+        median_tip_tao: d.median_tip_tao ?? null,
+      })),
+      top_fee_payers: (data.top_fee_payers ?? []).map((p) => ({
+        signer: p.signer,
+        total_fee_tao: p.total_fee_tao ?? null,
+        total_tip_tao: p.total_tip_tao ?? null,
+        extrinsic_count: p.extrinsic_count ?? 0,
       })),
     };
   },

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -8221,6 +8221,166 @@ describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fa
   });
 });
 
+describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store fallback)", () => {
+  function feesQuery(argsClause) {
+    return `{ chain_fees${argsClause} {
+      schema_version window observed_at day_count
+      daily { day extrinsic_count total_fee_tao avg_fee_tao median_fee_tao total_tip_tao avg_tip_tao median_tip_tao }
+      top_fee_payers { signer total_fee_tao total_tip_tao extrinsic_count }
+    } }`;
+  }
+
+  test("cold store, default args: schema-stable empty series (7d)", async () => {
+    const { status, body } = await gql(feesQuery(""));
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_fees, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      day_count: 0,
+      daily: [],
+      top_fee_payers: [],
+    });
+  });
+
+  test("resolves Postgres-tier daily series + top payers", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            window: "30d",
+            observed_at: "2026-07-14T00:00:00.000Z",
+            day_count: 1,
+            daily: [
+              {
+                day: "2026-07-14",
+                extrinsic_count: 4,
+                total_fee_tao: 0.4,
+                avg_fee_tao: 0.1,
+                median_fee_tao: 0.1,
+                total_tip_tao: 0.02,
+                avg_tip_tao: 0.005,
+                median_tip_tao: 0.004,
+              },
+            ],
+            top_fee_payers: [
+              {
+                signer: "5Signer",
+                total_fee_tao: 0.4,
+                total_tip_tao: 0.02,
+                extrinsic_count: 4,
+              },
+            ],
+          }),
+      },
+    };
+    const { status, body } = await gql(feesQuery(`(window: "30d")`), env);
+    assert.equal(status, 200);
+    const d = body.data.chain_fees;
+    assert.equal(d.window, "30d");
+    assert.equal(d.day_count, 1);
+    assert.equal(d.daily[0].day, "2026-07-14");
+    assert.equal(d.daily[0].total_fee_tao, 0.4);
+    assert.equal(d.daily[0].median_tip_tao, 0.004);
+    assert.equal(d.top_fee_payers[0].signer, "5Signer");
+    assert.equal(d.top_fee_payers[0].extrinsic_count, 4);
+  });
+
+  test("partial rows in each list degrade missing fields to their schema-stable defaults", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      // Each row carries only its required key; every other field is omitted so
+      // the per-item ?? default fallbacks (both lists) must fire.
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            daily: [{ day: "2026-07-14" }],
+            top_fee_payers: [{ signer: "5Signer" }],
+          }),
+      },
+    };
+    const { status, body } = await gql(feesQuery(""), env);
+    assert.equal(status, 200);
+    const d = body.data.chain_fees;
+    assert.equal(d.schema_version, 1);
+    assert.equal(d.window, "7d");
+    assert.equal(d.observed_at, null);
+    assert.equal(d.day_count, 0);
+    const day = d.daily[0];
+    assert.equal(day.extrinsic_count, 0);
+    assert.equal(day.total_fee_tao, null);
+    assert.equal(day.avg_fee_tao, null);
+    assert.equal(day.median_fee_tao, null);
+    assert.equal(day.total_tip_tao, null);
+    assert.equal(day.avg_tip_tao, null);
+    assert.equal(day.median_tip_tao, null);
+    const payer = d.top_fee_payers[0];
+    assert.equal(payer.total_fee_tao, null);
+    assert.equal(payer.total_tip_tao, null);
+    assert.equal(payer.extrinsic_count, 0);
+  });
+
+  test("an empty Postgres-tier body (no daily/top_fee_payers keys) degrades to empty lists", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(feesQuery(""), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_fees, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      day_count: 0,
+      daily: [],
+      top_fee_payers: [],
+    });
+  });
+
+  test("window/limit/call_module args are forwarded to the /chain/fees path", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            day_count: 0,
+            daily: [],
+            top_fee_payers: [],
+          });
+        },
+      },
+    };
+    await gql(
+      feesQuery(`(window: "30d", limit: 5, call_module: "Balances")`),
+      env,
+    );
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/fees");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl.searchParams.get("call_module"), "Balances");
+  });
+
+  test("rejects an unsupported window with BAD_USER_INPUT", async () => {
+    const { body } = await gql(feesQuery(`(window: "99d")`));
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("rejects an over-long call_module with BAD_USER_INPUT", async () => {
+    const { body } = await gql(feesQuery(`(call_module: "${"x".repeat(101)}")`));
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("chain_fees is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.chain_fees, 5);
+  });
+});
+
 describe("graphql — chain_serving (#5873, Postgres-tier + D1-live fallback)", () => {
   function servingQuery(argsClause) {
     return `{ chain_serving${argsClause} {


### PR DESCRIPTION
## Summary

Closes the REST/GraphQL/MCP parity gap on the network fee surface. `GET /api/v1/chain/fees` and MCP `get_chain_fees` already ship, but had no GraphQL mirror.

Adds `Query.chain_fees(window, limit, call_module)` returning a new `ChainFees` type (`schema_version`, `window`, `observed_at`, `day_count`, `daily[]`, `top_fee_payers[]`) with a `ChainFeesDay` item (day + extrinsic_count + total/avg/median fee & tip) and a `ChainFeePayer` item (signer + total fee/tip + extrinsic_count). The resolver reuses the exact `analyticsWindow` validation (7d/30d, default 7d) and hits the same DATA_API extrinsics-tier path `/api/v1/chain/fees` the REST route uses — the tier owns the daily/median/payer aggregation, no logic duplicated. An over-long `call_module` and an unsupported window are `BAD_USER_INPUT`; a cold tier falls back to `buildChainFees`'s schema-stable empty series. Priced at `RELATIONSHIP_FIELD_COMPLEXITY`.

Entirely within `src/graphql.mjs` + its test.

## Testing

- `tests/graphql.test.mjs` — 8 new tests: cold-store empty series, Postgres daily+payer resolution, **partial rows and an empty body (exercising every `?? default` / `|| []` fallback across BOTH nested lists)**, arg forwarding to `/chain/fees`, the two `BAD_USER_INPUT` rejections, and the complexity weight. **Full graphql suite: 460 pass.**
- eslint + prettier clean; resolver verified **at the branch level** — all statements and branches covered.

Closes #5881
