### PR TITLE
fix(ui): guard useDensity/useHealthPalette against a throwing localStorage

### DIFF
--- a/apps/ui/src/lib/density.test.ts
+++ b/apps/ui/src/lib/density.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { readChoice } from "./density";
+
+describe("readChoice", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns comfortable during SSR when window is absent", () => {
+    expect(readChoice()).toBe("comfortable");
+  });
+
+  it("returns comfortable when localStorage is empty", () => {
+    vi.stubGlobal("window", {
+      localStorage: { getItem: vi.fn(() => null) },
+    });
+    expect(readChoice()).toBe("comfortable");
+  });
+
+  it("restores a persisted compact choice", () => {
+    vi.stubGlobal("window", {
+      localStorage: { getItem: vi.fn(() => "compact") },
+    });
+    expect(readChoice()).toBe("compact");
+  });
+
+  it("falls back to comfortable for unknown stored values", () => {
+    vi.stubGlobal("window", {
+      localStorage: { getItem: vi.fn(() => "spacious") },
+    });
+    expect(readChoice()).toBe("comfortable");
+  });
+
+  it("degrades to comfortable when localStorage.getItem throws (#6027)", () => {
+    // Safari private browsing / storage blocked by policy or an extension makes
+    // getItem throw; readChoice must not throw during the initial render.
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: vi.fn(() => {
+          throw new Error("localStorage is not available");
+        }),
+      },
+    });
+    expect(() => readChoice()).not.toThrow();
+    expect(readChoice()).toBe("comfortable");
+  });
+});

--- a/apps/ui/src/lib/density.ts
+++ b/apps/ui/src/lib/density.ts
@@ -3,10 +3,17 @@ import { useCallback, useEffect, useState } from "react";
 export type Density = "comfortable" | "compact";
 const STORAGE_KEY = "mg-density";
 
-function readChoice(): Density {
+export function readChoice(): Density {
   if (typeof window === "undefined") return "comfortable";
-  const v = window.localStorage.getItem(STORAGE_KEY);
-  return v === "compact" ? "compact" : "comfortable";
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    return v === "compact" ? "compact" : "comfortable";
+  } catch {
+    // Match theme.ts's readChoice: a throwing localStorage (Safari private
+    // browsing, storage blocked by policy/extension) degrades to the default
+    // instead of throwing during the initial render.
+    return "comfortable";
+  }
 }
 
 function apply(d: Density) {

--- a/apps/ui/src/lib/health-palette.test.ts
+++ b/apps/ui/src/lib/health-palette.test.ts
@@ -53,4 +53,18 @@ describe("readId", () => {
       vi.unstubAllGlobals();
     }
   });
+
+  it("degrades to the default when localStorage.getItem throws (#6027)", () => {
+    // Safari private browsing / storage blocked by policy or an extension makes
+    // getItem throw; readId must not throw during the initial render.
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: vi.fn(() => {
+          throw new Error("localStorage is not available");
+        }),
+      },
+    });
+    expect(() => readId()).not.toThrow();
+    expect(readId()).toBe("traffic-light");
+  });
 });

--- a/apps/ui/src/lib/health-palette.ts
+++ b/apps/ui/src/lib/health-palette.ts
@@ -104,8 +104,15 @@ const DEFAULT_ID: HealthPaletteId = "traffic-light";
 
 export function readId(): HealthPaletteId {
   if (typeof window === "undefined") return DEFAULT_ID;
-  const v = window.localStorage.getItem(STORAGE_KEY);
-  return (HEALTH_PALETTES.find((p) => p.id === v)?.id ?? DEFAULT_ID) as HealthPaletteId;
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    return (HEALTH_PALETTES.find((p) => p.id === v)?.id ?? DEFAULT_ID) as HealthPaletteId;
+  } catch {
+    // Match theme.ts's readChoice: a throwing localStorage (Safari private
+    // browsing, storage blocked by policy/extension) degrades to the default
+    // instead of throwing during the initial render.
+    return DEFAULT_ID;
+  }
 }
 
 export function cssFor(p: HealthPaletteDef): string {


### PR DESCRIPTION
## Summary

`apps/ui/src/lib/theme.ts`'s `readChoice` wraps `window.localStorage.getItem` in `try/catch`, falling back to `"system"`. `density.ts`'s `readChoice` and `health-palette.ts`'s `readId` use the same SSR-guard + render-time call shape (`useState(() => read…())`) but do **not** catch a throwing read. When `localStorage.getItem` throws — Safari private browsing, storage blocked by policy or an extension — `useDensity()` / `useHealthPalette()` throw during the initial render instead of degrading gracefully the way `useTheme()` already does.

## Fix

Wrap both reads in the same `try/catch`-with-fallback pattern `theme.ts` already uses (default `comfortable` / `traffic-light`). `theme.ts` is unchanged — it's the reference pattern. `density.ts`'s `readChoice` is now exported so its fallback is unit-testable (matching `health-palette.ts`'s already-exported `readId`).

## Tests

New `density.test.ts` and an added case in `health-palette.test.ts`, each stubbing a throwing `localStorage.getItem` and asserting the read does not throw and returns the default (mirroring the existing `readId` test conventions — `node` env, `vi.stubGlobal`). Both files' full suites pass (12 tests); eslint + prettier clean.

UI-only change under `apps/**`; pure lib logic with no rendered-output change, so no screenshot matrix applies.

Closes #6027