### PR TITLE
fix(ui): add copy button to the blocks Events hotkey without inflating rows

### DIFF
--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -418,14 +418,17 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                       </td>
                       <td className="px-4 py-2.5 font-mono text-[11px] text-ink">
                         {event.hotkey ? (
-                          <Link
-                            to="/accounts/$ss58"
-                            params={{ ss58: event.hotkey }}
-                            className="hover:underline"
-                            title={event.hotkey}
-                          >
-                            {shortHash(event.hotkey, 10)}
-                          </Link>
+                          <div className="flex items-center gap-1.5">
+                            <Link
+                              to="/accounts/$ss58"
+                              params={{ ss58: event.hotkey }}
+                              className="hover:underline"
+                              title={event.hotkey}
+                            >
+                              {shortHash(event.hotkey, 10)}
+                            </Link>
+                            <CopyButton value={event.hotkey} label="hotkey" className="-my-3.5" />
+                          </div>
                         ) : (
                           "—"
                         )}


### PR DESCRIPTION
Closes #5860

`blocks.$ref.tsx`'s "Events" section rendered its hotkey column as a tooltip-only `title=` link, while the same file's "Chain events" section already pairs its value with a `CopyButton`. This adds one to the Events hotkey to match.

The shared `CopyButton` carries a 44px touch target, so dropped in as-is it would inflate the row. It's given `-my-3.5` so the button keeps its full 44px hit area while the row height is unchanged (measured 37px → 37px on `/blocks/8632500`, which has hotkey-bearing events). Same approach that landed in #6160 and #6166.

Captured at the Phase C2 matrix — fixed viewports (375×812 / 768×1024 / 1280×800), each theme forced via `mg-theme`, on `/blocks/8632500`.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5860/5860-after-mobile-dark.png)<br><sub>after</sub> |

### Verification

`prettier` clean · `eslint` 0 errors · `tsc --noEmit` 0 · `vitest` 1010/1010 passing (128 files). The zero row-height delta was measured in the browser via `getBoundingClientRect()` with the button toggled on/off.
