### PR TITLE
fix(backend): restrict surface verify to GET and HEAD (#6015)

### DIFF
--- a/tests/request-handlers-rpc-proxy.test.mjs
+++ b/tests/request-handlers-rpc-proxy.test.mjs
@@ -256,10 +256,42 @@ describe("handleRpcUsage", () => {
 });
 
 describe("handleSurfaceVerify", () => {
-  const verifyReq = (id) =>
+  const verifyReq = (id, init = {}) =>
     req(`/api/v1/surfaces/${id}/verify`, {
       headers: { "cf-connecting-ip": "203.0.113.10" },
+      ...init,
     });
+
+  test("405 for non-GET/HEAD methods without probing", async () => {
+    let fetched = false;
+    let limited = false;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      fetched = true;
+      return new Response("{}", { status: 200 });
+    };
+    const env = createLocalArtifactEnv();
+    env.RPC_RATE_LIMITER = {
+      limit: async () => {
+        limited = true;
+        return { success: true };
+      },
+    };
+    try {
+      const res = await handleSurfaceVerify(
+        verifyReq(SURFACE_ID, { method: "POST" }),
+        env,
+        SURFACE_ID,
+      );
+      const body = await errorJson(res, 405);
+      assert.equal(body.error.code, "method_not_allowed");
+      assert.equal(res.headers.get("allow"), "GET, HEAD, OPTIONS");
+      assert.equal(fetched, false);
+      assert.equal(limited, false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 
   test("404s for an unknown surface without probing", async () => {
     let fetched = false;

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -218,6 +218,21 @@ async function verifyMeta(env) {
 // outbound probes. An agent (or the verify_integration MCP tool) calls this to
 // confirm "callable right now" before wiring.
 export async function handleSurfaceVerify(request, env, surfaceId, ctx = {}) {
+  // No request body — path param only — so this is a GET/HEAD action endpoint
+  // (same method set as handleBadgeSvgRequest). Reject anything else before the
+  // rate limiter or outbound probe can run (#6015).
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return errorResponse(
+      "method_not_allowed",
+      "Surface verify only accepts GET and HEAD.",
+      405,
+      {},
+      {
+        allow: "GET, HEAD, OPTIONS",
+      },
+    );
+  }
+
   if (env.RPC_RATE_LIMITER?.limit) {
     const clientKey = `verify:${resolveClientIp(request)}`;
     const { success } = await env.RPC_RATE_LIMITER.limit({ key: clientKey });


### PR DESCRIPTION
## Summary
- Add an explicit HTTP method gate to `handleSurfaceVerify`, matching `handleRpcProxyRequest` / `handleBadgeSvgRequest`.
- Allow only `GET` and `HEAD` (no request body; path param only); return `405 method_not_allowed` with `Allow: GET, HEAD, OPTIONS` for anything else, before the rate limiter or live outbound probe runs.
- Add a regression test that a disallowed method (`POST`) returns 405 without reaching the probe or rate limiter.

Closes #6015

## Test plan
- [x] `npx vitest run tests/request-handlers-rpc-proxy.test.mjs tests/surface-verify.test.mjs tests/request-handlers-rpc-proxy-branch-coverage.test.mjs`
- [ ] Confirm `GET /api/v1/surfaces/{id}/verify` still succeeds
- [ ] Confirm `POST`/`PUT`/`DELETE`/`PATCH` return 405 with `Allow: GET, HEAD, OPTIONS`