### PR TITLE
fix(ui): add copy button to validator hotkey/coldkey without inflating rows

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
@@ -37,18 +38,25 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
               >
                 {f.hotkeyShort}
               </Link>
+              <CopyButton value={v.hotkey} label="hotkey" className="-my-3.5" />
             </div>
-            <div className="font-mono text-[11px] text-ink-muted">
-              <span className="uppercase tracking-widest text-[10px]">coldkey </span>
+            {/* Mirrors the hotkey row above: a flex row so the copy button's 44px
+                touch target centers against the value. `-my-3.5` folds that height
+                back into the row so it does not add vertical spacing. */}
+            <div className="flex min-w-0 items-center gap-1.5 font-mono text-[11px] text-ink-muted">
+              <span className="uppercase tracking-widest text-[10px]">coldkey</span>
               {v.coldkey ? (
-                <Link
-                  to="/accounts/$ss58"
-                  params={{ ss58: v.coldkey }}
-                  title={v.coldkey}
-                  className="hover:text-accent hover:underline"
-                >
-                  {f.coldkeyShort}
-                </Link>
+                <>
+                  <Link
+                    to="/accounts/$ss58"
+                    params={{ ss58: v.coldkey }}
+                    title={v.coldkey}
+                    className="truncate hover:text-accent hover:underline"
+                  >
+                    {f.coldkeyShort}
+                  </Link>
+                  <CopyButton value={v.coldkey} label="coldkey" className="-my-3.5" />
+                </>
               ) : (
                 "—"
               )}

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
@@ -50,14 +51,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     thClassName: TH_BASE,
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) => (
-      <Link
-        to="/validators/$hotkey"
-        params={{ hotkey: v.hotkey }}
-        className="text-ink-strong hover:text-accent hover:underline"
-        title={v.hotkey}
-      >
-        {shortHash(v.hotkey) ?? v.hotkey}
-      </Link>
+      <div className="flex items-center gap-1.5">
+        <Link
+          to="/validators/$hotkey"
+          params={{ hotkey: v.hotkey }}
+          className="text-ink-strong hover:text-accent hover:underline"
+          title={v.hotkey}
+        >
+          {shortHash(v.hotkey) ?? v.hotkey}
+        </Link>
+        <CopyButton value={v.hotkey} label="hotkey" className="-my-3.5" />
+      </div>
     ),
   },
   {
@@ -66,14 +70,17 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     tdClassName: `${TD_BASE} text-ink-muted`,
     cell: (v) =>
       v.coldkey ? (
-        <Link
-          to="/accounts/$ss58"
-          params={{ ss58: v.coldkey }}
-          className="hover:text-accent hover:underline"
-          title={v.coldkey}
-        >
-          {shortHash(v.coldkey) ?? v.coldkey}
-        </Link>
+        <div className="flex items-center gap-1.5">
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: v.coldkey }}
+            className="hover:text-accent hover:underline"
+            title={v.coldkey}
+          >
+            {shortHash(v.coldkey) ?? v.coldkey}
+          </Link>
+          <CopyButton value={v.coldkey} label="coldkey" className="-my-3.5" />
+        </div>
       ) : (
         "—"
       ),


### PR DESCRIPTION
Closes #5859

Resubmit of #6131, which was closed because the `CopyButton`'s 44px touch target added vertical spacing to every row. This addresses that directly, using the same approach that landed in #6160.

`/validators` rendered hotkey and coldkey as tooltip-only `title=` values in both renderers. Each is now paired with a `CopyButton` given `-my-3.5`, which folds the button's 44px height back into the row's existing padding — the button keeps its full 44px hit area, and the row height is unchanged:

| Renderer | row before (no button) | row after | Δ | button hit-area |
|---|---|---|---|---|
| Desktop table | 37px | 37px | **0** | 44px |
| Mobile card | 161px | 161px | **0** | 44px |

Captured at the Phase C2 matrix — fixed viewports (375×812 / 768×1024 / 1280×800), each theme forced via `mg-theme`. Mobile shows `ValidatorCardList` (`md:hidden`); tablet/desktop show the `VALIDATOR_COLUMNS` table (`hidden md:block`).

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5859/5859-after-mobile-dark.png)<br><sub>after</sub> |

### The change

- `validator-columns.tsx` — `CopyButton` in both the Hotkey and Coldkey cell renderers, each in a `flex items-center gap-1.5` row.
- `validator-card-list.tsx` — `CopyButton` next to the hotkey; the coldkey line becomes a flex row (mirroring the hotkey row above it) so the button centers against the value.
- Every button carries `className="-my-3.5"` so it does not inflate the row (the reason #6131 was closed).

### Verification

`prettier` clean · `eslint` 0 errors · `tsc --noEmit` 0 · `vitest` 1010/1010 passing (128 files). The zero row-height delta above was measured in the browser via `getBoundingClientRect()` with the buttons toggled on/off. `validator-columns.test.ts` still passes — the header/cell 1:1 invariants (#5307) are unaffected.
