### PR TITLE
fix(registry): SN91 Bitstarter #1 accuracy pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1238,16 +1238,16 @@
       "netuid": 91,
       "slug": "sn-91",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-08T09:25:00.000Z",
+      "reviewed_at": "2026-07-15T00:00:00.000Z",
       "confidence": "high",
       "source_urls": [
-        "https://bitstarter.ai/",
+        "https://www.bitstarter.ai/",
         "https://github.com/AlphaCoreBittensor/alphacore",
         "https://app.bitstarter.ai/",
         "https://app.bitstarter.ai/how-it-works/",
         "https://app.bitstarter.ai/submit-a-project/incubator/"
       ],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/bitstarter-1.json (reviewed_at 2026-06-08T09:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): updated the website surface to the canonical www.bitstarter.ai URL after bitstarter.ai started 307-redirecting."
     },
     {
       "netuid": 92,

--- a/registry/subnets/bitstarter-1.json
+++ b/registry/subnets/bitstarter-1.json
@@ -31,14 +31,14 @@
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T09:25:00.000Z",
+    "reviewed_at": "2026-07-15T00:00:00.000Z",
     "source_count": 7,
-    "verified_at": "2026-06-08T09:25:00.000Z"
+    "verified_at": "2026-07-15T00:00:00.000Z"
   },
   "dashboard_url": "https://taomarketcap.com/subnets/91",
   "name": "Bitstarter #1",
   "netuid": 91,
-  "notes": "Reviewed overlay for SN91 using the public Bitstarter website, app surface, how-it-works page, project submission page, AlphaCore source repository, and universal TaoMarketCap dashboard. Common docs/API/OpenAPI paths currently return 404 and no verified machine-readable schema, safe public subnet API endpoint, or SSE surface has been found yet.",
+  "notes": "Reviewed overlay for SN91 using the public Bitstarter website, app surface, how-it-works page, project submission page, AlphaCore source repository, and universal TaoMarketCap dashboard. Common docs/API/OpenAPI paths currently return 404 and no verified machine-readable schema, safe public subnet API endpoint, or SSE surface has been found yet. Re-review pass (2026-07-15): updated the website surface to the canonical www.bitstarter.ai URL after bitstarter.ai started 307-redirecting.",
   "schema_version": 1,
   "slug": "sn-91",
   "social": {
@@ -53,7 +53,7 @@
       "id": "sn-91-bitstarter-website",
       "kind": "website",
       "name": "Bitstarter website",
-      "notes": "Public Bitstarter website.",
+      "notes": "Public Bitstarter website. bitstarter.ai now 307-redirects to www.bitstarter.ai (previously served directly); tracked URL updated to the canonical resolved form to avoid redirect ambiguity, per the same pattern applied across other subnets in this audit.",
       "probe": {
         "enabled": true,
         "expect": "html",
@@ -62,8 +62,8 @@
       },
       "provider": "bitstarter",
       "public_safe": true,
-      "source_urls": ["https://bitstarter.ai/"],
-      "url": "https://bitstarter.ai/"
+      "source_urls": ["https://bitstarter.ai/", "https://www.bitstarter.ai/"],
+      "url": "https://www.bitstarter.ai/"
     },
     {
       "auth_required": false,


### PR DESCRIPTION
## Summary
- Update the website surface to the canonical `www.bitstarter.ai` URL after `bitstarter.ai` started 307-redirecting
- Updates the existing `maintainer-reviewed.json` ledger entry (netuid 91)

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check`