### PR TITLE
feat(ui): show a Last updated timestamp on docs pages

### DIFF
--- a/apps/ui/source.config.ts
+++ b/apps/ui/source.config.ts
@@ -3,6 +3,16 @@ import { defineConfig, defineDocs } from "fumadocs-mdx/config";
 
 export const docs = defineDocs({
   dir: "content/docs",
+  docs: {
+    // Computed from local `git log` at build/dev-compile time -- NOT a live
+    // GitHub API call. That distinction matters here: this app deploys to a
+    // Cloudflare Worker with no .git directory at runtime, and an
+    // unauthenticated runtime call to the GitHub REST API would rate-limit
+    // fast (60/hr, shared across every visitor hitting the edge). Baking
+    // this into the compiled page data at build time sidesteps both
+    // problems entirely.
+    lastModified: true,
+  },
 });
 
 // Adds a `_markdown` export (clean, JSX-stripped markdown of the compiled

--- a/apps/ui/src/routes/docs.$.tsx
+++ b/apps/ui/src/routes/docs.$.tsx
@@ -5,6 +5,7 @@ import { useFumadocsLoader } from "fumadocs-core/source/client";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/layouts/docs/page";
 import { RootProvider } from "fumadocs-ui/provider/tanstack";
+import { TimeAgo } from "@jsonbored/ui-kit";
 import browserCollections from "collections/browser";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { CopyMarkdownButton } from "@/components/metagraphed/copy-markdown-button";
@@ -68,7 +69,7 @@ const serverLoader = createServerFn({ method: "GET" })
   });
 
 const clientLoader = browserCollections.docs.createClientLoader({
-  component({ toc, frontmatter, default: MDX, _markdown }, _props: undefined) {
+  component({ toc, frontmatter, default: MDX, _markdown, lastModified }, _props: undefined) {
     return (
       <DocsPage toc={toc}>
         <div className="flex items-start justify-between gap-4">
@@ -78,6 +79,17 @@ const clientLoader = browserCollections.docs.createClientLoader({
           </div>
           <CopyMarkdownButton markdown={_markdown} />
         </div>
+        {/* lastModified comes from local `git log` at build/dev-compile time
+            (source.config.ts's docs.lastModified: true), not a live GitHub
+            API call -- this app deploys to a Cloudflare Worker with no .git
+            directory at runtime, so a runtime call would need its own
+            caching/token and could rate-limit. Baked in at compile time
+            instead, same as frontmatter/toc already are. */}
+        {lastModified ? (
+          <p className="text-[12px] text-ink-muted -mt-4">
+            Last updated <TimeAgo at={lastModified.toISOString()} />
+          </p>
+        ) : null}
         <DocsBody>
           {/* getMDXComponents, not the useMDXComponents alias -- this
               `component` callback is a plain object method (fumadocs'


### PR DESCRIPTION
## Summary

Adds a "Last updated \<time ago\>" line below each docs page's description, sourced from `fumadocs-mdx`'s `docs.lastModified: true` (`source.config.ts`).

**Deliberately not the live GitHub API.** `fumadocs-core` also ships `getGithubLastEdit()`, which calls the GitHub REST API at request time — that's the wrong tool here: this app deploys to a Cloudflare Worker with no `.git` directory at runtime, and an *unauthenticated* runtime call to GitHub's API would rate-limit fast (60/hr, shared across every visitor hitting that edge route — Workers don't have a stable per-visitor IP to spread that budget across). Fixing that "properly" would mean either a new GitHub PAT (a new secret to provision and manage) or a caching layer, neither of which is warranted for a "last updated" badge.

`lastModified: true` instead runs local `git log` at **build/dev-compile time** — the same point `frontmatter`/`toc` already get baked into the compiled page data — so the value ships as static data with the deploy, no runtime dependency at all. Verified the compiled export matches real git history exactly: `git log` shows the last commit touching `feeds.mdx` at `2026-07-15 23:37:31 -0700`; the compiled `lastModified` export decodes to the identical timestamp.

**One real risk I could verify locally, one I couldn't.** `git log`'s behavior under a shallow clone: confirmed via `git clone --depth 1` that it doesn't error — worst case it returns the shallow boundary commit's date instead of the true last-touching commit, which is a fine degradation (a slightly-off date, not a broken build). What I could *not* verify from this repo: whether Cloudflare Workers Builds' actual checkout does a full or shallow clone — that's Cloudflare-managed infrastructure with no visibility from the repo config. Worth confirming against a real deploy after merge; flagging rather than asserting it's fine.

## Screenshots

`/docs/feeds` with the new "Last updated" line:

| Viewport · Theme | Screenshot |
| --- | --- |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-lastedit-feeds-desktop-dark-after.png" width="360">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-lastedit-feeds-desktop-dark-after.png) |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-lastedit-feeds-desktop-light-after.png" width="360">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-lastedit-feeds-desktop-light-after.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-lastedit-feeds-tablet-dark-after.png" width="360">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-lastedit-feeds-tablet-dark-after.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-lastedit-feeds-tablet-light-after.png" width="360">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-lastedit-feeds-tablet-light-after.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-lastedit-feeds-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-lastedit-feeds-mobile-dark-after.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-lastedit-feeds-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/fumadocs-lastedit-feeds-mobile-light-after.png) |

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint`/`prettier --check` clean
- [x] Full `vitest` suite: 130 files / 1015 tests passing
- [x] Production build verified locally with the exact Cloudflare build command
- [x] CI's client-bundle-size budget re-run locally: 294 KB / 300 KB budget (unchanged)
- [x] Compiled `lastModified` value cross-checked against real `git log` output — exact match
- [x] Shallow-clone degradation tested directly (`git clone --depth 1`) — doesn't error
- [x] Verified across desktop/tablet/mobile × light/dark, zero console errors (fresh tab + Playwright)
- [ ] **Not verified**: actual Cloudflare Workers Builds checkout depth — flagged above, worth confirming post-merge