### PR TITLE
fix(registry): SN100 Platform accuracy re-review pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1356,14 +1356,14 @@
       "netuid": 100,
       "slug": "sn-100",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-08T19:30:00.000Z",
+      "reviewed_at": "2026-07-16T00:00:00.000Z",
       "confidence": "high",
       "source_urls": [
         "https://www.platform.network/",
         "https://www.platform.network/docs",
         "https://github.com/PlatformNetwork/platform"
       ],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/pla-form.json (reviewed_at 2026-06-08T19:30:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): all 7 surfaces re-verified live, fixed 1 missing probe block. Diffed the 27-path BASE Challenge Proxy OpenAPI schema -- no new candidates promoted (remaining routes are HTTPBearer-gated or path-parameterized; /v1/weights/latest is real but currently 404s pending a sealed weight vector)."
     },
     {
       "netuid": 101,

--- a/registry/subnets/pla-form.json
+++ b/registry/subnets/pla-form.json
@@ -21,19 +21,20 @@
       "Common API, health, OpenAPI, Swagger JSON, and Swagger UI paths currently return 404.",
       "CortexLM/platform redirects to PlatformNetwork/platform and is excluded as duplicate source evidence.",
       "The PlatformNetwork GitHub organization page is not promoted as a source repository.",
-      "No verified SSE/event stream yet."
+      "No verified SSE/event stream yet.",
+      "Diffed the 27-path chain.joinbase.ai OpenAPI schema for undiscovered public GET endpoints -- everything not already tracked is either HTTPBearer-gated (/admin, /admin/challenges, /v1/admin/*, /v1/validators) or a path-parameterized detail route. /v1/weights/latest declares no security and is real (cited as evidence in the dashboard surface's notes) but currently 404s with \"no sealed weight vector available\" -- not promoted as its own surface until it stably returns data."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T19:30:00.000Z",
+    "reviewed_at": "2026-07-16T00:00:00.000Z",
     "source_count": 7,
-    "verified_at": "2026-06-08T19:30:00.000Z"
+    "verified_at": "2026-07-16T00:00:00.000Z"
   },
   "dashboard_url": "https://taomarketcap.com/subnets/100",
   "docs_url": "https://www.platform.network/docs",
   "name": "Plaτform",
   "netuid": 100,
-  "notes": "Reviewed overlay for SN100 Plaτform using the official Platform Network website, docs, and source repository. Common API, health, OpenAPI, and Swagger probe paths currently return 404 and are not promoted as public operational API surfaces.",
+  "notes": "Reviewed overlay for SN100 Plaτform using the official Platform Network website, docs, and source repository. Common API, health, OpenAPI, and Swagger probe paths currently return 404 and are not promoted as public operational API surfaces. Root->128 accuracy audit re-review pass (#5903): fixed 1 missing probe block; diffed the 27-path BASE Challenge Proxy OpenAPI schema, no new candidates promoted.",
   "schema_version": 1,
   "slug": "sn-100",
   "social": {
@@ -109,6 +110,12 @@
       "kind": "openapi",
       "name": "Plaτform BASE Challenge Proxy OpenAPI",
       "notes": "OpenAPI 3.1 spec for the BASE challenge proxy public edge at chain.joinbase.ai. The official SN100 source repository (PlatformNetwork/platform README) documents this host as the live public API front door for the multi-challenge subnet platform.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "platform-network",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary
- Re-verify all 7 SN100 Platform surfaces, fix 1 missing probe block on the OpenAPI surface — systemic gap #5932.
- Diff the 27-path BASE Challenge Proxy OpenAPI schema for undiscovered public GET endpoints. No new candidates promoted: the remaining routes are HTTPBearer-gated (`/admin`, `/admin/challenges`, `/v1/admin/*`, `/v1/validators`) or path-parameterized. `/v1/weights/latest` declares no security and is real (already cited as evidence in an existing surface's notes) but currently 404s with "no sealed weight vector available" — not promoted until it stably returns data.

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check registry/subnets/pla-form.json registry/reviews/maintainer-reviewed.json`