### PR TITLE
feat(registry): SN96 Verathos accuracy pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1286,7 +1286,7 @@
       "netuid": 96,
       "slug": "sn-96",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-08T07:45:00.000Z",
+      "reviewed_at": "2026-07-15T00:00:00.000Z",
       "confidence": "high",
       "source_urls": [
         "https://verathos.ai/",
@@ -1296,9 +1296,10 @@
         "https://api.verathos.ai/v1/models",
         "https://verathos.ai/chat",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_96/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/96"
+        "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/96",
+        "https://api.verathos.ai/openapi.json"
       ],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/verathos.json (reviewed_at 2026-06-08T07:45:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): fixed 4 missing probe blocks. Diffed both OpenAPI schemas (protocol + validator proxy, 59 combined paths) for undiscovered public GET endpoints -- added 12 new no-param surfaces; excluded account-scoped and consistently-503 routes."
     },
     {
       "netuid": 98,

--- a/registry/subnets/verathos.json
+++ b/registry/subnets/verathos.json
@@ -12,12 +12,15 @@
   ],
   "contact": "info@verathos.ai",
   "curation": {
-    "gap_notes": ["No verified SSE/event stream yet."],
+    "gap_notes": [
+      "No verified SSE/event stream yet.",
+      "Diffed both OpenAPI schemas (verathos.ai/openapi.json \"Verathos\" 24 paths, api.verathos.ai/openapi.json \"Verathos Validator Proxy\" 35 paths) for undiscovered public GET endpoints -- added 11 new no-param surfaces (one candidate, api.verathos.ai/v1/models, was already tracked under a different surface id). Excluded clearly account-scoped routes (auth/me, deposits/*, api-keys, balance, usage, user/*, admin/*) and routes that consistently return 503 (tee/info, deposit-info, deposits/base -- capacity-dependent, not stably available) or ambiguous empty-array 200s (conversations/, likely session-scoped despite no declared security)."
+    ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T07:45:00.000Z",
+    "reviewed_at": "2026-07-15T00:00:00.000Z",
     "source_count": 8,
-    "verified_at": "2026-06-08T07:45:00.000Z"
+    "verified_at": "2026-07-15T00:00:00.000Z"
   },
   "dashboard_url": "https://verathos.ai/chat",
   "docs_url": "https://verathos.ai/docs",
@@ -238,6 +241,12 @@
       "kind": "data-artifact",
       "name": "Verathos on-chain model-registry snapshot",
       "notes": "Public no-auth JSON snapshot of SN96's Bittensor chain identity and on-chain model/miner registry contract addresses; path is declared in the official OpenAPI spec.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "verathos",
       "public_safe": true,
       "review": {
@@ -257,6 +266,12 @@
       "kind": "data-artifact",
       "name": "Verathos model presets catalog",
       "notes": "Public no-auth JSON catalog of SN96's supported model presets and quantization options; path is declared in the official OpenAPI spec.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "verathos",
       "public_safe": true,
       "review": {
@@ -276,6 +291,12 @@
       "kind": "subnet-api",
       "name": "Verathos circulating-supply API",
       "notes": "Public no-auth GET returning the subnet's circulating supply. Documented in the subnet's own OpenAPI (api.verathos.ai/openapi.json); same host as the existing subnet-api (/v1/models) surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "verathos",
       "public_safe": true,
       "review": {
@@ -295,6 +316,12 @@
       "kind": "subnet-api",
       "name": "Verathos API health",
       "notes": "Public no-auth GET /health returning Verathos API status. Live on api.verathos.ai, the same host as the existing models subnet-api surface; documented in the subnet's OpenAPI spec.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "verathos",
       "public_safe": true,
       "review": {
@@ -374,6 +401,248 @@
       },
       "source_urls": ["https://api.verathos.ai/openapi.json"],
       "url": "https://api.verathos.ai/v1/supply/info"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-protocol-health",
+      "kind": "subnet-api",
+      "name": "Verathos protocol API health",
+      "notes": "Public no-auth GET /api/health on verathos.ai returning protocol-side liveness (observed: {\"status\":\"ok\",\"mode\":\"proxy\"}). Documented in the protocol OpenAPI schema; distinct from the already-tracked api.verathos.ai/health on the validator-proxy host.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-models-status",
+      "kind": "subnet-api",
+      "name": "Verathos active model status",
+      "notes": "Public no-auth GET /api/models/status on verathos.ai returning the currently-loaded chat model's runtime status (loaded, preset_id, num_layers, quant_label, max_model_len). Documented in the protocol OpenAPI schema on the same host as the existing model-registry surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/models/status"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-docs-list",
+      "kind": "docs",
+      "name": "Verathos docs index",
+      "notes": "Public no-auth GET /api/docs/list on verathos.ai returning the machine-readable documentation index (slug, title, group per page). Documented in the protocol OpenAPI schema; the machine-readable counterpart to the already-tracked HTML /docs surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/docs/list"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-dashboard-api",
+      "kind": "data-artifact",
+      "name": "Verathos protocol dashboard snapshot",
+      "notes": "Public no-auth GET /api/dashboard on verathos.ai returning a live network snapshot (proxy_connected, epoch_number, per-miner address/ss58/uid/endpoint/model_id list). Documented in the protocol OpenAPI schema. Aggregate/public data only, no account-specific fields.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/dashboard"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-dashboard-timeseries",
+      "kind": "data-artifact",
+      "name": "Verathos protocol dashboard timeseries",
+      "notes": "Public no-auth GET /api/dashboard/timeseries on verathos.ai returning historical aggregate network metrics. Documented in the protocol OpenAPI schema on the same host as the existing dashboard-snapshot surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "url": "https://verathos.ai/api/dashboard/timeseries"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-capacity-audit-health",
+      "kind": "subnet-api",
+      "name": "Verathos capacity-audit health",
+      "notes": "Public no-auth GET /capacity/audit/v1/health on api.verathos.ai returning capacity-audit backend liveness (observed: {\"status\":\"ok\",\"service\":\"verathos-validator-proxy\",\"capacity_audit\":true,...}). Documented in the validator-proxy OpenAPI schema on the same host as the existing /health surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.verathos.ai/openapi.json"],
+      "url": "https://api.verathos.ai/capacity/audit/v1/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-subnet-config",
+      "kind": "data-artifact",
+      "name": "Verathos subnet scoring config",
+      "notes": "Public no-auth GET /v1/subnet-config on api.verathos.ai returning the live scoring configuration (tee_bonus_bps, ema_alpha_bps, throughput/proof-sample weighting) validators apply, plus effective_epoch and refresh interval. Documented in the validator-proxy OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.verathos.ai/openapi.json"],
+      "url": "https://api.verathos.ai/v1/subnet-config"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-supply-total",
+      "kind": "data-artifact",
+      "name": "Verathos total supply",
+      "notes": "Public no-auth GET /v1/supply/total on api.verathos.ai returning the token's total supply figure. Documented in the validator-proxy OpenAPI schema on the same host as the existing circulating-supply and supply-info surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.verathos.ai/openapi.json"],
+      "url": "https://api.verathos.ai/v1/supply/total"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-supply-max",
+      "kind": "data-artifact",
+      "name": "Verathos max supply",
+      "notes": "Public no-auth GET /v1/supply/max on api.verathos.ai returning the token's max-supply figure. Documented in the validator-proxy OpenAPI schema on the same host as the existing supply surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.verathos.ai/openapi.json"],
+      "url": "https://api.verathos.ai/v1/supply/max"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-usage-timeseries",
+      "kind": "data-artifact",
+      "name": "Verathos network usage timeseries",
+      "notes": "Public no-auth GET /v1/network/usage-timeseries on api.verathos.ai returning aggregate request/token-volume buckets over time (range, bucket_seconds, per-bucket requests/tokens). Documented in the validator-proxy OpenAPI schema on the same host as the existing network-stats surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.verathos.ai/openapi.json"],
+      "url": "https://api.verathos.ai/v1/network/usage-timeseries"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-96-verathos-price-quote",
+      "kind": "subnet-api",
+      "name": "Verathos price quote",
+      "notes": "Public no-auth GET /v1/price on api.verathos.ai returning a default cost quote (model, input/output tokens, cost_usd, cost_tao). Documented in the validator-proxy OpenAPI schema on the same host as the existing models/supply surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.verathos.ai/openapi.json"],
+      "url": "https://api.verathos.ai/v1/price"
     }
   ],
   "website_url": "https://verathos.ai/"


### PR DESCRIPTION
## Summary
- Fix 4 missing `probe` blocks (chain-info, presets, circulating-supply, health) — systemic gap #5932.
- Diff both OpenAPI schemas: `verathos.ai/openapi.json` (Verathos protocol, 24 paths) and `api.verathos.ai/openapi.json` (Verathos Validator Proxy, 35 paths).
- Live-test every no-param/no-security candidate individually; add 11 new confirmed-public surfaces: `/api/health`, `/api/models/status`, `/api/docs/list`, `/api/dashboard`, `/api/dashboard/timeseries`, `/capacity/audit/v1/health`, `/v1/subnet-config`, `/v1/supply/total`, `/v1/supply/max`, `/v1/network/usage-timeseries`, `/v1/price`.
- Exclude account-scoped/unstable routes: `auth/me` (401), `deposits/*` and `tee/info`/`deposit-info` (503, capacity-dependent), `conversations/` (ambiguous empty-array 200, likely session-scoped), `api-keys`, `balance`, `usage`, `user/*`, `admin/*`.

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check registry/subnets/verathos.json registry/reviews/maintainer-reviewed.json`