### PR TITLE
feat(graphql): add Query.account_history mirroring REST + MCP get_account_history (#5888)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -135,6 +135,7 @@ import {
   buildAccountsList,
 } from "./accounts-list.mjs";
 import {
+  buildAccountHistory,
   buildAccountSubnets,
   buildAccountSummary,
   buildAccountTransfers,
@@ -375,6 +376,8 @@ export const SDL = `
     account_counterparties(ss58: String!, counterparty: String, limit: Int): AccountCounterparties!
     "One account's native-TAO transfer feed from the Balances.Transfer event stream, newest first -- each event's block/index, from/to, amount_tao, a direction relative to the queried address (sent = it paid, received = it was paid), and observed_at. direction narrows to sent | received only (default both); block_start/block_end bound the block-height range; page with limit/offset or cursor (opaque keyset from a prior response's next_cursor). An address with no transfers resolves to a schema-stable empty feed, never null. Mirrors GET /api/v1/accounts/{ss58}/transfers."
     account_transfers(ss58: String!, limit: Int, offset: Int, cursor: String, direction: String, block_start: Int, block_end: Int): AccountTransfers!
+    "One account's per-day activity history by ss58 (newest first): each day the account's hotkey had account_events, with the event count, the distinct event kinds, and the first/last block that day, keyset-paginated. Optional netuid scopes to one subnet; from/to (YYYY-MM-DD) bound the day range. A malformed ss58 is a GraphQL error; an address with no history resolves to a schema-stable empty feed, never null. Mirrors GET /api/v1/accounts/{ss58}/history."
+    account_history(ss58: String!, limit: Int, offset: Int, cursor: String, netuid: Int, from: String, to: String): AccountHistory!
     "One account's signed-extrinsic feed, newest first -- the extrinsics whose signer is this address (matched by signer only, not the hotkey/coldkey union account_events uses), each carrying its block/index, hash, call_module/call_function, decoded call_args, success flag, fee and tip. block_start/block_end bound the block-height range; page with limit/offset or cursor (opaque keyset from a prior response's next_cursor). extrinsic_count is the page count, not a grand total. An address that signed nothing resolves to a schema-stable empty feed, never null. Mirrors GET /api/v1/accounts/{ss58}/extrinsics."
     account_extrinsics(ss58: String!, limit: Int, offset: Int, cursor: String, block_start: Int, block_end: Int): AccountExtrinsics!
     "Network-wide economics time series, aggregated per UTC day across all subnets; day_count is 0 and days is empty on a cold rollup, never null. Mirrors GET /api/v1/economics/trends."
@@ -2169,6 +2172,27 @@ export const SDL = `
     transfers: [AccountTransfer!]!
   }
 
+  "One day of an account's activity, aggregated from account_events_daily for the queried hotkey (optionally one subnet)."
+  type AccountHistoryDay {
+    day: String
+    netuid: Int
+    event_count: Int
+    event_kinds: [String!]!
+    first_block: Int
+    last_block: Int
+  }
+
+  "One account's per-day activity history, keyset-paginated newest-first. Mirrors GET /api/v1/accounts/{ss58}/history' data envelope."
+  type AccountHistory {
+    schema_version: Int!
+    ss58: String!
+    day_count: Int!
+    limit: Int
+    offset: Int
+    next_cursor: String
+    days: [AccountHistoryDay!]!
+  }
+
   "One account's signed-extrinsic feed (newest first), backing account_extrinsics. Matched by the extrinsic signer only. extrinsic_count is the page count, matching the REST feed convention. Each item is a full Extrinsic (block/index/hash/call/success/fee/tip)."
   type AccountExtrinsics {
     schema_version: Int!
@@ -2487,6 +2511,7 @@ export const FIELD_COMPLEXITY = {
   account_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   account_counterparties: RELATIONSHIP_FIELD_COMPLEXITY,
   account_transfers: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_history: RELATIONSHIP_FIELD_COMPLEXITY,
   account_extrinsics: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks: RELATIONSHIP_FIELD_COMPLEXITY,
   // A single latest-only row -- but it fans out into the full hyperparameter
@@ -4905,6 +4930,58 @@ const rootValue = {
         direction: t.direction ?? null,
         observed_at: t.observed_at ?? null,
       })),
+    };
+  },
+
+  async account_history(
+    { ss58, limit, offset, cursor, netuid, from, to },
+    context,
+  ) {
+    // Same SS58 validation every account_* resolver uses -- a malformed address
+    // is a GraphQL BAD_USER_INPUT error, not a silent empty feed.
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same FEED_PAGINATION bounds parsePagination applies for REST; netuid/from/
+    // to/cursor are forwarded verbatim for the /history route to re-parse.
+    const safeLimit = clampLimit(limit, FEED_PAGINATION);
+    const safeOffset = clampOffset(offset);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    params.set("offset", String(safeOffset));
+    if (cursor != null) params.set("cursor", cursor);
+    if (netuid != null) params.set("netuid", String(netuid));
+    if (from != null) params.set("from", from);
+    if (to != null) params.set("to", to);
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) the REST handler and
+    // MCP get_account_history tool use. The account_events D1 write path is
+    // retired (#4772), so a tier miss resolves through buildAccountHistory over
+    // an empty scan -- a schema-stable empty feed, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}/history`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      buildAccountHistory([], ss58, {
+        limit: safeLimit,
+        offset: safeOffset,
+        nextCursor: null,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      ss58: data.ss58 ?? ss58,
+      day_count: data.day_count ?? 0,
+      limit: data.limit ?? safeLimit,
+      offset: data.offset ?? safeOffset,
+      next_cursor: data.next_cursor ?? null,
+      days: data.days ?? [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -7296,6 +7296,142 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
   });
 });
 
