### PR TITLE
feat(observability): add typed PostHog usage-telemetry wrapper (#6030)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "graphql": "^17.0.2",
         "graphql-ws": "^6.1.0",
         "postgres": "^3.4.9",
+        "posthog-node": "^5.44.0",
         "workers-og": "^0.0.27"
       },
       "devDependencies": {
@@ -40,7 +41,7 @@
     },
     "apps/ui": {
       "name": "metagraphed-ui",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@jsonbored/metagraphed": "*",
@@ -3726,6 +3727,21 @@
       "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.42.1.tgz",
+      "integrity": "sha512-cZojBmvf92gZAn0MGf/J2S+3t2sZqb9E2/6mjY4jJsImwz7PuYqdNj870Wx2iwwlf++wfhRuH4K4bpDy9GIoCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.395.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.395.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.395.0.tgz",
+      "integrity": "sha512-Ty0gbVc6d9ku9H3caF54PmEfu4PHUGpJKTriMyDb4rjCTsEYOOjD4r6Fw/UMYSSWg8Ls3KnCtTow8LL6ciqNDg==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
@@ -9549,6 +9565,26 @@
         "url": "https://github.com/sponsors/porsager"
       }
     },
+    "node_modules/posthog-node": {
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.44.0.tgz",
+      "integrity": "sha512-dTKnUffCFfA4lSD8dD7sQ7SnGb0g8S42jEbhyGJxNim6SPHd95OBvhWSf9uDc/1X26XLZRGEln01IRPjLey+yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.42.1"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11746,7 +11782,7 @@
     },
     "packages/client": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.15.13",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "metagraphed-contract": "*",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "graphql": "^17.0.2",
     "graphql-ws": "^6.1.0",
     "postgres": "^3.4.9",
