### PR TITLE
fix(scripts): promote-reviewed promotes curation.level from any starting tier

### DIFF
--- a/registry/subnets/babelbit.json
+++ b/registry/subnets/babelbit.json
@@ -2,8 +2,9 @@
   "categories": [],
   "contact": "mk@babelbit.ai",
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-20T00:00:00.000Z"
   },
   "name": "Babelbit",
   "netuid": 59,

--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -1,8 +1,9 @@
 {
   "categories": [],
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-20T00:00:00.000Z"
   },
   "name": "Minos",
   "netuid": 107,

--- a/scripts/lib/maintainer-reviewed.mjs
+++ b/scripts/lib/maintainer-reviewed.mjs
@@ -1,0 +1,62 @@
+// Shared, pure helpers for the maintainer-reviewed trust tier so the promotion
+// writer (scripts/promote-reviewed.mjs) and the CI guard (scripts/validate.mjs)
+// agree on one definition. registry/reviews/maintainer-reviewed.json is the
+// single source of truth for the tier (see docs/curation-playbook.md): a
+// recorded decision is the ONLY sanctioned way an overlay reaches
+// curation.level "maintainer-reviewed".
+
+// The two top trust tiers. `adapter-backed` sits ABOVE `maintainer-reviewed`
+// (see TOP_TRUST_LEVELS / the level-resolution order in scripts/lib.mjs), so a
+// maintainer-reviewed decision must never DOWN-grade an already adapter-backed
+// overlay, and the CI guard must accept either tier as satisfying the decision.
+export const TOP_TRUST_LEVELS = new Set([
+  "maintainer-reviewed",
+  "adapter-backed",
+]);
+
+// Apply a review decision to an overlay's curation block. Always records the
+// decision's review_state/reviewed_at; and, for a maintainer-reviewed decision,
+// promotes curation.level to "maintainer-reviewed" from ANY lower starting tier
+// (community-seeded / candidate-discovered / native / machine-verified) — not
+// only machine-verified as before, which silently left the rest un-promoted
+// (live drift: SN59, SN107). An already top-trust level is left untouched.
+export function curationForDecision(curation, decision) {
+  const next = {
+    ...(curation || {}),
+    review_state: decision.decision,
+    reviewed_at: decision.reviewed_at,
+  };
+  if (
+    decision.decision === "maintainer-reviewed" &&
+    !TOP_TRUST_LEVELS.has(next.level)
+  ) {
+    next.level = "maintainer-reviewed";
+  }
+  return next;
+}
+
+// The inverse of validate.mjs's existing "a maintainer-reviewed level needs a
+// backing decision" gate: find every maintainer-reviewed DECISION whose subnet
+// overlay is NOT actually at a top-trust level — i.e. a recorded decision that
+// never took effect on the overlay. Returns [{ netuid, slug, level }] so the
+// caller can name the drifted overlays. Decisions with no loaded overlay are
+// skipped (a missing overlay is a separate concern).
+export function maintainerReviewedDrift(subnets, decisions) {
+  const levelByNetuid = new Map(
+    subnets.map((subnet) => [subnet.netuid, subnet.curation?.level]),
+  );
+  const drifted = [];
+  for (const decision of decisions || []) {
+    if (decision.decision !== "maintainer-reviewed") {
+      continue;
+    }
+    const level = levelByNetuid.get(decision.netuid);
+    if (level === undefined) {
+      continue;
+    }
+    if (!TOP_TRUST_LEVELS.has(level)) {
+      drifted.push({ netuid: decision.netuid, slug: decision.slug, level });
+    }
+  }
+  return drifted;
+}

--- a/scripts/promote-reviewed.mjs
+++ b/scripts/promote-reviewed.mjs
@@ -8,6 +8,7 @@ import {
   stableStringify,
   writeJson,
 } from "./lib.mjs";
+import { curationForDecision } from "./lib/maintainer-reviewed.mjs";
 
 const args = new Set(process.argv.slice(2));
 const shouldWrite = args.has("--write");
@@ -45,17 +46,7 @@ for (const decision of decisionsDocument.decisions || []) {
   }
 
   const nextOverlay = structuredClone(entry.overlay);
-  nextOverlay.curation = {
-    ...(nextOverlay.curation || {}),
-    review_state: decision.decision,
-    reviewed_at: decision.reviewed_at,
-  };
-  if (
-    decision.decision === "maintainer-reviewed" &&
-    nextOverlay.curation.level === "machine-verified"
-  ) {
-    nextOverlay.curation.level = "maintainer-reviewed";
-  }
+  nextOverlay.curation = curationForDecision(nextOverlay.curation, decision);
 
   const changed =
     stableStringify(nextOverlay) !== stableStringify(entry.overlay);

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -34,6 +34,7 @@ import {
   R2_STAGING_RELATIVE_ROOT,
   artifactStorageTierForRelativePath,
 } from "../src/artifact-storage.mjs";
