### PR TITLE
fix(scripts): run the brand-impersonation guard on the contributor URL path

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1382,7 +1382,13 @@ export function normalizePublicUrl(value) {
       url.username ||
       url.password ||
       isCredentialedUrl(url.toString()) ||
-      isUnsafeUrl(url.toString())
+      isUnsafeUrl(url.toString()) ||
+      // #5990: the brand-impersonation guard (ADR 0004) previously ran only on
+      // the deprecated discovery path's local copy; run it here too so every
+      // contributor-submitted surface URL -- the path that actually ships today
+      // (validate-surface.mjs / surface-add.mjs) -- is checked, not just
+      // auto-discovered candidates.
+      isBrandImpersonationUrl(url.toString())
     ) {
       return null;
     }

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -1663,6 +1663,16 @@ describe("script utility contracts", () => {
     assert.equal(normalizePublicUrl("http://10.0.0.1"), null);
     assert.equal(normalizePublicUrl("https://user:pass@metagraph.sh"), null);
     assert.equal(normalizePublicUrl("https://user@metagraph.sh"), null);
+    // #5990: the brand-impersonation guard now runs on the contributor-facing
+    // path too -- hostnames mimicking metagraph.sh (but not the real domain or a
+    // subdomain of it) are rejected here, not only on the discovery path.
+    assert.equal(normalizePublicUrl("https://metagraphsh.io"), null);
+    assert.equal(normalizePublicUrl("https://metagraph-sh.net/api"), null);
+    assert.equal(normalizePublicUrl("https://metagraph.sh.evil.com"), null);
+    assert.equal(
+      normalizePublicUrl("https://api.metagraph.sh/v1"),
+      "https://api.metagraph.sh/v1",
+    );
     assert.equal(isJsonContentType("application/openapi+json"), true);
     assert.equal(isHtmlContentType("text/html; charset=utf-8"), true);
     assert.equal(sha256Hex("metagraphed").length, 64);


### PR DESCRIPTION
## Summary

ADR 0004 documents `isBrandImpersonationUrl` (`scripts/lib.mjs`) as one of the three guards defending the path from attacker-controlled text to a callable URL. But the canonical `normalizePublicUrl` in `scripts/lib.mjs` — the version imported by `scripts/validate-surface.mjs` and `scripts/surface-add.mjs`, i.e. the single-file surface model contributions actually ship through today — **never called it**. Its only real caller was `discover-candidates.mjs`'s local copy, and ADR 0008/0011 retired that discovery pipeline. So the impersonation guard was effectively dead on the live contribution path.

## Fix

Add `isBrandImpersonationUrl(url.toString())` to the canonical `normalizePublicUrl`'s rejection conditions, so every contributor-submitted surface URL is checked — the same protection previously only exercised on the deprecated auto-discovery path.

## No false positives

Verified against **all 1289** `url`/`source_url(s)` values in the current `registry/subnets/*.json` + `registry/providers/*.json`: **zero** are flagged by the guard (it only matches hostnames/userinfo impersonating `metagraph.sh` that are not the real domain or a subdomain of it — no legitimate subnet URL does that). Existing registry data continues to validate unchanged.

## Tests

Extends the `scripts/lib.mjs` `normalizePublicUrl` test with impersonation cases: `metagraphsh.io`, `metagraph-sh.net`, and `metagraph.sh.evil.com` are now rejected, while the real `api.metagraph.sh` subdomain and unrelated subnet domains stay valid. 100% patch coverage of the new `scripts/lib.mjs` line; eslint + prettier clean.

Note: this is the companion to the "two divergent `normalizePublicUrl` implementations" issue (#5991); this PR applies the guard to the canonical version without depending on that broader dedup.

Closes #5990