### PR TITLE
chore(registry): SN122 Bitrecs accuracy re-review

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1619,14 +1619,15 @@
       "netuid": 122,
       "slug": "sn-122",
       "decision": "maintainer-reviewed",
-      "reviewed_at": "2026-06-08T10:35:00.000Z",
+      "reviewed_at": "2026-07-16T00:00:00.000Z",
       "confidence": "high",
       "source_urls": [
         "https://www.bitrecs.ai/",
         "https://bitrecs.gitbook.io/bitrecs-docs/",
-        "https://github.com/bitrecs/bitrecs-subnet"
+        "https://github.com/bitrecs/bitrecs-subnet",
+        "https://www.bitrecs.ai/llms.txt"
       ],
-      "notes": "Backfilled during the maintainer-reviews consolidation: this overlay was hand-curated to the maintainer-reviewed tier directly in registry/subnets/bitrecs.json (reviewed_at 2026-06-08T10:35:00.000Z). Recording the decision here so the trust tier has an auditable backing — not a fresh re-review."
+      "notes": "Root->128 accuracy audit re-review pass (#5903): live-verified all 5 surfaces (all HTTP 200), fixed 2 missing probe blocks (amazon-fashion-sample, llms-txt), and confirmed via the official llms.txt that a REST API/MCP server are still coming soon, not yet live."
     },
     {
       "netuid": 123,

--- a/registry/subnets/bitrecs.json
+++ b/registry/subnets/bitrecs.json
@@ -10,20 +10,20 @@
   "curation": {
     "gap_notes": [
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified unauthenticated public subnet API endpoint yet.",
+      "No verified unauthenticated public subnet API endpoint yet -- the official llms.txt states a REST API and MCP server for headless/agentic use are coming soon.",
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-06-08T10:35:00.000Z",
+    "reviewed_at": "2026-07-16T00:00:00.000Z",
     "source_count": 5,
-    "verified_at": "2026-06-08T10:35:00.000Z"
+    "verified_at": "2026-07-16T00:00:00.000Z"
   },
   "dashboard_url": "https://taomarketcap.com/subnets/122",
   "docs_url": "https://bitrecs.gitbook.io/bitrecs-docs/",
   "name": "Bitrecs",
   "netuid": 122,
-  "notes": "Reviewed overlay for SN122 using the official Bitrecs website, docs, and source repository. No machine-readable OpenAPI schema or unauthenticated public subnet API endpoint is promoted yet.",
+  "notes": "Reviewed overlay for SN122 using the official Bitrecs website, docs, and source repository. No machine-readable OpenAPI schema or unauthenticated public subnet API endpoint is promoted yet. Root->128 accuracy audit re-review pass (#5903): live-verified all 5 surfaces (all HTTP 200), fixed 2 missing probe blocks (amazon-fashion-sample, llms-txt), and confirmed via the official llms.txt that a REST API/MCP server are still coming soon, not yet live.",
   "schema_version": 1,
   "slug": "sn-122",
   "social": {
@@ -96,6 +96,12 @@
       "kind": "data-artifact",
       "name": "Bitrecs Amazon fashion sample catalog",
       "notes": "Public no-auth JSON sample ecommerce product-review catalog (ASIN, rating, title, price metadata) published in the official SN122 Bitrecs source repository at tests/data/amazon/fashion/. Referenced by the repo README (sample data setup) and exercised by tests/test_json.py for local recommendation-engine validation.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "bitrecs",
       "public_safe": true,
       "review": {
@@ -114,7 +120,13 @@
       "id": "sn-122-bitrecs-llms-txt",
       "kind": "data-artifact",
       "name": "Bitrecs llms.txt docs index",
-      "notes": "Machine-readable llms.txt docs index published on the official Bitrecs website; self-identifies as Bittensor subnet 122 and links the homepage, Shopify app, and Taostats subnet page.",
+      "notes": "Machine-readable llms.txt docs index published on the official Bitrecs website; self-identifies as Bittensor subnet 122 and links the homepage, Shopify app, and Taostats subnet page. States a REST API and MCP server for headless/agentic use are \"coming soon\" -- confirms no live public subnet-api surface exists yet, consistent with the tracked gap_notes.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "bitrecs",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
## Summary
- Live-verified all 5 tracked SN122 Bitrecs surfaces (website, docs, source repo, Amazon fashion sample dataset, llms.txt) -- all HTTP 200.
- Fixed 2 missing `probe` config blocks (`sn-122-bitrecs-amazon-fashion-sample`, `sn-122-bitrecs-llms-txt`).
- Read the official llms.txt content: it explicitly states a REST API and MCP server for headless/agentic use are "coming soon" -- confirms no live public subnet-api surface exists yet, consistent with the existing gap_notes. No new surfaces to add this pass.
- Updated `curation.reviewed_at`/`verified_at` and the corresponding `maintainer-reviewed.json` ledger entry.

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check` on changed files