### PR TITLE
fix(registry): GroundLayer (SN20) accuracy pass -- restore missing probes

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 229,
+  "surface_count": 231,
   "surfaces": [
     {
       "auth_required": false,
@@ -1757,6 +1757,42 @@
       "surface_id": "sn-19-blockmachine-subnet-api",
       "surface_key": "srf-f8bda901a1163175",
       "url": "https://api.blockmachine.io/leaderboard"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 20,
+      "probe": {
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "groundlayer",
+      "public_safe": true,
+      "subnet_name": "GroundLayer",
+      "subnet_slug": "sn-20",
+      "surface_id": "sn-20-groundlayer-og-card-image",
+      "surface_key": "srf-6db21964dec0114d",
+      "url": "https://www.groundlayer.xyz/og-groundlayer.png"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 20,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "subnet_name": "GroundLayer",
+      "subnet_slug": "sn-20",
+      "surface_id": "sn-20-taomarketcap-subnet-api",
+      "surface_key": "srf-ebe7ad3af0b78382",
+      "url": "https://api.taomarketcap.com/public/v1/subnets/20"
     },
     {
       "auth_required": false,

--- a/registry/subnets/groundlayer.json
+++ b/registry/subnets/groundlayer.json
@@ -33,7 +33,7 @@
   "dashboard_url": "https://taomarketcap.com/subnets/20",
   "name": "GroundLayer",
   "netuid": 20,
-  "notes": "Reviewed overlay for SN20 using the live GroundLayer website, subnet page, and roadmap. Previously discovered source repository candidates are not live and common API/docs/OpenAPI paths currently return 404.",
+  "notes": "Reviewed overlay for SN20 using the live GroundLayer website, subnet page, and roadmap. Previously discovered source repository candidates are not live and common API/docs/OpenAPI paths currently return 404. Investigated rizzo.network (from the contact email groundlayer@rizzo.network) as a possible operator site/source-repo lead: confirmed it's a validator operator (Taostats-linked) with no on-page mention of GroundLayer/SN20, and its linked GitHub account (RogueTensor) has a single unrelated repo -- not added as a surface, source_repo remains null. 2 community-submitted surfaces had no probe config at all -- the registry-wide gap tracked in #5932 -- fixed.",
   "schema_version": 1,
   "slug": "sn-20",
   "social": {
@@ -112,6 +112,12 @@
       "kind": "data-artifact",
       "name": "GroundLayer OpenGraph card image",
       "notes": "Public no-auth PNG brand image served at www.groundlayer.xyz/og-groundlayer.png and referenced by the official GroundLayer homepage OpenGraph and Twitter card metadata for SN20 social previews.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "groundlayer",
       "public_safe": true,
       "review": {
@@ -131,6 +137,12 @@
       "kind": "subnet-api",
       "name": "GroundLayer TaoMarketCap subnet snapshot API",
       "notes": "Public no-auth GET /public/v1/subnets/20 on api.taomarketcap.com returning machine-readable JSON for SN20 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. GroundLayer's official website paths under www.groundlayer.xyz do not expose a verified first-party public API; this indexed feed is documented in the TaoMarketCap developer API.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- Investigated `rizzo.network` (from the contact email `groundlayer@rizzo.network`) as a possible operator site/source-repo lead -- confirmed it's a validator operator (Taostats-linked), no on-page mention of GroundLayer or SN20, and its linked GitHub account (RogueTensor) has a single unrelated repo. Not added; `source_repo` correctly remains `null`.
- 2 community-submitted surfaces (OG card image, TaoMarketCap snapshot) had no probe config at all -- the registry-wide gap tracked in #5932 -- fixed.
- All 5 surfaces re-verified live; re-checked the docs-site gap (still 404/unresolvable) and the common API/OpenAPI paths (still 404) -- `gap_notes` remain accurate.

## Test plan

- [x] `npm run validate` — passes
- [x] `npm run validate:surface` — passes (923 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] Every surface URL live-tested individually; the rizzo.network lead was investigated and ruled out with evidence, not just skipped