### PR TITLE
fix(python-sdk): document Subnet.completeness_score as list-absent

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -23,17 +23,19 @@ from metagraphed import MetagraphedClient, metagraphed_fetch
 client = MetagraphedClient()  # base_url defaults to https://api.metagraph.sh
 
 # List subnets (query params; None values are dropped). The /subnets collection
-# nests its rows under data.subnets:
+# nests its rows under data.subnets. Sort/rank by integration_readiness — the
+# compact index does not carry completeness_score (that lives on /profiles).
 subnets = client.fetch(
     "/api/v1/subnets",
-    query={"limit": 10, "sort": "completeness_score", "order": "desc"},
+    query={"limit": 10, "sort": "integration_readiness", "order": "desc"},
 )
 print(subnets["data"]["subnets"][0]["name"])
 
 # One subnet by netuid (path params)
 detail = client.fetch("/api/v1/subnets/{netuid}", path_params={"netuid": 7})
 
-# Which subnets are buildable? (integration readiness lives in the agent catalog)
+# Which subnets are buildable? (integration readiness lives in the agent catalog;
+# completeness_score is also present there and on /api/v1/profiles)
 catalog = client.fetch("/api/v1/agent-catalog")
 
 # Health of the registry itself:
@@ -86,12 +88,15 @@ client = MetagraphedClient(retries=3)
 # Auto-paginate a list endpoint and collect every item (flattened data arrays):
 all_surfaces = client.fetch_all("/api/v1/surfaces")
 
-# Typed convenience methods — IDE autocomplete, while .raw keeps the full dict:
+# Typed convenience methods — IDE autocomplete, while .raw keeps the full dict.
+# client.subnets() uses the compact index: integration_readiness is set;
+# completeness_score stays None (use agent_catalog /profiles for that score).
 for subnet in client.subnets():
     print(subnet.netuid, subnet.name, subnet.integration_readiness)
+    # subnet.completeness_score is None here — not an index field
 
 catalog = client.agent_catalog(7)  # -> AgentCatalogSubnet
