### PR TITLE
fix(registry): Mainframe (SN25) accuracy pass -- website_url now stale too

### DIFF
--- a/registry/subnets/mainframe.json
+++ b/registry/subnets/mainframe.json
@@ -12,6 +12,7 @@
       "Previously discovered Mainframe docs URL currently returns 404.",
       "Previously discovered Mainframe API documentation URL currently returns 404.",
       "Previously discovered dashboard URL redirects to the general Macrocosmos homepage.",
+      "The registered website_url (macrocosmos.ai/sn25) now also redirects to the general Macrocosmos homepage rather than SN25-specific content, the same failure mode as the previously-flagged dashboard URL; not promoted as a website surface.",
       "No verified OpenAPI/Swagger schema yet.",
       "No verified SSE/event stream yet."
     ],
@@ -24,7 +25,7 @@
   "dashboard_url": "https://taomarketcap.com/subnets/25",
   "name": "Mainframe",
   "netuid": 25,
-  "notes": "Reviewed overlay for SN25 using the official Mainframe source repository. Previously discovered Mainframe docs/API URLs currently return 404 and the old dashboard URL redirects to the general Macrocosmos homepage, so they are not promoted.",
+  "notes": "Reviewed overlay for SN25 using the official Mainframe source repository. Previously discovered Mainframe docs/API URLs currently return 404 and the old dashboard URL redirects to the general Macrocosmos homepage, so they are not promoted. Re-tested live this pass: also found the registered website_url now redirects to the same generic homepage, so it is not promoted as a website surface either. 1 community-submitted surface (wandb dashboard) had no probe config at all -- the registry-wide gap tracked in #5932 -- fixed. All 4 tracked surfaces re-verified live.",
   "schema_version": 1,
   "slug": "sn-25",
   "social": {
@@ -110,6 +111,12 @@
       "kind": "dashboard",
       "name": "Mainframe (folding-openmm) Weights & Biases dashboard",
       "notes": "Public Weights & Biases project the SN25 Mainframe validators log to (wandb.ai/macrocosmos/folding-openmm) — live protein-folding validation runs and metrics (260k+ runs). Project 'folding-openmm' and entity 'macrocosmos' are the validator defaults in the official macrocosm-os/mainframe config (folding/utils/config.py), and wandb.init runs from folding/utils/logging.py. Publicly readable via the W&B API. Distinct host from the sn25 API and object storage.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "macrocosmos",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary

Continuation of the root->128 per-subnet accuracy audit (#5903).

- Re-tested all previously-flagged `gap_notes` live: docs/API-docs URLs still 404, the old dashboard URL still redirects to the general Macrocosmos homepage. **Found the same failure mode newly affects the registered `website_url`** (macrocosmos.ai/sn25) -- it now also redirects to the generic homepage rather than SN25-specific content. Documented in `gap_notes`; not promoted as a website surface, consistent with how the dashboard URL was already handled.
- 1 community-submitted surface (wandb dashboard) had no probe config at all -- the registry-wide gap tracked in #5932 -- fixed.
- All 4 tracked surfaces re-verified live.

Note: per house preference, this PR does not touch `public/metagraph/operational-surfaces.json` -- that file is owned by a separate automation.

## Test plan

- [x] `npm run validate` — passes
- [x] `npm run validate:surface` — passes (923 surfaces across 129 subnet files)
- [x] `npm run curation:stale-notes` — zero stale notes
- [x] `npm run build` — full build passes
- [x] `npm run scan:public-safety` — passes
- [x] Every surface URL live-tested individually; the website_url redirect was traced through its full chain, not assumed from the first hop