### PR TITLE
feat(graphql): add Query.chain_signers mirroring REST

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -194,6 +194,12 @@ import {
 } from "../workers/config.mjs";
 import { loadRpcUsage } from "./rpc-usage-loader.mjs";
 import {
+  loadChainSigners,
+  CHAIN_SIGNERS_SORTS,
+  CHAIN_SIGNERS_LIMIT_DEFAULT,
+  CHAIN_SIGNERS_LIMIT_MAX,
+} from "./chain-query-loaders.mjs";
+import {
   parseHistoryWindow,
   unsupportedWindowMessage,
 } from "./neuron-history.mjs";
@@ -401,6 +407,8 @@ export const SDL = `
     chain_axon_removals(window: String, limit: Int): ChainAxonRemovals!
     "Network-wide weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators driving consensus network-wide, each with its total WeightsSet count, share of the network total, and first/last set times, ranked by activity. The setter-level drill-in behind chain_weights. Mirrors GET /api/v1/chain/weights/setters."
     chain_weight_setters(window: String, limit: Int): ChainWeightSetters!
+    "Most-active signer leaderboard over a 7d/30d window (default 7d): the accounts submitting the most extrinsics, each with its extrinsic count, total fees and tips paid in TAO, and last-seen block. Rank by tx_count (default) or total_fee_tao, optionally scoped to a single call_module pallet (limit default 50, max 100). Computed live from the extrinsics tier; a cold store yields a schema-stable empty leaderboard, never a GraphQL error. Mirrors GET /api/v1/chain/signers."
+    chain_signers(window: String, limit: Int, sort: String, call_module: String): ChainSigners!
     "Compact all-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history (probed every ~15 minutes); a cold store still returns both windows, schema-stable and zeroed, never a GraphQL error. Mirrors GET /api/v1/health/trends."
     health_trends: HealthTrends!
     "RPC reverse-proxy usage analytics over a 7d/30d window (default 7d): total request volume, error + failover rates, cache-hit rate, latency p50/p95/avg, the per-endpoint and per-network request distribution, and bounded time buckets (1h for 7d, 6h for 30d), computed live from the rpc_proxy_events telemetry. A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/rpc/usage."
@@ -950,6 +958,26 @@ export const SDL = `
   }
 
   "Network-wide weight-setter leaderboard over a lookback window, summed live from the account_events WeightsSet stream. The setter-level drill-in behind ChainWeights. Mirrors GET /api/v1/chain/weights/setters."
