### PR TITLE
fix(python-sdk): drop dead Endpoint.base_url; keep EndpointResource url

### DIFF
--- a/python/src/metagraphed/models.py
+++ b/python/src/metagraphed/models.py
@@ -90,11 +90,11 @@ class Surface(_Model):
 
 @dataclass
 class Endpoint(_Model):
+    # EndpointResource uses ``url``; ``base_url`` is agent-catalog services[] only.
     surface_id: Optional[str] = None
     netuid: Optional[int] = None
     kind: Optional[str] = None
     url: Optional[str] = None
-    base_url: Optional[str] = None
     provider: Optional[str] = None
     classification: Optional[str] = None
     monitoring_status: Optional[str] = None

--- a/python/tests/test_aio.py
+++ b/python/tests/test_aio.py
@@ -259,6 +259,7 @@ class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(endpoint.classification, "primary")
         self.assertEqual(endpoint.monitoring_status, "monitored")
         self.assertEqual(endpoint.raw["id"], "ep-sn-7-subnet-api")
+        self.assertFalse(hasattr(endpoint, "base_url"))
 
     async def test_agent_catalog_returns_typed_model(self):
         client = self._client(

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -719,14 +719,18 @@ class FetchAllAndModelsTest(unittest.TestCase):
         self.assertEqual(endpoint.monitoring_status, "monitored")
         self.assertEqual(endpoint.raw["id"], "ep-sn-7-subnet-api")
         self.assertEqual(endpoint.raw["url"], "https://api.example.com/v1")
+        self.assertFalse(hasattr(endpoint, "base_url"))
 
     def test_endpoint_from_dict_populates_url_from_endpoint_resource(self):
+        # EndpointResource has ``url``; ``base_url`` is agent-catalog-only and
+        # must not be a typed Endpoint field (or it stays forever None).
         endpoint = Endpoint.from_dict(
             {
                 "surface_id": "sn-22-docs",
                 "netuid": 22,
                 "kind": "docs",
                 "url": "https://docs.example.com",
+                "base_url": "https://should-not-become-a-typed-field.example",
                 "provider": "desearch",
                 "classification": "reference",
                 "monitoring_status": "not_monitored",
@@ -736,6 +740,11 @@ class FetchAllAndModelsTest(unittest.TestCase):
         self.assertEqual(endpoint.url, "https://docs.example.com")
         self.assertEqual(endpoint.surface_id, "sn-22-docs")
         self.assertEqual(endpoint.kind, "docs")
+        self.assertFalse(hasattr(endpoint, "base_url"))
+        self.assertEqual(
+            endpoint.raw["base_url"],
+            "https://should-not-become-a-typed-field.example",
+        )
         self.assertIs(endpoint.raw["unknown_extra"], True)
 
     def test_agent_catalog_returns_typed_model(self):


### PR DESCRIPTION
## Summary
- Remove the unused `Endpoint.base_url` field — `EndpointResource` exposes `url`, not `base_url` (`base_url` belongs only to agent-catalog `services[]`).
- Keep reading `url` via `Endpoint.from_dict()` / `client.endpoints()`, and harden tests so a realistic EndpointResource fixture populates `.url` and does not invent a typed `.base_url`.

Closes #5985

## Test plan
- [x] `python -m unittest python.tests.test_client python.tests.test_aio`
- [ ] Confirm `Endpoint.from_dict({"url": "..."})` sets `.url` and has no `.base_url` attribute
- [ ] Confirm `client.endpoints()` / async `endpoints()` still return typed models with `.url` set from fixture data