### PR TITLE
feat(observability): instrument REST/GraphQL request handlers with usage events

### DIFF
--- a/src/usage-telemetry.mjs
+++ b/src/usage-telemetry.mjs
@@ -1,15 +1,21 @@
 // Typed PostHog usage-event wrapper for the Worker backend (#6030 / #366).
 //
 // Single chokepoint for product-usage capture: callers pass an allowlisted
-// UsageEvent; this module owns the PostHog event name/properties and the
-// Workers-safe client lifecycle (flushAt:1, captureImmediate, shutdown).
+// UsageEvent; this module owns the PostHog event name/properties and posts
+// them straight to PostHog's public capture API with fetch.
 // Nothing outside this file should construct a raw PostHog event.
 //
+// This module deliberately does NOT import `posthog-node`. That SDK is built
+// for long-lived Node servers (batching, flush intervals, shutdown draining) —
+// none of which survives a Workers isolate anyway — and it costs ~40 KiB
+// gzipped in the bundle. The Worker entry is already within a few KiB of
+// Cloudflare's 1 MiB script limit (scripts/worker-bundle-budget.mjs), so
+// importing it here pushes the deployable bundle past the limit outright.
+// One fetch to the documented capture endpoint does the same job at zero
+// bundle cost, and fetch is the platform-native transport here.
+//
 // Safe no-op when POSTHOG_PROJECT_TOKEN is unset — self-hosters / local / CI
-// see zero behavior change. Never throws. Not wired into request or MCP
-// dispatch yet (#6031 / #6032 are the callers).
-
-import { PostHog } from "posthog-node";
+// see zero behavior change. Never throws.
 
 /** Env var holding the PostHog project API token (wrangler secret). */
 export const POSTHOG_PROJECT_TOKEN_ENV = "POSTHOG_PROJECT_TOKEN";
@@ -36,9 +42,12 @@ const MAX_LABEL_CHARS = 256;
  * @property {number} durationMs Wall-clock duration in milliseconds (>= 0).
  */
 
+/** Public capture endpoint, appended to the resolved PostHog host. */
+export const POSTHOG_CAPTURE_PATH = "/i/v0/e/";
+
 /**
  * @typedef {object} RecordUsageEventDeps
- * @property {typeof PostHog} [PostHog] Injectable client class (tests).
+ * @property {typeof fetch} [fetch] Injectable fetch (tests).
  * @property {string} [distinctId] Override distinct_id (tests).
  */
 
