### PR TITLE
fix(ui): add CopyButton to validator hotkey/coldkey cells

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
@@ -37,18 +38,22 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
               >
                 {f.hotkeyShort}
               </Link>
+              <CopyButton value={v.hotkey} label="hotkey" />
             </div>
             <div className="font-mono text-[11px] text-ink-muted">
               <span className="uppercase tracking-widest text-[10px]">coldkey </span>
               {v.coldkey ? (
-                <Link
-                  to="/accounts/$ss58"
-                  params={{ ss58: v.coldkey }}
-                  title={v.coldkey}
-                  className="hover:text-accent hover:underline"
-                >
-                  {f.coldkeyShort}
-                </Link>
+                <span className="inline-flex items-center gap-1">
+                  <Link
+                    to="/accounts/$ss58"
+                    params={{ ss58: v.coldkey }}
+                    title={v.coldkey}
+                    className="hover:text-accent hover:underline"
+                  >
+                    {f.coldkeyShort}
+                  </Link>
+                  <CopyButton value={v.coldkey} label="coldkey" />
+                </span>
               ) : (
                 "—"
               )}

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
@@ -50,14 +51,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     thClassName: TH_BASE,
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) => (
-      <Link
-        to="/validators/$hotkey"
-        params={{ hotkey: v.hotkey }}
-        className="text-ink-strong hover:text-accent hover:underline"
-        title={v.hotkey}
-      >
-        {shortHash(v.hotkey) ?? v.hotkey}
-      </Link>
+      <span className="inline-flex items-center gap-1">
+        <Link
+          to="/validators/$hotkey"
+          params={{ hotkey: v.hotkey }}
+          className="text-ink-strong hover:text-accent hover:underline"
+          title={v.hotkey}
+        >
+          {shortHash(v.hotkey) ?? v.hotkey}
+        </Link>
+        <CopyButton value={v.hotkey} label="hotkey" />
+      </span>
     ),
   },
   {
@@ -66,14 +70,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) =>
       v.coldkey ? (
-        <Link
-          to="/accounts/$ss58"
-          params={{ ss58: v.coldkey }}
-          className="hover:text-accent hover:underline"
-          title={v.coldkey}
-        >
-          {shortHash(v.coldkey) ?? v.coldkey}
-        </Link>
+        <span className="inline-flex items-center gap-1">
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: v.coldkey }}
+            className="hover:text-accent hover:underline"
+            title={v.coldkey}
+          >
+            {shortHash(v.coldkey) ?? v.coldkey}
+          </Link>
+          <CopyButton value={v.coldkey} label="coldkey" />
+        </span>
       ) : (
         "—"
       ),


### PR DESCRIPTION
`validator-card-list.tsx` (the mobile-card renderer for `/validators`) and `validator-columns.tsx` (the desktop-table renderer) rendered hotkey and coldkey as tooltip-only text (`title={v.hotkey}`/`title={v.coldkey}`), with no `CopyButton` — the established pattern elsewhere (`neuron-table.tsx:213-234`) already pairs a `<CopyButton>` next to each such identifier.

## What
- `validator-card-list.tsx`: added `<CopyButton value={v.hotkey} label="hotkey" />` next to the hotkey link, and wrapped the coldkey link + a matching `<CopyButton value={v.coldkey} label="coldkey" />` in an inline-flex span.
- `validator-columns.tsx`: same pairing for both the Hotkey and Coldkey column cell renderers, each wrapped in an inline-flex span alongside its `Link`.
- No other surfaces touched; matches `neuron-table.tsx`'s exact `<CopyButton value={...} label="..." />` convention.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/claytonlin1110/metagraphed/screenshots/5859-validators-after-mobile-dark.png)<br><sub>after</sub> |

## Testing
```
npx eslint apps/ui/src/components/metagraphed/validator-card-list.tsx apps/ui/src/components/metagraphed/validator-columns.tsx
npx prettier --check apps/ui/src/components/metagraphed/validator-card-list.tsx apps/ui/src/components/metagraphed/validator-columns.tsx
npm run typecheck --workspace=apps/ui
npm test --workspace=apps/ui
# 131 test files, 1020 tests passed
```

Closes #5859