### PR TITLE
fix: rename manifest file to .loopover.yml, backfill live settings

### DIFF
--- a/.loopover.yml
+++ b/.loopover.yml
@@ -58,6 +58,12 @@ gate:
 settings:
   reviewEvasionProtection: close
 
+  # Config-as-code backfill (#6442): carries this repo's existing effective values forward now that
+  # these fields are moving off the dashboard's repository_settings row and onto config-as-code.
+  commentMode: all_prs
+  checkRunDetailLevel: standard
+  includeMaintainerAuthors: true
+
   # Linked-issue label propagation (#4000): a PR closing an issue inherits that issue's point-bearing
   # gittensor:* label, instead of the PR's own label being decided purely by commit-title regex. Mirrors
   # the block already live on JSONbored/gittensory (#3903). bug/feature trust a maintainer-authored linked


### PR DESCRIPTION
## Summary

- This repo's manifest file was still named \`.gittensory.yml\`, but the review engine's manifest-file candidate list only tries \`.loopover.yml\` / \`.github/loopover.yml\` / \`.loopover.json\` / \`.github/loopover.json\` post-rename. Confirmed via the engine's own \`fetchRepoFocusManifestFile\` candidate loop -- every candidate 404s for this repo, so the whole custom manifest (wantedPaths, blockedPaths, \`gate.aiJudgmentBlockers: gate\`, linkedIssueLabelPropagation, reviewEvasionProtection) has been silently inert since the rename, falling back to hardcoded engine defaults instead of this repo's real policy.
- Renames \`.gittensory.yml\` -> \`.loopover.yml\` (content otherwise unchanged) so it's actually read again.
- Backfills this repo's current dashboard-configured \`commentMode: all_prs\`, \`checkRunDetailLevel: standard\`, and \`includeMaintainerAuthors: true\` into \`settings:\`, ahead of those fields moving off the dashboard DB entirely (loopover#6442).

## Validation
- [x] YAML syntax validated (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- [x] Content diff is a rename + additive settings only -- no other manifest content changed