### PR TITLE
feat(mcp): add read-only compare_validators stake-decision tool (#6035)

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -398,6 +398,7 @@ import {
   buildSubnetValidators,
   buildGlobalValidators,
   buildValidatorDetail,
+  composeValidatorComparison,
   GLOBAL_VALIDATOR_SORTS,
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
@@ -1777,6 +1778,29 @@ function requireHotkey(args) {
     );
   }
   return value;
+}
+
+// Upper bound on compare_validators' hotkey list: each hotkey is one detail
+// load, so the fan-out is capped to keep a single compare call bounded (a
+// side-by-side view of more than this many validators isn't a comparison
+// anyone reads anyway). Mirrors parseCompareNetuidList's own cap-and-dedupe
+// shape, but validates SS58 hotkeys instead of netuids.
+const COMPARE_VALIDATORS_MAX = 16;
+
+function parseHotkeyList(hotkeys) {
+  if (!Array.isArray(hotkeys) || hotkeys.length === 0) return null;
+  const result = [];
+  const seen = new Set();
+  for (const value of hotkeys) {
+    if (typeof value !== "string" || !SS58_ADDRESS_PATTERN.test(value)) {
+      return null;
+    }
+    if (seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+  if (result.length > COMPARE_VALIDATORS_MAX) return null;
+  return result;
 }
 
 // The optional `blocks` window for get_chain_activity: a missing value defaults
@@ -4954,6 +4978,72 @@ export const MCP_TOOLS = [
           "METAGRAPH_NEURONS_SOURCE",
         )) ?? buildValidatorDetail([], hotkey)
       );
+    },
+  },
+  {
+    name: "compare_validators",
+    title: "Compare validators side by side (read-only)",
+    description:
+      "Place several validators side by side for a stake/delegate decision: " +
+      "for each hotkey, its take rate, estimated APY, nominator count, and " +
+      "on-chain (coldkey) identity, plus the cross-subnet stake/emission/trust " +
+      "aggregates that give those numbers context -- the same per-validator " +
+      "detail list_global_validators / get_validator_detail expose, projected " +
+      "to the fields that drive a delegate choice. Pass an optional netuid to " +
+      "add each validator's membership in that one subnet (subnet_context). " +
+      "Strictly READ-ONLY and decision-support only: it builds no transaction, " +
+      "produces no signable/extrinsic artifact, and never touches a wallet or " +
+      "key -- the validator equivalent of compare_subnets.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        hotkeys: {
+          type: "array",
+          items: { type: "string", pattern: SS58_PATTERN_SOURCE },
+          minItems: 1,
+          maxItems: COMPARE_VALIDATORS_MAX,
+          description:
+            "Validator hotkeys (SS58 addresses) to compare, in display order.",
+        },
+        netuid: {
+          type: "integer",
+          minimum: 0,
+          description:
+            "Optional subnet context -- when set, each validator also carries " +
+            "its membership row in that subnet (subnet_context), or null when " +
+            "it holds no validator permit there.",
+        },
+      },
+      required: ["hotkeys"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const hotkeys = parseHotkeyList(args?.hotkeys);
+      if (!hotkeys) {
+        throw toolError(
+          "invalid_params",
+          `hotkeys must be a non-empty array of 1-${COMPARE_VALIDATORS_MAX} distinct valid SS58 validator addresses.`,
+        );
+      }
+      const netuid = optionalNonNegativeInt(args, "netuid");
+      // One detail load per hotkey, each via the exact Postgres-tier-or-empty
+      // path get_validator_detail uses -- no new data source, just the same
+      // cross-subnet aggregate fetched for each compared validator, then
+      // projected side by side. Sequential (not parallel) to keep the
+      // fan-out's request pattern identical to N get_validator_detail calls.
+      const details = [];
+      for (const hotkey of hotkeys) {
+        details.push(
+          (await tryPostgresTier(
+            ctx.env,
+            mcpNeuronsTierRequest(
+              `/api/v1/validators/${encodeURIComponent(hotkey)}`,
+            ),
+            "METAGRAPH_NEURONS_SOURCE",
+          )) ?? buildValidatorDetail([], hotkey),
+        );
+      }
+      return composeValidatorComparison(details, { netuid });
     },
   },
   {
@@ -11720,6 +11810,17 @@ const TOOL_OUTPUT_SCHEMAS = {
       captured_at: NULLABLE_STRING,
       block_number: NULLABLE_INT,
       subnets: { type: "array", items: { type: "object" } },
+    },
+  },
+  compare_validators: {
+    type: "object",
+    additionalProperties: true,
+    required: ["validator_count", "validators"],
+    properties: {
+      schema_version: { type: "integer" },
+      netuid: NULLABLE_INT,
+      validator_count: { type: "integer" },
+      validators: { type: "array", items: { type: "object" } },
     },
   },
   get_webhook_subscription: {

--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -815,3 +815,55 @@ export async function loadValidatorDetail(d1, hotkey) {
   );
   return buildValidatorDetail(rows, hotkey);
 }
