### PR TITLE
fix(registry): Trishool (SN23) accuracy pass -- restore missing probes

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 236,
+  "surface_count": 237,
   "surfaces": [
     {
       "auth_required": false,
@@ -1919,6 +1919,24 @@
       "surface_id": "sn-23-trishool-api-root",
       "surface_key": "srf-b98c53721003635a",
       "url": "https://api.trishool.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 23,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "trishool",
+      "public_safe": true,
+      "subnet_name": "Trishool",
+      "subnet_slug": "sn-23",
+      "surface_id": "sn-23-trishool-submission-schema",
+      "surface_key": "srf-c1aaa6aede0e3c28",
+      "url": "https://raw.githubusercontent.com/TrishoolAI/trishool-phase2/main/tri-check/data/submission_schema.json"
     },
     {
       "auth_required": false,

--- a/registry/subnets/trishool.json
+++ b/registry/subnets/trishool.json
@@ -22,7 +22,7 @@
   "dashboard_url": "https://trishool.ai/dashboard",
   "name": "Trishool",
   "netuid": 23,
-  "notes": "Reviewed overlay for SN23 using the official Trishool dashboard, phase-two source repository, and public API landing URL. The API root returns a public landing response, but OpenAPI and docs paths currently require auth or return 404, so no schema-backed API is promoted.",
+  "notes": "Reviewed overlay for SN23 using the official Trishool dashboard, phase-two source repository, and public API landing URL. The API root returns a public landing response, but OpenAPI and docs paths currently require auth or return 404, so no schema-backed API is promoted (re-tested live, still accurate). 3 community-submitted surfaces had no probe config at all -- the registry-wide gap tracked in #5932 -- fixed. All 6 surfaces re-verified live.",
   "schema_version": 1,
   "slug": "sn-23",
   "social": {
@@ -96,6 +96,12 @@
       "kind": "docs",
       "name": "Trishool documentation",
       "notes": "Official Trishool documentation site (docs.trishool.ai), hosted on the subnet's own domain and linked from the official website trishool.ai.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "trishool",
       "public_safe": true,
       "review": {
@@ -112,6 +118,12 @@
       "kind": "data-artifact",
       "name": "Trishool tri-check submission schema template",
       "notes": "Public no-auth JSON template for the tri-check / alignet-style miner submission format (Q1–Q12 prompt object keys). Used for local testing and documentation of the expected batch submission shape.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "trishool",
       "public_safe": true,
       "review": {
@@ -131,6 +143,12 @@
       "kind": "docs",
       "name": "Trishool litepaper",
       "notes": "Public no-auth Trishool litepaper (PDF) for SN23, served at litepaper.trishool.ai — a dedicated subdomain of the registered official website trishool.ai (same operator as the api.trishool.ai and docs.trishool.ai surfaces). A machine-readable primary-source document describing the subnet's design, mechanism, and roles. Distinct in URL from the docs.trishool.ai API documentation already registered.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "trishool",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- 3 community-submitted surfaces (docs, submission schema, litepaper) had no probe config at all -- the registry-wide gap tracked in #5932 -- confirmed all 3 live and fixed.
- Re-tested the OpenAPI/docs/Swagger gap notes live: still accurate (`openapi.json` and `/docs` still 401, `/swagger.json` still 404).
- All 6 surfaces re-verified live.

## Test plan

- [x] `npm run validate` — passes
- [x] `npm run validate:surface` — passes (923 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] `npm run scan:public-safety` — passes
- [x] Every surface URL live-tested individually before assigning a probe