### PR TITLE
feat(graphql): add Query.chain_identity_history mirroring REST + MCP

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -92,6 +92,7 @@ import {
   clampOffset,
 } from "../workers/request-params.mjs";
 import { loadSubnetIdentityHistory } from "./subnet-identity-history.mjs";
+import { loadChainIdentityHistory } from "./chain-identity-history.mjs";
 import {
   buildGlobalHealth,
   formatLeaderboards,
@@ -388,6 +389,8 @@ export const SDL = `
     subnet_movers(window: String, sort: String, limit: Int): SubnetMovers!
     "Network-wide validator-set churn across all subnets over a 7d/30d/90d window (default 30d): every subnet ranked by gross validator churn (entered + exited) between the window's start and end snapshots, each with its retention and 0-100 stability score, plus a network rollup and the network-wide stability spread. neuron_daily-derived; comparable is false and the leaderboard empty on a cold or single-snapshot store, never null. Mirrors GET /api/v1/chain/turnover."
     chain_turnover(window: String, limit: Int): ChainTurnover!
+    "Network-wide identity-change feed: the most-recent SubnetIdentitiesV3 changes across every subnet (each entry carries its netuid), newest first, capped by limit; a cold/absent store resolves to a schema-stable empty feed (count 0), never null. Mirrors GET /api/v1/chain/identity-history."
+    chain_identity_history(limit: Int): ChainIdentityHistory!
     "Network-wide validator weight-setting activity leaderboard over a 7d/30d window (default 7d): subnets ranked by WeightsSet events with each's distinct-setter count and sets-per-setter update intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. Mirrors GET /api/v1/chain/weights."
     chain_weights(window: String, limit: Int): ChainWeights!
     "Network-wide axon-serving announcement leaderboard over a 7d/30d window (default 7d): subnets ranked by AxonServed announcements with each's distinct-server count and announcements-per-server re-announcement intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The network-wide counterpart of subnet_serving. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/serving."
@@ -1253,6 +1256,28 @@ export const SDL = `
     discord: String
     logo_url: String
     identity_hash: String
+  }
+
+  "One cross-subnet identity change in the network-wide feed (carries its netuid)."
+  type ChainIdentityHistoryEntry {
+    netuid: Int
+    block_number: Int
+    observed_at: String
+    subnet_name: String
+    symbol: String
+    description: String
+    github_repo: String
+    subnet_url: String
+    discord: String
+    logo_url: String
+    identity_hash: String
+  }
+
+  type ChainIdentityHistory {
+    schema_version: Int!
+    count: Int!
+    subnet_count: Int!
+    changes: [ChainIdentityHistoryEntry!]!
   }
 
   "Per-subnet neuron-registration activity over a window (#5720). Zeroed card (0 counts) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/registrations."
