### PR TITLE
fix(python-sdk): follow redirects safely in async client

### DIFF
--- a/python/src/metagraphed/aio.py
+++ b/python/src/metagraphed/aio.py
@@ -27,11 +27,17 @@ from .client import (
     _interpolate,
     _jsonrpc_result,
     _next_cursor,
+    _url_origin,
 )
 from .models import AgentCatalogSubnet, Endpoint, Provider, Subnet, Surface
 
 if TYPE_CHECKING:  # pragma: no cover - type-checking only
     import httpx
+
+
+# Parity with ``client._CrossOriginSafeRedirectHandler``: only these survive an
+# origin change. Compared case-insensitively (httpx normalizes header names).
+_CROSS_ORIGIN_HEADER_ALLOWLIST = frozenset({"accept", "user-agent"})
 
 
 def _require_httpx() -> Any:
@@ -43,6 +49,32 @@ def _require_httpx() -> Any:
             "pip install 'metagraphed[async]'"
         ) from error
     return httpx
+
+
+def _cross_origin_safe_async_client(
+    httpx: Any, *, timeout: float, **client_kwargs: Any
+) -> "httpx.AsyncClient":
+    """``AsyncClient`` that follows redirects like the sync client — including
+    stripping non-allowlisted headers on a cross-origin hop.
+
+    httpx's built-in ``follow_redirects=True`` only drops ``Authorization``
+    (and rebuilds ``Cookie``) across origins, so custom headers like
+    ``X-Api-Key`` would still leak. Overriding ``_redirect_headers`` matches
+    ``_CrossOriginSafeRedirectHandler``'s allowlist safety property.
+    """
+
+    class _CrossOriginSafeAsyncClient(httpx.AsyncClient):
+        def _redirect_headers(self, request: Any, url: Any, method: str) -> Any:
+            headers = super()._redirect_headers(request, url, method)
+            if _url_origin(str(request.url)) != _url_origin(str(url)):
+                for key in list(headers):
+                    if key.lower() not in _CROSS_ORIGIN_HEADER_ALLOWLIST:
+                        del headers[key]
+            return headers
+
+    return _CrossOriginSafeAsyncClient(
+        timeout=timeout, follow_redirects=True, **client_kwargs
+    )
 
 
 def _retry_after_seconds(
@@ -96,7 +128,7 @@ class AsyncMetagraphedClient:
         self.retries = retries
         self.backoff = backoff
         self._httpx = httpx
-        self._client = httpx.AsyncClient(timeout=timeout)
+        self._client = _cross_origin_safe_async_client(httpx, timeout=timeout)
 
     async def __aenter__(self) -> "AsyncMetagraphedClient":
         return self

--- a/python/tests/test_aio.py
+++ b/python/tests/test_aio.py
@@ -369,6 +369,58 @@ class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
             await client.fetch_all("/api/v1/subnets")
         self.assertTrue(getattr(client._client, "closed", False))
 
+    async def test_cross_origin_redirect_strips_custom_headers(self):
+        # Mirrors test_client.ClientTest.test_cross_origin_redirect_strips_custom_headers:
+        # follow a cross-origin redirect and keep only the allowlisted headers
+        # (Accept / User-Agent) — not Authorization / X-Api-Key / Cookie.
+        from metagraphed import aio as aio_mod
+
+        hops = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            hops.append(request)
+            if request.url.host == "api.example.test":
+                return httpx.Response(
+                    302,
+                    headers={
+                        "Location": "https://attacker.example.test/api/v1/subnets/7"
+                    },
+                )
+            return httpx.Response(200, json={"ok": True, "data": {"netuid": 7}})
+
+        client = AsyncMetagraphedClient(base_url="https://api.example.test")
+        await client.aclose()
+        client._client = aio_mod._cross_origin_safe_async_client(
+            httpx, timeout=30.0, transport=httpx.MockTransport(handler)
+        )
+        try:
+            self.assertTrue(client._client.follow_redirects)
+            out = await client.fetch(
+                "/api/v1/subnets/7",
+                headers={
+                    "Authorization": "Bearer SECRET",
+                    "X-Api-Key": "SECRET",
+                    "Cookie": "session=SECRET",
+                },
+            )
+            self.assertEqual(out["data"]["netuid"], 7)
+            self.assertEqual(len(hops), 2)
+
+            first, second = hops
+            self.assertEqual(first.url.host, "api.example.test")
+            self.assertEqual(first.headers["Authorization"], "Bearer SECRET")
+            self.assertEqual(first.headers["X-Api-Key"], "SECRET")
+            self.assertEqual(first.headers["Cookie"], "session=SECRET")
+
+            self.assertEqual(second.url.host, "attacker.example.test")
+            self.assertEqual(second.headers.get("Accept"), "application/json")
+            self.assertIsNotNone(second.headers.get("User-Agent"))
+            self.assertNotIn("authorization", second.headers)
+            self.assertNotIn("x-api-key", second.headers)
+            self.assertNotIn("cookie", second.headers)
+        finally:
+            await client.aclose()
+
 
 class AsyncImportGuardTest(unittest.TestCase):
     @unittest.skipIf(


### PR DESCRIPTION
## Summary
- Enable redirect following on `AsyncMetagraphedClient`, matching the sync client.
- Strip non-allowlisted headers on cross-origin redirects (parity with `_CrossOriginSafeRedirectHandler`) instead of relying on httpx’s weaker built-in strip of only `Authorization`.
- Add an async redirect test mirroring the sync client’s cross-origin header-stripping coverage.

Closes #5986

## Test plan
- [x] `python -m pytest python/tests/test_aio.py -q`
- [x] Confirm redirect is followed and `Authorization` / `X-Api-Key` / `Cookie` are not forwarded cross-origin
- [x] Sync redirect test still passes