### PR TITLE
feat(registry): SN38 ChronoLLM accuracy pass

### DIFF
--- a/registry/providers/tao-colosseum.json
+++ b/registry/providers/tao-colosseum.json
@@ -1,10 +1,10 @@
 {
   "authority": "official",
-  "github_url": "https://github.com/TAO-Colosseum/tao-colosseum-subnet",
+  "github_url": "https://github.com/chronollm/sn38",
   "id": "tao-colosseum",
   "kind": "subnet-team",
-  "name": "TAO Colosseum",
-  "notes": "Provider entry for TAO Colosseum SN38. The source repository is live, while the previously discovered website currently redirects to a parked-domain sale page and is not promoted.",
+  "name": "ChronoLLM",
+  "notes": "Provider entry for SN38, on-chain re-registered from \"TAO Colosseum\" to \"ChronoLLM\" (native_name and description confirmed on-chain; the internal id \"tao-colosseum\" is kept stable as the existing key referenced by this subnet's surfaces). The current source repository is chronollm/sn38; the website is chronollm.com (the operator's chronollm.crunchdao.com domain now permanently redirects there).",
   "schema_version": 1,
-  "website_url": "https://github.com/TAO-Colosseum/tao-colosseum-subnet"
+  "website_url": "https://chronollm.com/"
 }

