### PR TITLE
fix(ui): show StaleBanner on validator detail when meta is stale

### DIFF
--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -6,7 +6,7 @@ import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { Boxes, Coins, Gauge, Percent, Users, Zap } from "lucide-react";
 import { useWallet } from "@/hooks/use-wallet";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
+import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
@@ -25,7 +25,7 @@ import { taoCompact, scoreStr } from "@/components/metagraphed/neuron-table";
 import { validatorDetailQuery, validatorNominatorsQuery } from "@/lib/metagraphed/queries";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { hasValidatorIdentity } from "@/lib/metagraphed/validator-identity";
 import {
   annualizedDelegatorApyPct,
@@ -241,6 +241,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
   const sourceRef = ss58PathSegment(hotkey);
   const detailRes = useSuspenseQuery(validatorDetailQuery(hotkey)).data;
   const detail = detailRes.data;
+  const meta = detailRes.meta;
   const identity = detail.coldkey_identity;
   const hasIdentity = hasValidatorIdentity(identity);
   const displayName =
@@ -257,9 +258,19 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
   // "only surfaced when..." requirement, not just a submit-time guard.
   const { wallet } = useWallet();
   const isOwner = !!wallet && !!detail.coldkey && wallet.address === detail.coldkey;
+  const stale = Boolean(meta?.stale) || isStaleFreshness(meta?.generated_at);
 
   return (
     <>
+      {stale ? (
+        <StaleBanner
+          generatedAt={meta?.generated_at}
+          refreshQueryKeys={[
+            validatorDetailQuery(hotkey).queryKey,
+            validatorNominatorsQuery(hotkey).queryKey,
+          ]}
+        />
+      ) : null}
       <PageHero
         eyebrow="Explorer · validator"
         live


### PR DESCRIPTION
## Summary

- Wire `StaleBanner` / `isStaleFreshness` on `validators.$hotkey.tsx` to `validatorDetailQuery`'s existing `meta` (same pattern as providers/subnets detail and the validators list).
- Display-only; query unchanged. Refresh invalidates detail + nominators query keys.

Closes #5861

## Screenshots

| Viewport Â· Theme | Before | After |
| --- | --- | --- |
| Mobile Â· Light | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5861-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5861-after-mobile-light.png) |
| Mobile Â· Dark | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5861-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5861-after-mobile-dark.png) |
| Tablet Â· Light | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5861-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5861-after-tablet-light.png) |
| Tablet Â· Dark | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5861-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5861-after-tablet-dark.png) |
| Desktop Â· Light | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5861-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5861-after-desktop-light.png) |
| Desktop Â· Dark | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5861-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5861-after-desktop-dark.png) |

## Test plan

- [ ] Open a validator detail page when `meta.generated_at` is older than the freshness threshold (or `meta.stale`) and confirm the stale banner appears above the hero
- [ ] Confirm banner is absent when the snapshot is fresh
- [ ] Click **Refresh now** and confirm detail (and nominators) refetch
- [ ] Spot-check mobile / tablet / dark theme layout against the screenshot table
