### PR TITLE
feat(graphql): add Query.chain_registrations (#5876)

### DIFF
--- a/src/chain-registrations.mjs
+++ b/src/chain-registrations.mjs
@@ -14,6 +14,11 @@ export const REGISTRATION_EVENT_KIND = "NeuronRegistered";
 export const CHAIN_REGISTRATIONS_LIMIT_DEFAULT = 20;
 export const CHAIN_REGISTRATIONS_LIMIT_MAX = 100;
 
+// Analytics windows this endpoint accepts (label -> days). Kept beside the loader so the
+// schema and runtime validation cannot drift from the endpoint.
+export const CHAIN_REGISTRATIONS_WINDOWS = { "7d": 7, "30d": 30 };
+export const DEFAULT_CHAIN_REGISTRATIONS_WINDOW = "7d";
+
 // Round a registrations-per-registrant ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct registrants, with the divisor guarded below).
 function round(value, dp = 2) {

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -24,6 +24,13 @@ import {
   CHAIN_DEREGISTRATIONS_LIMIT_MAX,
 } from "./chain-deregistrations.mjs";
 import {
+  loadChainRegistrations,
+  CHAIN_REGISTRATIONS_WINDOWS,
+  DEFAULT_CHAIN_REGISTRATIONS_WINDOW,
+  CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
+  CHAIN_REGISTRATIONS_LIMIT_MAX,
+} from "./chain-registrations.mjs";
+import {
   loadChainPrometheus,
   CHAIN_PROMETHEUS_WINDOWS,
   DEFAULT_CHAIN_PROMETHEUS_WINDOW,
@@ -424,6 +431,8 @@ export const SDL = `
     chain_prometheus(window: String, limit: Int): ChainPrometheus!
     "Network-wide neuron-deregistration leaderboard over a 7d/30d window (default 7d): subnets ranked by NeuronDeregistered events with each's distinct-hotkey count and deregistrations-per-hotkey churn intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The network-wide, exit-side counterpart of subnet_deregistrations -- where neurons are being pushed out. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/deregistrations."
     chain_deregistrations(window: String, limit: Int): ChainDeregistrations!
+    "Network-wide neuron-registration leaderboard over a 7d/30d window (default 7d): subnets ranked by NeuronRegistered events with each's distinct-hotkey count and registrations-per-registrant re-registration intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The network-wide, entry-side counterpart of subnet_registrations -- where neurons are joining. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/registrations."
+    chain_registrations(window: String, limit: Int): ChainRegistrations!
     "Per-UTC-day network fee/tip series over a 7d/30d window (default 7d): each day's extrinsic count and total/avg/median fee + tip in TAO, plus the top fee-paying signers (limit default 25, max 100), optionally scoped to a single call_module. Computed live from the extrinsics tier; a cold store yields a schema-stable empty series, never a GraphQL error. Mirrors GET /api/v1/chain/fees."
     chain_fees(window: String, limit: Int, call_module: String): ChainFees!
     "Network-wide axon-removal (teardown) leaderboard over a 7d/30d window (default 7d): subnets ranked by AxonInfoRemoved events with each's distinct-remover count and removals-per-remover teardown intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The teardown counterpart of chain_serving's announcements -- where neurons are tearing endpoints down. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/axon-removals."
@@ -837,6 +846,44 @@ export const SDL = `
     distinct_removers: Int!
     removals: Int!
     removals_per_remover: Float
+  }
+
+  type ChainRegistrations {
+    schema_version: Int!
+    window: String
+    observed_at: String
+    subnet_count: Int!
+    network: ChainRegistrationsNetwork!
+    intensity_distribution: ChainRegistrationsIntensityDistribution
+    subnets: [ChainRegistrationsSubnet!]!
+  }
+
+  "Network-wide registration rollup: every subnet with NeuronRegistered events in the window, combined. distinct_registrants counts a hotkey once even when it registers on several subnets, so it is NOT the sum of the per-subnet counts."
+  type ChainRegistrationsNetwork {
+    distinct_registrants: Int!
+    registrations: Int!
+    "Null when distinct_registrants is 0 (no defined intensity without hotkeys)."
+    registrations_per_registrant: Float
+  }
+
+  "Spread of per-subnet registration intensity (NeuronRegistered events per hotkey) across EVERY subnet with registrations in the window -- network-wide even when limit truncates the leaderboard."
+  type ChainRegistrationsIntensityDistribution {
+    count: Int!
+    mean: Float!
+    min: Float!
+    p25: Float!
+    median: Float!
+    p75: Float!
+    p90: Float!
+    max: Float!
+  }
+
+  "One subnet's neuron-registration activity in the window, ranked by registrations."
+  type ChainRegistrationsSubnet {
+    netuid: Int!
+    distinct_registrants: Int!
+    registrations: Int!
+    registrations_per_registrant: Float
   }
 
   type ChainDeregistrations {
@@ -2749,6 +2796,7 @@ export const FIELD_COMPLEXITY = {
   chain_serving: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_prometheus: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_deregistrations: RELATIONSHIP_FIELD_COMPLEXITY,
+  chain_registrations: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   chain_signers: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5874,6 +5922,50 @@ const rootValue = {
         distinct_deregistered_hotkeys: 0,
         deregistrations: 0,
         deregistrations_per_hotkey: null,
+      },
+      intensity_distribution: data.intensity_distribution ?? null,
+      subnets: data.subnets || [],
+    };
+  },
+
+  async chain_registrations({ window, limit }, context) {
+    const requestedWindow = window ?? DEFAULT_CHAIN_REGISTRATIONS_WINDOW;
+    if (!Object.hasOwn(CHAIN_REGISTRATIONS_WINDOWS, requestedWindow)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(requestedWindow, CHAIN_REGISTRATIONS_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const safeLimit = clampLimit(limit, {
+      defaultLimit: CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
+      maxLimit: CHAIN_REGISTRATIONS_LIMIT_MAX,
+    });
+    const params = new URLSearchParams();
+    params.set("window", requestedWindow);
+    params.set("limit", String(safeLimit));
+    // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> loadChainRegistrations
+    // fallback contract REST's handleChainRegistrations uses -- a cold store yields a
+    // schema-stable zeroed card, never a GraphQL error.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, "/api/v1/chain/registrations", params),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      (await loadChainRegistrations(graphqlD1(context), {
+        windowLabel: requestedWindow,
+        windowDays: CHAIN_REGISTRATIONS_WINDOWS[requestedWindow],
+        limit: safeLimit,
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      window: data.window ?? requestedWindow,
+      observed_at: data.observed_at ?? null,
+      subnet_count: data.subnet_count ?? 0,
+      network: data.network ?? {
+        distinct_registrants: 0,
+        registrations: 0,
+        registrations_per_registrant: null,
       },
       intensity_distribution: data.intensity_distribution ?? null,
       subnets: data.subnets || [],

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -25,6 +25,7 @@ import { LEADERBOARD_BOARDS } from "../src/health-serving.mjs";
 import { CHAIN_PROMETHEUS_WINDOWS } from "../src/chain-prometheus.mjs";
 import { CHAIN_SIGNERS_SORTS } from "../src/chain-query-loaders.mjs";
 import { CHAIN_DEREGISTRATIONS_WINDOWS } from "../src/chain-deregistrations.mjs";
+import { CHAIN_REGISTRATIONS_WINDOWS } from "../src/chain-registrations.mjs";
 import { CHAIN_AXON_REMOVALS_WINDOWS } from "../src/chain-axon-removals.mjs";
 import { handleRequest } from "../workers/api.mjs";
 import { resolveClientIp } from "../workers/config.mjs";
@@ -12657,6 +12658,228 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
   test("is priced at the relationship-field complexity weight", () => {
     assert.equal(
       FIELD_COMPLEXITY.chain_axon_removals,
+      FIELD_COMPLEXITY.chain_serving,
+    );
+  });
+});
+
+describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallback)", () => {
+  function regQuery(argsClause) {
+    return `{ chain_registrations${argsClause} {
+      schema_version window observed_at subnet_count
+      network { distinct_registrants registrations registrations_per_registrant }
+      intensity_distribution { count mean min p25 median p75 p90 max }
+      subnets { netuid distinct_registrants registrations registrations_per_registrant }
+    } }`;
+  }
+
+  // loadChainRegistrations issues the network aggregate (COUNT DISTINCT hotkey
+  // / MAX(observed_at), no GROUP BY) and only then the GROUP BY netuid
+  // leaderboard, and only when newest_observed is non-null.
+  function chainRegD1({ network, subnets = [] } = {}) {
+    return {
+      prepare(sql) {
+        return {
+          bind() {
+            return {
+              async all() {
+                if (sql.includes("GROUP BY netuid")) {
+                  return { results: subnets };
+                }
+                return { results: network ? [network] : [] };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  test("cold store, default args: schema-stable empty leaderboard, never an error", async () => {
+    const { status, body } = await gql(regQuery(""));
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_registrations, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_registrants: 0,
+        registrations: 0,
+        registrations_per_registrant: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("resolves the D1-live tier: per-subnet leaderboard + network rollup", async () => {
+    const env = {
+      METAGRAPH_HEALTH_DB: chainRegD1({
+        network: {
+          distinct_registrants: 3,
+          newest_observed: 1780000000000,
+        },
+        subnets: [
+          { netuid: 1, registrations: 9, distinct_registrants: 3 },
+          { netuid: 7, registrations: 3, distinct_registrants: 1 },
+        ],
+      }),
+    };
+    const { status, body } = await gql(regQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const got = body.data.chain_registrations;
+    assert.equal(got.subnet_count, 2);
+    assert.equal(got.observed_at, new Date(1780000000000).toISOString());
+    // The rollup uses the true network-wide distinct count (3), not the sum of
+    // the per-subnet hotkeys (4) -- a hotkey registered on several subnets
+    // counts once.
+    assert.deepEqual(got.network, {
+      distinct_registrants: 3,
+      registrations: 12,
+      registrations_per_registrant: 4,
+    });
+    assert.deepEqual(got.subnets, [
+      {
+        netuid: 1,
+        distinct_registrants: 3,
+        registrations: 9,
+        registrations_per_registrant: 3,
+      },
+      {
+        netuid: 7,
+        distinct_registrants: 1,
+        registrations: 3,
+        registrations_per_registrant: 3,
+      },
+    ]);
+    assert.equal(got.intensity_distribution.count, 2);
+  });
+
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            window: "30d",
+            observed_at: "2026-07-01T00:00:00.000Z",
+            subnet_count: 1,
+            network: {
+              distinct_registrants: 5,
+              registrations: 20,
+              registrations_per_registrant: 4,
+            },
+            intensity_distribution: {
+              count: 1,
+              mean: 4,
+              min: 4,
+              p25: 4,
+              median: 4,
+              p75: 4,
+              p90: 4,
+              max: 4,
+            },
+            subnets: [
+              {
+                netuid: 3,
+                distinct_registrants: 5,
+                registrations: 20,
+                registrations_per_registrant: 4,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      regQuery('(window: "30d", limit: 5)'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(capturedUrl.pathname, "/api/v1/chain/registrations");
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "5");
+    assert.equal(body.data.chain_registrations.window, "30d");
+    assert.equal(body.data.chain_registrations.network.distinct_registrants, 5);
+  });
+
+  test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
+    // The tier's shape is upstream-controlled, so every field falls back rather
+    // than surfacing null through a non-null SDL field.
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(regQuery(""), env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.chain_registrations, {
+      schema_version: 1,
+      window: "7d",
+      observed_at: null,
+      subnet_count: 0,
+      network: {
+        distinct_registrants: 0,
+        registrations: 0,
+        registrations_per_registrant: null,
+      },
+      intensity_distribution: null,
+      subnets: [],
+    });
+  });
+
+  test("clamps an over-max limit to the route's own ceiling", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(regQuery("(limit: 99999)"), env);
+    assert.equal(capturedUrl.searchParams.get("limit"), "100");
+  });
+
+  test("every documented window is accepted", async () => {
+    for (const window of Object.keys(CHAIN_REGISTRATIONS_WINDOWS)) {
+      const { status, body } = await gql(regQuery(`(window: "${window}")`));
+      assert.equal(status, 200, window);
+      assert.equal(body.errors, undefined);
+      assert.equal(body.data.chain_registrations.window, window);
+    }
+  });
+
+  test("an unsupported window is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(regQuery('(window: "1y")'), env);
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("is priced at the relationship-field complexity weight", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.chain_registrations,
       FIELD_COMPLEXITY.chain_serving,
     );
   });


### PR DESCRIPTION
Closes #5876.

Adds `Query.chain_registrations`, the network-wide NeuronRegistered leaderboard, mirroring the existing `GET /api/v1/chain/registrations` route (`workers/data-api.mjs`) and the `get_chain_registrations` MCP tool. It is the entry-side counterpart of the already-merged `Query.chain_deregistrations` (#5877) and shares its exact shape and tier-proxy contract.

- **Resolver** — `tryPostgresTier("METAGRAPH_ACCOUNT_EVENTS_SOURCE") ?? loadChainRegistrations(graphqlD1, …)`, reusing the same `loadChainRegistrations`/`buildChainRegistrations` loader the REST route and MCP tool already use. No query/aggregation logic is duplicated.
- **SDL** — `ChainRegistrations` plus `ChainRegistrationsNetwork` / `ChainRegistrationsIntensityDistribution` / `ChainRegistrationsSubnet`, priced at the relationship-field complexity weight (same as `chain_deregistrations`).
- **Windows** — added `CHAIN_REGISTRATIONS_WINDOWS` / `DEFAULT_CHAIN_REGISTRATIONS_WINDOW` beside the loader (the module already exported the limit constants), matching the deregistrations module so schema and runtime validation cannot drift.
- **Tests** — 8 cases mirroring the `chain_deregistrations` suite: cold-store empty card, D1-live leaderboard + network rollup, Postgres-tier param forwarding, sparse-payload fallbacks, over-max limit clamp, every documented window accepted, unsupported window → `BAD_USER_INPUT` (never reaches the tier), and complexity weight. The new resolver region is fully line- and branch-covered.