@@ -2522,6 +2547,7 @@ export const FIELD_COMPLEXITY = {
   subnet_concentration: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_concentration_history: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   blocks_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   runtime: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3313,6 +3339,34 @@ const rootValue = {
       offset: data.offset ?? safeOffset,
       next_cursor: data.next_cursor ?? null,
       entries: data.entries || [],
+    };
+  },
+
+  async chain_identity_history({ limit }, context) {
+    // Same FEED_PAGINATION clamp REST applies. This chain-wide feed is
+    // limit-only (no offset/cursor) -- the network view returns the most-recent
+    // changes across every subnet in one pass.
+    const safeLimit = clampLimit(limit, FEED_PAGINATION);
+    const params = new URLSearchParams();
+    params.set("limit", String(safeLimit));
+    // Same tryPostgresTier(METAGRAPH_SUBNET_IDENTITY_SOURCE) ->
+    // loadChainIdentityHistory fallback contract handleChainIdentityHistory
+    // uses; a store with no identity changes is a schema-stable empty feed
+    // (count 0), never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/identity-history", params),
+        "METAGRAPH_SUBNET_IDENTITY_SOURCE",
+      )) ??
+      (await loadChainIdentityHistory(graphqlD1(context), {
+        limit: safeLimit,
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      count: data.count ?? 0,
+      subnet_count: data.subnet_count ?? 0,
+      changes: data.changes || [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -3323,6 +3323,105 @@ describe("graphql — subnet_identity_history (#5721, Postgres-tier + empty time
   });
 });
 
+describe("graphql — chain_identity_history (#5878, Postgres-tier + empty-feed fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag / no D1 rows returns a schema-stable empty feed, never null", async () => {
+    const { status, body } = await gql(
+      `{ chain_identity_history {
+          schema_version count subnet_count changes { netuid subnet_name identity_hash }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_identity_history, {
+      schema_version: 1,
+      count: 0,
+      subnet_count: 0,
+      changes: [],
+    });
+  });
+
+  test("resolves the Postgres-tier network feed, mapping each cross-subnet change", async () => {
+    const env = {
+      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          count: 2,
+          subnet_count: 2,
+          changes: [
+            {
+              netuid: 7,
+              block_number: 4200,
+              observed_at: "2026-07-01T00:00:00.000Z",
+              subnet_name: "Example",
+              symbol: "EX",
+              description: "desc",
+              github_repo: "https://github.com/example/repo",
+              subnet_url: "https://example.com",
+              discord: "https://discord.gg/example",
+              logo_url: "https://example.com/logo.png",
+              identity_hash: "abc123",
+            },
+            {
+              netuid: 12,
+              block_number: 4180,
+              observed_at: "2026-06-30T00:00:00.000Z",
+              subnet_name: "Other",
+              symbol: "OT",
+              description: null,
+              github_repo: null,
+              subnet_url: null,
+              discord: null,
+              logo_url: null,
+              identity_hash: "def456",
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ chain_identity_history(limit: 50) {
+          schema_version count subnet_count
+          changes { netuid block_number observed_at subnet_name symbol identity_hash }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    const r = body.data.chain_identity_history;
+    assert.equal(r.count, 2);
+    assert.equal(r.subnet_count, 2);
+    assert.equal(r.changes.length, 2);
+    assert.equal(r.changes[0].netuid, 7);
+    assert.equal(r.changes[0].subnet_name, "Example");
+    assert.equal(r.changes[1].netuid, 12);
+    assert.equal(r.changes[1].identity_hash, "def456");
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ chain_identity_history {
+          schema_version count subnet_count changes { netuid }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.chain_identity_history, {
+      schema_version: 1,
+      count: 0,
+      subnet_count: 0,
+      changes: [],
+    });
+  });
+});
+
 describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderboard)", () => {
   const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 


### PR DESCRIPTION
Adds a \`chain_identity_history(limit)\` GraphQL query mirroring \`GET /api/v1/chain/identity-history\` and the \`get_chain_identity_history\` MCP tool: the network-wide identity-change feed (most-recent SubnetIdentitiesV3 changes across every subnet, newest first, each entry carrying its netuid).

## What
- New \`ChainIdentityHistory\` + \`ChainIdentityHistoryEntry\` types (the entry carries \`netuid\`, distinct from the per-subnet \`SubnetIdentityHistoryEntry\`) and \`Query.chain_identity_history(limit: Int)\` in \`src/graphql.mjs\`, weighted \`RELATIONSHIP_FIELD_COMPLEXITY\`.
- Resolver reuses \`loadChainIdentityHistory\` from \`src/chain-identity-history.mjs\`, resolving through the same \`tryPostgresTier(METAGRAPH_SUBNET_IDENTITY_SOURCE)\` → D1-loader fallback contract the REST handler uses (a store with no changes resolves to a schema-stable empty feed, count 0, never null). Limit-only (no offset/cursor), clamped with the same \`FEED_PAGINATION\` bounds.

## Tests
Three cases in \`tests/graphql.test.mjs\`: cold-store empty feed (Postgres-absent → D1 fallback), Postgres-tier resolve mapping each cross-subnet change (incl. one with null identity fields), and partial-body degradation to defaults. Full graphql suite green (507 tests); resolver 100% covered (statements + branches).

Closes #5878