--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -538,6 +538,19 @@
       "notes": "First maintainer review for this subnet (previously candidate-discovered/unreviewed, categories empty, no source-repo surface despite source_repo already being set). Added the missing source-repo surface; the registered website (aureliusaligned.ai) is currently unreachable (DNS resolves, connection times out on both ports 80/443) so no website surface is promoted. Diffed the full Aurelius Central API OpenAPI schema (58 paths): the work-token/admin, config, submissions, benchmark, novelty, classifier, stats, reports, and admin/api prefixes all live-tested as 401-gated despite the schema declaring no security scheme for several of them. Found and added one new genuine no-auth public endpoint, GET /work-token/deposit-address/verify."
     },
     {
+      "netuid": 38,
+      "slug": "sn-38",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-07-16T01:20:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://chronollm.com/",
+        "https://github.com/chronollm/sn38",
+        "https://github.com/chronollm/sn38/blob/main/README.md"
+      ],
+      "notes": "First maintainer review for this subnet (previously community-seeded/unreviewed, categories empty, no website/source-repo surfaces despite website_url/source_repo already being set). Added the missing website and source-repo surfaces; the registered website_url (chronollm.crunchdao.com) permanently redirects (301) to the operator's new canonical domain chronollm.com, tracked there instead. Added the validator docs and ChronoGPT arXiv paper from the README's \"Getting started\" table. Confirmed via the README that the evaluation backend is intentionally private (TEE-protected), so no public API surface is expected."
+    },
+    {
       "netuid": 39,
       "slug": "sn-39",
       "decision": "maintainer-reviewed",

--- a/registry/subnets/chronollm.json
+++ b/registry/subnets/chronollm.json
@@ -1,15 +1,103 @@
 {
-  "categories": [],
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "language-models",
+    "official-docs",
+    "official-source-repo",
+    "official-website"
+  ],
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "gap_notes": [
+      "The evaluation backend is explicitly private (TEE-protected per the official README) by design, so no public subnet-api/OpenAPI/SSE surface is expected or promoted.",
+      "The registered website_url (chronollm.crunchdao.com) permanently redirects (301) to the operator's own dedicated domain chronollm.com; tracked at the new canonical URL."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-07-16T01:20:00.000Z",
+    "source_count": 8,
+    "verified_at": "2026-07-16T01:20:00.000Z"
   },
+  "docs_url": "https://github.com/chronollm/sn38/blob/main/docs/miner.md",
   "name": "ChronoLLM",
   "netuid": 38,
+  "notes": "First maintainer-reviewed pass for SN38 (previously community-seeded/unreviewed, categories empty, no website/source-repo surfaces despite website_url/source_repo already being set). Added the missing website and source-repo surfaces (website tracked at chronollm.com, the operator's new canonical domain -- chronollm.crunchdao.com now permanently redirects there). Fixed all 4 pre-existing surfaces having no probe config at all -- the registry-wide gap tracked in #5932. Added 2 new official surfaces found in the README's \"Getting started\" table: the validator docs page (sibling to the already-tracked miner docs) and the ChronoGPT arXiv paper. Confirmed via the README that the evaluation backend is intentionally private (TEE-protected), so no public API surface is expected.",
   "schema_version": 1,
   "slug": "sn-38",
   "status": "active",
   "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-38-chronollm-website",
+      "kind": "website",
+      "name": "ChronoLLM website",
+      "notes": "Official ChronoLLM website, at the operator's current canonical domain (chronollm.crunchdao.com permanently redirects here).",
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "html",
+        "timeout_ms": 10000
+      },
+      "provider": "tao-colosseum",
+      "public_safe": true,
+      "source_urls": ["https://github.com/chronollm/sn38"],
+      "url": "https://chronollm.com/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-38-chronollm-source-repo",
+      "kind": "source-repo",
+      "name": "ChronoLLM source repository",
+      "notes": "Official ChronoLLM (SN38) source repository.",
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "provider": "tao-colosseum",
+      "public_safe": true,
+      "source_urls": ["https://chronollm.com/"],
+      "url": "https://github.com/chronollm/sn38"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-38-chronollm-validator-docs",
+      "kind": "docs",
+      "name": "ChronoLLM validator docs",
+      "notes": "Public validator guide linked from the official ChronoLLM README's \"Getting started\" table, alongside the already-tracked miner docs.",
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "html",
+        "timeout_ms": 10000
+      },
+      "provider": "tao-colosseum",
+      "public_safe": true,
+      "source_urls": ["https://github.com/chronollm/sn38/blob/main/README.md"],
+      "url": "https://github.com/chronollm/sn38/blob/main/docs/validator.md"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-38-chronollm-arxiv-paper",
+      "kind": "docs",
+      "name": "ChronoGPT arXiv paper",
+      "notes": "ChronoGPT architecture paper (arXiv:2510.11677), linked as \"ChronoGPT paper\" from the official ChronoLLM README's \"Getting started\" table.",
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "html",
+        "timeout_ms": 10000
+      },
+      "provider": "tao-colosseum",
+      "public_safe": true,
+      "source_urls": ["https://github.com/chronollm/sn38/blob/main/README.md"],
+      "url": "https://arxiv.org/abs/2510.11677"
+    },
     {
       "auth_required": false,
       "authority": "community",
@@ -17,6 +105,12 @@
       "kind": "docs",
       "name": "ChronoLLM miner docs",
       "notes": "Public miner guide linked from the official ChronoLLM README.",
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "html",
+        "timeout_ms": 10000
+      },
       "provider": "tao-colosseum",
       "public_safe": true,
       "review": {
@@ -33,6 +127,12 @@
       "kind": "data-artifact",
       "name": "ChronoGPT models (HuggingFace)",
       "notes": "Official ChronoGPT collection on HuggingFace (per-year chrono-gpt-v1 models), listed as \"ChronoGPT models\" in the official ChronoLLM README.",
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
       "provider": "tao-colosseum",
       "public_safe": true,
       "review": {
@@ -49,6 +149,12 @@
       "kind": "data-artifact",
       "name": "ChronoInstruct SFT dataset",
       "notes": "Public ManelaLab (WashU) HuggingFace ChronoInstruct-SFT dataset — 647,944 chronologically-consistent instruction-response pairs (conversation/label/source columns; label marks pre-2000 vs post-1999) built to remove lookahead bias, the SFT corpus for the ChronoGPT architecture the ChronoLLM (SN38) subnet mandates; ODC-BY-1.0, not gated. The chronollm/sn38 repo README (source) declares Subnet 38 and links the manelalab HF org (already the subnet's registered ChronoGPT model-collection org).",
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "html",
+        "timeout_ms": 10000
+      },
       "provider": "tao-colosseum",
       "public_safe": true,
       "review": {
@@ -68,6 +174,12 @@
       "kind": "data-artifact",
       "name": "SN38 on-chain subnet snapshot",
       "notes": "Public no-auth GET /public/v1/subnets/38 on api.taomarketcap.com returning a machine-readable JSON snapshot of SN38 ChronoLLM on-chain subnet state (owner, emission, registration/burn parameters, and dTAO market fields) for netuid 38. This is the indexed public JSON feed for netuid 38 documented in the TaoMarketCap developer API.",
+      "probe": {
+        "enabled": true,
+        "method": "GET",
+        "expect": "json",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -83,7 +195,7 @@
   ],
   "source_repo": "https://github.com/chronollm/sn38",
   "contact": "crew@crunchdao.com",
-  "website_url": "https://chronollm.crunchdao.com/",
+  "website_url": "https://chronollm.com/",
   "social": {
     "x": "https://x.com/chronollm"
   }


### PR DESCRIPTION
## Summary
First maintainer-reviewed pass for SN38 ChronoLLM (previously community-seeded/unreviewed, categories empty, no website/source-repo surfaces despite \`website_url\`/\`source_repo\` already being set) — part of the root->128 accuracy audit tracked in #5903.

- Added the missing website and source-repo surfaces. The registered \`website_url\` (chronollm.crunchdao.com) permanently redirects (301) to the operator's new canonical domain chronollm.com; tracked there instead, and \`website_url\` updated to match.
- Fixed all 4 pre-existing surfaces having no probe config at all — the registry-wide gap tracked in #5932.
- Added 2 new official surfaces from the README's "Getting started" table: the validator docs page (sibling to the already-tracked miner docs) and the ChronoGPT arXiv paper.
- Confirmed via the README that the evaluation backend is intentionally private (TEE-protected), so no public API surface is expected.
- Fixed the \`tao-colosseum\` provider record (\`registry/providers/\`), which still described the subnet's pre-rename identity (name "TAO Colosseum", a stale \`github_url\`) despite the on-chain re-registration to ChronoLLM already reflected everywhere else in the registry — kept the internal id stable, updated the descriptive fields.
- Added the backing decision to \`registry/reviews/maintainer-reviewed.json\` (required for the \`maintainer-reviewed\` promotion; same pattern as #5952/#5955/#6028/#6041/#6066/#6067/#6070).
- Does not touch \`public/metagraph/operational-surfaces.json\` (owned by a separate automation).

## Test plan
- [x] \`npm run build\`
- [x] \`npm run validate\` — 129 subnets, 1695 surfaces
- [x] \`npm run validate:surface\`
- [x] \`npm run curation:stale-notes\`
- [x] \`node scripts/scan-public-safety.mjs\`
- [x] \`npx prettier --check\`