### PR TITLE
feat(observability): instrument the MCP tool-dispatch chokepoint with usage events

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -35,6 +35,10 @@
 // exists to prevent for a human clicking through a browser. Revisit only via
 // a dedicated ADR amendment with its own consent model, not as an incremental
 // tool addition.
+import {
+  isUsageTelemetryConfigured,
+  recordUsageEvent,
+} from "./usage-telemetry.mjs";
 import { resolveClientIp, SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
 import { DAY_PATTERN } from "../workers/request-params.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
@@ -14199,7 +14203,43 @@ function negotiateProtocol(requested) {
     : MCP_LATEST_PROTOCOL;
 }
 
+// Product-usage telemetry (#6031 / #366). callTool is the one point every
+// tools/call passes through, so wrapping it records exactly one event per
+// invocation instead of instrumenting ~150 handlers individually. It also
+// already funnels every outcome into an isError result rather than throwing,
+// which is what makes success/failure readable here without touching any
+// handler. Nothing but the tool name, that flag, and elapsed time is recorded —
+// never arguments or response content.
 async function callTool(params, ctx) {
+  const startedAt = Date.now();
+  const result = await dispatchTool(params, ctx);
+  scheduleToolUsageEvent(ctx, {
+    mcpTool: typeof params?.name === "string" ? params.name : undefined,
+    ok: result.isError !== true,
+    durationMs: Date.now() - startedAt,
+  });
+  return result;
+}
+
+/**
+ * Hand a tool-usage event to the recorder without ever blocking or failing the
+ * tool response.
+ *
+ * @param {object} ctx
+ * @param {object} event
+ */
+function scheduleToolUsageEvent(ctx, event) {
+  try {
+    if (!isUsageTelemetryConfigured(ctx?.env)) return;
+    const record = ctx?.recordUsageEvent ?? recordUsageEvent;
+    const pending = Promise.resolve(record(ctx.env, event)).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the tool path.
+  }
+}
+
+async function dispatchTool(params, ctx) {
   const name = params?.name;
   const tool = typeof name === "string" ? TOOLS_BY_NAME.get(name) : undefined;
   if (!tool) {
@@ -14372,6 +14412,11 @@ function buildContext(request, env, deps) {
     clientIp: mcpClientKey(request),
     readArtifact: deps.readArtifact,
     readHealthKv: deps.readHealthKv,
+    // The Worker's ExecutionContext, when the caller has one to give: only the
+    // real fetch entry does, so it stays optional and every direct-call test
+    // keeps working. Used solely to drain usage telemetry (#6031).
+    executionCtx: deps.executionCtx,
+    recordUsageEvent: deps.recordUsageEvent,
   };
 }
 

--- a/tests/mcp-usage-telemetry.test.mjs
+++ b/tests/mcp-usage-telemetry.test.mjs
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+
+const CONFIGURED_ENV = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" };
+const TOOL = "get_contracts";
+
+// Collects what each tools/call hands the recorder, plus what it hands
+// waitUntil, without going anywhere near PostHog.
+function recorder({ result = true } = {}) {
+  const events = [];
+  return {
+    events,
+    recordUsageEvent(env, event) {
+      events.push({ env, event });
+      return typeof result === "function" ? result() : result;
+    },
+  };
+}
+
+function fakeExecutionCtx() {
+  const scheduled = [];
+  return { scheduled, waitUntil: (promise) => scheduled.push(promise) };
+}
+
+function makeDeps(extra = {}) {
+  return {
+    readArtifact: (_env, path) =>
+      Promise.resolve({
+        ok: true,
+        data: { schema_version: 1, path },
+        source: "test",
+        storage_tier: "git",
+      }),
+    readHealthKv: () => Promise.resolve(null),
+    ...extra,
+  };
+}
+
+function toolCall(name, args = {}) {
+  return {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name, arguments: args },
+  };
+}
+
+async function callMcp(body, env, extraDeps = {}) {
+  const request = new Request("https://api.metagraph.sh/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify(body),
+  });
+  const response = await handleMcpRequest(request, env, makeDeps(extraDeps));
+  return response.json();
+}
+
+describe("MCP tool-dispatch usage telemetry", () => {
+  test("records exactly one event per tool call, keyed by tool name", async () => {
+    const spy = recorder();
+    const executionCtx = fakeExecutionCtx();
+
+    const payload = await callMcp(toolCall(TOOL), CONFIGURED_ENV, {
+      executionCtx,
+      recordUsageEvent: spy.recordUsageEvent,
+    });
+
+    assert.equal(payload.result.isError, false);
+    assert.equal(spy.events.length, 1);
+    const { env, event } = spy.events[0];
+    assert.equal(env, CONFIGURED_ENV);
+    assert.equal(event.mcpTool, TOOL);
+    assert.equal(event.ok, true);
+    assert.equal(typeof event.durationMs, "number");
+    assert.ok(event.durationMs >= 0);
+    // Never the arguments, never the response content.
+    assert.deepEqual(Object.keys(event).sort(), [
+      "durationMs",
+      "mcpTool",
+      "ok",
+    ]);
+    // Drained through waitUntil rather than awaited in the tool path.
+    assert.equal(executionCtx.scheduled.length, 1);
+  });
+
+  test("records an unknown tool as a failure", async () => {
+    const spy = recorder();
+    const payload = await callMcp(
+      toolCall("no_such_tool_at_all"),
+      CONFIGURED_ENV,
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordUsageEvent: spy.recordUsageEvent,
+      },
+    );
+
+    assert.equal(payload.result.isError, true);
+    assert.equal(spy.events.length, 1);
+    assert.equal(spy.events[0].event.mcpTool, "no_such_tool_at_all");
+    assert.equal(spy.events[0].event.ok, false);
+  });
+
+  test("records a failing tool as a failure", async () => {
+    const spy = recorder();
+    // Invalid arguments — the tool returns an isError result rather than throwing.
+    const payload = await callMcp(
+      toolCall("get_subnet", { netuid: "not-a-netuid" }),
+      CONFIGURED_ENV,
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordUsageEvent: spy.recordUsageEvent,
+      },
+    );
+
+    assert.equal(payload.result.isError, true);
+    assert.equal(spy.events.length, 1);
+    assert.equal(spy.events[0].event.ok, false);
+  });
+
+  test("does no telemetry work when the deployment is unconfigured", async () => {
+    const spy = recorder();
+    const payload = await callMcp(
+      toolCall(TOOL),
+      {},
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordUsageEvent: spy.recordUsageEvent,
+      },
+    );
+
+    assert.equal(payload.result.isError, false);
+    assert.deepEqual(spy.events, []);
+  });
+
+  test("does not record tools/list — only tool invocations", async () => {
+    const spy = recorder();
+    await callMcp(
+      { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      CONFIGURED_ENV,
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordUsageEvent: spy.recordUsageEvent,
+      },
+    );
+
+    assert.deepEqual(spy.events, []);
+  });
+
+  test("falls back to the real recorder when none is injected", async () => {
+    // Exercises the default path end-to-end: no injected recorder, so the
+    // module's own recordUsageEvent runs and posts through the platform fetch.
+    const original = globalThis.fetch;
+    const posted = [];
+    globalThis.fetch = async (url, init) => {
+      posted.push({ url, body: JSON.parse(init.body) });
+      return { ok: true };
+    };
+    try {
+      const executionCtx = fakeExecutionCtx();
+      const payload = await callMcp(toolCall(TOOL), CONFIGURED_ENV, {
+        executionCtx,
+      });
+      await Promise.all(executionCtx.scheduled);
+
+      assert.equal(payload.result.isError, false);
+      assert.equal(posted.length, 1);
+      assert.equal(posted[0].body.event, "usage_event");
+      assert.equal(posted[0].body.properties.mcp_tool, TOOL);
+      assert.equal(posted[0].body.properties.ok, true);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("records one event per call in a batch", async () => {
+    const spy = recorder();
+    await callMcp([toolCall(TOOL), toolCall(TOOL)], CONFIGURED_ENV, {
+      executionCtx: fakeExecutionCtx(),
+      recordUsageEvent: spy.recordUsageEvent,
+    });
+
+    assert.equal(spy.events.length, 2);
+  });
+
+  // The regression the issue asks for: a telemetry failure must never become a
+  // tool failure. Each shape is compared against the untelemetried response, so
+  // this asserts byte-identical behavior rather than merely "not an error".
+  test("a telemetry failure changes nothing about the tool result", async () => {
+    const baseline = await callMcp(toolCall(TOOL), {});
+    assert.equal(baseline.result.isError, false);
+
+    const failureModes = {
+      "recorder rejects": {
+        recordUsageEvent: recorder({
+          result: () => Promise.reject(new Error("posthog down")),
+        }).recordUsageEvent,
+        executionCtx: fakeExecutionCtx(),
+      },
+      "recorder throws synchronously": {
+        recordUsageEvent: recorder({
+          result: () => {
+            throw new Error("recorder exploded");
+          },
+        }).recordUsageEvent,
+        executionCtx: fakeExecutionCtx(),
+      },
+      "waitUntil throws": {
+        recordUsageEvent: recorder().recordUsageEvent,
+        executionCtx: {
+          waitUntil() {
+            throw new Error("isolate already finished");
+          },
+        },
+      },
+      "no ExecutionContext at all": {
+        recordUsageEvent: recorder().recordUsageEvent,
+      },
+    };
+
+    for (const [mode, deps] of Object.entries(failureModes)) {
+      const payload = await callMcp(toolCall(TOOL), CONFIGURED_ENV, deps);
+      assert.deepEqual(
+        payload,
+        baseline,
+        `telemetry mode changed the result: ${mode}`,
+      );
+    }
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1366,7 +1366,13 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // rejected there) like the RPC proxy. Artifact/KV readers are injected so
   // the MCP tools reuse the exact R2/ASSETS resolution.
   if (url.pathname === "/mcp") {
-    return handleMcpRequest(request, env, { readArtifact, readHealthKv });
+    // executionCtx is what lets tool-dispatch telemetry (#6031) drain its
+    // capture through waitUntil instead of stranding it on isolate exit.
+    return handleMcpRequest(request, env, {
+      readArtifact,
+      readHealthKv,
+      executionCtx: ctx,
+    });
   }
 
   // Grounded RAG answer endpoint (POST). Runs before the read-only method gate


### PR DESCRIPTION
Closes #6031

Completes #366's MCP half, on top of the REST/GraphQL wiring in #6140.

## The chokepoint

`callTool` is the one point every `tools/call` passes through, so wrapping it records exactly one event per invocation rather than instrumenting ~150 tool handlers individually.

It also already funnels every outcome into an `isError` result instead of throwing — unknown tool, invalid arguments, a handler rejection — which is what makes success/failure readable at the chokepoint with **zero handler edits**. The original body moves to `dispatchTool`; `callTool` becomes the timing wrapper around it.

Only the tool name, that flag, and elapsed time are recorded. Never arguments, never response content — asserted directly (`Object.keys(event)` is exactly `mcpTool`/`ok`/`durationMs`).

## Threading the ExecutionContext

`handleMcpRequest` never received one, so a capture would have been stranded when the isolate exits. It's threaded through the **existing `deps` channel** (alongside `readArtifact`/`readHealthKv`) into `buildContext`, so the event drains via `waitUntil`.

It stays **optional**: only the real `fetch` entry has a context to give, and every direct-call test passes `{}` or omits it — so nothing else changes.

## Zero behavior change

An unconfigured deployment (no `POSTHOG_PROJECT_TOKEN`) short-circuits before any work — that's every existing test and every self-hoster. `tools/list` and the other JSON-RPC methods aren't tool invocations and aren't recorded. A batch records one event per call.

Telemetry can never surface into the tool path: a recorder that rejects, a recorder that throws synchronously, and a `waitUntil` that throws are all swallowed. **The regression test asserts the response is byte-identical to an untelemetried call in each of those four modes** — a stronger claim than "still not an error".

## Verification

- `tests/mcp-usage-telemetry.test.mjs` — 8 new tests, driving real `tools/call` traffic through `handleMcpRequest`.
- Patch coverage measured, not assumed: **0 uncovered statements and 0 uncovered branch arms** across every added line in `src/mcp-server.mjs` and `workers/api.mjs`.
- `worker:bundle:budget`: **1014.3 KiB, passes** (+0.2 KiB — no new dependency; the capture reuses the `fetch` transport from #6140).
- 1176 tests green across `mcp-server`, `mcp-usage-telemetry`, `worker-runtime`, `usage-telemetry`, `request-usage-telemetry`.
- `format:check`, `lint`, `validate:mcp`, `validate:contract-drift`, `validate:docs`, `validate:types`, `validate:private-boundary` all pass.