### PR TITLE
chore(ui): remove dead isHashRef helper

### DIFF
--- a/apps/ui/src/lib/metagraphed/blocks.test.ts
+++ b/apps/ui/src/lib/metagraphed/blocks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isValidBlockRef, blockRefPathSegment, shortHash, isHashRef } from "./blocks";
+import { isValidBlockRef, blockRefPathSegment, shortHash } from "./blocks";
 
 describe("isValidBlockRef", () => {
   it("accepts decimal block numbers (no leading zeros, up to 20 digits)", () => {
@@ -64,19 +64,5 @@ describe("shortHash", () => {
 
   it("trims before measuring", () => {
     expect(shortHash("  0x1234  ")).toBe("0x1234");
-  });
-});
-
-describe("isHashRef", () => {
-  it("is true only for 0x-prefixed hex", () => {
-    expect(isHashRef("0xabc123")).toBe(true);
-    expect(isHashRef("0xDEAD")).toBe(true);
-  });
-
-  it("is false for decimals and malformed hex", () => {
-    expect(isHashRef("12345")).toBe(false);
-    expect(isHashRef("0x")).toBe(false);
-    expect(isHashRef("0xghij")).toBe(false);
-    expect(isHashRef("abc")).toBe(false);
   });
 });

--- a/apps/ui/src/lib/metagraphed/blocks.ts
+++ b/apps/ui/src/lib/metagraphed/blocks.ts
@@ -28,8 +28,3 @@ export function shortHash(value?: string | null, keep = 6): string | undefined {
   if (v.length <= keep * 2 + 1) return v;
   return `${v.slice(0, keep)}…${v.slice(-keep)}`;
 }
-
-/** True when a ref looks like a 0x-prefixed block hash (vs a numeric block_number). */
-export function isHashRef(ref: string): boolean {
-  return /^0x[0-9a-fA-F]+$/.test(ref);
-}


### PR DESCRIPTION
## Summary

`isHashRef` in `apps/ui/src/lib/metagraphed/blocks.ts` is exported and unit-tested but has **zero production import sites** — referenced only by its own test block. Remove the function and its `describe("isHashRef", …)` tests (and drop it from the test's import).

Verified zero references across `apps/**` (`git grep isHashRef` is now empty). The remaining `blocks.test.ts` suite passes (10 tests); eslint + prettier clean.

Closes #6025