@@ -102,42 +111,28 @@ export async function recordUsageEvent(env, event, deps = {}) {
     const properties = usageEventProperties(event);
     if (!properties) return false;
 
-    const Client = postHogClientClass(deps);
-    const token = String(env[POSTHOG_PROJECT_TOKEN_ENV]).trim();
-    const host = resolvePostHogHost(env);
+    const doFetch = deps.fetch ?? globalThis.fetch;
+    const response = await doFetch(
+      `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: String(env[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
+          event: USAGE_EVENT_NAME,
+          distinct_id: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
+          properties,
+        }),
+      },
+    );
 
-    const client = new Client(token, {
-      host,
-      // Workers isolates can freeze the moment the response returns — never
-      // batch; flush each capture immediately (PostHog Workers docs).
-      flushAt: 1,
-      flushInterval: 0,
-    });
-
-    try {
-      await client.captureImmediate({
-        distinctId: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
-        event: USAGE_EVENT_NAME,
-        properties,
-      });
-    } finally {
-      // Always drain pending work so a capture isn't stranded on isolate exit.
-      await client.shutdown().catch(() => {});
-    }
-    return true;
+    // A rejected capture is PostHog's problem, not the request's — report it
+    // as not-recorded rather than throwing.
+    return response?.ok === true;
   } catch {
     // Telemetry must never surface into the request/tool path.
     return false;
   }
-}
-
-/**
- * PostHog client class — injectable for tests, defaults to posthog-node.
- * @param {RecordUsageEventDeps} [deps]
- * @returns {typeof PostHog}
- */
-export function postHogClientClass(deps = {}) {
-  return deps.PostHog ?? PostHog;
 }
 
 /**

--- a/tests/request-usage-telemetry.test.mjs
+++ b/tests/request-usage-telemetry.test.mjs
@@ -1,0 +1,300 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.mjs";
+import worker, {
+  usageRouteLabel,
+  withUsageTelemetry,
+} from "../workers/api.mjs";
+
+const CONFIGURED_ENV = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" };
+const SS58 = "5F3sa2TJAWMqDhXG6jhV4N8ko9SxwGy8TpaNS1repo5EYjQX";
+
+function label(pathname) {
+  return usageRouteLabel(new URL(`https://api.metagraph.sh${pathname}`));
+}
+
+function req(pathname = "/api/v1/subnets", init) {
+  return new Request(`https://api.metagraph.sh${pathname}`, init);
+}
+
+// Collects the events a run hands to the recorder, plus the promises it hands
+// to waitUntil, so a test can assert on both without touching PostHog.
+function recorder({ result = true } = {}) {
+  const events = [];
+  return {
+    events,
+    recordUsageEvent(env, event) {
+      events.push({ env, event });
+      return typeof result === "function" ? result() : result;
+    },
+  };
+}
+
+function fakeCtx() {
+  const scheduled = [];
+  return { scheduled, waitUntil: (promise) => scheduled.push(promise) };
+}
+
+describe("usageRouteLabel", () => {
+  test("labels every GraphQL operation with the transport, not the operation name", () => {
+    assert.equal(label("/api/v1/graphql"), "graphql");
+  });
+
+  test("collapses path parameters into the shared route id", () => {
+    assert.equal(label("/api/v1/subnets"), "subnets");
+    assert.equal(label("/api/v1/subnets/74"), "subnet-detail");
+    // One label for every account, not one label per ss58 address.
+    assert.equal(label(`/api/v1/accounts/${SS58}`), "account-summary");
+    assert.equal(label("/api/v1/blocks/123456"), "block-detail");
+  });
+
+  test("namespaces non-default networks onto the label", () => {
+    assert.equal(label("/api/v1/testnet/subnets"), "testnet:subnets");
+    assert.equal(label("/api/v1/local/subnets"), "local:subnets");
+    assert.equal(label("/api/v1/testnet/graphql"), "testnet:graphql");
+  });
+
+  test("leaves default-network aliases unprefixed", () => {
+    assert.equal(label("/api/v1/mainnet/subnets/74"), "subnet-detail");
+    assert.equal(label("/api/v1/finney/subnets"), "subnets");
+  });
+
+  test("skips MCP, which is instrumented at its own dispatch chokepoint", () => {
+    assert.equal(label("/mcp"), null);
+    assert.equal(label("/mcp/session"), null);
+  });
+
+  test("skips traffic that is not API usage", () => {
+    assert.equal(label("/"), null);
+    assert.equal(label("/favicon.ico"), null);
+    assert.equal(label("/badge/subnet/74.svg"), null);
+    assert.equal(label("/rpc/v1/anything"), null);
+  });
+
+  test("masks identifier-shaped segments on routes outside the contract", () => {
+    assert.equal(label("/api/v1/ask"), "/api/v1/ask");
+    assert.equal(
+      label("/api/v1/webhooks/subscriptions/123"),
+      "/api/v1/webhooks/subscriptions/:n",
+    );
+    assert.equal(
+      label("/api/v1/internal/0xdeadbeefcafe"),
+      "/api/v1/internal/:hash",
+    );
+    assert.equal(label(`/api/v1/internal/${SS58}`), "/api/v1/internal/:ss58");
+  });
+});
+
+describe("withUsageTelemetry", () => {
+  test("does no telemetry work when the deployment is unconfigured", async () => {
+    const spy = recorder();
+    const response = await withUsageTelemetry(
+      req(),
+      {},
+      fakeCtx(),
+      async () => new Response("ok"),
+      spy,
+    );
+
+    assert.equal(await response.text(), "ok");
+    assert.deepEqual(spy.events, []);
+  });
+
+  test("records exactly one event per request and returns the response untouched", async () => {
+    const spy = recorder();
+    const ctx = fakeCtx();
+    const handled = new Response("payload", { status: 200 });
+
+    const response = await withUsageTelemetry(
+      req("/api/v1/subnets/74"),
+      CONFIGURED_ENV,
+      ctx,
+      async () => handled,
+      spy,
+    );
+
+    assert.equal(response, handled);
+    assert.equal(spy.events.length, 1);
+    const { env, event } = spy.events[0];
+    assert.equal(env, CONFIGURED_ENV);
+    assert.equal(event.route, "subnet-detail");
+    assert.equal(event.ok, true);
+    assert.equal(typeof event.durationMs, "number");
+    assert.ok(event.durationMs >= 0);
+    // The event is drained through waitUntil, not awaited in the request path.
+    assert.equal(ctx.scheduled.length, 1);
+  });
+
+  test("records GraphQL POSTs without reading the request body", async () => {
+    const spy = recorder();
+    const body = JSON.stringify({ query: "{ subnets { netuid } }" });
+    const request = req("/api/v1/graphql", { method: "POST", body });
+
+    await withUsageTelemetry(
+      request,
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("{}"),
+      spy,
+    );
+
+    assert.equal(spy.events[0].event.route, "graphql");
+    // The handler downstream still owns an unread body.
+    assert.equal(request.bodyUsed, false);
+    assert.equal(await request.text(), body);
+  });
+
+  test("does not record a route the chokepoint skips", async () => {
+    const spy = recorder();
+    const response = await withUsageTelemetry(
+      req("/mcp", { method: "POST" }),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("ok"),
+      spy,
+    );
+
+    assert.equal(await response.text(), "ok");
+    assert.deepEqual(spy.events, []);
+  });
+
+  test("treats 4xx as a served request and 5xx as a failure", async () => {
+    const rejected = recorder();
+    await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("nope", { status: 404 }),
+      rejected,
+    );
+    assert.equal(rejected.events[0].event.ok, true);
+
+    const broken = recorder();
+    await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("boom", { status: 500 }),
+      broken,
+    );
+    assert.equal(broken.events[0].event.ok, false);
+  });
+
+  test("does not record a subscription upgrade as a request", async () => {
+    const spy = recorder();
+    const response = await withUsageTelemetry(
+      req("/api/v1/graphql", { headers: { upgrade: "websocket" } }),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("subscribed"),
+      spy,
+    );
+
+    assert.equal(await response.text(), "subscribed");
+    assert.deepEqual(spy.events, []);
+  });
+
+  test("records a thrown handler as a failure and still propagates the error", async () => {
+    const spy = recorder();
+    await assert.rejects(
+      withUsageTelemetry(
+        req(),
+        CONFIGURED_ENV,
+        fakeCtx(),
+        async () => {
+          throw new Error("handler exploded");
+        },
+        spy,
+      ),
+      /handler exploded/,
+    );
+
+    assert.equal(spy.events.length, 1);
+    assert.equal(spy.events[0].event.ok, false);
+  });
+
+  // The regression the issue asks for: a telemetry failure must never become a
+  // request failure, in any of the shapes it can fail in.
+  test("serves the request when the recorder rejects", async () => {
+    const spy = recorder({
+      result: () => Promise.reject(new Error("posthog down")),
+    });
+    const response = await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("ok"),
+      spy,
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "ok");
+  });
+
+  test("serves the request when the recorder throws synchronously", async () => {
+    const spy = recorder({
+      result: () => {
+        throw new Error("recorder exploded");
+      },
+    });
+    const response = await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      fakeCtx(),
+      async () => new Response("ok"),
+      spy,
+    );
+
+    assert.equal(await response.text(), "ok");
+  });
+
+  test("serves the request when waitUntil throws", async () => {
+    const spy = recorder();
+    const ctx = {
+      waitUntil() {
+        throw new Error("isolate already finished");
+      },
+    };
+    const response = await withUsageTelemetry(
+      req(),
+      CONFIGURED_ENV,
+      ctx,
+      async () => new Response("ok"),
+      spy,
+    );
+
+    assert.equal(await response.text(), "ok");
+    assert.equal(spy.events.length, 1);
+  });
+
+  test("serves the request when no usable ExecutionContext is supplied", async () => {
+    for (const ctx of [{}, undefined]) {
+      const spy = recorder();
+      const response = await withUsageTelemetry(
+        req(),
+        CONFIGURED_ENV,
+        ctx,
+        async () => new Response("ok"),
+        spy,
+      );
+
+      assert.equal(await response.text(), "ok");
+      assert.equal(spy.events.length, 1);
+    }
+  });
+});
+
+describe("worker entry instrumentation", () => {
+  test("serves a real request unchanged on an unconfigured deployment", async () => {
+    const env = createLocalArtifactEnv();
+    const before = await worker.fetch(req("/api/v1/health"), env, fakeCtx());
+    const status = before.status;
+    const body = await before.text();
+
+    const after = await worker.fetch(req("/api/v1/health"), env, fakeCtx());
+
+    assert.equal(after.status, status);
+    assert.equal(await after.text(), body);
+  });
+});

