### PR TITLE
fix(ui): apply the pre-2000 placeholder rule in normalizeFreshnessSources

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.test.ts
@@ -15,6 +15,7 @@ import {
   getNextPageParam,
   normalizeSubnetGaps,
   validateNextCursor,
+  normalizeFreshnessSources,
 } from "./queries";
 
 // These tests lock the canonical-only reads after #1756 collapsed the redundant
@@ -22,6 +23,40 @@ import {
 // served by /api/v1/subnets, /subnets/{n}/profile, /gaps, /compare as of the PR)
 // plus the edge cases #226 (stringArrayFromUnknown) and #1757 (null timestamps)
 // guard. A future API regression that drops a canonical field is caught here.
+
+describe("normalizeFreshnessSources", () => {
+  const NOW = Date.parse("2026-07-15T00:00:00.000Z");
+
+  it("excludes a 1970 placeholder timestamp from the freshness/staleness domain (#6021)", () => {
+    const out = normalizeFreshnessSources(
+      [
+        { id: "placeholder", as_of: "1970-01-01T00:00:00.000Z" },
+        { id: "fresh", as_of: "2026-07-14T00:00:00.000Z" },
+      ],
+      NOW,
+    );
+    // The placeholder must NOT feed a multi-decade age into the aggregates -- the
+    // only usable source (1 day old) drives maxAge/avgAge, so both are 86400s.
+    expect(out.maxAgeSeconds).toBe(86_400);
+    expect(out.avgAgeSeconds).toBe(86_400);
+    // And the placeholder is not counted stale via its (excluded) age.
+    expect(out.staleCount).toBe(0);
+    // The placeholder source still appears in the list, just with no last_seen.
+    const placeholder = out.sources.find((s) => s.name === "placeholder");
+    expect(placeholder?.last_seen).toBeUndefined();
+    const fresh = out.sources.find((s) => s.name === "fresh");
+    expect(fresh?.last_seen).toBe("2026-07-14T00:00:00.000Z");
+  });
+
+  it("still ages a genuinely stale (post-2000) source", () => {
+    const out = normalizeFreshnessSources(
+      [{ id: "old", as_of: "2026-07-01T00:00:00.000Z", stale_after_hours: 24 }],
+      NOW,
+    );
+    expect(out.maxAgeSeconds).toBe(14 * 86_400);
+    expect(out.staleCount).toBe(1);
+  });
+});
 
 describe("normalizeAccountEvent", () => {
   it("normalizes primitive event fields before rendering", () => {

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -5,6 +5,7 @@ import { blockRefPathSegment } from "./blocks";
 import { extrinsicHashPathSegment } from "./extrinsics";
 import { isValidSs58, ss58PathSegment } from "./accounts";
 import { isSchemaDrift, normalizeDriftStatus } from "./schema-drift";
+import { isUsableTimestamp } from "./format";
 import type {
   AdapterSnapshot,
   AgentResource,
@@ -592,14 +593,19 @@ function normalizeUptime(raw: Partial<Uptime> | undefined): Uptime {
   };
 }
 
-function normalizeFreshnessSources(raw: unknown, now = Date.now()) {
+export function normalizeFreshnessSources(raw: unknown, now = Date.now()) {
   let staleCount = 0;
   let ageTotal = 0;
   let ageCount = 0;
   let maxAgeSeconds: number | undefined;
 
   const sources = freshnessSourceRecords(raw).map<NormalizedFreshnessSource>((s) => {
-    const ts = finiteTimestamp(s.as_of) ?? finiteTimestamp(s.timestamp);
+    const candidate = finiteTimestamp(s.as_of) ?? finiteTimestamp(s.timestamp);
+    // Apply the same pre-2000 placeholder exclusion isUsableTimestamp enforces,
+    // so a "1970-01-01T00:00:00.000Z" registry placeholder isn't fed as a
+    // multi-decade age into the freshness/staleness domain (staleCount,
+    // avgAgeSeconds, maxAgeSeconds) the UI renders.
+    const ts = isUsableTimestamp(candidate) ? candidate : undefined;
     const ageSec =
       ts !== undefined ? Math.max(0, Math.round((now - Date.parse(ts)) / 1000)) : undefined;
 


### PR DESCRIPTION
Fixes #6021.

\`normalizeFreshnessSources\` (\`apps/ui/src/lib/metagraphed/queries.ts\`) computed the freshness/staleness domain via its own \`finiteTimestamp\` helper, which only checks \`Date.parse\` finiteness — no epoch floor. So the registry's \`"1970-01-01T00:00:00.000Z"\` placeholder fed a multi-decade \`ageSec\` into \`staleCount\`, \`avgAgeSeconds\`, and \`maxAgeSeconds\`, which reach real UI (\`health.tsx\` "Avg age"/"Max age", \`index.tsx\`, \`about.tsx\`, \`registry-ticker.tsx\`).

## Fix
- Gate the resolved timestamp through the existing \`isUsableTimestamp\` (from \`./format\`), which already enforces the documented pre-2000 exclusion everywhere else. A 1970 placeholder is now treated as unknown and excluded from the aggregates — the same contract \`isUsableTimestamp\` already applies in the direct callers.
- \`finiteTimestamp\` is left unchanged (its other, unrelated caller keeps its behavior). \`normalizeFreshnessSources\` is exported for the regression test.

## Tests
Two cases in \`queries.test.ts\`: a 1970 placeholder + a fresh source, asserting the placeholder is excluded from \`maxAgeSeconds\`/\`avgAgeSeconds\`/\`staleCount\` (both aggregates driven by the single usable source); and a genuinely-stale post-2000 source still ages + counts as stale. Full \`queries.test.ts\` green (55 tests).

No visual change — this is confined to \`apps/ui/src/lib/**\` + its test.