### PR TITLE
fix(ui): wire onRetry into account-history-chart.tsx's ErrorState

### DIFF
--- a/apps/ui/src/components/metagraphed/account-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-history-chart.tsx
@@ -118,7 +118,7 @@ function hoverLabel(day: AccountHistorySeriesDay, scope: Scope): string {
 
 export function AccountHistoryChart({ ss58 }: { ss58: string }) {
   const [scope, setScope] = useState<Scope>("all");
-  const { data, isLoading, isError, error } = useQuery(
+  const { data, isLoading, isError, error, refetch } = useQuery(
     accountHistoryQuery(ss58, { limit: DEFAULT_HISTORY_LIMIT }),
   );
 
@@ -151,7 +151,7 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
   }
 
   if (isError) {
-    return <ErrorState error={error} context="account history" />;
+    return <ErrorState error={error} onRetry={() => refetch()} context="account history" />;
   }
 
   if (days.length === 0 || scopedDays.length === 0) {


### PR DESCRIPTION
## Summary

`AccountHistoryChart` (rendered on the high-traffic `accounts.$ss58.tsx` page) destructured only `{ data, isLoading, isError, error }` from its `useQuery` call and rendered `<ErrorState>` with no `onRetry`, unlike every other `ErrorState` call site in the codebase (`resource-explorer.tsx`, `blocks.$ref.tsx`, `explorer.tsx`), which all wire `onRetry` to `refetch()`/`invalidateQueries`.

Closes #5862

## What Changed

- Destructured `refetch` from the `useQuery` call in `account-history-chart.tsx`.
- Passed `onRetry={() => refetch()}` to its `<ErrorState>`, matching the established pattern at the cited call sites.
- No other logic touched — this is a 2-line diff.

## Validation

- [x] `npx eslint apps/ui/src/components/metagraphed/account-history-chart.tsx` — clean
- [x] `npm run typecheck --workspace=apps/ui` — clean
- [x] `npm test --workspace=apps/ui` — 1027/1027 passed
- [x] `npm run test:e2e --workspace=apps/ui` — 24/24 passed (route not in the HAR-checked set, no re-record needed)
- [x] `npm run build --workspace=apps/ui` — clean

## Screenshots

This flips `ErrorState` from no-retry to retry-enabled, so it's a visual change. Forced a real error on the account-history endpoint (500 response) to capture the actual before/after state at `/accounts/<ss58>#history`.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://github.com/user-attachments/assets/1d60a5d2-a364-4b88-9e92-37a3e5c73e59" width="260">](https://github.com/user-attachments/assets/1d60a5d2-a364-4b88-9e92-37a3e5c73e59)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/749be16e-1176-480a-843a-3817b9b8c6c2" width="260">](https://github.com/user-attachments/assets/749be16e-1176-480a-843a-3817b9b8c6c2)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://github.com/user-attachments/assets/3b9b55d0-eafc-435c-a408-697da225840e" width="260">](https://github.com/user-attachments/assets/3b9b55d0-eafc-435c-a408-697da225840e)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/91f06742-8c55-442a-b2cd-8ea5e8a02d58" width="260">](https://github.com/user-attachments/assets/91f06742-8c55-442a-b2cd-8ea5e8a02d58)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://github.com/user-attachments/assets/144912b6-1129-4e99-a9cd-8e732f381223" width="260">](https://github.com/user-attachments/assets/144912b6-1129-4e99-a9cd-8e732f381223)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/65f55a8c-04c0-4ca7-a77e-08cf44ed3107" width="260">](https://github.com/user-attachments/assets/65f55a8c-04c0-4ca7-a77e-08cf44ed3107)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://github.com/user-attachments/assets/c525b512-24cb-4f4d-b506-7866cf6f6a97" width="260">](https://github.com/user-attachments/assets/c525b512-24cb-4f4d-b506-7866cf6f6a97)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/8aada6c8-893b-4113-9bb7-8eb35cc92fa0" width="260">](https://github.com/user-attachments/assets/8aada6c8-893b-4113-9bb7-8eb35cc92fa0)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://github.com/user-attachments/assets/2171c5a2-f669-45fb-b0f6-1d986b8ce90a" width="260">](https://github.com/user-attachments/assets/2171c5a2-f669-45fb-b0f6-1d986b8ce90a)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/f33b32ac-b5bc-4199-8459-37bc04f6d7b8" width="260">](https://github.com/user-attachments/assets/f33b32ac-b5bc-4199-8459-37bc04f6d7b8)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://github.com/user-attachments/assets/ffc68a96-c148-4b25-a0f5-9d03fbca6fd9" width="260">](https://github.com/user-attachments/assets/ffc68a96-c148-4b25-a0f5-9d03fbca6fd9)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/bd4b3a5a-91ab-4cc3-9b48-62d53a5f259e" width="260">](https://github.com/user-attachments/assets/bd4b3a5a-91ab-4cc3-9b48-62d53a5f259e)<br><sub>after</sub> |