### PR TITLE
fix(ui): report legacy clipboard-copy failure instead of a false success

### DIFF
--- a/apps/ui/src/hooks/use-copy.test.ts
+++ b/apps/ui/src/hooks/use-copy.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   copyErrorDescription,
   copySuccessTitle,
+  legacyExecCommandCopy,
   shouldUseNavigatorClipboard,
   truncateCopyPreview,
 } from "./use-copy";
@@ -51,5 +52,32 @@ describe("shouldUseNavigatorClipboard", () => {
   it("falls back when navigator or clipboard is missing", () => {
     expect(shouldUseNavigatorClipboard(undefined)).toBe(false);
     expect(shouldUseNavigatorClipboard({} as Navigator)).toBe(false);
+  });
+});
+
+describe("legacyExecCommandCopy", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  const stubDocument = (execResult: boolean) => {
+    const textarea = { value: "", style: {} as Record<string, string>, select: vi.fn() };
+    vi.stubGlobal("document", {
+      createElement: vi.fn().mockReturnValue(textarea),
+      body: { appendChild: vi.fn(), removeChild: vi.fn() },
+      execCommand: vi.fn().mockReturnValue(execResult),
+    });
+    return textarea;
+  };
+
+  it("reports failure when execCommand is rejected (returns false, not a false success)", () => {
+    stubDocument(false);
+    // #6026: execCommand returns false without throwing (no user activation /
+    // permissions-policy denial); the fallback must propagate that as failure.
+    expect(legacyExecCommandCopy("hello")).toBe(false);
+  });
+
+  it("reports success when execCommand copies", () => {
+    const textarea = stubDocument(true);
+    expect(legacyExecCommandCopy("hello")).toBe(true);
+    expect(textarea.value).toBe("hello");
   });
 });

--- a/apps/ui/src/hooks/use-copy.ts
+++ b/apps/ui/src/hooks/use-copy.ts
@@ -27,6 +27,24 @@ export function shouldUseNavigatorClipboard(navigatorValue: Navigator | undefine
 }
 
 /**
+ * Legacy `execCommand("copy")` fallback for environments without
+ * `navigator.clipboard`. Returns execCommand's boolean result verbatim: `false`
+ * means the copy was rejected (e.g. no user activation, or a permissions-policy
+ * denial) and must NOT be reported to the user as a success.
+ */
+export function legacyExecCommandCopy(value: string): boolean {
+  const ta = document.createElement("textarea");
+  ta.value = value;
+  ta.style.position = "fixed";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  const ok = document.execCommand("copy");
+  document.body.removeChild(ta);
+  return ok;
+}
+
+/**
  * Shared copy hook used by every "copy this URL/value" interaction.
  * Returns `copied` (truthy for ~1.4s after success) so callers can swap an
  * icon for a green check, plus a `copy(value)` action.
@@ -43,15 +61,13 @@ export function useCopy(opts: CopyOpts = {}) {
         if (shouldUseNavigatorClipboard(typeof navigator !== "undefined" ? navigator : undefined)) {
           await navigator.clipboard.writeText(value);
         } else if (typeof document !== "undefined") {
-          // Fallback for older browsers / SSR-safe access pattern.
-          const ta = document.createElement("textarea");
-          ta.value = value;
-          ta.style.position = "fixed";
-          ta.style.opacity = "0";
-          document.body.appendChild(ta);
-          ta.select();
-          document.execCommand("copy");
-          document.body.removeChild(ta);
+          // Fallback for older browsers / SSR-safe access pattern. execCommand
+          // returns false (without throwing) when the copy is rejected — route
+          // that through the shared catch below so the user sees an accurate
+          // failure instead of a false "Copied" success.
+          if (!legacyExecCommandCopy(value)) {
+            throw new Error("Clipboard copy command was rejected");
+          }
         }
         setCopied(true);
         if (toastOnSuccess) {


### PR DESCRIPTION
Closes #6026

## What

`use-copy.ts`'s `execCommand` fallback ignored the boolean return of `document.execCommand("copy")`, then unconditionally called `setCopied(true)` + showed a "Copied" success toast. `execCommand` returns `false` **without throwing** on failure (no user activation, permissions-policy denial) — so a real copy failure was reported to the user as success.

- Extract the fallback into **`legacyExecCommandCopy(value)`**, which returns `execCommand`'s result verbatim.
- The hook now **throws when it returns `false`**, routing the failure through the existing `catch` (error toast, `copy()` returns `false`) — the same failure-UX already used when `navigator.clipboard` throws.

## Test

Added `legacyExecCommandCopy` tests (node env, `vi.stubGlobal("document", …)`): asserts **failure → `false`** (the bug) and success → `true`.

## Verify

`lint` (0 errors) · `format:check` · `typecheck` · `test` (1022 pass) · `build` — all green. Change is confined to `apps/ui/src/hooks/**` + its test (no rendered output changes).