### PR TITLE
feat(graphql): add Query.subnet_health_incidents mirroring REST + MCP(#5884)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -103,6 +103,7 @@ import {
 import { composeLeaderboardsData } from "../workers/request-handlers/analytics-routes.mjs";
 import {
   loadCompareSubnets,
+  loadSubnetIncidents,
   parseCompareDimensionList,
   parseCompareNetuidList,
 } from "./analytics-live.mjs";
@@ -284,6 +285,8 @@ export const SDL = `
     subnet_deregistrations(netuid: Int!, window: String): SubnetDeregistrations!
     "Per-subnet axon-serving activity over a 7d/30d window (distinct servers, AxonServed announcement count, and announcements per server); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/serving."
     subnet_serving(netuid: Int!, window: String): SubnetServing!
+    "One subnet's per-surface SLA (uptime ratio) and reconstructed downtime incidents over a 7d/30d window (default 7d), computed live from the health-probe history: each surface's sample count, uptime_ratio, incident_count, total downtime_ms, and the gap-island incident list. A subnet with no probe history resolves to a schema-stable empty surfaces list, never null. Mirrors GET /api/v1/subnets/{netuid}/health/incidents."
+    subnet_health_incidents(netuid: Int!, window: String): SubnetHealthIncidents!
     "Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
     subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
     "Per-subnet validator weight-setting activity over a 7d/30d window (distinct weight-setters, WeightsSet count, and sets per setter); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/weights."
@@ -1632,6 +1635,34 @@ export const SDL = `
     user_reported: Boolean
   }
 
+  "One reconstructed downtime incident for a subnet surface: a gap-island of consecutive failing probes. Timestamps are epoch-ms."
+  type SubnetIncident {
+    started_at: Float
+    ended_at: Float
+    duration_ms: Float
+    failed_samples: Int!
+  }
+
+  "One operational surface's SLA + reconstructed downtime over the window for a single subnet."
+  type SubnetIncidentSurface {
+    surface_id: String
+    samples: Int!
+    uptime_ratio: Float
+    incident_count: Int!
+    downtime_ms: Float
+    incidents: [SubnetIncident!]!
+  }
+
+  "One subnet's per-surface SLA + reconstructed downtime incidents over the window. Mirrors GET /api/v1/subnets/{netuid}/health/incidents's data envelope."
+  type SubnetHealthIncidents {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    source: String
+    surfaces: [SubnetIncidentSurface!]!
+  }
+
   type ExtrinsicList {
     items: [Extrinsic!]!
     "Page count -- this feed has no cheap grand total, matching REST's extrinsic_count."
@@ -2512,6 +2543,7 @@ export const FIELD_COMPLEXITY = {
   subnet_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_serving: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_health_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3769,6 +3801,62 @@ const rootValue = {
       source: data.source ?? null,
       summary: data.summary ?? null,
       surfaces: data.surfaces ?? [],
+    };
+  },
+
+  async subnet_health_incidents({ netuid, window }, context) {
+    // Reuse the exact analyticsWindow parse/validate REST's handleHealthIncidents
+    // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL
+    // BAD_USER_INPUT error, not a silent empty result.
+    const windowUrl = new URL(context.request.url);
+    windowUrl.search = "";
+    if (window != null) windowUrl.searchParams.set("window", window);
+    const { label, error } = analyticsWindow(windowUrl);
+    if (error) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same tryPostgresTier(METAGRAPH_HEALTH_SOURCE) -> loadSubnetIncidents D1
+    // fallback contract handleHealthIncidents and the get_subnet_health_incidents
+    // MCP tool share -- the tier owns the gap-island incident reconstruction, so
+    // nothing is duplicated here, and a subnet with no probe history yields a
+    // schema-stable empty surfaces list, never a GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", label);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/health/incidents`,
+          params,
+        ),
+        "METAGRAPH_HEALTH_SOURCE",
+      )) ??
+      (await loadSubnetIncidents(graphqlD1(context), netuid, {
+        window: label,
+        observedAt: await loadObservedAt(context),
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? label,
+      observed_at: data.observed_at ?? null,
+      source: data.source ?? null,
+      surfaces: (data.surfaces ?? []).map((s) => ({
+        surface_id: s.surface_id ?? null,
+        samples: s.samples ?? 0,
+        uptime_ratio: s.uptime_ratio ?? null,
+        incident_count: s.incident_count ?? 0,
+        downtime_ms: s.downtime_ms ?? null,
+        incidents: (s.incidents ?? []).map((i) => ({
+          started_at: i.started_at ?? null,
+          ended_at: i.ended_at ?? null,
+          duration_ms: i.duration_ms ?? null,
+          failed_samples: i.failed_samples ?? 0,
+        })),
+      })),
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -6175,6 +6175,150 @@ describe("graphql — subnet_serving (#5715, Postgres-tier + zeroed-card fallbac
   });
 });
 
