### PR TITLE
feat(mcp): add get_subnet_detail mirroring REST subnet-detail

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -2444,6 +2444,38 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_subnet_detail",
+    title: "Get one subnet's raw structural detail",
+    description:
+      "Fetch one subnet's raw per-subnet record by netuid: chain-native " +
+      "structure, live economics, candidate surfaces, endpoints, gaps, and " +
+      "verified surfaces -- the underlying record get_subnet's composed " +
+      "overview is assembled from. Use get_subnet for the curated dashboard " +
+      "view (profile + health + curation + gaps + counts); use this for the " +
+      "raw structural record itself, or get_subnet_economics for economics " +
+      "alone. Mirrors GET /api/v1/subnets/{netuid}.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const detail = await loadArtifactData(
+        ctx,
+        `/metagraph/subnets/${netuid}.json`,
+      );
+      // Same live-economics overlay /api/v1/subnets/{netuid} attaches (#1308):
+      // one call carries validator/miner counts, registration, stake, and
+      // alpha price alongside the structural record.
+      const { economics } = await loadSubnetEconomics(ctx, netuid);
+      return economics ? { ...detail, economics } : detail;
+    },
+  },
+  {
     ...GET_NETWORK_HEALTH_MCP_TOOL,
     async handler(_args, ctx) {
       return loadGlobalOperationalHealth(
@@ -10255,6 +10287,23 @@ const TOOL_OUTPUT_SCHEMAS = {
       gap_priorities: { type: "array" },
       operational_observed_at: NULLABLE_STRING,
       health_source: NULLABLE_STRING,
+    },
+  },
+  get_subnet_detail: {
+    type: "object",
+    additionalProperties: true,
+    required: ["subnet"],
+    properties: {
+      schema_version: { type: "integer" },
+      generated_at: NULLABLE_STRING,
+      subnet: { type: "object" },
+      candidate_surfaces: { type: "array" },
+      candidates: { type: "array" },
+      endpoints: { type: "array" },
+      gaps: ANY,
+      surfaces: { type: "array" },
+      verified_surfaces: { type: "array" },
+      economics: { type: ["object", "null"] },
     },
   },
   get_subnet_health: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1631,6 +1631,69 @@ describe("MCP tools (injected deps)", () => {
     assert.equal(res.body.result.structuredContent.error.code, "not_found");
   });
 
+  test("get_subnet_detail merges the live economics row onto the raw structural record", async () => {
+    const localDeps = makeDeps({
+      "/metagraph/subnets/7.json": {
+        schema_version: 1,
+        subnet: { netuid: 7, slug: "allways", name: "Allways", tempo: 360 },
+        surfaces: [],
+        endpoints: [],
+        gaps: [],
+      },
+      "/metagraph/economics.json": {
+        schema_version: 1,
+        summary: { with_economics_count: 1 },
+        subnets: [{ netuid: 7, registration_cost_tao: 0.5, open_slots: 3 }],
+      },
+    });
+    const res = await callTool(
+      "get_subnet_detail",
+      { netuid: 7 },
+      { deps: localDeps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.subnet.netuid, 7);
+    assert.equal(out.subnet.tempo, 360);
+    assert.equal(out.economics.open_slots, 3);
+  });
+
+  test("get_subnet_detail omits economics when no live row exists for the netuid", async () => {
+    const localDeps = makeDeps({
+      "/metagraph/subnets/7.json": {
+        schema_version: 1,
+        subnet: { netuid: 7, slug: "allways", name: "Allways" },
+      },
+      "/metagraph/economics.json": {
+        schema_version: 1,
+        summary: {},
+        subnets: [],
+      },
+    });
+    const res = await callTool(
+      "get_subnet_detail",
+      { netuid: 7 },
+      { deps: localDeps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.subnet.netuid, 7);
+    assert.equal("economics" in out, false);
+  });
+
+  test("get_subnet_detail maps a missing artifact to a clean not_found", async () => {
+    const res = await callTool("get_subnet_detail", { netuid: 999 }, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.equal(res.body.result.structuredContent.error.code, "not_found");
+  });
+
+  test("get_subnet_detail rejects a non-integer netuid", async () => {
+    const res = await callTool(
+      "get_subnet_detail",
+      { netuid: "seven" },
+      { deps },
+    );
+    assert.equal(res.body.result.isError, true);
+  });
+
   test("get_subnet_health is live-only — ignores the static artifact, reports unknown when the live store is cold", async () => {
     // `deps` carries a static /metagraph/health/subnets/7.json (summary.status
     // "ok"), but current health is live-only: the retired static artifact must


### PR DESCRIPTION
Audit + completeness pass for MCP coverage of subnet-scoped REST/GraphQL endpoints, per #5966 (part of #5965).

## Audit method

- Enumerated every subnet-scoped route from `API_ROUTES` (`src/contracts.mjs`): 46 routes under `/api/v1/subnets/{netuid}/**` plus the one subnet-scoped chain-wide equivalent (`/api/v1/accounts/{ss58}/subnets/{netuid}/history`).
- Cross-referenced each against the MCP server's full tool registry — 176 tools across `src/mcp-server.mjs` and its sibling `src/*-mcp.mjs` modules (tools registered via spread-imported constants, e.g. `get_subnet_profile` from `profiles-mcp.mjs`, don't show up in a `src/mcp-server.mjs`-only grep — worth flagging for anyone repeating this audit later).
- Cross-referenced the registry's surface `kind` enum (`QUERY_ENUMS.surfaceKind`) against MCP coverage: every kind is just a field on a generic surface/endpoint row already returned (and filterable) by the existing `get_subnet_surfaces` / `get_subnet_endpoints` / `list_subnet_endpoints` / `list_subnet_apis` tools — no kind needs its own dedicated tool.

## Result

One genuine gap: the bare `GET /api/v1/subnets/{netuid}` (`subnet-detail`) — the raw chain-native structural record (the `subnet` object embedding tempo/immunity_period/max_validators/registration fields, plus `candidate_surfaces`/`endpoints`/`gaps`/`surfaces`), with a live economics overlay attached (mirroring the REST handler's own `#1308` behavior). `get_subnet` looks like it should cover this by name, but it actually returns the *composed overview* (`profile + health + curation + gaps + counts`) — a materially different, narrower shape read from a different artifact (`/metagraph/overview/{netuid}.json` vs `/metagraph/subnets/{netuid}.json`). Everything else already has 1:1 (or richer, query-filterable) coverage.

## Fix

- New `get_subnet_detail` tool in `src/mcp-server.mjs`: reads `/metagraph/subnets/{netuid}.json` (same artifact GraphQL's own `subnet` field already reads) and merges in the live economics row via the existing `loadSubnetEconomics` helper — the same building block `get_subnet_economics` and `get_subnet_stake_quote` already use, so no new economics-resolution logic. Its description explicitly cross-references `get_subnet` (composed overview) and `get_subnet_economics` (economics alone) so an agent picks the right one.
- Declared its `outputSchema` in `TOOL_OUTPUT_SCHEMAS` alongside the sibling entries.

## Tests

Four cases in `tests/mcp-server.test.mjs`: the structural record with the live economics row merged in, the record returned unchanged when no economics row exists for the netuid, a missing-artifact `not_found`, and an invalid-netuid rejection. Full MCP suite green (1079 tests); the new tool's line range is 100% branch-covered against the diff.

```
npx vitest run tests/mcp-server.test.mjs
node scripts/validate-mcp.mjs
# MCP validation passed: 176 tools, lifecycle + all tools/call + the resources/subscribe -> ingest -> notify round trip.
npm run validate
```

Closes #5966