### PR TITLE
feat(registry): SN112 Minotaur accuracy pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1494,6 +1494,19 @@
       "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/oneoneone.json (reviewed_at 2026-06-08T10:35:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
     },
     {
+      "netuid": 112,
+      "slug": "sn-112",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-07-16T00:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://minotaursubnet.com/",
+        "https://github.com/subnet112/minotaur_subnet",
+        "https://api.minotaursubnet.com/health"
+      ],
+      "notes": "Root->128 accuracy audit pass (#5903): first maintainer review for SN112. Added website + source-repo surfaces, fixed 3 missing probe blocks. Read the app-management API doc and added 2 new no-param surfaces (v1/chains, v1/apps/); the other documented reads are all path-parameterized."
+    },
+    {
       "netuid": 113,
       "slug": "sn-113",
       "decision": "maintainer-reviewed",

--- a/registry/subnets/minotaur.json
+++ b/registry/subnets/minotaur.json
@@ -4,10 +4,23 @@
   "name": "minotaur",
   "slug": "sn-112",
   "status": "active",
-  "categories": [],
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-source-repo",
+    "official-website"
+  ],
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "gap_notes": [
+      "No verified machine-readable OpenAPI/Swagger schema yet -- api.minotaursubnet.com/openapi.json and /docs both 404.",
+      "No verified SSE/event stream yet.",
+      "The app-management API doc describes several genuinely public reads (v1/apps/{app_id}/status, /admin-state, /auth-nonce) that are all path-parameterized, not bare no-param routes -- not promoted as their own surfaces."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-07-16T00:00:00.000Z",
+    "source_count": 5,
+    "verified_at": "2026-07-16T00:00:00.000Z"
   },
   "social": {
     "x": "https://x.com/minotaursubnet"
@@ -20,6 +33,12 @@
       "kind": "subnet-api",
       "name": "Minotaur API health",
       "notes": "Public no-auth GET /health on api.minotaursubnet.com returning application liveness JSON (observed: {\"status\":\"ok\",\"service\":\"app-intents-api\"}). Documented as the production API health probe in the official minotaur_subnet check_validator.sh script and served on the SN112 API host listed in docs/operator/network-reference.md.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "minotaur",
       "public_safe": true,
       "review": {
@@ -39,6 +58,12 @@
       "kind": "data-artifact",
       "name": "Minotaur operator network reference",
       "notes": "Public no-auth Markdown operator network reference (netuid 112, finney subtensor endpoint, production API host, mainnet contract addresses on Base and BT EVM, quorum targets) published in the official subnet112/minotaur_subnet repository at docs/operator/network-reference.md. Documented as the authoritative operator network reference and cited by scripts/check_validator.sh for ValidatorRegistry configuration.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "minotaur",
       "public_safe": true,
       "review": {
@@ -58,6 +83,12 @@
       "kind": "dashboard",
       "name": "Minotaur App dashboard",
       "notes": "Public no-auth Minotaur App web dashboard for SN112 (intent signing + quorum settlement), served on the official minotaursubnet.com domain (same host as the registered api.minotaursubnet.com health surface) and linked from the official docs at docs.minotaursubnet.com. Document title 'Minotaur App — Sign intents. Settle through quorum.'; wallet actions require signing but the dashboard itself loads without auth (verified HTTP 200).",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "minotaur",
       "public_safe": true,
       "review": {
@@ -69,8 +100,93 @@
         "https://github.com/subnet112/minotaur_subnet"
       ],
       "url": "https://app.minotaursubnet.com"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-112-minotaur-website",
+      "kind": "website",
+      "name": "Minotaur website",
+      "notes": "Official SN112 Minotaur website -- verified live 2026-07-16.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "minotaur",
+      "public_safe": true,
+      "source_urls": ["https://github.com/subnet112/minotaur_subnet"],
+      "url": "https://minotaursubnet.com/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-112-minotaur-source-repo",
+      "kind": "source-repo",
+      "name": "Minotaur source repository",
+      "notes": "Official SN112 Minotaur source repository -- verified live 2026-07-16.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "minotaur",
+      "public_safe": true,
+      "source_urls": ["https://github.com/subnet112/minotaur_subnet"],
+      "url": "https://github.com/subnet112/minotaur_subnet"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-112-minotaur-chains",
+      "kind": "data-artifact",
+      "name": "Minotaur chain registry addresses",
+      "notes": "Public no-auth GET /v1/chains on api.minotaursubnet.com returning per-chain registry contract addresses (chain_id, name, rpc_available, registry_address, app_registry_address) for Ethereum, Base, and BT EVM. Documented in the app-management API reference (docs/api/app-management.md).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minotaur",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://github.com/subnet112/minotaur_subnet/blob/develop/docs/api/app-management.md"
+      ],
+      "url": "https://api.minotaursubnet.com/v1/chains"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-112-minotaur-apps-list",
+      "kind": "subnet-api",
+      "name": "Minotaur deployed apps list",
+      "notes": "Public no-auth GET /v1/apps/ on api.minotaursubnet.com returning the list of deployed intent-processing apps, each carrying a per-chain deployments map and source (JS scoring module + Solidity). Documented in the app-management API reference (docs/api/app-management.md) as an intentionally open read.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "minotaur",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://github.com/subnet112/minotaur_subnet/blob/develop/docs/api/app-management.md"
+      ],
+      "url": "https://api.minotaursubnet.com/v1/apps/"
     }
   ],
   "source_repo": "https://github.com/subnet112/minotaur_subnet",
-  "website_url": "https://minotaursubnet.com/"
+  "website_url": "https://minotaursubnet.com/",
+  "notes": "First maintainer review for SN112. Added website + source-repo surfaces (previously only cited via top-level fields) and fixed 3 missing probe blocks on the existing surfaces. Read the official app-management API doc and added 2 new no-param surfaces (v1/chains, v1/apps/); the other documented reads (status, admin-state, auth-nonce) are all path-parameterized, not bare routes."
 }


### PR DESCRIPTION
## Summary
- First maintainer review of SN112 Minotaur. Add website + source-repo surfaces (previously only cited via top-level fields) and fix 3 missing probe blocks — systemic gap #5932.
- Read the official app-management API doc and add 2 new no-param surfaces: `v1/chains` (per-chain registry contract addresses) and `v1/apps/` (public deployed-app listing). The doc's other public reads (`status`, `admin-state`, `auth-nonce`) are all path-parameterized, not bare no-param routes.

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check registry/subnets/minotaur.json registry/reviews/maintainer-reviewed.json`