### PR TITLE
fix(ui): handle storage read failures in density settings

### DIFF
--- a/apps/ui/src/lib/density.test.ts
+++ b/apps/ui/src/lib/density.test.ts
@@ -1,0 +1,29 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useDensity } from "./density";
+
+function DensityProbe() {
+  const { density } = useDensity();
+  return React.createElement("output", null, density);
+}
+
+describe("useDensity", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to comfortable when localStorage.getItem throws during initial render", () => {
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: vi.fn(() => {
+          throw new Error("storage blocked");
+        }),
+      },
+    });
+
+    expect(() => renderToString(React.createElement(DensityProbe))).not.toThrow();
+    expect(renderToString(React.createElement(DensityProbe))).toContain("comfortable");
+  });
+});

--- a/apps/ui/src/lib/density.ts
+++ b/apps/ui/src/lib/density.ts
@@ -5,8 +5,12 @@ const STORAGE_KEY = "mg-density";
 
 function readChoice(): Density {
   if (typeof window === "undefined") return "comfortable";
-  const v = window.localStorage.getItem(STORAGE_KEY);
-  return v === "compact" ? "compact" : "comfortable";
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    return v === "compact" ? "compact" : "comfortable";
+  } catch {
+    return "comfortable";
+  }
 }
 
 function apply(d: Density) {

--- a/apps/ui/src/lib/health-palette.test.ts
+++ b/apps/ui/src/lib/health-palette.test.ts
@@ -1,6 +1,13 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { cssFor, HEALTH_PALETTES, readId } from "./health-palette";
+import { cssFor, HEALTH_PALETTES, readId, useHealthPalette } from "./health-palette";
+
+function HealthPaletteProbe() {
+  const { paletteId } = useHealthPalette();
+  return React.createElement("output", null, paletteId);
+}
 
 describe("cssFor", () => {
   it("maps each palette to light :root and dark .dark health variables", () => {
@@ -44,6 +51,17 @@ describe("readId", () => {
     expect(readId()).toBe("traffic-light");
   });
 
+  it("falls back to the default palette when localStorage.getItem throws", () => {
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: vi.fn(() => {
+          throw new Error("storage blocked");
+        }),
+      },
+    });
+    expect(readId()).toBe("traffic-light");
+  });
+
   it("resolves every registered palette id from storage", () => {
     for (const palette of HEALTH_PALETTES) {
       vi.stubGlobal("window", {
@@ -52,5 +70,24 @@ describe("readId", () => {
       expect(readId()).toBe(palette.id);
       vi.unstubAllGlobals();
     }
+  });
+});
+
+describe("useHealthPalette", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to the default palette when localStorage.getItem throws during initial render", () => {
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: vi.fn(() => {
+          throw new Error("storage blocked");
+        }),
+      },
+    });
+
+    expect(() => renderToString(React.createElement(HealthPaletteProbe))).not.toThrow();
+    expect(renderToString(React.createElement(HealthPaletteProbe))).toContain("traffic-light");
   });
 });

--- a/apps/ui/src/lib/health-palette.ts
+++ b/apps/ui/src/lib/health-palette.ts
@@ -104,8 +104,12 @@ const DEFAULT_ID: HealthPaletteId = "traffic-light";
 
 export function readId(): HealthPaletteId {
   if (typeof window === "undefined") return DEFAULT_ID;
-  const v = window.localStorage.getItem(STORAGE_KEY);
-  return (HEALTH_PALETTES.find((p) => p.id === v)?.id ?? DEFAULT_ID) as HealthPaletteId;
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    return (HEALTH_PALETTES.find((p) => p.id === v)?.id ?? DEFAULT_ID) as HealthPaletteId;
+  } catch {
+    return DEFAULT_ID;
+  }
 }
 
 export function cssFor(p: HealthPaletteDef): string {


### PR DESCRIPTION
Closes #6027

## Summary
- wrap density and health-palette localStorage reads in try/catch fallbacks, matching the existing theme storage behavior
- add regression coverage for initial render when localStorage.getItem throws
- keep the change scoped to non-visual UI lib behavior

## Validation
- npm run -w apps/ui test -- src/lib/density.test.ts src/lib/health-palette.test.ts
- npm run -w packages/ui-kit build
- npm run -w apps/ui typecheck

No screenshots: this is a non-visual apps/ui src/lib fallback-path change.