### PR TITLE
feat(ui): wire Download CSV into the /leaderboards weight-setting + deregistration boards (#5562)

### DIFF
--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -8,13 +8,21 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { PageHero, BrandIcon, TimeAgo, StatTile, ShareButton } from "@jsonbored/ui-kit";
+import {
+  PageHero,
+  BrandIcon,
+  TimeAgo,
+  StatTile,
+  ShareButton,
+  DownloadCsvButton,
+} from "@jsonbored/ui-kit";
 import {
   chainDeregistrationsQuery,
   chainWeightsQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
+import { buildUrl } from "@/lib/metagraphed/client";
 import type { Subnet } from "@/lib/metagraphed/types";
 
 const leaderboardsSearchSchema = z.object({
@@ -118,14 +126,17 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
 
   return (
     <div className="space-y-8">
-      <div>
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Weight-setting activity
-        </h2>
-        <p className="mt-1 text-sm text-ink-muted">
-          Validator consensus effort ranked by subnet — raw WeightsSet events over the selected
-          window.
-        </p>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Weight-setting activity
+          </h2>
+          <p className="mt-1 text-sm text-ink-muted">
+            Validator consensus effort ranked by subnet — raw WeightsSet events over the selected
+            window.
+          </p>
+        </div>
+        <DownloadCsvButton url={buildUrl("/api/v1/chain/weights", { window: win })} />
       </div>
 
       <div className="grid gap-4 sm:grid-cols-3">
@@ -287,14 +298,17 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
 
   return (
     <div className="space-y-8">
-      <div>
-        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
-          Deregistrations
-        </h2>
-        <p className="mt-1 text-sm text-ink-muted">
-          Neuron evictions ranked by subnet — raw NeuronDeregistered events over the selected
-          window.
-        </p>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Deregistrations
+          </h2>
+          <p className="mt-1 text-sm text-ink-muted">
+            Neuron evictions ranked by subnet — raw NeuronDeregistered events over the selected
+            window.
+          </p>
+        </div>
+        <DownloadCsvButton url={buildUrl("/api/v1/chain/deregistrations", { window: win })} />
       </div>
 
       <div className="grid gap-4 sm:grid-cols-3">


### PR DESCRIPTION
## What

Wires **Download CSV** into the two ranked boards on `/leaderboards` — the weight-setting activity board and the deregistrations board — matching the CSV-export affordance every sibling ranked-list page already ships (Subnets, Blocks, Extrinsics, Accounts, Surfaces/Endpoints, global Validators; issues #3403/#3404/#3406/#3407/#3408/#5482).

Frontend-only: both endpoints already support `?format=csv` (verified live) —
- `GET /api/v1/chain/weights?format=csv&window=…`
- `GET /api/v1/chain/deregistrations?format=csv&window=…`

## How

Adds a per-board `DownloadCsvButton` (the shared `@jsonbored/ui-kit` primitive the sibling pages use) right-aligned in each board's header, exporting that board's data for the currently selected 7d/30d window via `buildUrl(...)`. The button appends `format=csv` itself (`buildCsvDownloadUrl`). No backend change.

## Screenshots

The new button appears in each board header (weight-setting shown); everything else is unchanged, across the full viewport × theme matrix:

| View | Before | After |
|------|--------|-------|
| Desktop · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5562-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5562-after-desktop-light.png) |
| Desktop · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5562-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5562-after-desktop-dark.png) |
| Tablet · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5562-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5562-after-tablet-light.png) |
| Tablet · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5562-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5562-after-tablet-dark.png) |
| Mobile · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5562-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5562-after-mobile-light.png) |
| Mobile · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5562-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5562-after-mobile-dark.png) |

Closes #5562.