### PR TITLE
fix(scripts): promote curation.level from any pre-tier + catch unmaterialized decisions

### DIFF
--- a/registry/subnets/minos.json
+++ b/registry/subnets/minos.json
@@ -1,8 +1,9 @@
 {
   "categories": [],
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-20T00:00:00.000Z"
   },
   "name": "Minos",
   "netuid": 107,

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -2407,3 +2407,50 @@ export {
   buildEndpointPoolArtifact,
   buildEndpointIncidentArtifact,
 } from "./lib/endpoint-artifacts.mjs";
+
+// The two terminal trust-tier "ceiling" levels. The CurationLevel enum documents
+// a "maintainer-reviewed / adapter-backed ceiling" (schemas/api-components), so a
+// maintainer-reviewed decision promotes any lower pre-tier to maintainer-reviewed
+// but must NOT downgrade an adapter-backed overlay (first-party adapter
+// provenance) nor re-touch one already at maintainer-reviewed. (#5992)
+export const CEILING_TRUST_LEVELS = new Set([
+  "maintainer-reviewed",
+  "adapter-backed",
+]);
+
+// The curation.level a maintainer-reviewed decision materializes for an overlay
+// currently at `currentLevel`: promote any non-ceiling pre-tier
+// (native / candidate-discovered / community-seeded / machine-verified) to
+// maintainer-reviewed, per docs/curation-playbook.md's "reached ONLY by adding a
+// decision" contract; leave a ceiling level (adapter-backed / already
+// maintainer-reviewed) unchanged. A non-maintainer-reviewed decision never moves
+// the level. (#5992 — the bug was that only a machine-verified starting level was
+// promoted, so decisions against other pre-tiers silently never materialized.)
+export function promoteCurationLevel(currentLevel, decisionKind) {
+  if (decisionKind !== "maintainer-reviewed") return currentLevel;
+  if (CEILING_TRUST_LEVELS.has(currentLevel)) return currentLevel;
+  return "maintainer-reviewed";
+}
+
+// Forward-direction drift check (#5992): every recorded maintainer-reviewed
+// decision must have actually materialized on its subnet overlay — i.e. the
+// overlay sits at a ceiling trust tier (maintainer-reviewed or adapter-backed).
+// Returns the decisions whose overlay level is still a lower pre-tier (the drift
+// class that left SN59/SN107 with a recorded decision but an unpromoted level).
+// A decision for a netuid with no overlay is skipped (a separate concern).
+export function findUnmaterializedMaintainerReviews(
+  decisions,
+  subnetsByNetuid,
+) {
+  const violations = [];
+  for (const decision of decisions || []) {
+    if (decision.decision !== "maintainer-reviewed") continue;
+    const subnet = subnetsByNetuid.get(decision.netuid);
+    if (!subnet) continue;
+    const level = subnet.curation?.level;
+    if (!CEILING_TRUST_LEVELS.has(level)) {
+      violations.push({ netuid: decision.netuid, slug: subnet.slug, level });
+    }
+  }
+  return violations;
+}

--- a/scripts/promote-reviewed.mjs
+++ b/scripts/promote-reviewed.mjs
@@ -5,6 +5,7 @@ import {
   readJson,
   repoRoot,
   buildSubnetOverlaysByNetuid,
+  promoteCurationLevel,
   stableStringify,
   writeJson,
 } from "./lib.mjs";
@@ -50,12 +51,16 @@ for (const decision of decisionsDocument.decisions || []) {
     review_state: decision.decision,
     reviewed_at: decision.reviewed_at,
   };
-  if (
-    decision.decision === "maintainer-reviewed" &&
-    nextOverlay.curation.level === "machine-verified"
-  ) {
-    nextOverlay.curation.level = "maintainer-reviewed";
-  }
+  // Materialize the decision onto curation.level via the shared contract:
+  // promote any lower pre-tier to maintainer-reviewed, leave a ceiling tier
+  // (adapter-backed / already maintainer-reviewed) untouched. Previously only a
+  // machine-verified starting level was promoted, so a decision recorded against
+  // any other pre-tier silently updated review_state/reviewed_at without ever
+  // bumping the level -- the SN59/SN107 drift class (#5992).
+  nextOverlay.curation.level = promoteCurationLevel(
+    nextOverlay.curation.level,
+    decision.decision,
+  );
 
   const changed =
     stableStringify(nextOverlay) !== stableStringify(entry.overlay);

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -29,6 +29,7 @@ import {
   slugify,
   stableStringify,
   subnetSurfaceKey,
+  findUnmaterializedMaintainerReviews,
 } from "./lib.mjs";
 import {
   R2_STAGING_RELATIVE_ROOT,
@@ -1593,6 +1594,25 @@ for (const subnet of subnets) {
     );
   }
 }
