### PR TITLE
fix(rpc): validate optional block-hash at for state_getStorage/state_getKeysPaged

### DIFF
--- a/tests/request-handlers-rpc-proxy-branch-coverage.test.mjs
+++ b/tests/request-handlers-rpc-proxy-branch-coverage.test.mjs
@@ -683,6 +683,90 @@ describe("state-query methods (#4344/9.2)", () => {
     assert.match(body.error.message, /startKey/);
   });
 
+  test("400 rpc_invalid_request for a malformed state_getStorage at (never reaches upstream)", async () => {
+    // #6014: optional block-hash `at` must be validated before forwarding.
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = async (...args) => {
+      fetchCalls += 1;
+      return originalFetch(...args);
+    };
+    try {
+      const res = await handleRpcProxyRequest(
+        rpcPost({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "state_getStorage",
+          params: [HEX_KEY, "not-a-block-hash"],
+        }),
+        rpcEnv(poolWith(ep("a", SAFE_A))),
+        url("/rpc/v1/finney"),
+      );
+      const body = await errorJson(res, 400);
+      assert.equal(body.error.code, "rpc_invalid_request");
+      assert.match(body.error.message, /\bat\b/);
+      assert.equal(fetchCalls, 0, "malformed at must not reach upstream");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("400 rpc_invalid_request for a malformed state_getKeysPaged at (never reaches upstream)", async () => {
+    // #6014: optional block-hash `at` must be validated before forwarding.
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = async (...args) => {
+      fetchCalls += 1;
+      return originalFetch(...args);
+    };
+    try {
+      const res = await handleRpcProxyRequest(
+        rpcPost({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "state_getKeysPaged",
+          params: [HEX_KEY, 10, HEX_KEY, "0xshort"],
+        }),
+        rpcEnv(poolWith(ep("a", SAFE_A))),
+        url("/rpc/v1/finney"),
+      );
+      const body = await errorJson(res, 400);
+      assert.equal(body.error.code, "rpc_invalid_request");
+      assert.match(body.error.message, /\bat\b/);
+      assert.equal(fetchCalls, 0, "malformed at must not reach upstream");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("forwards a well-formed state_getStorage at to upstream", async () => {
+    const BLOCK_HASH = `0x${"cd".repeat(32)}`;
+    const originalFetch = globalThis.fetch;
+    let forwardedBodyText = null;
+    globalThis.fetch = async (_endpointUrl, init) => {
+      forwardedBodyText = init?.body ?? null;
+      return jsonResponse(200, { jsonrpc: "2.0", id: 1, result: "0x01" });
+    };
+    try {
+      const res = await handleRpcProxyRequest(
+        rpcPost({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "state_getStorage",
+          params: [HEX_KEY, BLOCK_HASH],
+        }),
+        rpcEnv(poolWith(ep("a", SAFE_A))),
+        url("/rpc/v1/finney"),
+      );
+      assert.equal(res.status, 200);
+      assert.ok(forwardedBodyText, "expected the upstream fetch to be called");
+      const forwardedBody = JSON.parse(forwardedBodyText);
+      assert.equal(forwardedBody.params[1], BLOCK_HASH);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("400 rpc_invalid_request for a non-integer/negative state_getKeysPaged count", async () => {
     for (const count of [-1, "not-a-number", Number.NaN]) {
       const res = await handleRpcProxyRequest(

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -1239,6 +1239,13 @@ function isValidStateQueryHex(value) {
   );
 }
 
+// Substrate block hashes are H256 -- exactly 32 bytes as 0x-prefixed hex.
+// Narrower than isValidStateQueryHex (variable-length storage keys): an
+// optional `at` param that isn't this shape must not reach upstream (#6014).
+function isValidBlockHashHex(value) {
+  return typeof value === "string" && /^0x[0-9a-fA-F]{64}$/.test(value);
+}
+
 // Validates + (for state_getKeysPaged) clamps the caller-supplied params for
 // a state-query method (#4344/9.2). Returns {ok:true, params} -- `params` is
 // the SAME array reference when nothing needed clamping, a new one otherwise,
@@ -1249,11 +1256,20 @@ function isValidStateQueryHex(value) {
 function validateStateQueryParams(method, params) {
   const args = Array.isArray(params) ? params : [];
   if (method === "state_getStorage") {
+    // state_getStorage: [key, at?]
     if (!isValidStateQueryHex(args[0])) {
       return {
         ok: false,
         message:
           "state_getStorage requires params[0] to be a 0x-prefixed hex storage key.",
+      };
+    }
+    // at (params[1]), when present, is a block hash (H256).
+    if (args[1] !== undefined && !isValidBlockHashHex(args[1])) {
+      return {
+        ok: false,
+        message:
+          "state_getStorage requires params[1] (at), when present, to be a 0x-prefixed 32-byte block hash.",
       };
     }
     return { ok: true, params };
@@ -1272,6 +1288,14 @@ function validateStateQueryParams(method, params) {
       ok: false,
       message:
         "state_getKeysPaged requires params[2] (startKey), when present, to be a 0x-prefixed hex key.",
+    };
+  }
+  // at (params[3]), when present, is a block hash (H256).
+  if (args[3] !== undefined && !isValidBlockHashHex(args[3])) {
+    return {
+      ok: false,
+      message:
+        "state_getKeysPaged requires params[3] (at), when present, to be a 0x-prefixed 32-byte block hash.",
     };
   }
   const rawCount = args[1];


### PR DESCRIPTION
## Summary
- Validate the optional `at` (block-hash) param for `state_getStorage` and `state_getKeysPaged` before forwarding to upstream RPC (`#6014`).
- Use an H256-shaped check (`0x` + 64 hex chars), not the variable-length storage-key hex validator.
- Audited the rest of the state-query validation path; no other optional-trailing-param gaps in this file.

Closes #6014

## Test plan
- [x] `npx vitest run tests/request-handlers-rpc-proxy-branch-coverage.test.mjs`
- [ ] Confirm malformed `at` yields `rpc_invalid_request` and zero upstream fetches
- [ ] Confirm well-formed `at` is forwarded unchanged