### PR TITLE
fix(registry): SN115 HashiChain accuracy re-review pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1538,10 +1538,10 @@
       "netuid": 115,
       "slug": "sn-115",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-08T10:50:00.000Z",
+      "reviewed_at": "2026-07-16T00:00:00.000Z",
       "confidence": "high",
       "source_urls": ["https://github.com/hashi115/hashichain"],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/hashichain.json (reviewed_at 2026-06-08T10:50:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): all 3 surfaces re-verified live, fixed 1 missing probe block. Still no verified website, docs, or first-party API."
     },
     {
       "netuid": 116,

--- a/registry/subnets/hashichain.json
+++ b/registry/subnets/hashichain.json
@@ -15,9 +15,9 @@
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T10:50:00.000Z",
+    "reviewed_at": "2026-07-16T00:00:00.000Z",
     "source_count": 4,
-    "verified_at": "2026-06-08T10:50:00.000Z"
+    "verified_at": "2026-07-16T00:00:00.000Z"
   },
   "dashboard_url": "https://taomarketcap.com/subnets/115",
   "name": "HashiChain",
@@ -81,6 +81,12 @@
       "kind": "data-artifact",
       "name": "HashiChain intro logo image",
       "notes": "Public no-auth PNG brand image published in the official hashi115/hashichain repository assets directory, referenced as the SN115 on-chain subnet logo in SubnetIdentitiesV3, and pinned to an immutable commit.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "hashichain",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary
- Re-verify all 3 SN115 HashiChain surfaces, fix 1 missing probe block on the logo data-artifact surface — systemic gap #5932.
- Still no verified website, docs, or first-party API.

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check registry/subnets/hashichain.json registry/reviews/maintainer-reviewed.json`