### PR TITLE
feat(mcp): add subscribable per-subnet status resource (#6034)

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -23,6 +23,8 @@ import {
   MCP_CHAIN_STREAM_RESOURCE_URI,
   McpSessionHub,
 } from "../workers/mcp-session-hub.mjs";
+import { SubnetStatusHub } from "../workers/subnet-status-hub.mjs";
+import { buildSubnetStatusResourceUri } from "../src/subnet-status-subscribe.mjs";
 import {
   artifactFilePath,
   createLocalArtifactEnv,
@@ -168,15 +170,19 @@ function fakeDoNamespace(makeInstance) {
   };
 }
 
-// Mutually-referencing by design (McpSessionHub tells ChainFirehoseHub about
-// a subscribe/unsubscribe; ChainFirehoseHub tells McpSessionHub about a new
-// event) -- safe because fakeDoNamespace only calls its factory lazily, by
-// which point both bindings below are fully initialized.
+// Mutually-referencing by design (McpSessionHub tells ChainFirehoseHub /
+// SubnetStatusHub about a subscribe/unsubscribe; those hubs tell
+// McpSessionHub about a new event) -- safe because fakeDoNamespace only
+// calls its factory lazily, by which point all bindings below are fully
+// initialized.
 const mcpSessionHubNS = fakeDoNamespace(
   () =>
     new McpSessionHub(
       { storage: inMemoryDoStorage() },
-      { CHAIN_FIREHOSE_HUB: chainFirehoseHubNS },
+      {
+        CHAIN_FIREHOSE_HUB: chainFirehoseHubNS,
+        SUBNET_STATUS_HUB: subnetStatusHubNS,
+      },
     ),
 );
 const chainFirehoseHubNS = fakeDoNamespace(
@@ -186,9 +192,17 @@ const chainFirehoseHubNS = fakeDoNamespace(
       { MCP_SESSION_HUB: mcpSessionHubNS },
     ),
 );
+const subnetStatusHubNS = fakeDoNamespace(
+  () =>
+    new SubnetStatusHub(
+      { storage: inMemoryDoStorage() },
+      { MCP_SESSION_HUB: mcpSessionHubNS },
+    ),
+);
 const lifecycleEnv = createLocalArtifactEnv({
   MCP_SESSION_HUB: mcpSessionHubNS,
   CHAIN_FIREHOSE_HUB: chainFirehoseHubNS,
+  SUBNET_STATUS_HUB: subnetStatusHubNS,
 });
 
 // --- Lifecycle -------------------------------------------------------------
@@ -1407,8 +1421,97 @@ assert.equal(
   "GET /mcp after DELETE must find no such session",
 );
 
+// --- MCP per-subnet status subscription lifecycle (#6034) ------------------
+//
+// Same session machinery as the chain-stream round trip above, but the
+// change signal comes from SubnetStatusHub /notify-changed (the health
+// prober's write path in production) rather than ChainFirehoseHub ingest.
+
+const statusLifecycleInit = await mcp(
+  { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+  { envOverride: lifecycleEnv },
+);
+const statusSessionId = statusLifecycleInit.headers.get("mcp-session-id");
+assert.ok(
+  statusSessionId,
+  "status-lifecycle initialize must mint a session id",
+);
+
+const statusUri = buildSubnetStatusResourceUri(1);
+const statusSubscribe = await mcp(
+  {
+    jsonrpc: "2.0",
+    id: 2,
+    method: "resources/subscribe",
+    params: { uri: statusUri },
+  },
+  {
+    envOverride: lifecycleEnv,
+    headers: { "mcp-session-id": statusSessionId },
+  },
+);
+assert.deepEqual(
+  statusSubscribe.body.result,
+  {},
+  "resources/subscribe on metagraph://subnet/{netuid}/status must succeed",
+);
+
+const statusStream = await mcpRaw(null, {
+  method: "GET",
+  headers: { "mcp-session-id": statusSessionId },
+  envOverride: lifecycleEnv,
+});
+assert.equal(statusStream.status, 200, "status subscription must open SSE");
+const statusReader = statusStream.body.getReader();
+
+const statusHubStub = subnetStatusHubNS.get(
+  subnetStatusHubNS.idFromName("global"),
+);
+const statusNotify = await statusHubStub.fetch(
+  "https://subnet-status-hub.internal/notify-changed",
+  {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ netuids: [1] }),
+  },
+);
+assert.equal(statusNotify.status, 200);
+const statusNotifyBody = await statusNotify.json();
+assert.equal(
+  statusNotifyBody.delivered,
+  1,
+  "SubnetStatusHub must deliver to the subscribed session",
+);
+
+const { value: statusFrameBytes } = await statusReader.read();
+const statusFrame = new TextDecoder().decode(statusFrameBytes);
+const statusNotification = JSON.parse(
+  statusFrame.slice(statusFrame.indexOf("data: ") + 6).trim(),
+);
+assert.deepEqual(statusNotification, {
+  jsonrpc: "2.0",
+  method: "notifications/resources/updated",
+  params: { uri: statusUri },
+});
+await statusReader.cancel();
+
+const statusUnsubscribe = await mcp(
+  {
+    jsonrpc: "2.0",
+    id: 4,
+    method: "resources/unsubscribe",
+    params: { uri: statusUri },
+  },
+  {
+    envOverride: lifecycleEnv,
+    headers: { "mcp-session-id": statusSessionId },
+  },
+);
+assert.deepEqual(statusUnsubscribe.body.result, {});
+
 console.log(
   `MCP validation passed: ${MCP_TOOLS.length} tools, lifecycle + ${
     schemaService ? "all" : "all-but-schema"
-  } tools/call + the resources/subscribe -> ingest -> notify round trip.`,
+  } tools/call + the resources/subscribe -> ingest -> notify round trip ` +
+    `+ the subnet-status subscribe -> notify-changed -> notify round trip.`,
 );

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -33,6 +33,10 @@ import {
   KV_HEALTH_META,
   KV_HEALTH_RPC_POOL,
 } from "./kv-keys.mjs";
+import {
+  diffChangedSubnetNetuids,
+  notifySubnetStatusChanged,
+} from "./subnet-status-subscribe.mjs";
 
 // Re-export so existing importers (workers/api.mjs, mcp-server, discovery) keep
 // resolving the KV health keys through the prober; the names now live in kv-keys.
@@ -507,7 +511,14 @@ export async function runHealthProber(env, ctx, overrides = {}) {
   sanitizeRpcLatestBlocks(probed);
 
   const d1Persist = await persistToD1(db, probed, runAt);
-  await persistToKv(kv, probed, runAt);
+  const priorCurrent = await readHealthCurrentSnapshot(kv);
+  const nextCurrent = await persistToKv(kv, probed, runAt);
+  const changedNetuids = diffChangedSubnetNetuids(priorCurrent, nextCurrent);
+  // Best-effort: never fail the probe sweep because a status subscriber
+  // notify couldn't land (#6034).
+  if (changedNetuids.length > 0) {
+    await notifySubnetStatusChanged(env, changedNetuids);
+  }
   await syncHealthChecksToPostgres(env, probed);
 
   const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
@@ -606,8 +617,19 @@ async function persistToD1(db, probed, runAt) {
   }
 }
 
+async function readHealthCurrentSnapshot(kv) {
+  if (!kv?.get) return null;
+  try {
+    const raw = await kv.get(KV_HEALTH_CURRENT);
+    if (!raw) return null;
+    return typeof raw === "string" ? JSON.parse(raw) : raw;
+  } catch {
+    return null;
+  }
+}
+
 async function persistToKv(kv, probed, runAt) {
-  if (!kv?.put) return;
+  if (!kv?.put) return null;
   const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
   for (const row of probed) counts[normalizeProbeStatus(row.status)] += 1;
 
@@ -689,6 +711,7 @@ async function persistToKv(kv, probed, runAt) {
     kv.put(KV_HEALTH_RPC_POOL, JSON.stringify(rpcPool)),
     kv.put(KV_HEALTH_META, JSON.stringify(meta)),
   ]);
+  return current;
 }
 
 // #4832 gap-closure: best-effort Postgres mirror of the D1 write above --

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -7,16 +7,17 @@
 // the JSON-RPC 2.0 envelope rather than pulling in `@modelcontextprotocol/sdk`
 // so the Worker bundle stays lean and the hot REST/RPC path is untouched.
 //
-// The ONE stateful exception (#4983 MCP half, ADR 0015): resources/subscribe
-// on `metagraph://chain/stream`. A subscribed session gets a Durable Object
-// (McpSessionHub, one per Mcp-Session-Id, minted at `initialize`) that holds
-// a bounded-duration GET-opened SSE stream and pushes
-// notifications/resources/updated when the realtime firehose (ChainFirehoseHub,
-// #4982) broadcasts a new chain event. Every OTHER method on this server is
-// unaffected -- stateless POST, no session required. See
-// workers/mcp-session-hub.mjs's own header comment for why this is a
-// separate DO from ChainFirehoseHub, and docs/realtime-firehose.md for the
-// full architecture.
+// The stateful exception (#4983 MCP half + #6034, ADR 0015): resources/subscribe
+// on `metagraph://chain/stream` and `metagraph://subnet/{netuid}/status`. A
+// subscribed session gets a Durable Object (McpSessionHub, one per
+// Mcp-Session-Id, minted at `initialize`) that holds a bounded-duration
+// GET-opened SSE stream and pushes notifications/resources/updated when the
+// realtime firehose (ChainFirehoseHub, #4982) broadcasts a new chain event, or
+// when the health prober (#6034) detects a per-subnet health/status/surface
+// change via SubnetStatusHub. Every OTHER method on this server is unaffected
+// -- stateless POST, no session required. See workers/mcp-session-hub.mjs's
+// own header comment for why this is a separate DO from ChainFirehoseHub, and
+// docs/realtime-firehose.md for the full architecture.
 //
 // Artifact/KV reads are injected (`deps.readArtifact`, `deps.readHealthKv`) so
 // this module is pure and unit-testable, and so it reuses the exact same
