### PR TITLE
fix(python-sdk): drop None elements in list-valued query params

### DIFF
--- a/python/src/metagraphed/aio.py
+++ b/python/src/metagraphed/aio.py
@@ -27,6 +27,7 @@ from .client import (
     _interpolate,
     _jsonrpc_result,
     _next_cursor,
+    _query_pairs,
     _url_origin,
 )
 from .models import AgentCatalogSubnet, Endpoint, Provider, Subnet, Surface
@@ -199,11 +200,10 @@ class AsyncMetagraphedClient:
         numeric ``Retry-After`` capped at 60 seconds.
         """
         url = self.base_url.rstrip("/") + _interpolate(path, path_params)
-        params = (
-            {key: value for key, value in query.items() if value is not None}
-            if query
-            else None
-        )
+        # Same normalization as the sync client (`_query_pairs`): drop top-level
+        # and in-list ``None``, coerce bools — so both clients emit identical
+        # query strings for the same input.
+        params = dict(_query_pairs(query)) if query else None
         merged_headers = _default_headers(headers)
         return await self._send_json(
             lambda: self._client.get(url, params=params, headers=merged_headers),

--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -183,13 +183,16 @@ def _jsonrpc_result(parsed: Any, method: str) -> Any:
 def _query_pairs(query: Mapping[str, Any]) -> List[Tuple[str, Any]]:
     """Normalize a query mapping into ``urlencode``-ready ``(key, value)`` pairs.
 
-    Drops ``None`` values and coerces Python ``bool`` to the lowercase
-    ``"true"``/``"false"`` the API expects. ``str(True)`` would otherwise send
-    ``"True"``, which the API compares ``=== "true"`` and silently ignores — so a
-    boolean filter such as ``validator_permit=True`` would be dropped and return
-    unfiltered results (diverging from both the async/httpx client and the
-    TypeScript client). Booleans nested in a sequence value — expanded by
-    ``doseq=True`` — are coerced element-wise so list-valued filters normalize too.
+    Drops ``None`` values (including ``None`` elements inside list/tuple values)
+    and coerces Python ``bool`` to the lowercase ``"true"``/``"false"`` the API
+    expects. ``str(True)`` would otherwise send ``"True"``, which the API
+    compares ``=== "true"`` and silently ignores — so a boolean filter such as
+    ``validator_permit=True`` would be dropped and return unfiltered results
+    (diverging from both the async/httpx client and the TypeScript client).
+    Booleans nested in a sequence value — expanded by ``doseq=True`` — are
+    coerced element-wise so list-valued filters normalize too. Filtering
+    ``None`` out of sequences (not stringifying them as ``"None"`` or ``""``)
+    keeps the sync and async clients on the same wire form.
     """
 
     def coerce(value: Any) -> Any:
@@ -198,7 +201,7 @@ def _query_pairs(query: Mapping[str, Any]) -> List[Tuple[str, Any]]:
         if isinstance(value, bool):
             return "true" if value else "false"
         if isinstance(value, (list, tuple)):
-            return [coerce(item) for item in value]
+            return [coerce(item) for item in value if item is not None]
         return value
 
     return [

--- a/python/tests/test_aio.py
+++ b/python/tests/test_aio.py
@@ -73,6 +73,20 @@ class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
         await client.fetch("/api/v1/subnets", query={"limit": 5, "cursor": None})
         self.assertEqual(client._client.calls[0][2], {"limit": 5})
 
+    async def test_fetch_drops_none_elements_in_list_query_values(self):
+        # None inside a list must be dropped — not left for httpx to stringify
+        # as "" — and must match the sync client's _query_pairs output.
+        from metagraphed.client import _query_pairs
+
+        query = {"kind": ["docs", None, "openapi"]}
+        client = self._client(httpx.Response(200, json={"data": []}))
+        await client.fetch("/api/v1/surfaces", query=query)
+        expected = dict(_query_pairs(query))
+        self.assertEqual(expected, {"kind": ["docs", "openapi"]})
+        self.assertEqual(client._client.calls[0][2], expected)
+        self.assertNotIn(None, client._client.calls[0][2]["kind"])
+        self.assertNotIn("", client._client.calls[0][2]["kind"])
+
     async def test_fetch_all_collects_nested_collection_following_cursor(self):
         # List endpoints nest rows under data[meta.pagination.collection].
         page1 = httpx.Response(

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -118,6 +118,31 @@ class ClientTest(unittest.TestCase):
         self.assertIn("flags=true", captured["url"])
         self.assertIn("flags=false", captured["url"])
 
+    def test_sequence_query_drops_none_elements(self):
+        # None inside a list must be dropped (not stringified as "None" or "").
+        # Regression: urlencode(doseq=True) otherwise emitted kind=None.
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            return _FakeResponse({"ok": True})
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            metagraphed_fetch(
+                "/api/v1/surfaces",
+                query={"kind": ["docs", None, "openapi"]},
+            )
+
+        self.assertIn("kind=docs", captured["url"])
+        self.assertIn("kind=openapi", captured["url"])
+        self.assertNotIn("None", captured["url"])
+        self.assertNotIn("kind=&", captured["url"])
+        self.assertFalse(captured["url"].endswith("kind="))
+        self.assertEqual(
+            client._query_pairs({"kind": ["docs", None, "openapi"]}),
+            [("kind", ["docs", "openapi"])],
+        )
+
     def test_base_url_override(self):
         captured = {}
 


### PR DESCRIPTION
## Summary
- Filter `None` out of list/tuple query-param values in `_query_pairs`, so they are not serialized as the literal `"None"` (sync/`urlencode`) or `""` (async/httpx).
- Route the async client through the same `_query_pairs` helper so sync and async emit identical query strings for the same input.

Closes #5983

## Test plan
- [x] `python -m pytest python/tests/test_client.py python/tests/test_aio.py -q`
- [x] Sync: `{"kind": ["docs", None, "openapi"]}` → `kind=docs&kind=openapi` (no `None` / empty segment)
- [x] Async: same input → params `{"kind": ["docs", "openapi"]}`, matching `_query_pairs`