### PR TITLE
fix(registry): SN53 EfficientFrontier accuracy re-review pass

### DIFF
--- a/registry/subnets/efficientfrontier.json
+++ b/registry/subnets/efficientfrontier.json
@@ -12,21 +12,22 @@
     "gap_notes": [
       "SignalPlus website is live and is tracked as the team/project website.",
       "The subnet mining app currently returns a 403/auth-challenge response to simple probes and is expected to appear degraded rather than healthy.",
-      "Previously discovered GitHub source repository currently returns 404.",
+      "The community source repository (oxylok/53-EfficientFrontier) previously 404d; re-verified live (200) as of this pass.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet."
+      "No verified SSE/event stream yet.",
+      "On-chain SubnetIdentitiesV3 for netuid 53 now reports subnetName \"engy\" / description \"Verified inference for frontier open models.\" -- a completely different identity than the tracked EfficientFrontier/SignalPlus branding, corroborated by two independent indexers (metagraph.sh, TaoMarketCap). The live website and source repository both still describe EfficientFrontier/SignalPlus with no mention of \"engy\", and no GitHub presence for \"engy\" was found. The on-chain snapshot also shows subnet_emission_enabled=false, consistent with a dormant/deregistered subnet possibly being repurposed by a new operator whose infrastructure is not yet discoverable. Deliberately NOT renamed given zero infrastructure corroboration for the new on-chain identity; flagging for close attention on the next pass."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T14:15:00.000Z",
+    "reviewed_at": "2026-07-16T04:20:00.000Z",
     "source_count": 6,
-    "verified_at": "2026-06-08T14:15:00.000Z"
+    "verified_at": "2026-07-16T04:20:00.000Z"
   },
   "dashboard_url": "https://t.signalplus.com/mining",
   "name": "EfficientFrontier",
   "netuid": 53,
-  "notes": "Reviewed overlay for SN53 EfficientFrontier by SignalPlus. The SignalPlus company website is live; the mining app surface returns an auth/challenge-style response to simple probes. The previously discovered EfficientFrontier source repository currently returns 404 and is not promoted.",
+  "notes": "Reviewed overlay for SN53 EfficientFrontier by SignalPlus. The SignalPlus company website is live; the mining app surface returns an auth/challenge-style response to simple probes. This pass re-verified the community source repository is now live (previously 404) and fixed 1 surface having no probe config at all -- the registry-wide gap tracked in #5932. Also found and documented a significant discrepancy: on-chain SubnetIdentitiesV3 now reports an entirely different identity (\"engy\") than the tracked EfficientFrontier/SignalPlus branding, with no corroborating infrastructure found for the new name -- deliberately not renamed (see gap_notes).",
   "schema_version": 1,
   "slug": "efficientfrontier",
   "source_repo": "https://github.com/oxylok/53-EfficientFrontier",
@@ -124,7 +125,13 @@
       "id": "sn-53-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "EfficientFrontier TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/53 on api.taomarketcap.com returning machine-readable JSON for SN53 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. SignalPlus EfficientFrontier documents validator scoring in its community source repository and mining app, but exposes no verified first-party no-auth public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/53/ on api.taomarketcap.com returning machine-readable JSON for SN53 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. SignalPlus EfficientFrontier documents validator scoring in its community source repository and mining app, but exposes no verified first-party no-auth public API endpoint; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -135,7 +142,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/53"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/53/"
     },
     {
       "auth_required": false,


### PR DESCRIPTION
## Summary
- Fixed 1 surface having no `probe` config at all — the registry-wide gap tracked in #5932 (the TaoMarketCap subnet snapshot API). TaoMarketCap now enforces a trailing slash on its subnet endpoint (the non-slash path 301s) and rejects HEAD (405); tracked URL and probe updated accordingly.
- Re-verified the community source repository (`oxylok/53-EfficientFrontier`) is now live — the "returns 404" gap_note was stale and has been resolved.
- **Found and documented a significant discrepancy**: on-chain `SubnetIdentitiesV3` for netuid 53 now reports an entirely different identity ("engy" / "Verified inference for frontier open models") than the tracked EfficientFrontier/SignalPlus branding, corroborated by two independent indexers (metagraph.sh, TaoMarketCap). The live website and source repository both still describe EfficientFrontier/SignalPlus with no trace of "engy" anywhere, including no matching GitHub presence. The on-chain snapshot also shows `subnet_emission_enabled=false`, consistent with a dormant subnet possibly being repurposed by a new, not-yet-discoverable operator. Deliberately **not** renamed given zero infrastructure corroboration — flagged in `gap_notes` for close attention on the next pass, matching the SN27/SN44 precedent of not forcing a rename on a single uncorroborated on-chain field.

Part of the root->128 registry accuracy audit tracked in #5903.

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check registry/subnets/efficientfrontier.json`