### PR TITLE
fix(ui): tier negative amounts by magnitude in formatTao

### DIFF
--- a/apps/ui/src/lib/metagraphed/format.test.ts
+++ b/apps/ui/src/lib/metagraphed/format.test.ts
@@ -162,4 +162,12 @@ describe("formatTao", () => {
     expect(formatTao(1_000_000)).toBe("1.00M τ"); // lower boundary of M-tier
     expect(formatTao(2_500_000)).toBe("2.50M τ");
   });
+
+  it("mirrors the magnitude tiers for negative amounts, preserving the sign", () => {
+    expect(formatTao(-0.5)).toBe("-0.5000 τ"); // negative dust
+    expect(formatTao(-256.5)).toBe("-256.50 τ"); // negative whole-unit
+    expect(formatTao(-12_345)).toBe("-12.3k τ"); // negative k-tier
+    expect(formatTao(-1_000_000)).toBe("-1.00M τ"); // negative M-tier boundary
+    expect(formatTao(-2_500_000)).toBe("-2.50M τ");
+  });
 });

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -14,9 +14,13 @@ export function formatNumber(n: number | undefined | null, fallback = "—"): st
  */
 export function formatTao(v?: number | null): string {
   if (v == null || !Number.isFinite(v)) return "—";
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
+  // Tier by magnitude so a signed amount (e.g. a negative net flow) gets the
+  // same M/k/2dp/4dp tiering as its positive counterpart; the sign is preserved
+  // by formatting the original `v`, never `Math.abs(v)`.
+  const magnitude = Math.abs(v);
+  if (magnitude >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
+  if (magnitude >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
+  if (magnitude >= 1) return `${v.toFixed(2)} τ`;
   return `${v.toFixed(4)} τ`;
 }
 

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -115,7 +115,10 @@ function sum(values: number[]): number {
 }
 
 function fmtTaoSigned(v: number): string {
-  return v < 0 ? `-${formatTao(-v)}` : `+${formatTao(v)}`;
+  // formatTao now tiers negative amounts itself (#6019) and carries the "-",
+  // so a negative value is formatted directly; only the explicit "+" for a
+  // non-negative value is prepended here.
+  return v < 0 ? formatTao(v) : `+${formatTao(v)}`;
 }
 
 function ExplorerPage() {


### PR DESCRIPTION
Closes #6019

`formatTao` (`apps/ui/src/lib/metagraphed/format.ts`) tested each magnitude tier with `v >= threshold`, so a negative amount fell through every tier to the 4-decimal branch — e.g. `-2,000,000 τ` rendered `"-2000000.0000 τ"` instead of `"-2.00M τ"`.

- Tier by `Math.abs(v)` while formatting the original signed `v`, so negative amounts get the same M/k/2dp/4dp tiering as their positive counterparts, with the sign preserved.
- Removed `explorer.tsx`'s `fmtTaoSigned` negate-before-calling workaround, now redundant — a negative value is formatted directly (it carries its own `-`). Output is unchanged: for `v < 0`, `formatTao(v)` is identical to the old `-${formatTao(-v)}`.

Tests: negative amounts at each tier boundary (negative dust, whole-unit, k-tier, M-tier boundary), confirming correct tiering and sign preservation.
