### PR TITLE
fix(registry): update TaoMarketCap subnet-detail URLs for trailing-slash 301s

### DIFF
--- a/registry/subnets/academia.json
+++ b/registry/subnets/academia.json
@@ -77,7 +77,13 @@
       "id": "sn-109-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "Academia TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/109 on api.taomarketcap.com returning machine-readable JSON for SN109 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Academia exposes source repositories and archives but no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/109/ on api.taomarketcap.com returning machine-readable JSON for SN109 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Academia exposes source repositories and archives but no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -88,7 +94,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/fx-integral/academia"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/109"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/109/"
     }
   ]
 }

--- a/registry/subnets/ain.json
+++ b/registry/subnets/ain.json
@@ -51,7 +51,13 @@
       "id": "sn-69-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "ain TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/69 on api.taomarketcap.com returning machine-readable JSON for SN69 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Herald (ain) exposes outlet registry seed data and heraldmedia.ai but no verified no-auth first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/69/ on api.taomarketcap.com returning machine-readable JSON for SN69 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Herald (ain) exposes outlet registry seed data and heraldmedia.ai but no verified no-auth first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -62,7 +68,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/HeraldMedia/herald/blob/4de1577e82b74807d4081c3f61edffaee9ed718a/README.md"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/69"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/69/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/ansuz.json
+++ b/registry/subnets/ansuz.json
@@ -115,7 +115,13 @@
       "id": "sn-84-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "ansuz TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/84 on api.taomarketcap.com returning machine-readable JSON for SN84 ansuz on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/84/ on api.taomarketcap.com returning machine-readable JSON for SN84 ansuz on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -126,7 +132,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/TatsuProject/ChipForge_SN84"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/84"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/84/"
     }
   ],
   "website_url": "https://www.chipforge.io/"

--- a/registry/subnets/bitads.json
+++ b/registry/subnets/bitads.json
@@ -131,7 +131,7 @@
       "id": "sn-16-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "BitAds TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/16 on api.taomarketcap.com returning machine-readable JSON for SN16 BitAds on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/16/ on api.taomarketcap.com returning machine-readable JSON for SN16 BitAds on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -148,7 +148,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/study-service/BitAds.ai"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/16"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/16/"
     }
   ],
   "website_url": null

--- a/registry/subnets/byteleap.json
+++ b/registry/subnets/byteleap.json
@@ -16,7 +16,13 @@
       "id": "sn-128-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "ByteLeap TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/128 on api.taomarketcap.com returning machine-readable JSON for SN128 ByteLeap on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. ByteLeap is the distributed-compute network on Bittensor SN128 (the official byteleapai validator/miner repositories declare \"Bittensor SN128 Compute Network\"). This indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/128/ on api.taomarketcap.com returning machine-readable JSON for SN128 ByteLeap on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. ByteLeap is the distributed-compute network on Bittensor SN128 (the official byteleapai validator/miner repositories declare \"Bittensor SN128 Compute Network\"). This indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -27,7 +33,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/byteleapai/byteleap-Validator"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/128"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/128/"
     }
   ],
   "source_repo": "https://github.com/byteleapai/byteleap-Validator",

--- a/registry/subnets/byzantium.json
+++ b/registry/subnets/byzantium.json
@@ -107,7 +107,13 @@
       "id": "sn-76-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "Byzantium TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/76 on api.taomarketcap.com returning machine-readable JSON for SN76 Byzantium on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — the indexed subnet-state snapshot feed, complementary to the subnet's first-party validator-weights endpoint. Documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/76/ on api.taomarketcap.com returning machine-readable JSON for SN76 Byzantium on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields — the indexed subnet-state snapshot feed, complementary to the subnet's first-party validator-weights endpoint. Documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -115,7 +121,7 @@
         "submitted_by": "jaytbarimbao-collab"
       },
       "source_urls": ["https://api.taomarketcap.com/developer/documentation/"],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/76"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/76/"
     }
   ],
   "website_url": "https://www.byzantiumai.net/"

--- a/registry/subnets/chronollm.json
+++ b/registry/subnets/chronollm.json
@@ -173,7 +173,7 @@
       "id": "sn-38-taomarketcap-subnet-snapshot",
       "kind": "data-artifact",
       "name": "SN38 on-chain subnet snapshot",
