### PR TITLE
fix(registry): blockmachine (SN19) accuracy pass -- slow-endpoint timeout

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 224,
+  "surface_count": 229,
   "surfaces": [
     {
       "auth_required": false,
@@ -1653,6 +1653,78 @@
     {
       "auth_required": false,
       "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 19,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "blockmachine",
+      "public_safe": true,
+      "subnet_name": "blockmachine",
+      "subnet_slug": "sn-19",
+      "surface_id": "sn-19-blockmachine-data-artifact",
+      "surface_key": "srf-0cf09195357d6450",
+      "url": "https://api.blockmachine.io/epochs/latest-finalized"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 19,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "blockmachine",
+      "public_safe": true,
+      "subnet_name": "blockmachine",
+      "subnet_slug": "sn-19",
+      "surface_id": "sn-19-blockmachine-data-artifact-api-blockmachine-io",
+      "surface_key": "srf-f96ef1de905a31d2",
+      "url": "https://api.blockmachine.io/epochs/current"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 19,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "blockmachine",
+      "public_safe": true,
+      "subnet_name": "blockmachine",
+      "subnet_slug": "sn-19",
+      "surface_id": "sn-19-blockmachine-epochs-catalog",
+      "surface_key": "srf-13e601b8e71500b5",
+      "url": "https://api.blockmachine.io/epochs"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 19,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "blockmachine",
+      "public_safe": true,
+      "subnet_name": "blockmachine",
+      "subnet_slug": "sn-19",
+      "surface_id": "sn-19-blockmachine-health",
+      "surface_key": "srf-fa68a799d2a0e7c3",
+      "url": "https://api.blockmachine.io/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
       "kind": "subnet-api",
       "netuid": 19,
       "probe": {
@@ -1667,6 +1739,24 @@
       "surface_id": "sn-19-blockmachine-ready",
       "surface_key": "srf-4eefba22b5905e9d",
       "url": "https://api.blockmachine.io/ready"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 19,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 25000
+      },
+      "provider": "blockmachine",
+      "public_safe": true,
+      "subnet_name": "blockmachine",
+      "subnet_slug": "sn-19",
+      "surface_id": "sn-19-blockmachine-subnet-api",
+      "surface_key": "srf-f8bda901a1163175",
+      "url": "https://api.blockmachine.io/leaderboard"
     },
     {
       "auth_required": false,

--- a/registry/subnets/blockmachine.json
+++ b/registry/subnets/blockmachine.json
@@ -8,12 +8,7 @@
   ],
   "contact": "team@blockmachine.io",
   "curation": {
-    "gap_notes": [
-      "No verified safe public subnet API endpoint yet.",
-      "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
-    ],
+    "gap_notes": ["No verified SSE/event stream yet."],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T10:10:00.000Z",
@@ -24,7 +19,7 @@
   "docs_url": "https://blockmachine.io/whitepaper",
   "name": "blockmachine",
   "netuid": 19,
-  "notes": "Reviewed overlay for SN19 using the official BlockMachine website, whitepaper, and source repository.",
+  "notes": "Reviewed overlay for SN19 using the official BlockMachine website, whitepaper, and source repository. 5 community-submitted surfaces had no probe config at all -- the registry-wide gap tracked in #5932 -- fixed. The leaderboard endpoint is consistently slow (~17s across repeated live tests) though genuinely working, not down; timeout extended to 25s so it isn't misreported unhealthy. Diffed the tracked OpenAPI schema (27 paths) against tracked surfaces: found and added the public CLI install script (/install.sh); the remaining untracked paths are either HTTPBearer-auth-gated, X-API-Key-gated, or need a specific epoch_id with no stable canonical value.",
   "schema_version": 1,
   "slug": "sn-19",
   "social": {
@@ -117,6 +112,13 @@
       "id": "sn-19-blockmachine-subnet-api",
       "kind": "subnet-api",
       "name": "BlockMachine public leaderboard API",
+      "notes": "Public no-auth GET returning the BlockMachine leaderboard. Consistently slow (~17s observed across repeated live tests, TLS handshake succeeds immediately but the response body takes that long) -- timeout extended well past this file's usual 10s default so it isn't misreported unhealthy for being slow rather than down.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 25000
+      },
       "provider": "blockmachine",
       "public_safe": true,
       "review": {
@@ -135,6 +137,13 @@
       "id": "sn-19-blockmachine-data-artifact",
       "kind": "data-artifact",
       "name": "BlockMachine finalized-epoch snapshot",
+      "notes": "Public no-auth GET returning the latest finalized epoch (id, number, participating gateway_ids, per-gateway manifest). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "blockmachine",
       "public_safe": true,
       "review": {
@@ -153,6 +162,13 @@
       "id": "sn-19-blockmachine-data-artifact-api-blockmachine-io",
       "kind": "data-artifact",
       "name": "BlockMachine current-epoch snapshot",
+      "notes": "Public no-auth GET returning the current epoch (epoch_id, current_block, observed_at). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "blockmachine",
       "public_safe": true,
       "review": {
@@ -172,6 +188,12 @@
       "kind": "data-artifact",
       "name": "BlockMachine epochs catalog",
       "notes": "Public no-auth BlockMachine epochs listing — every epoch's id/number, participating gateway_ids, and per-gateway manifest (request log files + finalized CU-allocation objects). The full-history catalog behind the already-registered latest-finalized/current single-epoch endpoints; declared as GET /epochs (\"List Epochs\") in the operator's OpenAPI (source).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "blockmachine",
       "public_safe": true,
       "review": {
@@ -191,6 +213,12 @@
       "kind": "subnet-api",
       "name": "BlockMachine API health",
       "notes": "Public no-auth GET /health returning BlockMachine API status and version. Documented in the subnet's OpenAPI spec on the same host as the existing leaderboard and epoch snapshot surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "blockmachine",
       "public_safe": true,
       "review": {
@@ -224,6 +252,24 @@
       },
       "source_urls": ["https://api.blockmachine.io/ready"],
       "url": "https://api.blockmachine.io/ready"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-19-blockmachine-install-script",
+      "kind": "sdk",
+      "name": "BlockMachine CLI install script",
+      "notes": "Public no-auth GET /install.sh serving the shell installer for the Blockmachine CLI (bm), which pip-installs the blockmachine package. Documented in the subnet's own OpenAPI schema; same host as the other api.blockmachine.io surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "blockmachine",
+      "public_safe": true,
+      "source_urls": ["https://api.blockmachine.io/openapi.json"],
+      "url": "https://api.blockmachine.io/install.sh"
     }
   ],
   "website_url": "https://blockmachine.io/"


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- 5 community-submitted surfaces had no probe config at all -- the registry-wide gap tracked in #5932 -- fixed.
- The leaderboard endpoint is consistently slow: ~17s across repeated live tests (TLS handshake succeeds immediately, but the response body takes that long) -- genuinely working, not down. Extended its timeout to 25s (this file's other endpoints use the usual 10s default) so it isn't misreported unhealthy for being slow rather than actually broken.
- Diffed the tracked OpenAPI schema (27 paths) against tracked surfaces: found and added the public CLI install script (`/install.sh`, no auth, no params). The remaining untracked paths are either HTTPBearer-auth-gated, X-API-Key-gated, or need a specific epoch_id with no stable canonical value (same reasoning as prior passes, e.g. #5914/#5934).
- Removed 3 stale `gap_notes` entries claiming no subnet-api/OpenAPI/data-artifact surface was verified, despite this file already tracking all three kinds -- the automated stale-notes checker didn't flag this particular phrasing, caught by manual review instead.

## Test plan

- [x] `npm run validate` — passes
- [x] `npm run validate:surface` — passes (923 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] Every surface URL live-tested individually; leaderboard slowness confirmed non-transient across repeated tests before extending its timeout instead of assuming it was down