### PR TITLE
fix(registry): SN87 Luminar Network accuracy re-review pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1165,7 +1165,7 @@
       "netuid": 87,
       "slug": "sn-87",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-07T00:00:00.000Z",
+      "reviewed_at": "2026-07-15T00:00:00.000Z",
       "confidence": "high",
       "source_urls": [
         "https://luminar.network/",
@@ -1173,9 +1173,10 @@
         "https://demo.luminar.network/",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_87/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/87",
-        "https://taomarketcap.com/subnets/87"
+        "https://taomarketcap.com/subnets/87",
+        "https://github.com/Luminar-Network/luminar-sn"
       ],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/luminar-network.json (reviewed_at 2026-06-07T00:00:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): gave the source-repo surface a proper name/notes (was the generic placeholder \"unknown community source-repo\") and added the missing top-level source_repo field."
     },
     {
       "netuid": 88,

--- a/registry/subnets/luminar-network.json
+++ b/registry/subnets/luminar-network.json
@@ -9,21 +9,21 @@
   ],
   "curation": {
     "gap_notes": [
-      "No verified OpenAPI/Swagger surface yet.",
+      "No verified OpenAPI/Swagger surface yet (luminar.network/openapi.json 404s).",
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-07T00:00:00.000Z",
+    "reviewed_at": "2026-07-15T00:00:00.000Z",
     "source_count": 6,
-    "verified_at": "2026-06-08T06:48:46.000Z"
+    "verified_at": "2026-07-15T00:00:00.000Z"
   },
   "dashboard_url": "https://demo.luminar.network/",
   "docs_url": "https://docs.luminar.network/",
   "links": [],
   "name": "Luminar Network",
   "netuid": 87,
-  "notes": "Reviewed identity overlay because live chain metadata currently reports a placeholder name for SN87.",
+  "notes": "Reviewed identity overlay because live chain metadata currently reports a placeholder name for SN87. Re-review pass (2026-07-15): gave the source-repo surface a proper name/notes (was the generic placeholder \"unknown community source-repo\") and added the top-level source_repo field, which was missing despite the surface already being tracked.",
   "schema_version": 1,
   "slug": "sn-87",
   "status": "active",
@@ -196,10 +196,11 @@
     },
     {
       "auth_required": false,
-      "authority": "community",
+      "authority": "official",
       "id": "sn-87-luminar-network-source-repo",
       "kind": "source-repo",
-      "name": "unknown community source-repo",
+      "name": "Luminar Network source repository",
+      "notes": "Official SN87 miner/validator source repository (org name matches the file's own \"Luminar Network\" identity) -- verified live 2026-07-15. Already cited as a source for the existing health and benchmark-submission surfaces.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -209,7 +210,7 @@
       "provider": "luminar-network",
       "public_safe": true,
       "review": {
-        "confidence": "medium",
+        "confidence": "high",
         "state": "community-submitted",
         "submitted_by": "jsonbored"
       },
@@ -274,5 +275,6 @@
       "url": "https://docs.luminar.network/llms.txt"
     }
   ],
+  "source_repo": "https://github.com/Luminar-Network/luminar-sn",
   "website_url": "https://luminar.network/"
 }


### PR DESCRIPTION
## Summary
- Give the source-repo surface a proper name/notes -- it carried the generic placeholder name "unknown community source-repo" despite being a legitimate, already-cited official repository (org name matches the file's own "Luminar Network" identity, and the repo is already used as a source for the health and benchmark-submission surfaces)
- Add the missing top-level `source_repo` field
- Updates the existing `maintainer-reviewed.json` ledger entry (netuid 87)

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check`