### PR TITLE
feat(graphql): add Query.chain_registrations mirroring REST

### DIFF
--- a/src/chain-registrations.mjs
+++ b/src/chain-registrations.mjs
@@ -14,6 +14,12 @@ export const REGISTRATION_EVENT_KIND = "NeuronRegistered";
 export const CHAIN_REGISTRATIONS_LIMIT_DEFAULT = 20;
 export const CHAIN_REGISTRATIONS_LIMIT_MAX = 100;
 
+// Supported lookback windows (label -> days), matching the REST route's analytics
+// window set (7d/30d, default 7d). Kept next to the loader so the MCP tool's input
+// schema and runtime validation cannot drift from the endpoint.
+export const CHAIN_REGISTRATIONS_WINDOWS = { "7d": 7, "30d": 30 };
+export const DEFAULT_CHAIN_REGISTRATIONS_WINDOW = "7d";
+
 // Round a registrations-per-registrant ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct registrants, with the divisor guarded below).
 function round(value, dp = 2) {

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -16,6 +16,13 @@ import {
   CHAIN_PROMETHEUS_LIMIT_DEFAULT,
   CHAIN_PROMETHEUS_LIMIT_MAX,
 } from "./chain-prometheus.mjs";
+import {
+  loadChainRegistrations,
+  CHAIN_REGISTRATIONS_WINDOWS,
+  DEFAULT_CHAIN_REGISTRATIONS_WINDOW,
+  CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
+  CHAIN_REGISTRATIONS_LIMIT_MAX,
+} from "./chain-registrations.mjs";
 import { buildSubnetHyperparams } from "./subnet-hyperparams.mjs";
 import { buildSubnetHyperparamsHistory } from "./subnet-hyperparams-history.mjs";
 import {
@@ -368,6 +375,8 @@ export const SDL = `
     chain_calls(window: String, group_by: String, limit: Int, call_module: String): ChainCalls!
     "Network-wide Prometheus telemetry-endpoint announcement leaderboard over a 7d/30d window (default 7d): subnets ranked by PrometheusServed announcements with each's distinct-exporter count and announcements-per-exporter re-announcement intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The telemetry-endpoint companion to chain_serving's axon endpoints -- which subnets run observability infrastructure. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/prometheus."
     chain_prometheus(window: String, limit: Int): ChainPrometheus!
+    "Network-wide neuron-registration activity leaderboard over a 7d/30d window (default 7d): subnets ranked by NeuronRegistered events with each's distinct-registrant count and registrations-per-registrant re-registration intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. Raw registration demand -- the account_events companion to chain_turnover's neuron_daily validator-set churn. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/registrations."
+    chain_registrations(window: String, limit: Int): ChainRegistrations!
     "Network-wide weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators driving consensus network-wide, each with its total WeightsSet count, share of the network total, and first/last set times, ranked by activity. The setter-level drill-in behind chain_weights. Mirrors GET /api/v1/chain/weights/setters."
     chain_weight_setters(window: String, limit: Int): ChainWeightSetters!
     "Compact all-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history (probed every ~15 minutes); a cold store still returns both windows, schema-stable and zeroed, never a GraphQL error. Mirrors GET /api/v1/health/trends."
@@ -741,6 +750,45 @@ export const SDL = `
     distinct_exporters: Int!
     announcements: Int!
     announcements_per_exporter: Float
+  }
+
+  "Network-wide neuron-registration activity leaderboard (#5876). Raw NeuronRegistered demand across every subnet -- the account_events companion to chain_turnover's neuron_daily churn. Mirrors GET /api/v1/chain/registrations's data envelope."
+  type ChainRegistrations {
+    schema_version: Int!
+    window: String
+    observed_at: String
+    subnet_count: Int!
+    network: ChainRegistrationsNetwork!
+    intensity_distribution: ChainRegistrationsIntensityDistribution
+    subnets: [ChainRegistrationsSubnet!]!
+  }
+
+  "Network-wide registration rollup: every subnet with NeuronRegistered events in the window, combined. distinct_registrants counts a hotkey once even when it registers on several subnets, so it is NOT the sum of the per-subnet counts."
+  type ChainRegistrationsNetwork {
+    distinct_registrants: Int!
+    registrations: Int!
+    "Null when distinct_registrants is 0 (no defined intensity without registrants)."
+    registrations_per_registrant: Float
+  }
+
+  "Spread of per-subnet re-registration intensity (NeuronRegistered events per registrant) across EVERY subnet with registrations in the window -- network-wide even when limit truncates the leaderboard."
+  type ChainRegistrationsIntensityDistribution {
+    count: Int!
+    mean: Float!
+    min: Float!
+    p25: Float!
+    median: Float!
+    p75: Float!
+    p90: Float!
+    max: Float!
+  }
+
+  "One subnet's neuron-registration activity in the window, ranked by registrations."
+  type ChainRegistrationsSubnet {
+    netuid: Int!
+    distinct_registrants: Int!
+    registrations: Int!
+    registrations_per_registrant: Float
   }
 
   "Network-wide rolling 24h buy/sell alpha-volume leaderboard, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/alpha-volume's data envelope."
@@ -2296,6 +2344,7 @@ export const FIELD_COMPLEXITY = {
   chain_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_prometheus: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   validator_nominators: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4993,6 +5042,50 @@ const rootValue = {
         distinct_exporters: 0,
         announcements: 0,
         announcements_per_exporter: null,
+      },
+      intensity_distribution: data.intensity_distribution ?? null,
+      subnets: data.subnets || [],
+    };
+  },
+
+  async chain_registrations({ window, limit }, context) {
+    const requestedWindow = window ?? DEFAULT_CHAIN_REGISTRATIONS_WINDOW;
+    if (!Object.hasOwn(CHAIN_REGISTRATIONS_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(requestedWindow, CHAIN_REGISTRATIONS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
+      maxLimit: CHAIN_REGISTRATIONS_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    params.set("limit", String(safeLimit));
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> loadChainRegistrations
+    // fallback contract REST's handleChainRegistrations uses -- a cold store yields a
+    // schema-stable zeroed card, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/registrations", params),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      (await loadChainRegistrations(graphqlD1(context), {
+        windowLabel: requestedWindow,
+        windowDays: CHAIN_REGISTRATIONS_WINDOWS[requestedWindow],
+        limit: safeLimit,
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? requestedWindow,
+      observed_at: data.observed_at ?? null,
+      subnet_count: data.subnet_count ?? 0,
+      network: data.network ?? {
+        distinct_registrants: 0,
+        registrations: 0,
+        registrations_per_registrant: null,
       },
       intensity_distribution: data.intensity_distribution ?? null,
       subnets: data.subnets || [],

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -23,6 +23,7 @@ import {
 } from "../src/graphql.mjs";
 import { LEADERBOARD_BOARDS } from "../src/health-serving.mjs";
 import { CHAIN_PROMETHEUS_WINDOWS } from "../src/chain-prometheus.mjs";
+import { CHAIN_REGISTRATIONS_WINDOWS } from "../src/chain-registrations.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { resolveClientIp } from "../workers/config.mjs";
 import {
@@ -10603,6 +10604,231 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
   test("is priced at the relationship-field complexity weight", () => {
     assert.equal(
       FIELD_COMPLEXITY.chain_prometheus,
+      FIELD_COMPLEXITY.chain_serving,
+    );
+  });
+});
+
+describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallback)", () => {
+  function registrationsQuery(argsClause) {
+    return `{ chain_registrations${argsClause} {
+      schema_version window observed_at subnet_count
+      network { distinct_registrants registrations registrations_per_registrant }
+      intensity_distribution { count mean min p25 median p75 p90 max }
+      subnets { netuid distinct_registrants registrations registrations_per_registrant }
+    } }`;
+  }
+
+  // Mirrors chainPrometheusD1: loadChainRegistrations issues the network aggregate
+  // (COUNT DISTINCT hotkey / MAX(observed_at), no GROUP BY) and only then the
+  // GROUP BY netuid leaderboard, and only when newest_observed is non-null.
+  function chainRegistrationsD1({ network, subnets = [] } = {}) {
+    return {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              async all() {
+                if (sql.includes("GROUP BY netuid")) {
+                  return { results: subnets };
+                }
+                return { results: network ? [network] : [] };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  test("cold store, default args: schema-stable empty leaderboard, never an error", async () => {
+    const { status, body } = await gql(registrationsQuery(""));
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_registrations, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_registrants: 0,
+        registrations: 0,
+        registrations_per_registrant: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("resolves the D1-live tier: per-subnet leaderboard + network rollup", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: chainRegistrationsD1({
+        network: { distinct_registrants: 3, newest_observed: 1780000000000 },
+        subnets: [
+          { netuid: 1, registrations: 10, distinct_registrants: 2 },
+          { netuid: 7, registrations: 4, distinct_registrants: 2 },
+        ],
+      }),
+    };
+    const { status, body } = await gql(registrationsQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const got = body.data.chain_registrations;
+    assert.equal(got.subnet_count, 2);
+    assert.equal(got.observed_at, new Date(1780000000000).toISOString());
+    // The network rollup is the true distinct count, not the sum of per-subnet
+    // registrants (a hotkey registering on several subnets counts once).
+    assert.deepEqual(got.network, {
+      distinct_registrants: 3,
+      registrations: 14,
+      // 14 registrations / 3 distinct registrants, rounded to the builder's 2dp.
+      registrations_per_registrant: 4.67,
+    });
+    assert.deepEqual(got.subnets, [
+      {
+        netuid: 1,
+        distinct_registrants: 2,
+        registrations: 10,
+        registrations_per_registrant: 5,
+      },
+      {
+        netuid: 7,
+        distinct_registrants: 2,
+        registrations: 4,
+        registrations_per_registrant: 2,
+      },
+    ]);
+    assert.equal(got.intensity_distribution.count, 2);
+  });
+
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            observed_at: "2026-07-01T00:00:00.000Z",
+            subnet_count: 1,
+            network: {
+              distinct_registrants: 5,
+              registrations: 20,
+              registrations_per_registrant: 4,
+            },
+            intensity_distribution: {
+              count: 1,
+              mean: 4,
+              min: 4,
+              p25: 4,
+              median: 4,
+              p75: 4,
+              p90: 4,
+              max: 4,
+            },
+            subnets: [
+              {
+                netuid: 3,
+                distinct_registrants: 5,
+                registrations: 20,
+                registrations_per_registrant: 4,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      registrationsQuery('(window: "30d", limit: 5)'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/registrations");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(body.data.chain_registrations.window, "30d");
+    assert.equal(body.data.chain_registrations.subnet_count, 1);
+    assert.equal(body.data.chain_registrations.network.distinct_registrants, 5);
+  });
+
+  test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
+    // The tier's shape is upstream-controlled, so every field falls back rather
+    // than surfacing null through a non-null SDL field.
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(registrationsQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_registrations, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_registrants: 0,
+        registrations: 0,
+        registrations_per_registrant: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("clamps an over-max limit to the route's own ceiling", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(registrationsQuery("(limit: 99999)"), env);
+    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+  });
+
+  test("every documented window is accepted", async () => {
+    for (const window of Object.keys(CHAIN_REGISTRATIONS_WINDOWS)) {
+      const { status, body } = await gql(
+        registrationsQuery(`(window: "${window}")`),
+      );
+      assert.equal(status, 200, window);
+      assert.equal(body.errors, undefined);
+      assert.equal(body.data.chain_registrations.window, window);
+    }
+  });
+
+  test("an unsupported window is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      registrationsQuery('(window: "1y")'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("is priced at the relationship-field complexity weight", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.chain_registrations,
       FIELD_COMPLEXITY.chain_serving,
     );
   });


### PR DESCRIPTION
Closes #5876

## What

Adds `Query.chain_registrations`, mirroring `GET /api/v1/chain/registrations` and MCP `get_chain_registrations`: the network-wide neuron-registration activity leaderboard — raw `NeuronRegistered` demand across every subnet.

It is the account_events companion to the already-shipped `Query.chain_turnover` (neuron_daily validator-set churn); both answer "who is registering," one as event volume and one as net snapshot change.

## How

**No query/aggregation logic is duplicated.** The resolver reuses `chain-registrations.mjs`'s `loadChainRegistrations` through the same `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` → D1-live fallback that `handleChainRegistrations` takes, so the GraphQL, REST and MCP shapes cannot drift apart.

- **`window`** is validated against the route's own `CHAIN_REGISTRATIONS_WINDOWS` (`7d`/`30d`, default `7d`) and raises `BAD_USER_INPUT` rather than silently defaulting — matching the sibling `chain_serving`/`chain_prometheus` resolvers.
- **`limit`** is clamped with the route's own `CHAIN_REGISTRATIONS_LIMIT_DEFAULT`/`MAX` (20/100), so a GraphQL caller cannot request a wider leaderboard than REST allows.
- A cold store yields a schema-stable zeroed card, never a GraphQL error.

**Types** mirror the `ChainServing`/`ChainPrometheus` family field-for-field, keyed on *registrants* (`ChainRegistrations`, `ChainRegistrationsNetwork`, `ChainRegistrationsIntensityDistribution`, `ChainRegistrationsSubnet`). The doc-comments record the two contracts worth knowing: `network.distinct_registrants` counts a hotkey once even when it registers on several subnets (so it is **not** the sum of the per-subnet counts), and `intensity_distribution` spans every subnet in the window even when `limit` truncates the leaderboard.

`FIELD_COMPLEXITY` entry at `RELATIONSHIP_FIELD_COMPLEXITY`, matching `chain_serving`.

## Tests

8 new cases in `tests/graphql.test.mjs`, following the `chain_prometheus` (#5874) suite's conventions including its two-query D1 stub:

- cold store → schema-stable empty leaderboard, never an error
- D1-live tier → per-subnet leaderboard + network rollup, asserting the rollup uses the *true* distinct count (3) rather than the sum of per-subnet registrants (4)
- Postgres tier for a non-default `window`/`limit`, asserting both are forwarded as query params
- sparse upstream payload → every field falls back rather than surfacing null through a non-null SDL field
- over-max `limit` clamped to the route ceiling (99999 → 100)
- every documented window accepted
- unsupported window → `BAD_USER_INPUT`, never reaching the tier
- complexity weight matches `chain_serving`
