### PR TITLE
feat(graphql): add Query.subnet_trajectory mirroring REST + MCP get_subnet_trajectory (#5887)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -82,6 +82,7 @@ import {
   buildGlobalHealth,
   formatLeaderboards,
   LEADERBOARD_BOARDS,
+  loadSubnetTrajectory,
   resolveLiveEconomics,
   resolveLiveHealth,
   subnetBadgeStatus,
@@ -280,6 +281,8 @@ export const SDL = `
     subnet_concentration_history(netuid: Int!, window: String): SubnetConcentrationHistory!
     "Append-only on-chain SubnetIdentitiesV3 change timeline for one subnet (name, symbol, description, repo, website, discord, logo), newest first; page with limit/offset or follow next_cursor. A subnet with no matching events resolves to a schema-stable empty timeline (entry_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/identity-history."
     subnet_identity_history(netuid: Int!, limit: Int, offset: Int, cursor: String): SubnetIdentityHistory!
+    "One subnet's weekly structural + economics trajectory from the daily snapshots: a chronological series of points (completeness/surface/endpoint counts plus validator/miner counts and economics — stake, alpha price, emission share, pool reserves, volume), and the latest-vs-window-ago deltas for the 7d and 30d windows. A subnet with no snapshots resolves to a schema-stable empty trajectory (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/trajectory."
+    subnet_trajectory(netuid: Int!): SubnetTrajectory!
     "Paginated provider/source registry."
     providers(limit: Int, cursor: String): ProviderList!
     "One provider with its subnets."
@@ -1060,6 +1063,46 @@ export const SDL = `
     offset: Int
     next_cursor: String
     entries: [SubnetIdentityHistoryEntry!]!
+  }
+
+  "One subnet's weekly structural + economics trajectory from the daily snapshots (#5887). Mirrors GET /api/v1/subnets/{netuid}/trajectory's data envelope. The REST envelope's window-keyed deltas map (7d/30d) is exposed here as a list carrying each window label, since those keys are not valid GraphQL field names."
+  type SubnetTrajectory {
+    schema_version: Int!
+    netuid: Int!
+    point_count: Int!
+    points: [SubnetTrajectoryPoint!]!
+    "Latest-vs-window-ago deltas -- one entry per window (7d, 30d) that has a prior point to compare against; empty when the series is too short."
+    deltas: [SubnetTrajectoryDelta!]!
+  }
+
+  "One daily-snapshot point on a subnet's trajectory (chronological). Economics fields are null on rows captured before those columns existed / when economics was unavailable that day."
+  type SubnetTrajectoryPoint {
+    date: String
+    completeness_score: Int
+    surface_count: Int
+    endpoint_count: Int
+    validator_count: Int
+    miner_count: Int
+    total_stake_tao: Float
+    alpha_price_tao: Float
+    emission_share: Float
+    tao_in_pool_tao: Float
+    alpha_in_pool: Float
+    alpha_out_pool: Float
+    subnet_volume_tao: Float
+  }
+
+  "Change in a subnet's key metrics over a trailing window (latest point minus the point at-or-before the window start). Pool-reserve deltas double as the net TAO/alpha flow over the window."
+  type SubnetTrajectoryDelta {
+    window: String!
+    from_date: String
+    to_date: String
+    completeness_score: Int
+    surface_count: Int
+    endpoint_count: Int
+    tao_in_pool_tao: Float
+    alpha_in_pool: Float
+    alpha_out_pool: Float
   }
 
   "One SubnetIdentitiesV3 snapshot recorded when a tracked identity field changed."
@@ -2319,6 +2362,7 @@ export const FIELD_COMPLEXITY = {
   subnet_concentration: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_concentration_history: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_trajectory: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   runtime: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -2917,6 +2961,30 @@ const rootValue = {
       offset: data.offset ?? safeOffset,
       next_cursor: data.next_cursor ?? null,
       entries: data.entries ?? [],
+    };
+  },
+
+  async subnet_trajectory({ netuid }, context) {
+    // Same tryPostgresTier(METAGRAPH_SUBNET_SNAPSHOTS_SOURCE) -> loadSubnetTrajectory
+    // fallback contract handleTrajectory uses; a subnet with no daily snapshots is
+    // a schema-stable empty trajectory, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, `/api/v1/subnets/${netuid}/trajectory`),
+        "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
+      )) ?? (await loadSubnetTrajectory(graphqlD1(context), netuid));
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      point_count: data.point_count ?? 0,
+      points: data.points ?? [],
+      // The REST envelope keys deltas by window ("7d"/"30d") -- names that
+      // aren't valid GraphQL fields -- so flatten to a list carrying the label,
+      // dropping windows with no comparable prior point (null delta).
+      deltas: Object.entries(data.deltas ?? {})
+        .filter(([, delta]) => delta != null)
+        .map(([window, delta]) => ({ window, ...delta })),
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3125,6 +3125,145 @@ describe("graphql — validator_history (#5710, Postgres-tier + empty-points fal
   });
 });
 
