### PR TITLE
fix(ui): source command palette docs entries from docsSource, not a hand-list

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -15,6 +15,7 @@ import {
   ArrowRightLeft,
   Bot,
   Braces,
+  BookOpen,
   Compass,
   Copy,
   ExternalLink,
@@ -40,6 +41,7 @@ import { searchQuery, semanticSearchQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
 import { isValidSs58 } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { getDocsNav } from "@/lib/docs-nav.functions";
 import {
   CommandDialog,
   CommandEmpty,
@@ -70,13 +72,31 @@ import {
   trackAction,
 } from "@/lib/metagraphed/palette-analytics";
 
-const ROUTE_INDEX: Array<{
+interface RouteEntry {
   label: string;
   to: string;
   hint?: string;
   icon: typeof Compass;
   scope: "route";
-}> = [
+}
+
+// Docs pages that want a bespoke icon instead of the generic BookOpen
+// fallback -- cosmetic only. Unlike the old hardcoded ROUTE_INDEX entries,
+// leaving a page out of this map never hides it from the palette (see
+// docsRoutes below), it just renders with the default icon.
+const DOCS_ICON_OVERRIDES: Record<string, typeof Compass> = {
+  "/docs/graphql": Braces,
+  "/docs/rpc": Zap,
+  "/docs/feeds": Rss,
+  "/docs/chain-events": History,
+};
+
+// Non-docs routes, in display order. The docs subset used to be hand-listed
+// here too, but that's exactly how /docs/chain-events silently went missing
+// from the palette for a while -- it's now sourced live via getDocsNav()
+// (see docsRoutes in CommandPaletteBody) and spliced in between "Schemas"
+// and "Gaps" below.
+const STATIC_ROUTES_HEAD: RouteEntry[] = [
   { label: "Home", to: "/", hint: "Registry overview", icon: Compass, scope: "route" },
   {
     label: "Subnets",
@@ -121,34 +141,9 @@ const ROUTE_INDEX: Array<{
     icon: FileJson,
     scope: "route",
   },
-  {
-    label: "GraphQL",
-    to: "/docs/graphql",
-    hint: "Schema, root queries, limits",
-    icon: Braces,
-    scope: "route",
-  },
-  {
-    label: "RPC",
-    to: "/docs/rpc",
-    hint: "Proxy, pools, endpoints, usage",
-    icon: Zap,
-    scope: "route",
-  },
-  {
-    label: "Feeds",
-    to: "/docs/feeds",
-    hint: "RSS, Atom, JSON Feed subscriptions",
-    icon: Rss,
-    scope: "route",
-  },
-  {
-    label: "Chain events reference",
-    to: "/docs/chain-events",
-    hint: "Deep-history all-events tier",
-    icon: History,
-    scope: "route",
-  },
+];
+
+const STATIC_ROUTES_TAIL: RouteEntry[] = [
   {
     label: "Gaps",
     to: "/gaps",
@@ -349,20 +344,48 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
     return map;
   }, [hits]);
 
+  // Docs pages -- fetched once per palette session (they're static content
+  // baked in at build time, so an Infinity staleTime is correct here, unlike
+  // the API-freshness-driven STALE_* constants used by the search queries
+  // above).
+  const { data: docsNav } = useQuery({
+    queryKey: ["docs-nav"],
+    queryFn: () => getDocsNav(),
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
+  const docsRoutes = useMemo<RouteEntry[]>(
+    () =>
+      (docsNav ?? []).map((page) => ({
+        label: page.title,
+        to: page.url,
+        hint: page.description || undefined,
+        icon: DOCS_ICON_OVERRIDES[page.url] ?? BookOpen,
+        scope: "route",
+      })),
+    [docsNav],
+  );
+
+  const allRoutes = useMemo<RouteEntry[]>(
+    () => [...STATIC_ROUTES_HEAD, ...docsRoutes, ...STATIC_ROUTES_TAIL],
+    [docsRoutes],
+  );
+
   const filteredRoutes = useMemo(() => {
     if (scope !== "all" && scope !== ("route" as SearchScope)) return [];
-    if (!debounced) return ROUTE_INDEX;
+    if (!debounced) return allRoutes;
     const n = debounced.toLowerCase();
-    return ROUTE_INDEX.filter(
-      (r) => r.label.toLowerCase().includes(n) || (r.hint ?? "").toLowerCase().includes(n),
-    ).sort((a, b) => {
-      const an = a.label.toLowerCase();
-      const bn = b.label.toLowerCase();
-      const ax = an === n ? 3 : an.startsWith(n) ? 2 : 1;
-      const bx = bn === n ? 3 : bn.startsWith(n) ? 2 : 1;
-      return bx - ax;
-    });
-  }, [debounced, scope]);
+    return allRoutes
+      .filter((r) => r.label.toLowerCase().includes(n) || (r.hint ?? "").toLowerCase().includes(n))
+      .sort((a, b) => {
+        const an = a.label.toLowerCase();
+        const bn = b.label.toLowerCase();
+        const ax = an === n ? 3 : an.startsWith(n) ? 2 : 1;
+        const bx = bn === n ? 3 : bn.startsWith(n) ? 2 : 1;
+        return bx - ax;
+      });
+  }, [debounced, scope, allRoutes]);
 
   const navigateTargets = useMemo(() => {
     if (!debounced) return [];

--- a/apps/ui/src/lib/docs-nav.functions.ts
+++ b/apps/ui/src/lib/docs-nav.functions.ts
@@ -1,0 +1,23 @@
+import { createServerFn } from "@tanstack/react-start";
+import { docsSource } from "@/lib/docs-source";
+
+export interface DocsNavEntry {
+  url: string;
+  title: string;
+  description: string;
+}
+
+// Flattened index of every content/docs/*.mdx page, sourced live from
+// docsSource rather than a hand-maintained list. The ⌘K command palette's
+// "Jump to" group is built from this so a new docs page shows up
+// automatically -- previously it relied on a hardcoded ROUTE_INDEX entry per
+// page, which is exactly how /docs/chain-events went missing from the
+// palette for a while after its route shipped.
+export const getDocsNav = createServerFn({ method: "GET" }).handler(
+  async (): Promise<DocsNavEntry[]> =>
+    docsSource.getPages().map((page) => ({
+      url: page.url,
+      title: page.data.title,
+      description: page.data.description ?? "",
+    })),
+);

--- a/apps/ui/tests/e2e/capture-command-palette-docs-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-command-palette-docs-screenshots.mjs
@@ -1,0 +1,78 @@
+/**
+ * Capture command palette "Jump to" screenshots for the docs-nav-drift fix
+ * (fix/docs-nav-drift).
+ *
+ * before = ROUTE_INDEX hardcoded docs entries (stale hand-written hints).
+ * after  = docs entries sourced live from docsSource via getDocsNav().
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=before node tests/e2e/capture-command-palette-docs-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8085 VARIANT=after  node tests/e2e/capture-command-palette-docs-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/command-palette-docs-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8085";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const VIEWPORT_FILTER = process.env.VIEWPORT_FILTER;
+const ALL_VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const VIEWPORTS = VIEWPORT_FILTER
+  ? ALL_VIEWPORTS.filter((v) => v.name === VIEWPORT_FILTER)
+  : ALL_VIEWPORTS;
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function openPaletteFilteredToReference(page) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 8000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+  await page.keyboard.press("Meta+k");
+  const input = page.getByPlaceholder("Search subnets, surfaces, endpoints, providers, docs…");
+  await input.waitFor({ state: "visible", timeout: 10_000 });
+  await input.fill("reference");
+  await page.waitForTimeout(400);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await setTheme(page, theme);
+      await openPaletteFilteredToReference(page);
+      const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+      await context.close();
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- The ⌘K command palette's `ROUTE_INDEX` hardcoded one entry per `content/docs/*` page. That's exactly how `/docs/chain-events` silently went missing from the palette for a while after its route shipped in an earlier Fumadocs-migration PR — nothing forced the list to stay in sync with the actual docs content.
- Adds `getDocsNav()`, a `createServerFn` that flattens `docsSource.getPages()` into `{url, title, description}`.
- `CommandPaletteBody` now fetches it once per session (docs content is static per build, so an `Infinity` staleTime is correct) and splices the results into the palette's route list between "Schemas" and "Gaps", replacing the four hand-listed `/docs/*` entries.
- A new docs page now appears in the palette automatically, with its real frontmatter description as the hint instead of a second hand-written blurb that can drift from the page's actual content.
- Per-page icon choice stays as a small, purely cosmetic override map (`DOCS_ICON_OVERRIDES`) — missing from it just means the generic `BookOpen` icon renders, it never hides the page.

No behavior change for non-docs routes; `apps/ui/src/lib/docs-nav.functions.ts` is new, `command-palette-body.tsx`'s route-index data source is the only other change.

## Screenshots

Command palette filtered to "reference", showing `Chain events reference`'s hint text — before shows the old hardcoded "Deep-history all-events tier" blurb, after shows the real MDX frontmatter description.

| Viewport | Theme | Before | After |
| --- | --- | --- | --- |
| Mobile | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/docs-nav-drift/before-mobile-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/docs-nav-drift/after-mobile-light.png) |
| Mobile | Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/docs-nav-drift/before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/docs-nav-drift/after-mobile-dark.png) |
| Tablet | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/docs-nav-drift/before-tablet-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/docs-nav-drift/after-tablet-light.png) |
| Tablet | Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/docs-nav-drift/before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/docs-nav-drift/after-tablet-dark.png) |
| Desktop | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/docs-nav-drift/before-desktop-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/docs-nav-drift/after-desktop-light.png) |
| Desktop | Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/docs-nav-drift/before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/docs-nav-drift/after-desktop-dark.png) |

## Test plan

- [x] `npx tsc --noEmit -p apps/ui` clean
- [x] `npx eslint` clean (one pre-existing, unrelated warning on `allHits` confirmed present on `origin/main` too)
- [x] `npx prettier --check` clean
- [x] `npm run test --workspace=apps/ui` — 128 files / 1010 tests pass
- [x] Real production build (`LOVABLE_SANDBOX=1 NITRO_PRESET=cloudflare-module npm run build --workspace=apps/ui`) succeeds
- [x] Manually verified in-browser: opened ⌘K, confirmed all 4 docs pages render with live descriptions; confirmed the `_serverFn` network call returns real `docsSource` data (not a hardcoded array); confirmed filtering ("chain", "reference") correctly surfaces docs pages