### PR TITLE
feat(mcp): add read-only get_stake_action_preview tool

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -2710,6 +2710,86 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_stake_action_preview",
+    title: "Preview a hypothetical stake/unstake action (read-only)",
+    description:
+      "READ-ONLY, INFORMATIONAL preview of what a hypothetical stake or unstake " +
+      "against one subnet would look like, computed from the same live AMM pool " +
+      "reserves get_subnet_stake_quote reads. Returns a human-readable summary -- " +
+      "estimated resulting amount, effective price, and price impact -- plus an " +
+      "explicit disclaimer. It builds NO transaction, signs nothing, touches no " +
+      "key or wallet, and produces NO signable or submittable artifact of any " +
+      "kind: the response cannot be executed on-chain and must not be treated as " +
+      "something to submit. Same inputs as get_subnet_stake_quote. direction " +
+      "stake (default) previews spending amount TAO for alpha; unstake previews " +
+      "spending amount alpha for TAO. Root (netuid 0) has no AMM pool and previews " +
+      "a 1:1, zero-impact action. Mirrors GET /api/v1/subnets/{netuid}/stake-quote's " +
+      "data, reframed as a preview.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        amount: {
+          type: "number",
+          description:
+            "Amount to preview, in TAO for direction=stake or alpha for " +
+            "direction=unstake. Must be a finite number greater than 0.",
+          exclusiveMinimum: 0,
+        },
+        direction: {
+          type: "string",
+          enum: STAKE_QUOTE_DIRECTIONS,
+          description: 'Swap direction: stake or unstake (default "stake").',
+        },
+      },
+      required: ["netuid", "amount"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const amount = args?.amount;
+      const direction = optionalString(args, "direction") ?? "stake";
+      const { economics } = await loadSubnetEconomics(ctx, netuid);
+      // Reuse the exact stake-quote calculation -- no duplicated pool math.
+      const result = computeStakeQuote({
+        netuid,
+        taoInPool: economics?.tao_in_pool_tao,
+        alphaInPool: economics?.alpha_in_pool,
+        amount,
+        direction,
+      });
+      if (!result.ok) {
+        throw toolError(result.code, result.error);
+      }
+      const q = result.quote;
+      const inUnit = direction === "stake" ? "TAO" : "alpha";
+      const verb = direction === "stake" ? "Staking" : "Unstaking";
+      const prep = direction === "stake" ? "into" : "from";
+      const summary =
+        `${verb} ${amount} ${inUnit} ${prep} subnet ${netuid} would yield ` +
+        `approximately ${q.expected_out} ${q.expected_out_unit} at an effective ` +
+        `price of ${q.effective_price_tao} TAO/alpha ` +
+        `(${q.price_impact_pct}% price impact). Informational preview only.`;
+      return {
+        schema_version: 1,
+        netuid: q.netuid,
+        direction: q.direction,
+        amount: q.amount,
+        summary,
+        estimated_out: q.expected_out,
+        estimated_out_unit: q.expected_out_unit,
+        effective_price_tao: q.effective_price_tao,
+        price_impact_pct: q.price_impact_pct,
+        is_root: q.is_root,
+        disclaimer:
+          "This is a read-only, informational estimate computed from live pool " +
+          "reserves. It does NOT build, prepare, sign, or submit any transaction, " +
+          "and produces no signable or executable artifact. Actual on-chain " +
+          "results may differ.",
+      };
+    },
+  },
+  {
     ...GET_ECONOMICS_MCP_TOOL,
     async handler(args, ctx) {
       try {
@@ -10200,6 +10280,36 @@ const TOOL_OUTPUT_SCHEMAS = {
       tao_in_pool_tao: { type: ["number", "null"] },
       alpha_in_pool: { type: ["number", "null"] },
       is_root: { type: "boolean" },
+    },
+  },
+  get_stake_action_preview: {
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "schema_version",
+      "netuid",
+      "direction",
+      "amount",
+      "summary",
+      "estimated_out",
+      "estimated_out_unit",
+      "effective_price_tao",
+      "price_impact_pct",
+      "is_root",
+      "disclaimer",
+    ],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: { type: "integer" },
+      direction: { type: "string", enum: STAKE_QUOTE_DIRECTIONS },
+      amount: { type: "number" },
+      summary: { type: "string" },
+      estimated_out: { type: "number" },
+      estimated_out_unit: { type: "string", enum: ["alpha", "tao"] },
+      effective_price_tao: { type: "number" },
+      price_impact_pct: { type: "number" },
+      is_root: { type: "boolean" },
+      disclaimer: { type: "string" },
     },
   },
   get_economics: GET_ECONOMICS_OUTPUT_SCHEMA,

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -7912,6 +7912,106 @@ describe("MCP economics + metagraph data tools", () => {
     assert.match(res.body.result.content[0].text, /insufficient_liquidity/);
   });
 
