### PR TITLE
feat(registry): SN126 Poker44 first accuracy review

### DIFF
--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1682,6 +1682,19 @@
         "https://github.com/Barbariandev/8Ball_miner#readme"
       ],
       "notes": "Root->128 accuracy audit re-review pass (#5903): the official website and its markets API are currently returning a consistent nginx 502 (observed across 3 attempts) while the site's static deployment.json asset stays live; documented as a backend outage rather than a dead domain, all surfaces kept tracked. Fixed 2 missing probe blocks (markets API, deployment manifest)."
+    },
+    {
+      "netuid": 126,
+      "slug": "sn-126",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-07-16T00:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://github.com/Poker44/Poker44-subnet",
+        "https://poker44.net/",
+        "https://github.com/Poker44/Poker44-subnet/blob/main/docs/training-benchmark.md"
+      ],
+      "notes": "Root->128 accuracy audit first review pass (#5903): promoted from community-seeded/unreviewed. Added website, source-repo, and whitepaper surfaces, fixed 3 missing probe blocks on pre-existing community-submitted surfaces, and added a new public no-param surface (benchmark/releases) explicitly documented alongside the already-tracked benchmark status endpoint."
     }
   ]
 }

--- a/registry/subnets/poker44.json
+++ b/registry/subnets/poker44.json
@@ -1,11 +1,26 @@
 {
-  "categories": [],
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-source-repo",
+    "official-website",
+    "security"
+  ],
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "gap_notes": [
+      "No verified machine-readable OpenAPI/Swagger schema yet.",
+      "No verified SSE/event stream yet.",
+      "The /api/v1/benchmark/chunks route requires a sourceDate/chunkId parameter and is not promotable."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-07-16T00:00:00.000Z",
+    "source_count": 6,
+    "verified_at": "2026-07-16T00:00:00.000Z"
   },
   "name": "Poker44",
   "netuid": 126,
+  "notes": "Reviewed overlay for SN126 Poker44, a poker bot-detection subnet (security infrastructure, not a poker room). Root->128 accuracy audit first review pass (#5903): added website, source-repo, and whitepaper surfaces, fixed 3 missing probe blocks on pre-existing community-submitted surfaces, and added a new public no-param surface (benchmark/releases) explicitly documented alongside the already-tracked benchmark status endpoint.",
   "schema_version": 1,
   "slug": "sn-126",
   "social": {
@@ -21,6 +36,12 @@
       "kind": "subnet-api",
       "name": "Poker44 platform health API",
       "notes": "Public no-auth GET /health on api.poker44.net returning platform liveness JSON (observed: status healthy, database and redis connected). Same host as the internal validator routes configured in the official Poker44-subnet validator neuron.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "poker44",
       "public_safe": true,
       "review": {
@@ -40,6 +61,12 @@
       "kind": "data-artifact",
       "name": "Poker44 shadow-training benchmark dataset",
       "notes": "Public no-auth GET /api/v1/benchmark on api.poker44.net — the official Poker44 (SN126) benchmark dataset release endpoint documented in the subnet repo's docs/training-benchmark.md (GET /api/v1/benchmark, GET /api/v1/benchmark/releases). Returns JSON release metadata (observed releaseVersion v1.13, schemaVersion shadow-training-v1, 121 chunks / 29,680 hands, auto-release schedule); miners fetch the hand chunks from this endpoint. Same api.poker44.net host as the already-listed platform health surface.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "poker44",
       "public_safe": true,
       "review": {
@@ -59,6 +86,12 @@
       "kind": "dashboard",
       "name": "Poker44 live benchmark dashboard",
       "notes": "Public no-auth Poker44 (SN126) web dashboard at poker44.net/dashboard — the 'Live Benchmark for Bot Detection' leaderboard showing per-round miner scores, validator fleet status, and cycle progress across the subnet's competition rounds. Served on the official poker44.net platform linked from the Poker44/Poker44-subnet README; distinct from the api.poker44.net JSON benchmark/health endpoints.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
       "provider": "poker44",
       "public_safe": true,
       "review": {
@@ -69,6 +102,87 @@
         "https://github.com/Poker44/Poker44-subnet/blob/main/README.md"
       ],
       "url": "https://poker44.net/dashboard"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-126-poker44-website",
+      "kind": "website",
+      "name": "Poker44 website",
+      "notes": "Official Poker44 website.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "poker44",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Poker44/Poker44-subnet"],
+      "url": "https://poker44.net/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-126-poker44-source",
+      "kind": "source-repo",
+      "name": "Poker44 source repository",
+      "notes": "Official Poker44 source repository for SN126.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "poker44",
+      "public_safe": true,
+      "source_urls": ["https://github.com/Poker44/Poker44-subnet"],
+      "url": "https://github.com/Poker44/Poker44-subnet"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "id": "sn-126-poker44-benchmark-releases",
+      "kind": "data-artifact",
+      "name": "Poker44 benchmark release history",
+      "notes": "Public no-auth GET /api/v1/benchmark/releases on api.poker44.net returning the history of published shadow-training benchmark releases (per-release chunk/hand counts, audit thresholds, source dates). Explicitly documented as a standalone route in docs/training-benchmark.md alongside the already-tracked /api/v1/benchmark status endpoint; the sibling /api/v1/benchmark/chunks route requires a sourceDate/chunkId parameter and is not promotable. No wallet/hotkey data.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "poker44",
+      "public_safe": true,
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "source_urls": [
+        "https://github.com/Poker44/Poker44-subnet/blob/main/docs/training-benchmark.md"
+      ],
+      "url": "https://api.poker44.net/api/v1/benchmark/releases"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-126-poker44-whitepaper",
+      "kind": "docs",
+      "name": "Poker44 whitepaper",
+      "notes": "Official Poker44 (SN126) whitepaper PDF, linked from the official website and README under Official Links.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "poker44",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/Poker44/Poker44-subnet/blob/main/README.md",
+        "https://poker44.net/"
+      ],
+      "url": "https://poker44.net/Poker44_Whitepaper.pdf"
     }
   ],
   "website_url": "https://poker44.net/"


### PR DESCRIPTION
## Summary
- Promoted SN126 Poker44 (a poker bot-detection subnet -- "security infrastructure, not a poker room") from `community-seeded`/`unreviewed` to `maintainer-reviewed`.
- Added official website, source-repo, and whitepaper surfaces (all confirmed live), previously not tracked despite the top-level `website_url`/`source_repo` fields already existing.
- Fixed 3 missing `probe` config blocks on the pre-existing community-submitted surfaces (health, benchmark, dashboard).
- Added a new public no-param subnet-api surface, `benchmark/releases` -- explicitly documented in `docs/training-benchmark.md` alongside the already-tracked `benchmark` status endpoint, live-tested, and confirmed free of wallet/hotkey data. The sibling `benchmark/chunks` route requires a `sourceDate`/`chunkId` parameter and is not promotable.

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check` on changed files