-      "notes": "Public no-auth GET /public/v1/subnets/38 on api.taomarketcap.com returning a machine-readable JSON snapshot of SN38 ChronoLLM on-chain subnet state (owner, emission, registration/burn parameters, and dTAO market fields) for netuid 38. This is the indexed public JSON feed for netuid 38 documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/38/ on api.taomarketcap.com returning a machine-readable JSON snapshot of SN38 ChronoLLM on-chain subnet state (owner, emission, registration/burn parameters, and dTAO market fields) for netuid 38. This is the indexed public JSON feed for netuid 38 documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
       "probe": {
         "enabled": true,
         "method": "GET",
@@ -190,7 +190,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://taomarketcap.com/subnets/38"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/38"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/38/"
     }
   ],
   "source_repo": "https://github.com/chronollm/sn38",

--- a/registry/subnets/cliqueai.json
+++ b/registry/subnets/cliqueai.json
@@ -52,7 +52,13 @@
       "id": "sn-83-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "CliqueAI TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/83 on api.taomarketcap.com returning machine-readable JSON for SN83 CliqueAI on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/83/ on api.taomarketcap.com returning machine-readable JSON for SN83 CliqueAI on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -63,7 +69,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/toptensor/CliqueAI"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/83"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/83/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/ditto.json
+++ b/registry/subnets/ditto.json
@@ -273,7 +273,13 @@
       "id": "sn-118-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "Ditto TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/118 on api.taomarketcap.com returning machine-readable JSON for SN118 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Ditto exposes source repositories, docs, and an SDK but no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/118/ on api.taomarketcap.com returning machine-readable JSON for SN118 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Ditto exposes source repositories, docs, and an SDK but no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -284,7 +290,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/ditto-assistant/dittobench-starter-kit"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/118"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/118/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/dogelayer.json
+++ b/registry/subnets/dogelayer.json
@@ -54,7 +54,13 @@
       "id": "sn-80-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "DogeLayer TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/80 on api.taomarketcap.com returning machine-readable JSON for SN80 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. DogeLayer's documented proxy API requires Bearer auth and has no verified no-auth first-party public endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/80/ on api.taomarketcap.com returning machine-readable JSON for SN80 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. DogeLayer's documented proxy API requires Bearer auth and has no verified no-auth first-party public endpoint; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -65,7 +71,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/dogelayer-ai/dogelayer"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/80"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/80/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/endure-network.json
+++ b/registry/subnets/endure-network.json
@@ -87,7 +87,13 @@
       "id": "sn-30-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "Endure Network TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/30 on api.taomarketcap.com returning machine-readable JSON for SN30 Endure Network on-chain subnet state, hyperparameters, economics, and dTAO market fields. Endure publishes a website and documentation but no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/30/ on api.taomarketcap.com returning machine-readable JSON for SN30 Endure Network on-chain subnet state, hyperparameters, economics, and dTAO market fields. Endure publishes a website and documentation but no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -98,7 +104,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/30/subnet.json"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/30"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/30/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/eni.json
+++ b/registry/subnets/eni.json
@@ -31,7 +31,13 @@
       "id": "sn-101-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "eni TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/101 on api.taomarketcap.com returning machine-readable JSON for SN101 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Tag101 (eni) documents validator task flows in its official source repository but exposes no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/101/ on api.taomarketcap.com returning machine-readable JSON for SN101 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. Tag101 (eni) documents validator task flows in its official source repository but exposes no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -42,7 +48,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/tag101-ai/tag101"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/101"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/101/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/for-sale-burn-to-uid1.json
+++ b/registry/subnets/for-sale-burn-to-uid1.json
@@ -37,7 +37,13 @@
       "id": "sn-104-taomarketcap-subnet-snapshot",
       "kind": "data-artifact",
       "name": "SN104 on-chain subnet snapshot",
-      "notes": "Public no-auth GET /public/v1/subnets/104 on api.taomarketcap.com returning a machine-readable JSON snapshot of SN104 on-chain subnet state and SubnetIdentitiesV3 metadata (subnetName \"for sale (burn to uid1)\", owner description: subnet parked for sale with emissions burning to uid1, plus economics, registration/burn parameters, and dTAO market fields). SN104 exposes no first-party API, repository, or static dataset; this is the indexed public JSON feed for netuid 104 documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/104/ on api.taomarketcap.com returning a machine-readable JSON snapshot of SN104 on-chain subnet state and SubnetIdentitiesV3 metadata (subnetName \"for sale (burn to uid1)\", owner description: subnet parked for sale with emissions burning to uid1, plus economics, registration/burn parameters, and dTAO market fields). SN104 exposes no first-party API, repository, or static dataset; this is the indexed public JSON feed for netuid 104 documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -48,7 +54,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://backprop.finance/dtao/subnets/104-for-sale-burn-to-uid1"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/104"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/104/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/groundlayer.json
+++ b/registry/subnets/groundlayer.json
@@ -136,7 +136,7 @@
       "id": "sn-20-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "GroundLayer TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/20 on api.taomarketcap.com returning machine-readable JSON for SN20 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. GroundLayer's official website paths under www.groundlayer.xyz do not expose a verified first-party public API; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/20/ on api.taomarketcap.com returning machine-readable JSON for SN20 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. GroundLayer's official website paths under www.groundlayer.xyz do not expose a verified first-party public API; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -153,7 +153,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://www.groundlayer.xyz/"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/20"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/20/"
     }
   ],
   "website_url": "https://www.groundlayer.xyz/"

