### PR TITLE
fix(tests): restore real drift-detection for docs-content constants

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -3105,8 +3105,10 @@ export function maxComplexityRule(max) {
 
 // --- Pagination ---
 
-const DEFAULT_PAGE_LIMIT = 20;
-const MAX_PAGE_LIMIT = 100;
+// Exported so tests/docs-content-drift.test.mjs can assert
+// content/docs/graphql.mdx documents the real values.
+export const DEFAULT_PAGE_LIMIT = 20;
+export const MAX_PAGE_LIMIT = 100;
 
 function paginate(items, limit, cursor, keyFn) {
   // A missing/blank/<1 limit falls back to the default — it must NOT clamp UP to

--- a/tests/docs-content-drift.test.mjs
+++ b/tests/docs-content-drift.test.mjs
@@ -1,0 +1,182 @@
+// Real cross-checking for the numbers hand-written into apps/ui's Fumadocs
+// content pages -- imports the actual Worker constants those pages describe
+// and asserts the documented values against them, rather than a second
+// hardcoded copy. Replaces the pre-Fumadocs-migration graphql-docs.test.ts /
+// rpc-docs.test.ts, which only asserted a docs-only TS module against a
+// second literal in the same test file -- self-consistent, never touching
+// the real Worker source. See docs/migration discussion on issue #1652.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  DEFAULT_PAGE_LIMIT,
+  FIELD_COMPLEXITY,
+  GRAPHQL_MAX_BODY_BYTES,
+  GRAPHQL_MAX_COMPLEXITY,
+  GRAPHQL_MAX_DEPTH,
+  GRAPHQL_MAX_QUERY_BYTES,
+  MAX_PAGE_LIMIT,
+} from "../src/graphql.mjs";
+import {
+  DENIED_RPC_PREFIXES,
+  MAX_RPC_BODY_BYTES,
+  MAX_STATE_QUERY_KEYS_PAGE_SIZE,
+  MAX_STATE_QUERY_RESPONSE_BYTES,
+  SAFE_RPC_METHODS,
+  SAFE_RPC_STATE_QUERY_METHODS,
+} from "../workers/config.mjs";
+import {
+  RPC_MAX_ATTEMPTS,
+  RPC_PROXY_POOLS,
+  RPC_RATE_LIMIT,
+  STATE_QUERY_RATE_LIMIT,
+} from "../workers/request-handlers/rpc-proxy.mjs";
+
+const graphqlDocs = readFileSync("apps/ui/content/docs/graphql.mdx", "utf8");
+const rpcDocs = readFileSync("apps/ui/content/docs/rpc.mdx", "utf8");
+const chainEventsDocs = readFileSync(
+  "apps/ui/content/docs/chain-events.mdx",
+  "utf8",
+);
+const wranglerConfig = readFileSync("wrangler.jsonc", "utf8");
+
+/** Extracts a markdown table row's "Value" cell (2nd column) by its exact "Label" cell text. */
+function tableValue(text, label) {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^\\|\\s*${escaped}\\s*\\|\\s*([^|]+?)\\s*\\|`, "m");
+  const match = text.match(re);
+  assert.ok(match, `No table row found for "${label}"`);
+  return match[1].trim();
+}
+
+/** Mirrors the deleted graphql-docs.ts/rpc-docs.ts formatByteBudget helpers. */
+function formatBytes(bytes) {
+  if (bytes % 1024 === 0) return `${bytes / 1024} KiB`;
+  return `${bytes} B`;
+}
+
+/** Extracts a JSONC ratelimit binding's {limit, period} by its "name". */
+function wranglerRateLimit(name) {
+  const re = new RegExp(
+    `"name":\\s*"${name}"[\\s\\S]*?"limit":\\s*(\\d+),[\\s\\S]*?"period":\\s*(\\d+),`,
+  );
+  const match = wranglerConfig.match(re);
+  assert.ok(
+    match,
+    `No ratelimit binding found for "${name}" in wrangler.jsonc`,
+  );
+  return { limit: Number(match[1]), period: Number(match[2]) };
+}
+
+describe("content/docs/graphql.mdx matches src/graphql.mjs", () => {
+  test("limits table", () => {
+    assert.equal(
+      tableValue(graphqlDocs, "Max depth"),
+      String(GRAPHQL_MAX_DEPTH),
+    );
+    assert.equal(
+      tableValue(graphqlDocs, "Max complexity"),
+      String(GRAPHQL_MAX_COMPLEXITY),
+    );
+    assert.equal(
+      tableValue(graphqlDocs, "Max POST body"),
+      formatBytes(GRAPHQL_MAX_BODY_BYTES),
+    );
+    assert.equal(
+      tableValue(graphqlDocs, "Max query document"),
+      formatBytes(GRAPHQL_MAX_QUERY_BYTES),
+    );
+    const pageSize = tableValue(graphqlDocs, "Page size");
+    assert.match(pageSize, new RegExp(`${DEFAULT_PAGE_LIMIT}\\s*default`));
+    assert.match(pageSize, new RegExp(`${MAX_PAGE_LIMIT}\\s*max`));
+    const rateLimit = tableValue(graphqlDocs, "Rate limit");
+    assert.equal(
+      rateLimit,
+      `${RPC_RATE_LIMIT.limit} / ${RPC_RATE_LIMIT.windowSeconds}s`,
+    );
+  });
+
+  test("relationship-field complexity cost", () => {
+    // FIELD_COMPLEXITY.subnets is one of several relationship roots that all
+    // share the same weight -- see src/graphql.mjs's RELATIONSHIP_FIELD_COMPLEXITY.
+    assert.match(
+      graphqlDocs,
+      new RegExp(`relationship roots cost ${FIELD_COMPLEXITY.subnets}`),
+    );
+  });
+});
+
+describe("content/docs/rpc.mdx matches workers/config.mjs + rpc-proxy.mjs", () => {
+  test("limits table", () => {
+    assert.equal(
+      tableValue(rpcDocs, "Rate limit"),
+      `${RPC_RATE_LIMIT.limit} / ${RPC_RATE_LIMIT.windowSeconds}s`,
+    );
+    assert.equal(
+      tableValue(rpcDocs, "State-query rate"),
+      `${STATE_QUERY_RATE_LIMIT.limit} / ${STATE_QUERY_RATE_LIMIT.windowSeconds}s`,
+    );
+    assert.equal(
+      tableValue(rpcDocs, "Max POST body"),
+      formatBytes(MAX_RPC_BODY_BYTES),
+    );
+    assert.equal(
+      tableValue(rpcDocs, "Max state-query response"),
+      formatBytes(MAX_STATE_QUERY_RESPONSE_BYTES),
+    );
+    assert.equal(
+      tableValue(rpcDocs, "`state_getKeysPaged` page"),
+      String(MAX_STATE_QUERY_KEYS_PAGE_SIZE),
+    );
+    assert.equal(
+      tableValue(rpcDocs, "Failover attempts"),
+      String(RPC_MAX_ATTEMPTS),
+    );
+  });
+
+  test("network names", () => {
+    for (const network of Object.keys(RPC_PROXY_POOLS)) {
+      assert.match(rpcDocs, new RegExp(`\`${network}\``));
+    }
+  });
+
+  test("safe methods", () => {
+    for (const method of SAFE_RPC_METHODS) {
+      assert.match(
+        rpcDocs,
+        new RegExp(`\`${method}\``),
+        `missing safe method ${method}`,
+      );
+    }
+  });
+
+  test("state-query methods", () => {
+    for (const method of SAFE_RPC_STATE_QUERY_METHODS) {
+      assert.match(
+        rpcDocs,
+        new RegExp(`\`${method}\``),
+        `missing state-query method ${method}`,
+      );
+    }
+  });
+
+  test("denied prefixes", () => {
+    for (const prefix of DENIED_RPC_PREFIXES) {
+      assert.match(
+        rpcDocs,
+        new RegExp(`\`${prefix}\``),
+        `missing denied prefix ${prefix}`,
+      );
+    }
+  });
+});
+
+describe("content/docs/chain-events.mdx matches its rate-limit binding", () => {
+  test("rate limit mirrors wrangler.jsonc's DATA_RATE_LIMITER", () => {
+    // handleChainEventsProxy (workers/api.mjs) has no local mirror constant --
+    // env.DATA_RATE_LIMITER is read directly, so the binding config itself is
+    // the only source of truth to check the docs against.
+    const { limit, period } = wranglerRateLimit("DATA_RATE_LIMITER");
+    assert.match(chainEventsDocs, new RegExp(`${limit} requests / ${period}s`));
+  });
+});

