### PR TITLE
feat(mcp): add read-only get_stake_action_preview tool

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -2710,6 +2710,110 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_stake_action_preview",
+    title: "Preview a hypothetical stake action (read-only)",
+    description:
+      "Produce a clearly-labeled, human-readable PREVIEW of what a hypothetical " +
+      "stake or unstake against one subnet would look like: the estimated " +
+      "resulting amount out, the effective vs spot price, and the estimated " +
+      "price-impact/slippage -- computed from the same live AMM pool economics " +
+      "get_subnet_stake_quote reads (direction stake spends amount TAO for " +
+      "alpha; unstake spends amount alpha for TAO; root netuid 0 is 1:1). This " +
+      "is INFORMATIONAL ONLY and strictly READ-ONLY: it does NOT execute, build, " +
+      "prepare, or sign any transaction, produces no signable/extrinsic " +
+      "artifact, and never touches a wallet or key. Submitting a stake requires " +
+      "a separate signed extrinsic outside this tool. Use it to explain a " +
+      "prospective stake's outcome to a user, not to act on-chain.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        amount: {
+          type: "number",
+          description:
+            "Amount to preview, in TAO for direction=stake or alpha for " +
+            "direction=unstake. Must be a finite number greater than 0.",
+          exclusiveMinimum: 0,
+        },
+        direction: {
+          type: "string",
+          enum: STAKE_QUOTE_DIRECTIONS,
+          description: 'Action direction: stake or unstake (default "stake").',
+        },
+      },
+      required: ["netuid", "amount"],
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer" },
+        direction: { type: "string" },
+        amount: { type: "number" },
+        summary: {
+          type: "string",
+          description: "Human-readable one-line preview of the action.",
+        },
+        estimated_out: {
+          type: "object",
+          properties: {
+            amount: { type: "number" },
+            unit: { type: "string" },
+          },
+          required: ["amount", "unit"],
+          additionalProperties: false,
+        },
+        spot_price_tao: { type: "number" },
+        effective_price_tao: { type: "number" },
+        price_impact_pct: { type: "number" },
+        disclaimer: { type: "string" },
+      },
+      required: ["netuid", "direction", "amount", "summary", "disclaimer"],
+      additionalProperties: true,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const amount = args?.amount;
+      const direction = optionalString(args, "direction") ?? "stake";
+      // Reuse the exact stake-quote data loader + pure-math calculation -- no
+      // duplicated economics logic. This is a presentation layer over the same
+      // numbers get_subnet_stake_quote returns.
+      const { economics } = await loadSubnetEconomics(ctx, netuid);
+      const result = computeStakeQuote({
+        netuid,
+        taoInPool: economics?.tao_in_pool_tao,
+        alphaInPool: economics?.alpha_in_pool,
+        amount,
+        direction,
+      });
+      if (!result.ok) {
+        throw toolError(result.code, result.error);
+      }
+      const q = result.quote;
+      const inUnit = direction === "stake" ? "TAO" : "alpha";
+      const outUnit = q.expected_out_unit === "alpha" ? "alpha" : "TAO";
+      const verb = direction === "stake" ? "Staking" : "Unstaking";
+      const summary = q.is_root
+        ? `${verb} ${amount} ${inUnit} on subnet ${netuid} (root) previews an estimated ${q.expected_out} ${outUnit} at a 1:1 price with no price impact.`
+        : `${verb} ${amount} ${inUnit} on subnet ${netuid} previews an estimated ${q.expected_out} ${outUnit} at an effective price of ${q.effective_price_tao} TAO/alpha (spot ${q.spot_price_tao}), with an estimated ${q.price_impact_pct}% price impact (slippage).`;
+      return {
+        netuid: q.netuid,
+        direction: q.direction,
+        amount: q.amount,
+        summary,
+        estimated_out: { amount: q.expected_out, unit: q.expected_out_unit },
+        spot_price_tao: q.spot_price_tao,
+        effective_price_tao: q.effective_price_tao,
+        price_impact_pct: q.price_impact_pct,
+        disclaimer:
+          "Informational preview only. This does not execute, build, prepare, " +
+          "or sign any transaction, produces no signable or extrinsic artifact, " +
+          "and makes no wallet or key interaction. Submitting a stake requires a " +
+          "separate signed extrinsic outside this tool.",
+      };
+    },
+  },
+  {
     ...GET_ECONOMICS_MCP_TOOL,
     async handler(args, ctx) {
       try {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -7912,6 +7912,118 @@ describe("MCP economics + metagraph data tools", () => {
     assert.match(res.body.result.content[0].text, /insufficient_liquidity/);
   });
 
+  test("get_stake_action_preview previews a stake with a human-readable summary + disclaimer", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 64, amount: 1000, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 64);
+    assert.equal(out.direction, "stake");
+    assert.equal(out.estimated_out.unit, "alpha");
+    assert.ok(out.estimated_out.amount > 0);
+    assert.ok(out.price_impact_pct > 0);
+    assert.match(out.summary, /Staking 1000 TAO on subnet 64/);
+    assert.match(out.summary, /price impact \(slippage\)/);
+    assert.match(out.disclaimer, /does not execute/i);
+  });
+
+  test("get_stake_action_preview defaults direction to stake when omitted", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 64, amount: 10 },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    assert.equal(res.body.result.structuredContent.direction, "stake");
+  });
+
+  test("get_stake_action_preview previews an unstake (alpha in, TAO out)", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 64, amount: 500, direction: "unstake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.direction, "unstake");
+    assert.equal(out.estimated_out.unit, "tao");
+    assert.match(out.summary, /Unstaking 500 alpha on subnet 64/);
+    assert.ok(out.estimated_out.amount > 0);
+  });
+
+  test("get_stake_action_preview previews root (netuid 0) as 1:1 with no price impact", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 0, amount: 42, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 0);
+    assert.equal(out.price_impact_pct, 0);
+    assert.match(out.summary, /root/);
+    assert.match(out.summary, /no price impact/);
+  });
+
+  test("get_stake_action_preview output carries NO signable/extrinsic payload — only the human-readable summary", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 64, amount: 10, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    // The read-only guarantee: the response must be a plain summary with a
+    // disclaimer and expose nothing an agent could mistake for a submittable tx.
+    assert.ok(out.summary && out.disclaimer);
+    // Scan every field EXCEPT the disclaimer (which intentionally names these
+    // words to state the tool does none of them) for any transaction shape.
+    const { disclaimer: _disclaimer, ...scanned } = out;
+    const serialized = JSON.stringify(scanned).toLowerCase();
+    for (const forbidden of [
+      "extrinsic",
+      "unsigned",
+      "signraw",
+      "signature",
+      "call_data",
+      "calldata",
+      "0x",
+      "mortality",
+      "nonce",
+    ]) {
+      assert.ok(
+        !serialized.includes(forbidden),
+        `preview output must not contain a transaction-shaped field: "${forbidden}"`,
+      );
+    }
+  });
+
+  test("get_stake_action_preview surfaces insufficient_liquidity when the subnet has no pool row", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 999, amount: 10, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /insufficient_liquidity/);
+  });
+
   test("get_economics serves the live KV economics tier with REST list-query filters", async () => {
     const blob = {
       ...ECON_BLOB,


### PR DESCRIPTION
Adds a read-only \`get_stake_action_preview\` MCP tool (part of #5229): a clearly-labeled, human-readable preview of a hypothetical stake/unstake against one subnet.

Closes #5973.

## What
- New \`get_stake_action_preview\` tool in \`src/mcp-server.mjs\`. Same inputs as \`get_subnet_stake_quote\` (\`netuid\`, \`amount\`, \`direction\`); returns \`summary\` (a human-readable one-liner), \`estimated_out\` {amount, unit}, \`spot_price_tao\`/\`effective_price_tao\`, \`price_impact_pct\` (the slippage estimate), and an explicit \`disclaimer\`.
- **Reuses the existing stake-quote data path** — \`loadSubnetEconomics\` + the pure-math \`computeStakeQuote\` — as a presentation layer over the same numbers, with no duplicated economics logic.
- **Stays fully within the ADR 0018 boundary**: strictly read-only, builds/prepares/signs no transaction, produces no signable or extrinsic artifact, never touches a wallet or key. The tool description states this unmistakably so an agent can't mistake the response for something submittable.

## Tests
Six cases in \`tests/mcp-server.test.mjs\`: a stake preview (summary + slippage + disclaimer), the direction default, an unstake preview (alpha in / TAO out), the root (netuid 0) 1:1 no-impact path, \`insufficient_liquidity\` when the subnet has no pool row, and an **explicit assertion that the output carries no transaction-shaped/extrinsic field** (only the human-readable summary). Full MCP suite green (1068 tests); \`scripts/validate-mcp.mjs\` passes (174 tools); new handler 100% covered (statements + branches).