### PR TITLE
feat(registry): SN105 Beam accuracy pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1424,6 +1424,19 @@
       "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/for-sale-burn-to-uid1.json (reviewed_at 2026-06-08T15:00:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
     },
     {
+      "netuid": 105,
+      "slug": "sn-105",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-07-16T00:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://b1m.ai/",
+        "https://github.com/Beam-Network/beam",
+        "https://beamcore.b1m.ai/openapi.json"
+      ],
+      "notes": "Root->128 accuracy audit pass (#5903): first maintainer review for SN105. Corrected source_repo from a generic org repositories-listing page to the specific Beam-Network/beam repo. Added website + source-repo surfaces. Diffed the 53-path BeamCore OpenAPI schema and live-tested every no-param candidate: most declare no security but are actually 401-gated in practice; only 2 genuinely public routes were promoted."
+    },
+    {
       "netuid": 107,
       "slug": "sn-107",
       "decision": "maintainer-reviewed",

--- a/registry/subnets/beam.json
+++ b/registry/subnets/beam.json
@@ -1,18 +1,31 @@
 {
-  "categories": [],
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-source-repo",
+    "official-website"
+  ],
   "contact": "info@b1m.ai",
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "gap_notes": [
+      "No verified SSE/event stream yet -- /logs/stream/{source} exists but is path-parameterized, not a bare no-param route.",
+      "The BeamCore OpenAPI schema declares no security on all 53 paths, but most are actually auth-gated in practice (401): auth/me, auth/keys, clients, destinations, transfers, orchestrators/pending-transfers, orchestrators/workers, Validator/epoch-summary/latest-epoch, jobs, internal/routing/live. Only validators/orchestrators and status/orchestrator-relays are genuinely public -- both added as new surfaces."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-07-16T00:00:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-07-16T00:00:00.000Z"
   },
   "name": "Beam",
   "netuid": 105,
+  "notes": "First maintainer review for SN105. Corrected source_repo from a generic Beam-Network org repositories-listing page to the specific Beam-Network/beam repo already cited throughout the file's existing surfaces. Added website + source-repo surfaces. Diffed the 53-path BeamCore OpenAPI schema and live-tested every no-param candidate: most declare no security but are actually 401-gated in practice; only 2 genuinely public routes were promoted.",
   "schema_version": 1,
   "slug": "sn-105",
   "social": {
     "x": "https://x.com/b1m_ai"
   },
-  "source_repo": "https://github.com/orgs/Beam-Network/repositories",
+  "source_repo": "https://github.com/Beam-Network/beam",
   "status": "active",
   "surfaces": [
     {
@@ -114,6 +127,86 @@
       },
       "source_urls": ["https://beamcore.b1m.ai/routing/worker-capacity"],
       "url": "https://beamcore.b1m.ai/routing/worker-capacity"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-105-beam-website",
+      "kind": "website",
+      "name": "Beam website",
+      "notes": "Official SN105 Beam website -- verified live 2026-07-16.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Beam-Network/beam"],
+      "url": "https://b1m.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-105-beam-source-repo",
+      "kind": "source-repo",
+      "name": "Beam source repository",
+      "notes": "Official SN105 Beam source repository -- verified live 2026-07-16.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Beam-Network/beam"],
+      "url": "https://github.com/Beam-Network/beam"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-105-beam-validators-orchestrators",
+      "kind": "subnet-api",
+      "name": "Beam validator orchestrator list",
+      "notes": "Public no-auth GET /validators/orchestrators on beamcore.b1m.ai returning the orchestrator list as seen by validators (uid, hotkey, name, url, status, worker_count, bandwidth_mbps). Documented in the subnet's own OpenAPI schema. Distinct from the already-registered /routing/orchestrators surface (a different endpoint on the same host).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/validators/orchestrators"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-105-beam-orchestrator-relays",
+      "kind": "data-artifact",
+      "name": "Beam orchestrator relay hotkeys",
+      "notes": "Public no-auth GET /status/orchestrator-relays on beamcore.b1m.ai returning the list of orchestrator relay hotkeys. Documented in the subnet's own OpenAPI schema.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "url": "https://beamcore.b1m.ai/status/orchestrator-relays"
     }
   ],
   "website_url": "https://b1m.ai/"


### PR DESCRIPTION
## Summary
- First maintainer review of SN105 Beam. Correct `source_repo` from a generic Beam-Network org repositories-listing page to the specific `Beam-Network/beam` repo already cited throughout the file's existing surfaces. Add website + source-repo surfaces.
- Diff the 53-path BeamCore OpenAPI schema and live-test every no-param candidate: the schema declares no security on all 53 paths, but most are actually 401-gated in practice (`auth/me`, `auth/keys`, `clients`, `destinations`, `transfers`, several orchestrator/validator/jobs routes) — a schema-authoring artifact, not reality. Only 2 genuinely public routes were promoted (`validators/orchestrators`, `status/orchestrator-relays`).

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check registry/subnets/beam.json registry/reviews/maintainer-reviewed.json`