### PR TITLE
fix(registry): SN92 Tensorclaw accuracy pass -- project abandonment

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1253,16 +1253,17 @@
       "netuid": 92,
       "slug": "sn-92",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-09T12:25:00.000Z",
+      "reviewed_at": "2026-07-15T00:00:00.000Z",
       "confidence": "high",
       "source_urls": [
         "https://taomarketcap.com/subnets/92",
         "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/92",
         "https://www.tensorclaw.ai/",
         "https://github.com/tensorclaw/tensorclaw",
-        "https://www.tensorclaw.ai/dashboard"
+        "https://www.tensorclaw.ai/dashboard",
+        "https://github.com/fx-integral/academia-archives/tree/main/repos/tensorclaw__tensorclaw"
       ],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/tensorclaw.json (reviewed_at 2026-06-09T12:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): the project looks fully abandoned -- website 521, GitHub org deleted (404), emission disabled, on-chain identity re-drifted to a new blank placeholder (\"wgmi\"). Added a surface for the third-party academia-archives mirror, now the only remaining copy of the source. Dead surfaces kept tracked, not removed."
     },
     {
       "netuid": 95,

--- a/registry/subnets/tensorclaw.json
+++ b/registry/subnets/tensorclaw.json
@@ -11,8 +11,9 @@
   ],
   "curation": {
     "gap_notes": [
-      "Native chain name currently reports as luis while the public website identifies the project as Tensorclaw Network / Subnet 92.",
-      "Official website, dashboard, and source repository are verified live.",
+      "Project appears fully abandoned as of 2026-07-15: the official website (www.tensorclaw.ai, including the /dashboard page) now returns HTTP 521 (Cloudflare: web server is down), the GitHub org github.com/tensorclaw is fully deleted (404, not just the repo), subnet_emission_enabled is false, and the on-chain identity has drifted again -- from the previously-noted \"luis\" placeholder to a new placeholder \"wgmi\" with every identity field (githubRepo, subnetUrl, contact, discord) now blank.",
+      "The official source repository is gone, but a third-party Bittensor-subnet archival project (fx-integral/academia-archives, description \"Bittensor Subnet Archives\") mirrors the full tensorclaw/tensorclaw tree as of the point it was archived -- now the only remaining evidence of the subnet's codebase. Tracked as a dedicated archived-mirror surface.",
+      "Website, source-repo, and live-demo surfaces kept tracked despite being dead (521/404) rather than removed, consistent with how outages are handled elsewhere in this registry -- their existing probes will correctly report the ongoing outage.",
       "No verified docs site yet beyond directory pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
@@ -20,14 +21,14 @@
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-09T12:25:00.000Z",
+    "reviewed_at": "2026-07-15T00:00:00.000Z",
     "source_count": 6,
-    "verified_at": "2026-06-09T12:25:00.000Z"
+    "verified_at": "2026-07-15T00:00:00.000Z"
   },
   "dashboard_url": "https://www.tensorclaw.ai/dashboard",
   "name": "Tensorclaw",
   "netuid": 92,
-  "notes": "Reviewed overlay for SN92 using the live Tensorclaw Network website, dashboard, and source repository. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The website links https://github.com/tensorclaw/tensorclaw and the repository README identifies it as Bittensor Tensorclaw Subnet 92.",
+  "notes": "Reviewed overlay for SN92 using the live Tensorclaw Network website, dashboard, and source repository. Native chain identity currently reports luis, so this remains an explicit identity-drift entry rather than a silent rename. The website links https://github.com/tensorclaw/tensorclaw and the repository README identifies it as Bittensor Tensorclaw Subnet 92. Re-review pass (2026-07-15): the project now looks fully abandoned -- website 521, GitHub org deleted, emission disabled, on-chain identity re-drifted to a new blank placeholder (\"wgmi\"). Added a surface for the third-party academia-archives mirror, now the only remaining copy of the source.",
   "schema_version": 1,
   "slug": "sn-92",
   "source_repo": "https://github.com/tensorclaw/tensorclaw",
@@ -147,6 +148,30 @@
         "https://github.com/fx-integral/academia-archives/blob/main/repos/tensorclaw__tensorclaw/README.md"
       ],
       "url": "https://raw.githubusercontent.com/fx-integral/academia-archives/main/repos/tensorclaw__tensorclaw/VALID_MODEL_SERIES.txt"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-92-tensorclaw-archived-source-mirror",
+      "kind": "source-repo",
+      "name": "Tensorclaw archived source mirror",
+      "notes": "Third-party archival mirror of the full tensorclaw/tensorclaw repository tree, hosted by fx-integral/academia-archives (\"Bittensor Subnet Archives\"). The official github.com/tensorclaw org has been fully deleted (404) as of 2026-07-15, making this the only remaining copy of the SN92 source code -- distinct from (and broader than) the single VALID_MODEL_SERIES.txt file already tracked.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorclaw",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://github.com/fx-integral/academia-archives/tree/main/repos/tensorclaw__tensorclaw"
+      ],
+      "url": "https://github.com/fx-integral/academia-archives/tree/main/repos/tensorclaw__tensorclaw"
     },
     {
       "auth_required": false,


### PR DESCRIPTION
## Summary
- Document that the project looks fully abandoned as of 2026-07-15: the official website (including `/dashboard`) returns HTTP 521, the GitHub org `github.com/tensorclaw` is fully deleted (404, not just the repo), `subnet_emission_enabled` is false, and the on-chain identity has re-drifted to a new blank placeholder ("wgmi")
- Add a surface for `fx-integral/academia-archives`' mirror of the full `tensorclaw/tensorclaw` tree ("Bittensor Subnet Archives"), now the only remaining copy of the source code
- Dead website/repo/dashboard surfaces kept tracked rather than removed, consistent with outage handling elsewhere in this registry -- their existing probes will correctly report the ongoing outage
- Updates the existing `maintainer-reviewed.json` ledger entry (netuid 92)

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check`