+  type ChainSigners {
+    schema_version: Int!
+    window: String
+    "The rank order actually applied: tx_count or total_fee_tao."
+    sort: String!
+    observed_at: String
+    signer_count: Int!
+    signers: [ChainSigner!]!
+  }
+
+  "One account's extrinsic-submission activity in the window, ranked by the requested sort."
+  type ChainSigner {
+    signer: String!
+    tx_count: Int!
+    "Total fees paid across the window's extrinsics; null when the tier has no fee data."
+    total_fee_tao: Float
+    total_tip_tao: Float
+    last_tx_block: Int
+  }
+
   type ChainWeightSetters {
     schema_version: Int!
     window: String
@@ -2523,6 +2551,7 @@ export const FIELD_COMPLEXITY = {
   chain_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_signers: RELATIONSHIP_FIELD_COMPLEXITY,
   health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   rpc_usage: RELATIONSHIP_FIELD_COMPLEXITY,
   validator_nominators: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5464,6 +5493,82 @@ const rootValue = {
       },
       intensity_distribution: data.intensity_distribution ?? null,
       subnets: data.subnets || [],
+    };
+  },
+
+  async chain_signers(
+    { window, limit, sort, call_module: callModule },
+    context,
+  ) {
+    // Reuse the exact analyticsWindow parse/validate REST's handleChainSigners
+    // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL
+    // BAD_USER_INPUT error, not a silent empty leaderboard.
+    const windowUrl = new URL(context.request.url);
+    windowUrl.search = "";
+    if (window != null) windowUrl.searchParams.set("window", window);
+    const { label, days, error } = analyticsWindow(windowUrl);
+    if (error) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same CHAIN_SIGNERS_SORTS allow-list REST validates against; sort is
+    // optional (null -> the loader's tx_count default), so only a non-null
+    // value is checked.
+    if (sort != null && !CHAIN_SIGNERS_SORTS.includes(sort)) {
+      throw new GraphQLError(
+        `"${sort}" is not a supported sort. Supported: ${CHAIN_SIGNERS_SORTS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    if (callModule != null && callModule.length > 100) {
+      throw new GraphQLError("call_module must be at most 100 characters.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: CHAIN_SIGNERS_LIMIT_DEFAULT,
+      maxLimit: CHAIN_SIGNERS_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("window", label);
+    params.set("limit", String(safeLimit));
+    if (sort != null) params.set("sort", sort);
+    if (callModule != null) params.set("call_module", callModule);
+    // Same tryPostgresTier(METAGRAPH_EXTRINSICS_SOURCE) -> loadChainSigners
+    // fallback contract handleChainSigners uses, including the KV health:meta
+    // observed_at stamp REST passes; no ranking/aggregation logic is duplicated
+    // here, and a cold store yields a schema-stable empty leaderboard.
+    const tier = await tryPostgresTier(
+      context.env,
+      postgresTierRequest(context, "/api/v1/chain/signers", params),
+      "METAGRAPH_EXTRINSICS_SOURCE",
+    );
+    const data =
+      tier ??
+      (
+        await loadChainSigners(graphqlD1(context), {
+          windowLabel: label,
+          windowDays: days,
+          observedAt: await loadObservedAt(context),
+          limit: safeLimit,
+          callModule,
+          sort,
+        })
+      ).data;
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? label,
+      sort: data.sort ?? CHAIN_SIGNERS_SORTS[0],
+      observed_at: data.observed_at ?? null,
+      signer_count: data.signer_count ?? 0,
+      signers: (data.signers ?? []).map((entry) => ({
+        signer: entry.signer,
+        tx_count: entry.tx_count ?? 0,
+        total_fee_tao: entry.total_fee_tao ?? null,
+        total_tip_tao: entry.total_tip_tao ?? null,
+        last_tx_block: entry.last_tx_block ?? null,
+      })),
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -23,6 +23,7 @@ import {
 } from "../src/graphql.mjs";
 import { LEADERBOARD_BOARDS } from "../src/health-serving.mjs";
 import { CHAIN_PROMETHEUS_WINDOWS } from "../src/chain-prometheus.mjs";
+import { CHAIN_SIGNERS_SORTS } from "../src/chain-query-loaders.mjs";
 import { CHAIN_DEREGISTRATIONS_WINDOWS } from "../src/chain-deregistrations.mjs";
 import { CHAIN_AXON_REMOVALS_WINDOWS } from "../src/chain-axon-removals.mjs";
 import { handleRequest } from "../workers/api.mjs";
@@ -11799,6 +11800,262 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
     assert.equal(
       FIELD_COMPLEXITY.chain_deregistrations,
       FIELD_COMPLEXITY.chain_serving,
+    );
+  });
+});
+
+describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", () => {
+  const SIGNER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  function signersQuery(argsClause) {
+    return `{ chain_signers${argsClause} {
+      schema_version window sort observed_at signer_count
+      signers { signer tx_count total_fee_tao total_tip_tao last_tx_block }
+    } }`;
+  }
+
+  // loadChainSigners issues one ranked extrinsics-tier read; the rows carry the
+  // per-signer aggregate.
+  function signersD1(rows = []) {
+    return {
+      prepare: () => ({
+        bind: () => ({ all: async () => ({ results: rows }) }),
+      }),
+    };
+  }
+
+  test("cold store, default args: schema-stable empty leaderboard, never an error", async () => {
+    const { status, body } = await gql(signersQuery(""));
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_signers, {
+      schema_version: 1,
+      window: "7d",
+      sort: "tx_count",
+      observed_at: null,
+      signer_count: 0,
+      signers: [],
+    });
+  });
+
+  test("resolves the D1-live tier and shapes each signer row", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: signersD1([
+        {
+          signer: SIGNER,
+          tx_count: 12,
+          total_fee_tao: 1.5,
+          total_tip_tao: 0.25,
+          last_tx_block: 5000000,
+        },
+      ]),
+    };
+    const { status, body } = await gql(signersQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const got = body.data.chain_signers;
+    assert.equal(got.signer_count, 1);
+    assert.equal(got.sort, "tx_count");
+    assert.deepEqual(got.signers, [
+      {
+        signer: SIGNER,
+        tx_count: 12,
+        total_fee_tao: 1.5,
+        total_tip_tao: 0.25,
+        last_tx_block: 5000000,
+      },
+    ]);
+  });
+
+  test("resolves Postgres-tier data, forwarding window/limit/sort/call_module", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            sort: "total_fee_tao",
+            observed_at: "2026-07-01T00:00:00.000Z",
+            signer_count: 1,
+            signers: [
+              {
+                signer: SIGNER,
+                tx_count: 3,
+                total_fee_tao: 9.5,
+                total_tip_tao: 0,
+                last_tx_block: 42,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      signersQuery(
+        '(window: "30d", limit: 5, sort: "total_fee_tao", call_module: "Balances")',
+      ),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/signers");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(capturedUrl.searchParams.get("sort"), "total_fee_tao");
+    assert.equal(capturedUrl.searchParams.get("call_module"), "Balances");
+    assert.equal(body.data.chain_signers.sort, "total_fee_tao");
+    assert.equal(body.data.chain_signers.signers[0].total_fee_tao, 9.5);
+  });
+
+  test("omits the optional sort/call_module params when the caller supplies neither", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({ signers: [] });
+        },
+      },
+    };
+    await gql(signersQuery(""), env);
+    assert.equal(capturedUrl.searchParams.get("sort"), null);
+    assert.equal(capturedUrl.searchParams.get("call_module"), null);
+    assert.equal(capturedUrl.searchParams.get("window"), "7d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "50");
+  });
+
+  test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
+    // The tier's shape is upstream-controlled, so every field falls back rather
+    // than surfacing null through a non-null SDL field.
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(signersQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_signers, {
+      schema_version: 1,
+      window: "7d",
+      sort: "tx_count",
+      observed_at: null,
+      signer_count: 0,
+      signers: [],
+    });
+  });
+
+  test("a signer row missing every optional metric resolves to nulls, not an error", async () => {
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => Response.json({ signers: [{ signer: SIGNER }] }),
+      },
+    };
+    const { status, body } = await gql(signersQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_signers.signers, [
+      {
+        signer: SIGNER,
+        tx_count: 0,
+        total_fee_tao: null,
+        total_tip_tao: null,
+        last_tx_block: null,
+      },
+    ]);
+  });
+
+  test("clamps an over-max limit to the route's own ceiling", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(signersQuery("(limit: 99999)"), env);
+    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+  });
+
+  test("every documented sort is accepted", async () => {
+    for (const sort of CHAIN_SIGNERS_SORTS) {
+      const { status, body } = await gql(signersQuery(`(sort: "${sort}")`));
+      assert.equal(status, 200, sort);
+      assert.equal(body.errors, undefined);
+      assert.equal(body.data.chain_signers.sort, sort);
+    }
+  });
+
+  test("an unsupported sort is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      signersQuery('(sort: "not_a_real_sort")'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("an unsupported window is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(signersQuery('(window: "1y")'), env);
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("an over-long call_module is BAD_USER_INPUT, matching REST's 100-char bound", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      signersQuery(`(call_module: "${"x".repeat(101)}")`),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(called, false);
+  });
+
+  test("is priced at the relationship-field complexity weight", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.chain_signers,
+      FIELD_COMPLEXITY.chain_weight_setters,
     );
   });
 });


### PR DESCRIPTION
Closes #5882

## What

Adds `Query.chain_signers`, mirroring `GET /api/v1/chain/signers` and MCP `get_chain_signers`: the most-active signer leaderboard — the accounts submitting the most extrinsics, each with its extrinsic count, total fees and tips paid, and last-seen block. Ranked by `tx_count` (default) or `total_fee_tao`, optionally scoped to a single `call_module` pallet.

## How

**No ranking/aggregation logic is duplicated.** The resolver reuses `chain-query-loaders.mjs`'s `loadChainSigners` through the same `tryPostgresTier(METAGRAPH_EXTRINSICS_SOURCE)` → D1-live fallback that `handleChainSigners` takes.

- **`window`** reuses REST's own `analyticsWindow` parse (7d/30d, default 7d) rather than re-implementing it — the same approach the merged `chain_fees`/`chain_calls` resolvers use.
- **`sort`** is validated against `CHAIN_SIGNERS_SORTS`, and **`call_module`** against REST's 100-character bound. Both raise `BAD_USER_INPUT` rather than silently defaulting. `sort` is optional (null → the loader's `tx_count` default), so only a non-null value is checked — matching REST.
- **`limit`** is clamped with the route's own `CHAIN_SIGNERS_LIMIT_DEFAULT`/`MAX` (50/100).
- **`observed_at`** carries the same KV `health:meta` `last_run_at` stamp REST passes. It reuses graphql.mjs's existing memoized `loadObservedAt(context)` rather than importing `readHealthMetaKv` from `workers/api.mjs` — that would be an **import cycle**, since `api.mjs` already imports this module.
- A cold store yields a schema-stable empty leaderboard, never a GraphQL error.

`FIELD_COMPLEXITY` entry at `RELATIONSHIP_FIELD_COMPLEXITY`, matching `chain_weight_setters`.

## Tests

12 new cases in `tests/graphql.test.mjs`:

- cold store → schema-stable empty leaderboard, never an error
- D1-live tier → each signer row shaped correctly
- Postgres tier → `window`/`limit`/`sort`/`call_module` all forwarded as query params
- optional params omitted upstream when the caller supplies neither (defaults: `window=7d`, `limit=50`)
- sparse upstream payload → every field falls back rather than surfacing null through a non-null SDL field
- a signer row missing every optional metric → nulls, not an error
- over-max `limit` clamped to the route ceiling (99999 → 100)
- every documented sort accepted
- unsupported `sort` → `BAD_USER_INPUT`, never reaching the tier
- unsupported `window` → `BAD_USER_INPUT`, never reaching the tier
- over-long `call_module` (101 chars) → `BAD_USER_INPUT`
- complexity weight matches `chain_weight_setters`

```
tests/graphql.test.mjs        passed
tests/chain-analytics.test.mjs passed   (builder unregressed)
tests/analytics.test.mjs      passed   (REST unregressed)
```

Patch coverage measured locally the way codecov measures it — every added line mapped against `coverage-final.json`'s `statementMap`/`branchMap`: **61/61 covered statements and branch arms = 100%** (target 99%), no partials. `eslint` clean, `prettier --check` clean, pushed at `behind: 0`.
