### PR TITLE
feat(graphql): add Query.chain_deregistrations mirroring REST

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -17,6 +17,13 @@ import {
   CHAIN_AXON_REMOVALS_LIMIT_MAX,
 } from "./chain-axon-removals.mjs";
 import {
+  loadChainDeregistrations,
+  CHAIN_DEREGISTRATIONS_WINDOWS,
+  DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW,
+  CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT,
+  CHAIN_DEREGISTRATIONS_LIMIT_MAX,
+} from "./chain-deregistrations.mjs";
+import {
   loadChainPrometheus,
   CHAIN_PROMETHEUS_WINDOWS,
   DEFAULT_CHAIN_PROMETHEUS_WINDOW,
@@ -386,6 +393,8 @@ export const SDL = `
     chain_calls(window: String, group_by: String, limit: Int, call_module: String): ChainCalls!
     "Network-wide Prometheus telemetry-endpoint announcement leaderboard over a 7d/30d window (default 7d): subnets ranked by PrometheusServed announcements with each's distinct-exporter count and announcements-per-exporter re-announcement intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The telemetry-endpoint companion to chain_serving's axon endpoints -- which subnets run observability infrastructure. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/prometheus."
     chain_prometheus(window: String, limit: Int): ChainPrometheus!
+    "Network-wide neuron-deregistration leaderboard over a 7d/30d window (default 7d): subnets ranked by NeuronDeregistered events with each's distinct-hotkey count and deregistrations-per-hotkey churn intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The network-wide, exit-side counterpart of subnet_deregistrations -- where neurons are being pushed out. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/deregistrations."
+    chain_deregistrations(window: String, limit: Int): ChainDeregistrations!
     "Per-UTC-day network fee/tip series over a 7d/30d window (default 7d): each day's extrinsic count and total/avg/median fee + tip in TAO, plus the top fee-paying signers (limit default 25, max 100), optionally scoped to a single call_module. Computed live from the extrinsics tier; a cold store yields a schema-stable empty series, never a GraphQL error. Mirrors GET /api/v1/chain/fees."
     chain_fees(window: String, limit: Int, call_module: String): ChainFees!
     "Network-wide axon-removal (teardown) leaderboard over a 7d/30d window (default 7d): subnets ranked by AxonInfoRemoved events with each's distinct-remover count and removals-per-remover teardown intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The teardown counterpart of chain_serving's announcements -- where neurons are tearing endpoints down. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/axon-removals."
@@ -797,6 +806,44 @@ export const SDL = `
     distinct_removers: Int!
     removals: Int!
     removals_per_remover: Float
+  }
+
+  type ChainDeregistrations {
+    schema_version: Int!
+    window: String
+    observed_at: String
+    subnet_count: Int!
+    network: ChainDeregistrationsNetwork!
+    intensity_distribution: ChainDeregistrationsIntensityDistribution
+    subnets: [ChainDeregistrationsSubnet!]!
+  }
+
+  "Network-wide deregistration rollup: every subnet with NeuronDeregistered events in the window, combined. distinct_deregistered_hotkeys counts a hotkey once even when it is deregistered from several subnets, so it is NOT the sum of the per-subnet counts."
+  type ChainDeregistrationsNetwork {
+    distinct_deregistered_hotkeys: Int!
+    deregistrations: Int!
+    "Null when distinct_deregistered_hotkeys is 0 (no defined intensity without hotkeys)."
+    deregistrations_per_hotkey: Float
+  }
+
+  "Spread of per-subnet churn intensity (NeuronDeregistered events per hotkey) across EVERY subnet with deregistrations in the window -- network-wide even when limit truncates the leaderboard."
+  type ChainDeregistrationsIntensityDistribution {
+    count: Int!
+    mean: Float!
+    min: Float!
+    p25: Float!
+    median: Float!
+    p75: Float!
+    p90: Float!
+    max: Float!
+  }
+
+  "One subnet's neuron-deregistration activity in the window, ranked by deregistrations."
+  type ChainDeregistrationsSubnet {
+    netuid: Int!
+    distinct_deregistered_hotkeys: Int!
+    deregistrations: Int!
+    deregistrations_per_hotkey: Float
   }
 
   type ChainPrometheus {
@@ -2473,6 +2520,7 @@ export const FIELD_COMPLEXITY = {
   chain_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_prometheus: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5322,6 +5370,53 @@ const rootValue = {
         distinct_removers: 0,
         removals: 0,
         removals_per_remover: null,
+      },
+      intensity_distribution: data.intensity_distribution ?? null,
+      subnets: data.subnets || [],
+    };
+  },
+
+  async chain_deregistrations({ window, limit }, context) {
+    const requestedWindow = window ?? DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW;
+    if (!Object.hasOwn(CHAIN_DEREGISTRATIONS_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(
+          requestedWindow,
+          CHAIN_DEREGISTRATIONS_WINDOWS,
+        ),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT,
+      maxLimit: CHAIN_DEREGISTRATIONS_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    params.set("limit", String(safeLimit));
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> loadChainDeregistrations
+    // fallback contract REST's handleChainDeregistrations uses -- a cold store yields a
+    // schema-stable zeroed card, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/deregistrations", params),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      (await loadChainDeregistrations(graphqlD1(context), {
+        windowLabel: requestedWindow,
+        windowDays: CHAIN_DEREGISTRATIONS_WINDOWS[requestedWindow],
+        limit: safeLimit,
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? requestedWindow,
+      observed_at: data.observed_at ?? null,
+      subnet_count: data.subnet_count ?? 0,
+      network: data.network ?? {
+        distinct_deregistered_hotkeys: 0,
+        deregistrations: 0,
+        deregistrations_per_hotkey: null,
       },
       intensity_distribution: data.intensity_distribution ?? null,
       subnets: data.subnets || [],

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -23,6 +23,7 @@ import {
 } from "../src/graphql.mjs";
 import { LEADERBOARD_BOARDS } from "../src/health-serving.mjs";
 import { CHAIN_PROMETHEUS_WINDOWS } from "../src/chain-prometheus.mjs";
+import { CHAIN_DEREGISTRATIONS_WINDOWS } from "../src/chain-deregistrations.mjs";
 import { CHAIN_AXON_REMOVALS_WINDOWS } from "../src/chain-axon-removals.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { resolveClientIp } from "../workers/config.mjs";
@@ -11572,6 +11573,231 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
   test("is priced at the relationship-field complexity weight", () => {
     assert.equal(
       FIELD_COMPLEXITY.chain_axon_removals,
+      FIELD_COMPLEXITY.chain_serving,
+    );
+  });
+});
+
+describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fallback)", () => {
+  function deregQuery(argsClause) {
+    return `{ chain_deregistrations${argsClause} {
+      schema_version window observed_at subnet_count
+      network { distinct_deregistered_hotkeys deregistrations deregistrations_per_hotkey }
+      intensity_distribution { count mean min p25 median p75 p90 max }
+      subnets { netuid distinct_deregistered_hotkeys deregistrations deregistrations_per_hotkey }
+    } }`;
+  }
+
+  // loadChainDeregistrations issues the network aggregate (COUNT DISTINCT hotkey
+  // / MAX(observed_at), no GROUP BY) and only then the GROUP BY netuid
+  // leaderboard, and only when newest_observed is non-null.
+  function chainDeregD1({ network, subnets = [] } = {}) {
+    return {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              async all() {
+                if (sql.includes("GROUP BY netuid")) {
+                  return { results: subnets };
+                }
+                return { results: network ? [network] : [] };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  test("cold store, default args: schema-stable empty leaderboard, never an error", async () => {
+    const { status, body } = await gql(deregQuery(""));
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_deregistrations, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_deregistered_hotkeys: 0,
+        deregistrations: 0,
+        deregistrations_per_hotkey: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("resolves the D1-live tier: per-subnet leaderboard + network rollup", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: chainDeregD1({
+        network: {
+          distinct_deregistered_hotkeys: 3,
+          newest_observed: 1780000000000,
+        },
+        subnets: [
+          { netuid: 1, deregistrations: 9, distinct_deregistered_hotkeys: 3 },
+          { netuid: 7, deregistrations: 3, distinct_deregistered_hotkeys: 1 },
+        ],
+      }),
+    };
+    const { status, body } = await gql(deregQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const got = body.data.chain_deregistrations;
+    assert.equal(got.subnet_count, 2);
+    assert.equal(got.observed_at, new Date(1780000000000).toISOString());
+    // The rollup uses the true network-wide distinct count (3), not the sum of
+    // the per-subnet hotkeys (4) -- a hotkey deregistered from several subnets
+    // counts once.
+    assert.deepEqual(got.network, {
+      distinct_deregistered_hotkeys: 3,
+      deregistrations: 12,
+      deregistrations_per_hotkey: 4,
+    });
+    assert.deepEqual(got.subnets, [
+      {
+        netuid: 1,
+        distinct_deregistered_hotkeys: 3,
+        deregistrations: 9,
+        deregistrations_per_hotkey: 3,
+      },
+      {
+        netuid: 7,
+        distinct_deregistered_hotkeys: 1,
+        deregistrations: 3,
+        deregistrations_per_hotkey: 3,
+      },
+    ]);
+    assert.equal(got.intensity_distribution.count, 2);
+  });
+
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            observed_at: "2026-07-01T00:00:00.000Z",
+            subnet_count: 1,
+            network: {
+              distinct_deregistered_hotkeys: 5,
+              deregistrations: 20,
+              deregistrations_per_hotkey: 4,
+            },
+            intensity_distribution: {
+              count: 1,
+              mean: 4,
+              min: 4,
+              p25: 4,
+              median: 4,
+              p75: 4,
+              p90: 4,
+              max: 4,
+            },
+            subnets: [
+              {
+                netuid: 3,
+                distinct_deregistered_hotkeys: 5,
+                deregistrations: 20,
+                deregistrations_per_hotkey: 4,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      deregQuery('(window: "30d", limit: 5)'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/deregistrations");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(body.data.chain_deregistrations.window, "30d");
+    assert.equal(
+      body.data.chain_deregistrations.network.distinct_deregistered_hotkeys,
+      5,
+    );
+  });
+
+  test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
+    // The tier's shape is upstream-controlled, so every field falls back rather
+    // than surfacing null through a non-null SDL field.
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(deregQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_deregistrations, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_deregistered_hotkeys: 0,
+        deregistrations: 0,
+        deregistrations_per_hotkey: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("clamps an over-max limit to the route's own ceiling", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(deregQuery("(limit: 99999)"), env);
+    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+  });
+
+  test("every documented window is accepted", async () => {
+    for (const window of Object.keys(CHAIN_DEREGISTRATIONS_WINDOWS)) {
+      const { status, body } = await gql(deregQuery(`(window: "${window}")`));
+      assert.equal(status, 200, window);
+      assert.equal(body.errors, undefined);
+      assert.equal(body.data.chain_deregistrations.window, window);
+    }
+  });
+
+  test("an unsupported window is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(deregQuery('(window: "1y")'), env);
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("is priced at the relationship-field complexity weight", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.chain_deregistrations,
       FIELD_COMPLEXITY.chain_serving,
     );
   });


### PR DESCRIPTION
Closes #5877

Resubmitted from #5970, which was closed when `chain_fees` (#5963) and `chain_axon_removals` (#5971) merged into `src/graphql.mjs` and turned it `dirty` — not a review or CI failure. Re-applied cleanly on top of both; every check below was run after that.

## What

Adds `Query.chain_deregistrations`, mirroring `GET /api/v1/chain/deregistrations` and MCP `get_chain_deregistrations`: the network-wide neuron-deregistration leaderboard — the **exit side** of registration churn, and the network-wide counterpart of the existing `Query.subnet_deregistrations`.

## How

**No query/aggregation logic is duplicated.** The resolver reuses `chain-deregistrations.mjs`'s `loadChainDeregistrations` through the same `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` → D1-live fallback that `handleChainDeregistrations` takes, so the GraphQL, REST and MCP shapes cannot drift apart.

- **`window`** is validated against the route's own `CHAIN_DEREGISTRATIONS_WINDOWS` (`7d`/`30d`, default `7d`) and raises `BAD_USER_INPUT` rather than silently defaulting.
- **`limit`** is clamped with the route's own `CHAIN_DEREGISTRATIONS_LIMIT_DEFAULT`/`MAX` (20/100), so a GraphQL caller cannot request a wider leaderboard than REST allows.
- A cold store yields a schema-stable zeroed card, never a GraphQL error.

**Types** mirror the `ChainServing`/`ChainPrometheus`/`ChainAxonRemovals` family field-for-field, keyed on deregistered hotkeys. The doc-comments record the two contracts worth knowing: `network.distinct_deregistered_hotkeys` counts a hotkey once even when it is deregistered from several subnets (so it is **not** the sum of the per-subnet counts), and `intensity_distribution` spans every subnet in the window even when `limit` truncates the leaderboard.

`FIELD_COMPLEXITY` entry at `RELATIONSHIP_FIELD_COMPLEXITY`, matching `chain_serving`.

## Tests

8 new cases in `tests/graphql.test.mjs`, following the `chain_serving` (#5873) / `chain_prometheus` (#5874) suites' conventions including the two-query D1 stub:

- cold store → schema-stable empty leaderboard, never an error
- D1-live tier → per-subnet leaderboard + network rollup, asserting the rollup uses the *true* distinct count (3) rather than the sum of per-subnet hotkeys (4)
- Postgres tier for a non-default `window`/`limit`, asserting both are forwarded as query params
- sparse upstream payload → every field falls back rather than surfacing null through a non-null SDL field
- over-max `limit` clamped to the route ceiling (99999 → 100)
- every documented window accepted
- unsupported window → `BAD_USER_INPUT`, never reaching the tier
- complexity weight matches `chain_serving`

Patch coverage measured locally the way codecov measures it: **29/29 covered statements and branch arms = 100%** (target 99%), no partials. `eslint` clean, `prettier --check` clean, pushed at `behind: 0`.
