### PR TITLE
fix(registry): SN95 Actual accuracy re-review pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1277,10 +1277,10 @@
       "netuid": 95,
       "slug": "actual",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-08T18:08:00.000Z",
+      "reviewed_at": "2026-07-15T00:00:00.000Z",
       "confidence": "high",
       "source_urls": ["https://actual.inc/", "https://models.actual.inc/"],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/actual.json (reviewed_at 2026-06-08T18:08:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): fixed 1 missing probe block. Still no GitHub source repository reference found anywhere on the site."
     },
     {
       "netuid": 96,

--- a/registry/subnets/actual.json
+++ b/registry/subnets/actual.json
@@ -28,15 +28,15 @@
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T18:08:00.000Z",
+    "reviewed_at": "2026-07-15T00:00:00.000Z",
     "source_count": 5,
-    "verified_at": "2026-06-08T18:08:00.000Z"
+    "verified_at": "2026-07-15T00:00:00.000Z"
   },
   "dashboard_url": "https://backprop.finance/dtao/subnets/95-actual",
   "docs_url": null,
   "name": "Actual",
   "netuid": 95,
-  "notes": "Reviewed overlay for SN95 Actual. The Actual Computer website metadata identifies the project with Bittensor, Subnet 95, decentralized AI, and inference software. The previous GitHub organization candidate currently returns 404 and is not promoted.",
+  "notes": "Reviewed overlay for SN95 Actual. The Actual Computer website metadata identifies the project with Bittensor, Subnet 95, decentralized AI, and inference software. The previous GitHub organization candidate currently returns 404 and is not promoted. Re-review pass (2026-07-15): fixed 1 missing probe block; still no GitHub source repository reference found anywhere on the site.",
   "schema_version": 1,
   "slug": "actual",
   "source_repo": null,
@@ -85,6 +85,12 @@
       "kind": "subnet-api",
       "name": "Actual API health",
       "notes": "Public no-auth GET /api/health on actual.inc returning application liveness JSON. Served on the official Actual Computer website host registered in this manifest.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "actual-computer",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary
- Fix 1 missing `probe` block (#5932)
- Still no GitHub source repository reference found anywhere on the site (unchanged from last review)
- Updates the existing `maintainer-reviewed.json` ledger entry (netuid 95)

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check`