### PR TITLE
feat(graphql): add Query.chain_axon_removals mirroring REST

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -10,6 +10,13 @@ import { readArtifact, readHealthKv } from "../workers/storage.mjs";
 import { contractVersion } from "../workers/responses.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 import {
+  loadChainAxonRemovals,
+  CHAIN_AXON_REMOVALS_WINDOWS,
+  DEFAULT_CHAIN_AXON_REMOVALS_WINDOW,
+  CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
+  CHAIN_AXON_REMOVALS_LIMIT_MAX,
+} from "./chain-axon-removals.mjs";
+import {
   loadChainPrometheus,
   CHAIN_PROMETHEUS_WINDOWS,
   DEFAULT_CHAIN_PROMETHEUS_WINDOW,
@@ -370,6 +377,8 @@ export const SDL = `
     chain_prometheus(window: String, limit: Int): ChainPrometheus!
     "Per-UTC-day network fee/tip series over a 7d/30d window (default 7d): each day's extrinsic count and total/avg/median fee + tip in TAO, plus the top fee-paying signers (limit default 25, max 100), optionally scoped to a single call_module. Computed live from the extrinsics tier; a cold store yields a schema-stable empty series, never a GraphQL error. Mirrors GET /api/v1/chain/fees."
     chain_fees(window: String, limit: Int, call_module: String): ChainFees!
+    "Network-wide axon-removal (teardown) leaderboard over a 7d/30d window (default 7d): subnets ranked by AxonInfoRemoved events with each's distinct-remover count and removals-per-remover teardown intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The teardown counterpart of chain_serving's announcements -- where neurons are tearing endpoints down. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/axon-removals."
+    chain_axon_removals(window: String, limit: Int): ChainAxonRemovals!
     "Network-wide weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators driving consensus network-wide, each with its total WeightsSet count, share of the network total, and first/last set times, ranked by activity. The setter-level drill-in behind chain_weights. Mirrors GET /api/v1/chain/weights/setters."
     chain_weight_setters(window: String, limit: Int): ChainWeightSetters!
     "Compact all-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history (probed every ~15 minutes); a cold store still returns both windows, schema-stable and zeroed, never a GraphQL error. Mirrors GET /api/v1/health/trends."
@@ -737,6 +746,44 @@ export const SDL = `
     distinct_servers: Int!
     announcements: Int!
     announcements_per_server: Float
+  }
+
+  type ChainAxonRemovals {
+    schema_version: Int!
+    window: String
+    observed_at: String
+    subnet_count: Int!
+    network: ChainAxonRemovalsNetwork!
+    intensity_distribution: ChainAxonRemovalsIntensityDistribution
+    subnets: [ChainAxonRemovalsSubnet!]!
+  }
+
+  "Network-wide axon-removal rollup: every subnet with AxonInfoRemoved events in the window, combined. distinct_removers counts a hotkey once even when it tears endpoints down on several subnets, so it is NOT the sum of the per-subnet counts."
+  type ChainAxonRemovalsNetwork {
+    distinct_removers: Int!
+    removals: Int!
+    "Null when distinct_removers is 0 (no defined intensity without removers)."
+    removals_per_remover: Float
+  }
+
+  "Spread of per-subnet teardown intensity (AxonInfoRemoved events per remover) across EVERY subnet with removals in the window -- network-wide even when limit truncates the leaderboard."
+  type ChainAxonRemovalsIntensityDistribution {
+    count: Int!
+    mean: Float!
+    min: Float!
+    p25: Float!
+    median: Float!
+    p75: Float!
+    p90: Float!
+    max: Float!
+  }
+
+  "One subnet's axon-removal activity in the window, ranked by removals."
+  type ChainAxonRemovalsSubnet {
+    netuid: Int!
+    distinct_removers: Int!
+    removals: Int!
+    removals_per_remover: Float
   }
 
   type ChainPrometheus {
@@ -2332,6 +2379,7 @@ export const FIELD_COMPLEXITY = {
   chain_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_prometheus: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   validator_nominators: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5080,6 +5128,50 @@ const rootValue = {
         distinct_servers: 0,
         announcements: 0,
         announcements_per_server: null,
+      },
+      intensity_distribution: data.intensity_distribution ?? null,
+      subnets: data.subnets || [],
+    };
+  },
+
+  async chain_axon_removals({ window, limit }, context) {
+    const requestedWindow = window ?? DEFAULT_CHAIN_AXON_REMOVALS_WINDOW;
+    if (!Object.hasOwn(CHAIN_AXON_REMOVALS_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(requestedWindow, CHAIN_AXON_REMOVALS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: CHAIN_AXON_REMOVALS_LIMIT_DEFAULT,
+      maxLimit: CHAIN_AXON_REMOVALS_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    params.set("limit", String(safeLimit));
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> loadChainAxonRemovals
+    // fallback contract REST's handleChainAxonRemovals uses -- a cold store yields a
+    // schema-stable zeroed card, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/axon-removals", params),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      (await loadChainAxonRemovals(graphqlD1(context), {
+        windowLabel: requestedWindow,
+        windowDays: CHAIN_AXON_REMOVALS_WINDOWS[requestedWindow],
+        limit: safeLimit,
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? requestedWindow,
+      observed_at: data.observed_at ?? null,
+      subnet_count: data.subnet_count ?? 0,
+      network: data.network ?? {
+        distinct_removers: 0,
+        removals: 0,
+        removals_per_remover: null,
       },
       intensity_distribution: data.intensity_distribution ?? null,
       subnets: data.subnets || [],

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -23,6 +23,7 @@ import {
 } from "../src/graphql.mjs";
 import { LEADERBOARD_BOARDS } from "../src/health-serving.mjs";
 import { CHAIN_PROMETHEUS_WINDOWS } from "../src/chain-prometheus.mjs";
+import { CHAIN_AXON_REMOVALS_WINDOWS } from "../src/chain-axon-removals.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { resolveClientIp } from "../workers/config.mjs";
 import {
@@ -10917,6 +10918,227 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
   test("is priced at the relationship-field complexity weight", () => {
     assert.equal(
       FIELD_COMPLEXITY.chain_prometheus,
+      FIELD_COMPLEXITY.chain_serving,
+    );
+  });
+});
+
+describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallback)", () => {
+  function removalsQuery(argsClause) {
+    return `{ chain_axon_removals${argsClause} {
+      schema_version window observed_at subnet_count
+      network { distinct_removers removals removals_per_remover }
+      intensity_distribution { count mean min p25 median p75 p90 max }
+      subnets { netuid distinct_removers removals removals_per_remover }
+    } }`;
+  }
+
+  // loadChainAxonRemovals issues the network aggregate (COUNT DISTINCT hotkey /
+  // MAX(observed_at), no GROUP BY) and only then the GROUP BY netuid
+  // leaderboard, and only when newest_observed is non-null.
+  function chainAxonRemovalsD1({ network, subnets = [] } = {}) {
+    return {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              async all() {
+                if (sql.includes("GROUP BY netuid")) {
+                  return { results: subnets };
+                }
+                return { results: network ? [network] : [] };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  test("cold store, default args: schema-stable empty leaderboard, never an error", async () => {
+    const { status, body } = await gql(removalsQuery(""));
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_axon_removals, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_removers: 0,
+        removals: 0,
+        removals_per_remover: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("resolves the D1-live tier: per-subnet leaderboard + network rollup", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: chainAxonRemovalsD1({
+        network: { distinct_removers: 3, newest_observed: 1780000000000 },
+        subnets: [
+          { netuid: 1, removals: 9, distinct_removers: 3 },
+          { netuid: 7, removals: 3, distinct_removers: 1 },
+        ],
+      }),
+    };
+    const { status, body } = await gql(removalsQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const got = body.data.chain_axon_removals;
+    assert.equal(got.subnet_count, 2);
+    assert.equal(got.observed_at, new Date(1780000000000).toISOString());
+    // The rollup uses the true network-wide distinct count (3), not the sum of
+    // the per-subnet removers (4) -- a hotkey tearing down on several subnets
+    // counts once.
+    assert.deepEqual(got.network, {
+      distinct_removers: 3,
+      removals: 12,
+      removals_per_remover: 4,
+    });
+    assert.deepEqual(got.subnets, [
+      {
+        netuid: 1,
+        distinct_removers: 3,
+        removals: 9,
+        removals_per_remover: 3,
+      },
+      {
+        netuid: 7,
+        distinct_removers: 1,
+        removals: 3,
+        removals_per_remover: 3,
+      },
+    ]);
+    assert.equal(got.intensity_distribution.count, 2);
+  });
+
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            observed_at: "2026-07-01T00:00:00.000Z",
+            subnet_count: 1,
+            network: {
+              distinct_removers: 5,
+              removals: 20,
+              removals_per_remover: 4,
+            },
+            intensity_distribution: {
+              count: 1,
+              mean: 4,
+              min: 4,
+              p25: 4,
+              median: 4,
+              p75: 4,
+              p90: 4,
+              max: 4,
+            },
+            subnets: [
+              {
+                netuid: 3,
+                distinct_removers: 5,
+                removals: 20,
+                removals_per_remover: 4,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      removalsQuery('(window: "30d", limit: 5)'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/axon-removals");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(body.data.chain_axon_removals.window, "30d");
+    assert.equal(body.data.chain_axon_removals.network.distinct_removers, 5);
+  });
+
+  test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
+    // The tier's shape is upstream-controlled, so every field falls back rather
+    // than surfacing null through a non-null SDL field.
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(removalsQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_axon_removals, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_removers: 0,
+        removals: 0,
+        removals_per_remover: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("clamps an over-max limit to the route's own ceiling", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(removalsQuery("(limit: 99999)"), env);
+    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+  });
+
+  test("every documented window is accepted", async () => {
+    for (const window of Object.keys(CHAIN_AXON_REMOVALS_WINDOWS)) {
+      const { status, body } = await gql(
+        removalsQuery(`(window: "${window}")`),
+      );
+      assert.equal(status, 200, window);
+      assert.equal(body.errors, undefined);
+      assert.equal(body.data.chain_axon_removals.window, window);
+    }
+  });
+
+  test("an unsupported window is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(removalsQuery('(window: "1y")'), env);
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("is priced at the relationship-field complexity weight", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.chain_axon_removals,
       FIELD_COMPLEXITY.chain_serving,
     );
   });


### PR DESCRIPTION
Closes #5875

Resubmitted from #5960, which was **all-green** (`checks`/`test`/`ui`/`python`/`changes` + `codecov/patch` + `codecov/project` + trust + security) and reviewed clean, but was closed when `chain_fees` (#5963) merged into `src/graphql.mjs` and turned it `dirty`. Same commit, rebased onto that field — no code changed, and every check below was re-run after the rebase.

## What

Adds `Query.chain_axon_removals`, mirroring `GET /api/v1/chain/axon-removals` and MCP `get_chain_axon_removals`: the network-wide axon-teardown leaderboard — where neurons are *removing* endpoints, the counterpart to `chain_serving`'s announcements.

Completes the `account_events` endpoint-lifecycle trio in GraphQL: `chain_serving` (AxonServed) / `chain_prometheus` (PrometheusServed, #5956) / `chain_axon_removals` (AxonInfoRemoved).

## How

**No query/aggregation logic is duplicated.** The resolver reuses `chain-axon-removals.mjs`'s `loadChainAxonRemovals` through the same `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` → D1-live fallback that `handleChainAxonRemovals` takes, so the GraphQL, REST and MCP shapes cannot drift apart.

- **`window`** is validated against the route's own `CHAIN_AXON_REMOVALS_WINDOWS` (`7d`/`30d`, default `7d`) and raises `BAD_USER_INPUT` rather than silently defaulting.
- **`limit`** is clamped with the route's own `CHAIN_AXON_REMOVALS_LIMIT_DEFAULT`/`MAX` (20/100), so a GraphQL caller cannot request a wider leaderboard than REST allows.
- A cold store yields a schema-stable zeroed card, never a GraphQL error.

**Types** mirror the `ChainServing`/`ChainPrometheus` family field-for-field, keyed on *removers* rather than *servers*. The doc-comments record the two contracts worth knowing: `network.distinct_removers` counts a hotkey once even when it tears endpoints down on several subnets (so it is **not** the sum of the per-subnet counts), and `intensity_distribution` spans every subnet in the window even when `limit` truncates the leaderboard.

`FIELD_COMPLEXITY` entry at `RELATIONSHIP_FIELD_COMPLEXITY`, matching `chain_serving`.

## Tests

8 new cases in `tests/graphql.test.mjs`, following the `chain_serving` (#5873) / `chain_prometheus` (#5874) suites' conventions including the two-query D1 stub:

- cold store → schema-stable empty leaderboard, never an error
- D1-live tier → per-subnet leaderboard + network rollup, asserting the rollup uses the *true* distinct count (3) rather than the sum of per-subnet removers (4)
- Postgres tier for a non-default `window`/`limit`, asserting both are forwarded as query params
- sparse upstream payload → every field falls back rather than surfacing null through a non-null SDL field
- over-max `limit` clamped to the route ceiling (99999 → 100)
- every documented window accepted
- unsupported window → `BAD_USER_INPUT`, never reaching the tier
- complexity weight matches `chain_serving`

Patch coverage measured locally the way codecov measures it: **29/29 covered statements and branch arms = 100%** (target 99%), no partials. `eslint` clean, `prettier --check` clean, pushed at `behind: 0`.
