### PR TITLE
chore(ui): remove dead trendSurfaceSeries helper

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -6680,33 +6680,6 @@ export function sortedHealthTrendSurfaces(window: HealthTrendWindow | undefined)
   return surfaces.sort((a, b) => (a.uptime_ratio ?? 1) - (b.uptime_ratio ?? 1));
 }
 
-/**
- * Extract honest per-surface distribution series from a health-trends window.
- *
- * The window has no time dimension — it is an aggregate snapshot with a
- * per-surface breakdown — so these are distributions ACROSS surfaces (worst
- * uptime first), not time-series. Use them for spread sparklines, never for a
- * "trend over time". Returns empty arrays when the window has no surfaces.
- */
-export function trendSurfaceSeries(window: HealthTrendWindow | undefined): {
-  uptimePct: number[];
-  p50: number[];
-  p95: number[];
-} {
-  const surfaces = sortedHealthTrendSurfaces(window);
-  const finite = (v: number | undefined): v is number =>
-    typeof v === "number" && Number.isFinite(v);
-  return {
-    uptimePct: surfaces
-      .map((s) => (finite(s.uptime_ratio) ? s.uptime_ratio * 100 : null))
-      .filter((v): v is number => v != null),
-    p50: surfaces
-      .map((s) => (finite(s.latency_ms?.p50) ? s.latency_ms!.p50! : (s.avg_latency_ms ?? null)))
-      .filter((v): v is number => v != null && Number.isFinite(v)),
-    p95: surfaces.map((s) => s.latency_ms?.p95).filter((v): v is number => finite(v)),
-  };
-}
-
 // Candidate rows carry `review_notes` (not `notes`) and a nested
 // `verification.verified_at` (no top-level `discovered_at`).
 function normalizeCandidate(raw: unknown): Candidate {


### PR DESCRIPTION
## Summary

`trendSurfaceSeries` in `apps/ui/src/lib/metagraphed/queries.ts` has **zero call sites** anywhere in `apps/ui/src` — not even a test. Its sibling `sortedHealthTrendSurfaces` (which it wrapped) is kept: that one is used by `components/metagraphed/analytics/uptime-timeline.tsx`, confirming this is leftover code, not an unfinished feature.

Verified zero references across `apps/**` (`git grep` is now empty). `queries.test.ts` (55 tests) still passes; eslint + prettier clean.

Closes #6023