### PR TITLE
feat(ui): add Callout and multi-language code tabs to feeds.mdx

### DIFF
--- a/apps/ui/content/docs/feeds.mdx
+++ b/apps/ui/content/docs/feeds.mdx
@@ -39,8 +39,28 @@ Every param composes. Use `?since=` for incremental polling and `?tag=` to turn 
 | `?until=` | `<ISO-8601>` | Only items at or before that instant. A bare calendar date is inclusive of the whole UTC day (end-of-day), symmetric with `since`. Malformed input is a 400.  |
 | `?limit=` | `1..50`      | Cap the number of returned items (default and hard cap 50). A larger value clamps; a non-integer or < 1 is a 400.                                             |
 
-```bash
+<Callout title="50 items is a hard cap">
+  `?limit=` clamps at 50 regardless of what you pass — there's no way to get more in one response.
+  Poll with `?since=` for anything beyond that instead of raising the limit.
+</Callout>
+
+Feeds aren't part of the typed `@jsonbored/metagraphed` / `metagraphed` SDKs — they're plain content-negotiated HTTP, so any HTTP client works:
+
+```bash tab="cURL"
 curl -s 'https://api.metagraph.sh/api/v1/feeds/registry.json?limit=10'
+```
+
+```js tab="JavaScript"
+const res = await fetch("https://api.metagraph.sh/api/v1/feeds/registry.json?limit=10");
+const feed = await res.json();
+```
+
+```python tab="Python"
+from urllib.request import urlopen
+import json
+
+with urlopen("https://api.metagraph.sh/api/v1/feeds/registry.json?limit=10") as res:
+    feed = json.load(res)
 ```
 
 Responses are cached for 600s and capped at 50 items. Browse the same data: [Gaps](/gaps). Machine index: [For agents](/agents).


### PR DESCRIPTION
## Summary

- Adds a `<Callout>` flagging the `?limit=` hard cap (previously buried in a table cell) to `content/docs/feeds.mdx`.
- Replaces the single curl example with cURL/JavaScript/Python code tabs for the same request.
- Both ship in `fumadocs-ui`'s default MDX component set/preset, already wired in #6109 — `Callout` via `defaultMdxComponents` (already in `mdx.tsx`'s `getMDXComponents()`), tab grouping via `remarkCodeTab` in `fumadocs-mdx`'s default preset. No new plugin wiring, just using what's already there.

**Deliberately not SDK examples.** Feeds return RSS/Atom/JSON-Feed content and aren't in the OpenAPI contract the `@jsonbored/metagraphed` (TS) / `metagraphed` (Python) client SDKs are generated from — confirmed by grepping `public/metagraph/openapi.json` for `feeds` paths (none). Showing a typed SDK call here would be actively wrong, not just unhelpful, so the three tabs are plain HTTP clients (curl, `fetch`, stdlib `urllib`) instead. SDK-tab examples belong on the `rpc`/`graphql` pages once they migrate — those *do* cover typed operations.

## Screenshots

`/docs/feeds` — before (state as merged in #6109) vs. after (this PR):

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-feeds-desktop-dark-after2.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-feeds-desktop-dark-after2.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-primitives-feeds-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-primitives-feeds-desktop-dark-after.png) |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-feeds-desktop-light-after2.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-feeds-desktop-light-after2.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-primitives-feeds-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-primitives-feeds-desktop-light-after.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-feeds-tablet-dark-after2.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-feeds-tablet-dark-after2.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-primitives-feeds-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-primitives-feeds-tablet-dark-after.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-feeds-tablet-light-after2.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-feeds-tablet-light-after2.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-primitives-feeds-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-primitives-feeds-tablet-light-after.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-feeds-mobile-dark-after2.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-feeds-mobile-dark-after2.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-primitives-feeds-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-primitives-feeds-mobile-dark-after.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-feeds-mobile-light-after2.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-feeds-mobile-light-after2.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-primitives-feeds-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-primitives-feeds-mobile-light-after.png) |

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint`/`prettier --check` clean
- [x] Full `vitest` suite: 130 files / 1015 tests passing
- [x] Verified in a real browser: Callout renders correctly reskinned, tab bar switches content (confirmed via a real Playwright click, not just visual inspection) — cURL/JavaScript/Python all show correct, working example code
- [x] Zero console errors (fresh tab + Playwright, not just the interactive browser pane)