### PR TITLE
fix(ui): wire onRetry into account-history-chart's ErrorState

### DIFF
--- a/apps/ui/src/components/metagraphed/account-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-history-chart.tsx
@@ -118,7 +118,7 @@ function hoverLabel(day: AccountHistorySeriesDay, scope: Scope): string {
 
 export function AccountHistoryChart({ ss58 }: { ss58: string }) {
   const [scope, setScope] = useState<Scope>("all");
-  const { data, isLoading, isError, error } = useQuery(
+  const { data, isLoading, isError, error, refetch } = useQuery(
     accountHistoryQuery(ss58, { limit: DEFAULT_HISTORY_LIMIT }),
   );
 
@@ -151,7 +151,9 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
   }
 
   if (isError) {
-    return <ErrorState error={error} context="account history" />;
+    return (
+      <ErrorState error={error} context="account history" onRetry={() => refetch()} />
+    );
   }
 
   if (days.length === 0 || scopedDays.length === 0) {


### PR DESCRIPTION
## Summary

`AccountHistoryChart` (`apps/ui/src/components/metagraphed/account-history-chart.tsx`) rendered `<ErrorState error={error} context="account history" />` with **no retry button** — unlike every other `ErrorState` call site in the app (`resource-explorer.tsx`, `blocks.$ref.tsx`, `explorer.tsx`), all of which pass `onRetry` wired to `refetch()`. This component renders on the high-traffic `accounts.$ss58` page.

## Fix

Destructure `refetch` from the existing `useQuery` call and pass `onRetry={() => refetch()}` to the `ErrorState`, matching the established pattern — so a user hitting a transient error on the account history chart can retry in place. `ErrorState` already accepts `onRetry?: () => void` (`states.tsx`); eslint + prettier clean.

## Screenshots

Chart error state with the `/history` request forced to fail (rest of the page loads normally). **Before** = no retry affordance; **After** = the new Retry button.

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5862/before-desktop-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5862/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5862/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5862/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5862/before-tablet-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5862/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5862/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5862/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5862/before-mobile-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5862/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5862/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5862/after-mobile-dark.png) |

Closes #5862
