### PR TITLE
feat(graphql): add Query.subnet_health_trends mirroring REST + MCP (#5883)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -89,6 +89,7 @@ import {
 import { composeLeaderboardsData } from "../workers/request-handlers/analytics-routes.mjs";
 import {
   loadCompareSubnets,
+  loadSubnetHealthTrends,
   parseCompareDimensionList,
   parseCompareNetuidList,
 } from "./analytics-live.mjs";
@@ -260,6 +261,8 @@ export const SDL = `
     subnet_deregistrations(netuid: Int!, window: String): SubnetDeregistrations!
     "Per-subnet axon-serving activity over a 7d/30d window (distinct servers, AxonServed announcement count, and announcements per server); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/serving."
     subnet_serving(netuid: Int!, window: String): SubnetServing!
+    "One subnet's uptime + success-only latency trend windows (7d/30d) from the live health-probe history: per-window samples, uptime_ratio, latency sample count, and the per-surface uptime/latency series. A subnet with no probe history resolves to a schema-stable zeroed-windows card, never null. Mirrors GET /api/v1/subnets/{netuid}/health/trends."
+    subnet_health_trends(netuid: Int!): SubnetHealthTrends!
     "Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
     subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
     "Per-subnet validator weight-setting activity over a 7d/30d window (distinct weight-setters, WeightsSet count, and sets per setter); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/weights."
@@ -871,6 +874,16 @@ export const SDL = `
     observed_at: String
     source: String
     "The 7d/30d windows keyed by window label (7d, 30d), each holding days/granularity/subnet_count and the per-subnet daily point series. Opaque JSON: dynamic-keyed by window label, matching the get_health_trends MCP/REST shape."
+    windows: JSON!
+  }
+
+  "One subnet's uptime + latency trend windows. Mirrors GET /api/v1/subnets/{netuid}/health/trends's data envelope."
+  type SubnetHealthTrends {
+    schema_version: Int!
+    netuid: Int!
+    observed_at: String
+    source: String
+    "The 7d/30d windows keyed by window label, each holding this subnet's samples, uptime_ratio, latency_sample_count and the per-surface uptime/latency series. Opaque JSON: dynamic-keyed by window label, matching the get_subnet_health_trends MCP/REST shape."
     windows: JSON!
   }
 
@@ -2309,6 +2322,7 @@ export const FIELD_COMPLEXITY = {
   subnet_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_serving: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5228,6 +5242,32 @@ const rootValue = {
       ).data;
     return {
       schema_version: data.schema_version ?? 1,
+      observed_at: data.observed_at ?? null,
+      source: data.source ?? null,
+      windows: data.windows ?? {},
+    };
+  },
+
+  async subnet_health_trends({ netuid }, context) {
+    // Same tryPostgresTier(METAGRAPH_HEALTH_SOURCE) -> loadSubnetHealthTrends D1
+    // fallback contract REST's handleHealthTrends and the
+    // get_subnet_health_trends MCP tool share -- the route takes no window arg
+    // (it returns every configured window), and a subnet with no probe history
+    // yields a schema-stable zeroed-windows card, never a GraphQL error. The
+    // tier owns the per-surface uptime/latency aggregation; nothing is
+    // duplicated here.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, `/api/v1/subnets/${netuid}/health/trends`),
+        "METAGRAPH_HEALTH_SOURCE",
+      )) ??
+      (await loadSubnetHealthTrends(graphqlD1(context), netuid, {
+        observedAt: await loadObservedAt(context),
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
       observed_at: data.observed_at ?? null,
       source: data.source ?? null,
       windows: data.windows ?? {},

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -9250,6 +9250,90 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
   });
 });
 