+import { maintainerReviewedDrift } from "./lib/maintainer-reviewed.mjs";
 
 const providerKinds = new Set([
   "subnet-team",
@@ -1592,6 +1593,21 @@ for (const subnet of subnets) {
       `${subnet.slug}: curation.level "maintainer-reviewed" (netuid ${subnet.netuid}) has no backing decision in registry/reviews/maintainer-reviewed.json — add a decision there instead of hand-editing the overlay level`,
     );
   }
+}
+
+// The inverse gate: a recorded maintainer-reviewed decision must actually have
+// taken effect on the overlay (its level must be at a top-trust tier). Before
+// this check, promote-reviewed.mjs only promoted from machine-verified, so a
+// decision against a community-seeded/candidate-discovered/native overlay
+// silently never materialized — invisible drift (live-confirmed SN59, SN107).
+for (const drifted of maintainerReviewedDrift(
+  subnets,
+  reviewDecisionsDocument.decisions,
+)) {
+  assert(
+    false,
+    `${drifted.slug}: has a maintainer-reviewed decision in registry/reviews/maintainer-reviewed.json (netuid ${drifted.netuid}) but curation.level is "${drifted.level}" — run \`npm run review:promote\` so the recorded decision actually promotes the overlay`,
+  );
 }
 
 // Identity guardrail (the "Nodexo" class): a curated overlay's name matching

--- a/tests/maintainer-reviewed-promotion.test.mjs
+++ b/tests/maintainer-reviewed-promotion.test.mjs
@@ -1,0 +1,123 @@
+// #5992: promote-reviewed.mjs only promoted curation.level from
+// "machine-verified", so a maintainer-reviewed decision against any other
+// starting tier (community-seeded / candidate-discovered / native) silently
+// never took effect — live drift on SN59/SN107. These tests pin the shared
+// helpers both scripts now use: curationForDecision (the writer) and
+// maintainerReviewedDrift (the CI guard).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  TOP_TRUST_LEVELS,
+  curationForDecision,
+  maintainerReviewedDrift,
+} from "../scripts/lib/maintainer-reviewed.mjs";
+
+const reviewedDecision = (netuid = 59) => ({
+  netuid,
+  slug: `sn-${netuid}`,
+  decision: "maintainer-reviewed",
+  reviewed_at: "2026-06-20T00:00:00.000Z",
+});
+
+describe("curationForDecision (#5992)", () => {
+  for (const startLevel of [
+    "community-seeded",
+    "candidate-discovered",
+    "native",
+    "machine-verified",
+  ]) {
+    test(`promotes level to maintainer-reviewed from ${startLevel}`, () => {
+      const next = curationForDecision(
+        { level: startLevel, review_state: "unreviewed" },
+        reviewedDecision(),
+      );
+      assert.equal(next.level, "maintainer-reviewed");
+      assert.equal(next.review_state, "maintainer-reviewed");
+      assert.equal(next.reviewed_at, "2026-06-20T00:00:00.000Z");
+    });
+  }
+
+  test("never downgrades an adapter-backed overlay", () => {
+    const next = curationForDecision(
+      { level: "adapter-backed", review_state: "maintainer-reviewed" },
+      reviewedDecision(7),
+    );
+    assert.equal(next.level, "adapter-backed");
+    // still records the decision's review metadata
+    assert.equal(next.reviewed_at, "2026-06-20T00:00:00.000Z");
+  });
+
+  test("leaves an already maintainer-reviewed level unchanged", () => {
+    const next = curationForDecision(
+      { level: "maintainer-reviewed" },
+      reviewedDecision(),
+    );
+    assert.equal(next.level, "maintainer-reviewed");
+  });
+
+  test("a non-maintainer-reviewed decision records state but never promotes level", () => {
+    const next = curationForDecision(
+      { level: "community-seeded" },
+      { decision: "rejected", reviewed_at: "2026-06-20T00:00:00.000Z" },
+    );
+    assert.equal(next.level, "community-seeded");
+    assert.equal(next.review_state, "rejected");
+  });
+
+  test("handles a missing curation block", () => {
+    const next = curationForDecision(undefined, reviewedDecision());
+    assert.equal(next.level, "maintainer-reviewed");
+    assert.equal(next.review_state, "maintainer-reviewed");
+  });
+});
+
+describe("maintainerReviewedDrift (#5992)", () => {
+  const decisions = [
+    reviewedDecision(59),
+    reviewedDecision(7),
+    { netuid: 3, slug: "sn-3", decision: "rejected", reviewed_at: "x" },
+  ];
+
+  test("flags a maintainer-reviewed decision whose overlay is a lower tier", () => {
+    const drift = maintainerReviewedDrift(
+      [{ netuid: 59, slug: "sn-59", curation: { level: "community-seeded" } }],
+      decisions,
+    );
+    assert.deepEqual(drift, [
+      { netuid: 59, slug: "sn-59", level: "community-seeded" },
+    ]);
+  });
+
+  test("does not flag an overlay already at a top-trust tier", () => {
+    const drift = maintainerReviewedDrift(
+      [
+        {
+          netuid: 59,
+          slug: "sn-59",
+          curation: { level: "maintainer-reviewed" },
+        },
+        { netuid: 7, slug: "sn-7", curation: { level: "adapter-backed" } },
+      ],
+      decisions,
+    );
+    assert.deepEqual(drift, []);
+  });
+
+  test("ignores a decision with no loaded overlay", () => {
+    const drift = maintainerReviewedDrift([], decisions);
+    assert.deepEqual(drift, []);
+  });
+
+  test("ignores non-maintainer-reviewed decisions", () => {
+    const drift = maintainerReviewedDrift(
+      [{ netuid: 3, slug: "sn-3", curation: { level: "community-seeded" } }],
+      decisions,
+    );
+    assert.deepEqual(drift, []);
+  });
+
+  test("adapter-backed is the higher of the two top-trust tiers", () => {
+    assert.ok(TOP_TRUST_LEVELS.has("maintainer-reviewed"));
+    assert.ok(TOP_TRUST_LEVELS.has("adapter-backed"));
+  });
+});


