### PR TITLE
feat(registry): SN128 ByteLeap first accuracy review

### DIFF
--- a/registry/providers/byteleap.json
+++ b/registry/providers/byteleap.json
@@ -1,0 +1,13 @@
+{
+  "authority": "community",
+  "github_url": "https://github.com/byteleapai/byteleap-Validator",
+  "id": "byteleap",
+  "kind": "subnet-team",
+  "name": "ByteLeap",
+  "public_notes": "Subnet 128 (ByteLeap) team profile — a distributed compute-resource network. Identity from the official byteleap-Validator repository and website; X handle scraped from the official website homepage.",
+  "schema_version": 1,
+  "social": {
+    "x": "https://x.com/byteleap_ai"
+  },
+  "website_url": "https://byteleap.ai/"
+}

--- a/registry/reviews/maintainer-reviewed.json
+++ b/registry/reviews/maintainer-reviewed.json
@@ -1708,6 +1708,18 @@
         "https://github.com/astridintelligence/sn-127/blob/master/src/core/arena/api.ts"
       ],
       "notes": "Root->128 accuracy audit first review pass (#5903): promoted from community-seeded/unreviewed. Added website (astrid.global) and source-repo surfaces, fixed 3 missing probe blocks on pre-existing community-submitted surfaces. Confirmed via the official validator client source that the only other documented route (executions/presence) requires a participantIds query parameter -- not promotable."
+    },
+    {
+      "netuid": 128,
+      "slug": "sn-128",
+      "decision": "maintainer-reviewed",
+      "reviewed_at": "2026-07-16T00:00:00.000Z",
+      "confidence": "high",
+      "source_urls": [
+        "https://github.com/byteleapai/byteleap-Validator",
+        "https://byteleap.ai/"
+      ],
+      "notes": "Root->128 accuracy audit first review pass (#5903): promoted from community-seeded/unreviewed. Added website and source-repo surfaces, previously not tracked despite the top-level website_url/source_repo fields already existing. Reverse-engineered the official byteleap.ai frontend bundle to find its backend API host and confirmed via live-testing that it is entirely auth-gated (every path, including nonsense ones, returns an identical 406 error) -- not promotable. The already-tracked TaoMarketCap indexed feed remains the only public API surface. Created a new registry/providers/byteleap.json (previously missing)."
     }
   ]
 }

--- a/registry/subnets/byteleap.json
+++ b/registry/subnets/byteleap.json
@@ -1,11 +1,26 @@
 {
-  "categories": [],
+  "categories": [
+    "baseline-curated",
+    "identity-reviewed",
+    "official-source-repo",
+    "official-website",
+    "compute"
+  ],
   "curation": {
-    "level": "community-seeded",
-    "review_state": "unreviewed"
+    "gap_notes": [
+      "No verified machine-readable OpenAPI/Swagger schema yet.",
+      "No verified SSE/event stream yet.",
+      "The official platform's host-api.byteleap.ai/podsail/api backend is entirely auth-gated -- every tested path (including a nonexistent one) returns the same 406 \"Token not provided\" response, so no route on that host is promotable."
+    ],
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-07-16T00:00:00.000Z",
+    "source_count": 3,
+    "verified_at": "2026-07-16T00:00:00.000Z"
   },
   "name": "ByteLeap",
   "netuid": 128,
+  "notes": "Reviewed overlay for SN128 ByteLeap, the distributed compute-resource network on Bittensor SN128. Root->128 accuracy audit first review pass (#5903): added website and source-repo surfaces, previously not tracked despite the top-level website_url/source_repo fields already existing. Reverse-engineered the official byteleap.ai frontend bundle to find its backend API host (host-api.byteleap.ai/podsail/api) and confirmed via live-testing that it is entirely auth-gated (every path, including nonsense ones, returns the identical 406 \"Token not provided\" response) -- not promotable. The already-tracked TaoMarketCap indexed feed remains the only public API surface for this subnet.",
   "schema_version": 1,
   "slug": "sn-128",
   "status": "active",
@@ -34,8 +49,44 @@
         "https://github.com/byteleapai/byteleap-Validator"
       ],
       "url": "https://api.taomarketcap.com/public/v1/subnets/128/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-128-byteleap-website",
+      "kind": "website",
+      "name": "ByteLeap website",
+      "notes": "Official ByteLeap website.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "byteleap",
+      "public_safe": true,
+      "source_urls": ["https://github.com/byteleapai/byteleap-Validator"],
+      "url": "https://byteleap.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-128-byteleap-source",
+      "kind": "source-repo",
+      "name": "ByteLeap validator source repository",
+      "notes": "Official ByteLeap validator source repository for SN128.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "byteleap",
+      "public_safe": true,
+      "source_urls": ["https://github.com/byteleapai/byteleap-Validator"],
+      "url": "https://github.com/byteleapai/byteleap-Validator"
     }
   ],
   "source_repo": "https://github.com/byteleapai/byteleap-Validator",
-  "website_url": "https://byteleap.ai"
+  "website_url": "https://byteleap.ai/"
 }


### PR DESCRIPTION
## Summary
- Promoted SN128 ByteLeap, a distributed compute-resource network, from `community-seeded`/`unreviewed` to `maintainer-reviewed`. **This is the final subnet in the root->128 accuracy audit (netuid 0-128).**
- Added official website and source-repo surfaces, previously not tracked despite the top-level `website_url`/`source_repo` fields already existing.
- Created the previously-missing `registry/providers/byteleap.json` (required, or `npm run validate` fails with "unknown provider").
- Reverse-engineered the official `byteleap.ai` frontend bundle to locate its backend API host (`host-api.byteleap.ai/podsail/api`) and confirmed via live-testing that it is entirely auth-gated -- every path tested, including a nonexistent one, returns the identical `406 "Token not provided"` response. Not promotable; the already-tracked TaoMarketCap indexed feed remains the only public API surface for this subnet.

Part of the root->128 accuracy audit (#5903).

## Test plan
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:surface`
- [x] `npm run curation:stale-notes`
- [x] `node scripts/scan-public-safety.mjs`
- [x] `npx prettier --check` on changed files