### PR TITLE
fix(registry): SN94 Bitsota accuracy pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1273,6 +1273,19 @@
       "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/tensorclaw.json (reviewed_at 2026-06-09T12:25:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
     },
     {
+      "netuid": 94,
+      "slug": "sn-94",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-07-15T00:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://bitsota.ai/",
+        "https://github.com/AlveusLabs/SN94-BitSota",
+        "https://autoresearch.bitsota.com/openapi.json"
+      ],
+      "notes": "Root->128 accuracy audit pass (#5903): first maintainer review for SN94. Added website + source-repo surfaces, fixed 4 missing probe blocks. Diffed the 37-path OpenAPI schema for undiscovered public GET endpoints -- added 3 new surfaces; 2 candidates turned out to be auth-gated despite the schema saying otherwise."
+    },
+    {
       "netuid": 95,
       "slug": "actual",
       "decision": "maintainer-reviewed",

--- a/registry/subnets/bitsota.json
+++ b/registry/subnets/bitsota.json
@@ -1,12 +1,25 @@
 {
-  "categories": [],
+  "categories": [
+    "baseline-curated",
+    "official-api",
+    "official-source-repo",
+    "official-website"
+  ],
   "contact": "info@bitsota.ai",
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-07-15T00:00:00.000Z",
+    "verified_at": "2026-07-15T00:00:00.000Z",
+    "source_count": 8,
+    "gap_notes": [
+      "Diffed the autoresearch.bitsota.com OpenAPI schema (37 paths) for undiscovered public GET endpoints -- added 3 new no-param surfaces (reward-snapshot, readyz, disclaimer.md); /api/v1/submissions and /api/v1/reward-policy are actually auth-gated (401) live despite the schema declaring no security.",
+      "/readyz only supports GET (HEAD returns 405 Method Not Allowed) -- probe uses GET."
+    ]
   },
   "name": "Bitsota",
   "netuid": 94,
+  "notes": "First maintainer review for SN94. Added website + source-repo surfaces, fixed 4 missing probe blocks. Diffed the OpenAPI schema for undiscovered public GET endpoints -- added 3 new surfaces; 2 candidates turned out to be auth-gated despite the schema saying otherwise.",
   "schema_version": 1,
   "slug": "sn-94",
   "social": {
@@ -17,11 +30,53 @@
   "surfaces": [
     {
       "auth_required": false,
+      "authority": "official",
+      "id": "sn-94-bitsota-website",
+      "kind": "website",
+      "name": "Bitsota website",
+      "notes": "Official Bitsota SN94 public website -- verified live 2026-07-15.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "source_urls": ["https://bitsota.ai/"],
+      "url": "https://bitsota.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-94-bitsota-source-repo",
+      "kind": "source-repo",
+      "name": "Bitsota source repository",
+      "notes": "Official SN94 miner/validator source repository -- verified live 2026-07-15.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "source_urls": ["https://github.com/AlveusLabs/SN94-BitSota"],
+      "url": "https://github.com/AlveusLabs/SN94-BitSota"
+    },
+    {
+      "auth_required": false,
       "authority": "community",
       "id": "sn-94-alveus-labs-subnet-api",
       "kind": "subnet-api",
       "name": "Bitsota AutoResearch coordinator API",
       "notes": "Public no-auth endpoint of the SN94 Bitsota AutoResearch coordinator — live research task list served by the production coordinator at autoresearch.bitsota.com (documented in the official bitsota.ai backend-routes docs).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "alveus-labs",
       "public_safe": true,
       "review": {
@@ -38,6 +93,12 @@
       "kind": "openapi",
       "name": "Bitsota AutoResearch coordinator OpenAPI spec",
       "notes": "OpenAPI 3.1 spec for the Bitsota AutoResearch coordinator API. Host autoresearch.bitsota.com is the SN94 coordinator operated by Alveus Labs (referenced across the official AlveusLabs/SN94-BitSota repo docs); same host as the existing subnet-api surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "alveus-labs",
       "public_safe": true,
       "review": {
@@ -59,6 +120,12 @@
       "kind": "data-artifact",
       "name": "Bitsota idea rewards",
       "notes": "Public no-auth JSON feed of Bitsota's idea-reward allocations (rewarded research improvements per task), served by the official Bitsota API and defined in its OpenAPI spec. Distinct endpoint from the registered /api/v1/tasks route.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "alveus-labs",
       "public_safe": true,
       "review": {
@@ -75,6 +142,12 @@
       "kind": "subnet-api",
       "name": "Bitsota AutoResearch coordinator healthz",
       "notes": "Public no-auth GET /healthz on autoresearch.bitsota.com returning coordinator liveness JSON (observed: {\"status\":\"ok\"}). Documented as GET /healthz in the subnet OpenAPI spec on the same host as the registered tasks and idea-rewards surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "alveus-labs",
       "public_safe": true,
       "review": {
@@ -301,6 +374,73 @@
       },
       "source_urls": ["https://autoresearch.bitsota.com/api/v1/onchain/status"],
       "url": "https://autoresearch.bitsota.com/api/v1/onchain/status"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-reward-snapshot",
+      "kind": "data-artifact",
+      "name": "Bitsota reward snapshot",
+      "notes": "Public no-auth GET /api/v1/reward-snapshot on autoresearch.bitsota.com returning the current reward-policy snapshot (score_ema_days, competition_count, pool config, validator weight mode). Documented in the subnet's own OpenAPI schema on the same host as the existing dashboard and reward-related surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/reward-snapshot"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-readyz",
+      "kind": "subnet-api",
+      "name": "Bitsota AutoResearch coordinator readyz",
+      "notes": "Public no-auth GET /readyz on autoresearch.bitsota.com returning coordinator readiness (observed: HTTP 204 No Content). Only supports GET (HEAD returns 405 Method Not Allowed). Distinct from the existing /healthz liveness surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/readyz"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-94-bitsota-disclaimer-md",
+      "kind": "docs",
+      "name": "Bitsota disclaimer document",
+      "notes": "Public no-auth GET /api/v1/disclaimer.md on autoresearch.bitsota.com returning the plain-Markdown no-reward-guarantee disclaimer text. Distinct from the existing structured JSON /api/v1/disclaimer surface (same content, different format).",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "alveus-labs",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://autoresearch.bitsota.com/openapi.json"],
+      "url": "https://autoresearch.bitsota.com/api/v1/disclaimer.md"
     }
-  ]
+  ],
+  "website_url": "https://bitsota.ai/"
 }


### PR DESCRIPTION
## Summary
- First maintainer review for SN94 Bitsota: adds website + source-repo surfaces, fixes 4 missing `probe` blocks (#5932)
- Diffs the 37-path `autoresearch.bitsota.com` OpenAPI schema for undiscovered public GET endpoints -- adds 3 new no-param surfaces (`reward-snapshot`, `readyz`, `disclaimer.md`)
- 2 candidates (`submissions`, `reward-policy`) turned out to be auth-gated (401) live despite the schema declaring no security
- Adds a `maintainer-reviewed.json` ledger entry (netuid 94)

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check`