@@ -57,6 +58,12 @@ import {
   MCP_CHAIN_STREAM_RESOURCE_URI,
   isValidMcpSessionId,
 } from "../workers/mcp-session-hub.mjs";
+import {
+  buildSubnetStatusResourceUri,
+  isSubscribableMcpResourceUri,
+  listSubscribableMcpResourceClasses,
+  parseSubnetStatusResourceUri,
+} from "./subnet-status-subscribe.mjs";
 import { CONTRACT_VERSION, PRIMARY_DOMAIN, QUERY_ENUMS } from "./contracts.mjs";
 import {
   GET_ECONOMICS_INSTRUCTIONS,
@@ -13553,9 +13560,10 @@ export function listToolDefinitions() {
 // the generated server-card so the two can never drift.
 export const MCP_CAPABILITIES = {
   tools: { listChanged: false },
-  // subscribe: true (#4983 MCP half) -- only metagraph://chain/stream is
-  // actually subscribable (SUBSCRIBABLE_RESOURCE_URIS below); every other
-  // resource is a static R2 artifact with no change signal to subscribe to.
+  // subscribe: true (#4983 MCP half + #6034) -- metagraph://chain/stream and
+  // metagraph://subnet/{netuid}/status are subscribable
+  // (isSubscribableMcpResourceUri); every other resource is a static R2
+  // artifact with no change signal to subscribe to.
   resources: { subscribe: true, listChanged: false },
   prompts: { listChanged: false },
 };
@@ -13569,6 +13577,18 @@ export const MCP_RESOURCE_TEMPLATES = [
     description:
       "Composed overview for one subnet by netuid: identity, completeness, " +
       `curated surfaces, health summary, and gaps. ${UNTRUSTED_DATA_NOTE}`,
+    mimeType: "application/json",
+  },
+  {
+    uriTemplate: "metagraph://subnet/{netuid}/status",
+    name: "subnet-status",
+    title: "Subnet live status",
+    description:
+      "Live operational health for one subnet (probe-derived status, " +
+      "per-surface checks). Subscribe via resources/subscribe to receive " +
+      "notifications/resources/updated when that subnet's health tier, " +
+      "uptime status, or registered operational surfaces change, then " +
+      `resources/read for the current payload. ${UNTRUSTED_DATA_NOTE}`,
     mimeType: "application/json",
   },
   {
@@ -13647,10 +13667,13 @@ const FIXED_RESOURCES = [
 
 // Resources a client may actually call resources/subscribe on -- deliberately
 // NOT "any URI resourceArtifactPath resolves": every resource other than the
-// live one above is a static R2 artifact with no change signal, so
-// subscribing to one would accept silently and then never fire. Checked in
-// the resources/subscribe dispatch case below.
-const SUBSCRIBABLE_RESOURCE_URIS = new Set([MCP_CHAIN_STREAM_RESOURCE_URI]);
+// live ones (chain stream + per-subnet status) is a static R2 artifact with
+// no change signal, so subscribing to one would accept silently and then
+// never fire. Checked in the resources/subscribe dispatch case below.
+// #6034: also metagraph://subnet/{netuid}/status (predicate, not a fixed set).
+function isSubscribableResourceUri(uri) {
+  return isSubscribableMcpResourceUri(uri);
+}
 
 const RESOURCE_PAGE_SIZE = 100;
 
@@ -13678,6 +13701,17 @@ async function listAllResources(ctx) {
         `subnet-${s.netuid}`,
         s.name ? `SN${s.netuid} — ${s.name}` : `Subnet ${s.netuid}`,
         UNTRUSTED_DATA_NOTE,
+        "application/json",
+      ),
+    );
+    out.push(
+      resourceEntry(
+        buildSubnetStatusResourceUri(s.netuid),
+        `subnet-${s.netuid}-status`,
+        s.name
+          ? `SN${s.netuid} status — ${s.name}`
+          : `Subnet ${s.netuid} status`,
+        "Live operational health; subscribable for status-change notifications.",
         "application/json",
       ),
     );
@@ -13782,10 +13816,39 @@ async function readLiveChainStreamResource(ctx) {
   return payload ?? { table: null, message: "no chain event observed yet" };
 }
 
+async function readSubnetStatusResource(ctx, netuid) {
+  const [live, reliability] = await Promise.all([
+    mcpLiveHealth(ctx),
+    loadSubnetReliability({ db: ctx.env?.METAGRAPH_HEALTH_DB, netuid }),
+  ]);
+  const overlaid = overlaySubnetHealth(null, live, netuid);
+  if (overlaid) {
+    return { ...overlaid, reliability };
+  }
+  return {
+    schema_version: 1,
+    netuid,
+    summary: { status: "unknown", surface_count: 0 },
+    operational_observed_at: null,
+    health_source: "unavailable",
+    reliability,
+    surfaces: [],
+  };
+}
+
 async function readResource(params, ctx) {
   const uri = params?.uri;
   if (uri === MCP_CHAIN_STREAM_RESOURCE_URI) {
     const data = await readLiveChainStreamResource(ctx);
+    return {
+      contents: [
+        { uri, mimeType: "application/json", text: JSON.stringify(data) },
+      ],
+    };
+  }
+  const statusNetuid = parseSubnetStatusResourceUri(uri);
+  if (statusNetuid != null) {
+    const data = await readSubnetStatusResource(ctx, statusNetuid);
     return {
       contents: [
         { uri, mimeType: "application/json", text: JSON.stringify(data) },
@@ -13809,20 +13872,21 @@ async function readResource(params, ctx) {
   };
 }
 
-// resources/subscribe and resources/unsubscribe (#4983 MCP half) -- both are
-// session-scoped (require ctx.sessionId, set by buildContext from the
-// Mcp-Session-Id header) and reused verbatim's-worth of validation:
-// SUBSCRIBABLE_RESOURCE_URIS is checked here rather than a second, looser
-// URI-shape check, mirroring the lesson from this session's graphql-ws fix
+// resources/subscribe and resources/unsubscribe (#4983 MCP half + #6034) --
+// both are session-scoped (require ctx.sessionId, set by buildContext from the
+// Mcp-Session-Id header). Subscribability is checked via
+// isSubscribableResourceUri rather than a second, looser URI-shape check,
+// mirroring the lesson from this session's graphql-ws fix
 // (validateChainEventsSubscribePayload) -- a hand-rolled second validation
 // path is exactly how a security guarantee quietly drifts from the first.
 async function subscribeResource(params, ctx) {
   const uri = params?.uri;
-  if (typeof uri !== "string" || !SUBSCRIBABLE_RESOURCE_URIS.has(uri)) {
+  if (typeof uri !== "string" || !isSubscribableResourceUri(uri)) {
     throw toolError(
       "invalid_params",
       `Resource is unknown or not subscribable: ${String(uri)}. Only ` +
-        `${[...SUBSCRIBABLE_RESOURCE_URIS].join(", ")} supports resources/subscribe.`,
+        `${listSubscribableMcpResourceClasses().join(", ")} support ` +
+        "resources/subscribe.",
     );
   }
   if (!ctx.sessionId) {

--- a/src/subnet-status-subscribe.mjs
+++ b/src/subnet-status-subscribe.mjs
@@ -1,0 +1,134 @@
+// Pure helpers for the per-subnet MCP status subscription (#6034).
+//
+// Complements the chain-firehose path (#4983): `metagraph://chain/stream` is
+// network-wide and event-driven from Postgres outbox ingest;
+// `metagraph://subnet/{netuid}/status` is scoped to one subnet and event-
+// driven from the health prober's write path (diff prior vs next
+// health:current, then fan out via SubnetStatusHub → McpSessionHub /notify).
+// No per-subnet poll loops — the 15-minute probe sweep is already the clock.
+//
+// Chain stream URI is the literal string (same value as
+// MCP_CHAIN_STREAM_RESOURCE_URI in workers/mcp-session-hub.mjs) — this module
+// must not import that file, or it would cycle with McpSessionHub's import of
+// parseSubnetStatusResourceUri below.
+
+export const MCP_SUBNET_STATUS_URI_RE = /^metagraph:\/\/subnet\/(\d+)\/status$/;
+
+export function buildSubnetStatusResourceUri(netuid) {
+  return `metagraph://subnet/${netuid}/status`;
+}
+
+export function parseSubnetStatusResourceUri(uri) {
+  if (typeof uri !== "string") return null;
+  const match = MCP_SUBNET_STATUS_URI_RE.exec(uri);
+  if (!match) return null;
+  // Regex admits only digits → Number(match[1]) is always a non-negative integer.
+  return Number(match[1]);
+}
+
+export function isSubscribableMcpResourceUri(uri) {
+  if (uri === "metagraph://chain/stream") return true;
+  return parseSubnetStatusResourceUri(uri) != null;
+}
+
+export function listSubscribableMcpResourceClasses() {
+  return ["metagraph://chain/stream", "metagraph://subnet/{netuid}/status"];
+}
+
+// Compact, order-stable fingerprint of one subnet's health tier + surface
+// membership/status. Used to decide whether a probe sweep produced a real
+// change worth notifying subscribers about.
+export function subnetStatusFingerprint(subnetRow, surfacesForNetuid) {
+  const status =
+    subnetRow && typeof subnetRow.status === "string"
+      ? subnetRow.status
+      : "unknown";
+  const surface_count = Number.isInteger(subnetRow?.surface_count)
+    ? subnetRow.surface_count
+    : (surfacesForNetuid?.length ?? 0);
+  const surfaces = (surfacesForNetuid || [])
+    .map((row) => {
+      const key = row.surface_key || row.surface_id || "";
+      const surfaceStatus =
+        typeof row.status === "string" ? row.status : "unknown";
+      return `${key}:${surfaceStatus}`;
+    })
+    .sort();
+  return JSON.stringify({ status, surface_count, surfaces });
+}
+
+function indexHealthCurrent(snapshot) {
+  const byNetuid = new Map();
+  if (!snapshot || typeof snapshot !== "object") return byNetuid;
+  const surfacesByNetuid = new Map();
+  for (const row of snapshot.surfaces || []) {
+    if (typeof row?.netuid !== "number") continue;
+    const group = surfacesByNetuid.get(row.netuid) || [];
+    group.push(row);
+    surfacesByNetuid.set(row.netuid, group);
+  }
+  for (const subnet of snapshot.subnets || []) {
+    if (typeof subnet?.netuid !== "number") continue;
+    byNetuid.set(
+      subnet.netuid,
+      subnetStatusFingerprint(subnet, surfacesByNetuid.get(subnet.netuid)),
+    );
+  }
+  // A netuid that only appears in surfaces (no rollup row yet) still needs a
+  // fingerprint so membership-only changes are detected.
+  for (const [netuid, rows] of surfacesByNetuid) {
+    if (byNetuid.has(netuid)) continue;
+    byNetuid.set(netuid, subnetStatusFingerprint(null, rows));
+  }
+  return byNetuid;
+}
+
+// Returns sorted unique netuids whose health tier, surface membership, or
+// per-surface status changed between two health:current snapshots. A cold
+// prior (null/empty) yields every netuid in `next` — first probe after
+// deploy is a real "status became known" signal for subscribers.
+export function diffChangedSubnetNetuids(prior, next) {
+  const priorIndex = indexHealthCurrent(prior);
+  const nextIndex = indexHealthCurrent(next);
+  const changed = new Set();
+  for (const [netuid, fingerprint] of nextIndex) {
+    if (priorIndex.get(netuid) !== fingerprint) changed.add(netuid);
+  }
+  for (const netuid of priorIndex.keys()) {
+    if (!nextIndex.has(netuid)) changed.add(netuid);
+  }
+  return [...changed].sort((a, b) => a - b);
+}
+
+// Best-effort fan-out into SubnetStatusHub. Never throws into the probe path —
+// a missing binding (local/CI) or a DO failure must not fail the health write.
+export async function notifySubnetStatusChanged(env, netuids) {
+  if (!env?.SUBNET_STATUS_HUB) {
+    return { notified: false, reason: "unbound" };
+  }
+  const list = Array.isArray(netuids)
+    ? netuids.filter((n) => Number.isInteger(n) && n >= 0)
+    : [];
+  if (list.length === 0) {
+    return { notified: false, reason: "no_netuids" };
+  }
+  try {
+    const stub = env.SUBNET_STATUS_HUB.get(
+      env.SUBNET_STATUS_HUB.idFromName("global"),
+    );
+    const upstream = await stub.fetch(
+      "https://subnet-status-hub.internal/notify-changed",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ netuids: list }),
+      },
+    );
+    if (!upstream.ok) {
+      return { notified: false, reason: `status_${upstream.status}` };
+    }
+    return { notified: true };
+  } catch {
+    return { notified: false, reason: "fetch_failed" };
+  }
+}

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -1868,6 +1868,85 @@ describe("summarizeGroup / rollupStatus via per-subnet rollup", () => {
     assert.equal(subnet.status, "degraded");
     assert.equal(subnet.degraded_count, 1);
   });
+
+  test("notifies SubnetStatusHub only when a subnet status fingerprint changes (#6034)", async () => {
+    const surfaces = [buildSurface("chg", 77)];
+    const kv = makeKv();
+    const notifyCalls = [];
+    const env = {
+      SUBNET_STATUS_HUB: {
+        idFromName: (name) => name,
+        get: () => ({
+          fetch: async (url, init) => {
+            notifyCalls.push({
+              url,
+              body: JSON.parse(init.body),
+            });
+            return new Response(JSON.stringify({ ok: true }), { status: 200 });
+          },
+        }),
+      },
+    };
+    // First run: cold prior → notify for the probed netuid.
+    await runHealthProber(
+      env,
+      {},
+      {
+        now: () => 10_000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => surfaces,
+        probeSurface: async () => ({
+          status: "ok",
+          classification: "live",
+          latency_ms: 12,
+        }),
+        probeOptions: {},
+      },
+    );
+    assert.equal(notifyCalls.length, 1);
+    assert.deepEqual(notifyCalls[0].body.netuids, [77]);
+
+    // Second run: identical status → no notify.
+    notifyCalls.length = 0;
+    await runHealthProber(
+      env,
+      {},
+      {
+        now: () => 20_000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => surfaces,
+        probeSurface: async () => ({
+          status: "ok",
+          classification: "live",
+          latency_ms: 12,
+        }),
+        probeOptions: {},
+      },
+    );
+    assert.equal(notifyCalls.length, 0);
+
+    // Third run: status flips → notify.
+    await runHealthProber(
+      env,
+      {},
+      {
+        now: () => 30_000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => surfaces,
+        probeSurface: async () => ({
+          status: "failed",
+          classification: "dead",
+          latency_ms: null,
+        }),
+        probeOptions: {},
+      },
+    );
+    assert.equal(notifyCalls.length, 1);
+    assert.deepEqual(notifyCalls[0].body.netuids, [77]);
+  });
 });
 
 describe("pruneHealthHistory edge paths", () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -332,11 +332,12 @@ describe("MCP resources (#742)", () => {
       method: "resources/templates/list",
     });
     const tpls = res.body.result.resourceTemplates;
-    assert.equal(tpls.length, 3);
+    assert.equal(tpls.length, 4);
     assert.deepEqual(tpls.map((t) => t.uriTemplate).sort(), [
       "metagraph://provider/{slug}",
       "metagraph://schema/{surface_id}",
       "metagraph://subnet/{netuid}",
+      "metagraph://subnet/{netuid}/status",
     ]);
     for (const t of tpls) {
       assert.ok(t.name && t.title && t.description && t.mimeType);
@@ -370,6 +371,7 @@ describe("MCP resources (#742)", () => {
     const uris = res.body.result.resources.map((r) => r.uri);
     assert.ok(uris.includes("metagraph://registry/summary"));
     assert.ok(uris.includes("metagraph://subnet/7"));
+    assert.ok(uris.includes("metagraph://subnet/7/status"));
     assert.ok(uris.includes("metagraph://provider/datura"));
     assert.ok(uris.includes("metagraph://schema/7:subnet-api:allways"));
     assert.equal(res.body.result.nextCursor, undefined);
@@ -781,11 +783,18 @@ describe("MCP prompts (#742)", () => {
 
 describe("MCP resources/prompts — branch coverage", () => {
   test("resources/list paginates with a cursor over a large catalog", async () => {
-    const subnets = Array.from({ length: 130 }, (_, i) => ({
+    // Each subnet contributes two list entries (overview + status, #6034),
+    // plus FIXED_RESOURCES. Stub providers/schemas empty so the catalog size
+    // is deterministic: 5 fixed + 2*70 = 145 → page1 full, page2 final.
+    const subnets = Array.from({ length: 70 }, (_, i) => ({
       netuid: i,
       name: `SN${i}`,
     }));
-    const deps = makeDeps({ "/metagraph/subnets.json": { subnets } });
+    const deps = makeDeps({
+      "/metagraph/subnets.json": { subnets },
+      "/metagraph/providers.json": { providers: [] },
+      "/metagraph/schemas/index.json": { schemas: [] },
+    });
     const page1 = await rpc(
       { jsonrpc: "2.0", id: 1, method: "resources/list" },
       { deps },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -658,6 +658,59 @@ describe("MCP resources/subscribe + resources/unsubscribe (#4983 MCP half)", () 
     assert.equal(hub.calls.length, 0);
   });
 
+  test("resources/subscribe accepts metagraph://subnet/{netuid}/status (#6034)", async () => {
+    const hub = fakeMcpSessionHubBinding();
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/subscribe",
+        params: { uri: "metagraph://subnet/42/status" },
+      },
+      {
+        headers: { "mcp-session-id": A_SESSION_ID },
+        env: { MCP_SESSION_HUB: hub },
+      },
+    );
+    assert.deepEqual(res.body.result, {});
+    assert.deepEqual(JSON.parse(hub.calls[0].init.body), {
+      sessionId: A_SESSION_ID,
+      uri: "metagraph://subnet/42/status",
+    });
+  });
+
+  test("resources/unsubscribe accepts metagraph://subnet/{netuid}/status (#6034)", async () => {
+    const hub = fakeMcpSessionHubBinding();
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "resources/unsubscribe",
+        params: { uri: "metagraph://subnet/42/status" },
+      },
+      {
+        headers: { "mcp-session-id": A_SESSION_ID },
+        env: { MCP_SESSION_HUB: hub },
+      },
+    );
+    assert.deepEqual(res.body.result, {});
+    assert.match(hub.calls[0].url, /\/unsubscribe$/);
+  });
+
+  test("resources/read on subnet status returns live health overlay (#6034)", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "resources/read",
+      params: { uri: "metagraph://subnet/1/status" },
+    });
+    assert.equal(res.status, 200);
+    const data = JSON.parse(res.body.result.contents[0].text);
+    assert.equal(data.netuid, 1);
+    assert.ok(data.summary);
+    assert.ok(Array.isArray(data.surfaces));
+  });
+
   test("resources/unsubscribe forwards to the session hub's /unsubscribe route and succeeds, even for a uri never subscribed to", async () => {
     const hub = fakeMcpSessionHubBinding();
     const res = await rpc(

--- a/tests/mcp-session-hub.test.mjs
+++ b/tests/mcp-session-hub.test.mjs
@@ -222,7 +222,7 @@ test("handleUnsubscribe: works even when CHAIN_FIREHOSE_HUB isn't bound (local/C
   assert.equal(hub.subscribedUris.size, 0);
 });
 
-test("handleUnsubscribe: unsubscribing something never subscribed to is a harmless no-op (no notify, since the set was already empty)", async () => {
+test("handleUnsubscribe: unsubscribing something never subscribed to is a harmless no-op", async () => {
   const firehose = fakeChainFirehoseHubBinding();
   const hub = new McpSessionHub(stubState(), { CHAIN_FIREHOSE_HUB: firehose });
   const res = await hub.fetch(
@@ -232,9 +232,9 @@ test("handleUnsubscribe: unsubscribing something never subscribed to is a harmle
     }),
   );
   assert.equal(res.status, 200);
-  // subscribedUris was already empty -> "becomes empty" fires the notify
-  // exactly once (size === 0 both before and after is still `=== 0`).
-  assert.equal(firehose.calls.length, 1);
+  // Never had the chain URI → do not ping ChainFirehoseHub (would be a
+  // spurious mcp-unsubscribe for a session that never mcp-subscribed).
+  assert.equal(firehose.calls.length, 0);
 });
 
 // --- handleNotify / deliverNow ----------------------------------------------------
@@ -665,6 +665,147 @@ test("touch: sets a Durable Object alarm MCP_SESSION_IDLE_TTL_MS in the future",
   const alarmTime = state.storage.lastAlarmTime;
   assert.ok(alarmTime >= before + MCP_SESSION_IDLE_TTL_MS);
   assert.ok(alarmTime <= Date.now() + MCP_SESSION_IDLE_TTL_MS + 1000);
+});
+
+// --- #6034 subnet status subscription -------------------------------------------
+
+function fakeSubnetStatusHubBinding() {
+  const calls = [];
+  return {
+    calls,
+    idFromName: (name) => name,
+    get: () => ({
+      fetch: async (url, init) => {
+        calls.push({
+          url,
+          body: init?.body ? JSON.parse(init.body) : null,
+        });
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    }),
+  };
+}
+
+test("handleSubscribe: subnet status uri registers with SubnetStatusHub, not the firehose", async () => {
+  const firehose = fakeChainFirehoseHubBinding();
+  const statusHub = fakeSubnetStatusHubBinding();
+  const hub = new McpSessionHub(stubState(), {
+    CHAIN_FIREHOSE_HUB: firehose,
+    SUBNET_STATUS_HUB: statusHub,
+  });
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: "metagraph://subnet/42/status",
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(hub.subscribedUris.has("metagraph://subnet/42/status"), true);
+  assert.equal(firehose.calls.length, 0);
+  assert.equal(statusHub.calls.length, 1);
+  assert.match(statusHub.calls[0].url, /\/mcp-subscribe$/);
+  assert.deepEqual(statusHub.calls[0].body, {
+    sessionId: "session-1",
+    netuid: 42,
+  });
+});
+
+test("handleUnsubscribe: subnet status uri unregisters that netuid from SubnetStatusHub", async () => {
+  const statusHub = fakeSubnetStatusHubBinding();
+  const hub = new McpSessionHub(stubState(), {
+    SUBNET_STATUS_HUB: statusHub,
+  });
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: "metagraph://subnet/7/status",
+    }),
+  );
+  statusHub.calls.length = 0;
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/unsubscribe", {
+      sessionId: "session-1",
+      uri: "metagraph://subnet/7/status",
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(hub.subscribedUris.size, 0);
+  assert.equal(statusHub.calls.length, 1);
+  assert.match(statusHub.calls[0].url, /\/mcp-unsubscribe$/);
+  assert.deepEqual(statusHub.calls[0].body, {
+    sessionId: "session-1",
+    netuid: 7,
+  });
+});
+
+test("handleStream: opens for a session subscribed only to subnet status", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: "metagraph://subnet/3/status",
+    }),
+  );
+  const res = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream?sessionId=session-1", {
+      method: "GET",
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/event-stream/);
+  // Close promptly so the stream timeout doesn't linger in the test process.
+  await res.body.cancel();
+});
+
+test("handleNotify: delivers a subnet status update on an open stream", async () => {
+  const hub = new McpSessionHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: "metagraph://subnet/3/status",
+    }),
+  );
+  const streamRes = await hub.fetch(
+    new Request("https://mcp-session-hub.internal/stream?sessionId=session-1", {
+      method: "GET",
+    }),
+  );
+  assert.equal(streamRes.status, 200);
+  const reader = streamRes.body.getReader();
+  const notifyRes = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/notify", {
+      uri: "metagraph://subnet/3/status",
+    }),
+  );
+  assert.equal(notifyRes.status, 200);
+  const { value } = await reader.read();
+  const frame = new TextDecoder().decode(value);
+  assert.match(frame, /notifications\/resources\/updated/);
+  assert.match(frame, /metagraph:\/\/subnet\/3\/status/);
+  await reader.cancel();
+});
+
+test("handleTerminate: clears SubnetStatusHub membership for status subscribers", async () => {
+  const statusHub = fakeSubnetStatusHubBinding();
+  const hub = new McpSessionHub(stubState(), {
+    SUBNET_STATUS_HUB: statusHub,
+  });
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: "metagraph://subnet/5/status",
+    }),
+  );
+  statusHub.calls.length = 0;
+  const res = await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/terminate", {
+      sessionId: "session-1",
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(statusHub.calls.length, 1);
+  assert.match(statusHub.calls[0].url, /\/mcp-unsubscribe-session$/);
+  assert.deepEqual(statusHub.calls[0].body, { sessionId: "session-1" });
 });
 
 test("MCP_SESSION_MAX_STREAM_DURATION_MS and MCP_SESSION_IDLE_TTL_MS are the documented magnitudes (minutes, not ms/hours by mistake)", () => {

--- a/tests/subnet-status-hub.test.mjs
+++ b/tests/subnet-status-hub.test.mjs
@@ -1,0 +1,306 @@
+// Unit tests for workers/subnet-status-hub.mjs (#6034).
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  SubnetStatusHub,
+  addSessionSubscription,
+  hydrateSubscriptionIndex,
+  removeSessionEverywhere,
+  removeSessionSubscription,
+  serializeSubscriptionIndex,
+} from "../workers/subnet-status-hub.mjs";
+import { buildSubnetStatusResourceUri } from "../src/subnet-status-subscribe.mjs";
+
+function createStubStorage(initial = {}) {
+  const data = new Map(Object.entries(initial));
+  return {
+    async get(keys) {
+      const result = new Map();
+      for (const key of keys) {
+        if (data.has(key)) result.set(key, data.get(key));
+      }
+      return result;
+    },
+    async put(entries) {
+      for (const [key, value] of Object.entries(entries)) {
+        data.set(key, value);
+      }
+    },
+    get raw() {
+      return data;
+    },
+  };
+}
+
+function stubState(initial) {
+  return { storage: createStubStorage(initial) };
+}
+
+function fakeMcpSessionHubBinding() {
+  const calls = [];
+  return {
+    calls,
+    idFromName: (name) => name,
+    get: () => ({
+      fetch: async (url, init) => {
+        calls.push({
+          url,
+          body: init?.body ? JSON.parse(init.body) : null,
+        });
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    }),
+  };
+}
+
+function jsonRequest(url, body) {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+test("index helpers: add/remove/serialize/hydrate round-trip", () => {
+  const byNetuid = new Map();
+  const sessionByNetuid = new Map();
+  addSessionSubscription(byNetuid, sessionByNetuid, "s1", 1);
+  addSessionSubscription(byNetuid, sessionByNetuid, "s2", 1);
+  addSessionSubscription(byNetuid, sessionByNetuid, "s1", 2);
+  assert.deepEqual([...byNetuid.get(1)].sort(), ["s1", "s2"]);
+  assert.deepEqual([...sessionByNetuid.get("s1")].sort(), [1, 2]);
+
+  removeSessionSubscription(byNetuid, sessionByNetuid, "s1", 1);
+  assert.deepEqual([...byNetuid.get(1)], ["s2"]);
+  assert.deepEqual([...sessionByNetuid.get("s1")], [2]);
+
+  removeSessionEverywhere(byNetuid, sessionByNetuid, "s1");
+  assert.equal(sessionByNetuid.has("s1"), false);
+  assert.equal(byNetuid.has(2), false);
+
+  const serialized = serializeSubscriptionIndex(byNetuid);
+  assert.deepEqual(serialized, { 1: ["s2"] });
+  const revived = hydrateSubscriptionIndex(serialized);
+  assert.deepEqual([...revived.byNetuid.get(1)], ["s2"]);
+});
+
+test("handleSubscribe: registers session for a netuid and persists", async () => {
+  const state = stubState();
+  const hub = new SubnetStatusHub(state, {});
+  const res = await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+      sessionId: "session-1",
+      netuid: 42,
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(hub.byNetuid.get(42).has("session-1"), true);
+  assert.deepEqual(state.storage.raw.get("byNetuid"), {
+    42: ["session-1"],
+  });
+});
+
+test("handleSubscribe: rejects missing sessionId / netuid", async () => {
+  const hub = new SubnetStatusHub(stubState(), {});
+  const missingSession = await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+      netuid: 1,
+    }),
+  );
+  assert.equal(missingSession.status, 400);
+  const missingNetuid = await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+      sessionId: "s",
+    }),
+  );
+  assert.equal(missingNetuid.status, 400);
+});
+
+test("handleUnsubscribe + unsubscribe-session clear membership", async () => {
+  const hub = new SubnetStatusHub(stubState(), {});
+  await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+      sessionId: "session-1",
+      netuid: 1,
+    }),
+  );
+  await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+      sessionId: "session-1",
+      netuid: 2,
+    }),
+  );
+  await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-unsubscribe", {
+      sessionId: "session-1",
+      netuid: 1,
+    }),
+  );
+  assert.equal(hub.byNetuid.has(1), false);
+  assert.equal(hub.byNetuid.get(2).has("session-1"), true);
+
+  await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-unsubscribe-session", {
+      sessionId: "session-1",
+    }),
+  );
+  assert.equal(hub.byNetuid.has(2), false);
+  assert.equal(hub.sessionByNetuid.has("session-1"), false);
+});
+
+test("handleNotifyChanged: fans out only to subscribed sessions for changed netuids", async () => {
+  const sessions = fakeMcpSessionHubBinding();
+  const hub = new SubnetStatusHub(stubState(), { MCP_SESSION_HUB: sessions });
+  await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+      sessionId: "interested",
+      netuid: 7,
+    }),
+  );
+  await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+      sessionId: "other",
+      netuid: 9,
+    }),
+  );
+  const res = await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/notify-changed", {
+      netuids: [7, 99],
+    }),
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.delivered, 1);
+  assert.equal(sessions.calls.length, 1);
+  assert.match(sessions.calls[0].url, /\/notify$/);
+  assert.deepEqual(sessions.calls[0].body, {
+    uri: buildSubnetStatusResourceUri(7),
+  });
+});
+
+test("handleNotifyChanged: best-effort — a failing session does not abort others", async () => {
+  let n = 0;
+  const sessions = {
+    idFromName: (name) => name,
+    get: () => ({
+      fetch: async () => {
+        n += 1;
+        if (n === 1) throw new Error("boom");
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    }),
+  };
+  const hub = new SubnetStatusHub(stubState(), { MCP_SESSION_HUB: sessions });
+  await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+      sessionId: "a",
+      netuid: 1,
+    }),
+  );
+  await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+      sessionId: "b",
+      netuid: 1,
+    }),
+  );
+  const res = await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/notify-changed", {
+      netuids: [1],
+    }),
+  );
+  const body = await res.json();
+  assert.equal(body.delivered, 1);
+});
+
+test("handleNotifyChanged: empty list or unbound MCP_SESSION_HUB delivers 0", async () => {
+  const hub = new SubnetStatusHub(stubState(), {});
+  const empty = await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/notify-changed", {
+      netuids: [1],
+    }),
+  );
+  assert.deepEqual(await empty.json(), { ok: true, delivered: 0 });
+
+  const hub2 = new SubnetStatusHub(stubState(), {
+    MCP_SESSION_HUB: fakeMcpSessionHubBinding(),
+  });
+  const none = await hub2.fetch(
+    jsonRequest("https://subnet-status-hub.internal/notify-changed", {
+      netuids: [],
+    }),
+  );
+  assert.deepEqual(await none.json(), { ok: true, delivered: 0 });
+
+  const bad = await hub2.fetch(
+    jsonRequest("https://subnet-status-hub.internal/notify-changed", {
+      netuids: "not-an-array",
+    }),
+  );
+  assert.deepEqual(await bad.json(), { ok: true, delivered: 0 });
+});
+
+test("handleSubscribe: accepts a status URI string as netuid", async () => {
+  const hub = new SubnetStatusHub(stubState(), {});
+  const res = await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-subscribe", {
+      sessionId: "session-1",
+      netuid: "metagraph://subnet/9/status",
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.equal(hub.byNetuid.get(9).has("session-1"), true);
+});
+
+test("index helpers: ignore invalid sessionId / netuid inputs", () => {
+  const byNetuid = new Map();
+  const sessionByNetuid = new Map();
+  addSessionSubscription(byNetuid, sessionByNetuid, "", 1);
+  addSessionSubscription(byNetuid, sessionByNetuid, "s", -1);
+  addSessionSubscription(byNetuid, sessionByNetuid, null, 1);
+  removeSessionSubscription(byNetuid, sessionByNetuid, "", 1);
+  removeSessionSubscription(byNetuid, sessionByNetuid, "s", -1);
+  removeSessionSubscription(byNetuid, sessionByNetuid, "missing", 1);
+  removeSessionEverywhere(byNetuid, sessionByNetuid, "missing");
+  assert.equal(byNetuid.size, 0);
+  assert.equal(hydrateSubscriptionIndex(null).byNetuid.size, 0);
+  const revived = hydrateSubscriptionIndex({
+    bad: "x",
+    "-1": ["s"],
+    2: ["ok", ""],
+    3: "not-array",
+  });
+  assert.deepEqual([...revived.byNetuid.get(2)], ["ok"]);
+  assert.equal(revived.byNetuid.has(-1), false);
+  assert.equal(revived.byNetuid.has(3), false);
+});
+
+test("handleUnsubscribe / unsubscribe-session no-op on bad payloads", async () => {
+  const hub = new SubnetStatusHub(stubState(), {});
+  const badUnsub = await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-unsubscribe", {
+      sessionId: 9,
+      netuid: "x",
+    }),
+  );
+  assert.equal(badUnsub.status, 200);
+  const badSession = await hub.fetch(
+    jsonRequest("https://subnet-status-hub.internal/mcp-unsubscribe-session", {
+      sessionId: 9,
+    }),
+  );
+  assert.equal(badSession.status, 200);
+});
+
+test("unknown route and wrong method return 404", async () => {
+  const hub = new SubnetStatusHub(stubState(), {});
+  const missing = await hub.fetch(
+    new Request("https://subnet-status-hub.internal/nope", { method: "GET" }),
+  );
+  assert.equal(missing.status, 404);
+  const wrongMethod = await hub.fetch(
+    new Request("https://subnet-status-hub.internal/notify-changed", {
+      method: "GET",
+    }),
+  );
+  assert.equal(wrongMethod.status, 404);
+});

