### PR TITLE
fix(ui): add CopyButton to validator hotkey/coldkey in both renderers

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
@@ -37,18 +38,24 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
               >
                 {f.hotkeyShort}
               </Link>
+              <CopyButton value={v.hotkey} label="hotkey" />
             </div>
-            <div className="font-mono text-[11px] text-ink-muted">
-              <span className="uppercase tracking-widest text-[10px]">coldkey </span>
+            {/* Mirrors the hotkey row above: a flex row so the copy button's 44px
+                touch target centers against the value instead of stretching the line box. */}
+            <div className="flex min-w-0 items-center gap-1.5 font-mono text-[11px] text-ink-muted">
+              <span className="uppercase tracking-widest text-[10px]">coldkey</span>
               {v.coldkey ? (
-                <Link
-                  to="/accounts/$ss58"
-                  params={{ ss58: v.coldkey }}
-                  title={v.coldkey}
-                  className="hover:text-accent hover:underline"
-                >
-                  {f.coldkeyShort}
-                </Link>
+                <>
+                  <Link
+                    to="/accounts/$ss58"
+                    params={{ ss58: v.coldkey }}
+                    title={v.coldkey}
+                    className="truncate hover:text-accent hover:underline"
+                  >
+                    {f.coldkeyShort}
+                  </Link>
+                  <CopyButton value={v.coldkey} label="coldkey" />
+                </>
               ) : (
                 "—"
               )}

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
@@ -50,14 +51,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     thClassName: TH_BASE,
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) => (
-      <Link
-        to="/validators/$hotkey"
-        params={{ hotkey: v.hotkey }}
-        className="text-ink-strong hover:text-accent hover:underline"
-        title={v.hotkey}
-      >
-        {shortHash(v.hotkey) ?? v.hotkey}
-      </Link>
+      <div className="flex items-center gap-1.5">
+        <Link
+          to="/validators/$hotkey"
+          params={{ hotkey: v.hotkey }}
+          className="text-ink-strong hover:text-accent hover:underline"
+          title={v.hotkey}
+        >
+          {shortHash(v.hotkey) ?? v.hotkey}
+        </Link>
+        <CopyButton value={v.hotkey} label="hotkey" />
+      </div>
     ),
   },
   {
@@ -66,14 +70,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) =>
       v.coldkey ? (
-        <Link
-          to="/accounts/$ss58"
-          params={{ ss58: v.coldkey }}
-          className="hover:text-accent hover:underline"
-          title={v.coldkey}
-        >
-          {shortHash(v.coldkey) ?? v.coldkey}
-        </Link>
+        <div className="flex items-center gap-1.5">
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: v.coldkey }}
+            className="hover:text-accent hover:underline"
+            title={v.coldkey}
+          >
+            {shortHash(v.coldkey) ?? v.coldkey}
+          </Link>
+          <CopyButton value={v.coldkey} label="coldkey" />
+        </div>
       ) : (
         "—"
       ),


### PR DESCRIPTION
Closes #5859

`/validators` rendered hotkey and coldkey as tooltip-only `title=` values in both renderers, so the only way to get one was to select the text by hand. Each is now paired with a `CopyButton`, matching the established `neuron-table.tsx` pattern.

Captured at the Phase C2 matrix — fixed viewports (375×812 / 768×1024 / 1280×800), each theme forced via `mg-theme` + reload. Both renderers are covered by the breakpoints: the mobile rows show `ValidatorCardList` (`md:hidden`), tablet/desktop show the `VALIDATOR_COLUMNS` table (`hidden md:block`).

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-mobile-dark.png)<br><sub>after</sub> |

### The change

- `validator-card-list.tsx` — `CopyButton` next to the hotkey (its row was already `flex items-center gap-1.5`) and next to the coldkey.
- `validator-columns.tsx` — `CopyButton` in both the Hotkey and Coldkey cell renderers, each wrapped in the same `flex items-center gap-1.5` row `neuron-table.tsx` uses.
- The card's coldkey row moves from a block line to a flex row, mirroring the hotkey row directly above it, so the button's 44px touch target (`min-h-11 min-w-11`, the ui-kit convention) centers against the value instead of stretching the line box. That taller row is the same trade `neuron-table.tsx` already makes.

No new component or prop: `CopyButton` comes from `@jsonbored/ui-kit`, called as `<CopyButton value={...} label="hotkey|coldkey" />` exactly as the reference does.

### Verification

`prettier` clean · `eslint` 0 errors · `tsc --noEmit` 0 · `vitest` 1015/1015 passing (130 files). `validator-columns.test.ts` still passes — its header/cell 1:1 invariants (#5307) are unaffected, since each `cell` remains a function returning a defined node.
