### PR TITLE
fix(registry): Desearch (SN22) accuracy pass -- restore missing probes

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 232,
+  "surface_count": 236,
   "surfaces": [
     {
       "auth_required": false,
@@ -1829,6 +1829,78 @@
       "surface_id": "sn-21-adtao-validator-api",
       "surface_key": "srf-34b5c51b4e147eef",
       "url": "https://validator.adtao.io/health"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "kind": "subnet-api",
+      "netuid": 22,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "desearch",
+      "public_safe": true,
+      "subnet_name": "Desearch",
+      "subnet_slug": "sn-22",
+      "surface_id": "sn-22-desearch-api",
+      "surface_key": "srf-ac4e81b516cfa7b2",
+      "url": "https://api.desearch.ai"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 22,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "desearch",
+      "public_safe": true,
+      "subnet_name": "Desearch",
+      "subnet_slug": "sn-22",
+      "surface_id": "sn-22-desearch-benchmark-questions",
+      "surface_key": "srf-6eeec6eb3562eadc",
+      "url": "https://huggingface.co/datasets/desearch/dataset"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 22,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "desearch",
+      "public_safe": true,
+      "subnet_name": "Desearch",
+      "subnet_slug": "sn-22",
+      "surface_id": "sn-22-desearch-health",
+      "surface_key": "srf-864324f9ccf05235",
+      "url": "https://api.desearch.ai/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 22,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "desearch",
+      "public_safe": true,
+      "subnet_name": "Desearch",
+      "subnet_slug": "sn-22",
+      "surface_id": "sn-22-desearch-search-evals",
+      "surface_key": "srf-8efc81833817d125",
+      "url": "https://huggingface.co/datasets/desearch/desearch-search-evals"
     },
     {
       "auth_required": false,

--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -30,7 +30,7 @@
   ],
   "name": "Desearch",
   "netuid": 22,
-  "notes": "Reviewed overlay for SN22 using the official Desearch website, docs, public OpenAPI schema, console, and source repository. The OpenAPI schema advertises api.desearch.ai as the API server; protected method calls require separate review before proxy eligibility.",
+  "notes": "Reviewed overlay for SN22 using the official Desearch website, docs, public OpenAPI schema, console, and source repository. The OpenAPI schema advertises api.desearch.ai as the API server; protected method calls require separate review before proxy eligibility. Confirmed the schema's global security requirement (ApiKeyAuth) applies to all 35 documented paths with no exceptions -- the only genuinely public surfaces on this host are the base URL, /health, and the OpenAPI schema itself, all already tracked. 4 surfaces had no probe config at all -- the registry-wide gap tracked in #5932 -- fixed.",
   "schema_version": 1,
   "slug": "sn-22",
   "social": {
@@ -146,6 +146,12 @@
       "kind": "subnet-api",
       "name": "Desearch API",
       "notes": "Public API host advertised by the Desearch OpenAPI schema. Protected methods require authentication, so proxy eligibility requires separate review.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "desearch",
       "public_safe": true,
       "rate_limit_notes": "OpenAPI schema is public; method-level auth and rate limits must be reviewed before routing.",
@@ -246,6 +252,12 @@
       "kind": "data-artifact",
       "name": "Desearch Search Evals (Hugging Face)",
       "notes": "Public CC-BY-4.0 Hugging Face dataset of Desearch search-quality evaluations, published and documented in the official Desearch-ai/desearch-search-evals repo.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "desearch",
       "public_safe": true,
       "review": {
@@ -264,6 +276,12 @@
       "kind": "data-artifact",
       "name": "Desearch search benchmark dataset",
       "notes": "Public Desearch (SN22) HuggingFace benchmark of ~196k fresh web + X search questions (id/question/difficulty/date-window columns), regenerated daily from recent news and posts; not gated, no answer keys. Distinct from the already-registered search-evals results dataset. The subnet-22 README (source) declares the Bittensor subnet and the desearch HF org owns it.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "desearch",
       "public_safe": true,
       "review": {
@@ -283,6 +301,12 @@
       "kind": "subnet-api",
       "name": "Desearch API health",
       "notes": "Public no-auth GET /health on api.desearch.ai returning API liveness JSON (observed: {\"status\":\"health\"}). Served on the API host advertised by the Desearch OpenAPI schemas (www.desearch.ai/openapi.json and api.desearch.ai/openapi.json) alongside the existing sn-22-desearch-api surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "desearch",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- 4 surfaces (API host, both HuggingFace datasets, health check) had no probe config at all -- the registry-wide gap tracked in #5932 -- all confirmed live and fixed.
- Diffed the tracked OpenAPI schema (35 paths) against tracked surfaces: confirmed the schema's global security requirement (ApiKeyAuth) applies to all 35 documented paths with no exceptions -- the only genuinely public surfaces on this host are the base URL, `/health`, and the OpenAPI schema itself, all already tracked. No new candidates found.
- All 13 surfaces re-verified live.

## Test plan

- [x] `npm run validate` — passes
- [x] `npm run validate:surface` — passes (923 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] `npm run scan:public-safety` — passes
- [x] Every surface URL live-tested individually