### PR TITLE
fix(scripts): consolidate divergent normalizePublicUrl onto the shared helper

### DIFF
--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -2,16 +2,15 @@ import path from "node:path";
 import {
   apiDocsSubdomainOrigins,
   buildTimestamp,
-  isBrandImpersonationUrl,
-  isCredentialedUrl,
   isLikelyExampleLink,
+  isPlaceholderIdentityUrl,
   isUnsafeResolvedUrl,
-  isUnsafeUrl,
   listJsonFilesRecursive,
   loadNativeSnapshot,
   loadProviders,
   loadSubnets,
   nativeDisplayName,
+  normalizePublicUrl,
   OPENAPI_PROBE_PATHS,
   probeOpenApiSpec,
   readCommittedManifestGeneratedAt,
@@ -82,15 +81,15 @@ const existingGeneratedCandidates = await loadExistingGeneratedCandidates();
 // follow-up). CI builds from committed data only, so it never sees the live
 // collision; that's why the publish failed while every PR's CI stayed green.
 // Reserve every committed community candidate's locator (same key format as
-// addCandidate, with the LOCAL normalizePublicUrl) so the discovery never emits
-// a duplicate of one — the committed candidate stands.
+// addCandidate, via the shared normalizeCandidateUrl) so the discovery never
+// emits a duplicate of one — the committed candidate stands.
 const reservedCandidateLocators = new Set();
 for (const file of await listJsonFilesRecursive(
   path.join(repoRoot, "registry/candidates/community"),
 )) {
   const document = await readJson(file);
   for (const candidate of document.candidates || []) {
-    const normalizedUrl = normalizePublicUrl(candidate.url);
+    const normalizedUrl = normalizeCandidateUrl(candidate.url);
     if (!normalizedUrl) continue;
     reservedCandidateLocators.add(
       `${candidate.netuid}:${candidate.kind}:${normalizedUrl.toLowerCase()}`,
@@ -704,7 +703,7 @@ async function discoverFromProjectWebsites() {
     (candidate) => candidate.kind === "website",
   );
   await mapLimit(websiteCandidates, 8, async (candidate) => {
-    const root = normalizePublicUrl(candidate.url);
+    const root = normalizeCandidateUrl(candidate.url);
     if (!root) {
       return;
     }
@@ -901,7 +900,7 @@ function collectOpenApiBaseOrigins() {
     if (netuid == null || !provider || netuidsWithOpenapi.has(netuid)) {
       return;
     }
-    const normalized = normalizePublicUrl(rawUrl);
+    const normalized = normalizeCandidateUrl(rawUrl);
     if (!normalized) {
       return;
     }
@@ -1082,7 +1081,7 @@ function githubSurfaceKind(urlValue) {
 }
 
 function addCandidate(candidate) {
-  const normalizedUrl = normalizePublicUrl(candidate.url);
+  const normalizedUrl = normalizeCandidateUrl(candidate.url);
   if (!normalizedUrl) {
     return;
   }
@@ -1094,7 +1093,7 @@ function addCandidate(candidate) {
   if (reservedCandidateLocators.has(key)) {
     return;
   }
-  const sourceUrl = normalizePublicUrl(candidate.source_url);
+  const sourceUrl = normalizeCandidateUrl(candidate.source_url);
   if (!sourceUrl) {
     return;
   }
@@ -1162,80 +1161,22 @@ function extractUrls(value) {
     return explicitUrls.length > 0 ? explicitUrls : [trimmed];
   });
 
-  return [...new Set(values.map(normalizePublicUrl).filter(Boolean))];
+  return [...new Set(values.map(normalizeCandidateUrl).filter(Boolean))];
 }
 
-function normalizePublicUrl(value) {
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  let candidate = value
-    .trim()
-    .replace(/^[<`"']+|[>`"',.;:!]+$/g, "")
-    .split("](")[0]
-    .replace(/[\]`"',.;:!]+$/g, "");
-  if (!candidate || isPlaceholder(candidate)) {
-    return null;
-  }
-
-  if (
-    !/^https?:\/\//i.test(candidate) &&
-    /^[a-z0-9.-]+\.[a-z]{2,}(?:\/.*)?$/i.test(candidate)
-  ) {
-    candidate = `https://${candidate}`;
-  }
-
-  try {
-    const url = new URL(candidate);
-    if (
-      !["http:", "https:"].includes(url.protocol) ||
-      url.username ||
-      url.password ||
-      isCredentialedUrl(url.toString())
-    ) {
-      return null;
-    }
-    if (url.username || url.password) {
-      return null;
-    }
-    // SSRF pre-filter: literal private/loopback/link-local/metadata IPs +
-    // localhost. The authoritative, DNS-resolving check (isUnsafeResolvedUrl)
-    // still runs at probe + overlay-promotion time; this just keeps obviously
-    // internal targets out of the bundle entirely.
-    if (isUnsafeUrl(url.toString())) {
-      return null;
-    }
-    // Reject base_urls that impersonate metagraphed's own domain — they pass the
-    // SSRF guard (public attacker domain) but could trick an agent into trusting
-    // them. See ADR 0004.
-    if (isBrandImpersonationUrl(url.toString())) {
-      return null;
-    }
-    url.hash = "";
-    if (url.pathname !== "/") {
-      url.pathname = url.pathname.replace(/\/+$/, "");
-    }
-    return url.toString();
-  } catch {
-    return null;
-  }
-}
-
-function isPlaceholder(value) {
-  const normalized = value.toLowerCase();
-  return [
-    "example.com",
-    "github.com/deprecated/deprecated",
-    "github.com/username/repo",
-    "github.com/yourusername/yourrepo",
-    "yourwebsite",
-    "your-org",
-    "deprecated.com",
-    "deprecated.png",
-    "localhost",
-    "127.0.0.1",
-  ].some((placeholder) => normalized.includes(placeholder));
+// Canonical URL normalization lives in scripts/lib.mjs (normalizePublicUrl) and
+// is shared with the contributor-facing path (validate-surface.mjs /
+// surface-add.mjs) so protocol/credential/SSRF/impersonation handling can never
+// diverge by call site (#5991). Discovery layers on one extra rejection: the
+// placeholder/template identity URLs (example.com, github.com/username/repo,
+// deprecated + "your*" README stubs) that clear those guards but must never
+// enter the candidate bundle. isPlaceholderIdentityUrl now carries the union of
+// both former placeholder lists, so this is a thin compose, not a reimpl.
+function normalizeCandidateUrl(value) {
+  const normalized = normalizePublicUrl(value);
+  return normalized && !isPlaceholderIdentityUrl(normalized)
+    ? normalized
+    : null;
 }
 
 function cleanName(value) {
@@ -1333,10 +1274,10 @@ function extractMarkdownLinks(markdown, baseUrl) {
   const markdownLinkPattern = /\[([^\]]{1,120})\]\((https?:\/\/[^)\s]+)\)/g;
   const bareUrlPattern = /https?:\/\/[^\s<>)"'`\]]+/g;
   for (const match of markdown.matchAll(markdownLinkPattern)) {
-    links.push({ label: match[1], url: normalizePublicUrl(match[2]) });
+    links.push({ label: match[1], url: normalizeCandidateUrl(match[2]) });
   }
   for (const match of markdown.matchAll(bareUrlPattern)) {
-    links.push({ label: "", url: normalizePublicUrl(match[0]) });
+    links.push({ label: "", url: normalizeCandidateUrl(match[0]) });
   }
   return dedupeLinks(
     links.filter((link) => link.url),
@@ -1368,14 +1309,14 @@ function normalizeLinkedUrl(value, baseUrl) {
     return null;
   }
   try {
-    return normalizePublicUrl(new URL(value, baseUrl).toString());
+    return normalizeCandidateUrl(new URL(value, baseUrl).toString());
   } catch {
     return null;
   }
 }
 
 function dedupeLinks(links, baseUrl) {
-  const seen = new Set([normalizePublicUrl(baseUrl)]);
+  const seen = new Set([normalizeCandidateUrl(baseUrl)]);
   const result = [];
   for (const link of links) {
     if (!link.url || seen.has(link.url) || isSocialUrl(link.url)) {

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1361,9 +1361,9 @@ export function normalizePublicUrl(value) {
 
   let candidate = value
     .trim()
-    .replace(/^<|>$/g, "")
+    .replace(/^[<`"']+|[>`"',.;:!]+$/g, "")
     .split("](")[0]
-    .replace(/\]+$/g, "");
+    .replace(/[\]`"',.;:!]+$/g, "");
   if (!candidate) {
     return null;
   }
@@ -1414,8 +1414,13 @@ export function normalizePublicHttpUrl(value) {
 
 // Placeholder/junk identity URLs some subnets carry on-chain (e.g. the
 // deprecated subnets' "https://deprecated.png" + "github.com/username/repo",
-// or "example.com" stubs). These must never surface as real links.
-const PLACEHOLDER_IDENTITY_URL = /deprecated|username\/repo|example\.com/i;
+// or "example.com" stubs), plus the README template stubs the discovery path
+// used to filter with its own local list (github.com/yourusername/yourrepo,
+// "yourwebsite", "your-org"). These must never surface as real links. The
+// `your*` tokens are word-anchored so a legitimate host that merely contains
+// the substring (e.g. myyour-organization.com) is not a false positive.
+const PLACEHOLDER_IDENTITY_URL =
+  /deprecated|username\/repo|example\.com|\byour-?org\b|\byourwebsite\b|\byourusername\b/i;
 
 export function isPlaceholderIdentityUrl(value) {
   return typeof value === "string" && PLACEHOLDER_IDENTITY_URL.test(value);

--- a/tests/discover-candidates-domain.test.mjs
+++ b/tests/discover-candidates-domain.test.mjs
@@ -15,6 +15,16 @@ describe("discover-candidates project-domain matching", () => {
     assert.doesNotMatch(source, /slice\(-2\)\.join\("\."\)/);
   });
 
+  test("discover-candidates uses the shared normalizePublicUrl, not a local copy (#5991)", async () => {
+    const source = await readFile("scripts/discover-candidates.mjs", "utf8");
+    // The canonical helper + placeholder guard are imported from lib.mjs...
+    assert.match(source, /normalizePublicUrl,/);
+    assert.match(source, /isPlaceholderIdentityUrl,/);
+    // ...and the divergent local reimplementations are gone.
+    assert.doesNotMatch(source, /function normalizePublicUrl\(/);
+    assert.doesNotMatch(source, /function isPlaceholder\(/);
+  });
+
   test("registrableHostDomain keeps distinct pages.dev tenants separate", () => {
     assert.equal(
       registrableHostDomain("project-a.pages.dev"),

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -578,12 +578,27 @@ describe("isPlaceholderIdentityUrl", () => {
     );
     assert.equal(isPlaceholderIdentityUrl("https://example.com"), true);
   });
+  test("flags the README template stubs the discovery path folded in (#5991)", () => {
+    assert.equal(
+      isPlaceholderIdentityUrl("https://github.com/yourusername/yourrepo"),
+      true,
+    );
+    assert.equal(isPlaceholderIdentityUrl("https://yourwebsite.com"), true);
+    assert.equal(isPlaceholderIdentityUrl("https://your-org.io"), true);
+    assert.equal(isPlaceholderIdentityUrl("https://your-org.github.io"), true);
+  });
   test("passes real links and non-strings through as not-placeholder", () => {
     assert.equal(
       isPlaceholderIdentityUrl("https://github.com/opentensor/bt"),
       false,
     );
     assert.equal(isPlaceholderIdentityUrl("https://taofu.xyz"), false);
+    // Word-anchored `your*` tokens don't false-positive on a legitimate host
+    // that merely contains the substring (the loopover review nit on #5991).
+    assert.equal(
+      isPlaceholderIdentityUrl("https://myyour-organization.com"),
+      false,
+    );
     assert.equal(isPlaceholderIdentityUrl(null), false);
     assert.equal(isPlaceholderIdentityUrl(undefined), false);
   });

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -1657,6 +1657,21 @@ describe("script utility contracts", () => {
       normalizePublicUrl("<https://metagraph.sh/docs/#section>"),
       "https://metagraph.sh/docs",
     );
+    // #5991: the canonical helper now carries the discovery path's robust
+    // trimming (backticks, wrapping quotes, trailing sentence punctuation) so
+    // both call sites clean prose-extracted URLs identically.
+    assert.equal(
+      normalizePublicUrl("`https://metagraph.sh/docs`,"),
+      "https://metagraph.sh/docs",
+    );
+    assert.equal(
+      normalizePublicUrl("'https://metagraph.sh/docs/'."),
+      "https://metagraph.sh/docs",
+    );
+    assert.equal(
+      normalizePublicUrl("wss://metagraph.sh/stream"),
+      "wss://metagraph.sh/stream",
+    );
     assert.equal(normalizePublicUrl(""), null);
     assert.equal(normalizePublicUrl(null), null);
     assert.equal(normalizePublicUrl("notaurl"), null);


### PR DESCRIPTION
## Summary

`scripts/discover-candidates.mjs` carried its own local `normalizePublicUrl`
(plus a local `isPlaceholder` list) that diverged from the canonical
`scripts/lib.mjs` helper the contributor path (`validate-surface.mjs` /
`surface-add.mjs`) already uses: the discovery copy allowed only `http`/`https`
(no `ws`/`wss`) and baked in a broader placeholder list, while the canonical copy
allowed `ws`/`wss` and — since #6010 — carried the brand-impersonation guard.
Same name, two contracts, no single source of truth.

This consolidates onto the one canonical helper:

- **`scripts/lib.mjs` is now the single `normalizePublicUrl`.** It adopts the
  discovery path's more robust trimming (backticks, wrapping quotes, trailing
  sentence punctuation) so prose-extracted URLs clean up identically on both
  paths, and keeps the `http`/`https`/`ws`/`wss` allowlist plus the
  credential/SSRF/impersonation guards.
- **Placeholder handling is unified in `isPlaceholderIdentityUrl`.** Its regex now
  carries the union of both former placeholder lists (adds
  `github.com/yourusername/yourrepo`, `yourwebsite`, `your-org`). The `your*`
  tokens are word-anchored so a legitimate host that merely contains the
  substring (e.g. `myyour-organization.com`) is no longer a false positive —
  which the old discovery `.includes()` list wrongly rejected.
- **`discover-candidates.mjs` drops both local reimplementations** and imports the
  shared helpers. It keeps its one extra behavior — rejecting placeholder URLs —
  as a thin `normalizeCandidateUrl` compose (`normalizePublicUrl` +
  `isPlaceholderIdentityUrl`), mirroring how `lib.mjs` itself gates identity
  links. `localhost`/`127.0.0.1` stubs it used to list are already covered by the
  shared SSRF guard.

Net: URL normalization/validation now behaves identically regardless of which
script processes a given URL.

## Test plan

- [x] `isPlaceholderIdentityUrl` — new tokens flagged, and the word-anchored
      `your*` tokens don't false-positive on legitimate hosts
      (`tests/lib-helpers.test.mjs`)
- [x] Canonical `normalizePublicUrl` — robust trimming + `wss` allowlist
      (`tests/script-utils.test.mjs`)
- [x] `discover-candidates.mjs` imports the shared helpers and no longer defines
      a local `normalizePublicUrl` / `isPlaceholder`
      (`tests/discover-candidates-domain.test.mjs`)
- [x] `npm run build && vitest run --coverage` — 8899 tests pass; changed
      `scripts/lib.mjs` lines are 100% covered
- [x] `npm run lint && npm run format:check` clean

Closes #5991