--- a/workers/request-handlers/rpc-proxy.mjs
+++ b/workers/request-handlers/rpc-proxy.mjs
@@ -683,12 +683,14 @@ export async function handleRpcProxyRequest(request, env, url, ctx = {}) {
   return new Response(response.body, { status: response.status, headers });
 }
 
-const RPC_MAX_ATTEMPTS = 3;
+// Exported so tests/docs-content-drift.test.mjs can assert content/docs/rpc.mdx
+// documents the real values instead of a second hand-copied literal.
+export const RPC_MAX_ATTEMPTS = 3;
 const RPC_ATTEMPT_TIMEOUT_MS = 6000;
 const RPC_CLASSIFY_BODY_LIMIT_BYTES = 64 * 1024;
 // /rpc/v1/{network} → the pool id served from rpc/pools.json. Adding a network
 // here (plus its pool + allowlisted origins) is all the proxy needs to serve it.
-const RPC_PROXY_POOLS = { finney: "finney-rpc", test: "test-rpc" };
+export const RPC_PROXY_POOLS = { finney: "finney-rpc", test: "test-rpc" };
 // Max blocks an endpoint may trail the freshest reported tip before the proxy
 // demotes it behind synced nodes. Bittensor block time is ~12s, so ~10 blocks
 // (~15 min) tolerates cross-provider probe-timing skew while still routing around
