### PR TITLE
feat(observability): instrument the MCP tool-dispatch chokepoint with usage events

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -45,6 +45,7 @@ import {
   graphqlRateLimited,
 } from "../workers/request-handlers/rpc-proxy.mjs";
 import { handleGraphQLRequest } from "./graphql.mjs";
+import { recordUsageEvent } from "./usage-telemetry.mjs";
 import {
   isValidSubscriptionId,
   subscriptionStorageKey,
@@ -14199,6 +14200,22 @@ function negotiateProtocol(requested) {
     : MCP_LATEST_PROTOCOL;
 }
 
+// Record one usage event for a resolved tool invocation at the single dispatch
+// chokepoint (callTool). Fire-and-forget: telemetry must never block or fault
+// the tool response, so the recorder's result is never awaited and any
+// synchronous throw is swallowed. recordUsageEvent itself already swallows its
+// own async errors; the ctx.recordUsage seam is test-only.
+function recordToolUsage(ctx, mcpTool, ok, durationMs) {
+  try {
+    const record = ctx?.recordUsage ?? recordUsageEvent;
+    void Promise.resolve(record(ctx?.env, { mcpTool, ok, durationMs })).catch(
+      () => {},
+    );
+  } catch {
+    // Never surface a telemetry fault into the tool path.
+  }
+}
+
 async function callTool(params, ctx) {
   const name = params?.name;
   const tool = typeof name === "string" ? TOOLS_BY_NAME.get(name) : undefined;
@@ -14208,9 +14225,12 @@ async function callTool(params, ctx) {
       isError: true,
     };
   }
+  const startedAt = Date.now();
+  let ok = false;
   try {
     const args = validateToolArguments(tool, params?.arguments);
     const data = await tool.handler(args, ctx);
+    ok = true;
     return {
       content: [{ type: "text", text: JSON.stringify(data) }],
       structuredContent: data,
@@ -14248,6 +14268,10 @@ async function callTool(params, ctx) {
       },
       isError: true,
     };
+  } finally {
+    // Exactly one usage event per resolved-tool invocation, on both the success
+    // and the (toolError / internal) failure paths. ok reflects the outcome.
+    recordToolUsage(ctx, name, ok, Date.now() - startedAt);
   }
 }
 
@@ -14372,6 +14396,10 @@ function buildContext(request, env, deps) {
     clientIp: mcpClientKey(request),
     readArtifact: deps.readArtifact,
     readHealthKv: deps.readHealthKv,
+    // Optional test seam: the usage-telemetry recorder (defaults to the real
+    // recordUsageEvent at the call site). Injecting a spy/throwing stub here
+    // lets a test prove a tool call is unaffected when telemetry fails.
+    recordUsage: deps.recordUsage,
   };
 }
 

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -6021,6 +6021,98 @@ describe("MCP query_graphql (#5591 — GraphQL bridge tool)", () => {
   });
 });
 
+describe("MCP usage-telemetry instrumentation (#6031)", () => {
+  function spyRecorder() {
+    const calls = [];
+    return {
+      calls,
+      fn: (env, event) => {
+        calls.push({ env, event });
+        return Promise.resolve(true);
+      },
+    };
+  }
+
+  // get_subnet succeeds by returning the overview artifact for netuid 7.
+  function okDeps(extra = {}) {
+    return {
+      ...makeDeps({ "/metagraph/overview/7.json": { netuid: 7 } }),
+      ...extra,
+    };
+  }
+
+  test("records exactly one usage event per successful tool invocation (tool name, ok, latency)", async () => {
+    const spy = spyRecorder();
+    const res = await callTool(
+      "get_subnet",
+      { netuid: 7 },
+      { deps: okDeps({ recordUsage: spy.fn }) },
+    );
+    assert.equal(res.body.result.isError ?? false, false);
+    assert.equal(res.body.result.structuredContent.netuid, 7);
+    assert.equal(spy.calls.length, 1);
+    const { event } = spy.calls[0];
+    assert.equal(event.mcpTool, "get_subnet");
+    assert.equal(event.ok, true);
+    assert.equal(typeof event.durationMs, "number");
+    assert.ok(event.durationMs >= 0);
+  });
+
+  test("records ok:false for a failing tool, still returning the normal error result", async () => {
+    const spy = spyRecorder();
+    const res = await callTool(
+      "get_subnet",
+      { netuid: -1 },
+      { deps: { ...makeDeps(), recordUsage: spy.fn } },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(spy.calls.length, 1);
+    assert.equal(spy.calls[0].event.mcpTool, "get_subnet");
+    assert.equal(spy.calls[0].event.ok, false);
+  });
+
+  test("an unknown tool records no usage event (not a real invocation)", async () => {
+    const spy = spyRecorder();
+    const res = await callTool(
+      "definitely_not_a_tool",
+      {},
+      { deps: { ...makeDeps(), recordUsage: spy.fn } },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(spy.calls.length, 0);
+  });
+
+  test("a telemetry recorder that throws synchronously does not fault the tool response", async () => {
+    const res = await callTool(
+      "get_subnet",
+      { netuid: 7 },
+      {
+        deps: okDeps({
+          recordUsage: () => {
+            throw new Error("telemetry boom");
+          },
+        }),
+      },
+    );
+    assert.equal(res.body.result.isError ?? false, false);
+    assert.equal(res.body.result.structuredContent.netuid, 7);
+  });
+
+  test("a telemetry recorder that rejects asynchronously is swallowed, not surfaced", async () => {
+    const res = await callTool(
+      "get_subnet",
+      { netuid: 7 },
+      {
+        deps: okDeps({
+          recordUsage: () => Promise.reject(new Error("async boom")),
+        }),
+      },
+    );
+    assert.equal(res.body.result.isError ?? false, false);
+    assert.equal(res.body.result.structuredContent.netuid, 7);
+  });
+});
+
 describe("MCP get_account_counterparties", () => {
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
   const CP = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy";


### PR DESCRIPTION
Wires the usage-telemetry module (#6030) into `src/mcp-server.mjs`'s single tool-dispatch chokepoint — `callTool`, the one point every resolved tool call passes through — rather than instrumenting each of the ~150 tools individually.

Closes #6031.

## What
- On both the success and failure paths, records **exactly one** usage event per resolved-tool invocation via `recordUsageEvent`: the **tool name**, **ok** (success/failure), and **coarse wall-clock latency** — nothing from arguments or response content. An unknown-tool call isn't a real invocation and records nothing.
- **Strictly out-of-band**: the recorder result is never awaited (fire-and-forget → cannot block the tool response) and any synchronous throw is swallowed (`recordUsageEvent` already swallows its own async errors), so a telemetry fault can never change a tool's behavior or response shape.
- A `ctx.recordUsage` seam (defaulting to the real `recordUsageEvent`) lets tests inject a spy/throwing/rejecting recorder.

## Tests
Five cases in `tests/mcp-server.test.mjs`: one event per successful call (name/ok/latency), `ok:false` on a failing tool with the normal error result still returned, no event for an unknown tool, and a tool call unaffected by a recorder that **throws synchronously** or **rejects asynchronously**. Full MCP suite green (1087 tests); `validate-mcp` passes (176 tools); the instrumented chokepoint is 100% covered (statements + branches).