### PR TITLE
feat(registry): SN99 Leoma accuracy pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1340,6 +1340,19 @@
       "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/forevermoney.json (reviewed_at 2026-06-08T10:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
     },
     {
+      "netuid": 99,
+      "slug": "sn-99",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-07-16T00:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://leoma.ai/",
+        "https://github.com/RendixNetwork/leoma",
+        "https://api.leoma.ai/openapi.json"
+      ],
+      "notes": "Root->128 accuracy audit pass (#5903): first maintainer review for SN99. Added website + source-repo surfaces, fixed 2 missing probe blocks. Diffed the 28-path OpenAPI schema for undiscovered public GET endpoints -- added 6 new surfaces; 2 candidates (miners/valid, miners/all) turned out to require validator-signed headers despite the schema saying no auth."
+    },
+    {
       "netuid": 100,
       "slug": "sn-100",
       "decision": "maintainer-reviewed",

--- a/registry/subnets/leoma.json
+++ b/registry/subnets/leoma.json
@@ -1,11 +1,24 @@
 {
-  "categories": [],
+  "categories": [
+    "baseline-curated",
+    "official-source-repo",
+    "official-website"
+  ],
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-07-16T00:00:00.000Z",
+    "verified_at": "2026-07-16T00:00:00.000Z",
+    "source_count": 6,
+    "gap_notes": [
+      "No verified official docs URL yet.",
+      "No verified SSE/event stream yet.",
+      "/miners/valid and /miners/all both declare no security in the OpenAPI schema but return 422 in practice requiring three custom auth headers (caller identity, request signature, timestamp) -- excluded as a schema-vs-reality mismatch."
+    ]
   },
   "name": "Leoma",
   "netuid": 99,
+  "notes": "First maintainer review for SN99. Added website + source-repo surfaces, fixed 2 missing probe blocks. Diffed the 28-path OpenAPI schema for undiscovered public GET endpoints -- added 6 new surfaces (scores, scores/rank, blacklist, blacklist/miners, tasks/latest, weights); 2 candidates (miners/valid, miners/all) turned out to require validator-signed headers despite the schema saying no auth.",
   "schema_version": 1,
   "slug": "sn-99",
   "social": {
@@ -21,6 +34,12 @@
       "kind": "subnet-api",
       "name": "Leoma API health",
       "notes": "Public no-auth GET /health on api.leoma.ai returning application liveness JSON (observed: status, version, database, metagraph_synced, last_sync). Documented in the subnet OpenAPI spec and implemented in the official RendixNetwork/leoma health route used by validator API clients.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "leoma",
       "public_safe": true,
       "review": {
@@ -41,6 +60,12 @@
       "kind": "data-artifact",
       "name": "Leoma network score summary",
       "notes": "Public no-auth GET /scores/stats on api.leoma.ai returning network-wide aggregate counters (total_validators, total_miners, total_samples, total_score_entries, overall_pass_rate). Documented as a route in the subnet's own OpenAPI schema (api.leoma.ai/openapi.json, already cited as a source for the existing health surface); same api.leoma.ai host.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "leoma",
       "public_safe": true,
       "review": {
@@ -143,6 +168,174 @@
       },
       "source_urls": ["https://api.leoma.ai/scores/validators"],
       "url": "https://api.leoma.ai/scores/validators"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-99-leoma-website",
+      "kind": "website",
+      "name": "Leoma website",
+      "notes": "Official SN99 Leoma website -- verified live 2026-07-16.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "leoma",
+      "public_safe": true,
+      "source_urls": ["https://github.com/RendixNetwork/leoma"],
+      "url": "https://leoma.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-99-leoma-source-repo",
+      "kind": "source-repo",
+      "name": "Leoma source repository",
+      "notes": "Official SN99 Leoma source repository -- verified live 2026-07-16.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "leoma",
+      "public_safe": true,
+      "source_urls": ["https://github.com/RendixNetwork/leoma"],
+      "url": "https://github.com/RendixNetwork/leoma"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-scores",
+      "kind": "data-artifact",
+      "name": "Leoma per-miner scores",
+      "notes": "Public no-auth GET /scores on api.leoma.ai returning per-miner scoring aggregates keyed by hotkey (avg_score, total_samples, total_passed, pass_rate, validator_count). Documented in the subnet's own OpenAPI schema; same api.leoma.ai host as the existing scores/stats and scores/validators surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.leoma.ai/openapi.json"],
+      "url": "https://api.leoma.ai/scores"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-scores-rank",
+      "kind": "data-artifact",
+      "name": "Leoma miner rank leaderboard",
+      "notes": "Public no-auth GET /scores/rank on api.leoma.ai returning the ranked miner leaderboard (miner_hotkey, uid, rank, passed_count, pass_rate, block, eligible). Documented in the subnet's own OpenAPI schema; same host as the other scores surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.leoma.ai/openapi.json"],
+      "url": "https://api.leoma.ai/scores/rank"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-blacklist",
+      "kind": "data-artifact",
+      "name": "Leoma blacklist records",
+      "notes": "Public no-auth GET /blacklist on api.leoma.ai returning full blacklist entries (hotkey, reason, added_by, created_at). Documented in the subnet's own OpenAPI schema. Distinct in shape from the hotkey-only /blacklist/miners list.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.leoma.ai/openapi.json"],
+      "url": "https://api.leoma.ai/blacklist"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-blacklist-miners",
+      "kind": "data-artifact",
+      "name": "Leoma blacklisted miner hotkeys",
+      "notes": "Public no-auth GET /blacklist/miners on api.leoma.ai returning a plain array of blacklisted miner hotkeys. Documented in the subnet's own OpenAPI schema. Distinct in shape from the full-record /blacklist surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.leoma.ai/openapi.json"],
+      "url": "https://api.leoma.ai/blacklist/miners"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-tasks-latest",
+      "kind": "subnet-api",
+      "name": "Leoma latest task id",
+      "notes": "Public no-auth GET /tasks/latest on api.leoma.ai returning the most recent evaluation task_id. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.leoma.ai/openapi.json"],
+      "url": "https://api.leoma.ai/tasks/latest"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-99-leoma-weights",
+      "kind": "subnet-api",
+      "name": "Leoma current weight-setting result",
+      "notes": "Public no-auth GET /weights on api.leoma.ai returning the current round's winning miner and per-miner weight allocation (winner_uid, miners[].miner_hotkey/uid/pass_rate/weight). Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "leoma",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://api.leoma.ai/openapi.json"],
+      "url": "https://api.leoma.ai/weights"
     }
   ],
   "website_url": "https://leoma.ai/"


### PR DESCRIPTION
## Summary
- First maintainer review of SN99 Leoma. Add website + source-repo surfaces, fix 2 missing probe blocks — systemic gap #5932.
- Diff the 28-path OpenAPI schema for undiscovered public GET endpoints. Add 6 new surfaces (`scores`, `scores/rank`, `blacklist`, `blacklist/miners`, `tasks/latest`, `weights`), all live-tested with real JSON content.
- Exclude 2 candidates (`miners/valid`, `miners/all`) that declare no security in the schema but return 422 in practice, requiring three custom auth headers — a schema-vs-reality mismatch.

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check registry/subnets/leoma.json registry/reviews/maintainer-reviewed.json`