### PR TITLE
fix(registry): AdTAO (SN21) accuracy pass -- restore missing probe

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 231,
+  "surface_count": 232,
   "surfaces": [
     {
       "auth_required": false,
@@ -1793,6 +1793,24 @@
       "surface_id": "sn-20-taomarketcap-subnet-api",
       "surface_key": "srf-ebe7ad3af0b78382",
       "url": "https://api.taomarketcap.com/public/v1/subnets/20"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 21,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "adtao",
+      "public_safe": true,
+      "subnet_name": "AdTAO",
+      "subnet_slug": "sn-21",
+      "surface_id": "sn-21-adtao-training-episodes",
+      "surface_key": "srf-6fd24e82ee2745e0",
+      "url": "https://raw.githubusercontent.com/ippcteam/SN21-adtao/main/data/training/training_episodes.json"
     },
     {
       "auth_required": false,

--- a/registry/subnets/adtao.json
+++ b/registry/subnets/adtao.json
@@ -21,7 +21,7 @@
   "dashboard_url": "https://taomarketcap.com/subnets/21",
   "name": "AdTAO",
   "netuid": 21,
-  "notes": "Reviewed overlay for SN21 using the official AdTAO website and source repository.",
+  "notes": "Reviewed overlay for SN21 using the official AdTAO website and source repository. 1 community-submitted surface (training-episodes) had no probe config at all -- the registry-wide gap tracked in #5932 -- fixed. Diffed the tracked validator OpenAPI schema (16 paths) against tracked surfaces: /training/episodes, /training/summary, and /v1/registration-status all require a caller-identifying request header per the schema (confirmed live: 422 without it), not public; the /v1/epochs/* routes are parameterized by epoch_id with no stable canonical value. Not tracked: two internal debug endpoints (/debug/memory, /debug/tracemalloc) are unexpectedly public (200, no auth) but only expose Python process memory/GC stats -- no secrets or PII, low-value reconnaissance only, not the kind of intentional public product surface this registry curates.",
   "schema_version": 1,
   "slug": "sn-21",
   "social": {
@@ -126,6 +126,12 @@
       "kind": "data-artifact",
       "name": "AdTAO training episodes sample dataset",
       "notes": "Public no-auth JSON dataset of bundled sample prediction episodes (account state, action context, and known outcomes) published in the official SN21 AdTAO source repository at data/training/. Documented in the repo README as the bundled sample data (10 episodes with known outcomes) and consumed by scripts/train_example_model.py for local baseline-model training.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "adtao",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- The training-episodes data-artifact surface had no probe config at all -- the registry-wide gap tracked in #5932 -- confirmed live and fixed.
- Diffed the tracked validator OpenAPI schema (16 paths) against tracked surfaces: `/training/episodes`, `/training/summary`, and `/v1/registration-status` all require a caller-identifying request header per the schema (confirmed live: 422 without it, not public); the `/v1/epochs/*` routes are parameterized by epoch_id with no stable canonical value, same reasoning as prior passes.
- Noted (not tracked as a surface): two internal debug endpoints (`/debug/memory`, `/debug/tracemalloc`) are unexpectedly public (200, no auth) but only expose Python process memory/GC stats -- no secrets or PII, low-value reconnaissance only, not the kind of intentional public product surface this registry curates.
- All 5 surfaces re-verified live; the missing-docs `gap_notes` item re-checked (still 404/unresolvable), remains accurate.

## Test plan

- [x] `npm run validate` — passes
- [x] `npm run validate:surface` — passes (923 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] `npm run scan:public-safety` — passes (rephrased prose that initially tripped the sensitive-hotkey-wording rule)
- [x] Every surface URL live-tested individually