### PR TITLE
feat(observability): instrument REST/GraphQL request handlers with usage events

### DIFF
--- a/tests/request-usage-telemetry.test.mjs
+++ b/tests/request-usage-telemetry.test.mjs
@@ -1,0 +1,300 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.mjs";
+import worker, {
+  usageRouteLabel,
+  withUsageTelemetry,
+} from "../workers/api.mjs";
+
+const CONFIGURED_ENV = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" };
+const SS58 = "5F3sa2TJAWMqDhXG6jhV4N8ko9SxwGy8TpaNS1repo5EYjQX";
+
+function label(pathname) {
+  return usageRouteLabel(new URL(`https://api.metagraph.sh${pathname}`));
+}
+
+function req(pathname = "/api/v1/subnets", init) {
+  return new Request(`https://api.metagraph.sh${pathname}`, init);
+}
+
+// Collects the events a run hands to the recorder, plus the promises it hands
+// to waitUntil, so a test can assert on both without touching PostHog.
+function recorder({ result = true } = {}) {
+  const events = [];
+  return {
+    events,
+    recordUsageEvent(env, event) {
+      events.push({ env, event });
+      return typeof result === "function" ? result() : result;
+    },
+  };
+}
+
+function fakeCtx() {
+  const scheduled = [];
+  return { scheduled, waitUntil: (promise) => scheduled.push(promise) };
+}
+
+describe("usageRouteLabel", () => {
+  test("labels every GraphQL operation with the transport, not the operation name", () => {
+    assert.equal(label("/api/v1/graphql"), "graphql");
+  });
+
+  test("collapses path parameters into the shared route id", () => {
+    assert.equal(label("/api/v1/subnets"), "subnets");
+    assert.equal(label("/api/v1/subnets/74"), "subnet-detail");
+    // One label for every account, not one label per ss58 address.
+    assert.equal(label(`/api/v1/accounts/${SS58}`), "account-summary");
+    assert.equal(label("/api/v1/blocks/123456"), "block-detail");
+  });
+
+  test("namespaces non-default networks onto the label", () => {
+    assert.equal(label("/api/v1/testnet/subnets"), "testnet:subnets");
+    assert.equal(label("/api/v1/local/subnets"), "local:subnets");
+    assert.equal(label("/api/v1/testnet/graphql"), "testnet:graphql");
+  });
+
+  test("leaves default-network aliases unprefixed", () => {
+    assert.equal(label("/api/v1/mainnet/subnets/74"), "subnet-detail");
+    assert.equal(label("/api/v1/finney/subnets"), "subnets");
+  });
+
+  test("skips MCP, which is instrumented at its own dispatch chokepoint", () => {
+    assert.equal(label("/mcp"), null);
+    assert.equal(label("/mcp/session"), null);
+  });
+
+  test("skips traffic that is not API usage", () => {
+    assert.equal(label("/"), null);
+    assert.equal(label("/favicon.ico"), null);
+    assert.equal(label("/badge/subnet/74.svg"), null);
+    assert.equal(label("/rpc/v1/anything"), null);
+  });
+
+  test("masks identifier-shaped segments on routes outside the contract", () => {
+    assert.equal(label("/api/v1/ask"), "/api/v1/ask");
+    assert.equal(
+      label("/api/v1/webhooks/subscriptions/123"),
+      "/api/v1/webhooks/subscriptions/:n",
+    );
+    assert.equal(
+      label("/api/v1/internal/0xdeadbeefcafe"),
+      "/api/v1/internal/:hash",
+    );
+    assert.equal(label(`/api/v1/internal/${SS58}`), "/api/v1/internal/:ss58");
+  });
+});
+
+describe("withUsageTelemetry", () => {
+  test("does no telemetry work when the deployment is unconfigured", async () => {
+    const spy = recorder();
+    const response = await withUsageTelemetry(
+      req(),
+      {},
+      fakeCtx(),
+      async () => new Response("ok"),
+      spy,
+    );
+
+    assert.equal(await response.text(), "ok");
+    assert.deepEqual(spy.events, []);
+  });
+
+  test("records exactly one event per request and returns the response untouched", async () => {
+    const spy = recorder();
+    const ctx = fakeCtx();
+    const handled = new Response("payload", { status: 200 });
+
+    const response = await withUsageTelemetry(
+      req("/api/v1/subnets/74"),
+      CONFIGURED_ENV,
+      ctx,
+      async () => handled,
+      spy,
+    );
+
+    assert.equal(response, handled);
+    assert.equal(spy.events.length, 1);
+    const { env, event } = spy.events[0];
+    assert.equal(env, CONFIGURED_ENV);
+    assert.equal(event.route, "subnet-detail");
+    assert.equal(event.ok, true);
+    assert.equal(typeof event.durationMs, "number");
+    assert.ok(event.durationMs >= 0);
+    // The event is drained through waitUntil, not awaited in the request path.
+    assert.equal(ctx.scheduled.length, 1);
+  });
+
+  test("records GraphQL POSTs without reading the request body", async () => {
+    const spy = recorder();
+    const body = JSON.stringify({ query: "{ subnets { netuid } }" });
+    const request = req("/api/v1/graphql", { method: "POST", body });
+
+    await withUsageTelemetry(
+      request,
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("{}"),
+      spy,
+    );
+
+    assert.equal(spy.events[0].event.route, "graphql");
+    // The handler downstream still owns an unread body.
+    assert.equal(request.bodyUsed, false);
+    assert.equal(await request.text(), body);
+  });
+
+  test("does not record a route the chokepoint skips", async () => {
+    const spy = recorder();
+    const response = await withUsageTelemetry(
+      req("/mcp", { method: "POST" }),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("ok"),
+      spy,
+    );
+
+    assert.equal(await response.text(), "ok");
+    assert.deepEqual(spy.events, []);
+  });
+
+  test("treats 4xx as a served request and 5xx as a failure", async () => {
+    const rejected = recorder();
+    await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("nope", { status: 404 }),
+      rejected,
+    );
+    assert.equal(rejected.events[0].event.ok, true);
+
+    const broken = recorder();
+    await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("boom", { status: 500 }),
+      broken,
+    );
+    assert.equal(broken.events[0].event.ok, false);
+  });
+
+  test("does not record a subscription upgrade as a request", async () => {
+    const spy = recorder();
+    const response = await withUsageTelemetry(
+      req("/api/v1/graphql", { headers: { upgrade: "websocket" } }),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("subscribed"),
+      spy,
+    );
+
+    assert.equal(await response.text(), "subscribed");
+    assert.deepEqual(spy.events, []);
+  });
+
+  test("records a thrown handler as a failure and still propagates the error", async () => {
+    const spy = recorder();
+    await assert.rejects(
+      withUsageTelemetry(
+        req(),
+        CONFIGURED_ENV,
+        fakeCtx(),
+        async () => {
+          throw new Error("handler exploded");
+        },
+        spy,
+      ),
+      /handler exploded/,
+    );
+
+    assert.equal(spy.events.length, 1);
+    assert.equal(spy.events[0].event.ok, false);
+  });
+
+  // The regression the issue asks for: a telemetry failure must never become a
+  // request failure, in any of the shapes it can fail in.
+  test("serves the request when the recorder rejects", async () => {
+    const spy = recorder({
+      result: () => Promise.reject(new Error("posthog down")),
+    });
+    const response = await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("ok"),
+      spy,
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "ok");
+  });
+
+  test("serves the request when the recorder throws synchronously", async () => {
+    const spy = recorder({
+      result: () => {
+        throw new Error("recorder exploded");
+      },
+    });
+    const response = await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("ok"),
+      spy,
+    );
+
+    assert.equal(await response.text(), "ok");
+  });
+
+  test("serves the request when waitUntil throws", async () => {
+    const spy = recorder();
+    const ctx = {
+      waitUntil() {
+        throw new Error("isolate already finished");
+      },
+    };
+    const response = await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      ctx,
+      async () => new Response("ok"),
+      spy,
+    );
+
+    assert.equal(await response.text(), "ok");
+    assert.equal(spy.events.length, 1);
+  });
+
+  test("serves the request when no usable ExecutionContext is supplied", async () => {
+    for (const ctx of [{}, undefined]) {
+      const spy = recorder();
+      const response = await withUsageTelemetry(
+        req(),
+        CONFIGURED_ENV,
+        ctx,
+        async () => new Response("ok"),
+        spy,
+      );
+
+      assert.equal(await response.text(), "ok");
+      assert.equal(spy.events.length, 1);
+    }
+  });
+});
+
+describe("worker entry instrumentation", () => {
+  test("serves a real request unchanged on an unconfigured deployment", async () => {
+    const env = createLocalArtifactEnv();
+    const before = await worker.fetch(req("/api/v1/health"), env, fakeCtx());
+    const status = before.status;
+    const body = await before.text();
+
+    const after = await worker.fetch(req("/api/v1/health"), env, fakeCtx());
+
+    assert.equal(after.status, status);
+    assert.equal(await after.text(), body);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -6,6 +6,10 @@ import {
   compileRoutePattern,
 } from "../src/contracts.mjs";
 import {
+  isUsageTelemetryConfigured,
+  recordUsageEvent,
+} from "../src/usage-telemetry.mjs";
+import {
   applyQueryFilters,
   canonicalListSearch,
   paginationLinkHeader,
@@ -431,9 +435,154 @@ function canonicalCacheSearch(url, matched) {
   );
 }
 
+// Product-usage telemetry (#6032 / #366). The Worker entry is the single
+// cross-cutting chokepoint every REST and GraphQL request passes through while
+// an ExecutionContext is still live, so it is the one place a usage event can
+// be recorded exactly once per request. Every wrapper further down is partial:
+// withEdgeCache covers only the cached analytics GETs (and returns before
+// buildResponse on a hit, so it never sees a full request), the artifact edge
+// cache is artifact-routes-only, and handleGraphQLRequest is not handed ctx at
+// all. Instrumenting here also keeps this to one point per transport rather
+// than one per route handler.
+
+// GraphQL is one transport with one HTTP route — every operation shares this
+// label rather than fanning out into client-supplied operation names, which are
+// unbounded and would have to be read out of the request body.
+const GRAPHQL_USAGE_ROUTE = "graphql";
+
+/**
+ * Low-cardinality usage label for a request URL, or null when the request must
+ * not be recorded at this chokepoint.
+ *
+ * Route ids come from the shared API_ROUTES contract, so path parameters
+ * (netuid, ss58, block ref, ...) collapse into one stable label instead of one
+ * label per account. Non-default networks are namespaced onto the label, which
+ * is what gives #366 its route+network dimensions without widening the event
+ * allowlist (the day dimension is the event timestamp).
+ *
+ * @param {URL} url
+ * @returns {string | null}
+ */
+export function usageRouteLabel(url) {
+  const { network, url: resolved } = resolveNetworkPrefix(url);
+  const { pathname } = resolved;
+
+  // MCP tool dispatch is instrumented at its own chokepoint, keyed by tool
+  // name (companion issue) — recording it here too would double-count every
+  // tool call, including the ones it bridges into GraphQL internally.
+  if (pathname === "/mcp" || pathname.startsWith("/mcp/")) {
+    return null;
+  }
+
+  const route =
+    pathname === "/api/v1/graphql"
+      ? GRAPHQL_USAGE_ROUTE
+      : (matchRoute(pathname)?.id ??
+        // Static assets, badges, OG images and the RPC proxy are not API usage.
+        (pathname.startsWith("/api/v1/")
+          ? maskUsageRouteParams(pathname)
+          : null));
+
+  if (route === null) {
+    return null;
+  }
+
+  return network.isDefault ? route : `${network.id}:${route}`;
+}
+
+/**
+ * Fallback label for the handful of /api/v1 routes that predate the API_ROUTES
+ * contract (/ask, /webhooks/..., /internal/...). Path segments that look like
+ * identifiers are masked so an unlisted route can never emit unbounded labels.
+ *
+ * @param {string} pathname
+ * @returns {string}
+ */
+function maskUsageRouteParams(pathname) {
+  return pathname
+    .split("/")
+    .map((segment) => {
+      if (/^\d+$/.test(segment)) return ":n";
+      if (/^0x[0-9a-fA-F]{6,}$/.test(segment)) return ":hash";
+      if (/^[1-9A-HJ-NP-Za-km-z]{47,48}$/.test(segment)) return ":ss58";
+      return segment;
+    })
+    .join("/");
+}
+
+/**
+ * Run the request pipeline and record exactly one usage event for it. Returns
+ * the handler's response untouched, and never converts a telemetry failure into
+ * a request failure: an unconfigured deployment skips the work entirely, and a
+ * recorder that rejects, throws, or a waitUntil that throws is swallowed.
+ *
+ * @param {Request} request
+ * @param {object} env
+ * @param {object} ctx ExecutionContext (may be a bare object in tests).
+ * @param {() => Promise<Response>} handle
+ * @param {{recordUsageEvent?: typeof recordUsageEvent}} [deps]
+ * @returns {Promise<Response>}
+ */
+export async function withUsageTelemetry(request, env, ctx, handle, deps = {}) {
+  const record = deps.recordUsageEvent ?? recordUsageEvent;
+  if (!isUsageTelemetryConfigured(env)) {
+    return handle();
+  }
+
+  // A subscription upgrade (GraphQL subscriptions reuse the /api/v1/graphql
+  // path over a WebSocket) opens a long-lived socket rather than serving a
+  // request/response pair, so its latency would be meaningless. Recognized the
+  // same way handleRequest itself dispatches it.
+  if (request.headers.get("upgrade") === "websocket") {
+    return handle();
+  }
+
+  const route = usageRouteLabel(new URL(request.url));
+  if (route === null) {
+    return handle();
+  }
+
+  const startedAt = Date.now();
+  let ok = false;
+  try {
+    const response = await handle();
+    // 4xx is a route correctly rejecting a bad request, not a broken route;
+    // only 5xx (and a thrown handler, which leaves ok false) is a failure.
+    ok = response.status < 500;
+    return response;
+  } finally {
+    scheduleUsageEvent(env, ctx, record, {
+      route,
+      ok,
+      durationMs: Date.now() - startedAt,
+    });
+  }
+}
+
+/**
+ * Hand the event to the recorder without ever blocking or failing the response.
+ *
+ * @param {object} env
+ * @param {object} ctx
+ * @param {typeof recordUsageEvent} record
+ * @param {object} event
+ */
+function scheduleUsageEvent(env, ctx, record, event) {
+  try {
+    const pending = Promise.resolve(record(env, event)).catch(() => false);
+    if (typeof ctx?.waitUntil === "function") {
+      ctx.waitUntil(pending);
+    }
+  } catch {
+    // Telemetry must never surface into the request path.
+  }
+}
+
 export default {
   async fetch(request, env, ctx) {
-    return handleRequest(request, env, ctx);
+    return withUsageTelemetry(request, env, ctx, () =>
+      handleRequest(request, env, ctx),
+    );
   },
   async scheduled(controller, env, ctx) {
     return handleScheduled(controller, env, ctx);


### PR DESCRIPTION
Closes #6032

Wires the usage-event wrapper from #6030 into REST and GraphQL, covering #366's non-MCP half.

## The chokepoint

The issue suggests `withEdgeCache` as a candidate. It isn't a chokepoint: it wraps 41 of the analytics GETs, returns before `buildResponse` on a cache hit, is a no-op for every non-GET, and never sees GraphQL at all. The artifact edge cache is artifact-routes-only, and `handleGraphQLRequest` is never handed `ctx`.

The Worker entry is the one place that has all of it — 100% of both transports, and a live `ExecutionContext`. So instrumentation goes there: one point, one event per request, one point per transport rather than one per route handler.

## Labels

Route labels come from the shared `API_ROUTES` contract, so path parameters collapse into a stable id rather than one label per value — `/api/v1/accounts/5F3sa2…` is `account-summary`, not 10k distinct labels. Non-default networks are namespaced onto the label (`testnet:subnets`); mainnet/finney aliases stay unprefixed, so existing labels are byte-identical. That covers #366's route+network dimensions without widening the wrapper's event allowlist — the day dimension is the event timestamp.

The handful of `/api/v1` routes outside the contract (`/ask`, `/webhooks/…`, `/internal/…`) fall back to a masked pathname, so an unlisted route still can't emit unbounded labels. Static assets, badges, OG images and the RPC proxy aren't API usage and aren't recorded.

Nothing is read from request bodies or response payloads: GraphQL is labelled by transport rather than by client-supplied `operationName`, and the downstream handler's body is left unread.

**MCP is deliberately skipped here.** It records its own tool-keyed event at its own dispatch chokepoint (the companion issue) — recording it here too would double-count every tool call, including the ones it bridges into GraphQL internally.

## Zero behavior change

An unconfigured deployment (no `POSTHOG_PROJECT_TOKEN`) short-circuits before any work, which is every existing test and every self-hoster. `4xx` is recorded as a served request, `5xx` and a thrown handler as failures; a thrown handler still propagates. A subscription upgrade opens a long-lived socket rather than serving a request/response pair, so it isn't recorded.

Telemetry can never surface into the request path — a recorder that rejects, a recorder that throws synchronously, and a `waitUntil` that throws are all swallowed, each covered by a test.

## Verification

- `tests/request-usage-telemetry.test.mjs` — 19 new tests. Includes the regression the issue asks for, in all three shapes the telemetry call can fail in, plus an end-to-end assertion that a real request is served unchanged.
- Full suite green: **9011 tests / 295 files**.
- Patch coverage measured, not assumed: **0 uncovered statements and 0 uncovered branch arms** across the 150 added lines.
- `format:check`, `lint`, `validate:contract-drift`, `validate:docs`, `validate:types`, `validate:private-boundary`, `validate:api` all pass.