+describe("graphql — subnet_trajectory (#5887, Postgres-tier + D1-live fallback)", () => {
+  const trajectoryQuery = `{ subnet_trajectory(netuid: 3) {
+    schema_version netuid point_count
+    points { date completeness_score surface_count total_stake_tao }
+    deltas { window from_date to_date completeness_score tao_in_pool_tao }
+  } }`;
+
+  // loadSubnetTrajectory issues a single SELECT over subnet_snapshots (no GROUP
+  // BY); formatTrajectory re-sorts ascending and derives the 7d/30d deltas.
+  function trajectoryD1(rows = []) {
+    return {
+      prepare() {
+        return {
+          bind() {
+            return {
+              async all() {
+                return { results: rows };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  const P1 = {
+    date: "2026-07-01",
+    completeness_score: 50,
+    surface_count: 4,
+    endpoint_count: 2,
+    validator_count: null,
+    miner_count: null,
+    total_stake_tao: 100,
+    alpha_price_tao: null,
+    emission_share: null,
+    tao_in_pool_tao: 10,
+    alpha_in_pool: null,
+    alpha_out_pool: null,
+    subnet_volume_tao: null,
+  };
+  const P2 = {
+    ...P1,
+    date: "2026-07-08",
+    completeness_score: 60,
+    tao_in_pool_tao: 15,
+  };
+
+  test("cold store: schema-stable empty trajectory", async () => {
+    const { status, body } = await gql(trajectoryQuery);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_trajectory, {
+      schema_version: 1,
+      netuid: 3,
+      point_count: 0,
+      points: [],
+      deltas: [],
+    });
+  });
+
+  test("resolves Postgres-tier data and flattens the window-keyed deltas map to a labelled list", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            netuid: 3,
+            point_count: 2,
+            points: [P1, P2],
+            deltas: {
+              "7d": {
+                from_date: "2026-07-01",
+                to_date: "2026-07-08",
+                completeness_score: 10,
+                surface_count: 0,
+                endpoint_count: 0,
+                tao_in_pool_tao: 5,
+                alpha_in_pool: null,
+                alpha_out_pool: null,
+              },
+              "30d": null,
+            },
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(trajectoryQuery, env);
+    assert.equal(status, 200);
+    assert.equal(capturedUrl.pathname, "/api/v1/subnets/3/trajectory");
+    assert.equal(body.data.subnet_trajectory.point_count, 2);
+    assert.equal(body.data.subnet_trajectory.points[0].date, "2026-07-01");
+    assert.equal(body.data.subnet_trajectory.points[1].completeness_score, 60);
+    // The window-keyed map becomes a list; the null 30d entry is dropped and
+    // the 7d entry carries its label.
+    assert.equal(body.data.subnet_trajectory.deltas.length, 1);
+    assert.equal(body.data.subnet_trajectory.deltas[0].window, "7d");
+    assert.equal(body.data.subnet_trajectory.deltas[0].completeness_score, 10);
+    assert.equal(body.data.subnet_trajectory.deltas[0].tao_in_pool_tao, 5);
+  });
+
+  test("a malformed Postgres-tier body degrades to a schema-stable empty trajectory", async () => {
+    const env = {
+      METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(trajectoryQuery, env);
+    assert.equal(status, 200);
+    assert.equal(body.data.subnet_trajectory.point_count, 0);
+    assert.deepEqual(body.data.subnet_trajectory.points, []);
+    assert.deepEqual(body.data.subnet_trajectory.deltas, []);
+  });
+
+  test("no Postgres tier flag: formats the subnet_snapshots rows straight off D1, deriving deltas", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: trajectoryD1([
+        { ...P2, snapshot_date: P2.date },
+        { ...P1, snapshot_date: P1.date },
+      ]),
+    };
+    const { status, body } = await gql(trajectoryQuery, env);
+    assert.equal(status, 200);
+    assert.equal(body.data.subnet_trajectory.point_count, 2);
+    // formatTrajectory re-sorts ascending, so the earliest point is first.
+    assert.equal(body.data.subnet_trajectory.points[0].date, "2026-07-01");
+    assert.equal(body.data.subnet_trajectory.points[1].completeness_score, 60);
+    const d7 = body.data.subnet_trajectory.deltas.find(
+      (d) => d.window === "7d",
+    );
+    assert.ok(d7);
+    assert.equal(d7.completeness_score, 10);
+  });
+
+  test("subnet_trajectory is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_trajectory, 5);
+  });
+});
+
 describe("graphql — subnet_identity_history (#5721, Postgres-tier + empty timeline fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
Closes the parity gap: `GET /api/v1/subnets/{netuid}/trajectory` and the `get_subnet_trajectory` MCP tool expose a subnet's weekly structural + economics trajectory from the daily snapshots, but GraphQL had no mirror.

## What
- Adds `Query.subnet_trajectory(netuid: Int!): SubnetTrajectory!` with its type family (`SubnetTrajectory` / `SubnetTrajectoryPoint` / `SubnetTrajectoryDelta`).
- The resolver reuses the same `tryPostgresTier(METAGRAPH_SUBNET_SNAPSHOTS_SOURCE)` → `loadSubnetTrajectory(d1)` fallback `handleTrajectory` uses — **no query/aggregation logic duplicated**. A subnet with no snapshots resolves to a schema-stable empty trajectory, never a GraphQL error.
- **Deltas modeling:** the REST envelope keys its latest-vs-window-ago deltas by window (`7d`/`30d`) — names that aren't valid GraphQL fields — so `deltas` is exposed as a **list of `{ window, ...delta }` entries** (null windows dropped), the idiomatic GraphQL representation of a dynamic/invalid-key map.

## Test coverage
`tests/graphql.test.mjs` — a `subnet_trajectory` block: cold-store empty, Postgres-tier resolution + `/api/v1/subnets/3/trajectory` path + the window-map→list flattening, malformed-body defaults, D1-live roll-up deriving deltas, and the fan-out complexity weight.

`npm run test -- graphql` green (471 tests); new resolver at 100% patch coverage; `lint` + `format:check` clean.

Closes #5887