--- a/tests/subnet-status-subscribe.test.mjs
+++ b/tests/subnet-status-subscribe.test.mjs
@@ -1,0 +1,308 @@
+// Unit tests for src/subnet-status-subscribe.mjs (#6034).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  buildSubnetStatusResourceUri,
+  diffChangedSubnetNetuids,
+  isSubscribableMcpResourceUri,
+  listSubscribableMcpResourceClasses,
+  notifySubnetStatusChanged,
+  parseSubnetStatusResourceUri,
+  subnetStatusFingerprint,
+} from "../src/subnet-status-subscribe.mjs";
+
+describe("subnet status resource URIs (#6034)", () => {
+  test("build/parse round-trip a valid netuid", () => {
+    assert.equal(
+      buildSubnetStatusResourceUri(42),
+      "metagraph://subnet/42/status",
+    );
+    assert.equal(
+      parseSubnetStatusResourceUri("metagraph://subnet/42/status"),
+      42,
+    );
+    assert.equal(
+      parseSubnetStatusResourceUri("metagraph://subnet/0/status"),
+      0,
+    );
+  });
+
+  test("parse rejects malformed URIs", () => {
+    assert.equal(parseSubnetStatusResourceUri(null), null);
+    assert.equal(parseSubnetStatusResourceUri("metagraph://subnet/42"), null);
+    assert.equal(
+      parseSubnetStatusResourceUri("metagraph://subnet/-1/status"),
+      null,
+    );
+    assert.equal(
+      parseSubnetStatusResourceUri("metagraph://subnet/x/status"),
+      null,
+    );
+    assert.equal(
+      parseSubnetStatusResourceUri("metagraph://chain/stream"),
+      null,
+    );
+  });
+
+  test("isSubscribableMcpResourceUri accepts chain stream and subnet status", () => {
+    assert.equal(
+      isSubscribableMcpResourceUri("metagraph://chain/stream"),
+      true,
+    );
+    assert.equal(
+      isSubscribableMcpResourceUri("metagraph://subnet/7/status"),
+      true,
+    );
+    assert.equal(isSubscribableMcpResourceUri("metagraph://subnet/7"), false);
+    assert.equal(
+      isSubscribableMcpResourceUri("metagraph://registry/summary"),
+      false,
+    );
+  });
+
+  test("listSubscribableMcpResourceClasses documents both classes", () => {
+    assert.deepEqual(listSubscribableMcpResourceClasses(), [
+      "metagraph://chain/stream",
+      "metagraph://subnet/{netuid}/status",
+    ]);
+  });
+});
+
+describe("subnetStatusFingerprint / diffChangedSubnetNetuids (#6034)", () => {
+  test("fingerprint is stable under surface row reordering", () => {
+    const a = subnetStatusFingerprint({ status: "ok", surface_count: 2 }, [
+      { surface_key: "b", status: "failed" },
+      { surface_key: "a", status: "ok" },
+    ]);
+    const b = subnetStatusFingerprint({ status: "ok", surface_count: 2 }, [
+      { surface_key: "a", status: "ok" },
+      { surface_key: "b", status: "failed" },
+    ]);
+    assert.equal(a, b);
+  });
+
+  test("diff detects health-tier change", () => {
+    const prior = {
+      subnets: [{ netuid: 1, status: "ok", surface_count: 1 }],
+      surfaces: [{ netuid: 1, surface_key: "s1", status: "ok" }],
+    };
+    const next = {
+      subnets: [{ netuid: 1, status: "degraded", surface_count: 1 }],
+      surfaces: [{ netuid: 1, surface_key: "s1", status: "degraded" }],
+    };
+    assert.deepEqual(diffChangedSubnetNetuids(prior, next), [1]);
+  });
+
+  test("diff detects surface membership change", () => {
+    const prior = {
+      subnets: [{ netuid: 3, status: "ok", surface_count: 1 }],
+      surfaces: [{ netuid: 3, surface_key: "only", status: "ok" }],
+    };
+    const next = {
+      subnets: [{ netuid: 3, status: "ok", surface_count: 2 }],
+      surfaces: [
+        { netuid: 3, surface_key: "only", status: "ok" },
+        { netuid: 3, surface_key: "new", status: "ok" },
+      ],
+    };
+    assert.deepEqual(diffChangedSubnetNetuids(prior, next), [3]);
+  });
+
+  test("diff is empty when nothing meaningful changed", () => {
+    const snap = {
+      subnets: [{ netuid: 2, status: "ok", surface_count: 1 }],
+      surfaces: [{ netuid: 2, surface_key: "s", status: "ok" }],
+    };
+    assert.deepEqual(diffChangedSubnetNetuids(snap, structuredClone(snap)), []);
+  });
+
+  test("cold prior reports every next netuid", () => {
+    const next = {
+      subnets: [
+        { netuid: 5, status: "ok", surface_count: 1 },
+        { netuid: 9, status: "failed", surface_count: 1 },
+      ],
+      surfaces: [
+        { netuid: 5, surface_key: "a", status: "ok" },
+        { netuid: 9, surface_key: "b", status: "failed" },
+      ],
+    };
+    assert.deepEqual(diffChangedSubnetNetuids(null, next), [5, 9]);
+  });
+
+  test("fingerprint falls back when surface_count / surfaces / status are missing", () => {
+    assert.equal(
+      subnetStatusFingerprint({ status: 1 }, null),
+      subnetStatusFingerprint({ status: "unknown", surface_count: 0 }, []),
+    );
+    assert.equal(
+      subnetStatusFingerprint(null, [{ surface_id: "only", status: 9 }]),
+      JSON.stringify({
+        status: "unknown",
+        surface_count: 1,
+        surfaces: ["only:unknown"],
+      }),
+    );
+    assert.equal(
+      subnetStatusFingerprint({ status: "ok", surface_count: "x" }, [
+        { status: "ok" },
+      ]),
+      JSON.stringify({
+        status: "ok",
+        surface_count: 1,
+        surfaces: [":ok"],
+      }),
+    );
+  });
+
+  test("diff tolerates missing subnets/surfaces arrays", () => {
+    assert.deepEqual(
+      diffChangedSubnetNetuids({}, { subnets: [], surfaces: [] }),
+      [],
+    );
+    assert.deepEqual(
+      diffChangedSubnetNetuids(
+        { subnets: [{ netuid: 1, status: "ok", surface_count: 0 }] },
+        {},
+      ),
+      [1],
+    );
+  });
+
+  test("diff skips malformed netuid entries", () => {
+    const next = {
+      subnets: [
+        { netuid: "x", status: "ok" },
+        { netuid: 4, status: "ok" },
+      ],
+      surfaces: [
+        { netuid: "y", surface_key: "bad", status: "ok" },
+        { netuid: 4, surface_key: "ok", status: "ok" },
+      ],
+    };
+    assert.deepEqual(diffChangedSubnetNetuids(null, next), [4]);
+  });
+
+  test("diff indexes a netuid that only appears in surfaces (no rollup row)", () => {
+    const prior = { subnets: [], surfaces: [] };
+    const next = {
+      subnets: [],
+      surfaces: [{ netuid: 12, surface_key: "solo", status: "ok" }],
+    };
+    assert.deepEqual(diffChangedSubnetNetuids(prior, next), [12]);
+  });
+});
+
+describe("notifySubnetStatusChanged (#6034)", () => {
+  test("no-ops when SUBNET_STATUS_HUB is unbound", async () => {
+    assert.deepEqual(await notifySubnetStatusChanged({}, [1]), {
+      notified: false,
+      reason: "unbound",
+    });
+  });
+
+  test("no-ops when netuid list is empty", async () => {
+    assert.deepEqual(
+      await notifySubnetStatusChanged(
+        {
+          SUBNET_STATUS_HUB: {
+            idFromName: () => "global",
+            get: () => ({ fetch: async () => new Response("ok") }),
+          },
+        },
+        [],
+      ),
+      { notified: false, reason: "no_netuids" },
+    );
+  });
+
+  test("posts notify-changed to the singleton hub", async () => {
+    const calls = [];
+    const result = await notifySubnetStatusChanged(
+      {
+        SUBNET_STATUS_HUB: {
+          idFromName: (name) => name,
+          get: () => ({
+            fetch: async (url, init) => {
+              calls.push({ url, body: JSON.parse(init.body) });
+              return new Response(JSON.stringify({ ok: true }), {
+                status: 200,
+              });
+            },
+          }),
+        },
+      },
+      [1, 2],
+    );
+    assert.deepEqual(result, { notified: true });
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].url, /\/notify-changed$/);
+    assert.deepEqual(calls[0].body, { netuids: [1, 2] });
+  });
+
+  test("returns fetch_failed when the hub throws", async () => {
+    const result = await notifySubnetStatusChanged(
+      {
+        SUBNET_STATUS_HUB: {
+          idFromName: () => "global",
+          get: () => ({
+            fetch: async () => {
+              throw new Error("boom");
+            },
+          }),
+        },
+      },
+      [1],
+    );
+    assert.deepEqual(result, { notified: false, reason: "fetch_failed" });
+  });
+
+  test("returns status_* when the hub responds non-2xx", async () => {
+    const result = await notifySubnetStatusChanged(
+      {
+        SUBNET_STATUS_HUB: {
+          idFromName: () => "global",
+          get: () => ({
+            fetch: async () => new Response("nope", { status: 503 }),
+          }),
+        },
+      },
+      [1],
+    );
+    assert.deepEqual(result, { notified: false, reason: "status_503" });
+  });
+
+  test("notifySubnetStatusChanged filters non-integer netuids", async () => {
+    assert.deepEqual(
+      await notifySubnetStatusChanged(
+        {
+          SUBNET_STATUS_HUB: {
+            idFromName: () => "global",
+            get: () => ({
+              fetch: async () => new Response(JSON.stringify({ ok: true })),
+            }),
+          },
+        },
+        [-1, 1.5, "2", null],
+      ),
+      { notified: false, reason: "no_netuids" },
+    );
+  });
+
+  test("notifySubnetStatusChanged rejects a non-array netuids argument", async () => {
+    assert.deepEqual(
+      await notifySubnetStatusChanged(
+        {
+          SUBNET_STATUS_HUB: {
+            idFromName: () => "global",
+            get: () => ({
+              fetch: async () => new Response(JSON.stringify({ ok: true })),
+            }),
+          },
+        },
+        "1",
+      ),
+      { notified: false, reason: "no_netuids" },
+    );
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -264,6 +264,7 @@ import {
 } from "./chain-firehose-hub.mjs";
 import { McpSessionHub } from "./mcp-session-hub.mjs";
 import { AlerterHub } from "./alerter-hub.mjs";
+import { SubnetStatusHub } from "./subnet-status-hub.mjs";
 import { handleMcpRequest } from "../src/mcp-server.mjs";
 import { handleFeedRequest, resolveFeedFormat } from "../src/feeds.mjs";
 import { handleBadgeRequest } from "../src/badge.mjs";
@@ -444,7 +445,7 @@ export default {
 // classes defined in chain-firehose-hub.mjs/mcp-session-hub.mjs is what
 // makes the "durable_objects"/"migrations" bindings in wrangler.jsonc
 // resolvable.
-export { ChainFirehoseHub, McpSessionHub, AlerterHub };
+export { ChainFirehoseHub, McpSessionHub, AlerterHub, SubnetStatusHub };
 
 // The staged-artifact loaders (request-handlers/staging.mjs, #1763) are fully
 // retired: loadStagedNeurons/Events/Blocks/Extrinsics went alongside their D1

--- a/workers/mcp-session-hub.mjs
+++ b/workers/mcp-session-hub.mjs
@@ -19,6 +19,12 @@
 // the broadcast() loop that pings this class's /notify route) -- this class
 // only owns session lifecycle and the one open SSE stream a session may have.
 //
+// #6034 extends the same session DO to also accept
+// `metagraph://subnet/{netuid}/status` subscriptions. Membership for those
+// URIs is registered with SubnetStatusHub (a separate singleton), mirroring
+// how the chain URI registers with ChainFirehoseHub — this class still only
+// owns the SSE stream + pending coalescing.
+//
 // SSE, not WebSocket: MCP's ratified transport (2025-06-18 spec) is
 // Streamable HTTP (POST + optional SSE-over-GET); there is no ratified
 // WebSocket transport (as of this writing an in-review SEP, not shipped in
@@ -45,6 +51,8 @@
 // get/put KV API, ReadableStream is a real Web Streams API in Node) --
 // unlike ChainFirehoseHub, nothing here needs WebSocketPair, so there is no
 // v8-ignored branch in this file.
+
+import { parseSubnetStatusResourceUri } from "../src/subnet-status-subscribe.mjs";
 
 export const MCP_CHAIN_STREAM_RESOURCE_URI = "metagraph://chain/stream";
 
@@ -172,7 +180,8 @@ export class McpSessionHub {
   async handleSubscribe(request) {
     const { sessionId, uri } = await request.json();
     this.sessionId = sessionId;
-    if (uri !== MCP_CHAIN_STREAM_RESOURCE_URI) {
+    const statusNetuid = parseSubnetStatusResourceUri(uri);
+    if (uri !== MCP_CHAIN_STREAM_RESOURCE_URI && statusNetuid == null) {
       return new Response(
         JSON.stringify({ error: "resource is not subscribable" }),
         { status: 400, headers: { "content-type": "application/json" } },
@@ -181,7 +190,7 @@ export class McpSessionHub {
     this.subscribedUris.add(uri);
     await this.persist();
     await this.touch();
-    if (this.env.CHAIN_FIREHOSE_HUB) {
+    if (uri === MCP_CHAIN_STREAM_RESOURCE_URI && this.env.CHAIN_FIREHOSE_HUB) {
       const stub = this.env.CHAIN_FIREHOSE_HUB.get(
         this.env.CHAIN_FIREHOSE_HUB.idFromName("global"),
       );
@@ -189,6 +198,16 @@ export class McpSessionHub {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ sessionId }),
+      });
+    }
+    if (statusNetuid != null && this.env.SUBNET_STATUS_HUB) {
+      const stub = this.env.SUBNET_STATUS_HUB.get(
+        this.env.SUBNET_STATUS_HUB.idFromName("global"),
+      );
+      await stub.fetch("https://subnet-status-hub.internal/mcp-subscribe", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sessionId, netuid: statusNetuid }),
       });
     }
     return new Response(JSON.stringify({ ok: true }), {
@@ -200,10 +219,17 @@ export class McpSessionHub {
   async handleUnsubscribe(request) {
     const { sessionId, uri } = await request.json();
     this.sessionId = sessionId;
+    const hadChain = this.subscribedUris.has(MCP_CHAIN_STREAM_RESOURCE_URI);
+    const statusNetuid = parseSubnetStatusResourceUri(uri);
     this.subscribedUris.delete(uri);
     this.pendingUris.delete(uri);
     await this.persist();
-    if (this.subscribedUris.size === 0 && this.env.CHAIN_FIREHOSE_HUB) {
+    if (
+      hadChain &&
+      uri === MCP_CHAIN_STREAM_RESOURCE_URI &&
+      !this.subscribedUris.has(MCP_CHAIN_STREAM_RESOURCE_URI) &&
+      this.env.CHAIN_FIREHOSE_HUB
+    ) {
       const stub = this.env.CHAIN_FIREHOSE_HUB.get(
         this.env.CHAIN_FIREHOSE_HUB.idFromName("global"),
       );
@@ -211,6 +237,16 @@ export class McpSessionHub {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ sessionId }),
+      });
+    }
+    if (statusNetuid != null && this.env.SUBNET_STATUS_HUB) {
+      const stub = this.env.SUBNET_STATUS_HUB.get(
+        this.env.SUBNET_STATUS_HUB.idFromName("global"),
+      );
+      await stub.fetch("https://subnet-status-hub.internal/mcp-unsubscribe", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sessionId, netuid: statusNetuid }),
       });
     }
     return new Response(JSON.stringify({ ok: true }), {
@@ -290,16 +326,29 @@ export class McpSessionHub {
         clearTimeout(this.streamCloseTimer);
         this.streamCloseTimer = null;
       }
-      if (
-        this.subscribedUris.size > 0 &&
-        effectiveSessionId &&
-        this.env.CHAIN_FIREHOSE_HUB
-      ) {
+      const hadChain = this.subscribedUris.has(MCP_CHAIN_STREAM_RESOURCE_URI);
+      const hadStatus = [...this.subscribedUris].some(
+        (u) => parseSubnetStatusResourceUri(u) != null,
+      );
+      if (hadChain && effectiveSessionId && this.env.CHAIN_FIREHOSE_HUB) {
         const stub = this.env.CHAIN_FIREHOSE_HUB.get(
           this.env.CHAIN_FIREHOSE_HUB.idFromName("global"),
         );
         await stub.fetch(
           "https://chain-firehose-hub.internal/mcp-unsubscribe",
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ sessionId: effectiveSessionId }),
+          },
+        );
+      }
+      if (hadStatus && effectiveSessionId && this.env.SUBNET_STATUS_HUB) {
+        const stub = this.env.SUBNET_STATUS_HUB.get(
+          this.env.SUBNET_STATUS_HUB.idFromName("global"),
+        );
+        await stub.fetch(
+          "https://subnet-status-hub.internal/mcp-unsubscribe-session",
           {
             method: "POST",
             headers: { "content-type": "application/json" },
@@ -322,7 +371,7 @@ export class McpSessionHub {
     if (
       !this.sessionId ||
       (sessionId && sessionId !== this.sessionId) ||
-      !this.subscribedUris.has(MCP_CHAIN_STREAM_RESOURCE_URI)
+      this.subscribedUris.size === 0
     ) {
       return new Response(JSON.stringify({ error: "session not found" }), {
         status: 404,

--- a/workers/subnet-status-hub.mjs
+++ b/workers/subnet-status-hub.mjs
@@ -1,0 +1,250 @@
+// SubnetStatusHub -- singleton Durable Object (idFromName("global")) that
+// owns the inverted netuid → MCP-session index for
+// `metagraph://subnet/{netuid}/status` subscriptions (#6034).
+//
+// Parallel to ChainFirehoseHub's mcpSubscribedSessions Set for the chain
+// stream, but keyed by netuid so a health-probe change fans out only to
+// sessions that subscribed to that subnet — never sessions × all subnets.
+// Change detection itself lives in the health prober write path
+// (src/subnet-status-subscribe.mjs + src/health-prober.mjs); this class only
+// stores membership and delivers pointer-only
+// notifications/resources/updated via each session's McpSessionHub /notify
+// route (same shape as ChainFirehoseHub.broadcast()'s MCP loop).
+//
+// Deliberately a SEPARATE DO from ChainFirehoseHub: that class is the hot
+// path for every chain ingest fan-out (SSE/WS/GraphQL/MCP/alerter). Health
+// status changes arrive on the 15-minute cron path, not the firehose, and
+// must not add work to broadcast().
+
+import {
+  buildSubnetStatusResourceUri,
+  parseSubnetStatusResourceUri,
+} from "../src/subnet-status-subscribe.mjs";
+
+// Pure helpers — unit-tested without spinning up the class.
+export function addSessionSubscription(
+  byNetuid,
+  sessionByNetuid,
+  sessionId,
+  netuid,
+) {
+  if (typeof sessionId !== "string" || sessionId.length === 0) return;
+  if (!Number.isInteger(netuid) || netuid < 0) return;
+  let sessions = byNetuid.get(netuid);
+  if (!sessions) {
+    sessions = new Set();
+    byNetuid.set(netuid, sessions);
+  }
+  sessions.add(sessionId);
+  let netuids = sessionByNetuid.get(sessionId);
+  if (!netuids) {
+    netuids = new Set();
+    sessionByNetuid.set(sessionId, netuids);
+  }
+  netuids.add(netuid);
+}
+
+export function removeSessionSubscription(
+  byNetuid,
+  sessionByNetuid,
+  sessionId,
+  netuid,
+) {
+  if (typeof sessionId !== "string" || sessionId.length === 0) return;
+  if (!Number.isInteger(netuid) || netuid < 0) return;
+  const sessions = byNetuid.get(netuid);
+  if (sessions) {
+    sessions.delete(sessionId);
+    if (sessions.size === 0) byNetuid.delete(netuid);
+  }
+  const netuids = sessionByNetuid.get(sessionId);
+  if (netuids) {
+    netuids.delete(netuid);
+    if (netuids.size === 0) sessionByNetuid.delete(sessionId);
+  }
+}
+
+export function removeSessionEverywhere(byNetuid, sessionByNetuid, sessionId) {
+  const netuids = sessionByNetuid.get(sessionId);
+  if (!netuids) return;
+  for (const netuid of [...netuids]) {
+    removeSessionSubscription(byNetuid, sessionByNetuid, sessionId, netuid);
+  }
+}
+
+export function serializeSubscriptionIndex(byNetuid) {
+  const out = {};
+  for (const [netuid, sessions] of byNetuid) {
+    out[String(netuid)] = [...sessions].sort();
+  }
+  return out;
+}
+
+export function hydrateSubscriptionIndex(stored) {
+  const byNetuid = new Map();
+  const sessionByNetuid = new Map();
+  if (!stored || typeof stored !== "object") {
+    return { byNetuid, sessionByNetuid };
+  }
+  for (const [key, sessions] of Object.entries(stored)) {
+    const netuid = Number(key);
+    if (!Number.isInteger(netuid) || netuid < 0) continue;
+    if (!Array.isArray(sessions)) continue;
+    for (const sessionId of sessions) {
+      if (typeof sessionId !== "string" || sessionId.length === 0) continue;
+      addSessionSubscription(byNetuid, sessionByNetuid, sessionId, netuid);
+    }
+  }
+  return { byNetuid, sessionByNetuid };
+}
+
+export class SubnetStatusHub {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+    this.byNetuid = new Map();
+    this.sessionByNetuid = new Map();
+    this.hydrated = false;
+  }
+
+  async hydrate() {
+    if (this.hydrated) return;
+    const stored = await this.state.storage.get(["byNetuid"]);
+    const { byNetuid, sessionByNetuid } = hydrateSubscriptionIndex(
+      stored.get("byNetuid"),
+    );
+    this.byNetuid = byNetuid;
+    this.sessionByNetuid = sessionByNetuid;
+    this.hydrated = true;
+  }
+
+  async persist() {
+    await this.state.storage.put({
+      byNetuid: serializeSubscriptionIndex(this.byNetuid),
+    });
+  }
+
+  async fetch(request) {
+    await this.hydrate();
+    const url = new URL(request.url);
+    if (url.pathname === "/mcp-subscribe" && request.method === "POST") {
+      return this.handleSubscribe(request);
+    }
+    if (url.pathname === "/mcp-unsubscribe" && request.method === "POST") {
+      return this.handleUnsubscribe(request);
+    }
+    if (
+      url.pathname === "/mcp-unsubscribe-session" &&
+      request.method === "POST"
+    ) {
+      return this.handleUnsubscribeSession(request);
+    }
+    if (url.pathname === "/notify-changed" && request.method === "POST") {
+      return this.handleNotifyChanged(request);
+    }
+    return new Response("not found", { status: 404 });
+  }
+
+  async handleSubscribe(request) {
+    const { sessionId, netuid } = await request.json();
+    const n =
+      typeof netuid === "number"
+        ? netuid
+        : parseSubnetStatusResourceUri(
+            typeof netuid === "string" ? netuid : "",
+          );
+    if (typeof sessionId !== "string" || sessionId.length === 0) {
+      return new Response(JSON.stringify({ error: "sessionId required" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (!Number.isInteger(n) || n < 0) {
+      return new Response(JSON.stringify({ error: "netuid required" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    addSessionSubscription(this.byNetuid, this.sessionByNetuid, sessionId, n);
+    await this.persist();
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  async handleUnsubscribe(request) {
+    const { sessionId, netuid } = await request.json();
+    if (typeof sessionId === "string" && Number.isInteger(netuid)) {
+      removeSessionSubscription(
+        this.byNetuid,
+        this.sessionByNetuid,
+        sessionId,
+        netuid,
+      );
+      await this.persist();
+    }
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  async handleUnsubscribeSession(request) {
+    const { sessionId } = await request.json();
+    if (typeof sessionId === "string") {
+      removeSessionEverywhere(this.byNetuid, this.sessionByNetuid, sessionId);
+      await this.persist();
+    }
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  // Called by the health prober after a real status/surface diff. Pointer-
+  // only notify per (session, uri); coalescing lives in McpSessionHub.
+  async handleNotifyChanged(request) {
+    const { netuids } = await request.json();
+    const list = Array.isArray(netuids)
+      ? [...new Set(netuids.filter((n) => Number.isInteger(n) && n >= 0))]
+      : [];
+    if (list.length === 0 || !this.env.MCP_SESSION_HUB) {
+      return new Response(JSON.stringify({ ok: true, delivered: 0 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    const tasks = [];
+    for (const netuid of list) {
+      const sessions = this.byNetuid.get(netuid);
+      if (!sessions || sessions.size === 0) continue;
+      const uri = buildSubnetStatusResourceUri(netuid);
+      for (const sessionId of sessions) {
+        tasks.push(
+          (async () => {
+            try {
+              const stub = this.env.MCP_SESSION_HUB.get(
+                this.env.MCP_SESSION_HUB.idFromName(sessionId),
+              );
+              await stub.fetch("https://mcp-session-hub.internal/notify", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ uri }),
+              });
+              return true;
+            } catch {
+              return false;
+            }
+          })(),
+        );
+      }
+    }
+    const results = await Promise.all(tasks);
+    const delivered = results.filter(Boolean).length;
+    return new Response(JSON.stringify({ ok: true, delivered }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -397,6 +397,11 @@
       // comment for why it stays a separate DO rather than in-memory state
       // on ChainFirehoseHub.
       { "name": "ALERTER_HUB", "class_name": "AlerterHub" },
+      // #6034: inverted netuid → MCP-session index for
+      // metagraph://subnet/{netuid}/status subscriptions. Singleton
+      // (idFromName("global")), pinged from the health prober write path —
+      // not from ChainFirehoseHub.broadcast(). See workers/subnet-status-hub.mjs.
+      { "name": "SUBNET_STATUS_HUB", "class_name": "SubnetStatusHub" },
     ],
   },
   // Durable Object class migrations are one-way and versioned: adding a new
@@ -417,6 +422,10 @@
     {
       "tag": "v3-alerter-hub",
       "new_sqlite_classes": ["AlerterHub"],
+    },
+    {
+      "tag": "v4-subnet-status-hub",
+      "new_sqlite_classes": ["SubnetStatusHub"],
     },
   ],
   // Cron prober: every 15 minutes probes the operational surfaces into D1/KV


### PR DESCRIPTION
## Summary

- Add subscribable MCP resource `metagraph://subnet/{netuid}/status` so an agent can be notified when one subnet’s health tier, surface status, or operational surface membership changes — without subscribing to the network-wide chain firehose.
- Reuses `McpSessionHub` SSE push; new singleton `SubnetStatusHub` holds an inverted `netuid → sessions` index. Change detection is event-driven on the health-prober write path (diff prior vs next `health:current`), not a per-subnet poll loop.
- Unit + `validate:mcp` lifecycle coverage for subscribe → notify → unsubscribe.

Closes #6034

## What Changed

- **MCP** (`src/mcp-server.mjs`): resource template + list entries; `resources/subscribe` / `unsubscribe` / `read` for `metagraph://subnet/{netuid}/status`; capabilities comment updated for the new subscribable class.
- **Helpers** (`src/subnet-status-subscribe.mjs`): URI parse/build, fingerprint + `diffChangedSubnetNetuids`, best-effort `notifySubnetStatusChanged`.
- **DO** (`workers/subnet-status-hub.mjs` + `wrangler.jsonc` v4 migration / `SUBNET_STATUS_HUB` binding): membership + `/notify-changed` fan-out to `McpSessionHub` `/notify`.
- **Session hub** (`workers/mcp-session-hub.mjs`): accepts status URIs; registers with `SubnetStatusHub`; SSE opens for any subscribed URI.
- **Prober** (`src/health-prober.mjs`): after KV persist, diff + notify changed netuids (never fails the probe sweep).
- **Tests / validate:mcp**: subscribe/notify/unsubscribe + fingerprint/diff + hub fan-out; MCP lifecycle round trip for status URI.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6034`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A — no OpenAPI/schema regen; MCP server card is worker-computed.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (MCP resources/subscribe surface only; REST/OpenAPI unchanged.)

## Validation

- [x] `npx vitest run tests/subnet-status-subscribe.test.mjs tests/subnet-status-hub.test.mjs tests/mcp-session-hub.test.mjs` (72 passed)
- [x] `npx vitest run tests/mcp-server.test.mjs -t "6034"` (3 passed)
- [x] `npx vitest run tests/health-prober.test.mjs -t "notifies SubnetStatusHub"` (1 passed)
- [x] Patch coverage on new modules: 100% statements/branches (`subnet-status-subscribe`, `subnet-status-hub`, `mcp-session-hub`)
- [x] `npm run lint`
- [x] `git diff --check`
- [x] `npm run worker:bundle:budget`
- [x] `npm run validate:mcp` (needs full local `public/metagraph/**` artifacts; extend covered in script — run in CI / after `npm run build`)
- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`

## Template Used

backend-code