@@ -851,11 +853,12 @@ function streamRpcResponse(upstream, endpoint, attempts, status) {
 // Advisory rate-limit headers on RPC proxy responses. The Cloudflare rate-limit
 // binding (RPC_RATE_LIMITER) only returns {success}, so an exact remaining/reset
 // is unavailable — we surface the static policy (mirrors wrangler.jsonc:
-// 100 requests / 60s) plus Retry-After on a 429.
-const RPC_RATE_LIMIT = { limit: 100, windowSeconds: 60 };
+// 100 requests / 60s) plus Retry-After on a 429. Exported (see
+// RPC_MAX_ATTEMPTS above) for the docs-content drift test.
+export const RPC_RATE_LIMIT = { limit: 100, windowSeconds: 60 };
 // Mirrors wrangler.jsonc's STATE_QUERY_RATE_LIMITER binding (#4344/9.2) --
 // a fifth of the general proxy's budget, its own separate bucket.
-const STATE_QUERY_RATE_LIMIT = { limit: 20, windowSeconds: 60 };
+export const STATE_QUERY_RATE_LIMIT = { limit: 20, windowSeconds: 60 };
 function setRpcRateLimitHeaders(headers) {
   headers.set("x-ratelimit-limit", String(RPC_RATE_LIMIT.limit));
   headers.set(


### PR DESCRIPTION
## Summary

- Fumadocs migration (#6149/#6158/#6168) deleted `graphql-docs.test.ts`/`rpc-docs.test.ts`/`feeds-docs.test.ts` along with the old hand-rolled routes, leaving zero coverage checking the numbers hand-written into `content/docs/{graphql,rpc,chain-events}.mdx` against the real Worker constants they describe.
- Those deleted tests never actually caught drift in the first place — they only asserted a docs-only TS module against a second hardcoded literal in the same test file, never touching `src/graphql.mjs`/`workers/**` directly.
- Adds `tests/docs-content-drift.test.mjs`, which imports the real constants (`src/graphql.mjs`, `workers/config.mjs`, `workers/request-handlers/rpc-proxy.mjs`, and `wrangler.jsonc`'s rate-limiter bindings for `chain-events`, which has no local JS mirror) and asserts the MDX tables/prose against them directly.
- Exports a handful of previously-private constants (`DEFAULT_PAGE_LIMIT`, `MAX_PAGE_LIMIT`, `RPC_MAX_ATTEMPTS`, `RPC_PROXY_POOLS`, `RPC_RATE_LIMIT`, `STATE_QUERY_RATE_LIMIT`) needed for the cross-check — no behavior changes.

Verified the test has real teeth: deliberately mutated `graphql.mdx`'s "Max depth" table cell and confirmed the new test fails with a real mismatch before reverting.

## Test plan

- [x] `npx prettier --check` clean on all changed files
- [x] `npm run test:ci` — `docs-content-drift.test.mjs` passes 8/8; only failure is the pre-existing, unrelated `validate-surface-duplicate-url.test.mjs` flakiness (confirmed via `git stash` — same failure reproduces on unmodified `main`)