### PR TITLE
fix(ui): add copy button to yield-panel hotkeys without inflating rows

### DIFF
--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -10,6 +10,7 @@ import {
   StatTile,
   BarMini,
   Sparkline,
+  CopyButton,
 } from "@jsonbored/ui-kit";
 import { taoCompact } from "@/components/metagraphed/neuron-table";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
@@ -145,14 +146,17 @@ export function YieldLoader({ netuid }: { netuid: number }) {
                     #{n.uid}
                   </span>
                   {n.hotkey ? (
-                    <Link
-                      to="/accounts/$ss58"
-                      params={{ ss58: n.hotkey }}
-                      className="truncate font-mono text-[12px] text-ink-strong hover:text-accent hover:underline"
-                      title={n.hotkey}
-                    >
-                      {shortHash(n.hotkey) ?? n.hotkey}
-                    </Link>
+                    <>
+                      <Link
+                        to="/accounts/$ss58"
+                        params={{ ss58: n.hotkey }}
+                        className="truncate font-mono text-[12px] text-ink-strong hover:text-accent hover:underline"
+                        title={n.hotkey}
+                      >
+                        {shortHash(n.hotkey) ?? n.hotkey}
+                      </Link>
+                      <CopyButton value={n.hotkey} label="hotkey" className="-my-3.5" />
+                    </>
                   ) : (
                     <span className="font-mono text-[12px] text-ink-muted">—</span>
                   )}
@@ -199,14 +203,17 @@ export function YieldLoader({ netuid }: { netuid: number }) {
                   </td>
                   <td className="px-3 py-2.5 font-mono text-[11px]">
                     {n.hotkey ? (
-                      <Link
-                        to="/accounts/$ss58"
-                        params={{ ss58: n.hotkey }}
-                        className="text-ink-muted hover:text-ink hover:underline"
-                        title={n.hotkey}
-                      >
-                        {shortHash(n.hotkey) ?? n.hotkey}
-                      </Link>
+                      <div className="flex items-center gap-1.5">
+                        <Link
+                          to="/accounts/$ss58"
+                          params={{ ss58: n.hotkey }}
+                          className="text-ink-muted hover:text-ink hover:underline"
+                          title={n.hotkey}
+                        >
+                          {shortHash(n.hotkey) ?? n.hotkey}
+                        </Link>
+                        <CopyButton value={n.hotkey} label="hotkey" className="-my-3.5" />
+                      </div>
                     ) : (
                       "—"
                     )}


### PR DESCRIPTION
Closes #5858

The `/subnets` yield leaderboard rendered hotkeys as tooltip-only `title=` values in both its mobile card and desktop table views. Each is now paired with a `CopyButton`.

**On row spacing:** the shared `CopyButton` carries a 44px (`min-h-11`/`min-w-11`) touch target, so dropped into a dense row as-is it inflates the row (41px → 65px). This PR offsets that with `-my-3.5` so the button keeps its full 44px hit area but its height folds back into the row's existing padding. Measured against the live dev server, the row height is **unchanged** by the addition:

| Renderer | row before (no button) | row after | Δ | button hit-area |
|---|---|---|---|---|
| Desktop table | 41px | 41px | **0** | 44px |
| Mobile card | 68px | 68px | **0** | 44px |

Captured at the Phase C2 matrix — fixed viewports (375×812 / 768×1024 / 1280×800), each theme forced via `mg-theme`, on `/subnets/64?tab=metagraph`. The mobile rows show the card view (`md:hidden`); tablet/desktop show the table.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5858/5858-after-mobile-dark.png)<br><sub>after</sub> |

### Verification

`prettier` clean · `eslint` 0 errors · `tsc --noEmit` 0 · `vitest` 1015/1015 passing (130 files). The zero row-height delta above was measured in the browser via `getBoundingClientRect()` with the button toggled on/off.
