### PR TITLE
chore(ci): add .github/superagent.yml, exempt established repeat contributors

### DIFF
--- a/.github/superagent.yml
+++ b/.github/superagent.yml
@@ -1,0 +1,15 @@
+# Superagent (https://superagent.sh) GitHub App configuration — PR security scanning + contributor trust
+# scoring. All fields are optional; anything omitted falls back to Superagent's own defaults.
+prScan:
+  enabled: true
+
+contributorTrust:
+  enabled: true
+  blockBelowScore: 30
+  # These are established, high-volume repeat contributors (dozens of merged PRs each) who kept tripping
+  # the trust scorer on volume/velocity alone, not on any real signal. Exempts them from contributor-trust
+  # scoring entirely going forward.
+  trustedAuthors: [dhgoal, shin-core, andriypolanski]
+
+comments:
+  mode: detailed


### PR DESCRIPTION
## Summary
- Adds `.github/superagent.yml` (this repo currently has no Superagent config at all — running on pure defaults).
- `contributorTrust.trustedAuthors: [dhgoal, shin-core, andriypolanski]` exempts these three established, high-volume repeat contributors from contributor-trust scoring. Cross-checked over the past 7 days: they show up as `contributor:flagged` on dozens of merged PRs each, purely on activity volume/velocity, not any real risk signal.
- `prScan.enabled: true` and `comments.mode: detailed` are set explicitly to their documented defaults for clarity — no behavior change there.

## Validation
- No `src/`/`workers/` changes — config file only, no test/coverage obligation.
- Validated the YAML parses correctly and matches Superagent's documented schema (`superagent-ai/superagent-github`).

## Safety
- [x] No secrets/PATs/wallet paths/private URLs
- [x] No `apps/ui/` visual changes