### PR TITLE
fix(ui): show ErrorState (not EmptyState) on a failed history-chart fetch

### DIFF
--- a/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { accountPositionHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { AccountPositionHistoryPoint } from "@/lib/metagraphed/types";
@@ -30,7 +30,13 @@ function yieldStr(v?: number) {
  * this position has no history yet (e.g. a freshly-registered neuron). */
 export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; netuid: number }) {
   const [win, setWin] = useState<Win>("90d");
-  const { data: res, isLoading } = useQuery(accountPositionHistoryQuery(ss58, netuid, win));
+  const {
+    data: res,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(accountPositionHistoryQuery(ss58, netuid, win));
   const points = useMemo<AccountPositionHistoryPoint[]>(
     () => res?.data?.points ?? [],
     [res?.data?.points],
@@ -79,6 +85,8 @@ export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; ne
       <div className="flex items-center justify-end">{windowSelector}</div>
       {isLoading ? (
         <Skeleton className="h-32 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} context="account position history" onRetry={() => refetch()} />
       ) : !hasData ? (
         <EmptyState
           title="No history yet"

--- a/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { subnetNeuronHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetNeuronHistoryPoint } from "@/lib/metagraphed/types";
 
@@ -22,7 +22,13 @@ function scoreStr(v?: number) {
  */
 export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: number }) {
   const [win, setWin] = useState<Win>("90d");
-  const { data: res, isLoading } = useQuery(subnetNeuronHistoryQuery(netuid, uid, win));
+  const {
+    data: res,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(subnetNeuronHistoryQuery(netuid, uid, win));
   const points = useMemo<SubnetNeuronHistoryPoint[]>(
     () => res?.data?.points ?? [],
     [res?.data?.points],
@@ -79,6 +85,8 @@ export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: numbe
       </div>
       {isLoading ? (
         <Skeleton className="h-32 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} context="neuron history" onRetry={() => refetch()} />
       ) : !hasData ? (
         <EmptyState
           title="No per-UID history"

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
@@ -20,7 +20,13 @@ const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
  */
 export function SubnetHistoryChart({ netuid }: { netuid: number }) {
   const [win, setWin] = useState<Win>("90d");
-  const { data: res, isLoading } = useQuery(subnetHistoryQuery(netuid, win));
+  const {
+    data: res,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(subnetHistoryQuery(netuid, win));
   const points = useMemo<SubnetHistoryPoint[]>(() => res?.data?.points ?? [], [res?.data?.points]);
 
   const series = useMemo(() => {
@@ -72,6 +78,8 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
       <div className="flex items-center justify-end">{windowSelector}</div>
       {isLoading ? (
         <Skeleton className="h-32 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} context="subnet history" onRetry={() => refetch()} />
       ) : !hasData ? (
         <EmptyState
           title="No on-chain history"

--- a/apps/ui/src/components/metagraphed/validator-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/validator-history-chart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { validatorHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { ValidatorHistoryPoint } from "@/lib/metagraphed/types";
@@ -29,7 +29,13 @@ function rewardsStr(v?: number) {
  * the validator has no history yet (e.g. a freshly-registered hotkey). */
 export function ValidatorHistoryChart({ hotkey }: { hotkey: string }) {
   const [win, setWin] = useState<Win>("90d");
-  const { data: res, isLoading } = useQuery(validatorHistoryQuery(hotkey, win));
+  const {
+    data: res,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(validatorHistoryQuery(hotkey, win));
   const points = useMemo<ValidatorHistoryPoint[]>(
     () => res?.data?.points ?? [],
     [res?.data?.points],
@@ -77,6 +83,8 @@ export function ValidatorHistoryChart({ hotkey }: { hotkey: string }) {
       <div className="flex items-center justify-end">{windowSelector}</div>
       {isLoading ? (
         <Skeleton className="h-32 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} context="validator history" onRetry={() => refetch()} />
       ) : !hasData ? (
         <EmptyState
           title="No history yet"


### PR DESCRIPTION
## Summary
- `neuron-history-chart.tsx`, `validator-history-chart.tsx`, `subnet-history-chart.tsx`, and `account-position-history-chart.tsx` each destructured only `{ data, isLoading }` from `useQuery`, so a real fetch failure silently fell through to the "no data yet" `EmptyState` instead of surfacing the error.
- Each now destructures `isError`, `error`, `refetch` too and renders the same `ErrorState` (with `onRetry={() => refetch()}`) that the structurally identical `account-history-chart.tsx` already uses. Loading and success rendering are unchanged.

Closes #5863

## Screenshots

Captured against `subnets.$netuid.tsx`'s Network History section (backed by `SubnetHistoryChart`, one of the 4 fixed components) with the `/history` request forced to fail via route interception.

| Viewport | Theme | Before | After |
|---|---|---|---|
| Desktop | Light | ![before](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5863-desktop-light-before.png) | ![after](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5863-desktop-light-after.png) |
| Desktop | Dark | ![before](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5863-desktop-dark-before.png) | ![after](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5863-desktop-dark-after.png) |
| Tablet | Light | ![before](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5863-tablet-light-before.png) | ![after](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5863-tablet-light-after.png) |
| Tablet | Dark | ![before](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5863-tablet-dark-before.png) | ![after](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5863-tablet-dark-after.png) |
| Mobile | Light | ![before](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5863-mobile-light-before.png) | ![after](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5863-mobile-light-after.png) |
| Mobile | Dark | ![before](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5863-mobile-dark-before.png) | ![after](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/5863-mobile-dark-after.png) |

## Test plan
- [x] `npx tsc --noEmit -p apps/ui` — clean
- [x] `npx vitest run` (apps/ui) — 128 files / 1010 tests pass
- [x] Manual verification: before shows "No on-chain history"; after shows "Couldn't load subnet history" with Retry / Open API URL, across all 6 viewport/theme combinations