### PR TITLE
feat(graphql): add Query.neuron and Query.neuron_history (#5900)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -131,6 +131,7 @@ import {
   GLOBAL_VALIDATOR_LIMIT_MAX,
   GLOBAL_VALIDATOR_SORTS,
   buildGlobalValidators,
+  buildNeuronDetail,
   buildValidatorDetail,
   overlayFeaturedValidators,
 } from "./metagraph-neurons.mjs";
@@ -208,6 +209,7 @@ import {
   CHAIN_SIGNERS_LIMIT_MAX,
 } from "./chain-query-loaders.mjs";
 import {
+  buildNeuronHistory,
   parseHistoryWindow,
   unsupportedWindowMessage,
 } from "./neuron-history.mjs";
@@ -321,6 +323,10 @@ export const SDL = `
     subnet_concentration(netuid: Int!): SubnetConcentration!
     "Per-subnet per-day stake and emission concentration trend from the neuron_daily rollup over a 7d/30d/90d window (default 30d): each day's stake/emission Gini, Nakamoto coefficient, and top-10% share, newest first; a subnet with no daily rollup resolves to a schema-stable empty series (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/concentration/history."
     subnet_concentration_history(netuid: Int!, window: String): SubnetConcentrationHistory!
+    "One neuron in a subnet by UID: hot/cold keys, stake, rank, trust, consensus, incentive, dividends, emission, validator permit, immunity, axon, and take. The nested neuron field is null when that UID is absent from the latest snapshot -- a schema-stable card, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}."
+    neuron(netuid: Int!, uid: Int!): Neuron!
+    "One neuron's per-day metagraph history in a subnet by UID from the neuron_daily rollup (window: 7d/30d/90d/1y/all, default 30d), newest first: stake, rank, trust, consensus, incentive, dividends, emission, validator permit, and axon per snapshot_date. A UID with no matching rows resolves to a schema-stable empty-points card, never null. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history."
+    neuron_history(netuid: Int!, uid: Int!, window: String): NeuronHistory!
     "Append-only on-chain SubnetIdentitiesV3 change timeline for one subnet (name, symbol, description, repo, website, discord, logo), newest first; page with limit/offset or follow next_cursor. A subnet with no matching events resolves to a schema-stable empty timeline (entry_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/identity-history."
     subnet_identity_history(netuid: Int!, limit: Int, offset: Int, cursor: String): SubnetIdentityHistory!
     "One subnet's weekly structural + economics trajectory from the daily snapshots: a chronological series of points (completeness/surface/endpoint counts plus validator/miner counts and economics — stake, alpha price, emission share, pool reserves, volume), and the latest-vs-window-ago deltas for the 7d and 30d windows. A subnet with no snapshots resolves to a schema-stable empty trajectory (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/trajectory."
@@ -2059,6 +2065,73 @@ export const SDL = `
     rewards_per_1000_tao: Float
   }
 
