### PR TITLE
fix(registry): SN79 MVTRX accuracy re-review pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1064,14 +1064,16 @@
       "netuid": 79,
       "slug": "sn-79",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-08T09:50:00.000Z",
+      "reviewed_at": "2026-07-15T00:00:00.000Z",
       "confidence": "high",
       "source_urls": [
         "https://taos.im/",
         "https://simulate.trading/taos-im-paper",
-        "https://github.com/taos-im/sn-79"
+        "https://github.com/taos-im/sn-79",
+        "https://mvtrx.fi/",
+        "https://mvtrx.simulate.trading/"
       ],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/mvtrx.json (reviewed_at 2026-06-08T09:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): added mvtrx.fi (the MVTRX exchange product site, matching the file's contact domain) and mvtrx.simulate.trading (a public Simulation Terminal dashboard), both badge-linked from the official README but previously untracked."
     },
     {
       "netuid": 81,

--- a/registry/subnets/mvtrx.json
+++ b/registry/subnets/mvtrx.json
@@ -9,20 +9,20 @@
   "curation": {
     "gap_notes": [
       "Public paper link redirects to Proton Drive and is not a documentation site.",
-      "No verified OpenAPI/Swagger schema yet.",
+      "No verified OpenAPI/Swagger schema yet (mvtrx.exchange/openapi.json and /api/openapi.json both 404).",
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T09:50:00.000Z",
+    "reviewed_at": "2026-07-15T00:00:00.000Z",
     "source_count": 5,
-    "verified_at": "2026-06-08T09:50:00.000Z"
+    "verified_at": "2026-07-15T00:00:00.000Z"
   },
   "dashboard_url": "https://taomarketcap.com/subnets/79",
   "docs_url": "https://simulate.trading/taos-im-paper",
   "name": "MVTRX",
   "netuid": 79,
-  "notes": "Reviewed overlay for SN79 using the TAOS IM website, source repository, and public paper link. The paper URL redirects to a public Proton Drive document, so it is tracked as a data artifact rather than a docs site.",
+  "notes": "Reviewed overlay for SN79 using the TAOS IM website, source repository, and public paper link. The paper URL redirects to a public Proton Drive document, so it is tracked as a data artifact rather than a docs site. Re-review pass (2026-07-15): the official README also badge-links mvtrx.fi (the MVTRX exchange product site, matching the file's own contact domain) and mvtrx.simulate.trading (a public Simulation Terminal dashboard) -- both added as additional official surfaces.",
   "schema_version": 1,
   "slug": "sn-79",
   "social": {
@@ -116,6 +116,42 @@
       },
       "source_urls": ["https://github.com/taos-im/sn-79/blob/main/README.md"],
       "url": "https://taos.simulate.trading/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-79-mvtrx-exchange-website",
+      "kind": "website",
+      "name": "MVTRX exchange website",
+      "notes": "Official MVTRX exchange product website (page title \"MVTRX -- A New Kind of Exchange\"), matching the file's own contact domain (to@mvtrx.fi). Badge-linked from the official taos-im/sn-79 README alongside taos.im -- verified live 2026-07-15.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taos-im",
+      "public_safe": true,
+      "source_urls": ["https://github.com/taos-im/sn-79/blob/main/README.md"],
+      "url": "https://mvtrx.fi/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-79-mvtrx-simulation-terminal",
+      "kind": "dashboard",
+      "name": "MVTRX Simulation Terminal",
+      "notes": "Public no-auth Simulation Terminal dashboard for SN79 (page title \"MVTRX Terminal\"), badge-linked from the official taos-im/sn-79 README as \"dashboard\". Distinct from the Grafana metrics dashboard at taos.simulate.trading -- verified live 2026-07-15.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taos-im",
+      "public_safe": true,
+      "source_urls": ["https://github.com/taos-im/sn-79/blob/main/README.md"],
+      "url": "https://mvtrx.simulate.trading/"
     }
   ],
   "website_url": "https://taos.im/"


### PR DESCRIPTION
## Summary
- Add `mvtrx.fi` (the MVTRX exchange product site, matching the file's contact domain `to@mvtrx.fi`) and `mvtrx.simulate.trading` (a public Simulation Terminal dashboard) -- both badge-linked from the official `taos-im/sn-79` README but previously untracked
- Updates the existing `maintainer-reviewed.json` ledger entry (netuid 79)

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check`