### PR TITLE
feat(graphql): add Query.account_events mirroring REST + MCP account events

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -128,6 +128,7 @@ import {
   buildAccountsList,
 } from "./accounts-list.mjs";
 import {
+  buildAccountEvents,
   buildAccountSubnets,
   buildAccountSummary,
   buildAccountTransfers,
@@ -370,6 +371,8 @@ export const SDL = `
     account_transfers(ss58: String!, limit: Int, offset: Int, cursor: String, direction: String, block_start: Int, block_end: Int): AccountTransfers!
     "One account's signed-extrinsic feed, newest first -- the extrinsics whose signer is this address (matched by signer only, not the hotkey/coldkey union account_events uses), each carrying its block/index, hash, call_module/call_function, decoded call_args, success flag, fee and tip. block_start/block_end bound the block-height range; page with limit/offset or cursor (opaque keyset from a prior response's next_cursor). extrinsic_count is the page count, not a grand total. An address that signed nothing resolves to a schema-stable empty feed, never null. Mirrors GET /api/v1/accounts/{ss58}/extrinsics."
     account_extrinsics(ss58: String!, limit: Int, offset: Int, cursor: String, block_start: Int, block_end: Int): AccountExtrinsics!
+    "One account's first-party chain-event feed, newest first -- every event where this address is the hotkey OR coldkey (the union account_extrinsics does not use), each carrying its block/event index, event_kind, hotkey/coldkey, netuid/uid, amount_tao/alpha_amount, extrinsic_index and observed_at. kind filters to one event kind (e.g. StakeAdded, NeuronRegistered, AxonServed, WeightsSet); netuid scopes to one subnet; block_start/block_end bound the block-height range; page with limit/offset or cursor (opaque keyset from a prior response's next_cursor). event_count is the page count, not a grand total. An address with no matching events resolves to a schema-stable empty feed, never null. Mirrors GET /api/v1/accounts/{ss58}/events."
+    account_events(ss58: String!, kind: String, netuid: Int, block_start: Int, block_end: Int, limit: Int, offset: Int, cursor: String): AccountEvents!
     "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
     economics_trends(window: String): EconomicsTrends!
     "Registry leaderboards: the operational boards (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing, most-reliable) and the economic-opportunity boards (open-slots, cheapest-registration, highest-emission, validator-headroom), composed live from the registry profiles projection plus D1 health/rpc/growth/reliability rows and the economics tier. Pass board to return just that board (default: every board); limit caps each board's entries (default 20, max 100). An unknown board is a BAD_USER_INPUT error, matching REST's invalid_query 400. Mirrors GET /api/v1/registry/leaderboards."
@@ -2147,6 +2150,17 @@ export const SDL = `
     extrinsic_index: Int
   }
 
+  "One account's first-party chain-event feed (matched by the hotkey OR coldkey union, newest first), keyset-paginated. event_count is the page count, not a grand total. Mirrors GET /api/v1/accounts/{ss58}/events' data envelope. Each item is an AccountEvent."
+  type AccountEvents {
+    schema_version: Int!
+    ss58: String!
+    event_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    events: [AccountEvent!]!
+  }
+
   "Signing-activity aggregate from the extrinsics tier, matched by signer only -- an account queried by a key that did not sign returns tx_count 0, other fields null/empty."
   type AccountActivity {
     tx_count: Int!
@@ -2441,6 +2455,7 @@ export const FIELD_COMPLEXITY = {
   account_counterparties: RELATIONSHIP_FIELD_COMPLEXITY,
   account_transfers: RELATIONSHIP_FIELD_COMPLEXITY,
   account_extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_events: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   // A single latest-only row -- but it fans out into the full hyperparameter
   // block, so it is priced with the other per-subnet relationship fields.
@@ -4912,6 +4927,73 @@ const rootValue = {
       offset: data.offset ?? safeOffset,
       next_cursor: data.next_cursor ?? null,
       extrinsics: (data.extrinsics || []).map(extrinsicNode),
+    };
+  },
+
+  async account_events(
+    { ss58, kind, netuid, block_start, block_end, limit, offset, cursor },
+    context,
+  ) {
+    // Same SS58 validation every account_* resolver uses -- a malformed address
+    // is a GraphQL BAD_USER_INPUT error, not a silent empty feed.
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same FEED_PAGINATION bounds the /events route's clampEventsLimit applies,
+    // so a GraphQL caller cannot request a wider page than REST allows;
+    // kind/netuid/cursor/block_start/block_end are forwarded verbatim for the
+    // route to re-parse, matching account_transfers and the sibling feeds.
+    const safeLimit = clampLimit(limit, FEED_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    if (kind != null) params.set("kind", kind);
+    if (netuid != null) params.set("netuid", String(netuid));
+    if (cursor != null) params.set("cursor", cursor);
+    if (block_start != null) params.set("block_start", String(block_start));
+    if (block_end != null) params.set("block_end", String(block_end));
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) the REST handler and
+    // MCP get_account_events tool use. The account_events D1 write path is
+    // retired (#4772), so a tier miss resolves through buildAccountEvents over an
+    // empty scan -- a schema-stable empty feed, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}/events`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      buildAccountEvents([], ss58, {
+        limit: safeLimit,
+        offset: safeOffset,
+        nextCursor: null,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      ss58: data.ss58 ?? ss58,
+      event_count: data.event_count ?? 0,
+      limit: data.limit ?? safeLimit,
+      offset: data.offset ?? safeOffset,
+      next_cursor: data.next_cursor ?? null,
+      events: (data.events ?? []).map((e) => ({
+        block_number: e.block_number ?? null,
+        event_index: e.event_index ?? null,
+        event_kind: e.event_kind ?? null,
+        hotkey: e.hotkey ?? null,
+        coldkey: e.coldkey ?? null,
+        netuid: e.netuid ?? null,
+        uid: e.uid ?? null,
+        amount_tao: e.amount_tao ?? null,
+        alpha_amount: e.alpha_amount ?? null,
+        observed_at: e.observed_at ?? null,
+        extrinsic_index: e.extrinsic_index ?? null,
+      })),
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7520,6 +7520,227 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
   });
 });
 
+describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)", () => {
+  const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+  const OTHER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  function dataApi(response, capture) {
+    return {
+      fetch: async (req) => {
+        if (capture) capture.url = new URL(req.url);
+        return response;
+      },
+    };
+  }
+
+  function query(argsClause) {
+    return `{ account_events${argsClause} {
+      schema_version ss58 event_count limit offset next_cursor
+      events { block_number event_index event_kind hotkey coldkey netuid uid amount_tao alpha_amount observed_at extrinsic_index }
+    } }`;
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty feed, never null", async () => {
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`));
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_events, {
+      schema_version: 1,
+      ss58: SS58,
+      event_count: 0,
+      limit: 100,
+      offset: 0,
+      next_cursor: null,
+      events: [],
+    });
+  });
+
+  test("resolves the Postgres-tier envelope, mapping each event's fields", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          event_count: 1,
+          limit: 50,
+          offset: 0,
+          next_cursor: "b:1200:3",
+          events: [
+            {
+              block_number: 1200,
+              event_index: 3,
+              event_kind: "StakeAdded",
+              hotkey: SS58,
+              coldkey: OTHER,
+              netuid: 7,
+              uid: 42,
+              amount_tao: 1.5,
+              alpha_amount: 2.25,
+              observed_at: "2026-07-15T00:00:00.000Z",
+              extrinsic_index: 4,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_events, {
+      schema_version: 1,
+      ss58: SS58,
+      event_count: 1,
+      limit: 50,
+      offset: 0,
+      next_cursor: "b:1200:3",
+      events: [
+        {
+          block_number: 1200,
+          event_index: 3,
+          event_kind: "StakeAdded",
+          hotkey: SS58,
+          coldkey: OTHER,
+          netuid: 7,
+          uid: 42,
+          amount_tao: 1.5,
+          alpha_amount: 2.25,
+          observed_at: "2026-07-15T00:00:00.000Z",
+          extrinsic_index: 4,
+        },
+      ],
+    });
+  });
+
+  test("hits /api/v1/accounts/{ss58}/events and forwards every filter", async () => {
+    const capture = {};
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          event_count: 0,
+          limit: 5,
+          offset: 2,
+          next_cursor: null,
+          events: [],
+        }),
+        capture,
+      ),
+    };
+    const { status } = await gql(
+      query(
+        `(ss58: "${SS58}", kind: "StakeAdded", netuid: 7, block_start: 10, block_end: 20, limit: 5, offset: 2, cursor: "c:9:1")`,
+      ),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(capture.url.pathname, `/api/v1/accounts/${SS58}/events`);
+    assert.equal(capture.url.searchParams.get("limit"), "5");
+    assert.equal(capture.url.searchParams.get("offset"), "2");
+    assert.equal(capture.url.searchParams.get("kind"), "StakeAdded");
+    assert.equal(capture.url.searchParams.get("netuid"), "7");
+    assert.equal(capture.url.searchParams.get("cursor"), "c:9:1");
+    assert.equal(capture.url.searchParams.get("block_start"), "10");
+    assert.equal(capture.url.searchParams.get("block_end"), "20");
+  });
+
+  test("clamps limit/offset to FEED_PAGINATION bounds and omits absent filters", async () => {
+    const capture = {};
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({}), capture),
+    };
+    await gql(query(`(ss58: "${SS58}", limit: 100000, offset: -5)`), env);
+    const forwardedLimit = Number(capture.url.searchParams.get("limit"));
+    const forwardedOffset = Number(capture.url.searchParams.get("offset"));
+    assert.ok(forwardedLimit > 0 && forwardedLimit < 100000);
+    assert.equal(forwardedOffset, 0);
+    // No filter params were supplied, so none are forwarded.
+    assert.equal(capture.url.searchParams.get("kind"), null);
+    assert.equal(capture.url.searchParams.get("netuid"), null);
+    assert.equal(capture.url.searchParams.get("cursor"), null);
+    assert.equal(capture.url.searchParams.get("block_start"), null);
+    assert.equal(capture.url.searchParams.get("block_end"), null);
+  });
+
+  test("a partial tier envelope degrades missing scalars to schema-stable defaults", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_events, {
+      schema_version: 1,
+      ss58: SS58,
+      event_count: 0,
+      limit: 100,
+      offset: 0,
+      next_cursor: null,
+      events: [],
+    });
+  });
+
+  test("an event row with missing fields degrades each to null", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          event_count: 1,
+          next_cursor: null,
+          events: [{}],
+        }),
+      ),
+    };
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_events.events, [
+      {
+        block_number: null,
+        event_index: null,
+        event_kind: null,
+        hotkey: null,
+        coldkey: null,
+        netuid: null,
+        uid: null,
+        amount_tao: null,
+        alpha_amount: null,
+        observed_at: null,
+        extrinsic_index: null,
+      },
+    ]);
+  });
+
+  test("an invalid ss58 is a GraphQL error and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { body } = await gql(query('(ss58: "not-an-address")'), env);
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/ss58/i.test(body.errors[0].message));
+    assert.equal(body.data?.account_events ?? null, null);
+    assert.equal(called, false);
+  });
+
+  test("account_events is weighted as a relationship field", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.account_events,
+      FIELD_COMPLEXITY.account_transfers,
+    );
+  });
+});
+
 describe("graphql — account_identity_history (#5709, Postgres-tier + D1-live fallback)", () => {
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 


### PR DESCRIPTION
## Summary

Adds `Query.account_events` to the GraphQL SDL, closing the last REST/MCP → GraphQL
parity gap on the account event feed. `GET /api/v1/accounts/{ss58}/events`
(`workers/data-api.mjs`) and the `get_account_events` MCP tool
(`src/mcp-server.mjs`) both already expose this data; the GraphQL surface did not.

## What Changed

- New `account_events(ss58: String!, kind: String, netuid: Int, block_start: Int, block_end: Int, limit: Int, offset: Int, cursor: String): AccountEvents!`
  field on the `Query` type, mirroring the REST route's parameters exactly.
- New `AccountEvents` envelope type (reusing the existing `AccountEvent` item type
  already defined for `AccountSummary.recent_events`).
- Resolver routes through the same
  `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` path the REST handler and MCP
  tool use — no duplicated query/aggregation logic. A tier miss falls back to
  `buildAccountEvents([])` for a schema-stable empty feed, and a malformed SS58 is a
  `BAD_USER_INPUT` error, matching every sibling `account_*` resolver
  (`account_transfers`, `account_extrinsics`).
- `account_events` weighted as a relationship fan-out field in `FIELD_COMPLEXITY`.
- Unit tests covering the cold-store fallback, the populated Postgres-tier envelope,
  filter forwarding (kind/netuid/block-range/cursor/pagination), limit/offset
  clamping, partial-envelope degradation, null-field row mapping, SS58 validation,
  and the complexity weight.

Scope matches the recently-merged sibling parity PRs (#5961 `account_extrinsics`,
#5971 `chain_axon_removals`): only `src/graphql.mjs` + `tests/graphql.test.mjs`. No
generated artifacts or schema regeneration are involved — the GraphQL SDL lives in
`src/graphql.mjs`.

## Validation

- `npx vitest run tests/graphql.test.mjs` — 496 passed
- Coverage: 100% statements/lines on `src/graphql.mjs` for the diff (patch ≥99%)
- `npm run lint` — clean
- `npm run format:check` — clean
- `npm run worker:bundle:budget` — passes (1005.5 KiB, under the 1008 KiB fail budget)
- `git diff --check` — clean

Closes #5890
