### PR TITLE
fix(registry): Quasar (SN24) accuracy pass -- restore missing probes

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 239,
+  "surface_count": 237,
   "surfaces": [
     {
       "auth_required": false,
@@ -1991,42 +1991,6 @@
       "surface_id": "sn-24-quasar-launch-teacher",
       "surface_key": "srf-840a2605f8fb23c0",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "data-artifact",
-      "netuid": 24,
-      "probe": {
-        "expect": "html",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "silx-labs",
-      "public_safe": true,
-      "subnet_name": "Quasar",
-      "subnet_slug": "sn-24",
-      "surface_id": "sn-24-quasar-training-corpus",
-      "surface_key": "srf-25089541aa0cece3",
-      "url": "https://huggingface.co/datasets/silx-ai/Quasar-SN3"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 24,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "subnet_name": "Quasar",
-      "subnet_slug": "sn-24",
-      "surface_id": "sn-24-taomarketcap-subnet-api",
-      "surface_key": "srf-4262382b60db3bb7",
-      "url": "https://api.taomarketcap.com/public/v1/subnets/24"
     },
     {
       "auth_required": false,

--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 237,
+  "surface_count": 239,
   "surfaces": [
     {
       "auth_required": false,
@@ -1991,6 +1991,42 @@
       "surface_id": "sn-24-quasar-launch-teacher",
       "surface_key": "srf-840a2605f8fb23c0",
       "url": "https://huggingface.co/Qwen/Qwen3.5-4B"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 24,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "silx-labs",
+      "public_safe": true,
+      "subnet_name": "Quasar",
+      "subnet_slug": "sn-24",
+      "surface_id": "sn-24-quasar-training-corpus",
+      "surface_key": "srf-25089541aa0cece3",
+      "url": "https://huggingface.co/datasets/silx-ai/Quasar-SN3"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subnet-api",
+      "netuid": 24,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "subnet_name": "Quasar",
+      "subnet_slug": "sn-24",
+      "surface_id": "sn-24-taomarketcap-subnet-api",
+      "surface_key": "srf-4262382b60db3bb7",
+      "url": "https://api.taomarketcap.com/public/v1/subnets/24"
     },
     {
       "auth_required": false,

--- a/registry/subnets/quasar.json
+++ b/registry/subnets/quasar.json
@@ -36,7 +36,7 @@
   ],
   "name": "Quasar",
   "netuid": 24,
-  "notes": "Reviewed overlay for SN24 using the official SILX Labs website, Quasar source repository, README, and public model artifacts.",
+  "notes": "Reviewed overlay for SN24 using the official SILX Labs website, Quasar source repository, README, and public model artifacts. 2 community-submitted surfaces had no probe config at all -- the registry-wide gap tracked in #5932 -- fixed. Confirmed the remaining gap_notes are accurate, not stale: the TaoMarketCap surface is a third-party indexed snapshot, not a first-party subnet API, so \"no verified subnet API surface yet\" still correctly describes the lack of a first-party one. All 11 surfaces re-verified live.",
   "schema_version": 1,
   "slug": "sn-24",
   "source_repo": "https://github.com/SILX-LABS/QUASAR-SUBNET",
@@ -207,6 +207,12 @@
       "kind": "data-artifact",
       "name": "Quasar training corpus dataset",
       "notes": "Public SILX Labs HuggingFace tokenized training corpus for Quasar (SN24) — ~1.05M rows (tokens/loss/shard/bucket scoring columns) fitting the subnet's continued-pretraining task; parquet, not gated. Published by silx-ai, whose SILX-LABS/QUASAR-SUBNET README (source) declares Mainnet netuid 24. The -SN3 suffix is a model/series version label, not a subnet-3 reference.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "silx-labs",
       "public_safe": true,
       "review": {
@@ -226,6 +232,12 @@
       "kind": "subnet-api",
       "name": "Quasar TaoMarketCap subnet snapshot API",
       "notes": "Public no-auth GET /public/v1/subnets/24 on api.taomarketcap.com returning machine-readable JSON for SN24 Quasar on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- 2 community-submitted surfaces (training corpus, TaoMarketCap snapshot) had no probe config at all -- the registry-wide gap tracked in #5932 -- confirmed both live and fixed.
- Checked whether "No verified subnet API surface yet" in `gap_notes` was stale given the already-tracked TaoMarketCap subnet-api surface: confirmed accurate, not stale -- that surface is a third-party indexed snapshot, not a first-party subnet API (the automated stale-notes checker's own first-party/third-party distinction correctly did not flag it either).
- All 11 surfaces re-verified live.

## Test plan

- [x] `npm run validate` — passes
- [x] `npm run validate:surface` — passes (923 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] `npm run scan:public-safety` — passes
- [x] Every surface URL live-tested individually before assigning a probe