+
+// The buildValidatorDetail fields a stake-decision comparison actually reads
+// (#6035): the take rate, estimated APY, nominator count, and on-chain identity
+// the delegate-selection UI (#5245) surfaces, plus the cross-subnet stake/
+// emission/trust aggregates that give those numbers context. Every field is
+// copied verbatim from the already-loaded detail -- nothing is recomputed here.
+const VALIDATOR_COMPARISON_FIELDS = [
+  "hotkey",
+  "coldkey",
+  "coldkey_identity",
+  "take",
+  "apy_estimate",
+  "apy_estimate_eligible_subnet_count",
+  "nominator_count",
+  "total_stake_tao",
+  "total_emission_tao",
+  "avg_validator_trust",
+  "max_validator_trust",
+  "subnet_count",
+];
+
+// Place several validators side by side for a stake/delegate decision (#6035):
+// project each buildValidatorDetail-shaped `detail` down to the decision-
+// relevant fields above (take rate, estimated APY, nominator count, on-chain
+// identity, plus supporting aggregates), preserving the caller's order. This is
+// a pure READ-ONLY projection of already-loaded detail objects -- it constructs
+// no transaction, references no key material, and derives nothing new from
+// chain state. When `netuid` is provided (the subnet context), each row also
+// carries that validator's membership row in that subnet (`subnet_context`), or
+// null when the validator holds no permit there -- letting a caller weigh the
+// global picture against one subnet at a time. `details` that isn't an array is
+// treated as an empty comparison, mirroring the cold-safe builders above.
+export function composeValidatorComparison(details, { netuid = null } = {}) {
+  const list = Array.isArray(details) ? details : [];
+  const validators = list.map((detail) => {
+    const projected = {};
+    for (const field of VALIDATOR_COMPARISON_FIELDS) {
+      projected[field] = detail?.[field] ?? null;
+    }
+    projected.subnet_context =
+      netuid == null
+        ? null
+        : (detail?.subnets?.find((subnet) => subnet.netuid === netuid) ?? null);
+    return projected;
+  });
+  return {
+    schema_version: 1,
+    netuid,
+    validator_count: validators.length,
+    validators,
+  };
+}

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -15368,6 +15368,171 @@ describe("MCP validator detail/nominators/history tools (#5225 parity)", () => {
     assert.match(bad.body.result.content[0].text, /ss58/i);
   });
 