-print(catalog.service_count, catalog.services)
+print(catalog.service_count, catalog.services, catalog.completeness_score)
 ```
 
 `fetch` / `fetch_all` still return raw dicts; the models (`Subnet`, `Surface`,

--- a/python/src/metagraphed/aio.py
+++ b/python/src/metagraphed/aio.py
@@ -287,6 +287,13 @@ class AsyncMetagraphedClient:
     # -- typed convenience methods (raw-dict path stays via fetch/fetch_all) --
 
     async def subnets(self, **query: Any) -> List[Subnet]:
+        """Every subnet as a typed :class:`~metagraphed.models.Subnet`.
+
+        Rows come from the compact ``/api/v1/subnets`` index, which populates
+        ``integration_readiness`` but not ``completeness_score`` (that score
+        lives on profiles / the agent catalog). Sort with
+        ``sort="integration_readiness"``, not ``completeness_score``.
+        """
         return Subnet.list_from(
             await self.fetch_all("/api/v1/subnets", query=query or None)
         )

--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -534,7 +534,13 @@ class MetagraphedClient:
     # -- typed convenience methods (the raw-dict path stays via fetch/fetch_all) --
 
     def subnets(self, **query: Any) -> List[Subnet]:
-        """Every subnet as a typed :class:`~metagraphed.models.Subnet`."""
+        """Every subnet as a typed :class:`~metagraphed.models.Subnet`.
+
+        Rows come from the compact ``/api/v1/subnets`` index, which populates
+        ``integration_readiness`` but not ``completeness_score`` (that score
+        lives on profiles / the agent catalog). Sort with
+        ``sort="integration_readiness"``, not ``completeness_score``.
+        """
         return Subnet.list_from(
             self.fetch_all("/api/v1/subnets", query=query or None)
         )

--- a/python/src/metagraphed/models.py
+++ b/python/src/metagraphed/models.py
@@ -62,12 +62,24 @@ class _Model:
 
 @dataclass
 class Subnet(_Model):
+    """One row from ``GET /api/v1/subnets`` (``SubnetIndexEntry``).
+
+    The compact index carries ``integration_readiness`` for list/ranking.
+    ``completeness_score`` is **not** part of that shape — it lives on the
+    per-subnet profile (``/api/v1/profiles``) and on
+    :class:`AgentCatalogSubnet`. When built via ``client.subnets()``,
+    ``completeness_score`` is therefore always ``None`` unless a non-index
+    payload that includes the field is passed to :meth:`from_dict`.
+    """
+
     netuid: Optional[int] = None
     slug: Optional[str] = None
     name: Optional[str] = None
     subnet_type: Optional[str] = None
     status: Optional[str] = None
     categories: Optional[List[str]] = None
+    # Absent from SubnetIndexEntry; kept Optional so from_dict stays tolerant
+    # if a richer payload is projected onto this model.
     completeness_score: Optional[float] = None
     integration_readiness: Optional[int] = None
     updated_at: Optional[str] = None
@@ -114,6 +126,12 @@ class Provider(_Model):
 
 @dataclass
 class AgentCatalogSubnet(_Model):
+    """One subnet from ``GET /api/v1/agent-catalog/{netuid}``.
+
+    Unlike the compact :class:`Subnet` index row, this payload includes
+    ``completeness_score`` when the backend provides it.
+    """
+
     netuid: Optional[int] = None
     slug: Optional[str] = None
     name: Optional[str] = None

--- a/python/tests/test_aio.py
+++ b/python/tests/test_aio.py
@@ -105,6 +105,37 @@ class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(subnets[0].name, "Allways")
         self.assertEqual(subnets[0].raw["name"], "Allways")
 
+    async def test_subnets_completeness_score_absent_from_index(self):
+        # Mirrors the sync contract: index rows set integration_readiness and
+        # leave completeness_score unset (None).
+        client = self._client(
+            httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "subnets": [
+                            {
+                                "netuid": 7,
+                                "name": "Allways",
+                                "integration_readiness": 72,
+                            }
+                        ]
+                    },
+                    "meta": {
+                        "pagination": {
+                            "collection": "subnets",
+                            "next_cursor": None,
+                        }
+                    },
+                },
+            )
+        )
+        subnets = await client.subnets()
+        self.assertEqual(len(subnets), 1)
+        self.assertEqual(subnets[0].integration_readiness, 72)
+        self.assertIsNone(subnets[0].completeness_score)
+        self.assertNotIn("completeness_score", subnets[0].raw)
+
     async def test_paginate_follows_next_cursor_with_nested_collection(self):
         # Mirrors README async usage of paginate via fetch_all / typed helpers:
         # nested collection rows + cursor continuation.

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -525,6 +525,35 @@ class FetchAllAndModelsTest(unittest.TestCase):
         self.assertEqual(subnets[0].categories, ["inference"])
         self.assertEqual(subnets[0].raw["name"], "Allways")
 
+    def test_subnets_completeness_score_absent_from_index(self):
+        # SubnetIndexEntry carries integration_readiness for list/ranking, not
+        # completeness_score (that score lives on profiles / agent-catalog).
+        pages = [
+            {
+                "data": {
+                    "subnets": [
+                        {
+                            "netuid": 7,
+                            "name": "Allways",
+                            "integration_readiness": 72,
+                        }
+                    ]
+                },
+                "meta": {
+                    "pagination": {
+                        "collection": "subnets",
+                        "next_cursor": None,
+                    }
+                },
+            }
+        ]
+        with self._patch_pages(pages):
+            subnets = MetagraphedClient().subnets()
+        self.assertEqual(len(subnets), 1)
+        self.assertEqual(subnets[0].integration_readiness, 72)
+        self.assertIsNone(subnets[0].completeness_score)
+        self.assertNotIn("completeness_score", subnets[0].raw)
+
     def test_model_from_dict_ignores_unknown_and_keeps_raw(self):
         surface = Surface.from_dict(
             {"id": "x", "kind": "openapi", "unknown_field": 1}


### PR DESCRIPTION
## Summary
- Clarify that `Subnet.completeness_score` is Optional and is **not** populated by `client.subnets()` / the compact `/api/v1/subnets` index (which carries `integration_readiness` instead). Completeness lives on profiles and `AgentCatalogSubnet`.
- Update the README so examples sort/rank by `integration_readiness` and do not imply `completeness_score` comes from the list endpoint.
- Add sync + async tests asserting index-backed `Subnet` rows leave `completeness_score` as `None` while populating `integration_readiness`.

Chose SDK documentation (option a) over a backend change: `SubnetIndexEntry` and `scripts/build-artifacts.mjs` intentionally keep completeness on the per-subnet profile, not the compact index.

Closes #5984

## Test plan
- [x] `cd python && uv run --extra test python -m unittest discover -s tests -v`
- [ ] Confirm README examples no longer sort `/api/v1/subnets` by `completeness_score`