### PR TITLE
fix(python-sdk): bump async extra httpx floor to >=0.28.1 (#5987)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 # The base package is dependency-free (stdlib only). The async client pulls
 # httpx behind this extra: `pip install 'metagraphed[async]'`.
 [project.optional-dependencies]
-async = ["httpx>=0.27"]
+async = ["httpx>=0.28.1"]
 test = ["httpx>=0.28.1"]
 
 [project.urls]


### PR DESCRIPTION
Closes #5987.

`6d58dfbd` (the "update dependency httpx to >=0.28.1" fix documented at `python/CHANGELOG.md:21`) only bumped the `test` extra; the `async` extra still read `httpx>=0.27`. A user following the README's own install instruction (`pip install metagraphed[async]`) could therefore still resolve httpx 0.27.x, undermining what the changelog claims was fixed.

This bumps the `async` extra's floor to `>=0.28.1`, matching the `test` extra. It is a one-line packaging-metadata change; the `test` extra (and the CI unittest run) already pinned `>=0.28.1`, so nothing else moves.
