### PR TITLE
test(python-sdk): cover paginate, endpoints, surfaces, agent_catalog

### DIFF
--- a/python/tests/test_aio.py
+++ b/python/tests/test_aio.py
@@ -9,7 +9,14 @@ try:
 except ImportError:  # pragma: no cover - exercised only without the extra
     _HAS_HTTPX = False
 
-from metagraphed import AsyncMetagraphedClient, MetagraphedError, Subnet
+from metagraphed import (
+    AgentCatalogSubnet,
+    AsyncMetagraphedClient,
+    Endpoint,
+    MetagraphedError,
+    Subnet,
+    Surface,
+)
 
 
 class _FakeAsyncHttp:
@@ -97,6 +104,203 @@ class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(subnets[0].netuid, 7)
         self.assertEqual(subnets[0].name, "Allways")
         self.assertEqual(subnets[0].raw["name"], "Allways")
+
+    async def test_paginate_follows_next_cursor_with_nested_collection(self):
+        # Mirrors README async usage of paginate via fetch_all / typed helpers:
+        # nested collection rows + cursor continuation.
+        page1 = httpx.Response(
+            200,
+            json={
+                "ok": True,
+                "data": {
+                    "subnets": [
+                        {
+                            "netuid": 1,
+                            "name": "Apex",
+                            "integration_readiness": 40,
+                        }
+                    ]
+                },
+                "meta": {
+                    "pagination": {
+                        "collection": "subnets",
+                        "next_cursor": "c2",
+                    }
+                },
+            },
+        )
+        page2 = httpx.Response(
+            200,
+            json={
+                "ok": True,
+                "data": {
+                    "subnets": [
+                        {
+                            "netuid": 7,
+                            "name": "Allways",
+                            "integration_readiness": 90,
+                        }
+                    ]
+                },
+                "meta": {
+                    "pagination": {
+                        "collection": "subnets",
+                        "next_cursor": None,
+                    }
+                },
+            },
+        )
+        client = self._client(page1, page2)
+        seen = []
+        async for page in client.paginate("/api/v1/subnets", query={"limit": 1}):
+            seen.extend(page["data"]["subnets"])
+
+        self.assertEqual(
+            [(row["netuid"], row["name"], row["integration_readiness"]) for row in seen],
+            [(1, "Apex", 40), (7, "Allways", 90)],
+        )
+        self.assertEqual(client._client.calls[0][2], {"limit": 1})
+        self.assertEqual(client._client.calls[1][2]["cursor"], "c2")
+
+    async def test_surfaces_returns_typed_models(self):
+        client = self._client(
+            httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "surfaces": [
+                            {
+                                "id": "sn-7-openapi",
+                                "netuid": 7,
+                                "kind": "openapi",
+                                "name": "Allways OpenAPI",
+                                "url": "https://api.example.com/openapi.json",
+                                "provider": "allways",
+                                "auth_required": False,
+                                "authority": "official",
+                                "public_safe": True,
+                                "schema_url": "https://api.example.com/openapi.json",
+                            }
+                        ]
+                    },
+                    "meta": {
+                        "pagination": {
+                            "collection": "surfaces",
+                            "next_cursor": None,
+                        }
+                    },
+                },
+            )
+        )
+        surfaces = await client.surfaces(kind="openapi")
+        self.assertEqual(len(surfaces), 1)
+        surface = surfaces[0]
+        self.assertIsInstance(surface, Surface)
+        self.assertEqual(surface.id, "sn-7-openapi")
+        self.assertEqual(surface.netuid, 7)
+        self.assertEqual(surface.kind, "openapi")
+        self.assertEqual(surface.name, "Allways OpenAPI")
+        self.assertEqual(surface.url, "https://api.example.com/openapi.json")
+        self.assertEqual(surface.provider, "allways")
+        self.assertIs(surface.auth_required, False)
+        self.assertIs(surface.public_safe, True)
+        self.assertEqual(surface.schema_url, "https://api.example.com/openapi.json")
+        self.assertEqual(surface.raw["authority"], "official")
+
+    async def test_endpoints_returns_typed_models(self):
+        client = self._client(
+            httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "endpoints": [
+                            {
+                                "id": "ep-sn-7-subnet-api",
+                                "surface_id": "sn-7-subnet-api",
+                                "surface_key": "hk7subnetapi",
+                                "netuid": 7,
+                                "layer": "subnet",
+                                "kind": "subnet-api",
+                                "url": "https://api.example.com/v1",
+                                "provider": "allways",
+                                "operator": "allways",
+                                "auth_required": False,
+                                "public_safe": True,
+                                "classification": "primary",
+                                "monitoring_policy": "probe",
+                                "monitoring_status": "monitored",
+                                "health_source": "probe-derived",
+                                "health_stale": False,
+                                "last_checked": "2026-07-15T00:00:00.000Z",
+                                "last_ok": "2026-07-15T00:00:00.000Z",
+                                "status": "ok",
+                                "score": 100,
+                            }
+                        ]
+                    },
+                    "meta": {
+                        "pagination": {
+                            "collection": "endpoints",
+                            "next_cursor": None,
+                        }
+                    },
+                },
+            )
+        )
+        endpoints = await client.endpoints()
+        self.assertEqual(len(endpoints), 1)
+        endpoint = endpoints[0]
+        self.assertIsInstance(endpoint, Endpoint)
+        self.assertEqual(endpoint.surface_id, "sn-7-subnet-api")
+        self.assertEqual(endpoint.netuid, 7)
+        self.assertEqual(endpoint.kind, "subnet-api")
+        self.assertEqual(endpoint.url, "https://api.example.com/v1")
+        self.assertEqual(endpoint.provider, "allways")
+        self.assertEqual(endpoint.classification, "primary")
+        self.assertEqual(endpoint.monitoring_status, "monitored")
+        self.assertEqual(endpoint.raw["id"], "ep-sn-7-subnet-api")
+
+    async def test_agent_catalog_returns_typed_model(self):
+        client = self._client(
+            httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "schema_version": 1,
+                    "data": {
+                        "netuid": 7,
+                        "slug": "allways",
+                        "name": "AllwaysAI",
+                        "subnet_type": "inference",
+                        "completeness_score": 82.5,
+                        "integration_readiness": 90,
+                        "service_count": 1,
+                        "services": [
+                            {
+                                "surface_id": "sn-7-subnet-api",
+                                "kind": "subnet-api",
+                                "base_url": "https://api.example.com/v1",
+                                "auth_required": False,
+                            }
+                        ],
+                    },
+                },
+            )
+        )
+        catalog = await client.agent_catalog(7)
+        self.assertIsInstance(catalog, AgentCatalogSubnet)
+        self.assertEqual(catalog.netuid, 7)
+        self.assertEqual(catalog.slug, "allways")
+        self.assertEqual(catalog.name, "AllwaysAI")
+        self.assertEqual(catalog.subnet_type, "inference")
+        self.assertEqual(catalog.completeness_score, 82.5)
+        self.assertEqual(catalog.integration_readiness, 90)
+        self.assertEqual(catalog.service_count, 1)
+        self.assertEqual(catalog.services[0]["base_url"], "https://api.example.com/v1")
+        self.assertEqual(
+            client._client.calls[0][1],
+            "https://api.metagraph.sh/api/v1/agent-catalog/7",
+        )
 
     async def test_http_error_raises_with_status_and_message(self):
         client = self._client(

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -9,6 +9,8 @@ from unittest import mock
 import metagraphed.client as client
 
 from metagraphed import (
+    AgentCatalogSubnet,
+    Endpoint,
     MetagraphedClient,
     MetagraphedError,
     Provider,
@@ -540,6 +542,229 @@ class FetchAllAndModelsTest(unittest.TestCase):
         # up as a slug (Subnet has no such alias).
         subnet = Subnet.from_dict({"id": "x", "slug": "real-slug"})
         self.assertEqual(subnet.slug, "real-slug")
+
+    def test_client_paginate_follows_next_cursor_with_nested_collection(self):
+        # Mirrors README's client.paginate usage: list endpoints nest rows under
+        # data[meta.pagination.collection] and follow next_cursor across pages.
+        pages = [
+            {
+                "ok": True,
+                "data": {
+                    "subnets": [
+                        {
+                            "netuid": 1,
+                            "name": "Apex",
+                            "integration_readiness": 40,
+                        }
+                    ]
+                },
+                "meta": {
+                    "pagination": {
+                        "collection": "subnets",
+                        "next_cursor": "c2",
+                    }
+                },
+            },
+            {
+                "ok": True,
+                "data": {
+                    "subnets": [
+                        {
+                            "netuid": 7,
+                            "name": "Allways",
+                            "integration_readiness": 90,
+                        }
+                    ]
+                },
+                "meta": {
+                    "pagination": {
+                        "collection": "subnets",
+                        "next_cursor": None,
+                    }
+                },
+            },
+        ]
+        captured_urls = []
+        responses = iter(_FakeResponse(page) for page in pages)
+
+        def fake_urlopen(request, timeout=None):
+            captured_urls.append(request.full_url)
+            return next(responses)
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            seen = []
+            for page in MetagraphedClient().paginate(
+                "/api/v1/subnets", query={"limit": 1}
+            ):
+                seen.extend(page["data"]["subnets"])
+
+        self.assertEqual(
+            [(row["netuid"], row["name"], row["integration_readiness"]) for row in seen],
+            [(1, "Apex", 40), (7, "Allways", 90)],
+        )
+        self.assertIn("limit=1", captured_urls[0])
+        self.assertIn("cursor=c2", captured_urls[1])
+
+    def test_surfaces_convenience_returns_typed_models(self):
+        # Realistic SurfacesArtifact row shape (schemas/components/04-surfaces.schema.json).
+        pages = [
+            {
+                "data": {
+                    "surfaces": [
+                        {
+                            "id": "sn-7-openapi",
+                            "netuid": 7,
+                            "kind": "openapi",
+                            "name": "Allways OpenAPI",
+                            "url": "https://api.example.com/openapi.json",
+                            "provider": "allways",
+                            "auth_required": False,
+                            "authority": "official",
+                            "public_safe": True,
+                            "schema_url": "https://api.example.com/openapi.json",
+                        }
+                    ]
+                },
+                "meta": {
+                    "pagination": {
+                        "collection": "surfaces",
+                        "next_cursor": None,
+                    }
+                },
+            }
+        ]
+        with self._patch_pages(pages):
+            surfaces = MetagraphedClient().surfaces(kind="openapi")
+        self.assertEqual(len(surfaces), 1)
+        surface = surfaces[0]
+        self.assertIsInstance(surface, Surface)
+        self.assertEqual(surface.id, "sn-7-openapi")
+        self.assertEqual(surface.netuid, 7)
+        self.assertEqual(surface.kind, "openapi")
+        self.assertEqual(surface.name, "Allways OpenAPI")
+        self.assertEqual(surface.url, "https://api.example.com/openapi.json")
+        self.assertEqual(surface.provider, "allways")
+        self.assertIs(surface.auth_required, False)
+        self.assertIs(surface.public_safe, True)
+        self.assertEqual(surface.schema_url, "https://api.example.com/openapi.json")
+        self.assertEqual(surface.raw["authority"], "official")
+
+    def test_endpoints_convenience_returns_typed_models(self):
+        # Realistic EndpointResource shape (schemas/api-components.schema.json):
+        # the backend exposes `url`, not `base_url`.
+        pages = [
+            {
+                "data": {
+                    "endpoints": [
+                        {
+                            "id": "ep-sn-7-subnet-api",
+                            "surface_id": "sn-7-subnet-api",
+                            "surface_key": "hk7subnetapi",
+                            "netuid": 7,
+                            "layer": "subnet",
+                            "kind": "subnet-api",
+                            "url": "https://api.example.com/v1",
+                            "provider": "allways",
+                            "operator": "allways",
+                            "auth_required": False,
+                            "public_safe": True,
+                            "classification": "primary",
+                            "monitoring_policy": "probe",
+                            "monitoring_status": "monitored",
+                            "health_source": "probe-derived",
+                            "health_stale": False,
+                            "last_checked": "2026-07-15T00:00:00.000Z",
+                            "last_ok": "2026-07-15T00:00:00.000Z",
+                            "status": "ok",
+                            "score": 100,
+                        }
+                    ]
+                },
+                "meta": {
+                    "pagination": {
+                        "collection": "endpoints",
+                        "next_cursor": None,
+                    }
+                },
+            }
+        ]
+        with self._patch_pages(pages):
+            endpoints = MetagraphedClient().endpoints()
+        self.assertEqual(len(endpoints), 1)
+        endpoint = endpoints[0]
+        self.assertIsInstance(endpoint, Endpoint)
+        self.assertEqual(endpoint.surface_id, "sn-7-subnet-api")
+        self.assertEqual(endpoint.netuid, 7)
+        self.assertEqual(endpoint.kind, "subnet-api")
+        self.assertEqual(endpoint.url, "https://api.example.com/v1")
+        self.assertEqual(endpoint.provider, "allways")
+        self.assertEqual(endpoint.classification, "primary")
+        self.assertEqual(endpoint.monitoring_status, "monitored")
+        self.assertEqual(endpoint.raw["id"], "ep-sn-7-subnet-api")
+        self.assertEqual(endpoint.raw["url"], "https://api.example.com/v1")
+
+    def test_endpoint_from_dict_populates_url_from_endpoint_resource(self):
+        endpoint = Endpoint.from_dict(
+            {
+                "surface_id": "sn-22-docs",
+                "netuid": 22,
+                "kind": "docs",
+                "url": "https://docs.example.com",
+                "provider": "desearch",
+                "classification": "reference",
+                "monitoring_status": "not_monitored",
+                "unknown_extra": True,
+            }
+        )
+        self.assertEqual(endpoint.url, "https://docs.example.com")
+        self.assertEqual(endpoint.surface_id, "sn-22-docs")
+        self.assertEqual(endpoint.kind, "docs")
+        self.assertIs(endpoint.raw["unknown_extra"], True)
+
+    def test_agent_catalog_returns_typed_model(self):
+        # Realistic AgentCatalogSubnetArtifact data envelope
+        # (schemas/api-components.schema.json AgentCatalogSubnetArtifact).
+        def fake_urlopen(request, timeout=None):
+            self.assertIn("/api/v1/agent-catalog/7", request.full_url)
+            return _FakeResponse(
+                {
+                    "ok": True,
+                    "schema_version": 1,
+                    "data": {
+                        "netuid": 7,
+                        "slug": "allways",
+                        "name": "AllwaysAI",
+                        "subnet_type": "inference",
+                        "completeness_score": 82.5,
+                        "integration_readiness": 90,
+                        "service_count": 1,
+                        "services": [
+                            {
+                                "surface_id": "sn-7-subnet-api",
+                                "kind": "subnet-api",
+                                "base_url": "https://api.example.com/v1",
+                                "auth_required": False,
+                            }
+                        ],
+                    },
+                }
+            )
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            catalog = MetagraphedClient().agent_catalog(7)
+
+        self.assertIsInstance(catalog, AgentCatalogSubnet)
+        self.assertEqual(catalog.netuid, 7)
+        self.assertEqual(catalog.slug, "allways")
+        self.assertEqual(catalog.name, "AllwaysAI")
+        self.assertEqual(catalog.subnet_type, "inference")
+        self.assertEqual(catalog.completeness_score, 82.5)
+        self.assertEqual(catalog.integration_readiness, 90)
+        self.assertEqual(catalog.service_count, 1)
+        self.assertEqual(len(catalog.services), 1)
+        self.assertEqual(catalog.services[0]["base_url"], "https://api.example.com/v1")
+        self.assertEqual(catalog.services[0]["surface_id"], "sn-7-subnet-api")
+        self.assertEqual(catalog.raw["name"], "AllwaysAI")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #5989

## What

Adds hermetic sync + async coverage for the four Python SDK client methods that were documented in `python/README.md` but never exercised in CI: `.paginate()`, `.endpoints()`, `.surfaces()`, and `.agent_catalog()`, plus direct coverage of the `Endpoint` and `AgentCatalogSubnet` models.

## How

Mirrors the existing `subnets()` convenience-test style in `test_client.py` / `test_aio.py`:

- **`client.paginate()`** — nested collection pages with `next_cursor`, asserts row field values and cursor forwarding (not only the module-level `metagraphed_paginate` helper already covered).
- **`.surfaces()`** — realistic `SurfacesArtifact` row shape; asserts id/netuid/kind/name/url/provider/auth/public_safe/schema_url (+ `.raw`).
- **`.endpoints()`** — realistic `EndpointResource` fixture (backend exposes `url`, not `base_url`); asserts surface_id/netuid/kind/**url**/provider/classification/monitoring_status.
- **`.agent_catalog(netuid)`** — realistic `AgentCatalogSubnetArtifact` envelope; asserts completeness_score, integration_readiness, service_count, and `services[].base_url`.
- Extra: `Endpoint.from_dict()` asserts `url` populates from an EndpointResource-shaped dict.

Same cases land on both sync and async clients.

## Validation

```sh
cd python && uv run --extra test python -m unittest discover -s tests -v