+    "posthog-node": "^5.44.0",
     "workers-og": "^0.0.27"
   },
   "devDependencies": {

--- a/src/usage-telemetry.mjs
+++ b/src/usage-telemetry.mjs
@@ -1,0 +1,165 @@
+// Typed PostHog usage-event wrapper for the Worker backend (#6030 / #366).
+//
+// Single chokepoint for product-usage capture: callers pass an allowlisted
+// UsageEvent; this module owns the PostHog event name/properties and the
+// Workers-safe client lifecycle (flushAt:1, captureImmediate, shutdown).
+// Nothing outside this file should construct a raw PostHog event.
+//
+// Safe no-op when POSTHOG_PROJECT_TOKEN is unset — self-hosters / local / CI
+// see zero behavior change. Never throws. Not wired into request or MCP
+// dispatch yet (#6031 / #6032 are the callers).
+
+import { PostHog } from "posthog-node";
+
+/** Env var holding the PostHog project API token (wrangler secret). */
+export const POSTHOG_PROJECT_TOKEN_ENV = "POSTHOG_PROJECT_TOKEN";
+
+/** Optional PostHog host override (defaults to PostHog US cloud). */
+export const POSTHOG_HOST_ENV = "POSTHOG_HOST";
+
+const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+
+/** Stable distinct_id for anonymous Worker-side product events. */
+export const USAGE_EVENT_DISTINCT_ID = "metagraphed-worker";
+
+/** PostHog event name owned by this wrapper — do not emit it elsewhere. */
+export const USAGE_EVENT_NAME = "usage_event";
+
+// Cap free-form string fields so a buggy caller can't ship unbounded payloads.
+const MAX_LABEL_CHARS = 256;
+
+/**
+ * @typedef {object} UsageEvent
+ * @property {string} [route] REST/GraphQL route path (no query string / bodies).
+ * @property {string} [mcpTool] MCP tool name (no arguments / response content).
+ * @property {boolean} ok Whether the request/tool call succeeded.
+ * @property {number} durationMs Wall-clock duration in milliseconds (>= 0).
+ */
+
+/**
+ * @typedef {object} RecordUsageEventDeps
+ * @property {typeof PostHog} [PostHog] Injectable client class (tests).
+ * @property {string} [distinctId] Override distinct_id (tests).
+ */
+
+/**
+ * True when this deployment has a non-empty PostHog project token configured.
+ * @param {object | null | undefined} env
+ * @returns {boolean}
+ */
+export function isUsageTelemetryConfigured(env) {
+  const token = env?.[POSTHOG_PROJECT_TOKEN_ENV];
+  return typeof token === "string" && token.trim().length > 0;
+}
+
+/**
+ * Build the allowlisted PostHog properties object, or null when the event is
+ * too malformed to record (missing ok / non-finite duration).
+ * @param {UsageEvent | null | undefined} event
+ * @returns {Record<string, string | number | boolean> | null}
+ */
+export function usageEventProperties(event) {
+  if (!event || typeof event !== "object") return null;
+  if (typeof event.ok !== "boolean") return null;
+  if (
+    typeof event.durationMs !== "number" ||
+    !Number.isFinite(event.durationMs) ||
+    event.durationMs < 0
+  ) {
+    return null;
+  }
+
+  /** @type {Record<string, string | number | boolean>} */
+  const properties = {
+    ok: event.ok,
+    // Coarse integer ms — drop sub-ms noise; clamp absurd values at 24h.
+    duration_ms: Math.min(Math.round(event.durationMs), 86_400_000),
+  };
+
+  const route = sanitizeLabel(event.route);
+  if (route !== undefined) properties.route = route;
+
+  const mcpTool = sanitizeLabel(event.mcpTool);
+  if (mcpTool !== undefined) properties.mcp_tool = mcpTool;
+
+  return properties;
+}
+
+/**
+ * Record one product-usage event. Resolves without throwing; returns whether
+ * an event was handed to PostHog. Callers that need Workers flush semantics
+ * should schedule the returned promise via `ctx.waitUntil(...)`.
+ *
+ * @param {object | null | undefined} env Worker env (reads POSTHOG_* vars).
+ * @param {UsageEvent} event Allowlisted usage fields only.
+ * @param {RecordUsageEventDeps} [deps]
+ * @returns {Promise<boolean>}
+ */
+export async function recordUsageEvent(env, event, deps = {}) {
+  try {
+    if (!isUsageTelemetryConfigured(env)) return false;
+
+    const properties = usageEventProperties(event);
+    if (!properties) return false;
+
+    const Client = postHogClientClass(deps);
+    const token = String(env[POSTHOG_PROJECT_TOKEN_ENV]).trim();
+    const host = resolvePostHogHost(env);
+
+    const client = new Client(token, {
+      host,
+      // Workers isolates can freeze the moment the response returns — never
+      // batch; flush each capture immediately (PostHog Workers docs).
+      flushAt: 1,
+      flushInterval: 0,
+    });
+
+    try {
+      await client.captureImmediate({
+        distinctId: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
+        event: USAGE_EVENT_NAME,
+        properties,
+      });
+    } finally {
+      // Always drain pending work so a capture isn't stranded on isolate exit.
+      await client.shutdown().catch(() => {});
+    }
+    return true;
+  } catch {
+    // Telemetry must never surface into the request/tool path.
+    return false;
+  }
+}
+
+/**
+ * PostHog client class — injectable for tests, defaults to posthog-node.
+ * @param {RecordUsageEventDeps} [deps]
+ * @returns {typeof PostHog}
+ */
+export function postHogClientClass(deps = {}) {
+  return deps.PostHog ?? PostHog;
+}
+
+/**
+ * @param {object | null | undefined} env
+ * @returns {string}
+ */
+export function resolvePostHogHost(env) {
+  return typeof env?.[POSTHOG_HOST_ENV] === "string" &&
+    env[POSTHOG_HOST_ENV].trim()
+    ? env[POSTHOG_HOST_ENV].trim()
+    : DEFAULT_POSTHOG_HOST;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string | undefined}
+ */
+function sanitizeLabel(value) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > MAX_LABEL_CHARS
+    ? trimmed.slice(0, MAX_LABEL_CHARS)
+    : trimmed;
+}

