### PR TITLE
fix(ui): consolidate relative()/formatRelative() into one time-ago core (#6020)

### DIFF
--- a/apps/ui/src/lib/metagraphed/format.test.ts
+++ b/apps/ui/src/lib/metagraphed/format.test.ts
@@ -4,6 +4,7 @@ import {
   humaniseSeconds,
   durationLabel,
   formatRelative,
+  relativeFromDiff,
   isStaleFreshness,
   formatTao,
 } from "./format";
@@ -113,6 +114,27 @@ describe("formatRelative", () => {
 
   it("labels future timestamps with 'in'", () => {
     expect(formatRelative(new Date(Date.now() + 5 * 60_000).toISOString())).toMatch(/^in \d+m$/);
+  });
+});
+
+describe("relativeFromDiff (#6020 shared time-ago core)", () => {
+  it("defaults reproduce formatRelative: 1s floor, 24h→days, future shown as 'in'", () => {
+    expect(relativeFromDiff(400)).toBe("1s ago"); // sub-second floored to 1s
+    expect(relativeFromDiff(30_000)).toBe("30s ago");
+    expect(relativeFromDiff(90 * 60_000)).toBe("2h ago");
+    expect(relativeFromDiff(25 * 3_600_000)).toBe("1d ago"); // 24h cap → days
+    expect(relativeFromDiff(-5 * 60_000)).toBe("in 5m"); // future surfaced
+  });
+
+  it("clampFuture collapses a future diff to the zero point (the freshness stamp's behaviour)", () => {
+    expect(relativeFromDiff(-5_000, { clampFuture: true, secondsFloor: 0 })).toBe("0s ago");
+    expect(relativeFromDiff(-3_600_000, { clampFuture: true, secondsFloor: 0 })).toBe("0s ago");
+  });
+
+  it("secondsFloor 0 allows a bare '0s'; hourCapHours 48 keeps hours to 47h", () => {
+    expect(relativeFromDiff(0, { secondsFloor: 0 })).toBe("0s ago");
+    expect(relativeFromDiff(47 * 3_600_000, { hourCapHours: 48 })).toBe("47h ago");
+    expect(relativeFromDiff(48 * 3_600_000, { hourCapHours: 48 })).toBe("2d ago");
   });
 });
 

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -33,21 +33,51 @@ export function isUsableTimestamp(iso?: string | null): iso is string {
   return t > 946_684_800_000; // 2000-01-01
 }
 
-export function formatRelative(iso?: string | null): string {
-  if (!isUsableTimestamp(iso)) return "—";
-  const t = Date.parse(iso);
-  const diff = Date.now() - t;
-  const abs = Math.abs(diff);
+/**
+ * Options controlling how {@link relativeFromDiff} renders a "time ago" label.
+ * The two behavioural differences between this codebase's freshness stamp
+ * (`relative` in freshness.ts) and this general formatter are captured here so
+ * there is ONE bucketing implementation, not two that silently drift (#6020).
+ */
+export interface RelativeOptions {
+  /**
+   * How to treat a future (negative) diff — a timestamp ahead of the caller's
+   * clock. `false` (default) surfaces it as `"in Xunit"` (a genuine future
+   * event). `true` clamps it to the zero point (`"0s ago"`): for a *freshness*
+   * stamp a `generated_at`/`updated_at` ahead of the client clock is clock
+   * skew, not real future data, so "just now" is the correct read — never
+   * "in Xs" (#6020).
+   */
+  clampFuture?: boolean;
+  /** Floor for the seconds bucket — 1 hides a sub-second `"0s"`, 0 allows it. */
+  secondsFloor?: number;
+  /** Hours before rolling over to a `"Xd"` label (24 = days past one day; 48 = keep an hours label up to 47h). */
+  hourCapHours?: number;
+}
+
+/**
+ * Single "time ago" bucketing core (#6020), shared by {@link formatRelative}
+ * and the freshness `relative` stamp so the two can't silently diverge again.
+ * `diffMs` is (now - timestamp): positive is the past. Defaults reproduce
+ * {@link formatRelative}'s historical behaviour exactly; see {@link RelativeOptions}
+ * for the freshness-stamp overrides.
+ */
+export function relativeFromDiff(
+  diffMs: number,
+  { clampFuture = false, secondsFloor = 1, hourCapHours = 24 }: RelativeOptions = {},
+): string {
+  const diff = clampFuture ? Math.max(0, diffMs) : diffMs;
   const past = diff >= 0;
+  const abs = Math.abs(diff);
   let value: number;
   let unit: string;
   if (abs < 60_000) {
-    value = Math.max(1, Math.round(abs / 1000));
+    value = Math.max(secondsFloor, Math.round(abs / 1000));
     unit = "s";
   } else if (abs < 3_600_000) {
     value = Math.round(abs / 60_000);
     unit = "m";
-  } else if (abs < 86_400_000) {
+  } else if (abs < hourCapHours * 3_600_000) {
     value = Math.round(abs / 3_600_000);
     unit = "h";
   } else {
@@ -55,6 +85,12 @@ export function formatRelative(iso?: string | null): string {
     unit = "d";
   }
   return past ? `${value}${unit} ago` : `in ${value}${unit}`;
+}
+
+export function formatRelative(iso?: string | null): string {
+  if (!isUsableTimestamp(iso)) return "—";
+  // General relative formatter: surfaces a genuine future event as "in Xunit".
+  return relativeFromDiff(Date.now() - Date.parse(iso));
 }
 
 export function isStaleFreshness(iso?: string | null, thresholdMs = 12 * 60 * 60_000): boolean {

--- a/apps/ui/src/lib/metagraphed/freshness.test.ts
+++ b/apps/ui/src/lib/metagraphed/freshness.test.ts
@@ -24,6 +24,14 @@ describe("relative", () => {
     expect(relative(48 * 60 * 60_000)).toBe("2d ago");
     expect(relative(72 * 60 * 60_000)).toBe("3d ago");
   });
+
+  it("clamps a future timestamp to just-now — clock skew, not real future data (#6020)", () => {
+    // A generated_at/updated_at slightly ahead of the client clock must read
+    // "0s ago", never "in Xs" — the decided freshness behaviour, distinct from
+    // formatRelative which surfaces a genuine future event as "in Xunit".
+    expect(relative(-30_000)).toBe("0s ago");
+    expect(relative(-2 * 60 * 60_000)).toBe("0s ago");
+  });
 });
 
 describe("formatFreshness", () => {

--- a/apps/ui/src/lib/metagraphed/freshness.ts
+++ b/apps/ui/src/lib/metagraphed/freshness.ts
@@ -1,3 +1,5 @@
+import { relativeFromDiff } from "./format";
+
 /**
  * Centralized freshness formatter — used by StatWithSpark, NoDataSpark,
  * MethodologyCallout and OperationalPanel so every "last-updated" stamp
@@ -26,13 +28,19 @@ export function formatFreshnessAbsolute(updatedAt?: string | null): string | nul
   return t.toLocaleString();
 }
 
+/**
+ * Freshness "time ago" stamp. Delegates to the shared {@link relativeFromDiff}
+ * core (#6020) with the freshness-specific behaviour, decided here for its one
+ * caller ({@link formatFreshness}): a `generated_at`/`updated_at` a little ahead
+ * of the client clock is clock skew, not real future data, so a future diff is
+ * CLAMPED to "0s ago" ("just now") rather than surfaced as "in Xs" the way the
+ * general {@link formatRelative} does. Seconds floor at 0 and an hours label up
+ * to 47h preserve this stamp's long-standing output.
+ */
 export function relative(diffMs: number): string {
-  const sec = Math.max(0, Math.round(diffMs / 1000));
-  if (sec < 60) return `${sec}s ago`;
-  const min = Math.round(sec / 60);
-  if (min < 60) return `${min}m ago`;
-  const hr = Math.round(min / 60);
-  if (hr < 48) return `${hr}h ago`;
-  const day = Math.round(hr / 24);
-  return `${day}d ago`;
+  return relativeFromDiff(diffMs, {
+    clampFuture: true,
+    secondsFloor: 0,
+    hourCapHours: 48,
+  });
 }


### PR DESCRIPTION
`freshness.ts`'s `relative()` and `format.ts`'s `formatRelative()` were near-duplicate "time ago" formatters that diverged on future timestamps — `formatRelative` shows `"in Xunit"`, while `relative()` clamps a negative diff to `"0s ago"`.

## Decision (documented)
Clamping is **correct** for `relative()`'s only caller, `formatFreshness`: a `generated_at`/`updated_at` slightly ahead of the client clock is **clock skew, not real future data**, so a freshness stamp must read "just now" (`0s ago`), never `"in Xs"`. `formatRelative` stays a general formatter that surfaces genuine future events as `"in Xunit"`.

## Consolidation
Both now delegate to one shared `relativeFromDiff(diffMs, options)` core in `format.ts`, parameterized on the two callers' differences (`clampFuture`, plus the pre-existing `secondsFloor` / `hourCapHours` formatting differences) so the bucketing can't silently drift into two implementations again. The **defaults reproduce `formatRelative` exactly**; `relative()` passes the documented freshness overrides.

**Behaviour-preserving** — every existing test passes unchanged, so there is **no rendered difference** (lib-only under `apps/ui/src/lib/**`, no visual change, so no screenshot table applies).

## Tests
Added tests for the decided past/future behaviour of both functions, plus direct `relativeFromDiff` option coverage (`clampFuture`, `secondsFloor`, `hourCapHours`, all buckets).

Closes #6020
