### PR TITLE
fix(python-sdk): raise on malformed non-dict JSON-RPC response body

### DIFF
--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -169,11 +169,15 @@ def _request_json(
 
 def _jsonrpc_result(parsed: Any, method: str) -> Any:
     """Unwrap a JSON-RPC envelope: return its ``result``, or raise its ``error``."""
-    rpc_error = parsed.get("error") if isinstance(parsed, dict) else None
+    if not isinstance(parsed, dict):
+        raise MetagraphedError(
+            f"RPC {method} returned a malformed response (expected a JSON object)"
+        )
+    rpc_error = parsed.get("error")
     if rpc_error:
         message = rpc_error.get("message") if isinstance(rpc_error, dict) else None
         raise MetagraphedError(f"RPC {method} error: {message or rpc_error}")
-    return parsed.get("result") if isinstance(parsed, dict) else None
+    return parsed.get("result")
 
 
 def _query_pairs(query: Mapping[str, Any]) -> List[Tuple[str, Any]]:

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -387,6 +387,23 @@ class ClientTest(unittest.TestCase):
                 metagraphed_rpc("finney", "nope")
         self.assertIn("Method not found", str(ctx.exception))
 
+    def test_rpc_malformed_non_dict_body_raises(self):
+        def fake_urlopen(request, timeout=None):
+            return _FakeResponse(["not", "an", "object"])
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            with self.assertRaises(MetagraphedError) as ctx:
+                metagraphed_rpc("finney", "system_health")
+        self.assertIn("malformed", str(ctx.exception).lower())
+
+    def test_rpc_null_result_returns_none(self):
+        def fake_urlopen(request, timeout=None):
+            return _FakeResponse({"jsonrpc": "2.0", "id": 1, "result": None})
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            result = metagraphed_rpc("finney", "system_health")
+        self.assertIsNone(result)
+
     def test_rpc_retries_transient_error_then_succeeds(self):
         calls = {"n": 0}
 


### PR DESCRIPTION
## Summary
- Raise `MetagraphedError` from `_jsonrpc_result` when the parsed RPC body is not a JSON object (list/string/null), so callers can distinguish a broken envelope from a legitimate null result.
- Preserve existing behavior for `{"result": null}` — still returns `None` without raising.
- Add hermetic unit tests for both cases.

Closes #5988

## Test plan
- [x] `python -m unittest python.tests.test_client.ClientTest.test_rpc_malformed_non_dict_body_raises`
- [x] `python -m unittest python.tests.test_client.ClientTest.test_rpc_null_result_returns_none`
- [x] Existing RPC success/error tests still pass