--- a/tests/usage-telemetry.test.mjs
+++ b/tests/usage-telemetry.test.mjs
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { PostHog } from "posthog-node";
+import {
+  POSTHOG_HOST_ENV,
+  POSTHOG_PROJECT_TOKEN_ENV,
+  USAGE_EVENT_DISTINCT_ID,
+  USAGE_EVENT_NAME,
+  isUsageTelemetryConfigured,
+  postHogClientClass,
+  recordUsageEvent,
+  resolvePostHogHost,
+  usageEventProperties,
+} from "../src/usage-telemetry.mjs";
+
+function fakePostHog({
+  onConstruct,
+  onCapture,
+  onShutdown,
+  captureThrows = false,
+  shutdownThrows = false,
+} = {}) {
+  return class FakePostHog {
+    constructor(token, options) {
+      onConstruct?.(token, options);
+      this.token = token;
+      this.options = options;
+    }
+    async captureImmediate(payload) {
+      if (captureThrows) throw new Error("capture failed");
+      onCapture?.(payload);
+    }
+    async shutdown() {
+      if (shutdownThrows) throw new Error("shutdown failed");
+      onShutdown?.();
+    }
+  };
+}
+
+describe("isUsageTelemetryConfigured", () => {
+  test("false when env is missing / token empty / whitespace", () => {
+    assert.equal(isUsageTelemetryConfigured(undefined), false);
+    assert.equal(isUsageTelemetryConfigured({}), false);
+    assert.equal(
+      isUsageTelemetryConfigured({ [POSTHOG_PROJECT_TOKEN_ENV]: "" }),
+      false,
+    );
+    assert.equal(
+      isUsageTelemetryConfigured({ [POSTHOG_PROJECT_TOKEN_ENV]: "   " }),
+      false,
+    );
+    assert.equal(
+      isUsageTelemetryConfigured({ [POSTHOG_PROJECT_TOKEN_ENV]: 123 }),
+      false,
+    );
+  });
+
+  test("true when a non-empty token string is set", () => {
+    assert.equal(
+      isUsageTelemetryConfigured({
+        [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
+      }),
+      true,
+    );
+  });
+});
+
+describe("usageEventProperties", () => {
+  test("returns null for missing ok or non-finite / negative duration", () => {
+    assert.equal(usageEventProperties(null), null);
+    assert.equal(usageEventProperties({ durationMs: 10 }), null);
+    assert.equal(usageEventProperties({ ok: true }), null);
+    assert.equal(
+      usageEventProperties({ ok: true, durationMs: Number.NaN }),
+      null,
+    );
+    assert.equal(usageEventProperties({ ok: true, durationMs: -1 }), null);
+    assert.equal(usageEventProperties({ ok: "yes", durationMs: 10 }), null);
+  });
+
+  test("allowlists only route / mcp_tool / ok / duration_ms", () => {
+    assert.deepEqual(
+      usageEventProperties({
+        route: " /api/v1/subnets ",
+        mcpTool: " get_subnet ",
+        ok: true,
+        durationMs: 12.6,
+        args: { secret: "nope" },
+        wallet: "5Fake",
+      }),
+      {
+        route: "/api/v1/subnets",
+        mcp_tool: "get_subnet",
+        ok: true,
+        duration_ms: 13,
+      },
+    );
+  });
+
+  test("omits blank optional labels and truncates overlong ones", () => {
+    const long = "x".repeat(300);
+    assert.deepEqual(
+      usageEventProperties({
+        route: "   ",
+        mcpTool: long,
+        ok: false,
+        durationMs: 0,
+      }),
+      {
+        mcp_tool: "x".repeat(256),
+        ok: false,
+        duration_ms: 0,
+      },
+    );
+  });
+
+  test("clamps absurd durations at 24h", () => {
+    assert.equal(
+      usageEventProperties({ ok: true, durationMs: 999_999_999 }).duration_ms,
+      86_400_000,
+    );
+  });
+});
+
+describe("postHogClientClass / resolvePostHogHost", () => {
+  test("defaults to posthog-node's PostHog export", () => {
+    assert.equal(postHogClientClass(), PostHog);
+    assert.equal(postHogClientClass({}), PostHog);
+  });
+
+  test("honors an injected PostHog class", () => {
+    class Injected {}
+    assert.equal(postHogClientClass({ PostHog: Injected }), Injected);
+  });
+
+  test("resolvePostHogHost trims a custom host or falls back to US cloud", () => {
+    assert.equal(resolvePostHogHost(undefined), "https://us.i.posthog.com");
+    assert.equal(
+      resolvePostHogHost({ [POSTHOG_HOST_ENV]: "  https://eu.i.posthog.com " }),
+      "https://eu.i.posthog.com",
+    );
+    assert.equal(
+      resolvePostHogHost({ [POSTHOG_HOST_ENV]: "   " }),
+      "https://us.i.posthog.com",
+    );
+  });
+});
+
+describe("recordUsageEvent — unconfigured (safe no-op)", () => {
+  test("returns false and never constructs a PostHog client", async () => {
+    let constructed = 0;
+    const recorded = await recordUsageEvent(
+      {},
+      { route: "/api/v1/health", ok: true, durationMs: 5 },
+      {
+        PostHog: fakePostHog({
+          onConstruct: () => {
+            constructed += 1;
+          },
+        }),
+      },
+    );
+    assert.equal(recorded, false);
+    assert.equal(constructed, 0);
+  });
+
+  test("never throws when env is null", async () => {
+    await assert.doesNotReject(() =>
+      recordUsageEvent(null, { ok: true, durationMs: 1 }),
+    );
+  });
+});
+
+describe("recordUsageEvent — configured", () => {
+  test("captures an allowlisted usage_event via captureImmediate + shutdown", async () => {
+    const constructs = [];
+    const captures = [];
+    let shutdowns = 0;
+    const env = {
+      [POSTHOG_PROJECT_TOKEN_ENV]: " phc_token ",
+      [POSTHOG_HOST_ENV]: "https://eu.i.posthog.com",
+    };
+
+    const recorded = await recordUsageEvent(
+      env,
+      {
+        route: "/api/v1/subnets/1",
+        mcpTool: "get_subnet",
+        ok: true,
+        durationMs: 42,
+      },
+      {
+        PostHog: fakePostHog({
+          onConstruct: (token, options) => constructs.push({ token, options }),
+          onCapture: (payload) => captures.push(payload),
+          onShutdown: () => {
+            shutdowns += 1;
+          },
+        }),
+      },
+    );
+
+    assert.equal(recorded, true);
+    assert.equal(constructs.length, 1);
+    assert.equal(constructs[0].token, "phc_token");
+    assert.equal(constructs[0].options.host, "https://eu.i.posthog.com");
+    assert.equal(constructs[0].options.flushAt, 1);
+    assert.equal(constructs[0].options.flushInterval, 0);
+    assert.deepEqual(captures, [
+      {
+        distinctId: USAGE_EVENT_DISTINCT_ID,
+        event: USAGE_EVENT_NAME,
+        properties: {
+          route: "/api/v1/subnets/1",
+          mcp_tool: "get_subnet",
+          ok: true,
+          duration_ms: 42,
+        },
+      },
+    ]);
+    assert.equal(shutdowns, 1);
+  });
+
+  test("defaults host to PostHog US cloud when POSTHOG_HOST is unset", async () => {
+    const constructs = [];
+    await recordUsageEvent(
+      { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
+      { ok: false, durationMs: 1 },
+      {
+        PostHog: fakePostHog({
+          onConstruct: (_token, options) => constructs.push(options),
+        }),
+      },
+    );
+    assert.equal(constructs[0].host, "https://us.i.posthog.com");
+  });
+
+  test("returns false for an invalid event without capturing", async () => {
+    let captures = 0;
+    const recorded = await recordUsageEvent(
+      { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
+      { ok: true, durationMs: -5 },
+      {
+        PostHog: fakePostHog({
+          onCapture: () => {
+            captures += 1;
+          },
+        }),
+      },
+    );
+    assert.equal(recorded, false);
+    assert.equal(captures, 0);
+  });
+
+  test("swallows capture errors and still attempts shutdown", async () => {
+    let shutdowns = 0;
+    const recorded = await recordUsageEvent(
+      { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
+      { ok: true, durationMs: 3 },
+      {
+        PostHog: fakePostHog({
+          captureThrows: true,
+          onShutdown: () => {
+            shutdowns += 1;
+          },
+        }),
+      },
+    );
+    assert.equal(recorded, false);
+    assert.equal(shutdowns, 1);
+  });
+
+  test("swallows shutdown errors after a successful capture", async () => {
+    const recorded = await recordUsageEvent(
+      { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
+      { mcpTool: "list_tools", ok: true, durationMs: 9 },
+      {
+        PostHog: fakePostHog({ shutdownThrows: true }),
+      },
+    );
+    assert.equal(recorded, true);
+  });
+
+  test("never throws when the PostHog constructor itself throws", async () => {
+    class Boom {
+      constructor() {
+        throw new Error("construct failed");
+      }
+    }
+    await assert.doesNotReject(async () => {
+      const recorded = await recordUsageEvent(
+        { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
+        { ok: true, durationMs: 1 },
+        { PostHog: Boom },
+      );
+      assert.equal(recorded, false);
+    });
+  });
+
+  test("honors an injected distinctId override", async () => {
+    const captures = [];
+    await recordUsageEvent(
+      { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
+      { ok: true, durationMs: 2 },
+      {
+        distinctId: "test-distinct",
+        PostHog: fakePostHog({
+          onCapture: (payload) => captures.push(payload),
+        }),
+      },
+    );
+    assert.equal(captures[0].distinctId, "test-distinct");
+  });
+});


### PR DESCRIPTION
## Summary

- Add a typed PostHog usage-telemetry wrapper (`recordUsageEvent`) for the Worker backend, using `posthog-node`'s workerd-compatible export.
- Safe no-op when `POSTHOG_PROJECT_TOKEN` is unset; never throws. Allowlisted fields only (`route`, `mcp_tool`, `ok`, `duration_ms`) — no args, wallets, or response content.
- Not wired into REST/MCP dispatch yet (#6031 / #6032 are the callers).

Closes #6030

## What Changed

- **Dependency**: `posthog-node@^5.44.0` (Workers `workerd`/`edge` export; flush-immediate client options per PostHog Workers docs).
- **Wrapper** (`src/usage-telemetry.mjs`): `recordUsageEvent(env, event)`, `isUsageTelemetryConfigured`, allowlist helpers; Workers-safe `flushAt: 1` / `flushInterval: 0` / `captureImmediate` / `shutdown`.
- **Tests** (`tests/usage-telemetry.test.mjs`): configured + unconfigured paths, invalid events, capture/shutdown/constructor failures, host/distinctId overrides — 100% statements/branches on the new module.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6030`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A — no OpenAPI/schema regen.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No public API change; wrapper only.)

## Validation

- [x] `npx vitest run tests/usage-telemetry.test.mjs --coverage --coverage.include='src/usage-telemetry.mjs'` (18 passed; 100% stmts/branches/funcs/lines)
- [x] `npx prettier --check src/usage-telemetry.mjs tests/usage-telemetry.test.mjs`
- [x] `npx eslint src/usage-telemetry.mjs tests/usage-telemetry.test.mjs`
- [x] `git diff --check`
- [ ] `npm run lint`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:upvote`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`
- [ ] `npm run worker:bundle:budget` (module not imported from Worker entry yet — bundle size unchanged)

## Template Used

backend-code