--- a/tests/usage-telemetry.test.mjs
+++ b/tests/usage-telemetry.test.mjs
@@ -1,39 +1,24 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { PostHog } from "posthog-node";
 import {
+  POSTHOG_CAPTURE_PATH,
   POSTHOG_HOST_ENV,
   POSTHOG_PROJECT_TOKEN_ENV,
   USAGE_EVENT_DISTINCT_ID,
   USAGE_EVENT_NAME,
   isUsageTelemetryConfigured,
-  postHogClientClass,
   recordUsageEvent,
   resolvePostHogHost,
   usageEventProperties,
 } from "../src/usage-telemetry.mjs";
 
-function fakePostHog({
-  onConstruct,
-  onCapture,
-  onShutdown,
-  captureThrows = false,
-  shutdownThrows = false,
-} = {}) {
-  return class FakePostHog {
-    constructor(token, options) {
-      onConstruct?.(token, options);
-      this.token = token;
-      this.options = options;
-    }
-    async captureImmediate(payload) {
-      if (captureThrows) throw new Error("capture failed");
-      onCapture?.(payload);
-    }
-    async shutdown() {
-      if (shutdownThrows) throw new Error("shutdown failed");
-      onShutdown?.();
-    }
+// A capture is one POST — record what it was handed, and let a test choose the
+// outcome (accepted, rejected, transport failure).
+function fakeFetch({ onCall, ok = true, throws = false, response } = {}) {
+  return async (url, init) => {
+    if (throws) throw new Error("network unreachable");
+    onCall?.({ url, init, body: JSON.parse(init.body) });
+    return response === undefined ? { ok } : response;
   };
 }
 
@@ -122,17 +107,7 @@ describe("usageEventProperties", () => {
   });
 });
 
