### PR TITLE
fix(scripts): consolidate divergent normalizePublicUrl implementations

### DIFF
--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -2,16 +2,14 @@ import path from "node:path";
 import {
   apiDocsSubdomainOrigins,
   buildTimestamp,
-  isBrandImpersonationUrl,
-  isCredentialedUrl,
   isLikelyExampleLink,
   isUnsafeResolvedUrl,
-  isUnsafeUrl,
   listJsonFilesRecursive,
   loadNativeSnapshot,
   loadProviders,
   loadSubnets,
   nativeDisplayName,
+  normalizePublicUrl,
   OPENAPI_PROBE_PATHS,
   probeOpenApiSpec,
   readCommittedManifestGeneratedAt,
@@ -82,7 +80,7 @@ const existingGeneratedCandidates = await loadExistingGeneratedCandidates();
 // follow-up). CI builds from committed data only, so it never sees the live
 // collision; that's why the publish failed while every PR's CI stayed green.
 // Reserve every committed community candidate's locator (same key format as
-// addCandidate, with the LOCAL normalizePublicUrl) so the discovery never emits
+// addCandidate, via the shared normalizePublicUrl) so the discovery never emits
 // a duplicate of one — the committed candidate stands.
 const reservedCandidateLocators = new Set();
 for (const file of await listJsonFilesRecursive(
@@ -1163,79 +1161,6 @@ function extractUrls(value) {
   });
 
   return [...new Set(values.map(normalizePublicUrl).filter(Boolean))];
-}
-
-function normalizePublicUrl(value) {
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  let candidate = value
-    .trim()
-    .replace(/^[<`"']+|[>`"',.;:!]+$/g, "")
-    .split("](")[0]
-    .replace(/[\]`"',.;:!]+$/g, "");
-  if (!candidate || isPlaceholder(candidate)) {
-    return null;
-  }
-
-  if (
-    !/^https?:\/\//i.test(candidate) &&
-    /^[a-z0-9.-]+\.[a-z]{2,}(?:\/.*)?$/i.test(candidate)
-  ) {
-    candidate = `https://${candidate}`;
-  }
-
-  try {
-    const url = new URL(candidate);
-    if (
-      !["http:", "https:"].includes(url.protocol) ||
-      url.username ||
-      url.password ||
-      isCredentialedUrl(url.toString())
-    ) {
-      return null;
-    }
-    if (url.username || url.password) {
-      return null;
-    }
-    // SSRF pre-filter: literal private/loopback/link-local/metadata IPs +
-    // localhost. The authoritative, DNS-resolving check (isUnsafeResolvedUrl)
-    // still runs at probe + overlay-promotion time; this just keeps obviously
-    // internal targets out of the bundle entirely.
-    if (isUnsafeUrl(url.toString())) {
-      return null;
-    }
-    // Reject base_urls that impersonate metagraphed's own domain — they pass the
-    // SSRF guard (public attacker domain) but could trick an agent into trusting
-    // them. See ADR 0004.
-    if (isBrandImpersonationUrl(url.toString())) {
-      return null;
-    }
-    url.hash = "";
-    if (url.pathname !== "/") {
-      url.pathname = url.pathname.replace(/\/+$/, "");
-    }
-    return url.toString();
-  } catch {
-    return null;
-  }
-}
-
-function isPlaceholder(value) {
-  const normalized = value.toLowerCase();
-  return [
-    "example.com",
-    "github.com/deprecated/deprecated",
-    "github.com/username/repo",
-    "github.com/yourusername/yourrepo",
-    "yourwebsite",
-    "your-org",
-    "deprecated.com",
-    "deprecated.png",
-    "localhost",
-    "127.0.0.1",
-  ].some((placeholder) => normalized.includes(placeholder));
 }
 
 function cleanName(value) {

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1354,6 +1354,11 @@ export function surfaceFixtureReference(surfaceId, fixture) {
   };
 }
 
+// Canonical public-URL intake for both the contributor path (validate-surface /
+// surface-add) and auto-discovery. Allowlist keeps ws/wss (real registry
+// surfaces use them) alongside http/https; guards reject credentials, SSRF
+// literals, brand impersonation of metagraph.sh, and placeholder/template junk.
+// Callers that need HTTP(S) only should wrap with normalizePublicHttpUrl.
 export function normalizePublicUrl(value) {
   if (typeof value !== "string") {
     return null;
@@ -1361,10 +1366,10 @@ export function normalizePublicUrl(value) {
 
   let candidate = value
     .trim()
-    .replace(/^<|>$/g, "")
+    .replace(/^[<`"']+|[>`"',.;:!]+$/g, "")
     .split("](")[0]
-    .replace(/\]+$/g, "");
-  if (!candidate) {
+    .replace(/[\]`"',.;:!]+$/g, "");
+  if (!candidate || isPlaceholderIdentityUrl(candidate)) {
     return null;
   }
 
@@ -1382,7 +1387,8 @@ export function normalizePublicUrl(value) {
       url.username ||
       url.password ||
       isCredentialedUrl(url.toString()) ||
-      isUnsafeUrl(url.toString())
+      isUnsafeUrl(url.toString()) ||
+      isBrandImpersonationUrl(url.toString())
     ) {
       return null;
     }
@@ -1408,8 +1414,11 @@ export function normalizePublicHttpUrl(value) {
 
 // Placeholder/junk identity URLs some subnets carry on-chain (e.g. the
 // deprecated subnets' "https://deprecated.png" + "github.com/username/repo",
-// or "example.com" stubs). These must never surface as real links.
-const PLACEHOLDER_IDENTITY_URL = /deprecated|username\/repo|example\.com/i;
+// or "example.com" stubs) plus README template hosts. These must never surface
+// as real links — also consulted by normalizePublicUrl so discovery and
+// contributor intake share one reject list.
+const PLACEHOLDER_IDENTITY_URL =
+  /deprecated|username\/repo|yourusername\/yourrepo|example\.com|yourwebsite|your-org/i;
 
 export function isPlaceholderIdentityUrl(value) {
   return typeof value === "string" && PLACEHOLDER_IDENTITY_URL.test(value);

--- a/src/chain-identity-sanitize.mjs
+++ b/src/chain-identity-sanitize.mjs
@@ -28,7 +28,8 @@ const CREDENTIALED_URL_PARAMS = new Set([
   "token",
 ]);
 
-const PLACEHOLDER_IDENTITY_URL = /deprecated|username\/repo|example\.com/i;
+const PLACEHOLDER_IDENTITY_URL =
+  /deprecated|username\/repo|yourusername\/yourrepo|example\.com|yourwebsite|your-org/i;
 const CONTACT_HANDLE_PATTERN = /^@?[a-z0-9][a-z0-9._-]{1,63}(?:#\d{1,6})?$/i;
 const CONTACT_HANDLE_JUNK = /^(?:deprecated|none|null|n\/a|tbd|todo)$/i;
 

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -27,6 +27,7 @@ import {
   nativeContactHandle,
   nativeDisplayName,
   nativeContactUrl,
+  normalizePublicUrl,
   deriveDomainTags,
   DOMAIN_TAGS,
   deriveDescriptionFromNotes,
@@ -400,6 +401,65 @@ describe("isBrandImpersonationUrl", () => {
   });
 });
 
+describe("normalizePublicUrl (canonical intake)", () => {
+  test("keeps http(s) and ws(s); rejects other schemes", () => {
+    assert.equal(
+      normalizePublicUrl("https://docs.taofu.xyz/api"),
+      "https://docs.taofu.xyz/api",
+    );
+    assert.equal(
+      normalizePublicUrl("wss://entrypoint-finney.opentensor.ai"),
+      "wss://entrypoint-finney.opentensor.ai/",
+    );
+    assert.equal(
+      normalizePublicUrl("ws://stream.public-subnet.io/feed"),
+      "ws://stream.public-subnet.io/feed",
+    );
+    assert.equal(normalizePublicUrl("ftp://metagraph.sh/file"), null);
+  });
+
+  test("rejects brand-impersonating URLs on the contributor-facing path", () => {
+    // Regression for #5990/#5991: validate-surface / surface-add import this
+    // shared helper — impersonation must not be discovery-only.
+    for (const url of [
+      "https://metagraph.sh.evil.com/api",
+      "https://metagraphsh.com/openapi.json",
+      "https://metagraph-sh.io/call",
+      "https://api.metagraphsh.net",
+    ]) {
+      assert.equal(normalizePublicUrl(url), null, url);
+    }
+    assert.equal(
+      normalizePublicUrl("https://metagraph.sh/api/v1/subnets"),
+      "https://metagraph.sh/api/v1/subnets",
+    );
+  });
+
+  test("rejects placeholder and template junk shared with discovery", () => {
+    for (const url of [
+      "https://example.com/api",
+      "https://github.com/username/repo",
+      "https://github.com/yourusername/yourrepo",
+      "https://yourwebsite.com",
+      "https://your-org.github.io/docs",
+      "https://deprecated.png",
+    ]) {
+      assert.equal(normalizePublicUrl(url), null, url);
+    }
+  });
+
+  test("strips markdown wrappers and trailing punctuation from discovery-shaped input", () => {
+    assert.equal(
+      normalizePublicUrl("<https://docs.taofu.xyz/api/>"),
+      "https://docs.taofu.xyz/api",
+    );
+    assert.equal(
+      normalizePublicUrl("`https://docs.taofu.xyz/api`,"),
+      "https://docs.taofu.xyz/api",
+    );
+  });
+});
+
 describe("subnetLifecycle", () => {
   const withName = (name, description = "") => ({
     chain_identity: { subnet_name: name, description },
@@ -577,6 +637,14 @@ describe("isPlaceholderIdentityUrl", () => {
       true,
     );
     assert.equal(isPlaceholderIdentityUrl("https://example.com"), true);
+  });
+  test("flags README template hosts absorbed from discovery", () => {
+    assert.equal(
+      isPlaceholderIdentityUrl("https://github.com/yourusername/yourrepo"),
+      true,
+    );
+    assert.equal(isPlaceholderIdentityUrl("https://yourwebsite.com"), true);
+    assert.equal(isPlaceholderIdentityUrl("https://your-org.io/docs"), true);
   });
   test("passes real links and non-strings through as not-placeholder", () => {
     assert.equal(
@@ -1398,12 +1466,12 @@ describe("deriveAuthDetail (#746)", () => {
       o: {
         type: "oauth2",
         flows: {
-          clientCredentials: { tokenUrl: "https://auth.example.com/token" },
+          clientCredentials: { tokenUrl: "https://auth.issuer.test/token" },
         },
       },
     });
     assert.equal(out.scheme, "oauth2");
-    assert.equal(out.token_url, "https://auth.example.com/token");
+    assert.equal(out.token_url, "https://auth.issuer.test/token");
   });
 
   test("drops an unsafe/placeholder token_url rather than surfacing it", () => {
@@ -1415,6 +1483,21 @@ describe("deriveAuthDetail (#746)", () => {
     });
     assert.equal(out.scheme, "oauth2");
     assert.equal("token_url" in out, false);
+    // RFC 2606 example.com is placeholder junk for the shared intake guard.
+    assert.equal(
+      "token_url" in
+        deriveAuthDetail({
+          o: {
+            type: "oauth2",
+            flows: {
+              clientCredentials: {
+                tokenUrl: "https://auth.example.com/token",
+              },
+            },
+          },
+        }),
+      false,
+    );
   });
 
   test("prefers a concrete api-key/http scheme over oauth2", () => {
@@ -1438,10 +1521,10 @@ describe("deriveAuthDetail (#746)", () => {
         o: {
           type: "openIdConnect",
           openIdConnectUrl:
-            "https://idp.example.com/.well-known/openid-configuration",
+            "https://idp.issuer.test/.well-known/openid-configuration",
         },
       }).token_url,
-      "https://idp.example.com/.well-known/openid-configuration",
+      "https://idp.issuer.test/.well-known/openid-configuration",
     );
     assert.equal(
       deriveAuthDetail({
@@ -1449,18 +1532,18 @@ describe("deriveAuthDetail (#746)", () => {
           type: "oauth2",
           flows: {
             implicit: {
-              authorizationUrl: "https://auth.example.com/authorize",
+              authorizationUrl: "https://auth.issuer.test/authorize",
             },
           },
         },
       }).token_url,
-      "https://auth.example.com/authorize",
+      "https://auth.issuer.test/authorize",
     );
     assert.equal(
       deriveAuthDetail({
-        o: { type: "oauth2", tokenUrl: "https://auth.example.com/token" },
+        o: { type: "oauth2", tokenUrl: "https://auth.issuer.test/token" },
       }).token_url,
-      "https://auth.example.com/token",
+      "https://auth.issuer.test/token",
     );
     // Swagger-2 top-level authorizationUrl (no tokenUrl, no flows) is the last
     // fallback in oauthTokenUrl().
@@ -1468,10 +1551,10 @@ describe("deriveAuthDetail (#746)", () => {
       deriveAuthDetail({
         o: {
           type: "oauth2",
-          authorizationUrl: "https://auth.example.com/authorize",
+          authorizationUrl: "https://auth.issuer.test/authorize",
         },
       }).token_url,
-      "https://auth.example.com/authorize",
+      "https://auth.issuer.test/authorize",
     );
   });
 

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -90,9 +90,10 @@ describe("public URL safety checks", () => {
     }
 
     assert.equal(
-      normalizePublicHttpUrl("example.com/docs/#intro"),
-      "https://example.com/docs",
+      normalizePublicHttpUrl("docs.taofu.xyz/docs/#intro"),
+      "https://docs.taofu.xyz/docs",
     );
+    assert.equal(normalizePublicHttpUrl("example.com/docs/#intro"), null);
   });
 
   test("blocks hostnames that resolve to private addresses", async () => {

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -901,7 +901,7 @@ describe("script utility contracts", () => {
         },
         source_repo: "https://github.com/macrocosm-os/mainframe",
         baseline_excluded_surface_ids: ["sn-25-stale-docs"],
-        baseline_excluded_surface_urls: ["https://example.com/rejected"],
+        baseline_excluded_surface_urls: ["https://rejected.mainframe.test/rejected"],
         surfaces: [
           {
             id: "sn-25-mainframe-source",
@@ -938,12 +938,12 @@ describe("script utility contracts", () => {
         netuid: 25,
         name: "Mainframe rejected website",
         kind: "website",
-        url: "https://example.com/rejected",
+        url: "https://rejected.mainframe.test/rejected",
         provider: "macrocosmos",
         source_type: "native-chain-identity",
         source_tier: "native-chain",
-        source_url: "https://example.com/native",
-        source_urls: ["https://example.com/native"],
+        source_url: "https://rejected.mainframe.test/native",
+        source_urls: ["https://rejected.mainframe.test/native"],
         review_notes:
           "Native Subtensor identity URL for a previously rejected surface.",
       },
@@ -952,12 +952,12 @@ describe("script utility contracts", () => {
         netuid: 25,
         name: "Mainframe stale docs",
         kind: "docs",
-        url: "https://example.com/stale-docs",
+        url: "https://stale.mainframe.test/stale-docs",
         provider: "taomarketcap",
         source_type: "project-website-common-path",
         source_tier: "provider-claimed",
-        source_url: "https://example.com/stale-docs",
-        source_urls: ["https://example.com/stale-docs"],
+        source_url: "https://stale.mainframe.test/stale-docs",
+        source_urls: ["https://stale.mainframe.test/stale-docs"],
         review_notes: "Known stale generated candidate.",
       },
     ];
@@ -1017,7 +1017,7 @@ describe("script utility contracts", () => {
     const rejectedBaseline = overlaySet.manualBaselineOverlays[0].surfaces.find(
       (surface) => surface.id === "sn-25-native-chain-website",
     );
-    assert.equal(rejectedBaseline.url, "https://example.com/rejected");
+    assert.equal(rejectedBaseline.url, "https://rejected.mainframe.test/rejected");
     assert.equal(overlaySet.generatedOverlays.length, 0);
     assert.deepEqual(
       overlaySet.manualOverlays[0].surfaces.map((surface) => surface.id),
@@ -1049,12 +1049,12 @@ describe("script utility contracts", () => {
         netuid: 88,
         name: "Limiter API",
         kind: "subnet-api",
-        url: "https://limiter.example.com/api",
+        url: "https://limiter.subnet.test/api",
         provider: "limiter",
         source_type: "project-website-common-path",
         source_tier: "provider-claimed",
-        source_url: "https://limiter.example.com/docs",
-        source_urls: ["https://limiter.example.com/docs"],
+        source_url: "https://limiter.subnet.test/docs",
+        source_urls: ["https://limiter.subnet.test/docs"],
         rate_limit: rateLimit,
         rate_limit_notes: "See docs for tier details.",
       },
@@ -1382,10 +1382,10 @@ describe("script utility contracts", () => {
         provider: "reviewstate",
         source_tier: "provider-claimed",
         source_type: "project-website-link",
-        source_url: "https://reviewstate.example.com/",
-        source_urls: ["https://reviewstate.example.com/"],
+        source_url: "https://reviewstate.subnet.test/",
+        source_urls: ["https://reviewstate.subnet.test/"],
         state: "needs-review",
-        url: "https://reviewstate.example.com/docs",
+        url: "https://reviewstate.subnet.test/docs",
       },
     ];
     const verification = {
@@ -2245,7 +2245,7 @@ describe("script utility contracts", () => {
               {
                 id: surfaceId,
                 kind: "subnet-api",
-                url: "https://api.allways.example.com/v1",
+                url: "https://api.allways.subnet.test/v1",
                 provider: "allways",
                 authority: "official",
                 auth_required: false,
@@ -2277,7 +2277,7 @@ describe("script utility contracts", () => {
           subnet_slug: "allways",
           subnet_name: "Allways",
           kind: "subnet-api",
-          url: "https://api.allways.example.com/v1",
+          url: "https://api.allways.subnet.test/v1",
           provider: "allways",
           authority: "official",
           auth_required: false,

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -901,7 +901,9 @@ describe("script utility contracts", () => {
         },
         source_repo: "https://github.com/macrocosm-os/mainframe",
         baseline_excluded_surface_ids: ["sn-25-stale-docs"],
-        baseline_excluded_surface_urls: ["https://rejected.mainframe.test/rejected"],
+        baseline_excluded_surface_urls: [
+          "https://rejected.mainframe.test/rejected",
+        ],
         surfaces: [
           {
             id: "sn-25-mainframe-source",
@@ -1017,7 +1019,10 @@ describe("script utility contracts", () => {
     const rejectedBaseline = overlaySet.manualBaselineOverlays[0].surfaces.find(
       (surface) => surface.id === "sn-25-native-chain-website",
     );
-    assert.equal(rejectedBaseline.url, "https://rejected.mainframe.test/rejected");
+    assert.equal(
+      rejectedBaseline.url,
+      "https://rejected.mainframe.test/rejected",
+    );
     assert.equal(overlaySet.generatedOverlays.length, 0);
     assert.deepEqual(
       overlaySet.manualOverlays[0].surfaces.map((surface) => surface.id),

--- a/tests/scripts-lib-branch-coverage.test.mjs
+++ b/tests/scripts-lib-branch-coverage.test.mjs
@@ -545,10 +545,10 @@ describe("deriveAuthDetail (selection + default arms)", () => {
       o: {
         type: "oauth2",
         flows: { clientCredentials: {} },
-        tokenUrl: "https://auth.example.com/token",
+        tokenUrl: "https://auth.issuer.test/token",
       },
     });
-    assert.equal(out.token_url, "https://auth.example.com/token");
+    assert.equal(out.token_url, "https://auth.issuer.test/token");
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace the locally duplicated `normalizePublicUrl` in `discover-candidates.mjs` with the shared helper from `scripts/lib.mjs`.
- Make the canonical helper the single contract for both discovery and contributor intake: keep `http`/`https`/`ws`/`wss`, and apply the impersonation + placeholder guards in one place so behavior no longer diverges by call site.

## Test plan
- [x] Tests for protocol allowlist and guard behavior on the consolidated helper
- [x] Discovery / validate-surface call sites use the shared implementation
- [x] Current registry surface URLs scanned — no false positives

Closes #5991