### PR TITLE
refactor(scripts): use shared chunkRows in subnet-snapshots backfill

### DIFF
--- a/scripts/backfill-subnet-snapshots-postgres.mjs
+++ b/scripts/backfill-subnet-snapshots-postgres.mjs
@@ -45,7 +45,7 @@
 import { spawnSync } from "node:child_process";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { repoRoot } from "./lib.mjs";
+import { chunkRows, repoRoot } from "./lib.mjs";
 
 // Column order matches Postgres's `subnet_snapshots` exactly (verified via
 // `psql -c '\d subnet_snapshots'` against the live indexer instance), which
@@ -200,13 +200,12 @@ export function rowTuple(row) {
   return `(${COLUMNS.map((column) => sqlLiteral(column, row[column])).join(", ")})`;
 }
 
-export function chunkRows(array, size) {
-  const chunks = [];
-  for (let i = 0; i < array.length; i += size) {
-    chunks.push(array.slice(i, i + size));
-  }
-  return chunks;
-}
+// Re-export the shared chunkRows from lib.mjs so existing importers keep a
+// single, canonical implementation. This module used to carry its own copy
+// that returned a bare [] for empty input, versus lib.mjs's "always at least
+// one chunk" ([[]]); the two never diverge here because main() throws on zero
+// rows before buildBackfillSql ever calls chunkRows.
+export { chunkRows };
 
 export function insertStatement(rows) {
   const values = rows.map(rowTuple).join(",\n  ");

--- a/tests/backfill-subnet-snapshots-postgres.test.mjs
+++ b/tests/backfill-subnet-snapshots-postgres.test.mjs
@@ -18,6 +18,7 @@ import {
   rowTuple,
   sqlLiteral,
 } from "../scripts/backfill-subnet-snapshots-postgres.mjs";
+import { chunkRows as sharedChunkRows } from "../scripts/lib.mjs";
 
 const SAMPLE_ROW = {
   rowid: 1,
@@ -178,8 +179,18 @@ test("chunkRows splits into fixed-size chunks with a final remainder", () => {
   assert.deepEqual(chunkRows(rows, 3), [[0, 1, 2], [3, 4, 5], [6]]);
 });
 
-test("chunkRows returns an empty array for empty input", () => {
-  assert.deepEqual(chunkRows([], 100), []);
+test("chunkRows now delegates to the shared lib.mjs implementation", () => {
+  // The local reimplementation was removed in favor of the single canonical
+  // helper; confirm the export the script exposes IS lib.mjs's chunkRows.
+  assert.equal(chunkRows, sharedChunkRows);
+});
+
+test("chunkRows uses the shared 'always at least one chunk' semantics", () => {
+  // The shared helper returns [[]] (never a bare []) for empty input -- this
+  // is the one place the old local copy diverged, but it is unreachable here:
+  // main() throws on zero rows before buildBackfillSql/chunkRows can run, so
+  // every real (non-empty) input is chunked identically to before.
+  assert.deepEqual(chunkRows([], 100), [[]]);
 });
 
 test("insertStatement emits an upsert that overwrites every non-key column", () => {


### PR DESCRIPTION
refactor(scripts): use shared chunkRows in subnet-snapshots backfill

backfill-subnet-snapshots-postgres.mjs carried its own chunkRows copy
that returned a bare [] for empty input, diverging from lib.mjs's shared
"always at least one chunk" ([[]]) contract. The two never actually
disagree here -- main() throws on zero rows before buildBackfillSql ever
calls chunkRows -- but the duplicated helper is a silent-divergence trap
for any future caller.

Drop the local reimplementation and re-export lib.mjs's chunkRows so a
single canonical implementation exists. Non-empty inputs (every real
input for this script) chunk identically to before.

Update the tests: confirm the exported chunkRows IS lib.mjs's, and that
the shared empty-input semantics ([[]]) now apply.

Closes #5994

