### PR TITLE
fix(registry): SN88 Investing accuracy pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1190,7 +1190,7 @@
       "netuid": 88,
       "slug": "sn-88",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-08T09:50:00.000Z",
+      "reviewed_at": "2026-07-15T00:00:00.000Z",
       "confidence": "high",
       "source_urls": [
         "https://investing88.ai/",
@@ -1198,7 +1198,7 @@
         "https://api.investing88.ai/assets",
         "https://github.com/mobiusfund/investing"
       ],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/investing.json (reviewed_at 2026-06-08T09:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): diffed Investing/core/api.py for undiscovered public GET endpoints -- added /pnl and /dist, the 2 remaining GET routes beyond the already-tracked /days and /ratio."
     },
     {
       "netuid": 89,

--- a/registry/subnets/investing.json
+++ b/registry/subnets/investing.json
@@ -16,12 +16,12 @@
   "source_repo": "https://github.com/mobiusfund/investing",
   "dashboard_url": "https://db.investing88.ai/",
   "website_url": "https://investing88.ai/",
-  "notes": "Reviewed overlay for SN88 using the official Investing website, dashboard, source repository, and public asset-list data surface. The asset surface returns HTML/table content, not JSON or OpenAPI.",
+  "notes": "Reviewed overlay for SN88 using the official Investing website, dashboard, source repository, and public asset-list data surface. The asset surface returns HTML/table content, not JSON or OpenAPI. Re-review pass (2026-07-15): diffed Investing/core/api.py for undiscovered public GET endpoints -- added /pnl and /dist, the 2 remaining GET routes beyond the already-tracked /days and /ratio (the 5th function, rev, is a write-action POST, excluded).",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T09:50:00.000Z",
-    "verified_at": "2026-06-08T09:50:00.000Z",
+    "reviewed_at": "2026-07-15T00:00:00.000Z",
+    "verified_at": "2026-07-15T00:00:00.000Z",
     "source_count": 6,
     "gap_notes": [
       "Public asset-list surface is HTML/table content, not a schema-backed API.",
@@ -178,6 +178,56 @@
         "https://github.com/mobiusfund/investing/blob/main/README.md"
       ],
       "url": "https://kym.investing88.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-88-investing-pnl-api",
+      "kind": "subnet-api",
+      "name": "Investing PnL API",
+      "notes": "Public no-auth GET /pnl on api.investing88.ai returning JSON per-miner profit-and-loss records (hotkey SS58 address, date, block numbers, and value fields). The official Investing/core/api.py client fetches this endpoint via API_ROOT; const.py pins API_ROOT to api.investing88.ai. Same host as the existing days/ratio/assets surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "mobiusfund",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://github.com/mobiusfund/investing/blob/main/Investing/core/api.py",
+        "https://github.com/mobiusfund/investing/blob/main/Investing/core/const.py"
+      ],
+      "url": "https://api.investing88.ai/pnl"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-88-investing-dist-api",
+      "kind": "subnet-api",
+      "name": "Investing distribution API",
+      "notes": "Public no-auth GET /dist on api.investing88.ai returning JSON per-miner asset-distribution weight records (hotkey SS58 address plus a series of numeric allocation values). The official Investing/core/api.py client fetches this endpoint via API_ROOT; const.py pins API_ROOT to api.investing88.ai. Same host as the existing days/ratio/assets surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "mobiusfund",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://github.com/mobiusfund/investing/blob/main/Investing/core/api.py",
+        "https://github.com/mobiusfund/investing/blob/main/Investing/core/const.py"
+      ],
+      "url": "https://api.investing88.ai/dist"
     }
   ],
   "social": {


### PR DESCRIPTION
## Summary
- Diff `Investing/core/api.py` for undiscovered public GET endpoints -- add `/pnl` and `/dist`, the 2 remaining GET routes beyond the already-tracked `/days` and `/ratio` (the 5th function, `rev`, is a write-action POST, excluded)
- Updates the existing `maintainer-reviewed.json` ledger entry (netuid 88)

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check`