--- a/registry/subnets/hashichain.json
+++ b/registry/subnets/hashichain.json
@@ -55,7 +55,13 @@
       "id": "sn-115-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "HashiChain TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/115 on api.taomarketcap.com returning machine-readable JSON for SN115 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. HashiChain currently has no separately verified first-party public API; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/115/ on api.taomarketcap.com returning machine-readable JSON for SN115 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. HashiChain currently has no separately verified first-party public API; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -66,7 +72,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/hashi115/hashichain"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/115"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/115/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/infinitehash.json
+++ b/registry/subnets/infinitehash.json
@@ -75,7 +75,13 @@
       "id": "sn-89-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "InfiniteHash TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/89 on api.taomarketcap.com returning machine-readable JSON for SN89 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. InfiniteHash's official infinitehash.xyz deployment currently returns HTTP 402 (Payment required), and no other first-party public API is verified; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/89/ on api.taomarketcap.com returning machine-readable JSON for SN89 on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. InfiniteHash's official infinitehash.xyz deployment currently returns HTTP 402 (Payment required), and no other first-party public API is verified; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -86,7 +92,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/README.md"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/89"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/89/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/metahash.json
+++ b/registry/subnets/metahash.json
@@ -41,7 +41,13 @@
       "id": "sn-73-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "MetaHash TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/73 on api.taomarketcap.com returning machine-readable JSON for SN73 MetaHash on-chain subnet state, hyperparameters, economics, and dTAO market fields. MetaHash's previously discovered docs and source URLs do not resolve and no first-party public API endpoint is verified; this indexed on-chain feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/73/ on api.taomarketcap.com returning machine-readable JSON for SN73 MetaHash on-chain subnet state, hyperparameters, economics, and dTAO market fields. MetaHash's previously discovered docs and source URLs do not resolve and no first-party public API endpoint is verified; this indexed on-chain feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -52,7 +58,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/73"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/73/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -45,7 +45,13 @@
       "id": "sn-107-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "Minos TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/107 on api.taomarketcap.com returning machine-readable JSON for SN107 Minos on-chain subnet state, economics, registration/burn parameters, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API and provides the standalone public JSON data for netuid 107 alongside the subnet's first-party /health endpoint.",
+      "notes": "Public no-auth GET /public/v1/subnets/107/ on api.taomarketcap.com returning machine-readable JSON for SN107 Minos on-chain subnet state, economics, registration/burn parameters, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API and provides the standalone public JSON data for netuid 107 alongside the subnet's first-party /health endpoint. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -56,7 +62,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://taomarketcap.com/subnets/107"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/107"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/107/"
     }
   ],
   "contact": "contact@theminos.ai"

--- a/registry/subnets/ni-compute.json
+++ b/registry/subnets/ni-compute.json
@@ -105,7 +105,7 @@
       "id": "sn-27-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "NI Compute TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/27 on api.taomarketcap.com returning machine-readable JSON for SN27 NI Compute on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. NI Compute has no separately registered first-party public subnet-state API; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/27/ on api.taomarketcap.com returning machine-readable JSON for SN27 NI Compute on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. NI Compute has no separately registered first-party public subnet-state API; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -119,7 +119,7 @@
         "submitted_by": "jaytbarimbao-collab"
       },
       "source_urls": ["https://api.taomarketcap.com/developer/documentation/"],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/27"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/27/"
     }
   ]
 }

--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -133,7 +133,13 @@
       "id": "sn-111-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "oneoneone TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/111 on api.taomarketcap.com returning machine-readable JSON for SN111 oneoneone on-chain subnet state, hyperparameters, economics, and dTAO market fields. oneoneone's first-party API access is key-gated with no verified public no-auth endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/111/ on api.taomarketcap.com returning machine-readable JSON for SN111 oneoneone on-chain subnet state, hyperparameters, economics, and dTAO market fields. oneoneone's first-party API access is key-gated with no verified public no-auth endpoint; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -144,7 +150,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/oneoneone-io/subnet-111"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/111"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/111/"
     }
   ],
   "website_url": "https://oneoneone.io/"

