### PR TITLE
fix(registry): SN116 TaoLend accuracy re-review pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1547,10 +1547,10 @@
       "netuid": 116,
       "slug": "taolend",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-08T14:15:00.000Z",
+      "reviewed_at": "2026-07-16T00:00:00.000Z",
       "confidence": "high",
       "source_urls": ["https://taolend.io/"],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/taolend.json (reviewed_at 2026-06-08T14:15:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): fixed 1 missing probe block. On-chain identity has drifted again (now \"Memo\", previously \"hard_sign\") while the website/repo/community consistently identify SN116 as TaoLend -- the subnetName field looks unreliable for this subnet. Noted subnet_emission_enabled is currently false. Website still 500s (unchanged)."
     },
     {
       "netuid": 117,

--- a/registry/subnets/taolend.json
+++ b/registry/subnets/taolend.json
@@ -9,8 +9,9 @@
   ],
   "curation": {
     "gap_notes": [
-      "Native chain name currently reports as hard_sign; public directories identify SN116 as TaoLend.",
-      "Official website currently returns 500/server-error responses to simple probes and should appear degraded until it recovers.",
+      "Native chain name has continued to drift and now reports as \"Memo\" (previously \"hard_sign\" at the last review); public directories, the website, and the source repository all still identify SN116 consistently as TaoLend, so the on-chain SubnetIdentitiesV3 subnetName field looks unreliable for this subnet rather than a real rebrand.",
+      "subnet_emission_enabled is currently false per the TaoMarketCap snapshot -- worth re-checking on the next pass.",
+      "Official website currently still returns 500/server-error responses to simple probes (unchanged since the last review) and should appear degraded until it recovers.",
       "Previously discovered GitHub source repository currently returns 404.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
@@ -18,13 +19,13 @@
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T14:15:00.000Z",
+    "reviewed_at": "2026-07-16T00:00:00.000Z",
     "source_count": 6,
-    "verified_at": "2026-06-08T14:15:00.000Z"
+    "verified_at": "2026-07-16T00:00:00.000Z"
   },
   "name": "TaoLend",
   "netuid": 116,
-  "notes": "Reviewed overlay for SN116 TaoLend. Native chain identity currently reports hard_sign, while public subnet directories identify SN116 as TaoLend. The official website is tracked but currently returns server errors to simple probes. The previously discovered source repository currently returns 404 and is not promoted.",
+  "notes": "Reviewed overlay for SN116 TaoLend. Native chain identity has drifted again (now \"Memo\", previously \"hard_sign\"), while public subnet directories, the website, and the source repository all still identify SN116 as TaoLend. The official website is tracked but currently returns server errors to simple probes. The previously discovered source repository currently returns 404 and is not promoted. Root->128 accuracy audit re-review pass (#5903): fixed 1 missing probe block; noted subnet_emission_enabled is currently false.",
   "schema_version": 1,
   "slug": "taolend",
   "source_repo": null,
@@ -79,6 +80,12 @@
       "kind": "data-artifact",
       "name": "TaoLend contract and precompile constants",
       "notes": "Public no-auth TypeScript constants file from the official oxylok/116-taolend repository publishing SN116 TaoLend deployed LendingPoolV1 address (0xE41852a75e51812adA39C8D0aae18c7c59935C0d) and Bittensor EVM precompile addresses (metagraph, neuron, staking, alpha, subnet, balance transfer) used by the lending protocol CLI and validator.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "taolend",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary
- Fix 1 missing probe block — systemic gap #5932.
- On-chain identity has drifted again (now "Memo", previously "hard_sign" at the last review), while the website, source repo, and community all still identify SN116 consistently as TaoLend — the SubnetIdentitiesV3 `subnetName` field looks unreliable for this subnet rather than a real rebrand. Note `subnet_emission_enabled` is currently false. Website still returns 500 (unchanged since the last review).

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check registry/subnets/taolend.json registry/reviews/maintainer-reviewed.json`