+  // compare_validators (#6035): a read-only side-by-side of several validators
+  // for a stake/delegate decision, one get_validator_detail-shaped load per
+  // hotkey, projected to take/APY/nominator-count/identity + aggregates.
+  const HOTKEY2 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc6";
+
+  test("compare_validators returns a schema-stable comparison over the empty base", async () => {
+    const res = await callTool("compare_validators", {
+      hotkeys: [HOTKEY, HOTKEY2],
+    });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.netuid, null);
+    assert.equal(out.validator_count, 2);
+    assert.deepEqual(
+      out.validators.map((v) => v.hotkey),
+      [HOTKEY, HOTKEY2],
+    );
+    // Cold base: the decision fields resolve to their null aggregates.
+    assert.equal(out.validators[0].take, null);
+    assert.equal(out.validators[0].coldkey_identity, null);
+    assert.equal(out.validators[0].apy_estimate, null);
+    assert.equal(out.validators[0].subnet_context, null);
+  });
+
+  test("compare_validators dedupes repeated hotkeys", async () => {
+    const res = await callTool("compare_validators", {
+      hotkeys: [HOTKEY, HOTKEY, HOTKEY2],
+    });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.validator_count, 2);
+    assert.deepEqual(
+      out.validators.map((v) => v.hotkey),
+      [HOTKEY, HOTKEY2],
+    );
+  });
+
+  test("compare_validators output carries no transaction/signing fields", async () => {
+    const res = await callTool("compare_validators", { hotkeys: [HOTKEY] });
+    const keys = [];
+    const walk = (value) => {
+      if (Array.isArray(value)) {
+        for (const item of value) walk(item);
+      } else if (value && typeof value === "object") {
+        for (const [key, child] of Object.entries(value)) {
+          keys.push(key);
+          walk(child);
+        }
+      }
+    };
+    walk(res.body.result.structuredContent);
+    const forbidden =
+      /sign|signature|transaction|extrinsic|mnemonic|seed|private|wallet|custody/i;
+    const offending = keys.filter((key) => forbidden.test(key));
+    assert.deepEqual(offending, [], `unexpected fields: ${offending}`);
+  });
+
+  test("compare_validators: flag=postgres projects each detail and extracts the netuid subnet_context", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          const hotkey = decodeURIComponent(
+            new URL(req.url).pathname.split("/").pop(),
+          );
+          return Response.json({
+            schema_version: 1,
+            hotkey,
+            coldkey: "5Cold",
+            coldkey_identity: { has_identity: true, name: "Alice" },
+            take: 0.18,
+            apy_estimate: 0.2,
+            apy_estimate_eligible_subnet_count: 1,
+            nominator_count: 42,
+            total_stake_tao: 1000,
+            total_emission_tao: 5,
+            avg_validator_trust: 0.9,
+            max_validator_trust: 0.99,
+            subnet_count: 1,
+            subnets: [{ netuid: 7, uid: 3, stake_tao: 800 }],
+          });
+        },
+      },
+    };
+    const res = await callTool(
+      "compare_validators",
+      { hotkeys: [HOTKEY], netuid: 7 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.validators[0].take, 0.18);
+    assert.equal(out.validators[0].nominator_count, 42);
+    assert.deepEqual(out.validators[0].coldkey_identity, {
+      has_identity: true,
+      name: "Alice",
+    });
+    assert.deepEqual(out.validators[0].subnet_context, {
+      netuid: 7,
+      uid: 3,
+      stake_tao: 800,
+    });
+    // The raw detail's subnets[] is not passed through -- only the projection.
+    assert.equal(out.validators[0].subnets, undefined);
+  });
+
+  test("compare_validators: flag=postgres falls back to the empty base on failure", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const res = await callTool(
+      "compare_validators",
+      { hotkeys: [HOTKEY] },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.equal(out.validator_count, 1);
+    assert.equal(out.validators[0].take, null);
+  });
+
+  test("compare_validators rejects missing/empty/malformed hotkey lists", async () => {
+    const missing = await callTool("compare_validators", {});
+    assert.equal(missing.body.result.isError, true);
+    assert.match(missing.body.result.content[0].text, /hotkeys/);
+
+    const empty = await callTool("compare_validators", { hotkeys: [] });
+    assert.equal(empty.body.result.isError, true);
+
+    const nonString = await callTool("compare_validators", { hotkeys: [123] });
+    assert.equal(nonString.body.result.isError, true);
+
+    const badSs58 = await callTool("compare_validators", {
+      hotkeys: [HOTKEY, "not-ss58"],
+    });
+    assert.equal(badSs58.body.result.isError, true);
+
+    // More than COMPARE_VALIDATORS_MAX (16) distinct valid hotkeys.
+    const b58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    const base = HOTKEY.slice(0, -1);
+    const tooMany = Array.from({ length: 17 }, (_, i) => base + b58[i]);
+    const over = await callTool("compare_validators", { hotkeys: tooMany });
+    assert.equal(over.body.result.isError, true);
+    assert.match(over.body.result.content[0].text, /hotkeys/);
+  });
+
+  test("compare_validators rejects an invalid netuid", async () => {
+    const negative = await callTool("compare_validators", {
+      hotkeys: [HOTKEY],
+      netuid: -1,
+    });
+    assert.equal(negative.body.result.isError, true);
+
+    const nonInt = await callTool("compare_validators", {
+      hotkeys: [HOTKEY],
+      netuid: "seven",
+    });
+    assert.equal(nonInt.body.result.isError, true);
+    assert.match(nonInt.body.result.content[0].text, /netuid/);
+  });
+
   test("get_validator_nominators returns a schema-stable empty ranked list with defaults", async () => {
     const res = await callTool("get_validator_nominators", { hotkey: HOTKEY });
     const out = res.body.result.structuredContent;

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -7,6 +7,7 @@ import {
   buildGlobalValidators,
   buildNeuronDetail,
   buildValidatorDetail,
+  composeValidatorComparison,
   overlayFeaturedValidators,
   loadSubnetValidators,
   loadGlobalValidators,
@@ -1822,5 +1823,124 @@ describe("metagraph routes (#1304/#1305) via the Worker", () => {
       env,
     );
     assert.equal(badFormat.res.status, 400);
+  });
+});
+
+describe("composeValidatorComparison (#6035)", () => {
+  // A minimal buildValidatorDetail-shaped object -- only the fields the
+  // comparison projects, plus a subnets[] for the subnet_context path.
+  function detail(overrides = {}) {
+    return {
+      schema_version: 1,
+      hotkey: "5Hk-a",
+      coldkey: "5Co-a",
+      coldkey_identity: { has_identity: false, name: null },
+      take: 0.18,
+      apy_estimate: 0.2,
+      apy_estimate_eligible_subnet_count: 2,
+      nominator_count: 42,
+      total_stake_tao: 1000,
+      total_emission_tao: 5,
+      avg_validator_trust: 0.9,
+      max_validator_trust: 0.99,
+      subnet_count: 2,
+      subnets: [
+        { netuid: 7, uid: 3, stake_tao: 800, validator_trust: 0.9 },
+        { netuid: 12, uid: 4, stake_tao: 200, validator_trust: 0.8 },
+      ],
+      ...overrides,
+    };
+  }
+
+  test("projects the decision fields for each validator, preserving order", () => {
+    const out = composeValidatorComparison([
+      detail({ hotkey: "5Hk-a" }),
+      detail({ hotkey: "5Hk-b", take: 0.05, nominator_count: 7 }),
+    ]);
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.netuid, null);
+    assert.equal(out.validator_count, 2);
+    assert.deepEqual(
+      out.validators.map((v) => v.hotkey),
+      ["5Hk-a", "5Hk-b"],
+    );
+    const first = out.validators[0];
+    // Exactly the projected fields -- no subnets[] pass-through, and no
+    // transaction/signing field ever appears.
+    assert.deepEqual(Object.keys(first).sort(), [
+      "apy_estimate",
+      "apy_estimate_eligible_subnet_count",
+      "avg_validator_trust",
+      "coldkey",
+      "coldkey_identity",
+      "hotkey",
+      "max_validator_trust",
+      "nominator_count",
+      "subnet_context",
+      "subnet_count",
+      "take",
+      "total_emission_tao",
+      "total_stake_tao",
+    ]);
+    assert.equal(first.take, 0.18);
+    assert.equal(first.nominator_count, 42);
+    assert.deepEqual(first.coldkey_identity, {
+      has_identity: false,
+      name: null,
+    });
+    // netuid omitted -> no subnet context on any row.
+    assert.equal(first.subnet_context, null);
+    assert.equal(out.validators[1].subnet_context, null);
+  });
+
+  test("with a netuid, each row carries its membership in that subnet or null", () => {
+    const out = composeValidatorComparison(
+      [
+        detail({ hotkey: "5Hk-a" }),
+        // A validator that does not validate on netuid 7.
+        detail({
+          hotkey: "5Hk-b",
+          subnets: [{ netuid: 12, uid: 9, stake_tao: 200 }],
+        }),
+      ],
+      { netuid: 7 },
+    );
+    assert.equal(out.netuid, 7);
+    assert.deepEqual(out.validators[0].subnet_context, {
+      netuid: 7,
+      uid: 3,
+      stake_tao: 800,
+      validator_trust: 0.9,
+    });
+    assert.equal(out.validators[1].subnet_context, null);
+  });
+
+  test("missing fields and a missing subnets[] degrade to null, never throw", () => {
+    const out = composeValidatorComparison(
+      [
+        // No coldkey_identity, no take, no subnets -- every gap becomes null.
+        { hotkey: "5Hk-c" },
+        // A null element must not crash the projection.
+        null,
+      ],
+      { netuid: 7 },
+    );
+    assert.equal(out.validator_count, 2);
+    const sparse = out.validators[0];
+    assert.equal(sparse.hotkey, "5Hk-c");
+    assert.equal(sparse.take, null);
+    assert.equal(sparse.coldkey_identity, null);
+    assert.equal(sparse.subnet_context, null);
+    const nullRow = out.validators[1];
+    assert.equal(nullRow.hotkey, null);
+    assert.equal(nullRow.subnet_context, null);
+  });
+
+  test("a non-array `details` yields an empty, schema-stable comparison", () => {
+    const out = composeValidatorComparison(undefined);
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.netuid, null);
+    assert.equal(out.validator_count, 0);
+    assert.deepEqual(out.validators, []);
   });
 });


