### PR TITLE
fix(backend): retire the dead account_events/extrinsics D1 fallback in analytics.mjs

### DIFF
--- a/tests/chain-alpha-volume.test.mjs
+++ b/tests/chain-alpha-volume.test.mjs
@@ -343,15 +343,25 @@ describe("GET /api/v1/chain/alpha-volume", () => {
   const req = (q = "") =>
     new Request(`https://api.metagraph.sh/api/v1/chain/alpha-volume${q}`);
 
-  test("dispatches to the network alpha-volume leaderboard", async () => {
-    const res = await handleRequest(req(), alphaVolumeEnv(ROWS), {});
+  // #4909/#6013: account_events' D1 write path is retired and the table is
+  // dropped in production, so this handler no longer queries D1 at all --
+  // even a "warm" D1 mock (real rows) must not change the response.
+  test("never queries D1 even when mocked with real rows (retired -- #4909/#6013)", async () => {
+    let d1Called = false;
+    const env = alphaVolumeEnv(ROWS);
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error("D1 must not be queried -- account_events is retired");
+    };
+    const res = await handleRequest(req(), env, {});
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.equal(body.data.schema_version, 1);
     assert.equal(body.data.window, "24h");
-    assert.equal(body.data.subnet_count, 3);
-    assert.equal(body.data.subnets[0].netuid, 1);
+    assert.equal(body.data.subnet_count, 0);
+    assert.deepEqual(body.data.subnets, []);
     assert.equal(typeof body.data.network, "object");
+    assert.equal(d1Called, false);
   });
 
   test("serves a HEAD probe through the GET cache key with no body", async () => {
@@ -409,7 +419,10 @@ describe("GET /api/v1/chain/alpha-volume", () => {
     assert.equal(d1Called, false);
   });
 
-  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+  // #4909/#6013: the D1 "fallback" is a schema-stable empty stub, not a real
+  // D1 read (account_events is retired) -- a Postgres failure degrades to the
+  // empty card, not to whatever a D1 mock might return.
+  test("flag=postgres falls back to the empty stub (not D1) when DATA_API fails", async () => {
     const env = {
       ...alphaVolumeEnv(ROWS),
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
@@ -422,7 +435,7 @@ describe("GET /api/v1/chain/alpha-volume", () => {
     const res = await handleRequest(req(), env, {});
     assert.equal(res.status, 200);
     const body = await res.json();
-    assert.equal(body.data.subnet_count, 3);
+    assert.equal(body.data.subnet_count, 0);
   });
 
   test("rejects a ?window= param with 400 (fixed 24h window, no windowing on this route)", async () => {
@@ -440,7 +453,9 @@ describe("GET /api/v1/chain/alpha-volume", () => {
     assert.equal(res.status, 400);
   });
 
-  test("exports the per-subnet leaderboard as CSV with ?format=csv", async () => {
+  // #4909/#6013: even a "warm" D1 mock never reaches the response -- the CSV
+  // export is always header-only now (account_events is retired).
+  test("CSV export with ?format=csv is header-only even with a warm D1 mock", async () => {
     const res = await handleRequest(
       req("?format=csv"),
       alphaVolumeEnv(ROWS),
@@ -453,13 +468,11 @@ describe("GET /api/v1/chain/alpha-volume", () => {
       /attachment; filename="chain-alpha-volume\.csv"/,
     );
     const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines.length, 1);
     assert.equal(
       lines[0],
       "netuid,buy_volume_alpha,sell_volume_alpha,total_volume_alpha,buy_volume_tao,sell_volume_tao,total_volume_tao,buy_count,sell_count,net_volume_alpha,sentiment_ratio,sentiment,vol_mcap_ratio",
     );
-    // Biggest total volume first: netuid 1 (130) leads, then 2 (100), then 3 (20).
-    assert.equal(lines.length, 4); // header + 3 subnet rows
-    assert.equal(lines[1], "1,100,30,130,100,30,130,5,2,70,0.5385,bullish,");
   });
 
   test("honors Accept: text/csv the same as ?format=csv", async () => {
@@ -559,12 +572,14 @@ describe("chain/alpha-volume edge cache", () => {
     const res = await call();
     assert.equal(res.status, 200);
     const body = await res.json();
-    assert.equal(body.data.subnet_count, 3);
+    // #4909/#6013: account_events is retired, so even this "warm" D1 mock
+    // never reaches the response -- subnet_count stays 0.
+    assert.equal(body.data.subnet_count, 0);
     await Promise.all(waits); // let the deferred cache put settle
     assert.equal(store.size, 1); // the response was cached under one key
     // A second request is served from that cached entry (the mocked match() returns it).
     const cached = await call();
     assert.equal(cached.status, 200);
-    assert.equal((await cached.json()).data.subnet_count, 3);
+    assert.equal((await cached.json()).data.subnet_count, 0);
   });
 });

--- a/tests/chain-analytics.test.mjs
+++ b/tests/chain-analytics.test.mjs
@@ -544,31 +544,18 @@ test("buildChainSigners nulls blank and missing last_tx_block cells (not block 0
   assert.equal(numericString.signers[0].last_tx_block, 12345);
 });
 
-test("GET /api/v1/chain/signers ranks by tx_count via the signer GROUP BY", async () => {
-  const captured = [];
+// #4909/#6013: extrinsics' D1 write path is retired and the table is dropped
+// in production, so handleChainSigners no longer queries D1 at all -- even a
+// "warm" D1 mock (real rows) must not change the response. window/limit are
+// still shape-validated for REST contract stability but no longer feed a read.
+test("GET /api/v1/chain/signers never queries D1 even when mocked with real rows (retired -- #4909/#6013)", async () => {
+  let d1Called = false;
   const env = {
     ...createLocalArtifactEnv(),
     METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        return {
-          bind(...params) {
-            captured.push({ sql, params });
-            return {
-              all: () =>
-                Promise.resolve({
-                  results: [
-                    {
-                      signer: "5Top",
-                      tx_count: 900,
-                      total_fee_tao: 3.2,
-                      total_tip_tao: 0,
-                      last_tx_block: 8490697,
-                    },
-                  ],
-                }),
-            };
-          },
-        };
+      prepare() {
+        d1Called = true;
+        throw new Error("D1 must not be queried -- extrinsics is retired");
       },
     },
   };
@@ -582,71 +569,35 @@ test("GET /api/v1/chain/signers ranks by tx_count via the signer GROUP BY", asyn
   assert.equal(res.status, 200);
   const body = await res.json();
   assert.equal(body.data.sort, "tx_count");
-  assert.equal(body.data.signers[0].signer, "5Top");
-  assert.equal(body.data.signers[0].tx_count, 900);
-  const sql = captured[0].sql;
-  assert.match(sql, /GROUP BY signer/);
-  assert.match(sql, /ORDER BY tx_count DESC/);
-  assert.equal(captured[0].params.at(-1), 10);
+  assert.deepEqual(body.data.signers, []);
+  assert.equal(d1Called, false);
 });
 
-test("GET /api/v1/chain/signers ranks by total_fee_tao when requested", async () => {
-  const captured = [];
-  const env = {
-    ...createLocalArtifactEnv(),
-    METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        return {
-          bind(...params) {
-            captured.push({ sql, params });
-            return { all: () => Promise.resolve({ results: [] }) };
-          },
-        };
-      },
-    },
-  };
+test("GET /api/v1/chain/signers echoes the requested sort with an empty leaderboard", async () => {
   const res = await handleRequest(
     new Request(
       "https://api.metagraph.sh/api/v1/chain/signers?sort=total_fee_tao",
     ),
-    env,
+    createLocalArtifactEnv(),
     {},
   );
   assert.equal(res.status, 200);
   const body = await res.json();
   assert.equal(body.data.sort, "total_fee_tao");
-  const q = captured.find((c) => /FROM extrinsics/.test(c.sql));
-  assert.match(q.sql, /ORDER BY total_fee_tao DESC, signer ASC/);
+  assert.deepEqual(body.data.signers, []);
 });
 
-test("GET /api/v1/chain/signers scopes the leaderboard by call_module", async () => {
-  const captured = [];
-  const env = {
-    ...createLocalArtifactEnv(),
-    METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        return {
-          bind(...params) {
-            captured.push({ sql, params });
-            return { all: () => Promise.resolve({ results: [] }) };
-          },
-        };
-      },
-    },
-  };
+test("GET /api/v1/chain/signers still shape-validates call_module even though it no longer feeds a read", async () => {
   const res = await handleRequest(
     new Request(
       "https://api.metagraph.sh/api/v1/chain/signers?call_module=Balances",
     ),
-    env,
+    createLocalArtifactEnv(),
     {},
   );
   assert.equal(res.status, 200);
-  // Target the extrinsics query explicitly (not captured[0]) so the assertion
-  // holds even if a meta/KV read issues a prepare first.
-  const q = captured.find((c) => /FROM extrinsics/.test(c.sql));
-  assert.match(q.sql, /AND call_module = \?/);
-  assert.ok(q.params.includes("Balances"));
+  const body = await res.json();
+  assert.deepEqual(body.data.signers, []);
 });
 
 test("GET /api/v1/chain/signers rejects unsupported sort values", async () => {
@@ -660,48 +611,17 @@ test("GET /api/v1/chain/signers rejects unsupported sort values", async () => {
   assert.equal(body.meta.parameter, "sort");
 });
 
-test("GET /api/v1/chain/transfers aggregates volume + ranks senders/receivers", async () => {
-  const captured = [];
+// #4909/#6013: account_events' D1 write path is retired and the table is
+// dropped in production, so handleChainTransfers no longer queries D1 at all
+// -- even a "warm" D1 mock (real rows) must not change the response.
+test("GET /api/v1/chain/transfers never queries D1 even when mocked with real rows (retired -- #4909/#6013)", async () => {
+  let d1Called = false;
   const env = {
     ...createLocalArtifactEnv(),
     METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        return {
-          bind(...params) {
-            captured.push({ sql, params });
-            return {
-              all: () => {
-                if (/COUNT\(DISTINCT hotkey\)/.test(sql)) {
-                  return Promise.resolve({
-                    results: [
-                      {
-                        transfer_count: 10,
-                        total_volume_tao: 100,
-                        unique_senders: 4,
-                        unique_receivers: 6,
-                      },
-                    ],
-                  });
-                }
-                if (/GROUP BY hotkey/.test(sql)) {
-                  return Promise.resolve({
-                    results: [
-                      { address: "5Sa", volume_tao: 80, transfer_count: 5 },
-                    ],
-                  });
-                }
-                if (/GROUP BY coldkey/.test(sql)) {
-                  return Promise.resolve({
-                    results: [
-                      { address: "5Rx", volume_tao: 60, transfer_count: 4 },
-                    ],
-                  });
-                }
-                return Promise.resolve({ results: [] });
-              },
-            };
-          },
-        };
+      prepare() {
+        d1Called = true;
+        throw new Error("D1 must not be queried -- account_events is retired");
       },
     },
   };
@@ -715,14 +635,11 @@ test("GET /api/v1/chain/transfers aggregates volume + ranks senders/receivers", 
   assert.equal(res.status, 200);
   const body = await res.json();
   assert.equal(body.data.window, "7d");
-  assert.equal(body.data.total_volume_tao, 100);
-  assert.equal(body.data.top_senders[0].address, "5Sa");
-  assert.equal(body.data.top_receivers[0].address, "5Rx");
-  assert.equal(body.data.top_sender_share, 0.8); // 80 / 100
+  assert.equal(body.data.total_volume_tao, 0);
+  assert.deepEqual(body.data.top_senders, []);
+  assert.deepEqual(body.data.top_receivers, []);
   assert.equal(body.meta.source, "live-cron-prober");
-  const senders = captured.find((c) => /GROUP BY hotkey/.test(c.sql));
-  assert.match(senders.sql, /event_kind = \?/);
-  assert.equal(senders.params.at(-1), 5); // limit
+  assert.equal(d1Called, false);
 });
 
 test("HEAD /api/v1/chain/transfers shares the GET edge cache", async () => {
@@ -785,6 +702,10 @@ test("HEAD /api/v1/chain/transfers shares the GET edge cache", async () => {
   };
 
   try {
+    // #4909/#6013: account_events is retired, so this "warm" D1 mock is never
+    // actually queried (captured stays empty throughout) -- the response is
+    // always the schema-stable empty stub. What this test still exercises:
+    // HEAD populates the edge cache and a subsequent GET reuses that body.
     const url = "https://api.metagraph.sh/api/v1/chain/transfers?window=7d";
     const first = await handleRequest(
       new Request(url, { method: "HEAD" }),
@@ -797,7 +718,7 @@ test("HEAD /api/v1/chain/transfers shares the GET edge cache", async () => {
     );
     assert.equal(first.status, 200);
     assert.equal(await first.text(), "");
-    assert.equal(captured.length, 3);
+    assert.equal(captured.length, 0);
     assert.equal(cache.putKeys.length, 1);
 
     const second = await handleRequest(
@@ -807,16 +728,16 @@ test("HEAD /api/v1/chain/transfers shares the GET edge cache", async () => {
     );
     assert.equal(second.status, 200);
     assert.equal(await second.text(), "");
-    assert.equal(captured.length, 3, "warm HEAD must not re-run D1");
+    assert.equal(captured.length, 0, "D1 is never queried");
     assert.equal(cache.matchCalls, 2);
 
     const get = await handleRequest(new Request(url), env, {});
     assert.equal(get.status, 200);
     const body = await get.json();
-    assert.equal(body.data.total_volume_tao, 2);
+    assert.equal(body.data.total_volume_tao, 0);
     assert.equal(
       captured.length,
-      3,
+      0,
       "GET should reuse the HEAD-populated body",
     );
   } finally {
@@ -904,7 +825,9 @@ const TRANSFERS_TOTALS = {
   unique_receivers: 6,
 };
 
-test("GET /api/v1/chain/transfers exports top senders + receivers as CSV with ?format=csv", async () => {
+// #4909/#6013: even a "warm" D1 mock never reaches the response -- the CSV
+// export is always header-only now (account_events is retired).
+test("GET /api/v1/chain/transfers CSV export with ?format=csv is header-only even with a warm D1 mock", async () => {
   const res = await handleRequest(
     new Request(
       "https://api.metagraph.sh/api/v1/chain/transfers?window=7d&format=csv",
@@ -923,10 +846,8 @@ test("GET /api/v1/chain/transfers exports top senders + receivers as CSV with ?f
     /attachment; filename="chain-transfers\.csv"/,
   );
   const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines.length, 1);
   assert.equal(lines[0], TRANSFERS_CSV_HEADER);
-  assert.equal(lines.length, 3); // header + 1 sender row + 1 receiver row
-  assert.equal(lines[1], "sender,5Sa,80,5");
-  assert.equal(lines[2], "receiver,5Rx,60,4");
 });
 
 test("GET /api/v1/chain/transfers honors Accept: text/csv the same as ?format=csv", async () => {
@@ -1010,6 +931,45 @@ test("GET /api/v1/chain/transfers: flag=postgres serves the DATA_API response, D
   assert.equal(d1Called, false);
 });
 
+// D1 is permanently skipped (#4909/#6013), so the only path that can ever
+// populate top_senders/top_receivers with real rows is a Postgres-tier hit --
+// this exercises the CSV row-mapping for both arrays.
+test("GET /api/v1/chain/transfers: CSV export maps Postgres-tier senders/receivers", async () => {
+  const env = {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+    DATA_API: {
+      fetch: async () =>
+        Response.json({
+          schema_version: 1,
+          window: "7d",
+          observed_at: "2026-01-01T00:00:00.000Z",
+          total_volume_tao: 140,
+          transfer_count: 9,
+          unique_senders: 1,
+          unique_receivers: 1,
+          top_sender_share: 0.5714,
+          top_senders: [TRANSFERS_SENDER_ROW],
+          top_receivers: [TRANSFERS_RECEIVER_ROW],
+        }),
+    },
+  };
+  const res = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/chain/transfers?window=7d&format=csv",
+    ),
+    env,
+    {},
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type"), /text\/csv/);
+  const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines[0], TRANSFERS_CSV_HEADER);
+  assert.equal(lines.length, 3);
+  assert.equal(lines[1], "sender,5Sa,80,5");
+  assert.equal(lines[2], "receiver,5Rx,60,4");
+});
+
 test("GET /api/v1/chain/transfers: flag=postgres falls back to D1 when DATA_API fails", async () => {
   const env = {
     ...createLocalArtifactEnv(),
@@ -1037,50 +997,17 @@ test("GET /api/v1/chain/transfers: flag=postgres falls back to D1 when DATA_API 
   assert.equal(body.data.total_volume_tao, 0);
 });
 
-test("GET /api/v1/chain/transfer-pairs ranks directed transfer corridors", async () => {
-  const captured = [];
+// #4909/#6013: account_events' D1 write path is retired and the table is
+// dropped in production, so handleChainTransferPairs no longer queries D1 at
+// all -- even a "warm" D1 mock (real rows) must not change the response.
+test("GET /api/v1/chain/transfer-pairs never queries D1 even when mocked with real rows (retired -- #4909/#6013)", async () => {
+  let d1Called = false;
   const env = {
     ...createLocalArtifactEnv(),
     METAGRAPH_HEALTH_DB: {
-      prepare(sql) {
-        return {
-          bind(...params) {
-            captured.push({ sql, params });
-            return {
-              all: () => {
-                if (/WITH pair_totals/.test(sql)) {
-                  return Promise.resolve({
-                    results: [
-                      {
-                        transfer_count: 10,
-                        total_volume_tao: 100,
-                        unique_pairs: 4,
-                        top_pair_volume_tao: 80,
-                      },
-                    ],
-                  });
-                }
-                if (/ORDER BY/.test(sql)) {
-                  return Promise.resolve({
-                    results: [
-                      {
-                        from: "5Sa",
-                        to: "5Rx",
-                        volume_tao: 80,
-                        transfer_count: 5,
-                        last_block: "8454388",
-                        last_observed_at: Date.parse(
-                          "2026-07-03T00:00:00.000Z",
-                        ),
-                      },
-                    ],
-                  });
-                }
-                return Promise.resolve({ results: [] });
-              },
-            };
-          },
-        };
+      prepare() {
+        d1Called = true;
+        throw new Error("D1 must not be queried -- account_events is retired");
       },
     },
   };
@@ -1095,19 +1022,12 @@ test("GET /api/v1/chain/transfer-pairs ranks directed transfer corridors", async
   const body = await res.json();
   assert.equal(body.data.window, "7d");
   assert.equal(body.data.sort, "count");
-  assert.equal(body.data.total_volume_tao, 100);
-  assert.equal(body.data.unique_pairs, 4);
-  assert.equal(body.data.pair_count, 1);
-  assert.equal(body.data.top_pair_share, 0.8);
-  assert.equal(body.data.pairs[0].from, "5Sa");
-  assert.equal(body.data.pairs[0].to, "5Rx");
-  assert.equal(body.data.pairs[0].last_block, 8454388);
+  assert.equal(body.data.total_volume_tao, 0);
+  assert.equal(body.data.unique_pairs, 0);
+  assert.equal(body.data.pair_count, 0);
+  assert.deepEqual(body.data.pairs, []);
   assert.equal(body.meta.source, "live-cron-prober");
-  const pairs = captured.find((c) => /ORDER BY/.test(c.sql));
-  assert.match(pairs.sql, /hotkey <> coldkey/);
-  assert.match(pairs.sql, /amount_tao IS NOT NULL AND amount_tao >= 0/);
-  assert.match(pairs.sql, /ORDER BY transfer_count DESC, volume_tao DESC/);
-  assert.equal(pairs.params.at(-1), 5);
+  assert.equal(d1Called, false);
 });
 
 function transferPairsEnv({ pairs = [], totals } = {}) {
@@ -1158,7 +1078,9 @@ const PAIR_TOTALS = {
   top_pair_volume_tao: 80,
 };
 
-test("GET /api/v1/chain/transfer-pairs exports the ranked pairs as CSV with ?format=csv", async () => {
+// #4909/#6013: even a "warm" D1 mock never reaches the response -- the CSV
+// export is always header-only now (account_events is retired).
+test("GET /api/v1/chain/transfer-pairs CSV export with ?format=csv is header-only even with a warm D1 mock", async () => {
   const res = await handleRequest(
     new Request(
       "https://api.metagraph.sh/api/v1/chain/transfer-pairs?window=7d&format=csv",
@@ -1173,9 +1095,8 @@ test("GET /api/v1/chain/transfer-pairs exports the ranked pairs as CSV with ?for
     /attachment; filename="chain-transfer-pairs\.csv"/,
   );
   const lines = (await res.text()).trim().split("\r\n");
+  assert.equal(lines.length, 1);
   assert.equal(lines[0], PAIRS_CSV_HEADER);
-  assert.equal(lines.length, 2); // header + 1 pair row
-  assert.equal(lines[1], "5Sa,5Rx,80,5,8454388,2026-07-03T00:00:00.000Z");
 });
 
 test("GET /api/v1/chain/transfer-pairs honors Accept: text/csv the same as ?format=csv", async () => {

--- a/tests/chain-stake-flow.test.mjs
+++ b/tests/chain-stake-flow.test.mjs
@@ -313,6 +313,14 @@ describe("loadChainStakeFlow", () => {
     assert.equal(data.subnet_count, 0);
     assert.deepEqual(data.subnets, []);
   });
+
+  test("ignores a malformed out-of-range timestamp instead of throwing", () => {
+    const data = buildChainStakeFlow([ev(4, "StakeAdded", 10, 1, 1e100)], {
+      window: "7d",
+    });
+    assert.equal(data.subnet_count, 1);
+    assert.equal(data.observed_at, null);
+  });
 });
 
 describe("GET /api/v1/chain/stake-flow", () => {
@@ -336,14 +344,24 @@ describe("GET /api/v1/chain/stake-flow", () => {
   const req = (q = "") =>
     new Request(`https://api.metagraph.sh/api/v1/chain/stake-flow${q}`);
 
-  test("dispatches to the network capital-flow scorecard", async () => {
-    const res = await handleRequest(req("?window=7d"), stakeFlowEnv(ROWS), {});
+  // #4909/#6013: account_events' D1 write path is retired and the table is
+  // dropped in production, so this handler no longer queries D1 at all --
+  // even a "warm" D1 mock (real rows) must not change the response.
+  test("never queries D1 even when mocked with real rows (retired -- #4909/#6013)", async () => {
+    let d1Called = false;
+    const env = stakeFlowEnv(ROWS);
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error("D1 must not be queried -- account_events is retired");
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.equal(body.data.schema_version, 1);
-    assert.equal(body.data.subnet_count, 3);
-    assert.equal(body.data.subnets[0].netuid, 1);
+    assert.equal(body.data.subnet_count, 0);
+    assert.deepEqual(body.data.subnets, []);
     assert.equal(typeof body.data.network, "object");
+    assert.equal(d1Called, false);
   });
 
   test("serves a HEAD probe through the GET cache key with no body", async () => {
@@ -356,18 +374,6 @@ describe("GET /api/v1/chain/stake-flow", () => {
     );
     assert.equal(res.status, 200);
     assert.equal(await res.text(), ""); // HEAD carries no body
-  });
-
-  test("ignores malformed out-of-range timestamps instead of returning 500", async () => {
-    const res = await handleRequest(
-      req(),
-      stakeFlowEnv([ev(4, "StakeAdded", 10, 1, 1e100)]),
-      {},
-    );
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.subnet_count, 1);
-    assert.equal(body.data.observed_at, null);
   });
 
   test("serves a schema-stable empty card on a cold store", async () => {
@@ -415,7 +421,10 @@ describe("GET /api/v1/chain/stake-flow", () => {
     assert.equal(d1Called, false);
   });
 
-  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+  // #4909/#6013: the D1 "fallback" is a schema-stable empty stub, not a real
+  // D1 read (account_events is retired) -- a Postgres failure degrades to the
+  // empty card, not to whatever a D1 mock might return.
+  test("flag=postgres falls back to the empty stub (not D1) when DATA_API fails", async () => {
     const env = {
       ...stakeFlowEnv(ROWS),
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
@@ -428,7 +437,7 @@ describe("GET /api/v1/chain/stake-flow", () => {
     const res = await handleRequest(req("?window=7d"), env, {});
     assert.equal(res.status, 200);
     const body = await res.json();
-    assert.equal(body.data.subnet_count, 3);
+    assert.equal(body.data.subnet_count, 0);
   });
 
   test("rejects an unsupported window with 400", async () => {
@@ -446,7 +455,9 @@ describe("GET /api/v1/chain/stake-flow", () => {
     assert.equal(res.status, 400);
   });
 
-  test("exports the per-subnet leaderboard as CSV with ?format=csv", async () => {
+  // #4909/#6013: even a "warm" D1 mock never reaches the response -- the CSV
+  // export is always header-only now (account_events is retired).
+  test("CSV export with ?format=csv is header-only even with a warm D1 mock", async () => {
     const res = await handleRequest(
       req("?window=7d&format=csv"),
       stakeFlowEnv(ROWS),
@@ -459,13 +470,11 @@ describe("GET /api/v1/chain/stake-flow", () => {
       /attachment; filename="chain-stake-flow\.csv"/,
     );
     const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines.length, 1);
     assert.equal(
       lines[0],
       "netuid,total_staked_tao,total_unstaked_tao,net_flow_tao,gross_flow_tao,stake_events,unstake_events,direction",
     );
-    // Biggest net inflow first: netuid 1 (net +70) leads, then 3 (0), then 2 (-60).
-    assert.equal(lines.length, 4); // header + 3 subnet rows
-    assert.equal(lines[1], "1,100,30,70,130,5,2,inflow");
   });
 
   test("honors Accept: text/csv the same as ?format=csv", async () => {
@@ -567,12 +576,14 @@ describe("chain/stake-flow edge cache", () => {
     const res = await call();
     assert.equal(res.status, 200);
     const body = await res.json();
-    assert.equal(body.data.subnet_count, 3);
+    // #4909/#6013: account_events is retired, so even this "warm" D1 mock
+    // never reaches the response -- subnet_count stays 0.
+    assert.equal(body.data.subnet_count, 0);
     await Promise.all(waits); // let the deferred cache put settle
     assert.equal(store.size, 1); // the response was cached under one key
     // A second request is served from that cached entry (the mocked match() returns it).
     const cached = await call();
     assert.equal(cached.status, 200);
-    assert.equal((await cached.json()).data.subnet_count, 3);
+    assert.equal((await cached.json()).data.subnet_count, 0);
   });
 });

--- a/tests/chain-weights.test.mjs
+++ b/tests/chain-weights.test.mjs
@@ -355,14 +355,24 @@ describe("GET /api/v1/chain/weights", () => {
   const cold = { networkRow: [{ newest_observed: null }], subnetRows: [] };
   const warm = { networkRow: [NETWORK], subnetRows: SUBNETS };
 
-  test("dispatches to the network weight-setting scorecard", async () => {
-    const res = await handleRequest(req("?window=7d"), weightsEnv(warm), {});
+  // #4909/#6013: account_events' D1 write path is retired and the table is
+  // dropped in production, so this handler no longer queries D1 at all --
+  // even a "warm" D1 mock (real rows) must not change the response.
+  test("never queries D1 even when mocked with real rows (retired -- #4909/#6013)", async () => {
+    let d1Called = false;
+    const env = weightsEnv(warm);
+    env.METAGRAPH_HEALTH_DB.prepare = () => {
+      d1Called = true;
+      throw new Error("D1 must not be queried -- account_events is retired");
+    };
+    const res = await handleRequest(req("?window=7d"), env, {});
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.equal(body.data.schema_version, 1);
-    assert.equal(body.data.subnet_count, 3);
-    assert.equal(body.data.subnets[0].netuid, 1);
+    assert.equal(body.data.subnet_count, 0);
+    assert.deepEqual(body.data.subnets, []);
     assert.equal(body.meta.artifact_path, "/metagraph/chain/weights.json");
+    assert.equal(d1Called, false);
   });
 
   test("serves a HEAD probe through the GET cache key with no body", async () => {
@@ -433,7 +443,10 @@ describe("GET /api/v1/chain/weights", () => {
     assert.equal(d1Called, false);
   });
 
-  test("flag=postgres falls back to D1 when DATA_API fails", async () => {
+  // #4909/#6013: the D1 "fallback" is a schema-stable empty stub, not a real
+  // D1 read (account_events is retired) -- a Postgres failure degrades to the
+  // empty card, not to whatever a D1 mock might return.
+  test("flag=postgres falls back to the empty stub (not D1) when DATA_API fails", async () => {
     const env = {
       ...weightsEnv(warm),
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
@@ -446,7 +459,7 @@ describe("GET /api/v1/chain/weights", () => {
     const res = await handleRequest(req("?window=7d"), env, {});
     assert.equal(res.status, 200);
     const body = await res.json();
-    assert.equal(body.data.subnet_count, 3);
+    assert.equal(body.data.subnet_count, 0);
   });
 
   test("rejects an unsupported window with 400", async () => {
@@ -467,7 +480,9 @@ describe("GET /api/v1/chain/weights", () => {
   const WEIGHTS_CSV_HEADER =
     "netuid,distinct_setters,weight_sets,sets_per_setter";
 
-  test("exports the per-subnet leaderboard as CSV with ?format=csv", async () => {
+  // #4909/#6013: even a "warm" D1 mock never reaches the response -- the CSV
+  // export is always header-only now (account_events is retired).
+  test("CSV export with ?format=csv is header-only even with a warm D1 mock", async () => {
     const res = await handleRequest(
       req("?window=7d&format=csv"),
       weightsEnv(warm),
@@ -480,10 +495,8 @@ describe("GET /api/v1/chain/weights", () => {
       /attachment; filename="chain-weights\.csv"/,
     );
     const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines.length, 1);
     assert.equal(lines[0], WEIGHTS_CSV_HEADER);
-    // Ranked by total weight_sets desc: netuid 1 (40), 2 (30), 5 (25).
-    assert.equal(lines.length, 4); // header + 3 subnet rows
-    assert.equal(lines[1], "1,4,40,10");
   });
 
   test("honors Accept: text/csv the same as ?format=csv", async () => {
@@ -575,11 +588,13 @@ describe("chain/weights edge cache", () => {
       );
     const res = await call();
     assert.equal(res.status, 200);
-    assert.equal((await res.json()).data.subnet_count, 3);
+    // #4909/#6013: account_events is retired, so even this "warm" D1 mock
+    // never reaches the response -- subnet_count stays 0.
+    assert.equal((await res.json()).data.subnet_count, 0);
     await Promise.all(waits);
     assert.equal(store.size, 1);
     const cached = await call();
     assert.equal(cached.status, 200);
-    assert.equal((await cached.json()).data.subnet_count, 3);
+    assert.equal((await cached.json()).data.subnet_count, 0);
   });
 });

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -1682,6 +1682,10 @@ describe("chain analytics ?format=csv export", () => {
       path: "/api/v1/chain/signers",
       handler: handleChainSigners,
       header: "signer,tx_count,total_fee_tao,total_tip_tao,last_tx_block",
+      // #4909/#6013: extrinsics' D1 write path is retired, so chain-signers no
+      // longer queries D1 at all -- there is no "degraded D1" scenario to mark
+      // as fallback anymore (see the dedicated test below instead).
+      skipDegradedD1: true,
     },
     {
       name: "chain-fees",
@@ -1692,7 +1696,7 @@ describe("chain analytics ?format=csv export", () => {
     },
   ];
 
-  for (const { name, path, handler, header } of cases) {
+  for (const { name, path, handler, header, skipDegradedD1 } of cases) {
     test(`${name} ?window=7d&format=csv emits its columns as text/csv`, async () => {
       const { env } = dbWith({ rows: [] });
       const p = `${path}?window=7d&format=csv`;
@@ -1723,23 +1727,49 @@ describe("chain analytics ?format=csv export", () => {
       assert.equal(body.meta.parameter, "format");
     });
 
-    test(`${name} degraded D1 still emits header-only CSV, marked fallback (not edge-cached)`, async () => {
-      // A degraded D1 read yields fallback-marked rows; the CSV response must
-      // still be a valid header-only CSV (never a 500) AND be tagged as fallback
-      // so withEdgeCache never persists the degraded body.
-      originalCaches = globalThis.caches;
-      const cache = mockCaches();
-      cache.install();
-      const { env } = dbWith({ d1Error: new Error("d1 down") });
-      const p = `${path}?window=7d&format=csv`;
-      const res = await handler(req(p), env, url(p), ctx);
-      assert.equal(res.status, 200);
-      assert.match(res.headers.get("content-type") || "", /text\/csv/);
-      const text = await res.text();
-      assert.equal(text.split("\r\n")[0], header);
-      assert.deepEqual(cache.putKeys, []);
-    });
+    if (!skipDegradedD1) {
+      test(`${name} degraded D1 still emits header-only CSV, marked fallback (not edge-cached)`, async () => {
+        // A degraded D1 read yields fallback-marked rows; the CSV response must
+        // still be a valid header-only CSV (never a 500) AND be tagged as fallback
+        // so withEdgeCache never persists the degraded body.
+        originalCaches = globalThis.caches;
+        const cache = mockCaches();
+        cache.install();
+        const { env } = dbWith({ d1Error: new Error("d1 down") });
+        const p = `${path}?window=7d&format=csv`;
+        const res = await handler(req(p), env, url(p), ctx);
+        assert.equal(res.status, 200);
+        assert.match(res.headers.get("content-type") || "", /text\/csv/);
+        const text = await res.text();
+        assert.equal(text.split("\r\n")[0], header);
+        assert.deepEqual(cache.putKeys, []);
+      });
+    }
   }
+
+  // #4909/#6013: chain-signers skips D1 entirely (extrinsics is retired), so a
+  // "degraded D1" response never happens -- confirm the empty-stub CSV is a
+  // normal, cacheable 200 instead of the fallback-marked path the other three
+  // handlers exercise above.
+  test("chain-signers never touches D1 and is edge-cacheable even when METAGRAPH_HEALTH_DB would error", async () => {
+    originalCaches = globalThis.caches;
+    const cache = mockCaches();
+    cache.install();
+    const { env } = dbWith({ d1Error: new Error("d1 down") });
+    const p = "/api/v1/chain/signers?window=7d&format=csv";
+    const res = await handleChainSigners(req(p), env, url(p), ctx);
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type") || "", /text\/csv/);
+    const text = await res.text();
+    assert.equal(
+      text.split("\r\n")[0],
+      "signer,tx_count,total_fee_tao,total_tip_tao,last_tx_block",
+    );
+    await Promise.resolve();
+    assert.deepEqual(cache.putKeys, [
+      "https://edge-cache.metagraph.sh/analytics/2026-07-03.2/2026-06-18T00%3A00%3A00.000Z/chain-signers/api/v1/chain/signers?window=7d&format=csv",
+    ]);
+  });
 
   test("Accept: text/csv negotiates CSV without an explicit ?format", async () => {
     const { env } = dbWith({ rows: [] });

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -61,15 +61,13 @@ import {
   loadSubnetIncidents,
   loadSubnetPercentiles,
 } from "../../src/analytics-live.mjs";
-import {
-  CHAIN_SIGNERS_SORTS,
-  loadChainSigners,
-} from "../../src/chain-query-loaders.mjs";
+import { CHAIN_SIGNERS_SORTS } from "../../src/chain-query-loaders.mjs";
+import { buildChainSigners } from "../../src/chain-analytics.mjs";
 import {
   CHAIN_TRANSFER_PAIR_SORTS,
-  loadChainTransferPairs,
+  buildChainTransferPairs,
 } from "../../src/chain-transfer-pairs.mjs";
-import { loadChainTransfers } from "../../src/chain-transfers.mjs";
+import { buildChainTransfers } from "../../src/chain-transfers.mjs";
 import {
   loadChainServing,
   CHAIN_SERVING_LIMIT_DEFAULT,
@@ -106,7 +104,7 @@ import {
   CHAIN_STAKE_TRANSFERS_LIMIT_MAX,
 } from "../../src/chain-stake-transfers.mjs";
 import {
-  loadChainWeights,
+  buildChainWeights,
   CHAIN_WEIGHTS_LIMIT_DEFAULT,
   CHAIN_WEIGHTS_LIMIT_MAX,
 } from "../../src/chain-weights.mjs";
@@ -116,12 +114,12 @@ import {
   CHAIN_WEIGHT_SETTERS_LIMIT_MAX,
 } from "../../src/chain-weight-setters.mjs";
 import {
-  loadChainStakeFlow,
+  buildChainStakeFlow,
   CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
   CHAIN_STAKE_FLOW_LIMIT_MAX,
 } from "../../src/chain-stake-flow.mjs";
 import {
-  loadChainAlphaVolume,
+  buildChainAlphaVolume,
   CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT,
   CHAIN_ALPHA_VOLUME_LIMIT_MAX,
 } from "../../src/chain-alpha-volume.mjs";
@@ -1115,7 +1113,7 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
 // count over the window. The observed_at index bounds the scan to the hot window;
 // the aggregation is amortized behind the edge cache (runs only on a new snapshot).
 export async function handleChainSigners(request, env, url, ctx = {}) {
-  const { label, days, error } = analyticsWindow(url, [
+  const { label, error } = analyticsWindow(url, [
     "limit",
     "call_module",
     "sort",
@@ -1126,14 +1124,14 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
   if (formatError) return analyticsQueryError(formatError);
   const sortError = validateEnumParam(url, "sort", CHAIN_SIGNERS_SORTS);
   if (sortError) return analyticsQueryError(sortError);
-  const { limit, error: limitError } = parseLimitParam(url, {
+  // limit/call_module no longer feed a live D1 read (see the retirement note
+  // below) but are still shape-validated so the REST contract stays stable.
+  const { error: limitError } = parseLimitParam(url, {
     defaultLimit: 50,
     maxLimit: 100,
   });
   if (limitError) return analyticsQueryError(limitError);
   const sort = url.searchParams.get("sort") || "tx_count";
-  // Optional pallet scope, backed by idx_extrinsics_module_block.
-  const callModule = url.searchParams.get("call_module");
   const callModuleError = validateMaxLength(url, "call_module", 100);
   if (callModuleError) return analyticsQueryError(callModuleError);
   const csv = csvRequested(url, request);
@@ -1144,35 +1142,31 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
     "chain-signers",
     async (cacheRequest) => {
       const meta = await readHealthMetaKv(env);
-      let isFallback = false;
-      let data = await tryPostgresTier(
-        env,
-        cacheRequest,
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      );
-      if (!data) {
-        const result = await loadChainSigners(d1Runner(env), {
-          windowLabel: label,
-          windowDays: days,
-          observedAt: meta?.last_run_at || null,
-          limit,
-          callModule,
+      // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and
+      // the table is dropped in production, so a D1 query here would always
+      // miss (#6013). Postgres → schema-stable empty stub, never a live D1 read.
+      const data =
+        (await tryPostgresTier(
+          env,
+          cacheRequest,
+          "METAGRAPH_EXTRINSICS_SOURCE",
+        )) ??
+        buildChainSigners({
+          window: label,
           sort,
+          observedAt: meta?.last_run_at || null,
+          rows: [],
         });
-        data = result.data;
-        isFallback = hasD1FallbackRows(result.rows);
-      }
       if (csv) {
-        const csvRes = await csvResponse(
+        return csvResponse(
           data.signers,
           "chain-signers",
           "short",
           cacheRequest,
           CHAIN_SIGNERS_CSV_COLUMNS,
         );
-        return isFallback ? markD1FallbackResponse(csvRes) : csvRes;
       }
-      const response = await envelopeResponse(
+      return envelopeResponse(
         cacheRequest,
         {
           data,
@@ -1184,7 +1178,6 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
         },
         "short",
       );
-      return isFallback ? markD1FallbackResponse(response) : response;
     },
     `${canonicalAnalyticsCacheRoute(url, ["limit", "call_module", "sort"])}${csv ? "&format=csv" : ""}`,
   );
@@ -1195,11 +1188,13 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
 // volume (a concentration signal), from the account_events Transfer feed. The
 // network-level companion of /accounts/{ss58}/transfers + /counterparties.
 export async function handleChainTransfers(request, env, url, ctx = {}) {
-  const { label, days, error } = analyticsWindow(url, ["limit", "format"]);
+  const { label, error } = analyticsWindow(url, ["limit", "format"]);
   if (error) return analyticsQueryError(error);
   const formatError = validateFormatParam(url);
   if (formatError) return analyticsQueryError(formatError);
-  const { limit, error: limitError } = parseLimitParam(url, {
+  // limit no longer feeds a live D1 read (see the retirement note below) but
+  // is still shape-validated so the REST contract stays stable.
+  const { error: limitError } = parseLimitParam(url, {
     defaultLimit: 25,
     maxLimit: 100,
   });
@@ -1221,18 +1216,20 @@ export async function handleChainTransfers(request, env, url, ctx = {}) {
     "chain-transfers",
     async () => {
       const meta = await readHealthMetaKv(env);
+      // #4909 D1 retirement: account_events' D1 write path is retired (#4772)
+      // and the table is dropped in production, so a D1 query here would
+      // always miss (#6013). Postgres → schema-stable empty stub, never a
+      // live D1 read.
       const data =
         (await tryPostgresTier(
           env,
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) ??
-        (await loadChainTransfers(d1Runner(env), {
-          windowLabel: label,
-          windowDays: days,
+        buildChainTransfers({
+          window: label,
           observedAt: meta?.last_run_at || null,
-          limit,
-        }));
+        });
       if (csv) {
         return csvResponse(
           [
@@ -1276,17 +1273,15 @@ export async function handleChainTransfers(request, env, url, ctx = {}) {
 // /chain/transfers. Excludes malformed/self-transfer rows so every row represents
 // a real directed account corridor.
 export async function handleChainTransferPairs(request, env, url, ctx = {}) {
-  const { label, days, error } = analyticsWindow(url, [
-    "limit",
-    "sort",
-    "format",
-  ]);
+  const { label, error } = analyticsWindow(url, ["limit", "sort", "format"]);
   if (error) return analyticsQueryError(error);
   const sortError = validateEnumParam(url, "sort", CHAIN_TRANSFER_PAIR_SORTS);
   if (sortError) return analyticsQueryError(sortError);
   const formatError = validateFormatParam(url);
   if (formatError) return analyticsQueryError(formatError);
-  const { limit, error: limitError } = parseLimitParam(url, {
+  // limit no longer feeds a live D1 read (see the retirement note below) but
+  // is still shape-validated so the REST contract stays stable.
+  const { error: limitError } = parseLimitParam(url, {
     defaultLimit: 25,
     maxLimit: 100,
   });
@@ -1305,19 +1300,21 @@ export async function handleChainTransferPairs(request, env, url, ctx = {}) {
     "chain-transfer-pairs",
     async () => {
       const meta = await readHealthMetaKv(env);
+      // #4909 D1 retirement: account_events' D1 write path is retired (#4772)
+      // and the table is dropped in production, so a D1 query here would
+      // always miss (#6013). Postgres → schema-stable empty stub, never a
+      // live D1 read.
       const data =
         (await tryPostgresTier(
           env,
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         )) ??
-        (await loadChainTransferPairs(d1Runner(env), {
-          windowLabel: label,
-          windowDays: days,
-          observedAt: meta?.last_run_at || null,
-          limit,
+        buildChainTransferPairs({
+          window: label,
           sort,
-        }));
+          observedAt: meta?.last_run_at || null,
+        });
       // CSV exports the row-shaped top corridors; the totals + top_pair_share
       // rollup stay JSON-only (mirrors chain-stake-flow / chain-weights).
       if (csv) {
@@ -1354,7 +1351,7 @@ export async function handleChainTransferPairs(request, env, url, ctx = {}) {
 // distribution. The network companion to /api/v1/subnets/{netuid}/stake-flow; edge-cached like
 // the sibling chain-transfers route (account_events-derived, analytics cron freshness).
 export async function handleChainStakeFlow(request, env, url, ctx = {}) {
-  const { label, days, error } = analyticsWindow(url, ["limit", "format"]);
+  const { label, error } = analyticsWindow(url, ["limit", "format"]);
   if (error) return analyticsQueryError(error);
   const formatError = validateFormatParam(url);
   if (formatError) return analyticsQueryError(formatError);
@@ -1377,17 +1374,16 @@ export async function handleChainStakeFlow(request, env, url, ctx = {}) {
     env,
     "chain-stake-flow",
     async () => {
+      // #4909 D1 retirement: account_events' D1 write path is retired (#4772)
+      // and the table is dropped in production, so a D1 query here would
+      // always miss (#6013). Postgres → schema-stable empty stub, never a
+      // live D1 read.
       const data =
         (await tryPostgresTier(
           env,
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
-        (await loadChainStakeFlow(d1Runner(env), {
-          windowLabel: label,
-          windowDays: days,
-          limit,
-        }));
+        )) ?? buildChainStakeFlow([], { window: label, limit });
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // net_flow_distribution stay JSON-only (mirrors chain-fees' top_fee_payers).
       if (csv) {
@@ -1464,12 +1460,16 @@ export async function handleChainAlphaVolume(request, env, url, ctx = {}) {
     env,
     "chain-alpha-volume",
     async () => {
+      // #4909 D1 retirement: account_events' D1 write path is retired (#4772)
+      // and the table is dropped in production, so a D1 query here would
+      // always miss (#6013). Postgres → schema-stable empty stub, never a
+      // live D1 read.
       const data =
         (await tryPostgresTier(
           env,
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? (await loadChainAlphaVolume(d1Runner(env), { limit }));
+        )) ?? buildChainAlphaVolume([], { limit });
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // volume_distribution stay JSON-only (mirrors chain-stake-flow).
       if (csv) {
@@ -1507,7 +1507,7 @@ export async function handleChainAlphaVolume(request, env, url, ctx = {}) {
 // the edge cache and repeatedly force the network-wide aggregations, cache keyed on the analytics
 // cron freshness. The leaderboard is fixed to most-active-first (total WeightsSet events).
 export async function handleChainWeights(request, env, url, ctx = {}) {
-  const { label, days, error } = analyticsWindow(url, ["limit", "format"]);
+  const { label, error } = analyticsWindow(url, ["limit", "format"]);
   if (error) return analyticsQueryError(error);
   const formatError = validateFormatParam(url);
   if (formatError) return analyticsQueryError(formatError);
@@ -1528,17 +1528,16 @@ export async function handleChainWeights(request, env, url, ctx = {}) {
     env,
     "chain-weights",
     async () => {
+      // #4909 D1 retirement: account_events' D1 write path is retired (#4772)
+      // and the table is dropped in production, so a D1 query here would
+      // always miss (#6013). Postgres → schema-stable empty stub, never a
+      // live D1 read.
       const data =
         (await tryPostgresTier(
           env,
           cacheRequest,
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
-        (await loadChainWeights(d1Runner(env), {
-          windowLabel: label,
-          windowDays: days,
-          limit,
-        }));
+        )) ?? buildChainWeights([], { window: label, limit });
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // intensity_distribution stay JSON-only (mirrors chain-stake-flow).
       if (csv) {


### PR DESCRIPTION
## Summary

#6013 asked to resolve a contradiction: \`workers/request-handlers/entities.mjs\` has 10+ \`#4909 D1 retirement\` comments stating \`account_events\`' D1 write path is retired (#4772, table dropped in production), while \`workers/request-handlers/analytics.mjs\`'s network-wide siblings reading the *same* table (\`handleChainStakeFlow\`, \`handleChainTransfers\`, \`handleChainSigners\`, \`handleChainWeights\`, \`handleChainAlphaVolume\`, \`handleChainTransferPairs\`) still called \`loadChainX(d1Runner(env), ...)\` as a live D1 fallback, with no retirement comment anywhere in that file.

The companion PR (#6056, already merged) determined the answer: **\`entities.mjs\` was correct to skip D1**; \`analytics.mjs\`'s D1 fallbacks are dead weight and should get the same skip treatment as a follow-up. This PR is that follow-up.

- \`handleChainStakeFlow\`, \`handleChainTransfers\`, \`handleChainTransferPairs\`, \`handleChainAlphaVolume\`, \`handleChainWeights\`: all read \`account_events\` directly — confirmed retired per #4909/#4772.
- \`handleChainSigners\`: reads \`extrinsics\` (not \`account_events\`) via \`loadChainSigners\` — also confirmed retired, same #4909 note already used elsewhere in \`entities.mjs\` for the \`extrinsics\` table.

Each handler now falls back directly to the pure \`buildChainX([], ...)\` shaper instead of querying D1 (matching \`entities.mjs\`'s own retired-table pattern) — no D1 read, and no \`isFallback\`/\`markD1FallbackResponse\` marking, since there's nothing left to degrade from. \`limit\`/\`window\`/\`call_module\` params are still shape-validated for REST contract stability even though they no longer feed a read. Removed the now-dead \`loadChainSigners\`/\`loadChainTransferPairs\`/\`loadChainTransfers\`/\`loadChainStakeFlow\`/\`loadChainAlphaVolume\`/\`loadChainWeights\` imports in favor of their sibling \`buildChainX\` pure shapers.

## Test plan
- Updated HTTP-level tests across \`tests/chain-analytics.test.mjs\`, \`tests/chain-alpha-volume.test.mjs\`, \`tests/chain-stake-flow.test.mjs\`, \`tests/chain-weights.test.mjs\`, \`tests/request-handlers-analytics.test.mjs\`: "warm D1 mock" assertions that depended on a real D1 read are replaced with "D1 is never queried, even when mocked with real rows" assertions (the same pattern already used elsewhere in this codebase for retired tables).
- Moved one \`buildChainStakeFlow\` edge case (a malformed out-of-range timestamp) to the pure-function test tier, since it's no longer reachable through the HTTP handler once D1 is skipped.
- Added a dedicated CSV-export test against the Postgres-tier-hit path for \`chain-transfers\`, since that's now the *only* path that can populate \`top_senders\`/\`top_receivers\` with real rows (closing a coverage gap the refactor introduced).
- [x] \`npx eslint .\`
- [x] \`npx prettier --check\` on all touched files
- [x] Full \`npm run test:coverage\`-equivalent pass: 8908/8908 passing (1 pre-existing, unrelated \`usage-telemetry.test.mjs\` failure — missing \`posthog-node\` dependency, reproduces on clean \`main\` too)
- [x] \`npm run validate:contract-drift\`
- [x] New/changed code at 100% line coverage; the one remaining uncovered line in \`analytics.mjs\` (a pre-existing defensive throw, never reachable once \`configureAnalytics()\` runs) is unrelated to this diff

Closes #6013