### PR TITLE
fix(ui): report failure when the legacy clipboard copy is rejected

### DIFF
--- a/apps/ui/src/hooks/use-copy.test.ts
+++ b/apps/ui/src/hooks/use-copy.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   copyErrorDescription,
   copySuccessTitle,
+  legacyClipboardCopy,
   shouldUseNavigatorClipboard,
   truncateCopyPreview,
 } from "./use-copy";
@@ -51,5 +52,33 @@ describe("shouldUseNavigatorClipboard", () => {
   it("falls back when navigator or clipboard is missing", () => {
     expect(shouldUseNavigatorClipboard(undefined)).toBe(false);
     expect(shouldUseNavigatorClipboard({} as Navigator)).toBe(false);
+  });
+});
+
+describe("legacyClipboardCopy", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubDocument(execResult: boolean) {
+    vi.stubGlobal("document", {
+      createElement: vi.fn(() => ({ value: "", style: {}, select: vi.fn() })),
+      body: { appendChild: vi.fn(), removeChild: vi.fn() },
+      execCommand: vi.fn(() => execResult),
+    });
+  }
+
+  it("returns false during SSR when document is absent", () => {
+    expect(legacyClipboardCopy("x")).toBe(false);
+  });
+
+  it("returns true when execCommand succeeds", () => {
+    stubDocument(true);
+    expect(legacyClipboardCopy("hello")).toBe(true);
+  });
+
+  it("returns false when execCommand is rejected, not a false success (#6026)", () => {
+    stubDocument(false);
+    expect(legacyClipboardCopy("hello")).toBe(false);
   });
 });

--- a/apps/ui/src/hooks/use-copy.ts
+++ b/apps/ui/src/hooks/use-copy.ts
@@ -27,6 +27,26 @@ export function shouldUseNavigatorClipboard(navigatorValue: Navigator | undefine
 }
 
 /**
+ * Legacy `execCommand("copy")` fallback for browsers without the async
+ * Clipboard API. Returns whether the copy actually succeeded: `execCommand`
+ * returns `false` (without throwing) when the copy is rejected -- no user
+ * activation, blocked by permissions policy, etc. -- so callers must honor the
+ * return value rather than assume success.
+ */
+export function legacyClipboardCopy(value: string): boolean {
+  if (typeof document === "undefined") return false;
+  const ta = document.createElement("textarea");
+  ta.value = value;
+  ta.style.position = "fixed";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  const succeeded = document.execCommand("copy");
+  document.body.removeChild(ta);
+  return succeeded;
+}
+
+/**
  * Shared copy hook used by every "copy this URL/value" interaction.
  * Returns `copied` (truthy for ~1.4s after success) so callers can swap an
  * icon for a green check, plus a `copy(value)` action.
@@ -43,15 +63,12 @@ export function useCopy(opts: CopyOpts = {}) {
         if (shouldUseNavigatorClipboard(typeof navigator !== "undefined" ? navigator : undefined)) {
           await navigator.clipboard.writeText(value);
         } else if (typeof document !== "undefined") {
-          // Fallback for older browsers / SSR-safe access pattern.
-          const ta = document.createElement("textarea");
-          ta.value = value;
-          ta.style.position = "fixed";
-          ta.style.opacity = "0";
-          document.body.appendChild(ta);
-          ta.select();
-          document.execCommand("copy");
-          document.body.removeChild(ta);
+          // Fallback for older browsers / SSR-safe access pattern. Honor the
+          // return value so a rejected copy is reported as a failure below,
+          // instead of falsely toasting success.
+          if (!legacyClipboardCopy(value)) {
+            throw new Error("The clipboard copy command was rejected.");
+          }
         }
         setCopied(true);
         if (toastOnSuccess) {


### PR DESCRIPTION
## Summary

`apps/ui/src/hooks/use-copy.ts`'s fallback path (used when `navigator.clipboard` is unavailable) called `document.execCommand("copy")` **without checking its boolean return value**, then unconditionally ran `setCopied(true)` and showed a "Copied to clipboard" success toast. `execCommand` returns `false` **without throwing** when the copy is rejected (no user activation, blocked by permissions policy), so a genuine failure was reported to the user as a success.

## Fix

Extract the fallback into a pure, testable `legacyClipboardCopy(value): boolean` helper (matching this file's existing extract-pure-helper convention — `truncateCopyPreview`, `copySuccessTitle`, etc.) that returns whether the copy actually succeeded. `useCopy` now throws on a `false` return, so the **existing** `catch` reports "Copy failed" (via the already-present `toast.error`) and `copy()` returns `false` — instead of a false success.

## Tests

Adds `legacyClipboardCopy` cases to `use-copy.test.ts` (node env, `vi.stubGlobal`): returns `true` when `execCommand` succeeds, `false` when it's rejected (the bug), and `false` during SSR. Full `use-copy.test.ts` suite passes (12 tests); eslint + prettier clean.

UI-only change under `apps/**`; pure hook logic with no rendered-output change, so no screenshot matrix applies.

Closes #6026