### PR TITLE
fix(ui): formatTao tiers negative amounts by magnitude, not v itself

### DIFF
--- a/apps/ui/src/lib/metagraphed/format.test.ts
+++ b/apps/ui/src/lib/metagraphed/format.test.ts
@@ -162,4 +162,16 @@ describe("formatTao", () => {
     expect(formatTao(1_000_000)).toBe("1.00M τ"); // lower boundary of M-tier
     expect(formatTao(2_500_000)).toBe("2.50M τ");
   });
+
+  // #6019: tiering is by magnitude (|v|), not v itself, so a negative amount
+  // gets the same tier a positive one of equal size would.
+  it("tiers negative amounts by magnitude, preserving the sign", () => {
+    expect(formatTao(-0.48213)).toBe("-0.4821 τ"); // sub-unit
+    expect(formatTao(-256.5)).toBe("-256.50 τ"); // whole-unit, 2dp
+    expect(formatTao(-1_000)).toBe("-1.0k τ"); // lower boundary of k-tier
+    expect(formatTao(-12_345)).toBe("-12.3k τ");
+    expect(formatTao(-999_999)).toBe("-1000.0k τ"); // still < 1e6 → k-tier
+    expect(formatTao(-1_000_000)).toBe("-1.00M τ"); // lower boundary of M-tier
+    expect(formatTao(-2_500_000)).toBe("-2.50M τ");
+  });
 });

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -8,15 +8,20 @@ export function formatNumber(n: number | undefined | null, fallback = "—"): st
  * Format a TAO (τ) amount for compact display, tiering the precision by
  * magnitude so both dust and whole-subnet aggregates stay readable in a
  * single cell: ≥1e6 → "1.23M τ", ≥1e3 → "1.2k τ", ≥1 → "1.23 τ", and
- * sub-unit values keep 4 decimals ("0.5000 τ"). Nullish / non-finite input
- * renders the em-dash fallback. Shared by the per-subnet EconomicsPanel tiles
- * and the /subnets table Registration column so the two never drift.
+ * sub-unit values keep 4 decimals ("0.5000 τ"). Tiering is by magnitude
+ * (|v|), not v itself, so a negative amount gets the same tier a positive
+ * one of equal size would ("-2.00M τ", not "-2000000.0000 τ") -- the sign
+ * is preserved by dividing the signed value, not the magnitude. Nullish /
+ * non-finite input renders the em-dash fallback. Shared by the per-subnet
+ * EconomicsPanel tiles and the /subnets table Registration column so the
+ * two never drift.
  */
 export function formatTao(v?: number | null): string {
   if (v == null || !Number.isFinite(v)) return "—";
-  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
-  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
-  if (v >= 1) return `${v.toFixed(2)} τ`;
+  const magnitude = Math.abs(v);
+  if (magnitude >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M τ`;
+  if (magnitude >= 1_000) return `${(v / 1_000).toFixed(1)}k τ`;
+  if (magnitude >= 1) return `${v.toFixed(2)} τ`;
   return `${v.toFixed(4)} τ`;
 }
 


### PR DESCRIPTION
## Summary

\`apps/ui/src/lib/metagraphed/format.ts\`'s \`formatTao\` JSDoc promises magnitude-tiering (≥1e6→M, ≥1e3→k, ≥1→2dp, else 4dp) for "both dust and whole-subnet aggregates," but every branch tested \`v >= threshold\`, never \`Math.abs(v)\`. A large negative amount (e.g. -2,000,000 τ) fell through every tier to the 4-decimal branch: \`"-2000000.0000 τ"\` instead of \`"-2.00M τ"\`.

- Fixed the tier-selection branches to test \`Math.abs(v) >= threshold\` while the actual division still uses the signed \`v\`, so the sign is preserved naturally in the formatted output (no separate sign-handling needed).
- Audited the one caller with a pre-existing workaround: \`apps/ui/src/routes/explorer.tsx\`'s local \`fmtTaoSigned\` helper (\`v < 0 ? \`-${formatTao(-v)}\` : \`+${formatTao(v)}\`\`) pre-negates before calling \`formatTao\` and prepends its own sign. Verified this does **not** double-negate after the fix — since it always calls \`formatTao\` with an already-non-negative value, it never exercises \`formatTao\`'s negative branch at all. It also serves a distinct purpose beyond the tiering bug (an explicit "+" prefix for non-negative deltas), so it's left as-is rather than touched for a zero-behavior-change cleanup. Confirmed via \`grep\` that no other caller (\`extrinsic.fee_tao\`, \`tip_tao\`, \`volume_tao\`, etc.) has its own workaround — this was the only one.
- This PR is scoped to \`apps/ui/src/lib/**\` only (no route/component changes, no rendered-output difference anywhere) — per the skill, that's exempt from the before/after screenshot requirement.

## Test plan
- [x] Added a dedicated test case covering negative amounts at each tier boundary (sub-unit, whole-unit, k-tier lower bound, M-tier lower bound, and mid-tier values), mirroring the existing positive-tier test structure.
- [x] \`npx vitest run src/lib/metagraphed/format.test.ts\` — 25/25 passing
- [x] Full \`apps/ui\` test suite: 1011/1011 passing
- [x] \`npx eslint\` / \`npx prettier --check\` on both touched files
- [x] \`npx tsc --noEmit\` — no new errors (74 pre-existing, unrelated errors reproduce identically with or without this change; stale local \`ui-kit\`/\`fumadocs-mdx\` build artifacts)

Closes #6019