### PR TITLE
feat(registry): SN50 Synth accuracy pass

### DIFF
--- a/registry/providers/synth.json
+++ b/registry/providers/synth.json
@@ -1,11 +1,11 @@
 {
   "authority": "community",
-  "github_url": "https://github.com/mode-network/synth-subnet",
+  "github_url": "https://github.com/synthdataco/synth-subnet",
   "id": "synth",
   "kind": "subnet-team",
   "logo_url": "https://metagraph.sh/logos/synth.png",
   "name": "Synth",
-  "public_notes": "Subnet 50 (Synth) team profile — predictive intelligence for financial markets, operated by Mode Network. Public-safe identity from the subnet's on-chain SubnetIdentitiesV3 (name, website, source repo).",
+  "public_notes": "Subnet 50 (Synth) team profile — predictive intelligence for financial markets. Public-safe identity from the subnet's on-chain SubnetIdentitiesV3 (name, website, source repo). The GitHub org has since been renamed from mode-network to synthdataco (mode-network/synth-subnet now permanently redirects here); on-chain source_repo still cites the old org name.",
   "schema_version": 1,
   "website_url": "https://synthdata.co/"
 }

--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -697,6 +697,19 @@
       "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/nepher-robotics.json (reviewed_at 2026-06-08T07:12:52.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
     },
     {
+      "netuid": 50,
+      "slug": "sn-50",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-07-16T03:10:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://synthdata.co/",
+        "https://github.com/synthdataco/synth-subnet",
+        "https://api.synthdata.co/swagger.json"
+      ],
+      "notes": "First maintainer review for this subnet (previously community-seeded/unreviewed, categories empty, no website/source-repo surfaces despite website_url/source_repo already being set). Verified the official website and source repository. Diffed the full 48-path Swagger 2.0 schema: the 17 /insights/* routes declare no security in the schema but return HTTP 400 \"missing key in request header\" live -- an undocumented auth gate, left untracked. Added one new no-auth no-param surface, /v2/meta-leaderboard/latest. The on-chain-declared source_repo (mode-network/synth-subnet) now permanently redirects to synthdataco/synth-subnet -- same repo, org renamed; tracked URL updated accordingly."
+    },
+    {
       "netuid": 52,
       "slug": "sn-52",
       "decision": "maintainer-reviewed",

--- a/registry/subnets/synth.json
+++ b/registry/subnets/synth.json
@@ -1,15 +1,67 @@
 {
-  "categories": [],
+  "categories": [
+    "baseline-curated",
+    "finance",
+    "identity-reviewed",
+    "official-source-repo",
+    "official-website"
+  ],
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "gap_notes": [
+      "No verified docs site yet.",
+      "No verified SSE/event stream yet.",
+      "The /insights/* endpoints declare no security requirement in the subnet's own Swagger schema, but live-testing returns HTTP 400 \"missing key in request header\" on every one -- an undocumented API-key gate not reflected in the schema. Left untracked rather than added as broken/auth-gated surfaces."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-07-16T03:10:00.000Z",
+    "source_count": 3,
+    "verified_at": "2026-07-16T03:10:00.000Z"
   },
   "name": "Synth",
   "netuid": 50,
+  "notes": "First maintainer-reviewed pass for SN50 (previously community-seeded/unreviewed, categories empty, no website/source-repo surfaces despite website_url/source_repo already being set). Added the missing website and source-repo surfaces. Fixed 3 surfaces having no probe config at all -- the registry-wide gap tracked in #5932; two of them (leaderboard, validation-scores) reject HEAD (405/404) so their probes use GET. Diffed the full 48-path Swagger 2.0 schema: found the 17 /insights/* GET routes are undocumented-auth-gated in practice despite the schema declaring no security (see gap_notes); the /v2/prediction/*, /rewards/scores, /validation/miner|prompts|realized-path|scores/historical, and /v2/leaderboard/historical|meta-leaderboard/historical routes all require query parameters with no stable canonical value. Added one new no-auth no-param surface: /v2/meta-leaderboard/latest. The on-chain-declared source_repo (github.com/mode-network/synth-subnet) now permanently redirects (301) to github.com/synthdataco/synth-subnet -- same repo, org renamed; updated the tracked source_repo/provider github_url to the current URL since on-chain native_name/description/website_url are otherwise unchanged (not a full identity pivot).",
   "schema_version": 1,
   "slug": "sn-50",
+  "source_repo": "https://github.com/synthdataco/synth-subnet",
   "status": "active",
   "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-50-synth-website",
+      "kind": "website",
+      "name": "Synth website",
+      "notes": "Official Synth (SN50) website.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "synth",
+      "public_safe": true,
+      "source_urls": ["https://github.com/synthdataco/synth-subnet"],
+      "url": "https://synthdata.co/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-50-synth-source-repo",
+      "kind": "source-repo",
+      "name": "Synth source repository",
+      "notes": "Official Synth (SN50) source repository. The on-chain-declared URL (github.com/mode-network/synth-subnet) now permanently redirects here; same repo, org renamed.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "synth",
+      "public_safe": true,
+      "source_urls": ["https://synthdata.co/"],
+      "url": "https://github.com/synthdataco/synth-subnet"
+    },
     {
       "auth_required": false,
       "authority": "community",
@@ -17,6 +69,12 @@
       "kind": "openapi",
       "name": "Synth API OpenAPI spec",
       "notes": "Public Swagger 2.0 spec for the Synth API (48 unauthenticated GET endpoints — probabilistic price forecasts, market insights, leaderboards). The official synth-subnet README documents the API docs at api.synthdata.co/docs.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "synth",
       "public_safe": true,
       "review": {
@@ -36,7 +94,13 @@
       "id": "sn-50-synth-subnet-api",
       "kind": "subnet-api",
       "name": "Synth API",
-      "notes": "Public no-auth REST API at api.synthdata.co exposing Synth's probabilistic price forecasts, leaderboards, and market insights; the /v2/leaderboard/latest endpoint returns JSON with no authentication. Documented in the official synth-subnet README.",
+      "notes": "Public no-auth REST API at api.synthdata.co exposing Synth's probabilistic price forecasts, leaderboards, and market insights; the /v2/leaderboard/latest endpoint returns JSON with no authentication. Documented in the official synth-subnet README. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "synth",
       "public_safe": true,
       "review": {
@@ -54,7 +118,13 @@
       "id": "sn-50-synth-validation-scores",
       "kind": "data-artifact",
       "name": "Synth latest validation scores dataset",
-      "notes": "Public no-auth GET /validation/scores/latest on api.synthdata.co returning a JSON dataset of the latest per-miner, per-asset forecast validation scores for the SN50 Synth price-prediction network (miner_uid, asset, prompt_score, crps, scored_time, time_length). Documented as a security-free GET (\"Validations - Latest Scores\") in the subnet's registered OpenAPI spec at api.synthdata.co/swagger.json; distinct from the leaderboard subnet-api surface on the same host. Verified 200 application/json.",
+      "notes": "Public no-auth GET /validation/scores/latest on api.synthdata.co returning a JSON dataset of the latest per-miner, per-asset forecast validation scores for the SN50 Synth price-prediction network (miner_uid, asset, prompt_score, crps, scored_time, time_length). Documented as a security-free GET (\"Validations - Latest Scores\") in the subnet's registered OpenAPI spec at api.synthdata.co/swagger.json; distinct from the leaderboard subnet-api surface on the same host. Rejects HEAD (404); probe uses GET. Verified 200 application/json.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "synth",
       "public_safe": true,
       "review": {
@@ -67,8 +137,25 @@
         "https://github.com/synthdataco/synth-subnet/blob/main/README.md"
       ],
       "url": "https://api.synthdata.co/validation/scores/latest"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-50-synth-meta-leaderboard",
+      "kind": "subnet-api",
+      "name": "Synth meta-leaderboard API",
+      "notes": "Public no-auth GET /v2/meta-leaderboard/latest on api.synthdata.co, returning the current meta-model leaderboard (neuron_uid, rewards, coldkey, ip_address) -- distinct from the per-miner /v2/leaderboard/latest surface already tracked. Discovered via a full diff of the subnet's own Swagger schema for undiscovered public GET endpoints.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "synth",
+      "public_safe": true,
+      "source_urls": ["https://api.synthdata.co/swagger.json"],
+      "url": "https://api.synthdata.co/v2/meta-leaderboard/latest"
     }
   ],
-  "source_repo": "https://github.com/mode-network/synth-subnet",
   "website_url": "https://synthdata.co/"
 }


### PR DESCRIPTION
## Summary
- First maintainer-reviewed pass for SN50 (previously community-seeded/unreviewed, categories empty, no website/source-repo surfaces despite `website_url`/`source_repo` already being set). Added the missing website and source-repo surfaces.
- Fixed 3 surfaces having no `probe` config at all — the registry-wide gap tracked in #5932. Two (`leaderboard`, `validation-scores`) reject HEAD (405/404); their probes use GET.
- Diffed the full 48-path Swagger 2.0 schema (`https://api.synthdata.co/swagger.json`): the 17 `/insights/*` GET routes declare no security in the schema but return HTTP 400 "missing key in request header" live — an undocumented auth gate not reflected in the schema, left untracked (documented in `gap_notes`). The `/v2/prediction/*`, `/rewards/scores`, and `/validation/*` routes requiring query params have no stable canonical value. Added one new no-auth no-param surface: `/v2/meta-leaderboard/latest`.
- The on-chain-declared `source_repo` (`github.com/mode-network/synth-subnet`) now permanently redirects (301) to `github.com/synthdataco/synth-subnet` — same repo, org renamed. Updated the tracked `source_repo` and provider `github_url` to the current URL since on-chain `native_name`/`description`/`website_url` are otherwise unchanged (not a full identity pivot, unlike the SN40/SN45 renames earlier in this audit).

Part of the root->128 registry accuracy audit tracked in #5903.

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check registry/subnets/synth.json registry/providers/synth.json registry/reviews/maintainer-reviewed.json`