### PR TITLE
fix(scripts): promote curation.level for any maintainer-reviewed decision (SN59/SN107 drift)

### DIFF
--- a/registry/subnets/babelbit.json
+++ b/registry/subnets/babelbit.json
@@ -2,8 +2,9 @@
   "categories": [],
   "contact": "mk@babelbit.ai",
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-20T00:00:00.000Z"
   },
   "name": "Babelbit",
   "netuid": 59,

--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -1,8 +1,9 @@
 {
   "categories": [],
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-20T00:00:00.000Z"
   },
   "name": "Minos",
   "netuid": 107,

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -2108,7 +2108,60 @@ export function computeProvenanceElevations({
 // is NOT already at the top trust tier (maintainer-reviewed / adapter-backed).
 // Deterministic (generated_at is the fixed build placeholder) so the committed
 // queue is drift-checked by validate.mjs. Pure — takes the already-loaded inputs.
-const TOP_TRUST_LEVELS = new Set(["maintainer-reviewed", "adapter-backed"]);
+export const TOP_TRUST_LEVELS = new Set([
+  "maintainer-reviewed",
+  "adapter-backed",
+]);
+
+// Pure promotion helper shared by scripts/promote-reviewed.mjs and its unit
+// tests (#5992). Applies a maintainer review decision to a curation overlay:
+// always records review_state/reviewed_at, and promotes curation.level to
+// "maintainer-reviewed" ONLY when the decision is maintainer-reviewed AND the
+// current level is not already a TOP-TRUST tier. This keeps subnets already at
+// "adapter-backed" (an equal top tier) from being silently downgraded, while
+// still promoting community-seeded / candidate-discovered / native /
+// machine-verified levels that never took effect before.
+export function promoteCuration(curation, decision) {
+  const next = {
+    ...(curation || {}),
+    review_state: decision.decision,
+    reviewed_at: decision.reviewed_at,
+  };
+  if (
+    decision.decision === "maintainer-reviewed" &&
+    !TOP_TRUST_LEVELS.has(next.level)
+  ) {
+    next.level = "maintainer-reviewed";
+  }
+  return next;
+}
+
+// Forward drift guard for #5992: every maintainer-reviewed decision must have
+// been materialized onto its subnet overlay by promote-reviewed.mjs, i.e. the
+// overlay's curation.level must sit at a TOP-TRUST tier (maintainer-reviewed or
+// adapter-backed). Returns the decisions whose overlay is still below the top
+// tier. Decisions whose netuid has no subnet overlay are skipped (a separate
+// concern). Pure — takes already-loaded inputs so validate.mjs and tests can
+// share it.
+export function findUnpromotedMaintainerDecisions({
+  decisions = [],
+  subnets = [],
+} = {}) {
+  const levelByNetuid = new Map(
+    subnets.map((subnet) => [subnet.netuid, subnet.curation?.level ?? null]),
+  );
+  const drift = [];
+  for (const decision of decisions) {
+    if (decision.decision !== "maintainer-reviewed") continue;
+    if (!levelByNetuid.has(decision.netuid)) continue;
+    const level = levelByNetuid.get(decision.netuid);
+    if (!TOP_TRUST_LEVELS.has(level)) {
+      drift.push({ netuid: decision.netuid, slug: decision.slug, level });
+    }
+  }
+  return drift;
+}
+
 export function buildProvenanceReviewQueue({
   candidates = [],
   nativeSubnets = [],

--- a/scripts/promote-reviewed.mjs
+++ b/scripts/promote-reviewed.mjs
@@ -2,6 +2,7 @@ import path from "node:path";
 import {
   listJsonFiles,
   loadSubnets,
+  promoteCuration,
   readJson,
   repoRoot,
   buildSubnetOverlaysByNetuid,
@@ -45,17 +46,7 @@ for (const decision of decisionsDocument.decisions || []) {
   }
 
   const nextOverlay = structuredClone(entry.overlay);
-  nextOverlay.curation = {
-    ...(nextOverlay.curation || {}),
-    review_state: decision.decision,
-    reviewed_at: decision.reviewed_at,
-  };
-  if (
-    decision.decision === "maintainer-reviewed" &&
-    nextOverlay.curation.level === "machine-verified"
-  ) {
-    nextOverlay.curation.level = "maintainer-reviewed";
-  }
+  nextOverlay.curation = promoteCuration(nextOverlay.curation, decision);
 
   const changed =
     stableStringify(nextOverlay) !== stableStringify(entry.overlay);

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -21,6 +21,7 @@ import {
   listJsonFilesRecursive,
   cleanDescription,
   deriveDomainTags,
+  findUnpromotedMaintainerDecisions,
   subnetLifecycle,
   publicMetagraphRoot,
   readJson,
@@ -1592,6 +1593,22 @@ for (const subnet of subnets) {
       `${subnet.slug}: curation.level "maintainer-reviewed" (netuid ${subnet.netuid}) has no backing decision in registry/reviews/maintainer-reviewed.json — add a decision there instead of hand-editing the overlay level`,
     );
   }
+}
+
+// Forward direction of the same single-source-of-truth invariant (#5992): every
+// maintainer-reviewed decision must be MATERIALIZED onto its subnet overlay, so
+// the overlay's curation.level sits at a top trust tier (maintainer-reviewed or
+// adapter-backed). Otherwise a recorded decision silently never takes effect —
+// the live drift this guard closes. Decisions whose netuid has no overlay are a
+// separate concern and skipped.
+for (const drift of findUnpromotedMaintainerDecisions({
+  decisions: reviewDecisionsDocument.decisions || [],
+  subnets,
+})) {
+  assert(
+    false,
+    `${drift.slug ?? `netuid ${drift.netuid}`}: maintainer-reviewed decision (netuid ${drift.netuid}) is not materialized — curation.level "${drift.level}" is below the top trust tier; run \`node scripts/promote-reviewed.mjs --write\` to promote it`,
+  );
 }
 
 // Identity guardrail (the "Nodexo" class): a curated overlay's name matching

--- a/tests/promote-reviewed.test.mjs
+++ b/tests/promote-reviewed.test.mjs
@@ -1,0 +1,75 @@
+// Unit tests for the promotion helper behind scripts/promote-reviewed.mjs (#5992).
+// promoteCuration lives in scripts/lib.mjs (not the script) so it can be imported
+// side-effect-free — importing promote-reviewed.mjs would execute its top-level
+// process.argv / file-reading body under vitest. The fix under test: a
+// maintainer-reviewed decision must promote curation.level from ANY non-top tier
+// (community-seeded / candidate-discovered / native / machine-verified), not only
+// from "machine-verified" as the old script did — while leaving subnets already
+// at a TOP-TRUST tier (adapter-backed / maintainer-reviewed) untouched so an
+// equal-trust "adapter-backed" is never downgraded.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { promoteCuration, TOP_TRUST_LEVELS } from "../scripts/lib.mjs";
+
+const decision = {
+  decision: "maintainer-reviewed",
+  reviewed_at: "2026-06-20T00:00:00.000Z",
+};
+
+describe("promoteCuration (#5992 level-promotion fix)", () => {
+  test("TOP_TRUST_LEVELS is the shared two-tier set", () => {
+    assert.deepEqual([...TOP_TRUST_LEVELS].sort(), [
+      "adapter-backed",
+      "maintainer-reviewed",
+    ]);
+  });
+
+  for (const level of [
+    "community-seeded",
+    "candidate-discovered",
+    "native",
+    "machine-verified",
+  ]) {
+    test(`promotes curation.level from "${level}" to maintainer-reviewed`, () => {
+      const next = promoteCuration({ level }, decision);
+      assert.equal(next.level, "maintainer-reviewed");
+      assert.equal(next.review_state, "maintainer-reviewed");
+      assert.equal(next.reviewed_at, "2026-06-20T00:00:00.000Z");
+    });
+  }
+
+  test("promotes when curation is missing entirely", () => {
+    const next = promoteCuration(undefined, decision);
+    assert.equal(next.level, "maintainer-reviewed");
+    assert.equal(next.review_state, "maintainer-reviewed");
+    assert.equal(next.reviewed_at, "2026-06-20T00:00:00.000Z");
+  });
+
+  for (const level of ["adapter-backed", "maintainer-reviewed"]) {
+    test(`leaves an already TOP-TRUST "${level}" level unchanged`, () => {
+      const next = promoteCuration({ level }, decision);
+      assert.equal(next.level, level, "top-trust level must not change");
+      // review_state / reviewed_at are still recorded from the decision.
+      assert.equal(next.review_state, "maintainer-reviewed");
+      assert.equal(next.reviewed_at, "2026-06-20T00:00:00.000Z");
+    });
+  }
+
+  test("a non-maintainer-reviewed decision never touches the level", () => {
+    const next = promoteCuration(
+      { level: "community-seeded" },
+      { decision: "needs-review", reviewed_at: "2026-06-20T00:00:00.000Z" },
+    );
+    assert.equal(next.level, "community-seeded");
+    assert.equal(next.review_state, "needs-review");
+  });
+
+  test("preserves other curation fields and does not mutate the input", () => {
+    const curation = { level: "community-seeded", source_count: 4 };
+    const next = promoteCuration(curation, decision);
+    assert.equal(next.source_count, 4);
+    // input untouched (pure)
+    assert.equal(curation.level, "community-seeded");
+    assert.equal(curation.review_state, undefined);
+  });
+});

--- a/tests/validate-maintainer-promoted.test.mjs
+++ b/tests/validate-maintainer-promoted.test.mjs
@@ -1,0 +1,90 @@
+// Coverage for the FORWARD maintainer-reviewed drift guard added to
+// scripts/validate.mjs (#5992). validate.mjs is a monolithic top-level script
+// that loads the real registry (and its non-committed generated artifacts), so
+// the guard's decision logic is extracted into the pure, side-effect-free
+// findUnpromotedMaintainerDecisions() in scripts/lib.mjs. That is exactly what
+// validate.mjs asserts on, and what is exercised here with synthetic fixtures:
+// a maintainer-reviewed decision whose subnet still sits below the top trust
+// tier is flagged (validation would fail), while a decision whose subnet is at a
+// TOP-TRUST tier (adapter-backed or maintainer-reviewed) passes.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { findUnpromotedMaintainerDecisions } from "../scripts/lib.mjs";
+
+const reviewedDecision = (netuid, slug) => ({
+  netuid,
+  slug,
+  decision: "maintainer-reviewed",
+  reviewed_at: "2026-06-20T00:00:00.000Z",
+});
+
+describe("findUnpromotedMaintainerDecisions (#5992 forward drift guard)", () => {
+  test("flags a maintainer-reviewed decision whose subnet is community-seeded", () => {
+    const drift = findUnpromotedMaintainerDecisions({
+      decisions: [reviewedDecision(59, "sn-59")],
+      subnets: [{ netuid: 59, curation: { level: "community-seeded" } }],
+    });
+    assert.equal(drift.length, 1);
+    assert.deepEqual(drift[0], {
+      netuid: 59,
+      slug: "sn-59",
+      level: "community-seeded",
+    });
+  });
+
+  test("passes a subnet promoted to maintainer-reviewed", () => {
+    const drift = findUnpromotedMaintainerDecisions({
+      decisions: [reviewedDecision(59, "sn-59")],
+      subnets: [{ netuid: 59, curation: { level: "maintainer-reviewed" } }],
+    });
+    assert.deepEqual(drift, []);
+  });
+
+  test("passes an adapter-backed subnet with a decision (no downgrade)", () => {
+    const drift = findUnpromotedMaintainerDecisions({
+      decisions: [reviewedDecision(74, "gittensor")],
+      subnets: [{ netuid: 74, curation: { level: "adapter-backed" } }],
+    });
+    assert.deepEqual(drift, []);
+  });
+
+  test("skips a decision whose netuid has no subnet overlay", () => {
+    const drift = findUnpromotedMaintainerDecisions({
+      decisions: [reviewedDecision(999, "ghost")],
+      subnets: [{ netuid: 59, curation: { level: "maintainer-reviewed" } }],
+    });
+    assert.deepEqual(drift, []);
+  });
+
+  test("ignores non-maintainer-reviewed decisions", () => {
+    const drift = findUnpromotedMaintainerDecisions({
+      decisions: [
+        { netuid: 59, slug: "sn-59", decision: "needs-review" },
+        { netuid: 60, slug: "sn-60", decision: "rejected" },
+      ],
+      subnets: [
+        { netuid: 59, curation: { level: "community-seeded" } },
+        { netuid: 60, curation: { level: "community-seeded" } },
+      ],
+    });
+    assert.deepEqual(drift, []);
+  });
+
+  test("reports every drifted decision, not just the first", () => {
+    const drift = findUnpromotedMaintainerDecisions({
+      decisions: [
+        reviewedDecision(59, "sn-59"),
+        reviewedDecision(107, "sn-107"),
+      ],
+      subnets: [
+        { netuid: 59, curation: { level: "community-seeded" } },
+        { netuid: 107, curation: { level: "candidate-discovered" } },
+      ],
+    });
+    assert.equal(drift.length, 2);
+    assert.deepEqual(
+      drift.map((d) => d.netuid).sort((a, b) => a - b),
+      [59, 107],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/promote-reviewed.mjs` only bumped `curation.level` to `maintainer-reviewed` when the level was **exactly** `machine-verified`, so a recorded maintainer-reviewed decision for a subnet at any other level (`community-seeded`, `candidate-discovered`, `native`) silently updated `review_state`/`reviewed_at` but never actually promoted the level — the live SN59/SN107 drift.

## Fix

- Extracted `promoteCuration()` into `scripts/lib.mjs` (testable, side-effect-free) and replaced the inline `=== "machine-verified"` condition with it. It promotes to `maintainer-reviewed` whenever the decision is maintainer-reviewed **and** the current level is not already a top-trust tier.
- **Correctness note (the issue's literal ask would regress data):** `scripts/lib.mjs` already defines `TOP_TRUST_LEVELS = { maintainer-reviewed, adapter-backed }` — `adapter-backed` is an *equal* top tier. Blindly "promoting regardless of starting level" would **downgrade** the two `adapter-backed` subnets that also carry maintainer-reviewed decisions (netuid 7 allways, 74 gittensor). `promoteCuration` uses `TOP_TRUST_LEVELS` (now exported) so those are left untouched; only the genuinely-below-tier 59/107 promote.
- Materialized the two drifted files (`registry/subnets/babelbit.json` SN59, `registry/subnets/minos.json` SN107) to `level: maintainer-reviewed` per their `2026-06-20` decisions.
- Added a **forward CI guard** in `scripts/validate.mjs`: every maintainer-reviewed decision's subnet must sit at a top-trust level (else fail, pointing the reviewer at `promote-reviewed.mjs`). The pre-existing reverse gate only checked the other direction, so this drift was invisible to CI.

## Tests

`tests/promote-reviewed.test.mjs` — `promoteCuration` promotes from community-seeded / candidate-discovered / native / machine-verified, and leaves `adapter-backed`/`maintainer-reviewed` unchanged (only updating review_state/reviewed_at). `tests/validate-maintainer-promoted.test.mjs` — the guard fails on a drifted fixture and passes an adapter-backed subnet. 16 tests pass; 100% patch coverage of the new `scripts/lib.mjs` code; eslint + prettier clean.

## Out of scope (flagged for follow-up)

`promote-reviewed.mjs --write` also surfaces a **separate, pre-existing** drift on netuid 39/81/117 (basilica/brainplay/grail): their level is already `maintainer-reviewed` but `review_state` is stale `needs-review`. That's a review_state materialization, not the level bug #5992 targets, and it passes the new level guard — left untouched here.

Closes #5992