### PR TITLE
fix(ui): add Download CSV export to the leaderboards page actions (#5865)

### DIFF
--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -8,13 +8,22 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { PageHero, BrandIcon, TimeAgo, StatTile, ShareButton } from "@jsonbored/ui-kit";
+import {
+  PageHero,
+  BrandIcon,
+  TimeAgo,
+  StatTile,
+  ShareButton,
+  DownloadCsvButton,
+  ActionBar,
+} from "@jsonbored/ui-kit";
 import {
   chainDeregistrationsQuery,
   chainWeightsQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
+import { buildUrl } from "@/lib/metagraphed/client";
 import type { Subnet } from "@/lib/metagraphed/types";
 
 const leaderboardsSearchSchema = z.object({
@@ -64,7 +73,21 @@ function LeaderboardsPage() {
         live
         title="Leaderboards"
         description="Network-wide chain activity boards — ranked by subnet from live chain-direct analytics."
-        actions={<ShareButton />}
+        actions={
+          <ActionBar>
+            <DownloadCsvButton
+              url={buildUrl("/api/v1/chain/weights", { window: win })}
+              label="Weight-setting CSV"
+              bare
+            />
+            <DownloadCsvButton
+              url={buildUrl("/api/v1/chain/deregistrations", { window: win })}
+              label="Deregistrations CSV"
+              bare
+            />
+            <ShareButton bare />
+          </ActionBar>
+        }
       />
       <div className="flex flex-wrap items-center justify-end gap-2">
         <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">


### PR DESCRIPTION
## What

Adds **Download CSV** to `leaderboards.tsx`'s page actions — the page renders two full ranked tables (weight-setting activity, deregistrations) but exposed no CSV export, unlike every comparable list/directory route (`subnets.index.tsx`, `validators.index.tsx`, `blocks`, `extrinsics`, `endpoints`, `surfaces`, `accounts.$ss58`).

## How

Follows the established **page-actions** pattern (`subnets.index.tsx:181`, `validators.index.tsx:89`): a `DownloadCsvButton` (the shared ui-kit primitive) inside the `PageHero` `actions` `ActionBar`, `bare`, alongside `ShareButton`. The two boards have distinct column shapes and can't share one export, so there's one bare button per board — "Weight-setting CSV" and "Deregistrations CSV" — each exporting that board's data for the currently-selected 7d/30d window via `buildUrl(...)` (the button appends `format=csv`). Reuses the existing primitive rather than inventing a new export shape.

Both `/api/v1/chain/weights` and `/api/v1/chain/deregistrations` already support `?format=csv`. Frontend-only — no query/table changes.

## Screenshots

The two CSV buttons appear in the page actions (before: only "Share view"); everything else unchanged, across the full viewport × theme matrix:

| View | Before | After |
|------|--------|-------|
| Desktop · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5865-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5865-after-desktop-light.png) |
| Desktop · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5865-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5865-after-desktop-dark.png) |
| Tablet · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5865-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5865-after-tablet-light.png) |
| Tablet · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5865-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5865-after-tablet-dark.png) |
| Mobile · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5865-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5865-after-mobile-light.png) |
| Mobile · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5865-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5865-after-mobile-dark.png) |

Closes #5865.