### PR TITLE
fix(python-sdk): drop None elements in list-valued query params

### DIFF
--- a/python/src/metagraphed/aio.py
+++ b/python/src/metagraphed/aio.py
@@ -27,6 +27,7 @@ from .client import (
     _interpolate,
     _jsonrpc_result,
     _next_cursor,
+    _query_pairs,
 )
 from .models import AgentCatalogSubnet, Endpoint, Provider, Subnet, Surface
 
@@ -167,11 +168,10 @@ class AsyncMetagraphedClient:
         numeric ``Retry-After`` capped at 60 seconds.
         """
         url = self.base_url.rstrip("/") + _interpolate(path, path_params)
-        params = (
-            {key: value for key, value in query.items() if value is not None}
-            if query
-            else None
-        )
+        # Same `_query_pairs` normalization as the sync client: drop top-level
+        # None, drop None elements inside list values, and coerce bools to
+        # lowercase wire form so sync and async emit identical query strings.
+        params = dict(_query_pairs(query)) if query else None
         merged_headers = _default_headers(headers)
         return await self._send_json(
             lambda: self._client.get(url, params=params, headers=merged_headers),

--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -179,13 +179,15 @@ def _jsonrpc_result(parsed: Any, method: str) -> Any:
 def _query_pairs(query: Mapping[str, Any]) -> List[Tuple[str, Any]]:
     """Normalize a query mapping into ``urlencode``-ready ``(key, value)`` pairs.
 
-    Drops ``None`` values and coerces Python ``bool`` to the lowercase
-    ``"true"``/``"false"`` the API expects. ``str(True)`` would otherwise send
-    ``"True"``, which the API compares ``=== "true"`` and silently ignores — so a
-    boolean filter such as ``validator_permit=True`` would be dropped and return
-    unfiltered results (diverging from both the async/httpx client and the
-    TypeScript client). Booleans nested in a sequence value — expanded by
-    ``doseq=True`` — are coerced element-wise so list-valued filters normalize too.
+    Drops ``None`` values at the top level **and** ``None`` elements inside a
+    list/tuple value (so ``{"kind": ["docs", None, "openapi"]}`` becomes
+    ``kind=docs&kind=openapi``, never a literal ``"None"`` or an empty string).
+    Coerces Python ``bool`` to the lowercase ``"true"``/``"false"`` the API
+    expects — ``str(True)`` would otherwise send ``"True"``, which the API
+    compares ``=== "true"`` and silently ignores. Booleans nested in a sequence
+    are coerced element-wise. Sync (``urlencode(..., doseq=True)``) and async
+    (httpx ``params``) both consume this helper so they emit identical query
+    strings for the same input.
     """
 
     def coerce(value: Any) -> Any:
@@ -194,7 +196,7 @@ def _query_pairs(query: Mapping[str, Any]) -> List[Tuple[str, Any]]:
         if isinstance(value, bool):
             return "true" if value else "false"
         if isinstance(value, (list, tuple)):
-            return [coerce(item) for item in value]
+            return [coerce(item) for item in value if item is not None]
         return value
 
     return [

--- a/python/tests/test_aio.py
+++ b/python/tests/test_aio.py
@@ -1,5 +1,6 @@
 """Hermetic tests for the async client (httpx stubbed, no network)."""
 
+import urllib.parse
 import unittest
 
 try:
@@ -10,6 +11,7 @@ except ImportError:  # pragma: no cover - exercised only without the extra
     _HAS_HTTPX = False
 
 from metagraphed import AsyncMetagraphedClient, MetagraphedError, Subnet
+from metagraphed.client import _query_pairs
 
 
 class _FakeAsyncHttp:
@@ -65,6 +67,20 @@ class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
         client = self._client(httpx.Response(200, json={"data": []}))
         await client.fetch("/api/v1/subnets", query={"limit": 5, "cursor": None})
         self.assertEqual(client._client.calls[0][2], {"limit": 5})
+
+    async def test_sequence_query_drops_none_elements(self):
+        # Same contract as the sync client (#5983): None inside a list is dropped
+        # (not sent as "" the way raw httpx would), matching `_query_pairs`.
+        client = self._client(httpx.Response(200, json={"data": []}))
+        query = {"kind": ["docs", None, "openapi"], "cursor": None}
+        await client.fetch("/api/v1/surfaces", query=query)
+        self.assertEqual(client._client.calls[0][2], {"kind": ["docs", "openapi"]})
+        # Sync urlencode of the shared pairs must match that filtered list —
+        # never a literal "None" and never an empty kind= slot.
+        encoded = urllib.parse.urlencode(_query_pairs(query), doseq=True)
+        self.assertEqual(encoded, "kind=docs&kind=openapi")
+        self.assertNotIn("None", encoded)
+        self.assertNotIn("kind=&", encoded + "&")
 
     async def test_fetch_all_collects_nested_collection_following_cursor(self):
         # List endpoints nest rows under data[meta.pagination.collection].

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -116,6 +116,32 @@ class ClientTest(unittest.TestCase):
         self.assertIn("flags=true", captured["url"])
         self.assertIn("flags=false", captured["url"])
 
+    def test_sequence_query_drops_none_elements(self):
+        # None inside a list must be dropped (documented "None values are
+        # dropped"), not urlencoded as the literal string "None".
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            return _FakeResponse({"ok": True})
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            metagraphed_fetch(
+                "/api/v1/surfaces",
+                query={"kind": ["docs", None, "openapi"], "cursor": None},
+            )
+
+        self.assertIn("kind=docs", captured["url"])
+        self.assertIn("kind=openapi", captured["url"])
+        self.assertNotIn("kind=None", captured["url"])
+        self.assertNotIn("kind=&", captured["url"] + "&")
+        self.assertNotIn("cursor=", captured["url"])
+        # Same normalized pairs the async client feeds httpx (#5983).
+        self.assertEqual(
+            client._query_pairs({"kind": ["docs", None, "openapi"], "cursor": None}),
+            [("kind", ["docs", "openapi"])],
+        )
+
     def test_base_url_override(self):
         captured = {}
 


### PR DESCRIPTION
Closes #5983

## What

`_query_pairs` only dropped top-level `None` query values. A `None` inside a list (e.g. `{"kind": ["docs", None, "openapi"]}`) leaked through as the literal string `"None"` on the sync client, while httpx on the async path sent an empty string. Both violate the documented "None values are dropped" contract and diverged from each other.

## How

- Filter `None` elements out of list/tuple values inside `_query_pairs` (before bool coerce / `urlencode(..., doseq=True)`).
- Route the async client's `fetch` through the same `_query_pairs` helper (via `dict(...)`) so sync and async produce identical normalized params for the same input — including lowercase bool wire form.

## Tests

- Sync: `test_sequence_query_drops_none_elements` — asserts `kind=docs&kind=openapi`, no `kind=None` / empty slot, and shared `_query_pairs` output.
- Async: matching case — httpx `params == {"kind": ["docs", "openapi"]}`, and `urlencode(_query_pairs(...), doseq=True)` equals the sync string.

## Validation

```sh
cd python && uv run --extra test python -m unittest discover -s tests -v