### PR TITLE
feat(registry): SN47 EvolAI accuracy pass

### DIFF
--- a/registry/subnets/evolai.json
+++ b/registry/subnets/evolai.json
@@ -9,22 +9,25 @@
     "gap_notes": [
       "No verified docs site yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet."
+      "No verified SSE/event stream yet.",
+      "The universal_qa Hugging Face dataset now requires authentication (HTTP 401 on both GET and HEAD, observed live) -- it appears to have been gated or made private since originally registered; its probe is disabled pending re-verification.",
+      "The EvolAI Proxy API (evolai-gate.hf.space) is currently returning 503 \"Backend unavailable\" on all routes, including its own /openapi.json and /docs -- consistent with a Hugging Face Space outage rather than an access restriction; left enabled so live-status monitoring reflects the outage."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T09:25:00.000Z",
+    "reviewed_at": "2026-07-16T02:40:00.000Z",
     "source_count": 4,
-    "verified_at": "2026-06-08T09:25:00.000Z"
+    "verified_at": "2026-07-16T02:40:00.000Z"
   },
   "dashboard_url": "https://taomarketcap.com/subnets/47",
   "name": "EvolAI",
   "netuid": 47,
-  "notes": "Reviewed overlay for SN47 using the official EvolAI source repository, referenced public Hugging Face dataset, and universal TaoMarketCap dashboard. No verified official website, OpenAPI, safe public subnet API, or SSE surface has been promoted yet.",
+  "notes": "Reviewed overlay for SN47 using the official EvolAI source repository, referenced public Hugging Face dataset, and universal TaoMarketCap dashboard. This pass corrected stale top-level notes text that claimed no website or subnet-api surface existed despite both already being tracked (community-submitted, on-chain website_url now confirms evolai.ai). Also found and documented two live regressions: the universal_qa dataset now requires authentication (previously public), and the EvolAI Proxy API Space is currently down (503 Backend unavailable). No verified official OpenAPI, docs site, or SSE surface has been promoted yet.",
   "schema_version": 1,
   "slug": "sn-47",
   "source_repo": "https://github.com/openevolai/evolai",
   "status": "active",
+  "website_url": "https://evolai.ai/",
   "surfaces": [
     {
       "auth_required": false,
@@ -50,9 +53,9 @@
       "id": "sn-47-evolai-universal-qa-dataset",
       "kind": "data-artifact",
       "name": "EvolAI Universal QA dataset",
-      "notes": "Public Hugging Face dataset referenced by the EvolAI repository.",
+      "notes": "Hugging Face dataset referenced by the EvolAI repository. Previously public; now returns HTTP 401 on both GET and HEAD (live-tested), consistent with the dataset having been gated or made private since originally registered. Probe disabled pending re-verification rather than removed, since this may be reversed by the operator.",
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "expect": "html",
         "method": "HEAD",
         "timeout_ms": 10000
@@ -93,7 +96,7 @@
       "id": "sn-47-evolai-subnet-api",
       "kind": "subnet-api",
       "name": "EvolAI Proxy API",
-      "notes": "Public GET /datasets list endpoint on the EvolAI-operated Hugging Face Space proxy at https://evolai-gate.hf.space.",
+      "notes": "Public GET /datasets list endpoint on the EvolAI-operated Hugging Face Space proxy at https://evolai-gate.hf.space. At review time the Space is returning 503 \"Backend unavailable\" on all routes (including its own /openapi.json and /docs) -- consistent with a Space outage; probe left enabled so live-status monitoring reflects it.",
       "probe": {
         "enabled": true,
         "expect": "json",


### PR DESCRIPTION
## Summary
Re-review pass for SN47 EvolAI — part of the root->128 accuracy audit tracked in #5903.

- Corrected stale top-level notes text that claimed no website or subnet-api surface existed despite both already being tracked (community-submitted); added the missing top-level \`website_url\`, now confirmed on-chain.
- Found and documented two live regressions:
  - The \`universal_qa\` Hugging Face dataset now requires authentication (HTTP 401 on both GET and HEAD, live-tested) — appears to have been gated or made private since originally registered. Probe disabled pending re-verification rather than removed.
  - The EvolAI Proxy API (\`evolai-gate.hf.space\`) is currently returning 503 "Backend unavailable" on all routes — consistent with a Hugging Face Space outage. Probe left enabled so live-status monitoring reflects it.
- Does not touch \`public/metagraph/operational-surfaces.json\` (owned by a separate automation).

## Test plan
- [x] \`npm run build\`
- [x] \`npm run validate\` — 129 subnets, 1706 surfaces
- [x] \`npm run validate:surface\`
- [x] \`npm run curation:stale-notes\`
- [x] \`node scripts/scan-public-safety.mjs\`
- [x] \`npx prettier --check\`