### PR TITLE
fix(ui): wire onRetry into account-history-chart's ErrorState

### DIFF
--- a/apps/ui/src/components/metagraphed/account-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-history-chart.tsx
@@ -118,7 +118,7 @@ function hoverLabel(day: AccountHistorySeriesDay, scope: Scope): string {
 
 export function AccountHistoryChart({ ss58 }: { ss58: string }) {
   const [scope, setScope] = useState<Scope>("all");
-  const { data, isLoading, isError, error } = useQuery(
+  const { data, isLoading, isError, error, refetch } = useQuery(
     accountHistoryQuery(ss58, { limit: DEFAULT_HISTORY_LIMIT }),
   );
 
@@ -151,7 +151,7 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
   }
 
   if (isError) {
-    return <ErrorState error={error} context="account history" />;
+    return <ErrorState error={error} context="account history" onRetry={() => refetch()} />;
   }
 
   if (days.length === 0 || scopedDays.length === 0) {


### PR DESCRIPTION
## Summary

`AccountHistoryChart` (`apps/ui/src/components/metagraphed/account-history-chart.tsx`) rendered `<ErrorState error={error} context="account history" />` with **no retry button** — unlike every other `ErrorState` call site in the app (`resource-explorer.tsx`, `blocks.$ref.tsx`, `explorer.tsx`), all of which pass `onRetry` wired to `refetch()`. This component renders on the high-traffic `accounts.$ss58` page.

## Fix

Destructure `refetch` from the existing `useQuery` call and pass `onRetry={() => refetch()}` to the `ErrorState`, matching the established pattern. A user hitting a transient error on the account history chart can now retry in place, consistent with every other chart/panel error state.

`ErrorState` already accepts `onRetry?: () => void` (`states.tsx`), so this is a type-safe two-line wiring; eslint + prettier clean.

Closes #5862