-describe("postHogClientClass / resolvePostHogHost", () => {
-  test("defaults to posthog-node's PostHog export", () => {
-    assert.equal(postHogClientClass(), PostHog);
-    assert.equal(postHogClientClass({}), PostHog);
-  });
-
-  test("honors an injected PostHog class", () => {
-    class Injected {}
-    assert.equal(postHogClientClass({ PostHog: Injected }), Injected);
-  });
-
+describe("resolvePostHogHost", () => {
   test("resolvePostHogHost trims a custom host or falls back to US cloud", () => {
     assert.equal(resolvePostHogHost(undefined), "https://us.i.posthog.com");
     assert.equal(
@@ -147,21 +122,21 @@ describe("postHogClientClass / resolvePostHogHost", () => {
 });
 
 describe("recordUsageEvent — unconfigured (safe no-op)", () => {
-  test("returns false and never constructs a PostHog client", async () => {
-    let constructed = 0;
+  test("returns false and never issues a capture", async () => {
+    let calls = 0;
     const recorded = await recordUsageEvent(
       {},
       { route: "/api/v1/health", ok: true, durationMs: 5 },
       {
-        PostHog: fakePostHog({
-          onConstruct: () => {
-            constructed += 1;
+        fetch: fakeFetch({
+          onCall: () => {
+            calls += 1;
           },
         }),
       },
     );
     assert.equal(recorded, false);
-    assert.equal(constructed, 0);
+    assert.equal(calls, 0);
   });
 
   test("never throws when env is null", async () => {
@@ -172,10 +147,8 @@ describe("recordUsageEvent — unconfigured (safe no-op)", () => {
 });
 
 describe("recordUsageEvent — configured", () => {
-  test("captures an allowlisted usage_event via captureImmediate + shutdown", async () => {
-    const constructs = [];
-    const captures = [];
-    let shutdowns = 0;
+  test("posts one allowlisted usage_event to the capture endpoint", async () => {
+    const calls = [];
     const env = {
       [POSTHOG_PROJECT_TOKEN_ENV]: " phc_token ",
       [POSTHOG_HOST_ENV]: "https://eu.i.posthog.com",
@@ -189,126 +162,113 @@ describe("recordUsageEvent — configured", () => {
         ok: true,
         durationMs: 42,
       },
-      {
-        PostHog: fakePostHog({
-          onConstruct: (token, options) => constructs.push({ token, options }),
-          onCapture: (payload) => captures.push(payload),
-          onShutdown: () => {
-            shutdowns += 1;
-          },
-        }),
-      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
     );
 
     assert.equal(recorded, true);
-    assert.equal(constructs.length, 1);
-    assert.equal(constructs[0].token, "phc_token");
-    assert.equal(constructs[0].options.host, "https://eu.i.posthog.com");
-    assert.equal(constructs[0].options.flushAt, 1);
-    assert.equal(constructs[0].options.flushInterval, 0);
-    assert.deepEqual(captures, [
-      {
-        distinctId: USAGE_EVENT_DISTINCT_ID,
-        event: USAGE_EVENT_NAME,
-        properties: {
-          route: "/api/v1/subnets/1",
-          mcp_tool: "get_subnet",
-          ok: true,
-          duration_ms: 42,
-        },
+    assert.equal(calls.length, 1);
+    assert.equal(
+      calls[0].url,
+      `https://eu.i.posthog.com${POSTHOG_CAPTURE_PATH}`,
+    );
+    assert.equal(calls[0].init.method, "POST");
+    assert.equal(calls[0].init.headers["content-type"], "application/json");
+    assert.deepEqual(calls[0].body, {
+      api_key: "phc_token",
+      event: USAGE_EVENT_NAME,
+      distinct_id: USAGE_EVENT_DISTINCT_ID,
+      properties: {
+        route: "/api/v1/subnets/1",
+        mcp_tool: "get_subnet",
+        ok: true,
+        duration_ms: 42,
       },
-    ]);
-    assert.equal(shutdowns, 1);
+    });
   });
 
   test("defaults host to PostHog US cloud when POSTHOG_HOST is unset", async () => {
-    const constructs = [];
+    const calls = [];
     await recordUsageEvent(
       { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
       { ok: false, durationMs: 1 },
-      {
-        PostHog: fakePostHog({
-          onConstruct: (_token, options) => constructs.push(options),
-        }),
-      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
     );
-    assert.equal(constructs[0].host, "https://us.i.posthog.com");
+    assert.equal(
+      calls[0].url,
+      `https://us.i.posthog.com${POSTHOG_CAPTURE_PATH}`,
+    );
+  });
+
+  test("defaults to the platform fetch when none is injected", async () => {
+    const original = globalThis.fetch;
+    const calls = [];
+    globalThis.fetch = fakeFetch({ onCall: (call) => calls.push(call) });
+    try {
+      const recorded = await recordUsageEvent(
+        { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
+        { ok: true, durationMs: 1 },
+      );
+      assert.equal(recorded, true);
+      assert.equal(calls.length, 1);
+    } finally {
+      globalThis.fetch = original;
+    }
   });
 
   test("returns false for an invalid event without capturing", async () => {
-    let captures = 0;
+    let calls = 0;
     const recorded = await recordUsageEvent(
       { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
       { ok: true, durationMs: -5 },
       {
-        PostHog: fakePostHog({
-          onCapture: () => {
-            captures += 1;
+        fetch: fakeFetch({
+          onCall: () => {
+            calls += 1;
           },
         }),
       },
     );
     assert.equal(recorded, false);
-    assert.equal(captures, 0);
+    assert.equal(calls, 0);
   });
 
-  test("swallows capture errors and still attempts shutdown", async () => {
-    let shutdowns = 0;
+  test("swallows a transport failure", async () => {
     const recorded = await recordUsageEvent(
       { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
       { ok: true, durationMs: 3 },
-      {
-        PostHog: fakePostHog({
-          captureThrows: true,
-          onShutdown: () => {
-            shutdowns += 1;
-          },
-        }),
-      },
+      { fetch: fakeFetch({ throws: true }) },
     );
     assert.equal(recorded, false);
-    assert.equal(shutdowns, 1);
   });
 
-  test("swallows shutdown errors after a successful capture", async () => {
+  test("reports a rejected capture as not recorded", async () => {
     const recorded = await recordUsageEvent(
       { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
       { mcpTool: "list_tools", ok: true, durationMs: 9 },
-      {
-        PostHog: fakePostHog({ shutdownThrows: true }),
-      },
+      { fetch: fakeFetch({ ok: false }) },
     );
-    assert.equal(recorded, true);
+    assert.equal(recorded, false);
   });
 
-  test("never throws when the PostHog constructor itself throws", async () => {
-    class Boom {
-      constructor() {
-        throw new Error("construct failed");
-      }
-    }
-    await assert.doesNotReject(async () => {
-      const recorded = await recordUsageEvent(
-        { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
-        { ok: true, durationMs: 1 },
-        { PostHog: Boom },
-      );
-      assert.equal(recorded, false);
-    });
+  test("reports a missing response as not recorded", async () => {
+    const recorded = await recordUsageEvent(
+      { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
+      { ok: true, durationMs: 9 },
+      { fetch: fakeFetch({ response: null }) },
+    );
+    assert.equal(recorded, false);
   });
 
   test("honors an injected distinctId override", async () => {
-    const captures = [];
+    const calls = [];
     await recordUsageEvent(
       { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" },
       { ok: true, durationMs: 2 },
       {
         distinctId: "test-distinct",
-        PostHog: fakePostHog({
-          onCapture: (payload) => captures.push(payload),
-        }),
+        fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
       },
     );
-    assert.equal(captures[0].distinctId, "test-distinct");
+    assert.equal(calls[0].body.distinct_id, "test-distinct");
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -6,6 +6,10 @@ import {
   compileRoutePattern,
 } from "../src/contracts.mjs";
 import {
+  isUsageTelemetryConfigured,
+  recordUsageEvent,
+} from "../src/usage-telemetry.mjs";
+import {
   applyQueryFilters,
   canonicalListSearch,
   paginationLinkHeader,
@@ -431,9 +435,154 @@ function canonicalCacheSearch(url, matched) {
   );
 }
 
+// Product-usage telemetry (#6032 / #366). The Worker entry is the single
+// cross-cutting chokepoint every REST and GraphQL request passes through while
+// an ExecutionContext is still live, so it is the one place a usage event can
+// be recorded exactly once per request. Every wrapper further down is partial:
+// withEdgeCache covers only the cached analytics GETs (and returns before
+// buildResponse on a hit, so it never sees a full request), the artifact edge
+// cache is artifact-routes-only, and handleGraphQLRequest is not handed ctx at
+// all. Instrumenting here also keeps this to one point per transport rather
+// than one per route handler.
+
+// GraphQL is one transport with one HTTP route — every operation shares this
+// label rather than fanning out into client-supplied operation names, which are
+// unbounded and would have to be read out of the request body.
+const GRAPHQL_USAGE_ROUTE = "graphql";
+
+/**
+ * Low-cardinality usage label for a request URL, or null when the request must
+ * not be recorded at this chokepoint.
+ *
+ * Route ids come from the shared API_ROUTES contract, so path parameters
+ * (netuid, ss58, block ref, ...) collapse into one stable label instead of one
+ * label per account. Non-default networks are namespaced onto the label, which
+ * is what gives #366 its route+network dimensions without widening the event
+ * allowlist (the day dimension is the event timestamp).
+ *
+ * @param {URL} url
+ * @returns {string | null}
+ */
+export function usageRouteLabel(url) {
+  const { network, url: resolved } = resolveNetworkPrefix(url);
+  const { pathname } = resolved;
+
+  // MCP tool dispatch is instrumented at its own chokepoint, keyed by tool
+  // name (companion issue) — recording it here too would double-count every
+  // tool call, including the ones it bridges into GraphQL internally.
+  if (pathname === "/mcp" || pathname.startsWith("/mcp/")) {
+    return null;
+  }
+
+  const route =
+    pathname === "/api/v1/graphql"
+      ? GRAPHQL_USAGE_ROUTE
+      : (matchRoute(pathname)?.id ??
+        // Static assets, badges, OG images and the RPC proxy are not API usage.
+        (pathname.startsWith("/api/v1/")
+          ? maskUsageRouteParams(pathname)
+          : null));
+
+  if (route === null) {
+    return null;
+  }
+
+  return network.isDefault ? route : `${network.id}:${route}`;
+}
+
+/**
+ * Fallback label for the handful of /api/v1 routes that predate the API_ROUTES
+ * contract (/ask, /webhooks/..., /internal/...). Path segments that look like
+ * identifiers are masked so an unlisted route can never emit unbounded labels.
+ *
+ * @param {string} pathname
+ * @returns {string}
+ */
+function maskUsageRouteParams(pathname) {
+  return pathname
+    .split("/")
+    .map((segment) => {
+      if (/^\d+$/.test(segment)) return ":n";
+      if (/^0x[0-9a-fA-F]{6,}$/.test(segment)) return ":hash";
+      if (/^[1-9A-HJ-NP-Za-km-z]{47,48}$/.test(segment)) return ":ss58";
+      return segment;
+    })
+    .join("/");
+}
+
+/**
+ * Run the request pipeline and record exactly one usage event for it. Returns
+ * the handler's response untouched, and never converts a telemetry failure into
+ * a request failure: an unconfigured deployment skips the work entirely, and a
+ * recorder that rejects, throws, or a waitUntil that throws is swallowed.
+ *
+ * @param {Request} request
+ * @param {object} env
+ * @param {object} ctx ExecutionContext (may be a bare object in tests).
+ * @param {() => Promise<Response>} handle
+ * @param {{recordUsageEvent?: typeof recordUsageEvent}} [deps]
+ * @returns {Promise<Response>}
+ */
+export async function withUsageTelemetry(request, env, ctx, handle, deps = {}) {
+  const record = deps.recordUsageEvent ?? recordUsageEvent;
+  if (!isUsageTelemetryConfigured(env)) {
+    return handle();
+  }
+
+  // A subscription upgrade (GraphQL subscriptions reuse the /api/v1/graphql
+  // path over a WebSocket) opens a long-lived socket rather than serving a
+  // request/response pair, so its latency would be meaningless. Recognized the
+  // same way handleRequest itself dispatches it.
+  if (request.headers.get("upgrade") === "websocket") {
+    return handle();
+  }
+
+  const route = usageRouteLabel(new URL(request.url));
+  if (route === null) {
+    return handle();
+  }
+
+  const startedAt = Date.now();
+  let ok = false;
+  try {
+    const response = await handle();
+    // 4xx is a route correctly rejecting a bad request, not a broken route;
+    // only 5xx (and a thrown handler, which leaves ok false) is a failure.
+    ok = response.status < 500;
+    return response;
+  } finally {
+    scheduleUsageEvent(env, ctx, record, {
+      route,
+      ok,
+      durationMs: Date.now() - startedAt,
+    });
+  }
+}
+
+/**
+ * Hand the event to the recorder without ever blocking or failing the response.
+ *
+ * @param {object} env
+ * @param {object} ctx
+ * @param {typeof recordUsageEvent} record
+ * @param {object} event
+ */
+function scheduleUsageEvent(env, ctx, record, event) {
+  try {
+    const pending = Promise.resolve(record(env, event)).catch(() => false);
+    if (typeof ctx?.waitUntil === "function") {
+      ctx.waitUntil(pending);
+    }
+  } catch {
+    // Telemetry must never surface into the request path.
+  }
+}
+
 export default {
   async fetch(request, env, ctx) {
-    return handleRequest(request, env, ctx);
+    return withUsageTelemetry(request, env, ctx, () =>
+      handleRequest(request, env, ctx),
+    );
   },
   async scheduled(controller, env, ctx) {
     return handleScheduled(controller, env, ctx);


### PR DESCRIPTION
Closes #6032

Wires the usage-event wrapper from #6030 into REST and GraphQL, covering #366's non-MCP half.

Supersedes #6125, which was auto-closed on the Worker bundle-size budget. That failure was real and is fixed here — see "The bundle" below.

## The chokepoint

The issue suggests `withEdgeCache` as a candidate. It isn't a chokepoint: it wraps 41 of the analytics GETs, returns before `buildResponse` on a cache hit, is a no-op for every non-GET, and never sees GraphQL at all. The artifact edge cache is artifact-routes-only, and `handleGraphQLRequest` is never handed `ctx`.

The Worker entry is the one place that has all of it — 100% of both transports, and a live `ExecutionContext`. So instrumentation goes there: one point, one event per request, one point per transport rather than one per route handler.

## The bundle — why `src/usage-telemetry.mjs` changes here

The wrapper could not be wired into the Worker **at all** as written. `posthog-node` is a static import, so bringing it into the entry pushes the deployable bundle to **1048.8 KiB gzipped — past the 1016 KiB budget and past Cloudflare's hard 1024 KiB script limit.** That's why #6030 landed green: nothing imported it yet. The first caller was always going to hit this.

That SDK is built for long-lived Node servers — batching, flush intervals, shutdown draining — none of which survives a Workers isolate, which is why the wrapper already had to force `flushAt:1` / `captureImmediate` / `shutdown()` to approximate one-shot delivery. One POST to PostHog's documented capture endpoint does the same job, is the platform-native transport here, and costs nothing in the bundle:

| | api.js | Worker total |
|---|---|---|
| `main` (untouched) | 465.4 KiB | 1013.3 KiB |
| with `posthog-node` | 500.9 KiB | **1048.8 KiB** — over the deploy limit |
| this PR | 466.2 KiB | **1014.1 KiB** — passes |

So the instrumentation itself costs **+0.8 KiB**; the SDK was the whole problem. The module's contract is unchanged: same exports, same allowlisted event shape, same never-throws guarantee, same no-op when `POSTHOG_PROJECT_TOKEN` is unset.

## Labels

Route labels come from the shared `API_ROUTES` contract, so path parameters collapse into a stable id rather than one label per value — `/api/v1/accounts/5F3sa2…` is `account-summary`, not 10k distinct labels. Non-default networks are namespaced onto the label (`testnet:subnets`); mainnet/finney aliases stay unprefixed, so existing labels are byte-identical. That covers #366's route+network dimensions without widening the event allowlist — the day dimension is the event timestamp.

The handful of `/api/v1` routes outside the contract (`/ask`, `/webhooks/…`, `/internal/…`) fall back to a masked pathname, so an unlisted route still can't emit unbounded labels. Static assets, badges, OG images and the RPC proxy aren't API usage and aren't recorded.

Nothing is read from request bodies or response payloads: GraphQL is labelled by transport rather than by client-supplied `operationName`, and the downstream handler's body is left unread.

**MCP is deliberately skipped here.** It records its own tool-keyed event at its own dispatch chokepoint (the companion issue) — recording it here too would double-count every tool call, including the ones it bridges into GraphQL internally.

## Zero behavior change

An unconfigured deployment (no `POSTHOG_PROJECT_TOKEN`) short-circuits before any work, which is every existing test and every self-hoster. `4xx` is recorded as a served request, `5xx` and a thrown handler as failures; a thrown handler still propagates. A subscription upgrade opens a long-lived socket rather than serving a request/response pair, so it isn't recorded.

Telemetry can never surface into the request path — a recorder that rejects, a recorder that throws synchronously, and a `waitUntil` that throws are all swallowed, each covered by a test.

## Verification

- `tests/request-usage-telemetry.test.mjs` — 19 new tests, including the regression the issue asks for in all three shapes the telemetry call can fail in, plus an end-to-end assertion that a real request is served unchanged.
- `tests/usage-telemetry.test.mjs` — reworked to inject `fetch` instead of a client class; adds coverage for a rejected capture and a missing response.
- Patch coverage measured, not assumed: **0 uncovered statements and 0 uncovered branch arms** across every added/changed line in both `workers/api.mjs` and `src/usage-telemetry.mjs`.
- `worker:bundle:budget`, `format:check`, `lint`, `validate:contract-drift`, `validate:docs`, `validate:types`, `validate:private-boundary`, `validate:api` all pass.
- Full suite: 9007 passing. The 4 non-passing are `tests/artifacts.test.mjs > registry validates` (SN68/69/70 "not reproducible from registry inputs") and its knock-on — **reproduced identically on a clean `main` with no changes**, so they are pre-existing and unrelated to this PR.