### PR TITLE
fix(ui): show ErrorState (not EmptyState) on a failed history-chart fetch

### DIFF
--- a/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { accountPositionHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { AccountPositionHistoryPoint } from "@/lib/metagraphed/types";
@@ -30,7 +30,9 @@ function yieldStr(v?: number) {
  * this position has no history yet (e.g. a freshly-registered neuron). */
 export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; netuid: number }) {
   const [win, setWin] = useState<Win>("90d");
-  const { data: res, isLoading } = useQuery(accountPositionHistoryQuery(ss58, netuid, win));
+  const { data: res, isLoading, isError, error, refetch } = useQuery(
+    accountPositionHistoryQuery(ss58, netuid, win),
+  );
   const points = useMemo<AccountPositionHistoryPoint[]>(
     () => res?.data?.points ?? [],
     [res?.data?.points],
@@ -79,6 +81,8 @@ export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; ne
       <div className="flex items-center justify-end">{windowSelector}</div>
       {isLoading ? (
         <Skeleton className="h-32 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} context="account position history" onRetry={() => refetch()} />
       ) : !hasData ? (
         <EmptyState
           title="No history yet"

--- a/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { subnetNeuronHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetNeuronHistoryPoint } from "@/lib/metagraphed/types";
 
@@ -22,7 +22,9 @@ function scoreStr(v?: number) {
  */
 export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: number }) {
   const [win, setWin] = useState<Win>("90d");
-  const { data: res, isLoading } = useQuery(subnetNeuronHistoryQuery(netuid, uid, win));
+  const { data: res, isLoading, isError, error, refetch } = useQuery(
+    subnetNeuronHistoryQuery(netuid, uid, win),
+  );
   const points = useMemo<SubnetNeuronHistoryPoint[]>(
     () => res?.data?.points ?? [],
     [res?.data?.points],
@@ -79,6 +81,8 @@ export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: numbe
       </div>
       {isLoading ? (
         <Skeleton className="h-32 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} context="neuron history" onRetry={() => refetch()} />
       ) : !hasData ? (
         <EmptyState
           title="No per-UID history"

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
@@ -20,7 +20,9 @@ const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
  */
 export function SubnetHistoryChart({ netuid }: { netuid: number }) {
   const [win, setWin] = useState<Win>("90d");
-  const { data: res, isLoading } = useQuery(subnetHistoryQuery(netuid, win));
+  const { data: res, isLoading, isError, error, refetch } = useQuery(
+    subnetHistoryQuery(netuid, win),
+  );
   const points = useMemo<SubnetHistoryPoint[]>(() => res?.data?.points ?? [], [res?.data?.points]);
 
   const series = useMemo(() => {
@@ -72,6 +74,8 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
       <div className="flex items-center justify-end">{windowSelector}</div>
       {isLoading ? (
         <Skeleton className="h-32 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} context="subnet history" onRetry={() => refetch()} />
       ) : !hasData ? (
         <EmptyState
           title="No on-chain history"

--- a/apps/ui/src/components/metagraphed/validator-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/validator-history-chart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { validatorHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { ValidatorHistoryPoint } from "@/lib/metagraphed/types";
@@ -29,7 +29,9 @@ function rewardsStr(v?: number) {
  * the validator has no history yet (e.g. a freshly-registered hotkey). */
 export function ValidatorHistoryChart({ hotkey }: { hotkey: string }) {
   const [win, setWin] = useState<Win>("90d");
-  const { data: res, isLoading } = useQuery(validatorHistoryQuery(hotkey, win));
+  const { data: res, isLoading, isError, error, refetch } = useQuery(
+    validatorHistoryQuery(hotkey, win),
+  );
   const points = useMemo<ValidatorHistoryPoint[]>(
     () => res?.data?.points ?? [],
     [res?.data?.points],
@@ -77,6 +79,8 @@ export function ValidatorHistoryChart({ hotkey }: { hotkey: string }) {
       <div className="flex items-center justify-end">{windowSelector}</div>
       {isLoading ? (
         <Skeleton className="h-32 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} context="validator history" onRetry={() => refetch()} />
       ) : !hasData ? (
         <EmptyState
           title="No history yet"


### PR DESCRIPTION
## Summary

`NeuronHistoryChart`, `ValidatorHistoryChart`, `SubnetHistoryChart`, and `AccountPositionHistoryChart` each destructured only `{ data, isLoading }` from their `useQuery` — no `isError`. When the API request actually fails, `data` stays `undefined`, `points` is empty, and the component renders its `EmptyState` ("no data yet"), **misrepresenting a real fetch failure as an absence of data**. These render on `subnets.$netuid`, `accounts.$ss58`, and `validators.$hotkey`.

## Fix

In each of the 4 files, destructure `isError`, `error`, `refetch` and add an `ErrorState` branch (with `onRetry={() => refetch()}`) between the loading and empty-data branches — matching the already-correct sibling `account-history-chart.tsx`. Loading and success rendering are unchanged.

Final branch order per chart: `isLoading` → `Skeleton`, `isError` → `ErrorState`, empty → `EmptyState`, else the chart. A genuine API failure now shows a real error state with retry, not a misleading "no data yet".

`ErrorState` already accepts `onRetry?: () => void` (`states.tsx`); tsc + eslint + prettier clean on all 4 files.

Closes #5863