### PR TITLE
feat(ui): add a dedicated GraphQL explorer page

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -39,6 +39,7 @@
     "@tanstack/react-start": "^1.168.27",
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/zod-adapter": "^1.167.0",
+    "graphiql": "^4.1.2",
     "lucide-react": "^0.575.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -40,6 +40,7 @@
     "@tanstack/router-plugin": "^1.168.19",
     "@tanstack/zod-adapter": "^1.167.0",
     "graphiql": "^4.1.2",
+    "graphql": "^17.0.2",
     "lucide-react": "^0.575.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/apps/ui/src/components/metagraphed/graphiql-explorer-body.tsx
+++ b/apps/ui/src/components/metagraphed/graphiql-explorer-body.tsx
@@ -2,8 +2,31 @@ import { useMemo } from "react";
 import { GraphiQL } from "graphiql";
 import { createGraphiQLFetcher } from "@graphiql/toolkit";
 import { useTheme } from "@/lib/theme";
+import { classNames } from "@/lib/metagraphed/format";
 import "graphiql/style.css";
 import "./graphiql-explorer.css";
+
+// GraphiQL persists the query-editor/response split ratio to localStorage
+// under "graphiql:editorFlex" (@graphiql/react's internal horizontal resize
+// hook -- undocumented, no prop exposes it). The default 1:1 split leaves
+// most of the response pane looking like dead space until a query runs.
+// Only seed a wider editor share at desktop widths (matches the >=1024px
+// breakpoint in graphiql-explorer.css that also relaxes the pane's
+// min-width there) -- at narrower widths CodeMirror's own content width
+// already governs a reasonable split, and forcing this ratio there would
+// fight that and clip the query text instead. First-visit only: once a
+// user drags the divider, their own ratio takes over here.
+try {
+  if (
+    typeof window !== "undefined" &&
+    window.innerWidth >= 1024 &&
+    !window.localStorage.getItem("graphiql:editorFlex")
+  ) {
+    window.localStorage.setItem("graphiql:editorFlex", "1.6");
+  }
+} catch {
+  // ignore quota / privacy-mode errors
+}
 
 const DEFAULT_QUERY = `{
   subnet(netuid: 7) {
@@ -24,14 +47,20 @@ const DEFAULT_QUERY = `{
 
 export interface GraphiqlExplorerBodyProps {
   endpoint: string;
+  heightClassName: string;
 }
 
-export function GraphiqlExplorerBody({ endpoint }: GraphiqlExplorerBodyProps) {
+export function GraphiqlExplorerBody({ endpoint, heightClassName }: GraphiqlExplorerBodyProps) {
   const { resolved } = useTheme();
   const fetcher = useMemo(() => createGraphiQLFetcher({ url: endpoint }), [endpoint]);
 
   return (
-    <div className="mg-graphiql-frame h-[640px] overflow-hidden rounded-lg border border-border">
+    <div
+      className={classNames(
+        "mg-graphiql-frame overflow-hidden rounded-lg border border-border",
+        heightClassName,
+      )}
+    >
       <GraphiQL
         fetcher={fetcher}
         defaultQuery={DEFAULT_QUERY}

--- a/apps/ui/src/components/metagraphed/graphiql-explorer-body.tsx
+++ b/apps/ui/src/components/metagraphed/graphiql-explorer-body.tsx
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { GraphiQL } from "graphiql";
+import { createGraphiQLFetcher } from "@graphiql/toolkit";
+import { useTheme } from "@/lib/theme";
+import "graphiql/style.css";
+import "./graphiql-explorer.css";
+
+const DEFAULT_QUERY = `{
+  subnet(netuid: 7) {
+    name
+    health {
+      status
+    }
+    surfaces {
+      kind
+      url
+    }
+    economics {
+      emission_share
+    }
+  }
+}
+`;
+
+export interface GraphiqlExplorerBodyProps {
+  endpoint: string;
+}
+
+export function GraphiqlExplorerBody({ endpoint }: GraphiqlExplorerBodyProps) {
+  const { resolved } = useTheme();
+  const fetcher = useMemo(() => createGraphiQLFetcher({ url: endpoint }), [endpoint]);
+
+  return (
+    <div className="mg-graphiql-frame h-[640px] overflow-hidden rounded-lg border border-border">
+      <GraphiQL
+        fetcher={fetcher}
+        defaultQuery={DEFAULT_QUERY}
+        forcedTheme={resolved}
+        showPersistHeadersSettings={false}
+      />
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/graphiql-explorer.css
+++ b/apps/ui/src/components/metagraphed/graphiql-explorer.css
@@ -38,3 +38,46 @@ body.graphiql-dark [data-radix-popper-content-wrapper] {
 .mg-graphiql-frame .graphiql-container {
   border-radius: inherit;
 }
+
+/*
+ * GraphiQL's icon sidebar (--sidebar-width) and per-editor toolbar
+ * (--toolbar-width) are fixed desktop-sized rails with no built-in responsive
+ * behavior — at mobile/tablet widths they eat a disproportionate share of the
+ * frame. Narrow them progressively.
+ *
+ * The query/response split (a JS-driven flex-grow ratio, see
+ * graphiql-explorer-body.tsx) is left at its default below 1024px: flex
+ * items default to min-width: auto, so CodeMirror's unwrapped query content
+ * already keeps the editor pane at a readable width and naturally collapses
+ * the (empty, until a query runs) response pane on narrow viewports --
+ * forcing min-width: 0 there to let a wider ratio apply instead just clips
+ * the query text. At >=1024px there's enough absolute width that CodeMirror
+ * never needs the min-width floor, so it's safe to let the (wider) seeded
+ * ratio govern and reclaim the otherwise-empty response pane.
+ */
+@media (min-width: 1024px) {
+  .mg-graphiql-frame .graphiql-editors,
+  .mg-graphiql-frame .graphiql-response {
+    min-width: 0;
+  }
+}
+
+@media (max-width: 1023px) {
+  .mg-graphiql-frame .graphiql-container {
+    --sidebar-width: 48px;
+    --toolbar-width: 36px;
+  }
+}
+
+@media (max-width: 767px) {
+  .mg-graphiql-frame .graphiql-container {
+    --sidebar-width: 40px;
+    --toolbar-width: 32px;
+  }
+
+  /* Reclaim session-header space on narrow viewports; the page's own
+     "Explorer" heading already identifies the widget. */
+  .mg-graphiql-frame .graphiql-logo {
+    display: none;
+  }
+}

--- a/apps/ui/src/components/metagraphed/graphiql-explorer.css
+++ b/apps/ui/src/components/metagraphed/graphiql-explorer.css
@@ -1,0 +1,40 @@
+/*
+ * Harmonizes the embedded GraphiQL widget (#3499) with the Bone & Ink design
+ * system. GraphiQL toggles `body.graphiql-light` / `body.graphiql-dark`
+ * itself when the `forcedTheme` prop is set, and portals its dialogs and
+ * tooltips to <body>, so the overrides target those body classes directly
+ * (mirroring GraphiQL's own selector list) rather than our wrapper's scope.
+ */
+body.graphiql-light .graphiql-container,
+body.graphiql-light .CodeMirror-info,
+body.graphiql-light .CodeMirror-lint-tooltip,
+body.graphiql-light .graphiql-dialog,
+body.graphiql-light .graphiql-dialog-overlay,
+body.graphiql-light .graphiql-tooltip,
+body.graphiql-light [data-radix-popper-content-wrapper] {
+  --color-base: 48, 28%, 96%;
+  --color-neutral: 183, 21%, 8%;
+  --color-primary: 166, 100%, 39%;
+  --color-error: 1, 75%, 50%;
+  --font-family: var(--font-sans);
+  --font-family-mono: var(--font-mono);
+}
+
+body.graphiql-dark .graphiql-container,
+body.graphiql-dark .CodeMirror-info,
+body.graphiql-dark .CodeMirror-lint-tooltip,
+body.graphiql-dark .graphiql-dialog,
+body.graphiql-dark .graphiql-dialog-overlay,
+body.graphiql-dark .graphiql-tooltip,
+body.graphiql-dark [data-radix-popper-content-wrapper] {
+  --color-base: 212, 11%, 4%;
+  --color-neutral: 211, 27%, 95%;
+  --color-primary: 160, 78%, 64%;
+  --color-error: 4, 100%, 64%;
+  --font-family: var(--font-sans);
+  --font-family-mono: var(--font-mono);
+}
+
+.mg-graphiql-frame .graphiql-container {
+  border-radius: inherit;
+}

--- a/apps/ui/src/components/metagraphed/graphiql-explorer.tsx
+++ b/apps/ui/src/components/metagraphed/graphiql-explorer.tsx
@@ -1,0 +1,28 @@
+import { lazy, Suspense } from "react";
+import { ClientOnly } from "@tanstack/react-router";
+
+const GraphiqlExplorerBody = lazy(() =>
+  import("./graphiql-explorer-body").then((m) => ({ default: m.GraphiqlExplorerBody })),
+);
+
+export interface GraphiqlExplorerProps {
+  endpoint: string;
+}
+
+export function GraphiqlExplorer({ endpoint }: GraphiqlExplorerProps) {
+  return (
+    <ClientOnly fallback={<ExplorerFallback />}>
+      <Suspense fallback={<ExplorerFallback />}>
+        <GraphiqlExplorerBody endpoint={endpoint} />
+      </Suspense>
+    </ClientOnly>
+  );
+}
+
+function ExplorerFallback() {
+  return (
+    <div className="flex h-[640px] items-center justify-center rounded-lg border border-border bg-card font-mono text-xs text-ink-muted">
+      Loading explorer…
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/graphiql-explorer.tsx
+++ b/apps/ui/src/components/metagraphed/graphiql-explorer.tsx
@@ -1,27 +1,38 @@
 import { lazy, Suspense } from "react";
 import { ClientOnly } from "@tanstack/react-router";
+import { classNames } from "@/lib/metagraphed/format";
 
 const GraphiqlExplorerBody = lazy(() =>
   import("./graphiql-explorer-body").then((m) => ({ default: m.GraphiqlExplorerBody })),
 );
 
+const DEFAULT_HEIGHT_CLASSNAME = "h-[460px] md:h-[540px] lg:h-[640px]";
+
 export interface GraphiqlExplorerProps {
   endpoint: string;
+  /** Tailwind height classes; overrides the compact docs-embed default. */
+  heightClassName?: string;
 }
 
-export function GraphiqlExplorer({ endpoint }: GraphiqlExplorerProps) {
+export function GraphiqlExplorer({ endpoint, heightClassName }: GraphiqlExplorerProps) {
+  const height = heightClassName ?? DEFAULT_HEIGHT_CLASSNAME;
   return (
-    <ClientOnly fallback={<ExplorerFallback />}>
-      <Suspense fallback={<ExplorerFallback />}>
-        <GraphiqlExplorerBody endpoint={endpoint} />
+    <ClientOnly fallback={<ExplorerFallback heightClassName={height} />}>
+      <Suspense fallback={<ExplorerFallback heightClassName={height} />}>
+        <GraphiqlExplorerBody endpoint={endpoint} heightClassName={height} />
       </Suspense>
     </ClientOnly>
   );
 }
 
-function ExplorerFallback() {
+function ExplorerFallback({ heightClassName }: { heightClassName: string }) {
   return (
-    <div className="flex h-[640px] items-center justify-center rounded-lg border border-border bg-card font-mono text-xs text-ink-muted">
+    <div
+      className={classNames(
+        "flex items-center justify-center rounded-lg border border-border bg-card font-mono text-xs text-ink-muted",
+        heightClassName,
+      )}
+    >
       Loading explorer…
     </div>
   );

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -16,7 +16,6 @@ import { Route as SchemasRouteImport } from './routes/schemas'
 import { Route as RpcRouteImport } from './routes/rpc'
 import { Route as LeaderboardsRouteImport } from './routes/leaderboards'
 import { Route as HealthRouteImport } from './routes/health'
-import { Route as GraphqlRouteImport } from './routes/graphql'
 import { Route as GapsRouteImport } from './routes/gaps'
 import { Route as FeedsRouteImport } from './routes/feeds'
 import { Route as ExplorerRouteImport } from './routes/explorer'
@@ -30,6 +29,7 @@ import { Route as SudoIndexRouteImport } from './routes/sudo.index'
 import { Route as SubnetsIndexRouteImport } from './routes/subnets.index'
 import { Route as RuntimeIndexRouteImport } from './routes/runtime.index'
 import { Route as ProvidersIndexRouteImport } from './routes/providers.index'
+import { Route as GraphqlIndexRouteImport } from './routes/graphql.index'
 import { Route as ExtrinsicsIndexRouteImport } from './routes/extrinsics.index'
 import { Route as BlocksIndexRouteImport } from './routes/blocks.index'
 import { Route as AdminChangesIndexRouteImport } from './routes/admin-changes.index'
@@ -37,6 +37,7 @@ import { Route as AccountsIndexRouteImport } from './routes/accounts.index'
 import { Route as ValidatorsHotkeyRouteImport } from './routes/validators.$hotkey'
 import { Route as SubnetsNetuidRouteImport } from './routes/subnets.$netuid'
 import { Route as ProvidersSlugRouteImport } from './routes/providers.$slug'
+import { Route as GraphqlExplorerRouteImport } from './routes/graphql.explorer'
 import { Route as ExtrinsicsHashRouteImport } from './routes/extrinsics.$hash'
 import { Route as BlocksRefRouteImport } from './routes/blocks.$ref'
 import { Route as AccountsSs58RouteImport } from './routes/accounts.$ss58'
@@ -74,11 +75,6 @@ const LeaderboardsRoute = LeaderboardsRouteImport.update({
 const HealthRoute = HealthRouteImport.update({
   id: '/health',
   path: '/health',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const GraphqlRoute = GraphqlRouteImport.update({
-  id: '/graphql',
-  path: '/graphql',
   getParentRoute: () => rootRouteImport,
 } as any)
 const GapsRoute = GapsRouteImport.update({
@@ -146,6 +142,11 @@ const ProvidersIndexRoute = ProvidersIndexRouteImport.update({
   path: '/providers/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const GraphqlIndexRoute = GraphqlIndexRouteImport.update({
+  id: '/graphql/',
+  path: '/graphql/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ExtrinsicsIndexRoute = ExtrinsicsIndexRouteImport.update({
   id: '/extrinsics/',
   path: '/extrinsics/',
@@ -181,6 +182,11 @@ const ProvidersSlugRoute = ProvidersSlugRouteImport.update({
   path: '/providers/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
+const GraphqlExplorerRoute = GraphqlExplorerRouteImport.update({
+  id: '/graphql/explorer',
+  path: '/graphql/explorer',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ExtrinsicsHashRoute = ExtrinsicsHashRouteImport.update({
   id: '/extrinsics/$hash',
   path: '/extrinsics/$hash',
@@ -206,7 +212,6 @@ export interface FileRoutesByFullPath {
   '/explorer': typeof ExplorerRoute
   '/feeds': typeof FeedsRoute
   '/gaps': typeof GapsRoute
-  '/graphql': typeof GraphqlRoute
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
   '/rpc': typeof RpcRoute
@@ -217,6 +222,7 @@ export interface FileRoutesByFullPath {
   '/accounts/$ss58': typeof AccountsSs58Route
   '/blocks/$ref': typeof BlocksRefRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
+  '/graphql/explorer': typeof GraphqlExplorerRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
   '/validators/$hotkey': typeof ValidatorsHotkeyRoute
@@ -224,6 +230,7 @@ export interface FileRoutesByFullPath {
   '/admin-changes/': typeof AdminChangesIndexRoute
   '/blocks/': typeof BlocksIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
+  '/graphql/': typeof GraphqlIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/runtime/': typeof RuntimeIndexRoute
   '/subnets/': typeof SubnetsIndexRoute
@@ -239,7 +246,6 @@ export interface FileRoutesByTo {
   '/explorer': typeof ExplorerRoute
   '/feeds': typeof FeedsRoute
   '/gaps': typeof GapsRoute
-  '/graphql': typeof GraphqlRoute
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
   '/rpc': typeof RpcRoute
@@ -250,6 +256,7 @@ export interface FileRoutesByTo {
   '/accounts/$ss58': typeof AccountsSs58Route
   '/blocks/$ref': typeof BlocksRefRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
+  '/graphql/explorer': typeof GraphqlExplorerRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
   '/validators/$hotkey': typeof ValidatorsHotkeyRoute
@@ -257,6 +264,7 @@ export interface FileRoutesByTo {
   '/admin-changes': typeof AdminChangesIndexRoute
   '/blocks': typeof BlocksIndexRoute
   '/extrinsics': typeof ExtrinsicsIndexRoute
+  '/graphql': typeof GraphqlIndexRoute
   '/providers': typeof ProvidersIndexRoute
   '/runtime': typeof RuntimeIndexRoute
   '/subnets': typeof SubnetsIndexRoute
@@ -273,7 +281,6 @@ export interface FileRoutesById {
   '/explorer': typeof ExplorerRoute
   '/feeds': typeof FeedsRoute
   '/gaps': typeof GapsRoute
-  '/graphql': typeof GraphqlRoute
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
   '/rpc': typeof RpcRoute
@@ -284,6 +291,7 @@ export interface FileRoutesById {
   '/accounts/$ss58': typeof AccountsSs58Route
   '/blocks/$ref': typeof BlocksRefRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
+  '/graphql/explorer': typeof GraphqlExplorerRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
   '/validators/$hotkey': typeof ValidatorsHotkeyRoute
@@ -291,6 +299,7 @@ export interface FileRoutesById {
   '/admin-changes/': typeof AdminChangesIndexRoute
   '/blocks/': typeof BlocksIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
+  '/graphql/': typeof GraphqlIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/runtime/': typeof RuntimeIndexRoute
   '/subnets/': typeof SubnetsIndexRoute
@@ -308,7 +317,6 @@ export interface FileRouteTypes {
     | '/explorer'
     | '/feeds'
     | '/gaps'
-    | '/graphql'
     | '/health'
     | '/leaderboards'
     | '/rpc'
@@ -319,6 +327,7 @@ export interface FileRouteTypes {
     | '/accounts/$ss58'
     | '/blocks/$ref'
     | '/extrinsics/$hash'
+    | '/graphql/explorer'
     | '/providers/$slug'
     | '/subnets/$netuid'
     | '/validators/$hotkey'
@@ -326,6 +335,7 @@ export interface FileRouteTypes {
     | '/admin-changes/'
     | '/blocks/'
     | '/extrinsics/'
+    | '/graphql/'
     | '/providers/'
     | '/runtime/'
     | '/subnets/'
@@ -341,7 +351,6 @@ export interface FileRouteTypes {
     | '/explorer'
     | '/feeds'
     | '/gaps'
-    | '/graphql'
     | '/health'
     | '/leaderboards'
     | '/rpc'
@@ -352,6 +361,7 @@ export interface FileRouteTypes {
     | '/accounts/$ss58'
     | '/blocks/$ref'
     | '/extrinsics/$hash'
+    | '/graphql/explorer'
     | '/providers/$slug'
     | '/subnets/$netuid'
     | '/validators/$hotkey'
@@ -359,6 +369,7 @@ export interface FileRouteTypes {
     | '/admin-changes'
     | '/blocks'
     | '/extrinsics'
+    | '/graphql'
     | '/providers'
     | '/runtime'
     | '/subnets'
@@ -374,7 +385,6 @@ export interface FileRouteTypes {
     | '/explorer'
     | '/feeds'
     | '/gaps'
-    | '/graphql'
     | '/health'
     | '/leaderboards'
     | '/rpc'
@@ -385,6 +395,7 @@ export interface FileRouteTypes {
     | '/accounts/$ss58'
     | '/blocks/$ref'
     | '/extrinsics/$hash'
+    | '/graphql/explorer'
     | '/providers/$slug'
     | '/subnets/$netuid'
     | '/validators/$hotkey'
@@ -392,6 +403,7 @@ export interface FileRouteTypes {
     | '/admin-changes/'
     | '/blocks/'
     | '/extrinsics/'
+    | '/graphql/'
     | '/providers/'
     | '/runtime/'
     | '/subnets/'
@@ -408,7 +420,6 @@ export interface RootRouteChildren {
   ExplorerRoute: typeof ExplorerRoute
   FeedsRoute: typeof FeedsRoute
   GapsRoute: typeof GapsRoute
-  GraphqlRoute: typeof GraphqlRoute
   HealthRoute: typeof HealthRoute
   LeaderboardsRoute: typeof LeaderboardsRoute
   RpcRoute: typeof RpcRoute
@@ -419,6 +430,7 @@ export interface RootRouteChildren {
   AccountsSs58Route: typeof AccountsSs58Route
   BlocksRefRoute: typeof BlocksRefRoute
   ExtrinsicsHashRoute: typeof ExtrinsicsHashRoute
+  GraphqlExplorerRoute: typeof GraphqlExplorerRoute
   ProvidersSlugRoute: typeof ProvidersSlugRoute
   SubnetsNetuidRoute: typeof SubnetsNetuidRoute
   ValidatorsHotkeyRoute: typeof ValidatorsHotkeyRoute
@@ -426,6 +438,7 @@ export interface RootRouteChildren {
   AdminChangesIndexRoute: typeof AdminChangesIndexRoute
   BlocksIndexRoute: typeof BlocksIndexRoute
   ExtrinsicsIndexRoute: typeof ExtrinsicsIndexRoute
+  GraphqlIndexRoute: typeof GraphqlIndexRoute
   ProvidersIndexRoute: typeof ProvidersIndexRoute
   RuntimeIndexRoute: typeof RuntimeIndexRoute
   SubnetsIndexRoute: typeof SubnetsIndexRoute
@@ -482,13 +495,6 @@ declare module '@tanstack/react-router' {
       path: '/health'
       fullPath: '/health'
       preLoaderRoute: typeof HealthRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/graphql': {
-      id: '/graphql'
-      path: '/graphql'
-      fullPath: '/graphql'
-      preLoaderRoute: typeof GraphqlRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/gaps': {
@@ -582,6 +588,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProvidersIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/graphql/': {
+      id: '/graphql/'
+      path: '/graphql'
+      fullPath: '/graphql/'
+      preLoaderRoute: typeof GraphqlIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/extrinsics/': {
       id: '/extrinsics/'
       path: '/extrinsics'
@@ -631,6 +644,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProvidersSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/graphql/explorer': {
+      id: '/graphql/explorer'
+      path: '/graphql/explorer'
+      fullPath: '/graphql/explorer'
+      preLoaderRoute: typeof GraphqlExplorerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/extrinsics/$hash': {
       id: '/extrinsics/$hash'
       path: '/extrinsics/$hash'
@@ -664,7 +684,6 @@ const rootRouteChildren: RootRouteChildren = {
   ExplorerRoute: ExplorerRoute,
   FeedsRoute: FeedsRoute,
   GapsRoute: GapsRoute,
-  GraphqlRoute: GraphqlRoute,
   HealthRoute: HealthRoute,
   LeaderboardsRoute: LeaderboardsRoute,
   RpcRoute: RpcRoute,
@@ -675,6 +694,7 @@ const rootRouteChildren: RootRouteChildren = {
   AccountsSs58Route: AccountsSs58Route,
   BlocksRefRoute: BlocksRefRoute,
   ExtrinsicsHashRoute: ExtrinsicsHashRoute,
+  GraphqlExplorerRoute: GraphqlExplorerRoute,
   ProvidersSlugRoute: ProvidersSlugRoute,
   SubnetsNetuidRoute: SubnetsNetuidRoute,
   ValidatorsHotkeyRoute: ValidatorsHotkeyRoute,
@@ -682,6 +702,7 @@ const rootRouteChildren: RootRouteChildren = {
   AdminChangesIndexRoute: AdminChangesIndexRoute,
   BlocksIndexRoute: BlocksIndexRoute,
   ExtrinsicsIndexRoute: ExtrinsicsIndexRoute,
+  GraphqlIndexRoute: GraphqlIndexRoute,
   ProvidersIndexRoute: ProvidersIndexRoute,
   RuntimeIndexRoute: RuntimeIndexRoute,
   SubnetsIndexRoute: SubnetsIndexRoute,

--- a/apps/ui/src/routes/graphql.explorer.tsx
+++ b/apps/ui/src/routes/graphql.explorer.tsx
@@ -1,0 +1,48 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowLeft } from "lucide-react";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { GraphiqlExplorer } from "@/components/metagraphed/graphiql-explorer";
+import { API_BASE } from "@/lib/metagraphed/config";
+import { GRAPHQL_ENDPOINT_PATH } from "@/lib/metagraphed/graphql-docs";
+
+export const Route = createFileRoute("/graphql/explorer")({
+  head: () => ({
+    meta: [
+      { title: "GraphQL Explorer — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Interactive GraphiQL explorer for the Metagraphed API — schema-aware autocomplete, docs, and live queries against the public /api/v1/graphql endpoint. No API key.",
+      },
+    ],
+  }),
+  component: GraphqlExplorerPage,
+});
+
+const ENDPOINT_URL = `${API_BASE}${GRAPHQL_ENDPOINT_PATH}`;
+
+function GraphqlExplorerPage() {
+  return (
+    <AppShell>
+      <Link
+        to="/graphql"
+        className="inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted transition-colors hover:text-ink-strong"
+      >
+        <ArrowLeft aria-hidden className="size-3.5" />
+        GraphQL docs
+      </Link>
+      <h1 className="mt-2 font-display text-2xl font-semibold text-ink-strong md:text-3xl">
+        Explorer
+      </h1>
+      <p className="mt-1.5 max-w-2xl text-sm leading-relaxed text-ink-muted">
+        Schema-aware autocomplete, docs, and history against the live endpoint. No API key.
+      </p>
+      <div className="mt-6">
+        <GraphiqlExplorer
+          endpoint={ENDPOINT_URL}
+          heightClassName="h-[70vh] min-h-[520px] max-h-[900px]"
+        />
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/ui/src/routes/graphql.index.tsx
+++ b/apps/ui/src/routes/graphql.index.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowRight } from "lucide-react";
 import { CopyButton, PageHero, SectionHeading } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { GraphiqlExplorer } from "@/components/metagraphed/graphiql-explorer";
 import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
 import {
   GRAPHQL_ENDPOINT_PATH,
@@ -11,7 +11,7 @@ import {
   buildGraphqlLimitRows,
 } from "@/lib/metagraphed/graphql-docs";
 
-export const Route = createFileRoute("/graphql")({
+export const Route = createFileRoute("/graphql/")({
   head: () => ({
     meta: [
       { title: "GraphQL — Metagraphed" },
@@ -80,9 +80,23 @@ function GraphqlDocsPage() {
         <section id="explorer">
           <SectionHeading
             title="Explorer"
-            intro="Run a query against the live endpoint — schema-aware autocomplete, docs, and history, right in the browser."
+            intro="Run a query against the live endpoint — schema-aware autocomplete, docs, and history, in a full-page workspace."
           />
-          <GraphiqlExplorer endpoint={ENDPOINT_URL} />
+          <Link
+            to="/graphql/explorer"
+            className="group flex items-center justify-between gap-4 rounded-lg border border-border bg-card px-4 py-3 transition-colors hover:border-accent/40"
+          >
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-ink-strong">Open the GraphQL Explorer</div>
+              <div className="mt-0.5 text-[13px] text-ink-muted">
+                Interactive GraphiQL IDE, full height, on its own page.
+              </div>
+            </div>
+            <ArrowRight
+              aria-hidden
+              className="size-4 shrink-0 text-ink-muted transition-transform group-hover:translate-x-0.5 group-hover:text-accent"
+            />
+          </Link>
         </section>
 
         <section>

--- a/apps/ui/src/routes/graphql.tsx
+++ b/apps/ui/src/routes/graphql.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { CopyButton, PageHero, SectionHeading } from "@jsonbored/ui-kit";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { GraphiqlExplorer } from "@/components/metagraphed/graphiql-explorer";
 import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
 import {
   GRAPHQL_ENDPOINT_PATH,
@@ -74,6 +75,14 @@ function GraphqlDocsPage() {
               </pre>
             </div>
           </div>
+        </section>
+
+        <section id="explorer">
+          <SectionHeading
+            title="Explorer"
+            intro="Run a query against the live endpoint — schema-aware autocomplete, docs, and history, right in the browser."
+          />
+          <GraphiqlExplorer endpoint={ENDPOINT_URL} />
         </section>
 
         <section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
     },
     "apps/ui": {
       "name": "metagraphed-ui",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@jsonbored/metagraphed": "*",
@@ -55,6 +55,7 @@
         "@tanstack/react-start": "^1.168.27",
         "@tanstack/router-plugin": "^1.168.19",
         "@tanstack/zod-adapter": "^1.167.0",
+        "graphiql": "^4.1.2",
         "lucide-react": "^0.575.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -1870,6 +1871,21 @@
         "@floating-ui/utils": "^0.2.11"
       }
     },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@floating-ui/react-dom": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
@@ -1888,6 +1904,117 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@graphiql/plugin-doc-explorer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@graphiql/plugin-doc-explorer/-/plugin-doc-explorer-0.2.2.tgz",
+      "integrity": "sha512-0Pj0vsNFfZJZJ3moC7O9xF1Dt2KWyvdxke+cFFZQLN1L2VxdTUa4cfGSg5ujv/ikDUUyyPQNTZuyXzagM4NG5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphiql/react": "^0.34.1",
+        "@headlessui/react": "^2.2",
+        "react-compiler-runtime": "19.1.0-rc.1",
+        "zustand": "^5"
+      },
+      "peerDependencies": {
+        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
+    "node_modules/@graphiql/plugin-history": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@graphiql/plugin-history/-/plugin-history-0.2.2.tgz",
+      "integrity": "sha512-ta1k8ichGVfMg6eDwRYa/2e92PfLPh+wgtJTuTQagmXBLXhM7g8Hbk+CaE2clUahQ8/4CZOIRXJHbQ7B5tI9dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphiql/react": "^0.34.1",
+        "@graphiql/toolkit": "^0.11.3",
+        "react-compiler-runtime": "19.1.0-rc.1",
+        "zustand": "^5"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
+    "node_modules/@graphiql/react": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@graphiql/react/-/react-0.34.1.tgz",
+      "integrity": "sha512-Ykqt5uzIRKcbriyVisr/y6BwxK9ZIsilaJFPbajDAcoDiXlGEx/Pl86OcJNjslsqn79M9BkrphWvWa7cBGz3Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphiql/toolkit": "^0.11.3",
+        "@radix-ui/react-dialog": "^1.1",
+        "@radix-ui/react-dropdown-menu": "^2.1",
+        "@radix-ui/react-tooltip": "^1.2",
+        "@radix-ui/react-visually-hidden": "^1.2",
+        "@types/codemirror": "^5.60.8",
+        "clsx": "^1.2.1",
+        "codemirror": "^5.65.3",
+        "codemirror-graphql": "^2.2.1",
+        "copy-to-clipboard": "^3.2.0",
+        "framer-motion": "^12",
+        "get-value": "^3.0.1",
+        "graphql-language-service": "^5.3.1",
+        "markdown-it": "^14.1.0",
+        "react-compiler-runtime": "19.1.0-rc.1",
+        "set-value": "^4.1.0",
+        "zustand": "^5"
+      },
+      "peerDependencies": {
+        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
+    "node_modules/@graphiql/react/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@graphiql/toolkit": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@graphiql/toolkit/-/toolkit-0.11.3.tgz",
+      "integrity": "sha512-Glf0fK1cdHLNq52UWPzfSrYIJuNxy8h4451Pw1ZVpJ7dtU+tm7GVVC64UjEDQ/v2j3fnG4cX8jvR75IvfL6nzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@n1ru4l/push-pull-async-iterable-iterator": "^3.1.0",
+        "meros": "^1.1.4"
+      },
+      "peerDependencies": {
+        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+        "graphql-ws": ">= 4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.10.tgz",
+      "integrity": "sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -2445,6 +2572,33 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.9.tgz",
+      "integrity": "sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2552,6 +2706,15 @@
         "nitro": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@n1ru4l/push-pull-async-iterable-iterator": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@n1ru4l/push-pull-async-iterable-iterator/-/push-pull-async-iterable-iterator-3.2.0.tgz",
+      "integrity": "sha512-3fkKj25kEjsfObL6IlKPAlHYPq/oYwUkkQ03zsTTiDjD7vg/RxjdiLeCydqtxHZP0JgsXL3D/X5oAkMGzuUp/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3952,6 +4115,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.20.tgz",
+      "integrity": "sha512-slfm+rRaZRuQBvHq60lXvSVUPhid0IPtjSZzIuUlWZMUs01iYZNlGS3mJgRD3ChLQVBAYlKiL/tFyWGX+dz8Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-menu": "2.1.20",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
@@ -4037,6 +4229,46 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.20.tgz",
+      "integrity": "sha512-VsUrXxFe9d2ScbZF0fR/oPR1+qjyeLs5p0jzG8h90puMoA9bq4SirYlXbE+USRg9Q2qTeJSFNqjw2nts8jJe4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.3",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.15",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -4180,6 +4412,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.15.tgz",
+      "integrity": "sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
@@ -4284,6 +4549,21 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz",
+      "integrity": "sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-layout-effect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
@@ -4363,6 +4643,44 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
       "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
       "license": "MIT"
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.22.1.tgz",
+      "integrity": "sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.28.1.tgz",
+      "integrity": "sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.0.tgz",
+      "integrity": "sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
     },
     "node_modules/@redocly/ajv": {
       "version": "8.11.2",
@@ -5268,6 +5586,15 @@
       "integrity": "sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
@@ -5848,6 +6175,23 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.6.tgz",
+      "integrity": "sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@tanstack/router-core": {
       "version": "1.171.14",
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.14.tgz",
@@ -6125,6 +6469,16 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.4.tgz",
+      "integrity": "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/virtual-file-routes": {
       "version": "1.162.0",
       "resolved": "https://registry.npmjs.org/@tanstack/virtual-file-routes/-/virtual-file-routes-1.162.0.tgz",
@@ -6230,6 +6584,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/codemirror": {
+      "version": "5.60.17",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.17.tgz",
+      "integrity": "sha512-AZq2FIsUHVMlp7VSe2hTfl5w4pcUkoFkM3zVsRKsn1ca8CXRDYvnin04+HP2REkwsxemuHqvDofdlhUWNpbwfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -6248,7 +6611,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -6285,6 +6647,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -7102,6 +7473,36 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/codemirror": {
+      "version": "5.65.21",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.21.tgz",
+      "integrity": "sha512-6teYk0bA0nR3QP0ihGMoxuKzpl5W80FpnHpBJpgy66NK3cZv5b/d/HY8PnRvfSsCG1MTfr92u2WUl+wT0E40mQ==",
+      "license": "MIT"
+    },
+    "node_modules/codemirror-graphql": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-2.2.7.tgz",
+      "integrity": "sha512-L+kuJYVvMU0rsqOKPFvHIPsaOG38yCSdKkBWkm/atjC4JtA9Qt1HWe/aK0sDf+pwAwss465bgF7dw/e8G2/NxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/codemirror": "^0.0.90",
+        "graphql-language-service": "5.5.2"
+      },
+      "peerDependencies": {
+        "@codemirror/language": "6.0.0",
+        "codemirror": "^5.65.3",
+        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/codemirror-graphql/node_modules/@types/codemirror": {
+      "version": "0.0.90",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.90.tgz",
+      "integrity": "sha512-8Z9+tSg27NPRGubbUPUCrt5DDG/OWzLph5BvcDykwR5D7RyZh5mhHG0uS1ePKV1YFCA+/cwc4Ey2AJAEFfV3IA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7187,6 +7588,15 @@
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
       "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
       "license": "MIT"
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "license": "MIT",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7310,6 +7720,12 @@
         }
       }
     },
+    "node_modules/debounce-promise": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/debounce-promise/-/debounce-promise-3.1.2.tgz",
+      "integrity": "sha512-rZHcgBkbYavBeD9ej6sP56XfG53d51CD4dnaw989YX/nZ/ZJfgRx/9ePKmTNiUiyQvh4mtrMoS3OAWW+yoYtpg==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -7394,6 +7810,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-runner": {
@@ -7972,6 +8400,33 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.42.2",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -8003,6 +8458,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
+      "integrity": "sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/glob-parent": {
@@ -8043,6 +8510,23 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/graphiql": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/graphiql/-/graphiql-4.1.2.tgz",
+      "integrity": "sha512-rNlzQIAzm6i2KBXmVQWBgLvt0TloxFVB2d18bukvdsvjEuFDHsKx5IVOomL1W1o5WW+tE54+ioHb2AEKzO2cUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphiql/plugin-doc-explorer": "^0.2.2",
+        "@graphiql/plugin-history": "^0.2.2",
+        "@graphiql/react": "^0.34.1",
+        "react-compiler-runtime": "19.1.0-rc.1"
+      },
+      "peerDependencies": {
+        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
     "node_modules/graphql": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
@@ -8050,6 +8534,23 @@
       "license": "MIT",
       "engines": {
         "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
+      }
+    },
+    "node_modules/graphql-language-service": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/graphql-language-service/-/graphql-language-service-5.5.2.tgz",
+      "integrity": "sha512-NJhgEKTArkyNPcy4NRUFdbpNs5/F99LcvXbNtmGzNGwwruN8tBE3YPMjpYmp8KpBQtOx3uSuvXJlOOE3Vy2KRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debounce-promise": "^3.1.2",
+        "nullthrows": "^1.0.0",
+        "vscode-languageserver-types": "^3.17.1"
+      },
+      "bin": {
+        "graphql": "dist/temp-bin.js"
+      },
+      "peerDependencies": {
+        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/graphql-ws": {
@@ -8258,6 +8759,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-primitive": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
+      "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/isbot": {
       "version": "5.1.44",
       "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.44.tgz",
@@ -8273,6 +8795,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -8752,6 +9283,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/load-tsconfig": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
@@ -8847,6 +9397,56 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/meros": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/meros/-/meros-1.3.2.tgz",
+      "integrity": "sha512-Q3mobPbvEx7XbwhnC1J1r60+5H6EZyNccdzSz0eGexJRwouUtTZxPVRGdqKtxlpD84ScK4+tIGldkqDtCKdI0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=13"
+      },
+      "peerDependencies": {
+        "@types/node": ">=13"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/metagraphed-contract": {
       "resolved": "packages/contract",
       "link": true
@@ -8913,6 +9513,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -9090,6 +9705,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -9606,6 +10227,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
@@ -9613,6 +10243,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-aria": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.50.0.tgz",
+      "integrity": "sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.48.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-compiler-runtime": {
+      "version": "19.1.0-rc.1",
+      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.1.0-rc.1.tgz",
+      "integrity": "sha512-wCt6g+cRh8g32QT18/9blfQHywGjYu+4FlEc3CW1mx3pPxYzZZl1y+VtqxRgnKKBCFLIGUYxog4j4rs5YS86hw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
       }
     },
     "node_modules/react-dom": {
@@ -9682,6 +10342,23 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-stately": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.48.0.tgz",
+      "integrity": "sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/react-style-singleton": {
@@ -9900,6 +10577,24 @@
       },
       "peerDependencies": {
         "seroval": "^1.0"
+      }
+    },
+    "node_modules/set-value": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
+      "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
+      "funding": [
+        "https://github.com/sponsors/jonschlinkert",
+        "https://paypal.me/jonathanschlinkert",
+        "https://jonschlinkert.dev/sponsor"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "is-primitive": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=11.0"
       }
     },
     "node_modules/sharp": {
@@ -10145,6 +10840,12 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -10265,6 +10966,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -10980,6 +11687,12 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/ufo": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
@@ -11506,6 +12219,12 @@
         }
       }
     },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "license": "MIT"
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -11744,9 +12463,38 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
     "packages/client": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.15.13",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "metagraphed-contract": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "@tanstack/router-plugin": "^1.168.19",
         "@tanstack/zod-adapter": "^1.167.0",
         "graphiql": "^4.1.2",
+        "graphql": "^17.0.2",
         "lucide-react": "^0.575.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",


### PR DESCRIPTION
## Summary

- Adds an interactive, full-page GraphiQL explorer at `/graphql/explorer` — schema-aware query editor with autocomplete, docs, and history, running against the live `/api/v1/graphql` endpoint (no API key).
- The `/graphql` docs page links out to it via a CTA card instead of embedding the widget inline.

This replaces an earlier iteration that embedded GraphiQL directly inside a section of the `/graphql` docs page. That approach matched what a fixed-height card lets you do, but had two real problems: on mobile the 460px-tall widget dominated the screen and pushed the actual reference docs (Schema, Root queries, Limits) below the fold, and on desktop the response pane looked like dead space until a query ran, regardless of pane-ratio tuning. Every comparable public GraphQL API I found (countries.trevorblades.com, PokeAPI, the Rick & Morty API) gives GraphiQL the whole page rather than a docs-page section — moving to a dedicated route matches that and gives the widget real room (70vh) to work in.

Lazy-loaded and client-only (`ClientOnly` + `Suspense`, following the `command-palette.tsx` pattern) either way, so it never touches SSR.

Part of #3499 (maintainer-only — not linking `Closes` per the issue's own note that it'll trip the review gate's auto-close).

## Screenshots

### `/graphql/explorer` (new dedicated page)

| Viewport · Theme | Screenshot |
| --- | --- |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-explorer-route-desktop-dark.png" width="360">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-explorer-route-desktop-dark.png) |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-explorer-route-desktop-light.png" width="360">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-explorer-route-desktop-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-explorer-route-tablet-dark.png" width="360">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-explorer-route-tablet-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-explorer-route-tablet-light.png" width="360">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-explorer-route-tablet-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-explorer-route-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-explorer-route-mobile-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-explorer-route-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-explorer-route-mobile-light.png) |

### `/graphql` docs page (embedded widget → CTA card)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-after-desktop-dark.png)<br><sub>after</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-after-desktop-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-after-tablet-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-after-tablet-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-after-mobile-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3499-graphql-docs-after-mobile-light.png)<br><sub>after</sub> |

## Test plan

- [x] `tsc --noEmit` clean (only two pre-existing, unrelated errors elsewhere in the tree)
- [x] `eslint` / `prettier` clean on changed files
- [x] Production build verified locally with the exact Cloudflare build command (`npm install --legacy-peer-deps && ... && NITRO_PRESET=cloudflare-module npm run build`)
- [x] Verified in a real browser (Playwright) across all 3 viewports × 2 themes on both routes — widget renders, default query loads, theming matches Bone & Ink, navigation between the docs page and the explorer page works
- [x] Ran a live query against production `https://api.metagraph.sh/api/v1/graphql` through the widget — returned real data end-to-end
- [x] Known upstream quirk (not introduced by this PR, not blocking): `@graphiql/react`'s own tab-initialization has a low-probability (~1/15 in stress testing) race on a cold/empty localStorage that occasionally creates a duplicate empty tab. Confirmed independent of this PR's code via a control test with zero custom effects. Harmless (an extra tab a user can close, no errors) — not something to fix here.