### PR TITLE
fix(registry): SN121 sundae_bar accuracy re-review pass

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1607,13 +1607,13 @@
       "netuid": 121,
       "slug": "sn-121",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-08T10:10:00.000Z",
+      "reviewed_at": "2026-07-16T00:00:00.000Z",
       "confidence": "high",
       "source_urls": [
         "https://www.sundaebar.ai/",
         "https://github.com/sundae-bar/bittensor-subnet"
       ],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/sundae-bar.json (reviewed_at 2026-06-08T10:10:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): fixed 2 missing probe blocks. The site's own llms.txt documents its API as \"Public, read-only, and unauthenticated\" -- added 3 new no-param surfaces (categories, skill-categories, skill-creators)."
     },
     {
       "netuid": 122,

--- a/registry/subnets/sundae-bar.json
+++ b/registry/subnets/sundae-bar.json
@@ -14,14 +14,14 @@
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T10:10:00.000Z",
+    "reviewed_at": "2026-07-16T00:00:00.000Z",
     "source_count": 4,
-    "verified_at": "2026-06-08T10:10:00.000Z"
+    "verified_at": "2026-07-16T00:00:00.000Z"
   },
   "dashboard_url": "https://taomarketcap.com/subnets/121",
   "name": "sundae_bar",
   "netuid": 121,
-  "notes": "Reviewed overlay for SN121 using the official Sundae Bar website and source repository.",
+  "notes": "Reviewed overlay for SN121 using the official Sundae Bar website and source repository. Root->128 accuracy audit re-review pass (#5903): fixed 2 missing probe blocks. The site's llms.txt documents its API as \"Public, read-only, and unauthenticated\" -- added 3 new no-param surfaces (categories, skill-categories, skill-creators) after live-testing; the remaining documented routes are all path-parameterized.",
   "schema_version": 1,
   "slug": "sn-121",
   "social": {
@@ -73,6 +73,12 @@
       "kind": "subnet-api",
       "name": "Sundae Bar coordinator API",
       "notes": "Public no-auth GET on the SN121 coordinator API host documented in the official sb-validator README as API_URL (e.g. https://api.sundaebar.ai/api/v2/validators). Returns JSON liveness (observed: {\"status\":\"ok\"}).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "sundae-bar",
       "public_safe": true,
       "review": {
@@ -91,6 +97,12 @@
       "kind": "data-artifact",
       "name": "Sundae Bar SBC9 skill evaluation dataset",
       "notes": "Public no-auth JSONL benchmark dataset of customer-email response scenarios with rubric ground-truth metadata, published in the official SN121 sb-validator repository at python/dataset_sbc9.jsonl. Loaded at grader runtime by skill_evaluation.py (_load_variant_specifics) for skill-integrity checks during validator evaluation flows.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "sundae-bar",
       "public_safe": true,
       "review": {
@@ -152,6 +164,72 @@
         "https://www.sundaebar.ai/"
       ],
       "url": "https://www.sundaebar.ai/api/products"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-121-sundae-bar-categories-api",
+      "kind": "subnet-api",
+      "name": "Sundae Bar categories API",
+      "notes": "Public no-auth GET /api/categories on www.sundaebar.ai returning the category tree for agents, workflows, and prompts. Explicitly documented in the site's own llms.txt as \"Public, read-only, and unauthenticated\".",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "sundae-bar",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://www.sundaebar.ai/llms.txt"],
+      "url": "https://www.sundaebar.ai/api/categories"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-121-sundae-bar-skill-categories-api",
+      "kind": "subnet-api",
+      "name": "Sundae Bar skill categories API",
+      "notes": "Public no-auth GET /api/skill-categories on www.sundaebar.ai returning the category list for skills. Explicitly documented in the site's own llms.txt as \"Public, read-only, and unauthenticated\".",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "sundae-bar",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://www.sundaebar.ai/llms.txt"],
+      "url": "https://www.sundaebar.ai/api/skill-categories"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-121-sundae-bar-skill-creators-api",
+      "kind": "subnet-api",
+      "name": "Sundae Bar skill creators API",
+      "notes": "Public no-auth GET /api/skill-creators on www.sundaebar.ai returning the distinct list of skill creator names (values usable for the /api/products creators filter). Explicitly documented in the site's own llms.txt as \"Public, read-only, and unauthenticated\".",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "sundae-bar",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": ["https://www.sundaebar.ai/llms.txt"],
+      "url": "https://www.sundaebar.ai/api/skill-creators"
     }
   ],
   "website_url": "https://www.sundaebar.ai/"


### PR DESCRIPTION
## Summary
- Fix 2 missing probe blocks — systemic gap #5932.
- The site's own llms.txt documents its API as "Public, read-only, and unauthenticated". Add 3 new no-param surfaces after live-testing (`categories`, `skill-categories`, `skill-creators`); the remaining documented routes (`products/{slug}/public`, `ratings/{productId}`, `skills/{slug}/download`) are all path-parameterized.

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check registry/subnets/sundae-bar.json registry/reviews/maintainer-reviewed.json`