### PR DESCRIPTION
### The bug

`scripts/promote-reviewed.mjs` only bumped `curation.level` to `"maintainer-reviewed"` when the existing level was **exactly** `"machine-verified"`. A recorded maintainer-reviewed decision against any other pre-tier level (`community-seeded` / `candidate-discovered` / `native`) silently updated `review_state`/`reviewed_at` but **never promoted the level**.

`docs/curation-playbook.md` states the tier is "reached ONLY by adding a decision" with no carve-out for starting level, and `validate.mjs` only enforced the **reverse** direction (a `maintainer-reviewed` level needs a backing decision) — so this drift was invisible to CI. Live-confirmed on SN59 (babelbit) and SN107 (minos), both recorded as `maintainer-reviewed` but sitting at `community-seeded`.

### Fix

- **`scripts/lib/maintainer-reviewed.mjs`** (new, shared by the writer and the CI guard):
  - `curationForDecision(curation, decision)` — promotes `level` to `maintainer-reviewed` from **any** tier below top-trust. It **never downgrades** an already `adapter-backed` overlay: `adapter-backed` is the *higher* of the two top-trust tiers (`TOP_TRUST_LEVELS`), and two real overlays (SN7 allways, SN74 gittensor) sit at `adapter-backed` **with** maintainer-reviewed decisions — promoting them down would be a regression.
  - `maintainerReviewedDrift(subnets, decisions)` — finds recorded maintainer-reviewed decisions whose overlay is not at a top-trust level.
- **`promote-reviewed.mjs`** uses `curationForDecision`.
- **`validate.mjs`** adds the missing inverse gate: a maintainer-reviewed decision whose overlay isn't at a top-trust level now fails CI (accepting `adapter-backed` as satisfying, so SN7/SN74 don't false-positive). This is the check that would have caught the SN59/SN107 drift.
- **Corrected the live-drifted SN107 (`minos.json`)** overlay (curation block only — no surface edits). SN59 (babelbit) was independently brought to `maintainer-reviewed` by #6104 while this was being prepared, so only SN107 remained; the new CI guard confirms zero drift remains across the whole corpus.

### Tests

`tests/maintainer-reviewed-promotion.test.mjs` (13 tests): promotion from every starting tier, `adapter-backed` preservation, and the drift detector flagging a lower-tier overlay / clearing top-trust ones. Verified locally: new tests pass, the existing `validate-surface-reviewed-convention` test still passes, `npm run validate` passes with zero remaining drift, and `prettier`/`eslint` are clean on the changed files.

Scripts + registry-data change — no schema/contract regeneration.

Closes #5992
