### PR TITLE
fix(registry): SN84 ansuz accuracy re-review pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1131,14 +1131,14 @@
       "netuid": 84,
       "slug": "sn-84",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-08T10:45:00.000Z",
+      "reviewed_at": "2026-07-15T00:00:00.000Z",
       "confidence": "high",
       "source_urls": [
         "https://www.chipforge.io/",
         "https://docs.chipforge.io/",
         "https://github.com/TatsuProject/ChipForge_SN84"
       ],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/ansuz.json (reviewed_at 2026-06-08T10:45:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): confirmed the openapi.json the docs' own llms.txt links to returns an empty 200 response, and the API-reference stub pages don't state a base host to test the documented endpoints against. All existing surfaces re-verified live."
     },
     {
       "netuid": 85,

--- a/registry/subnets/ansuz.json
+++ b/registry/subnets/ansuz.json
@@ -10,21 +10,21 @@
   ],
   "curation": {
     "gap_notes": [
-      "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified unauthenticated public subnet API endpoint yet.",
+      "No verified machine-readable OpenAPI/Swagger schema yet -- the schema URL the llms.txt index itself declares (docs.chipforge.io/api-reference/openapi.json) returns HTTP 200 with content-type application/json but a zero-byte (empty) body.",
+      "No verified unauthenticated public subnet API endpoint yet -- the docs.chipforge.io API-reference stub pages (active.md, info.md, batch/current, testcases/download, etc.) describe endpoint paths and one-line summaries but never state a base host or example request, so the live API cannot be located to test.",
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T10:45:00.000Z",
+    "reviewed_at": "2026-07-15T00:00:00.000Z",
     "source_count": 5,
-    "verified_at": "2026-06-08T10:45:00.000Z"
+    "verified_at": "2026-07-15T00:00:00.000Z"
   },
   "dashboard_url": "https://taomarketcap.com/subnets/84",
   "docs_url": "https://docs.chipforge.io/",
   "name": "ansuz",
   "netuid": 84,
-  "notes": "Reviewed overlay for SN84 using the official ChipForge website, docs, and source repository. No machine-readable OpenAPI schema or unauthenticated public subnet API endpoint is promoted yet.",
+  "notes": "Reviewed overlay for SN84 using the official ChipForge website, docs, and source repository. No machine-readable OpenAPI schema or unauthenticated public subnet API endpoint is promoted yet. Re-review pass (2026-07-15): confirmed the openapi.json the docs' own llms.txt links to returns an empty 200 response, and the API-reference stub pages don't state a base host to test the documented endpoints against.",
   "schema_version": 1,
   "slug": "sn-84",
   "source_repo": "https://github.com/TatsuProject/ChipForge_SN84",


### PR DESCRIPTION
## Summary
- Confirm `docs.chipforge.io/api-reference/openapi.json` (the schema URL the docs' own `llms.txt` links to) returns an empty 200 response (content-type `application/json`, content-length 0) -- not a working schema
- Confirm the API-reference stub pages (`active.md`, `info.md`, etc.) describe endpoint paths but never state a base host, so the documented endpoints can't be located to test
- Document both precisely in `gap_notes` rather than the prior generic "not verified yet" wording
- Updates the existing `maintainer-reviewed.json` ledger entry (netuid 84)

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check`