+
+// Forward direction (#5992): the reverse gate above only enforces that a
+// maintainer-reviewed LEVEL has a backing decision — never that a recorded
+// decision actually PRODUCED the level. That let a decision sit in
+// maintainer-reviewed.json while the subnet's own overlay stayed at a lower
+// pre-tier (community-seeded etc.), invisibly, because promote-reviewed.mjs only
+// promoted a machine-verified starting level (the SN59/SN107 drift). Assert every
+// recorded maintainer-reviewed decision materialized onto a ceiling trust tier.
+const subnetsByNetuidForReview = new Map(subnets.map((s) => [s.netuid, s]));
+const unmaterializedReviews = findUnmaterializedMaintainerReviews(
+  reviewDecisionsDocument.decisions || [],
+  subnetsByNetuidForReview,
+);
+assert(
+  unmaterializedReviews.length === 0,
+  `maintainer-reviewed decision(s) recorded in registry/reviews/maintainer-reviewed.json but not materialized on the subnet overlay (run 'npm run promote-reviewed -- --write'): ${unmaterializedReviews
+    .map((v) => `${v.slug} (netuid ${v.netuid}, level "${v.level}")`)
+    .join(", ")}`,
+);
 
 // Identity guardrail (the "Nodexo" class): a curated overlay's name matching
 // the ON-CHAIN identity of a DIFFERENT netuid than the one it is keyed to is a