### PR DESCRIPTION
## Summary

Adds a read-only `compare_validators` MCP tool that places several validators
side by side for a stake/delegate decision — the validator equivalent of the
existing `compare_subnets`. Closes #6035.

For each hotkey it returns the delegate-choice fields the issue asks for — take
rate, estimated APY, nominator count, and on-chain (coldkey) identity — plus the
cross-subnet stake/emission/trust aggregates that give those numbers context.
An optional `netuid` supplies the subnet context: when set, each validator also
carries its membership row in that one subnet (`subnet_context`), or `null` when
it holds no validator permit there.

It reuses the exact per-validator detail load `get_validator_detail` already
uses (one `/api/v1/validators/{hotkey}` neurons-tier read per hotkey, with the
same schema-stable empty fallback), then projects each detail down to the
comparison fields — no new data source. It is strictly read-only and
decision-support only: it constructs no transaction, produces no
signable/extrinsic artifact, and never touches a wallet or key, staying entirely
within ADR 0018's existing read-only boundary.

## What Changed

- `src/metagraph-neurons.mjs`: new pure `composeValidatorComparison(details,
  { netuid })` — projects a list of `buildValidatorDetail`-shaped objects into
  the side-by-side comparison shape, extracting the per-subnet context when a
  netuid is given. Cold-safe (non-array / null entries degrade to a
  schema-stable empty comparison, never throws).