+describe("graphql — subnet_health_incidents (#5884, Postgres-tier + D1-live fallback)", () => {
+  const NETUID = 3;
+
+  function incidentsQuery(argsClause) {
+    return `{ subnet_health_incidents${argsClause} {
+      schema_version netuid window observed_at source
+      surfaces { surface_id samples uptime_ratio incident_count downtime_ms
+        incidents { started_at ended_at duration_ms failed_samples } }
+    } }`;
+  }
+
+  test("cold store: schema-stable empty surfaces via the D1-live loader", async () => {
+    const { status, body } = await gql(incidentsQuery(`(netuid: ${NETUID})`));
+    assert.equal(status, 200);
+    const d = body.data.subnet_health_incidents;
+    assert.equal(d.schema_version, 1);
+    assert.equal(d.netuid, NETUID);
+    assert.equal(d.window, "7d");
+    assert.equal(d.observed_at, null);
+    assert.equal(d.source, "live-cron-prober");
+    assert.deepEqual(d.surfaces, []);
+  });
+
+  test("resolves Postgres-tier data, forwarding netuid in the path + window param", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (r) => {
+          capturedUrl = new URL(r.url);
+          return Response.json({
+            schema_version: 1,
+            netuid: NETUID,
+            window: "30d",
+            observed_at: "2026-07-10T00:00:00.000Z",
+            source: "live-cron-prober",
+            surfaces: [
+              {
+                surface_id: "srf-1",
+                samples: 100,
+                uptime_ratio: 0.98,
+                incident_count: 1,
+                downtime_ms: 60000,
+                incidents: [
+                  {
+                    started_at: 1000,
+                    ended_at: 61000,
+                    duration_ms: 60000,
+                    failed_samples: 3,
+                  },
+                ],
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      incidentsQuery(`(netuid: ${NETUID}, window: "30d")`),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(
+      capturedUrl.pathname,
+      `/api/v1/subnets/${NETUID}/health/incidents`,
+    );
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    const d = body.data.subnet_health_incidents;
+    assert.equal(d.window, "30d");
+    const s = d.surfaces[0];
+    assert.equal(s.surface_id, "srf-1");
+    assert.equal(s.uptime_ratio, 0.98);
+    assert.equal(s.incident_count, 1);
+    assert.equal(s.incidents[0].duration_ms, 60000);
+    assert.equal(s.incidents[0].failed_samples, 3);
+  });
+
+  test("partial surface/incident rows degrade missing fields to their defaults", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      // First surface omits everything (surface_id + incidents absent); second
+      // has one fully-empty incident. Together they fire every per-surface and
+      // per-incident ?? default / || [] fallback.
+      DATA_API: {
+        fetch: async () =>
+          Response.json({ surfaces: [{}, { incidents: [{}] }] }),
+      },
+    };
+    const { status, body } = await gql(
+      incidentsQuery(`(netuid: ${NETUID})`),
+      env,
+    );
+    assert.equal(status, 200);
+    const d = body.data.subnet_health_incidents;
+    assert.equal(d.schema_version, 1);
+    assert.equal(d.netuid, NETUID);
+    assert.equal(d.window, "7d");
+    assert.equal(d.source, null);
+    const s0 = d.surfaces[0];
+    assert.equal(s0.surface_id, null);
+    assert.equal(s0.samples, 0);
+    assert.equal(s0.uptime_ratio, null);
+    assert.equal(s0.incident_count, 0);
+    assert.equal(s0.downtime_ms, null);
+    assert.deepEqual(s0.incidents, []);
+    const i = d.surfaces[1].incidents[0];
+    assert.equal(i.started_at, null);
+    assert.equal(i.ended_at, null);
+    assert.equal(i.duration_ms, null);
+    assert.equal(i.failed_samples, 0);
+  });
+
+  test("an empty Postgres-tier body degrades to schema-stable defaults with empty surfaces", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(
+      incidentsQuery(`(netuid: ${NETUID})`),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.subnet_health_incidents, {
+      schema_version: 1,
+      netuid: NETUID,
+      window: "7d",
+      observed_at: null,
+      source: null,
+      surfaces: [],
+    });
+  });
+
+  test("rejects an unsupported window with BAD_USER_INPUT", async () => {
+    const { body } = await gql(
+      incidentsQuery(`(netuid: ${NETUID}, window: "99d")`),
+    );
+    assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
+  });
+
+  test("subnet_health_incidents is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_health_incidents, 5);
+  });
+});
+
 describe("graphql — subnet_axon_removals (#5718, Postgres-tier + zeroed-card fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Summary

Closes the REST/GraphQL/MCP parity gap on the per-subnet health-incident surface. `GET /api/v1/subnets/{netuid}/health/incidents` and MCP `get_subnet_health_incidents` already ship, but had no GraphQL mirror.

Adds `Query.subnet_health_incidents(netuid, window)` returning a new `SubnetHealthIncidents` type (`schema_version`, `netuid`, `window`, `observed_at`, `source`, `surfaces[]`), where each `SubnetIncidentSurface` carries the surface's sample count, uptime_ratio, incident_count, total downtime_ms, and its gap-island `SubnetIncident` list (started_at/ended_at/duration_ms/failed_samples, epoch-ms). The resolver reuses the exact `analyticsWindow` validation (7d/30d, default 7d) and hits the same DATA_API health-tier path the REST route uses, with the identical `loadSubnetIncidents(graphqlD1)` D1-live fallback — the tier owns the gap-island reconstruction, no logic duplicated. An unsupported window is `BAD_USER_INPUT`; a subnet with no probe history yields a schema-stable empty surfaces list. Priced at `RELATIONSHIP_FIELD_COMPLEXITY`.

Entirely within `src/graphql.mjs` + its test.

## Testing

- `tests/graphql.test.mjs` — 6 new tests: cold-store empty surfaces, Postgres resolution with netuid-path + window forwarding and nested surface/incident mapping, partial rows exercising **every per-surface and per-incident `??`/`||[]` fallback**, an empty body, the window `BAD_USER_INPUT` rejection, and the complexity weight. **Full graphql suite: 502 pass.**
- eslint 0; **prettier `--check` (repo config) clean**; resolver verified at the branch level (all statements and branches).

Closes #5884