--- a/registry/subnets/quasar.json
+++ b/registry/subnets/quasar.json
@@ -231,7 +231,7 @@
       "id": "sn-24-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "Quasar TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/24 on api.taomarketcap.com returning machine-readable JSON for SN24 Quasar on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/24/ on api.taomarketcap.com returning machine-readable JSON for SN24 Quasar on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -248,7 +248,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/SILX-LABS/QUASAR-SUBNET"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/24"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/24/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/ralph.json
+++ b/registry/subnets/ralph.json
@@ -144,7 +144,7 @@
       "id": "sn-40-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "Ralph TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/40 on api.taomarketcap.com returning machine-readable JSON for SN40 on-chain subnet state, hyperparameters, economics, and dTAO market fields. Ralph has no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/40/ on api.taomarketcap.com returning machine-readable JSON for SN40 on-chain subnet state, hyperparameters, economics, and dTAO market fields. Ralph has no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -161,7 +161,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/RalphLabsAI/ralph"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/40"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/40/"
     }
   ],
   "website_url": "https://www.ralphlabs.ai/"

--- a/registry/subnets/satori.json
+++ b/registry/subnets/satori.json
@@ -34,7 +34,13 @@
       "id": "sn-119-taomarketcap-subnet-snapshot",
       "kind": "data-artifact",
       "name": "SN119 on-chain subnet snapshot",
-      "notes": "Public no-auth GET /public/v1/subnets/119 on api.taomarketcap.com returning a machine-readable JSON snapshot of SN119 on-chain subnet state and SubnetIdentitiesV3 metadata (subnetName \"Satori\", owner description: AI companionship and digital residency in Japan, plus economics, registration/burn parameters, and dTAO market fields). SN119 exposes no first-party API, repository, or static dataset; this is the indexed public JSON feed for netuid 119 documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/119/ on api.taomarketcap.com returning a machine-readable JSON snapshot of SN119 on-chain subnet state and SubnetIdentitiesV3 metadata (subnetName \"Satori\", owner description: AI companionship and digital residency in Japan, plus economics, registration/burn parameters, and dTAO market fields). SN119 exposes no first-party API, repository, or static dataset; this is the indexed public JSON feed for netuid 119 documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -45,7 +51,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://backprop.finance/dtao/subnets/119-satori"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/119"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/119/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/streetvision-by-natix.json
+++ b/registry/subnets/streetvision-by-natix.json
@@ -214,7 +214,13 @@
       "id": "sn-72-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "StreetVision TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/72 on api.taomarketcap.com returning machine-readable JSON for SN72 StreetVision on-chain subnet state, hyperparameters, economics, and dTAO market fields. NATIX publishes websites, docs, and dataset artifacts but no verified first-party public subnet API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/72/ on api.taomarketcap.com returning machine-readable JSON for SN72 StreetVision on-chain subnet state, hyperparameters, economics, and dTAO market fields. NATIX publishes websites, docs, and dataset artifacts but no verified first-party public subnet API endpoint; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -225,7 +231,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/natixnetwork/streetvision-subnet"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/72"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/72/"
     }
   ],
   "social": {

--- a/registry/subnets/subnet-86.json
+++ b/registry/subnets/subnet-86.json
@@ -38,7 +38,13 @@
       "id": "sn-86-taomarketcap-subnet-snapshot",
       "kind": "data-artifact",
       "name": "SN86 on-chain subnet snapshot",
-      "notes": "Public no-auth GET /public/v1/subnets/86 on api.taomarketcap.com returning a machine-readable JSON snapshot of SN86 on-chain subnet state and SubnetIdentitiesV3 metadata (subnetName \"⚒\", owner description about building a methodical foundation and onboarding a senior data scientist, plus economics, registration/burn parameters, and dTAO market fields). SN86 exposes no first-party API, repository, or static dataset; this is the indexed public JSON feed for netuid 86 documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/86/ on api.taomarketcap.com returning a machine-readable JSON snapshot of SN86 on-chain subnet state and SubnetIdentitiesV3 metadata (subnetName \"⚒\", owner description about building a methodical foundation and onboarding a senior data scientist, plus economics, registration/burn parameters, and dTAO market fields). SN86 exposes no first-party API, repository, or static dataset; this is the indexed public JSON feed for netuid 86 documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -49,7 +55,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://backprop.finance/dtao/subnets/86-subnet-86"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/86"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/86/"
     },
     {
       "auth_required": false,

--- a/registry/subnets/taolend.json
+++ b/registry/subnets/taolend.json
@@ -97,7 +97,13 @@
       "id": "sn-116-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "TaoLend TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/116 on api.taomarketcap.com returning machine-readable JSON for SN116 TaoLend on-chain subnet state, hyperparameters, economics, and dTAO market fields. TaoLend exposes no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/116/ on api.taomarketcap.com returning machine-readable JSON for SN116 TaoLend on-chain subnet state, hyperparameters, economics, and dTAO market fields. TaoLend exposes no verified first-party public API endpoint; this indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -108,7 +114,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/oxylok/116-taolend"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/116"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/116/"
     }
   ],
   "website_url": "https://taolend.io/"