- `src/mcp-server.mjs`: registers the `compare_validators` tool (input:
  `hotkeys[]` + optional `netuid`; capped at 16 hotkeys, SS58-validated,
  deduped) and its `outputSchema`; adds the `parseHotkeyList` helper.
- Tests: pure-function branch coverage in `tests/metagraph-neurons.test.mjs`
  and MCP wiring / validation / Postgres-tier / no-signing-fields coverage in
  `tests/mcp-server.test.mjs`.

No schema/contract changes, so no regenerated artifacts; MCP tool additions
don't require a server-card regen (worker-computed).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6035`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] No generated artifacts committed (diff is `src/**` + `tests/**` only).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes — this is an MCP-only addition that
      composes existing loaders.

## Validation

All run locally on Node 22, green:

- `npm test` — 291 files, 8899 tests passing.
- `npm run test:coverage` (scoped to the changed files) — every added line and
  branch in `src/mcp-server.mjs` and `src/metagraph-neurons.mjs` is covered
  (take rate / APY / nominator / identity projection, the netuid subnet-context
  path, the empty-base fallback, and all `parseHotkeyList` rejection branches).
- `npm run validate` — 129 subnets / 1686 surfaces / 133 providers OK.
- `npm run validate:mcp` — 175 tools, full lifecycle + tools/call round trip.
- `npm run validate:contract-drift` — passed (no contract change).
- `npm run lint` and `npm run format:check` — clean.
- `npm run worker:bundle:budget` — 1008.9 KiB, under the 1016 KiB fail budget.
- `git diff --check` — clean.

## Closes

Closes #6035
