### PR TITLE
fix(registry): SN101 eni accuracy re-review pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1369,10 +1369,13 @@
       "netuid": 101,
       "slug": "eni",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-08T15:00:00.000Z",
+      "reviewed_at": "2026-07-16T00:00:00.000Z",
       "confidence": "high",
-      "source_urls": [],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/eni.json (reviewed_at 2026-06-08T15:00:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "source_urls": [
+        "http://tag101.ai/",
+        "https://github.com/tag101-ai/tag101"
+      ],
+      "notes": "Root->128 accuracy audit re-review pass (#5903): the official website and source repository are now both live and added as tracked surfaces (previously only cited via top-level fields, not tracked). Website only serves over plain HTTP. No public API, OpenAPI schema, or docs site beyond what was already tracked."
     },
     {
       "netuid": 102,

--- a/registry/subnets/eni.json
+++ b/registry/subnets/eni.json
@@ -1,25 +1,29 @@
 {
-  "categories": ["baseline-curated", "identity-reviewed"],
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-source-repo",
+    "official-website"
+  ],
   "curation": {
     "gap_notes": [
-      "No verified official website yet.",
-      "No verified live source repository yet.",
       "No verified official docs site yet beyond public directory/community pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet."
+      "No verified safe public subnet API endpoint yet beyond the TaoMarketCap snapshot -- the README describes validators fetching posts from a centralized database via API but does not name a public host.",
+      "No verified SSE/event stream yet.",
+      "The official website (tag101.ai) only serves over plain HTTP -- https:// times out (no TLS)."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T15:00:00.000Z",
+    "reviewed_at": "2026-07-16T00:00:00.000Z",
     "source_count": 5,
-    "verified_at": "2026-06-08T15:00:00.000Z"
+    "verified_at": "2026-07-16T00:00:00.000Z"
   },
   "dashboard_url": null,
   "docs_url": null,
   "name": "eni",
   "netuid": 101,
-  "notes": "Reviewed overlay for SN101 eni. Public directories list the subnet, but no official website, source repository, API, OpenAPI schema, or docs site has been verified.",
+  "notes": "Reviewed overlay for SN101 eni. Public directories list the subnet. Root->128 accuracy audit re-review pass (#5903): the official website and source repository are now both live and added as tracked surfaces (previously only cited via top-level fields); no public API, OpenAPI schema, or docs site beyond what was already tracked.",
   "schema_version": 1,
   "slug": "eni",
   "source_repo": "https://github.com/tag101-ai/tag101",
@@ -74,6 +78,42 @@
         "https://github.com/tag101-ai/tag101"
       ],
       "url": "https://raw.githubusercontent.com/tag101-ai/tag101/115f36da7c483d16018d4c16a14f8fb8d0433306/min_compute.yml"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-101-eni-website",
+      "kind": "website",
+      "name": "eni (Tag101) website",
+      "notes": "Official SN101 eni (Tag101) website -- verified live 2026-07-16. Only serves over plain HTTP; https:// times out (no TLS certificate on this host).",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "eni",
+      "public_safe": true,
+      "source_urls": ["https://github.com/tag101-ai/tag101"],
+      "url": "http://tag101.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-101-eni-source-repo",
+      "kind": "source-repo",
+      "name": "eni (Tag101) source repository",
+      "notes": "Official SN101 eni (Tag101) source repository -- verified live 2026-07-16.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "eni",
+      "public_safe": true,
+      "source_urls": ["https://github.com/tag101-ai/tag101"],
+      "url": "https://github.com/tag101-ai/tag101"
     }
   ],
   "website_url": "http://tag101.ai/"


### PR DESCRIPTION
## Summary
- Add website + source-repo surfaces for SN101 eni (Tag101) — both were previously only cited via top-level fields (`website_url`, `source_repo`) but never tracked as their own surfaces.
- The website only serves over plain HTTP (`https://` times out, no TLS certificate) — documented in `gap_notes`.
- No public API, OpenAPI schema, or docs site found beyond the existing TaoMarketCap snapshot — the README describes validators fetching posts via API but names no public host.

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check registry/subnets/eni.json registry/reviews/maintainer-reviewed.json`