### PR TITLE
feat(registry): SN108 TalkHead accuracy pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1447,6 +1447,18 @@
       "notes": "Elevated from the provenance review queue (#1235): a live subnet-api is hosted on this subnet's on-chain-asserted domain (theminos.ai, Subtensor SubnetIdentitiesV3). Maintainer-confirmed."
     },
     {
+      "netuid": 108,
+      "slug": "sn-108",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-07-16T00:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://www.talkhead.ai/",
+        "https://github.com/talkheadai/talkhead-subnet"
+      ],
+      "notes": "Root->128 accuracy audit pass (#5903): first maintainer review for SN108. Added website + source-repo surfaces and fixed 3 missing probe blocks. No OpenAPI/Swagger schema or additional API routes found."
+    },
+    {
       "netuid": 109,
       "slug": "sn-109",
       "decision": "maintainer-reviewed",

--- a/registry/subnets/talkhead.json
+++ b/registry/subnets/talkhead.json
@@ -4,10 +4,23 @@
   "name": "TalkHead",
   "slug": "sn-108",
   "status": "active",
-  "categories": [],
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-source-repo",
+    "official-website"
+  ],
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "gap_notes": [
+      "No verified official docs URL yet.",
+      "No verified machine-readable OpenAPI/Swagger schema yet -- api.talkhead.ai/openapi.json and /docs both 404.",
+      "No verified SSE/event stream yet."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-07-16T00:00:00.000Z",
+    "source_count": 4,
+    "verified_at": "2026-07-16T00:00:00.000Z"
   },
   "social": {
     "x": "https://x.com/talkheadai"
@@ -20,6 +33,12 @@
       "kind": "subnet-api",
       "name": "TalkHead API health",
       "notes": "Public no-auth GET /health on api.talkhead.ai returning application liveness (observed plain-text response: Healthy). Served on the TalkHead subnet API host documented in the talkhead-subnet repository README for miner and validator submission flows.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "talkhead",
       "public_safe": true,
       "review": {
@@ -39,6 +58,12 @@
       "kind": "data-artifact",
       "name": "TalkHead minimum compute requirements",
       "notes": "Public no-auth YAML miner and validator minimum hardware specification published at the root of the official talkheadai/talkhead-executor repository as min_compute.yml. Documents baseline CPU, GPU (10GB+ VRAM, CUDA 8.6+), memory, storage, OS, and bandwidth floors for SN108 TalkHead talking-head model evaluation. Linked from the talkhead-subnet README as the official executor/scoring repo.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "talkhead",
       "public_safe": true,
       "review": {
@@ -58,6 +83,12 @@
       "kind": "dashboard",
       "name": "TalkHead validator W&B dashboard",
       "notes": "Public Weights & Biases project for SN108 TalkHead validator runs (entity talkhead-ai, project talkhead-subnet; 650+ logged runs). Declared as the subnet's default W&B target in the official talkheadai/talkhead-subnet config.py (WANDB_ENTITY_DEFAULT = 'talkhead-ai', WANDB_PROJECT_NAME_DEFAULT = 'talkhead-subnet', netuid = 108). Publicly readable, no auth.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "talkhead",
       "public_safe": true,
       "review": {
@@ -68,9 +99,46 @@
         "https://github.com/talkheadai/talkhead-subnet/blob/main/config.py"
       ],
       "url": "https://wandb.ai/talkhead-ai/talkhead-subnet"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-108-talkhead-website",
+      "kind": "website",
+      "name": "TalkHead website",
+      "notes": "Official SN108 TalkHead website -- verified live 2026-07-16.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "talkhead",
+      "public_safe": true,
+      "source_urls": ["https://github.com/talkheadai/talkhead-subnet"],
+      "url": "https://www.talkhead.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-108-talkhead-source-repo",
+      "kind": "source-repo",
+      "name": "TalkHead source repository",
+      "notes": "Official SN108 TalkHead source repository -- verified live 2026-07-16.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "talkhead",
+      "public_safe": true,
+      "source_urls": ["https://github.com/talkheadai/talkhead-subnet"],
+      "url": "https://github.com/talkheadai/talkhead-subnet"
     }
   ],
   "source_repo": "https://github.com/talkheadai/talkhead-subnet",
   "website_url": "https://www.talkhead.ai/",
-  "contact": "contact@talkhead.ai"
+  "contact": "contact@talkhead.ai",
+  "notes": "First maintainer review for SN108. Added website + source-repo surfaces (previously only cited via top-level fields) and fixed 3 missing probe blocks on the existing surfaces. No OpenAPI/Swagger schema or additional API routes found."
 }


### PR DESCRIPTION
## Summary
- First maintainer review of SN108 TalkHead. Add website + source-repo surfaces (previously only cited via top-level fields) and fix 3 missing probe blocks — systemic gap #5932.
- No OpenAPI/Swagger schema or additional API routes found beyond the existing health endpoint.

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check registry/subnets/talkhead.json registry/reviews/maintainer-reviewed.json`