+describe("graphql — account_history (#5888, Postgres-tier day feed)", () => {
+  const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+  function dataApi(response, capture) {
+    return {
+      fetch: async (req) => {
+        if (capture) capture.url = new URL(req.url);
+        return response;
+      },
+    };
+  }
+
+  const HISTORY_QUERY = `{ account_history(ss58: "${SS58}") {
+      schema_version ss58 day_count limit offset next_cursor
+      days { day netuid event_count event_kinds first_block last_block }
+    } }`;
+
+  test("cold store: no Postgres flag returns a schema-stable empty feed, never null", async () => {
+    const { status, body } = await gql(HISTORY_QUERY);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_history, {
+      schema_version: 1,
+      ss58: SS58,
+      day_count: 0,
+      limit: 100,
+      offset: 0,
+      next_cursor: null,
+      days: [],
+    });
+  });
+
+  test("an invalid ss58 is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      '{ account_history(ss58: "not-a-valid-address") { ss58 } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("resolves the Postgres-tier envelope, preserving each day's event_kinds list", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          day_count: 1,
+          limit: 50,
+          offset: 0,
+          next_cursor: "20260715:3",
+          days: [
+            {
+              day: "2026-07-15",
+              netuid: 3,
+              event_count: 12,
+              event_kinds: ["NeuronRegistered", "AxonServed"],
+              first_block: 1000,
+              last_block: 1050,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(HISTORY_QUERY, env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.account_history.day_count, 1);
+    assert.equal(body.data.account_history.next_cursor, "20260715:3");
+    const d = body.data.account_history.days[0];
+    assert.equal(d.day, "2026-07-15");
+    assert.equal(d.netuid, 3);
+    assert.equal(d.event_count, 12);
+    assert.deepEqual(d.event_kinds, ["NeuronRegistered", "AxonServed"]);
+    assert.equal(d.first_block, 1000);
+  });
+
+  test("hits /api/v1/accounts/{ss58}/history and forwards every filter", async () => {
+    const cap = {};
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          ss58: SS58,
+          day_count: 0,
+          limit: 5,
+          offset: 2,
+          next_cursor: null,
+          days: [],
+        }),
+        cap,
+      ),
+    };
+    await gql(
+      `{ account_history(ss58: "${SS58}", limit: 5, offset: 2, cursor: "abc", netuid: 7, from: "2026-07-01", to: "2026-07-15") { day_count } }`,
+      env,
+    );
+    assert.equal(cap.url.pathname, `/api/v1/accounts/${SS58}/history`);
+    assert.equal(cap.url.searchParams.get("limit"), "5");
+    assert.equal(cap.url.searchParams.get("offset"), "2");
+    assert.equal(cap.url.searchParams.get("cursor"), "abc");
+    assert.equal(cap.url.searchParams.get("netuid"), "7");
+    assert.equal(cap.url.searchParams.get("from"), "2026-07-01");
+    assert.equal(cap.url.searchParams.get("to"), "2026-07-15");
+  });
+
+  test("a malformed Postgres-tier body degrades to a schema-stable empty feed", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(HISTORY_QUERY, env);
+    assert.equal(status, 200);
+    assert.equal(body.data.account_history.day_count, 0);
+    assert.deepEqual(body.data.account_history.days, []);
+  });
+
+  test("account_history is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.account_history, 5);
+  });
+});
+
 describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () => {
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
   const OTHER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";


### PR DESCRIPTION
Closes the parity gap: `GET /api/v1/accounts/{ss58}/history` and the `get_account_history` MCP tool expose an account's per-day activity feed (from `account_events_daily`), but GraphQL had no mirror.

## What
- Adds `Query.account_history(ss58: String!, limit, offset, cursor, netuid, from, to): AccountHistory!` with its type family (`AccountHistory` / `AccountHistoryDay`).
- Mirrors the sibling `account_transfers` feed exactly: SS58 validation, `FEED_PAGINATION` clamp, and the `tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)` → `buildAccountHistory([], …)` empty-scan fallback the REST route / MCP tool use (the `account_events` D1 write path is retired, #4772) — **no query/aggregation logic duplicated**. `netuid`/`from`/`to`/`cursor` are forwarded verbatim for the route to re-parse.
- Malformed `ss58` → GraphQL `BAD_USER_INPUT`; an address with no history → schema-stable empty feed, never null.

## Test coverage
`tests/graphql.test.mjs` — an `account_history` block: cold-store empty, invalid-ss58 `BAD_USER_INPUT` (tier never called), Postgres-tier resolution preserving each day's `event_kinds` list, all filters forwarded to `/api/v1/accounts/{ss58}/history`, malformed-body defaults, and the fan-out complexity weight.

`npm run test -- graphql` green (502 tests); new resolver at 100% patch coverage; `lint` + `format:check` clean.

Closes #5888