+describe("graphql — subnet_health_trends (#5883, Postgres-tier + D1-live fallback)", () => {
+  const NETUID = 3;
+
+  function trendsQuery(netuid) {
+    return `{ subnet_health_trends(netuid: ${netuid}) { schema_version netuid observed_at source windows } }`;
+  }
+
+  test("cold store: schema-stable zeroed windows via the D1-live loader", async () => {
+    const { status, body } = await gql(trendsQuery(NETUID));
+    assert.equal(status, 200);
+    const d = body.data.subnet_health_trends;
+    assert.equal(d.schema_version, 1);
+    assert.equal(d.netuid, NETUID);
+    assert.equal(d.observed_at, null);
+    assert.equal(d.source, "live-cron-prober");
+    assert.equal(d.windows["7d"].samples, 0);
+    assert.deepEqual(d.windows["7d"].surfaces, []);
+    assert.equal(d.windows["30d"].samples, 0);
+  });
+
+  test("resolves Postgres-tier data, forwarding the netuid in the path", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            netuid: NETUID,
+            observed_at: "2026-07-10T00:00:00.000Z",
+            source: "live-cron-prober",
+            windows: {
+              "7d": {
+                samples: 20,
+                uptime_ratio: 0.95,
+                latency_sample_count: 18,
+                surfaces: [{ surface_id: "srf-1", samples: 20 }],
+              },
+              "30d": {
+                samples: 80,
+                uptime_ratio: 0.9,
+                latency_sample_count: 70,
+                surfaces: [{ surface_id: "srf-1", samples: 80 }],
+              },
+            },
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(trendsQuery(NETUID), env);
+    assert.equal(status, 200);
+    assert.equal(
+      capturedUrl.pathname,
+      `/api/v1/subnets/${NETUID}/health/trends`,
+    );
+    const d = body.data.subnet_health_trends;
+    assert.equal(d.netuid, NETUID);
+    assert.equal(d.observed_at, "2026-07-10T00:00:00.000Z");
+    assert.equal(d.windows["7d"].uptime_ratio, 0.95);
+    assert.equal(d.windows["30d"].surfaces[0].surface_id, "srf-1");
+  });
+
+  test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(trendsQuery(NETUID), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_health_trends, {
+      schema_version: 1,
+      netuid: NETUID,
+      observed_at: null,
+      source: null,
+      windows: {},
+    });
+  });
+
+  test("subnet_health_trends is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_health_trends, 5);
+  });
+});
+
 describe("Subscription.chainEvents", () => {
   test("yields a properly-shaped GraphQL execution result for each pushed payload", async () => {
     const hub = fakeChainFirehose((repeater) => {


### PR DESCRIPTION
## Summary

Closes the REST/GraphQL/MCP parity gap on the per-subnet health-trend surface. `GET /api/v1/subnets/{netuid}/health/trends` and MCP `get_subnet_health_trends` already ship, but had no GraphQL mirror.

Adds `Query.subnet_health_trends(netuid)` returning a new `SubnetHealthTrends` type (`schema_version`, `netuid`, `observed_at`, `source`, `windows`), where `windows` is opaque JSON keyed by window label (7d/30d) — each window's samples, uptime_ratio, latency_sample_count and per-surface uptime/latency series — matching the REST/MCP shape (dynamic-keyed, like the chain-wide `HealthTrends.windows`). The resolver hits the same DATA_API health-tier path the REST route uses, with the identical `loadSubnetHealthTrends(graphqlD1)` D1-live fallback, so the tier owns the aggregation — no logic duplicated. The route takes no window arg (returns every window); a subnet with no probe history yields a schema-stable zeroed-windows card. Priced at `RELATIONSHIP_FIELD_COMPLEXITY`.

Entirely within `src/graphql.mjs` + its test.

## Testing

- `tests/graphql.test.mjs` — 4 new tests: cold-store zeroed windows (via the D1-live loader), Postgres row resolution with netuid path-forwarding, a malformed body degrading to schema-stable defaults (every `??` fallback), and the complexity weight. **Full graphql suite: 470 pass.**
- eslint 0; **prettier `--check` (repo config, printWidth 80) clean**; resolver verified at the branch level (all statements and branches covered).

Closes #5883