+  test("get_stake_action_preview returns a human-readable summary reusing the quote math", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 64, amount: 1000, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.netuid, 64);
+    assert.equal(out.direction, "stake");
+    assert.equal(out.estimated_out_unit, "alpha");
+    assert.equal(out.is_root, false);
+    assert.ok(out.estimated_out > 0);
+    assert.ok(out.price_impact_pct > 0);
+    // The preview must be human-readable and carry an explicit read-only disclaimer.
+    assert.match(out.summary, /Staking 1000 TAO into subnet 64/);
+    assert.match(out.disclaimer, /read-only/i);
+    assert.match(out.disclaimer, /does NOT build, prepare, sign, or submit/);
+  });
+
+  test("get_stake_action_preview output carries NO signable/transaction artifact, only summary fields", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 64, amount: 500, direction: "unstake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.direction, "unstake");
+    assert.equal(out.estimated_out_unit, "tao");
+    // Guard the ADR-0018 boundary: no unsigned-tx / extrinsic / call-data payload,
+    // by field name or value — the response is a read-only summary only.
+    const keys = Object.keys(out);
+    for (const banned of [
+      "extrinsic",
+      "call",
+      "call_data",
+      "callData",
+      "unsigned",
+      "unsigned_tx",
+      "payload",
+      "signature",
+      "signed",
+      "tx",
+      "raw",
+      "hex",
+    ]) {
+      assert.ok(
+        !keys.includes(banned),
+        `preview must not expose a ${banned} field`,
+      );
+    }
+    assert.deepEqual(Object.keys(out).sort(), [
+      "amount",
+      "direction",
+      "disclaimer",
+      "effective_price_tao",
+      "estimated_out",
+      "estimated_out_unit",
+      "is_root",
+      "netuid",
+      "price_impact_pct",
+      "schema_version",
+      "summary",
+    ]);
+  });
+
+  test("get_stake_action_preview previews a 1:1 zero-impact action for root (netuid 0)", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 0, amount: 42, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.is_root, true);
+    assert.equal(out.estimated_out, 42);
+    assert.equal(out.price_impact_pct, 0);
+  });
+
+  test("get_stake_action_preview rejects a non-positive amount as invalid_amount", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 64, amount: -5, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /invalid_amount/);
+  });
+
   test("get_economics serves the live KV economics tier with REST list-query filters", async () => {
     const blob = {
       ...ECON_BLOB,


### PR DESCRIPTION
## Summary

Adds `get_stake_action_preview`, a **read-only, informational** MCP tool that previews what a hypothetical stake/unstake against one subnet would look like — estimated resulting amount, effective price, and price impact — as a human-readable summary plus an explicit disclaimer.

Part of #5229 (native staking epic); stays fully within the **ADR 0018 / #5252** boundary that keeps transaction-building out of MCP for v1. It builds no transaction, signs nothing, touches no key or wallet, and returns **no signable or executable artifact** — the response cannot be submitted on-chain. This is independent of the separate #5967 (transaction-building) discussion.

## Implementation

- Takes the same inputs as `get_subnet_stake_quote` (`netuid`, `amount`, `direction`).
- **Reuses** the existing `computeStakeQuote` pool math (`src/stake-quote.mjs`) via the same `loadSubnetEconomics` path — no duplicated calculation logic.
- Reframes the quote as a human-readable `summary` string + a clearly-labeled `disclaimer`, alongside the structured `estimated_out`/`effective_price_tao`/`price_impact_pct` fields.
- Tool `description` and `disclaimer` both state the read-only/no-execution nature unmistakably, so an agent can't mistake the response for something submittable.
- Registered a matching `TOOL_OUTPUT_SCHEMAS` entry; the tool inherits the default read-only annotations.

## Tests

4 new tests in `tests/mcp-server.test.mjs` (mirroring the `get_subnet_stake_quote` conventions): the human-readable summary + disclaimer, root (netuid 0) 1:1 zero-impact preview, invalid-amount rejection, and — per the coverage requirement — an assertion that the output carries **no** `extrinsic`/`call`/`call_data`/`unsigned`/`payload`/`signature`/`tx` field of any kind, only the read-only summary fields. Full `tests/mcp-server.test.mjs` suite (1066) passes; 100% patch coverage of the new `src/mcp-server.mjs` lines; eslint + prettier clean.

Closes #5973