--- a/tests/promote-reviewed-curation.test.mjs
+++ b/tests/promote-reviewed-curation.test.mjs
@@ -1,0 +1,120 @@
+// Coverage for #5992: promote-reviewed.mjs must promote curation.level to
+// maintainer-reviewed from ANY lower pre-tier (not just machine-verified), and
+// validate.mjs must catch a recorded maintainer-reviewed decision that never
+// materialized on its overlay. Both behaviours live in the pure, side-effect-free
+// helpers in scripts/lib.mjs (promoteCurationLevel /
+// findUnmaterializedMaintainerReviews) so they unit-test directly.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CEILING_TRUST_LEVELS,
+  promoteCurationLevel,
+  findUnmaterializedMaintainerReviews,
+} from "../scripts/lib.mjs";
+
+describe("promoteCurationLevel (#5992)", () => {
+  const PRE_TIERS = [
+    "native",
+    "candidate-discovered",
+    "community-seeded",
+    "machine-verified",
+  ];
+
+  test("a maintainer-reviewed decision promotes EVERY pre-tier level (not just machine-verified)", () => {
+    for (const level of PRE_TIERS) {
+      assert.equal(
+        promoteCurationLevel(level, "maintainer-reviewed"),
+        "maintainer-reviewed",
+        `expected ${level} to promote to maintainer-reviewed`,
+      );
+    }
+  });
+
+  test("a ceiling trust tier is never downgraded or re-touched by a decision", () => {
+    for (const level of CEILING_TRUST_LEVELS) {
+      assert.equal(promoteCurationLevel(level, "maintainer-reviewed"), level);
+    }
+    // adapter-backed specifically: the first-party self-referential entries
+    // (SN7 allways / SN74 gittensor) must stay adapter-backed despite a decision.
+    assert.equal(
+      promoteCurationLevel("adapter-backed", "maintainer-reviewed"),
+      "adapter-backed",
+    );
+  });
+
+  test("a non-maintainer-reviewed decision never moves the level", () => {
+    assert.equal(
+      promoteCurationLevel("community-seeded", "rejected"),
+      "community-seeded",
+    );
+    assert.equal(
+      promoteCurationLevel("machine-verified", "needs-info"),
+      "machine-verified",
+    );
+  });
+});
+
+describe("findUnmaterializedMaintainerReviews (#5992)", () => {
+  function subnetsByNetuid(entries) {
+    return new Map(entries.map((s) => [s.netuid, s]));
+  }
+
+  test("flags a decision whose overlay is still at a lower pre-tier (the SN107 drift)", () => {
+    const decisions = [{ netuid: 107, decision: "maintainer-reviewed" }];
+    const subnets = subnetsByNetuid([
+      { netuid: 107, slug: "minos", curation: { level: "community-seeded" } },
+    ]);
+    const violations = findUnmaterializedMaintainerReviews(decisions, subnets);
+    assert.deepEqual(violations, [
+      { netuid: 107, slug: "minos", level: "community-seeded" },
+    ]);
+  });
+
+  test("does NOT flag a decision materialized to either ceiling tier", () => {
+    const decisions = [
+      { netuid: 107, decision: "maintainer-reviewed" },
+      { netuid: 7, decision: "maintainer-reviewed" },
+    ];
+    const subnets = subnetsByNetuid([
+      // materialized straight to maintainer-reviewed
+      {
+        netuid: 107,
+        slug: "minos",
+        curation: { level: "maintainer-reviewed" },
+      },
+      // adapter-backed is a valid ceiling terminal (SN7 allways) — not drift
+      { netuid: 7, slug: "allways", curation: { level: "adapter-backed" } },
+    ]);
+    assert.deepEqual(
+      findUnmaterializedMaintainerReviews(decisions, subnets),
+      [],
+    );
+  });
+
+  test("ignores non-maintainer-reviewed decisions and decisions for unknown netuids", () => {
+    const decisions = [
+      { netuid: 5, decision: "rejected" }, // not a maintainer-reviewed decision
+      { netuid: 999, decision: "maintainer-reviewed" }, // no overlay
+    ];
+    const subnets = subnetsByNetuid([
+      { netuid: 5, slug: "sn-5", curation: { level: "community-seeded" } },
+    ]);
+    assert.deepEqual(
+      findUnmaterializedMaintainerReviews(decisions, subnets),
+      [],
+    );
+  });
+
+  test("handles a null/absent decisions list and an overlay with no curation block", () => {
+    assert.deepEqual(findUnmaterializedMaintainerReviews(null, new Map()), []);
+    // A decision whose overlay has no curation block at all is still drift
+    // (level is undefined, which is not a ceiling tier).
+    const violations = findUnmaterializedMaintainerReviews(
+      [{ netuid: 3, decision: "maintainer-reviewed" }],
+      new Map([[3, { netuid: 3, slug: "sn-3" }]]),
+    );
+    assert.deepEqual(violations, [
+      { netuid: 3, slug: "sn-3", level: undefined },
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #5992.

`promote-reviewed.mjs` only bumped `curation.level` to `maintainer-reviewed` when the existing level was exactly `machine-verified` — a decision recorded against any other pre-tier (`community-seeded`/`candidate-discovered`/`native`) silently updated `review_state`/`reviewed_at` but never promoted the level. The playbook says the tier is "reached ONLY by adding a decision" with no starting-level carve-out, and `validate.mjs` only enforced the *reverse* direction, so the drift was invisible to CI — live-confirmed on **SN107 (minos)**, which had a maintainer-reviewed decision but still read `community-seeded`/`unreviewed`.

## What
- **Two pure helpers in `scripts/lib.mjs`** (unit-testable, side-effect-free):
  - `promoteCurationLevel(currentLevel, decisionKind)` — promotes any lower pre-tier to `maintainer-reviewed`, but leaves a **ceiling** tier untouched. The `CurationLevel` enum documents a *"maintainer-reviewed / adapter-backed ceiling"*, so a decision must **not** downgrade the first-party `adapter-backed` self-referential entries (SN7 allways / SN74 gittensor).
  - `findUnmaterializedMaintainerReviews(decisions, subnetsByNetuid)` — returns any maintainer-reviewed decision whose overlay never reached a ceiling tier.
- **`promote-reviewed.mjs`** uses `promoteCurationLevel`.
- **`validate.mjs`** adds the missing **forward-direction gate** — a recorded maintainer-reviewed decision must have materialized onto a ceiling tier, else CI fails (the check that would have caught the SN107 drift).
- **Corrected `registry/subnets/minos.json` (SN107)** to reflect its recorded 2026-06-20 decision. (SN59 babelbit was already reconciled upstream; the only remaining true pre-tier drift was SN107 — SN7/SN74 are intentionally adapter-backed and correctly left alone.)

## Tests
`tests/promote-reviewed-curation.test.mjs` (7 cases): promotion from every pre-tier, ceiling tiers left intact (incl. adapter-backed), non-maintainer-reviewed decisions ignored, unknown-netuid/absent-list handling, and the drift detector flagging a deliberately-drifted fixture. Both helpers 100% covered (statements + branches). `scripts/lib.mjs` is in the coverage-gated scope; the two script wirings are not.

Closes #5992