### PR TITLE
fix(registry): SN114 SOMA accuracy re-review pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1522,7 +1522,7 @@
       "netuid": 114,
       "slug": "sn-114",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-08T19:30:00.000Z",
+      "reviewed_at": "2026-07-16T00:00:00.000Z",
       "confidence": "high",
       "source_urls": [
         "https://thesoma.ai/",
@@ -1532,7 +1532,7 @@
         "https://github.com/DendriteHQ/SOMA",
         "https://github.com/Level114/level114-subnet"
       ],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/soma.json (reviewed_at 2026-06-08T19:30:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): fixed 2 missing probe blocks. Diffed the 46-path SOMA platform OpenAPI schema -- both the private and \"public\"-frontend-key route groups declare no security but are actually gated in practice (403 / 401); no new candidates promoted."
     },
     {
       "netuid": 115,

--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -18,18 +18,19 @@
       "Level114/level114-subnet is live from Tensorplex evidence but is not promoted as the primary source repository.",
       "Common docs, health, OpenAPI, Swagger JSON, and Swagger UI paths currently return 404.",
       "The /api path currently fails simple safe fetch probes and is not promoted.",
-      "No verified SSE/event stream yet."
+      "No verified SSE/event stream yet.",
+      "Diffed the 46-path SOMA platform OpenAPI schema for undiscovered public GET endpoints -- both the /api/private/frontend/* and /api/public/frontend-key/* route groups declare no security in the schema, but every no-param candidate in both groups is actually gated in practice (403 for private/frontend, 401 for public/frontend-key -- the \"public\" name is misleading, it still requires a frontend-key credential). No new candidates promoted."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T19:30:00.000Z",
+    "reviewed_at": "2026-07-16T00:00:00.000Z",
     "source_count": 8,
-    "verified_at": "2026-06-08T19:30:00.000Z"
+    "verified_at": "2026-07-16T00:00:00.000Z"
   },
   "dashboard_url": "https://thesoma.ai/dashboard",
   "name": "SOMA",
   "netuid": 114,
-  "notes": "Reviewed overlay for SN114 SOMA using the public SOMA website, dashboard, MCP/access surfaces, and DendriteHQ source repository. Common docs/API/health/OpenAPI/Swagger probe paths currently return 404 or transient fetch failures and are not promoted.",
+  "notes": "Reviewed overlay for SN114 SOMA using the public SOMA website, dashboard, MCP/access surfaces, and DendriteHQ source repository. Common docs/API/health/OpenAPI/Swagger probe paths currently return 404 or transient fetch failures and are not promoted. Root->128 accuracy audit re-review pass (#5903): fixed 2 missing probe blocks; diffed the 46-path platform OpenAPI schema, no new candidates promoted (both the private and \"public\"-named route groups are actually gated).",
   "schema_version": 1,
   "slug": "sn-114",
   "social": {
@@ -165,6 +166,12 @@
       "kind": "subnet-api",
       "name": "SOMA API health",
       "notes": "Public no-auth GET /api/health on thesoma.ai returning application liveness JSON. Served on the official SN114 website host registered in this manifest and linked from the DendriteHQ/SOMA source repository.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "soma",
       "public_safe": true,
       "review": {
@@ -184,6 +191,12 @@
       "kind": "openapi",
       "name": "SOMA platform OpenAPI schema",
       "notes": "Public no-auth OpenAPI 3.1 schema (title \"MCP-subnet\", 46 paths) for the SN114 SOMA platform API on platform.thesoma.ai. The official DendriteHQ/SOMA validator/.env.example sets NETUID=114 and PLATFORM_URL=https://platform.thesoma.ai, tying this host to the subnet; Swagger UI is served at /docs on the same host. Distinct from thesoma.ai website and /api/health surfaces.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "soma",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary
- Fix 2 missing probe blocks — systemic gap #5932.
- Diff the 46-path SOMA platform OpenAPI schema for undiscovered public GET endpoints. Both the `/api/private/frontend/*` and `/api/public/frontend-key/*` route groups declare no security in the schema, but every no-param candidate in both groups is actually gated in practice (403 for `private/frontend`, 401 for `public/frontend-key` — the "public" name is misleading, it still requires a frontend-key credential). No new candidates promoted.

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check registry/subnets/soma.json registry/reviews/maintainer-reviewed.json`