--- a/registry/subnets/tensorclaw.json
+++ b/registry/subnets/tensorclaw.json
@@ -154,7 +154,13 @@
       "id": "sn-92-taomarketcap-subnet-api",
       "kind": "subnet-api",
       "name": "Tensorclaw TaoMarketCap subnet snapshot API",
-      "notes": "Public no-auth GET /public/v1/subnets/92 on api.taomarketcap.com returning machine-readable JSON for SN92 Tensorclaw on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API.",
+      "notes": "Public no-auth GET /public/v1/subnets/92/ on api.taomarketcap.com returning machine-readable JSON for SN92 Tensorclaw on-chain subnet state, SubnetIdentitiesV3 metadata, economics, and dTAO market fields. This indexed feed is documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taomarketcap",
       "public_safe": true,
       "review": {
@@ -165,7 +171,7 @@
         "https://api.taomarketcap.com/developer/documentation/",
         "https://github.com/tensorclaw/tensorclaw"
       ],
-      "url": "https://api.taomarketcap.com/public/v1/subnets/92"
+      "url": "https://api.taomarketcap.com/public/v1/subnets/92/"
     }
   ],
   "website_url": "https://www.tensorclaw.ai/"


### PR DESCRIPTION
## Summary

`api.taomarketcap.com` now enforces a trailing slash on `/public/v1/subnets/{netuid}`: the non-slash form 301-redirects to the slash form, and the slash form rejects `HEAD` (405, requires `GET`). This was discovered independently on two subnets during the root->128 registry accuracy audit — SN52 Dojo (#6092) and SN53 EfficientFrontier (#6094, tracked under #5903) — and both were fixed there as the reference pattern. This PR sweeps the remaining registry for the same issue and applies the identical fix.

Single mechanical fix applied consistently across 27 files in one PR, per direction from the repo owner (the one-file-per-PR contributor convention doesn't apply here — this is a uniform correction of pre-existing registry content, not new surface submissions).

## What Changed

For each of the 27 affected `registry/subnets/<slug>.json` files (all subnet-detail `subnet-api`/`subnet-snapshot` surfaces pointing at `api.taomarketcap.com/public/v1/subnets/{netuid}` without a trailing slash):

- Appended the trailing slash to the `url` field
- Updated `notes` to reflect the new URL and document the redirect/405 behavior (matching the #6092/#6094 reference wording)
- Added a `probe` block (`method: GET`, `expect: json`, `timeout_ms: 10000`) to the 21 files that had none at all, so the surface is actually probe-monitored going forward
- Left the 6 files that already had a correctly-configured `GET` probe untouched aside from the URL/notes fix

`registry/subnets/dojo.json` and `registry/subnets/efficientfrontier.json` (SN52/SN53) already carry this fix from #6092/#6094 and are not touched here. Three `source_urls` proof-links elsewhere (root.json, green-compute.json, data-universe.json) also reference bare `api.taomarketcap.com/public/v1/subnets/{n}` URLs but are proof citations, not probed endpoints — out of scope, left as-is. `/candle-chart` sub-route surfaces (a different endpoint, separate trailing-slash behavior not verified here) are also out of scope and untouched.

`public/metagraph/operational-surfaces.json` is not touched, per instruction — it's a generated artifact.

## Live Verification

All 27 endpoints curl-verified before editing (paced to respect the API's rate limiting): every non-slash form returned `301` to the slash form, and every slash form returned `200` with valid JSON.

## Validation

- [x] `npm run validate:surface -- <file>` — passes individually for all 27 files
- [x] `npm run scan:public-safety` — passes
- [x] `npm run validate` — no new findings; the only output (`per-subnet detail artifact is not reproducible from registry inputs` x129) is pre-existing on unmodified `main` (confirmed via `git stash` comparison) and is resolved by CI's own `npm run build` step that runs before `npm run validate` in the workflow
- [x] `npm test` — 8918/8918 tests pass; the one test-file-level failure (`tests/artifacts.test.mjs > registry validates`) also reproduces identically on unmodified `main` for the same pre-existing build-artifact-staleness reason (confirmed via `git stash` comparison)