### PR TITLE
chore(ui): remove dead paginate() helper (#6024)

### DIFF
--- a/apps/ui/src/lib/metagraphed/url-state.test.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { joinEconomics, joinHealth, matchesQuery, sortBy, paginate } from "./url-state";
+import { joinEconomics, joinHealth, matchesQuery, sortBy } from "./url-state";
 
 describe("matchesQuery", () => {
   it("matches everything for an empty needle", () => {
@@ -157,19 +157,5 @@ describe("joinEconomics", () => {
     expect(out[0]).toMatchObject({ emission_share: 0.0125 });
     // No entry for netuid 2 → passes through unchanged, "—" in the cell.
     expect(out[1]).toBe(rows[1]);
-  });
-});
-
-describe("paginate", () => {
-  const rows = [1, 2, 3, 4, 5, 6, 7];
-
-  it("slices the requested page", () => {
-    expect(paginate(rows, 1, 3)).toEqual([1, 2, 3]);
-    expect(paginate(rows, 2, 3)).toEqual([4, 5, 6]);
-    expect(paginate(rows, 3, 3)).toEqual([7]);
-  });
-
-  it("returns an empty slice past the end", () => {
-    expect(paginate(rows, 4, 3)).toEqual([]);
   });
 });

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -60,11 +60,6 @@ export function sortBy<T>(
   });
 }
 
-export function paginate<T>(rows: T[], page: number, pageSize: number): T[] {
-  const start = (page - 1) * pageSize;
-  return rows.slice(start, start + pageSize);
-}
-
 /**
  * Join a list of rows with a per-key health map, overlaying `health` and
  * back-filling `updated_at` from the probe's `last_checked` when the row lacks


### PR DESCRIPTION
## Summary
- Remove unused client-side `paginate()` from `apps/ui/src/lib/metagraphed/url-state.ts` (superseded by server-driven cursor pagination via `limit`/`cursor`).
- Drop its dedicated unit tests; keep legacy `page`/`pageSize` schema fields for URL back-compat with older callers.

## Context
Repo-wide search showed `paginate()` was only referenced from its own test. List routes (`/subnets`, `/surfaces`) already use cursor pagination; `/endpoints` does its own inline slice and does not import this helper.

## Test plan
- [x] `npm test --workspace=apps/ui -- src/lib/metagraphed/url-state.test.ts`
- [ ] Confirm no import of `paginate` from `url-state` remains

Closes #6024