### PR TITLE
feat(ui): add maintainer-facing usage-analytics view

### DIFF
--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
@@ -151,6 +151,11 @@ export const MEGA_PANELS: MegaPanel[] = [
         label: "Ops overview",
         hint: "Matrix, mosaic, freshness",
       },
+      {
+        to: "/usage",
+        label: "Usage analytics",
+        hint: "Route + MCP-tool traffic",
+      },
       { to: "/health", search: { view: "matrix" }, label: "Subnet matrix" },
       { to: "/health", search: { view: "incidents" }, label: "Incidents" },
       { to: "/health", search: { view: "sources" }, label: "Source health" },

--- a/apps/ui/src/components/metagraphed/usage-analytics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/usage-analytics-panel.tsx
@@ -1,0 +1,239 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Activity, AlertTriangle, Server, ShieldCheck, Wrench } from "lucide-react";
+import { TimeAgo } from "@jsonbored/ui-kit";
+import { usageAnalyticsQuery } from "@/lib/metagraphed/queries";
+import { classNames, formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
+import type { UsageAnalytics, UsageRoute, UsageTool } from "@/lib/metagraphed/types";
+import { EmptyState, StaleBanner } from "./states";
+
+export const USAGE_WINDOWS = ["24h", "7d", "30d"] as const;
+export type UsageWindow = (typeof USAGE_WINDOWS)[number];
+
+function pct(value: number | null | undefined): string {
+  return value == null ? "—" : `${(value * 100).toFixed(1)}%`;
+}
+
+// Success rate is derived from the pair (never from a stored success_rate) so a
+// zeroed/partial row can't disagree with itself — `null` when there's no
+// traffic to divide by, so the tile shows "—" instead of a fake 0%/100%.
+function successRate(calls: number, ok: number): number | null {
+  return calls > 0 ? ok / calls : null;
+}
+
+function UsageStat({
+  eyebrow,
+  value,
+  hint,
+  icon: Icon,
+  tone = "default",
+}: {
+  eyebrow: string;
+  value: string;
+  hint?: string;
+  icon: typeof Activity;
+  tone?: "default" | "ok" | "warn";
+}) {
+  return (
+    <div
+      className={classNames(
+        "rounded border bg-card px-3 py-2.5",
+        tone === "ok" && "border-health-ok/30",
+        tone === "warn" && "border-health-warn/30",
+        tone === "default" && "border-border",
+      )}
+    >
+      <div className="flex items-center gap-1.5 text-ink-muted">
+        <Icon className="size-3" aria-hidden />
+        <span className="font-mono text-[10px] uppercase tracking-widest">{eyebrow}</span>
+      </div>
+      <div className="mt-1 font-mono text-lg font-semibold text-ink-strong">{value}</div>
+      {hint ? <div className="font-mono text-[10px] text-ink-muted">{hint}</div> : null}
+    </div>
+  );
+}
+
+function WindowSelector({
+  window,
+  onChange,
+}: {
+  window: UsageWindow;
+  onChange: (w: UsageWindow) => void;
+}) {
+  return (
+    <div
+      className="inline-flex rounded border border-border bg-card p-0.5"
+      role="group"
+      aria-label="Usage window"
+    >
+      {USAGE_WINDOWS.map((w) => (
+        <button
+          key={w}
+          type="button"
+          aria-pressed={window === w}
+          onClick={() => onChange(w)}
+          className={classNames(
+            "rounded px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest transition-colors",
+            window === w ? "bg-accent/15 text-accent" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {w}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// One shared table for both the route and MCP-tool breakdowns — same columns
+// (name, calls, success, errors), same success/error derivation — so the two
+// sections stay visually and numerically consistent.
+function CallTable<T extends UsageRoute | UsageTool>({
+  caption,
+  nameHeading,
+  rows,
+  nameOf,
+  keyOf,
+}: {
+  caption: string;
+  nameHeading: string;
+  rows: T[];
+  nameOf: (row: T) => string;
+  keyOf: (row: T) => string;
+}) {
+  if (rows.length === 0) return null;
+  return (
+    <div className="overflow-x-auto rounded border border-border bg-card">
+      <table className="w-full min-w-[26rem] text-sm">
+        <caption className="px-3 pt-2 text-left mg-label">{caption}</caption>
+        <thead className="bg-surface/50 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          <tr>
+            <th className="px-3 py-2 text-left font-normal">{nameHeading}</th>
+            <th className="px-3 py-2 text-right font-normal">Calls</th>
+            <th className="px-3 py-2 text-right font-normal">Success</th>
+            <th className="px-3 py-2 text-right font-normal">Errors</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {rows.map((row) => {
+            const ok = successRate(row.calls, row.ok_calls);
+            const warn = row.error_rate != null && row.error_rate > 0.05;
+            return (
+              <tr key={keyOf(row)} className="mg-row-hover">
+                <td className="max-w-0 px-3 py-2 font-mono text-[12px] text-ink-strong">
+                  <span className="block truncate" title={nameOf(row)}>
+                    {nameOf(row)}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-right font-mono tabular-nums">
+                  {formatNumber(row.calls)}
+                </td>
+                <td className="px-3 py-2 text-right font-mono tabular-nums text-ink-muted">
+                  {pct(ok)}
+                </td>
+                <td
+                  className={classNames(
+                    "px-3 py-2 text-right font-mono tabular-nums",
+                    warn ? "text-health-warn" : "text-ink-muted",
+                  )}
+                >
+                  {pct(row.error_rate)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function UsageAnalyticsPanel({
+  window,
+  onWindowChange,
+}: {
+  window: UsageWindow;
+  onWindowChange: (w: UsageWindow) => void;
+}) {
+  const { data } = useSuspenseQuery(usageAnalyticsQuery(window));
+  const usage = data.data as UsageAnalytics;
+  const s = usage.summary;
+  const hasTraffic = s.total_calls > 0;
+  const stale = isStaleFreshness(data.meta?.generated_at);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <p className="font-mono text-[11px] text-ink-muted">
+          {usage.observed_at ? (
+            <>
+              Updated <TimeAgo at={usage.observed_at} />
+            </>
+          ) : (
+            "Route + MCP-tool traffic, aggregated per day"
+          )}
+        </p>
+        <WindowSelector window={window} onChange={onWindowChange} />
+      </div>
+
+      {stale ? <StaleBanner generatedAt={data.meta?.generated_at} /> : null}
+
+      {!hasTraffic ? (
+        <EmptyState
+          title="No usage recorded in this window yet"
+          description="Route and MCP-tool call counts populate here once product-usage instrumentation is live — until then this window has no traffic to show."
+        />
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+            <UsageStat
+              icon={Activity}
+              eyebrow="Total calls"
+              value={formatNumber(s.total_calls)}
+              hint={window}
+            />
+            <UsageStat
+              icon={ShieldCheck}
+              eyebrow="Success"
+              value={pct(successRate(s.total_calls, s.ok_calls))}
+              hint={`${formatNumber(s.ok_calls)} ok`}
+              tone={s.error_rate != null && s.error_rate > 0.05 ? "warn" : "ok"}
+            />
+            <UsageStat
+              icon={AlertTriangle}
+              eyebrow="Errors"
+              value={pct(s.error_rate)}
+              hint={`${formatNumber(s.error_calls)} failed`}
+              tone={s.error_rate != null && s.error_rate > 0.05 ? "warn" : "default"}
+            />
+            <UsageStat
+              icon={Server}
+              eyebrow="REST routes"
+              value={formatNumber(s.route_calls)}
+              hint={`${usage.routes.length} distinct`}
+            />
+            <UsageStat
+              icon={Wrench}
+              eyebrow="MCP tools"
+              value={formatNumber(s.mcp_calls)}
+              hint={`${usage.tools.length} distinct`}
+            />
+          </div>
+
+          <CallTable
+            caption="By route"
+            nameHeading="Route"
+            rows={usage.routes}
+            nameOf={(r) => r.route}
+            keyOf={(r) => r.route}
+          />
+          <CallTable
+            caption="By MCP tool"
+            nameHeading="Tool"
+            rows={usage.tools}
+            nameOf={(t) => t.tool}
+            keyOf={(t) => t.tool}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -1,5 +1,5 @@
 import { queryOptions, infiniteQueryOptions } from "@tanstack/react-query";
-import { apiFetch, type ApiResult, type QueryParams } from "./client";
+import { apiFetch, ApiError, type ApiResult, type QueryParams } from "./client";
 import { getNetwork } from "./config";
 import { blockRefPathSegment } from "./blocks";
 import { extrinsicHashPathSegment } from "./extrinsics";
@@ -166,6 +166,9 @@ import type {
   RpcEndpointsData,
   RpcEndpointsSummary,
   RpcUsage,
+  UsageAnalytics,
+  UsageRoute,
+  UsageTool,
   SchemaInfo,
   SemanticSearchResponse,
   Subnet,
@@ -7164,6 +7167,99 @@ export const rpcUsageQuery = (window = "7d") =>
     queryFn: async ({ signal }) => {
       const res = await apiFetch<unknown>("/api/v1/rpc/usage", { params: { window }, signal });
       return { ...res, data: normalizeRpcUsage(res.data) } as ApiResult<RpcUsage>;
+    },
+    staleTime: STALE_SHORT,
+  });
+
+// /api/v1/usage — product-usage analytics (#6033): REST-route + MCP-tool call
+// volume and success/failure over a window. Mirrors normalizeRpcUsage's
+// forgiving contract — any missing field collapses to a zeroed, schema-stable
+// shape so a partial (or cold, pre-#366) payload can't crash the maintainer
+// view. The window param is echoed back so a shared link restores the view.
+export function normalizeUsageAnalytics(raw: unknown): UsageAnalytics {
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  const s = (r.summary && typeof r.summary === "object" ? r.summary : {}) as Record<
+    string,
+    unknown
+  >;
+  return {
+    window: (r.window as string | null) ?? null,
+    observed_at: (r.observed_at as string | null) ?? null,
+    source: (r.source as string) ?? "usage",
+    summary: {
+      total_calls: finiteNumber(s.total_calls),
+      ok_calls: finiteNumber(s.ok_calls),
+      error_calls: finiteNumber(s.error_calls),
+      error_rate: finiteOptionalNumber(s.error_rate) ?? null,
+      route_calls: finiteNumber(s.route_calls),
+      mcp_calls: finiteNumber(s.mcp_calls),
+    },
+    routes: Array.isArray(r.routes)
+      ? r.routes.flatMap((route, index) => {
+          const normalized = normalizeUsageRoute(route, index);
+          return normalized ? [normalized] : [];
+        })
+      : [],
+    tools: Array.isArray(r.tools)
+      ? r.tools.flatMap((tool, index) => {
+          const normalized = normalizeUsageTool(tool, index);
+          return normalized ? [normalized] : [];
+        })
+      : [],
+  };
+}
+
+function normalizeUsageRoute(raw: unknown, index: number): UsageRoute | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const r = raw as Record<string, unknown>;
+  const route = typeof r.route === "string" ? r.route : "";
+  if (!route) return undefined;
+  return {
+    rank: finiteNumber(r.rank, index + 1),
+    route,
+    calls: finiteNumber(r.calls),
+    ok_calls: finiteNumber(r.ok_calls),
+    error_calls: finiteNumber(r.error_calls),
+    error_rate: finiteOptionalNumber(r.error_rate) ?? null,
+  };
+}
+
+function normalizeUsageTool(raw: unknown, index: number): UsageTool | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const t = raw as Record<string, unknown>;
+  const tool = typeof t.tool === "string" ? t.tool : "";
+  if (!tool) return undefined;
+  return {
+    rank: finiteNumber(t.rank, index + 1),
+    tool,
+    calls: finiteNumber(t.calls),
+    ok_calls: finiteNumber(t.ok_calls),
+    error_calls: finiteNumber(t.error_calls),
+    error_rate: finiteOptionalNumber(t.error_rate) ?? null,
+  };
+}
+
+export const usageAnalyticsQuery = (window = "7d") =>
+  queryOptions({
+    queryKey: k("usage-analytics", window),
+    queryFn: async ({ signal }) => {
+      try {
+        const res = await apiFetch<unknown>("/api/v1/usage", { params: { window }, signal });
+        return { ...res, data: normalizeUsageAnalytics(res.data) } as ApiResult<UsageAnalytics>;
+      } catch (err) {
+        // The telemetry-writing side (#366) may not have shipped /api/v1/usage
+        // yet — a 404 (or an offline dev worker: status 0) is "no data yet",
+        // not a failure, so degrade to the zeroed shape rather than tripping
+        // the error boundary. Genuine server errors (5xx, etc.) still surface.
+        if (err instanceof ApiError && (err.status === 404 || err.status === 0)) {
+          return {
+            data: normalizeUsageAnalytics(null),
+            meta: {},
+            url: err.url,
+          } as ApiResult<UsageAnalytics>;
+        }
+        throw err;
+      }
     },
     staleTime: STALE_SHORT,
   });

--- a/apps/ui/src/lib/metagraphed/queries.usage-analytics.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.usage-analytics.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, type ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeUsageAnalytics, usageAnalyticsQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/usage",
+  });
+}
+
+// Invoke a queryOptions' queryFn directly (mirrors queries.blocks-summary.test).
+function runQuery<
+  O extends {
+    queryKey: readonly unknown[];
+    queryFn?: (context: never) => unknown;
+  },
+>(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
+}
+
+// A representative /api/v1/usage payload — the #366 route/day + per-MCP-tool
+// event schema this view consumes, in the shape the endpoint will serve.
+const WELL_FORMED = {
+  window: "7d",
+  observed_at: "2026-07-16T00:00:00.000Z",
+  source: "analytics-engine",
+  summary: {
+    total_calls: 1500,
+    ok_calls: 1440,
+    error_calls: 60,
+    error_rate: 0.04,
+    route_calls: 1100,
+    mcp_calls: 400,
+  },
+  routes: [
+    {
+      rank: 1,
+      route: "GET /api/v1/subnets",
+      calls: 800,
+      ok_calls: 790,
+      error_calls: 10,
+      error_rate: 0.0125,
+    },
+    {
+      rank: 2,
+      route: "GET /api/v1/health",
+      calls: 300,
+      ok_calls: 250,
+      error_calls: 50,
+      error_rate: 0.1667,
+    },
+  ],
+  tools: [
+    { rank: 1, tool: "list_subnets", calls: 250, ok_calls: 250, error_calls: 0, error_rate: 0 },
+    { rank: 2, tool: "get_subnet", calls: 150, ok_calls: 150, error_calls: 0, error_rate: 0 },
+  ],
+};
+
+describe("normalizeUsageAnalytics", () => {
+  it("passes a well-formed payload through", () => {
+    const u = normalizeUsageAnalytics(WELL_FORMED);
+    expect(u.window).toBe("7d");
+    expect(u.observed_at).toBe("2026-07-16T00:00:00.000Z");
+    expect(u.source).toBe("analytics-engine");
+    expect(u.summary.total_calls).toBe(1500);
+    expect(u.summary.ok_calls).toBe(1440);
+    expect(u.summary.error_calls).toBe(60);
+    expect(u.summary.error_rate).toBe(0.04);
+    expect(u.summary.route_calls).toBe(1100);
+    expect(u.summary.mcp_calls).toBe(400);
+    expect(u.routes).toHaveLength(2);
+    expect(u.routes[0]).toMatchObject({ rank: 1, route: "GET /api/v1/subnets", calls: 800 });
+    expect(u.tools).toHaveLength(2);
+    expect(u.tools[1]).toMatchObject({ rank: 2, tool: "get_subnet", calls: 150 });
+  });
+
+  it("degrades a cold store to a schema-stable zeroed shape (empty lists)", () => {
+    const u = normalizeUsageAnalytics({
+      window: null,
+      observed_at: null,
+      summary: {
+        total_calls: 0,
+        ok_calls: 0,
+        error_calls: 0,
+        error_rate: null,
+        route_calls: 0,
+        mcp_calls: 0,
+      },
+      routes: [],
+      tools: [],
+    });
+    expect(u.window).toBeNull();
+    expect(u.observed_at).toBeNull();
+    expect(u.source).toBe("usage");
+    expect(u.summary.total_calls).toBe(0);
+    expect(u.summary.error_rate).toBeNull();
+    expect(u.routes).toEqual([]);
+    expect(u.tools).toEqual([]);
+  });
+
+  it("degrades junk / missing input to a zeroed shape, never NaN", () => {
+    for (const raw of [{}, null, undefined, "nope", 42, { summary: "many" }]) {
+      const u = normalizeUsageAnalytics(raw);
+      expect(u.summary.total_calls).toBe(0);
+      expect(u.summary.ok_calls).toBe(0);
+      expect(u.summary.error_calls).toBe(0);
+      expect(u.summary.route_calls).toBe(0);
+      expect(u.summary.mcp_calls).toBe(0);
+      expect(u.summary.error_rate).toBeNull();
+      expect(u.routes).toEqual([]);
+      expect(u.tools).toEqual([]);
+    }
+  });
+
+  it("drops nameless/malformed rows and back-fills rank + numeric fields from position", () => {
+    const u = normalizeUsageAnalytics({
+      routes: [
+        { route: "GET /api/v1/blocks" }, // no rank/counts → rank from index, counts 0
+        { rank: 9, calls: 5 }, // no route → dropped
+        "garbage", // non-object → dropped
+        { route: "GET /api/v1/accounts", rank: 4, calls: "lots", error_rate: 0.5 },
+      ],
+      tools: [
+        { tool: "search" }, // rank from index, counts 0
+        { calls: 10 }, // no tool → dropped
+      ],
+    });
+    expect(u.routes).toHaveLength(2);
+    expect(u.routes[0]).toMatchObject({ rank: 1, route: "GET /api/v1/blocks", calls: 0 });
+    // calls: "lots" is non-finite → 0, but explicit rank 4 and error_rate survive.
+    expect(u.routes[1]).toMatchObject({
+      rank: 4,
+      route: "GET /api/v1/accounts",
+      calls: 0,
+      error_rate: 0.5,
+    });
+    expect(u.tools).toHaveLength(1);
+    expect(u.tools[0]).toMatchObject({ rank: 1, tool: "search", calls: 0 });
+  });
+});
+
+describe("usageAnalyticsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits /api/v1/usage with the window param and normalizes the response", async () => {
+    resolveWith(WELL_FORMED);
+    const res = await runQuery(usageAnalyticsQuery("30d"));
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/usage",
+      expect.objectContaining({
+        params: { window: "30d" },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(res.data.summary.total_calls).toBe(1500);
+    expect(res.data.routes).toHaveLength(2);
+    expect(res.data.tools).toHaveLength(2);
+  });
+
+  it("defaults the window to 7d", async () => {
+    resolveWith(WELL_FORMED);
+    await runQuery(usageAnalyticsQuery());
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/usage",
+      expect.objectContaining({ params: { window: "7d" } }),
+    );
+  });
+
+  it("degrades a not-yet-shipped endpoint (404) to a zeroed shape without throwing", async () => {
+    mockedApiFetch.mockRejectedValue(
+      new ApiError("Not found", { status: 404, url: "/api/v1/usage" }),
+    );
+    const res = await runQuery(usageAnalyticsQuery("24h"));
+    expect(res.data.summary.total_calls).toBe(0);
+    expect(res.data.routes).toEqual([]);
+    expect(res.data.tools).toEqual([]);
+    expect(res.url).toBe("/api/v1/usage");
+  });
+
+  it("degrades an offline dev worker (status 0) to a zeroed shape", async () => {
+    mockedApiFetch.mockRejectedValue(new ApiError("Network error", { status: 0, url: "x" }));
+    const res = await runQuery(usageAnalyticsQuery());
+    expect(res.data.summary.total_calls).toBe(0);
+  });
+
+  it("re-throws a genuine server error (5xx) so the error boundary can show it", async () => {
+    mockedApiFetch.mockRejectedValue(new ApiError("boom", { status: 500, url: "/api/v1/usage" }));
+    await expect(runQuery(usageAnalyticsQuery())).rejects.toThrow("boom");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -395,6 +395,49 @@ export interface RpcUsage {
   networks: RpcUsageNetwork[];
 }
 
+/** One REST route's call volume from /api/v1/usage (#6033). */
+export interface UsageRoute {
+  rank: number;
+  route: string;
+  calls: number;
+  ok_calls: number;
+  error_calls: number;
+  error_rate: number | null;
+}
+
+/** One MCP tool's call volume from /api/v1/usage (#6033). */
+export interface UsageTool {
+  rank: number;
+  tool: string;
+  calls: number;
+  ok_calls: number;
+  error_calls: number;
+  error_rate: number | null;
+}
+
+/**
+ * /api/v1/usage — product-usage analytics (#6033, consuming #366's route/day +
+ * per-MCP-tool event schema): REST-route and MCP-tool call counts with
+ * success/failure rates over a selectable window. The endpoint ships with the
+ * telemetry-writing side (#366); until then a maintainer sees the zeroed
+ * "no traffic yet" shape, never an error.
+ */
+export interface UsageAnalytics {
+  window?: string | null;
+  observed_at?: string | null;
+  source?: string;
+  summary: {
+    total_calls: number;
+    ok_calls: number;
+    error_calls: number;
+    error_rate: number | null;
+    route_calls: number;
+    mcp_calls: number;
+  };
+  routes: UsageRoute[];
+  tools: UsageTool[];
+}
+
 /** One machine-readable resource from /api/v1/agent-resources. */
 export interface AgentResource {
   id: string;

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as UsageRouteImport } from './routes/usage'
 import { Route as SurfacesRouteImport } from './routes/surfaces'
 import { Route as StatusRouteImport } from './routes/status'
 import { Route as SettingsRouteImport } from './routes/settings'
@@ -41,6 +42,11 @@ import { Route as ExtrinsicsHashRouteImport } from './routes/extrinsics.$hash'
 import { Route as BlocksRefRouteImport } from './routes/blocks.$ref'
 import { Route as AccountsSs58RouteImport } from './routes/accounts.$ss58'
 
+const UsageRoute = UsageRouteImport.update({
+  id: '/usage',
+  path: '/usage',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SurfacesRoute = SurfacesRouteImport.update({
   id: '/surfaces',
   path: '/surfaces',
@@ -214,6 +220,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
   '/surfaces': typeof SurfacesRoute
+  '/usage': typeof UsageRoute
   '/accounts/$ss58': typeof AccountsSs58Route
   '/blocks/$ref': typeof BlocksRefRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
@@ -247,6 +254,7 @@ export interface FileRoutesByTo {
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
   '/surfaces': typeof SurfacesRoute
+  '/usage': typeof UsageRoute
   '/accounts/$ss58': typeof AccountsSs58Route
   '/blocks/$ref': typeof BlocksRefRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
@@ -281,6 +289,7 @@ export interface FileRoutesById {
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
   '/surfaces': typeof SurfacesRoute
+  '/usage': typeof UsageRoute
   '/accounts/$ss58': typeof AccountsSs58Route
   '/blocks/$ref': typeof BlocksRefRoute
   '/extrinsics/$hash': typeof ExtrinsicsHashRoute
@@ -316,6 +325,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/status'
     | '/surfaces'
+    | '/usage'
     | '/accounts/$ss58'
     | '/blocks/$ref'
     | '/extrinsics/$hash'
@@ -349,6 +359,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/status'
     | '/surfaces'
+    | '/usage'
     | '/accounts/$ss58'
     | '/blocks/$ref'
     | '/extrinsics/$hash'
@@ -382,6 +393,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/status'
     | '/surfaces'
+    | '/usage'
     | '/accounts/$ss58'
     | '/blocks/$ref'
     | '/extrinsics/$hash'
@@ -416,6 +428,7 @@ export interface RootRouteChildren {
   SettingsRoute: typeof SettingsRoute
   StatusRoute: typeof StatusRoute
   SurfacesRoute: typeof SurfacesRoute
+  UsageRoute: typeof UsageRoute
   AccountsSs58Route: typeof AccountsSs58Route
   BlocksRefRoute: typeof BlocksRefRoute
   ExtrinsicsHashRoute: typeof ExtrinsicsHashRoute
@@ -435,6 +448,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/usage': {
+      id: '/usage'
+      path: '/usage'
+      fullPath: '/usage'
+      preLoaderRoute: typeof UsageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/surfaces': {
       id: '/surfaces'
       path: '/surfaces'
@@ -672,6 +692,7 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsRoute: SettingsRoute,
   StatusRoute: StatusRoute,
   SurfacesRoute: SurfacesRoute,
+  UsageRoute: UsageRoute,
   AccountsSs58Route: AccountsSs58Route,
   BlocksRefRoute: BlocksRefRoute,
   ExtrinsicsHashRoute: ExtrinsicsHashRoute,

--- a/apps/ui/src/routes/usage.tsx
+++ b/apps/ui/src/routes/usage.tsx
@@ -1,0 +1,71 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Suspense } from "react";
+import { z } from "zod";
+import { fallback, zodValidator } from "@tanstack/zod-adapter";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { Skeleton } from "@/components/metagraphed/states";
+import { PageHero, ShareButton, ActionBar } from "@jsonbored/ui-kit";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import {
+  UsageAnalyticsPanel,
+  USAGE_WINDOWS,
+  type UsageWindow,
+} from "@/components/metagraphed/usage-analytics-panel";
+
+const usageSearchSchema = z.object({
+  window: fallback(z.enum(USAGE_WINDOWS), "7d").default("7d"),
+});
+
+export const Route = createFileRoute("/usage")({
+  validateSearch: zodValidator(usageSearchSchema),
+  head: () => ({
+    meta: [
+      { title: "Usage analytics — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Product-usage analytics for maintainers — REST-route and MCP-tool call counts with success/failure rates over a selectable window.",
+      },
+      { property: "og:title", content: "Usage analytics — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "REST-route and MCP-tool traffic with success/failure rates over 24h/7d/30d — so prioritization isn't blind.",
+      },
+    ],
+  }),
+  component: UsagePage,
+});
+
+function UsagePage() {
+  const { window } = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+
+  const setWindow = (w: UsageWindow) =>
+    navigate({
+      search: (prev) => ({ ...prev, window: w }),
+      resetScroll: false,
+    });
+
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Maintainer"
+        title="Usage analytics"
+        description="Which routes and MCP tools traffic actually hits, and how often they fail — the consumption side of product-usage telemetry, so prioritization isn't blind. No PostHog login required."
+        actions={
+          <ActionBar>
+            <ShareButton bare />
+          </ActionBar>
+        }
+      />
+      <QueryErrorBoundary>
+        <Suspense fallback={<Skeleton className="h-96 w-full" />}>
+          <UsageAnalyticsPanel window={window} onWindowChange={setWindow} />
+        </Suspense>
+      </QueryErrorBoundary>
+      <ApiSourceFooter paths={["/api/v1/usage"]} />
+    </AppShell>
+  );
+}


### PR DESCRIPTION
## What

Adds a maintainer-facing **Usage analytics** view (`/usage`) that surfaces REST-route and MCP-tool call counts with success/failure rates over a selectable window — the consumption side of the product-usage telemetry from #366, so a maintainer can read traffic patterns without logging into PostHog's own dashboard.

Closes #6033.

## Why

Per #366, "all prioritization … is blind" until usage data lives somewhere a maintainer can actually see it. This is the read side of that: a view over the route/day + per-MCP-tool event schema #366 defines.

## How

Mirrors the existing RPC-proxy usage-analytics precedent (`/api/v1/rpc/usage` → `rpcUsageQuery` → `ProxyUsagePanel`) end-to-end, so the shape, normalizer, and panel all match an already-shipped pattern:

- **Route** `apps/ui/src/routes/usage.tsx` — `PageHero` + URL-backed `window` search param (`24h` / `7d` / `30d`, default `7d`), so a shared link restores the same view. Suspense + `QueryErrorBoundary`, `ApiSourceFooter` for `/api/v1/usage`.
- **Panel** `usage-analytics-panel.tsx` — window selector, summary stat tiles (total calls, success %, error %, REST-route calls, MCP-tool calls), and a shared narrow, overflow-safe table for the per-route and per-tool breakdowns (name truncates with a `title`; success/error rates are derived from the count pair, never a stored field, so a partial row can't disagree with itself).
- **Query + normalizer** in `queries.ts` — `usageAnalyticsQuery(window)` + `normalizeUsageAnalytics`, forgiving of partial/cold payloads exactly like `normalizeRpcUsage`. Because the telemetry-writing side (#366) may not have shipped `/api/v1/usage` yet, a `404` (or an offline dev worker) degrades to the zeroed "no traffic yet" shape instead of tripping the error boundary; genuine `5xx` errors still surface.
- **Types** in `types.ts` — `UsageAnalytics` / `UsageRoute` / `UsageTool`.
- **Nav** — reachable from the maintainer-facing **Health** mega-panel ("ops drill-down for maintainers"), alongside the existing Ops overview.

The view is buildable and testable now against the defined mock data shape — it does **not** block on the telemetry writers shipping to production, only on their event schema, which #366 defines.

## Tests

`apps/ui/src/lib/metagraphed/queries.usage-analytics.test.ts` (new) — mocks the `/api/v1/usage` response shape and covers:
- well-formed payload passthrough (routes + tools + summary);
- cold-store and junk/missing input degrading to a schema-stable zeroed shape (never `NaN`);
- nameless/malformed rows dropped, rank/count fields back-filled from position;
- `usageAnalyticsQuery` hits `/api/v1/usage` with the `window` param (and defaults to `7d`);
- `404` / offline degrade to zeroed without throwing; genuine `5xx` re-throws.

```
npm run test --workspace=apps/ui        # 132 files, 1029 tests pass
npm run lint --workspace=apps/ui        # 0 errors
npm run format:check --workspace=apps/ui
npm run typecheck --workspace=apps/ui
npm run build --workspace=apps/ui
```

## Screenshots

`/usage`, fixed viewports (Mobile 375×812, Tablet 768×1024, Desktop 1280×800), both themes, before/after.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots/6033-usage-after-mobile-dark.png)<br><sub>after</sub> |

