### PR TITLE
fix(ui): add CopyButton next to Events hotkey on block detail

### DIFF
--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -418,14 +418,17 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                       </td>
                       <td className="px-4 py-2.5 font-mono text-[11px] text-ink">
                         {event.hotkey ? (
-                          <Link
-                            to="/accounts/$ss58"
-                            params={{ ss58: event.hotkey }}
-                            className="hover:underline"
-                            title={event.hotkey}
-                          >
-                            {shortHash(event.hotkey, 10)}
-                          </Link>
+                          <div className="flex max-w-xs items-center gap-1.5">
+                            <Link
+                              to="/accounts/$ss58"
+                              params={{ ss58: event.hotkey }}
+                              className="truncate hover:underline"
+                              title={event.hotkey}
+                            >
+                              {shortHash(event.hotkey, 10)}
+                            </Link>
+                            <CopyButton value={event.hotkey} label="hotkey" />
+                          </div>
                         ) : (
                           "—"
                         )}


### PR DESCRIPTION
## Summary

- Pair the Events-section hotkey `<Link>` with `<CopyButton value={event.hotkey} label=hotkey />`, matching the Chain events args row in the same file.
- No other sections changed.

Closes #5860

## Screenshots

| Viewport Â· Theme | Before | After |
| --- | --- | --- |
| Mobile Â· Light | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5860-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5860-after-mobile-light.png) |
| Mobile Â· Dark | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5860-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5860-after-mobile-dark.png) |
| Tablet Â· Light | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5860-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5860-after-tablet-light.png) |
| Tablet Â· Dark | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5860-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5860-after-tablet-dark.png) |
| Desktop Â· Light | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5860-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5860-after-desktop-light.png) |
| Desktop Â· Dark | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5860-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/5860-after-desktop-dark.png) |

## Test plan

- [ ] Open `/blocks/<ref>` scrolled to **Events**; rows with a hotkey show a copy control next to the link
- [ ] Copy button writes the full hotkey to the clipboard
- [ ] Rows without a hotkey still show `â€”` with no copy control
- [ ] Chain events section unchanged