+  "One neuron's live metagraph detail card (#5900). Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}: neuron is null when that UID is absent from the latest snapshot."
+  type Neuron {
+    schema_version: Int!
+    netuid: Int!
+    captured_at: String
+    block_number: Int
+    "The UID's live metagraph row; null when absent from the latest snapshot."
+    neuron: NeuronState
+  }
+
+  "One UID's live metagraph state within a subnet (hot/cold keys, scores, stake/emission, axon, take)."
+  type NeuronState {
+    uid: Int
+    hotkey: String
+    coldkey: String
+    active: Boolean
+    validator_permit: Boolean
+    rank: Float
+    trust: Float
+    validator_trust: Float
+    consensus: Float
+    incentive: Float
+    dividends: Float
+    emission_tao: Float
+    stake_tao: Float
+    registered_at_block: Int
+    is_immunity_period: Boolean
+    "Axon endpoint as host:port, or null when not served."
+    axon: String
+    "Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture."
+    take: Float
+  }
+
+  "One neuron's per-day metagraph history. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history."
+  type NeuronHistory {
+    schema_version: Int!
+    netuid: Int!
+    uid: Int!
+    window: String
+    point_count: Int!
+    points: [NeuronHistoryPoint!]!
+  }
+
+  "One day's metagraph state for a single UID (NeuronState fields plus snapshot_date/captured_at/block_number)."
+  type NeuronHistoryPoint {
+    snapshot_date: String!
+    captured_at: String
+    block_number: Int
+    uid: Int
+    hotkey: String
+    coldkey: String
+    active: Boolean
+    validator_permit: Boolean
+    rank: Float
+    trust: Float
+    validator_trust: Float
+    consensus: Float
+    incentive: Float
+    dividends: Float
+    emission_tao: Float
+    stake_tao: Float
+    registered_at_block: Int
+    is_immunity_period: Boolean
+    axon: String
+    take: Float
+  }
+
   type ValidatorSubnet {
     netuid: Int!
     uid: Int
@@ -2707,6 +2780,8 @@ export const FIELD_COMPLEXITY = {
   subnet_performance: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_concentration: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_concentration_history: RELATIONSHIP_FIELD_COMPLEXITY,
+  neuron: RELATIONSHIP_FIELD_COMPLEXITY,
+  neuron_history: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_trajectory: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_identity_history: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3667,6 +3742,83 @@ const rootValue = {
       window: data.window ?? windowParam,
       point_count: data.point_count ?? 0,
       points: data.points ?? [],
+    };
+  },
+
+  async neuron({ netuid, uid }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    if (!Number.isInteger(uid) || uid < 0) {
+      throw new GraphQLError("uid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildNeuronDetail(null)
+    // cold fallback contract handleNeuron / MCP get_neuron use: an absent UID
+    // is a schema-stable card with neuron:null, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/neurons/${uid}`,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildNeuronDetail(null, netuid);
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      captured_at: data.captured_at ?? null,
+      block_number: data.block_number ?? null,
+      neuron: data.neuron ?? null,
+    };
+  },
+
+  async neuron_history({ netuid, uid, window }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    if (!Number.isInteger(uid) || uid < 0) {
+      throw new GraphQLError("uid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same parseHistoryWindow REST's handleNeuronHistory uses, so accepted
+    // window labels (7d/30d/90d/1y/all, default 30d) match exactly.
+    const { label, error } = parseHistoryWindow(window);
+    if (error) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const params = new URLSearchParams();
+    params.set("window", label);
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildNeuronHistory([])
+    // fallback contract handleNeuronHistory / MCP get_neuron_history use; a
+    // UID with no neuron_daily rows in the window is a schema-stable
+    // empty-points card, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/neurons/${uid}/history`,
+          params,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildNeuronHistory([], netuid, uid, { window: label });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      uid: data.uid ?? uid,
+      window: data.window ?? label,
+      point_count: data.point_count ?? 0,
+      points: data.points || [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -5696,6 +5696,310 @@ describe("graphql — subnet_concentration_history (#5901, neuron_daily trend + 
   });
 });
 
+describe("graphql — neuron (#5900, Postgres-tier + neuron:null fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable card with neuron:null, never null", async () => {
+    const { status, body } = await gql(
+      `{ neuron(netuid: 5, uid: 12) {
+          schema_version netuid captured_at block_number
+          neuron { uid hotkey }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.neuron, {
+      schema_version: 1,
+      netuid: 5,
+      captured_at: null,
+      block_number: null,
+      neuron: null,
+    });
+  });
+
+  test("resolves the Postgres-tier neuron detail row", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          captured_at: "2026-07-01T00:00:00.000Z",
+          block_number: 8621331,
+          neuron: {
+            uid: 12,
+            hotkey: "5Hot",
+            coldkey: "5Cold",
+            active: true,
+            validator_permit: false,
+            rank: 0.1,
+            trust: 0.2,
+            validator_trust: 0,
+            consensus: 0.15,
+            incentive: 0.05,
+            dividends: 0,
+            emission_tao: 1.25,
+            stake_tao: 100.5,
+            registered_at_block: 8000000,
+            is_immunity_period: false,
+            axon: "1.2.3.4:8091",
+            take: 0.18,
+          },
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ neuron(netuid: 5, uid: 12) {
+          netuid captured_at block_number
+          neuron {
+            uid hotkey coldkey active validator_permit
+            rank trust stake_tao emission_tao axon take
+          }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const n = body.data.neuron;
+    assert.equal(n.block_number, 8621331);
+    assert.deepEqual(n.neuron, {
+      uid: 12,
+      hotkey: "5Hot",
+      coldkey: "5Cold",
+      active: true,
+      validator_permit: false,
+      rank: 0.1,
+      trust: 0.2,
+      stake_tao: 100.5,
+      emission_tao: 1.25,
+      axon: "1.2.3.4:8091",
+      take: 0.18,
+    });
+  });
+
+  test("hits /api/v1/subnets/{netuid}/neurons/{uid} on the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql("{ neuron(netuid: 3, uid: 7) { netuid neuron { uid } } }", env);
+    assert.equal(capturedUrl.pathname, "/api/v1/subnets/3/neurons/7");
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ neuron(netuid: 9, uid: 1) {
+          schema_version netuid captured_at block_number neuron { uid }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.neuron, {
+      schema_version: 1,
+      netuid: 9,
+      captured_at: null,
+      block_number: null,
+      neuron: null,
+    });
+  });
+
+  test("a negative netuid is a GraphQL error, not a null card", async () => {
+    const { body } = await gql(
+      "{ neuron(netuid: -1, uid: 0) { neuron { uid } } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/netuid/i.test(body.errors[0].message));
+    assert.equal(body.data?.neuron ?? null, null);
+  });
+
+  test("a negative uid is a GraphQL error, not a null card", async () => {
+    const { body } = await gql(
+      "{ neuron(netuid: 5, uid: -1) { neuron { uid } } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/uid/i.test(body.errors[0].message));
+    assert.equal(body.data?.neuron ?? null, null);
+  });
+
+  test("neuron is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.neuron, 5);
+  });
+});
+
+describe("graphql — neuron_history (#5900, Postgres-tier + empty-points fallback)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag / no neuron_daily rows returns a schema-stable empty-points card, never null", async () => {
+    const { status, body } = await gql(
+      `{ neuron_history(netuid: 5, uid: 12) {
+          schema_version netuid uid window point_count points { snapshot_date }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.neuron_history, {
+      schema_version: 1,
+      netuid: 5,
+      uid: 12,
+      window: "30d",
+      point_count: 0,
+      points: [],
+    });
+  });
+
+  test("resolves the Postgres-tier points for the requested window", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          uid: 12,
+          window: "90d",
+          point_count: 1,
+          points: [
+            {
+              snapshot_date: "2026-07-01",
+              captured_at: "2026-07-01T00:00:00.000Z",
+              block_number: 8621331,
+              uid: 12,
+              hotkey: "5Hot",
+              coldkey: "5Cold",
+              active: true,
+              validator_permit: true,
+              stake_tao: 200,
+              emission_tao: 3.5,
+              rank: 0.4,
+              trust: 0.5,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ neuron_history(netuid: 5, uid: 12, window: "90d") {
+          netuid uid window point_count
+          points {
+            snapshot_date captured_at block_number uid hotkey
+            stake_tao emission_tao rank trust
+          }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.neuron_history;
+    assert.equal(r.netuid, 5);
+    assert.equal(r.uid, 12);
+    assert.equal(r.window, "90d");
+    assert.equal(r.point_count, 1);
+    assert.deepEqual(r.points, [
+      {
+        snapshot_date: "2026-07-01",
+        captured_at: "2026-07-01T00:00:00.000Z",
+        block_number: 8621331,
+        uid: 12,
+        hotkey: "5Hot",
+        stake_tao: 200,
+        emission_tao: 3.5,
+        rank: 0.4,
+        trust: 0.5,
+      },
+    ]);
+  });
+
+  test("window is forwarded as a query param to the Postgres tier", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(
+      '{ neuron_history(netuid: 3, uid: 7, window: "7d") { window } }',
+      env,
+    );
+    assert.equal(
+      capturedUrl.pathname,
+      "/api/v1/subnets/3/neurons/7/history",
+    );
+    assert.equal(capturedUrl.searchParams.get("window"), "7d");
+  });
+
+  test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({})),
+    };
+    const { status, body } = await gql(
+      `{ neuron_history(netuid: 9, uid: 1, window: "30d") {
+          schema_version netuid uid window point_count points { snapshot_date }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.neuron_history, {
+      schema_version: 1,
+      netuid: 9,
+      uid: 1,
+      window: "30d",
+      point_count: 0,
+      points: [],
+    });
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent series", async () => {
+    const { body } = await gql(
+      '{ neuron_history(netuid: 5, uid: 12, window: "5d") { point_count } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window/i.test(body.errors[0].message));
+    assert.equal(body.data?.neuron_history ?? null, null);
+  });
+
+  test("a negative netuid is a GraphQL error, not an empty series", async () => {
+    const { body } = await gql(
+      "{ neuron_history(netuid: -1, uid: 0) { point_count } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/netuid/i.test(body.errors[0].message));
+    assert.equal(body.data?.neuron_history ?? null, null);
+  });
+
+  test("a negative uid is a GraphQL error, not an empty series", async () => {
+    const { body } = await gql(
+      "{ neuron_history(netuid: 5, uid: -1) { point_count } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/uid/i.test(body.errors[0].message));
+    assert.equal(body.data?.neuron_history ?? null, null);
+  });
+
+  test("neuron_history is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.neuron_history, 5);
+  });
+});
+
 describe("graphql — subnet_yield (#5713, Postgres-tier + zeroed-card fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -5938,10 +5938,7 @@ describe("graphql — neuron_history (#5900, Postgres-tier + empty-points fallba
       '{ neuron_history(netuid: 3, uid: 7, window: "7d") { window } }',
       env,
     );
-    assert.equal(
-      capturedUrl.pathname,
-      "/api/v1/subnets/3/neurons/7/history",
-    );
+    assert.equal(capturedUrl.pathname, "/api/v1/subnets/3/neurons/7/history");
     assert.equal(capturedUrl.searchParams.get("window"), "7d");
   });
 


### PR DESCRIPTION
## Summary
- Add `Query.neuron(netuid, uid)` mirroring `GET /api/v1/subnets/{netuid}/neurons/{uid}` and MCP `get_neuron`, via the shared Postgres-tier loader with `buildNeuronDetail` cold fallback (`neuron: null`).
- Add `Query.neuron_history(netuid, uid, window)` mirroring `GET /api/v1/subnets/{netuid}/neurons/{uid}/history` and MCP `get_neuron_history`, with the same `7d`/`30d`/`90d`/`1y`/`all` window validation (default `30d`) and empty-points cold card.
- Cover both fields with GraphQL unit tests (cold fallback, Postgres-tier happy path, URL/window forwarding, input validation, field complexity).

Closes #5900

## Test plan
- [x] `npx vitest run tests/graphql.test.mjs -t "graphql — neuron"` (15 passed)
- [ ] Confirm introspection exposes `neuron` / `neuron_history` on `Query`
- [ ] Spot-check a live query against a known netuid/uid when Postgres tier is available