### PR TITLE
fix(registry): SN74 Gittensor accuracy re-review pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -989,14 +989,15 @@
       "netuid": 74,
       "slug": "gittensor",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-06T00:00:00.000Z",
+      "reviewed_at": "2026-07-15T00:00:00.000Z",
       "confidence": "high",
       "source_urls": [
         "https://docs.gittensor.io/",
         "https://docs.gittensor.io/repository-hyperparameters",
-        "https://github.com/entrius/gittensor"
+        "https://github.com/entrius/gittensor",
+        "https://api.gittensor.io/swagger-json"
       ],
-      "notes": "Gittensor pilot surfaces reviewed from provider docs, public repository config, and source repository."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): fixed 3 missing probe blocks, renamed a generic-name surface (prs -> \"Gittensor merged pull requests\"), and diffed the api.gittensor.io OpenAPI schema (35 paths) for undiscovered public GET endpoints -- added 7 new no-param surfaces (lines/hist-trend, lines/total, repos/commits, commits, prices, prices/history, configurations/general). Also found gittensory-api.aethereal.dev fails DNS resolution entirely; documented in gap_notes rather than removing the 2 surfaces it backs."
     },
     {
       "netuid": 75,

--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -3,13 +3,14 @@
   "curation": {
     "gap_notes": [
       "No verified SSE/event stream yet.",
-      "Bounty state is documented through public CLI flows, but no unauthenticated public API has been verified yet."
+      "Bounty state is documented through public CLI flows, but no unauthenticated public API has been verified yet.",
+      "gittensory-api.aethereal.dev (backing the gittensory-contribution-interface and gittensory-mcp surfaces) currently fails DNS resolution entirely (as of 2026-07-15), while the sibling gittensory.aethereal.dev website resolves fine -- an observed outage/renamed host, not a registry gap; kept both surfaces tracked in case it comes back."
     ],
     "level": "adapter-backed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-06T00:00:00.000Z",
+    "reviewed_at": "2026-07-15T00:00:00.000Z",
     "source_count": 5,
-    "verified_at": null
+    "verified_at": "2026-07-15T00:00:00.000Z"
   },
   "dashboard_url": null,
   "docs_url": "https://docs.gittensor.io/",
@@ -390,7 +391,14 @@
       "authority": "community",
       "id": "sn-74-gittensor-data-artifact-api-gittensor-io-5",
       "kind": "data-artifact",
-      "name": "Gittensor data-artifact",
+      "name": "Gittensor merged pull requests",
+      "notes": "Public no-auth GET /prs on api.gittensor.io returning the list of scored merged pull requests (pullRequestNumber, hotkey, title, additions/deletions, label, minerIncentive, repository, score fields). Documented in the subnet swagger-json OpenAPI spec on the same host as the existing miners and dash surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "gittensor",
       "public_safe": true,
       "review": {
@@ -407,6 +415,12 @@
       "kind": "subnet-api",
       "name": "Gittensor API root health",
       "notes": "Public no-auth GET / on api.gittensor.io returning API liveness (observed plain-text response: Hello World!). Documented as AppController_getHello at path / in the subnet swagger-json OpenAPI spec on the same host as the existing miners and dash subnet-api surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "gittensor",
       "public_safe": true,
       "review": {
@@ -426,6 +440,12 @@
       "kind": "data-artifact",
       "name": "Gittensor programming-language scoring weights",
       "notes": "Public no-auth machine-readable JSON from the official SN74 Gittensor repository (entrius/gittensor), pinned to an immutable commit. Maps each programming language to the scoring weight the validators apply when evaluating miners' code contributions (e.g. per-language weight multipliers). Static data artifact documenting the subnet's language-weighting scoring parameters.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "gittensor",
       "public_safe": true,
       "review": {
@@ -437,6 +457,160 @@
         "https://github.com/entrius/gittensor/blob/a5b21df92d123f9bd5fe63cea05d98c13d20fa8f/gittensor/validator/weights/programming_languages.json"
       ],
       "url": "https://raw.githubusercontent.com/entrius/gittensor/a5b21df92d123f9bd5fe63cea05d98c13d20fa8f/gittensor/validator/weights/programming_languages.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-lines-hist-trend",
+      "kind": "data-artifact",
+      "name": "Gittensor lines-committed historical trend",
+      "notes": "Public no-auth GET /dash/lines/hist-trend on api.gittensor.io returning a daily time series of total lines committed across tracked repositories. Documented in the subnet swagger-json OpenAPI spec on the same host as the existing dash/* surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/lines/hist-trend"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-lines-total",
+      "kind": "data-artifact",
+      "name": "Gittensor total lines committed",
+      "notes": "Public no-auth GET /dash/lines/total on api.gittensor.io returning the all-time total linesCommitted count across tracked repositories. Documented in the subnet swagger-json OpenAPI spec on the same host as the existing dash/* surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/lines/total"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-repos-commits",
+      "kind": "data-artifact",
+      "name": "Gittensor per-repository commit stats",
+      "notes": "Public no-auth GET /dash/repos/commits on api.gittensor.io returning per-repository commit statistics (repositoryFullName, emissionShare, commits, additions/deletions, linesChanged). Documented in the subnet swagger-json OpenAPI spec on the same host as the existing dash/repos surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/repos/commits"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-dash-commits",
+      "kind": "data-artifact",
+      "name": "Gittensor recent scored commits",
+      "notes": "Public no-auth GET /dash/commits on api.gittensor.io returning recent scored pull-request commits (pullRequestNumber, hotkey, title, additions/deletions, label, repository, mergedAt). Documented in the subnet swagger-json OpenAPI spec on the same host as the existing prs surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/commits"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-dash-prices",
+      "kind": "data-artifact",
+      "name": "Gittensor TAO price snapshot",
+      "notes": "Public no-auth GET /dash/prices on api.gittensor.io returning a live TAO market data snapshot (price, marketCap, volume24h, percentChange24h/7d) used by the dashboard. Documented in the subnet swagger-json OpenAPI spec on the same host as the existing dash/* surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/prices"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-dash-prices-history",
+      "kind": "data-artifact",
+      "name": "Gittensor TAO price history",
+      "notes": "Public no-auth GET /dash/prices/history on api.gittensor.io returning a time series of TAO price/market snapshots. Documented in the subnet swagger-json OpenAPI spec on the same host as the existing dash/prices surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/dash/prices/history"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-74-gittensor-configurations-general",
+      "kind": "data-artifact",
+      "name": "Gittensor general scoring configuration",
+      "notes": "Public no-auth GET /configurations/general on api.gittensor.io returning the live scoring configuration (language-file scoring weights, repository PR scoring parameters, time-decay curve settings) validators apply. Documented in the subnet swagger-json OpenAPI spec on the same host as the existing surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
+      "url": "https://api.gittensor.io/configurations/general"
     }
   ],
   "website_url": "https://gittensor.io/"


### PR DESCRIPTION
## Summary
- Fix 3 missing `probe` blocks (#5932), rename a generic-name surface (`prs` -> "Gittensor merged pull requests")
- Diff the `api.gittensor.io` OpenAPI schema (35 paths) for undiscovered public GET endpoints -- add 7 new no-param surfaces (lines/hist-trend, lines/total, repos/commits, commits, prices, prices/history, configurations/general)
- Discover `gittensory-api.aethereal.dev` (backing 2 existing surfaces) fails DNS resolution entirely, while the sibling `gittensory.aethereal.dev` website resolves fine -- documented as an observed outage in `gap_notes` rather than removing the surfaces
- Updates the existing `maintainer-reviewed.json` ledger entry (netuid 74)

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check`