### PR TITLE
feat(api,ui): wire Download CSV into the Providers page

### DIFF
--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -22,6 +22,7 @@ import {
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
 import { matchesQuery } from "@/lib/metagraphed/url-state";
 import { matchesProviderAuthority } from "@/lib/metagraphed/providers-url-state";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { resolveProviderCard } from "@/lib/metagraphed/provider-card-fields";
 import { healthStatusSegments } from "@/lib/metagraphed/health-segments";
 import {
@@ -30,6 +31,7 @@ import {
   PageHero,
   ViewModeToggle,
   ShareButton,
+  DownloadCsvButton,
   TimeAgo,
   ActionBar,
   Donut,
@@ -78,6 +80,14 @@ function ProvidersPage() {
     search.q || search.kind || search.authority || (search.sort && search.sort !== "name"),
   );
   const onReset = () => navigate({ search: { view: search.view } as never, replace: true });
+  // This page fetches the full provider list once and filters/sorts client-side,
+  // so the CSV export hits the backend route directly (full provider snapshot, no
+  // client filters) — same shape as endpoints.tsx. Forwarding the page's own
+  // search state would also break: `authority=high` is a nav shortcut (official +
+  // provider-claimed) and the surfaces/endpoints/subnets/updated sort keys are
+  // client-only, none of which are valid /api/v1/providers query values — the
+  // route rejects them with 400 invalid_query.
+  const providersCsvUrl = buildUrl("/api/v1/providers");
   return (
     <AppShell>
       <PageHero
@@ -99,6 +109,7 @@ function ProvidersPage() {
             />
             <ActionBar>
               <ResetFiltersButton active={filtersActive} onReset={onReset} bare />
+              <DownloadCsvButton url={providersCsvUrl} bare />
               <ShareButton bare />
             </ActionBar>
           </>

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -19237,6 +19237,8 @@ export interface operations {
                 sort?: "authority" | "id" | "kind" | "name";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -19244,7 +19246,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19300,6 +19302,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProvidersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2648,6 +2648,17 @@
               "desc"
             ]
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -37984,6 +37984,19 @@
                 "desc"
               ]
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -38047,9 +38060,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -19237,6 +19237,8 @@ export interface operations {
                 sort?: "authority" | "id" | "kind" | "name";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -19244,7 +19246,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19300,6 +19302,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProvidersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1823,7 +1823,7 @@ export const API_ROUTES = [
     "List providers and sources.",
     "standard",
     ["providers"],
-    listQuery("providers"),
+    csvListQuery("providers"),
   ),
   route(
     "provider-detail",

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1325,10 +1325,11 @@ describe("subnets CSV export", () => {
   });
 
   test("Accept: text/csv is ignored for collection routes without CSV contracts", async () => {
-    // /api/v1/providers is a list route that intentionally has no CSV contract,
-    // so content negotiation must fall through to the JSON envelope.
+    // /api/v1/gaps is a list route that intentionally has no CSV contract, so
+    // content negotiation must fall through to the JSON envelope. (Providers had
+    // this role until #5665 gave it a real CSV contract.)
     const res = await handleRequest(
-      req("/api/v1/providers?limit=1", {
+      req("/api/v1/gaps?limit=1", {
         headers: { accept: "text/csv" },
       }),
       createLocalArtifactEnv(),
@@ -1339,7 +1340,7 @@ describe("subnets CSV export", () => {
 
     const body = await res.json();
     assert.equal(body.ok, true);
-    assert.equal(Array.isArray(body.data.providers), true);
+    assert.equal(Array.isArray(body.data.gaps), true);
   });
 
   test("empty projected CSV exports retain the requested header row", async () => {
@@ -1382,6 +1383,43 @@ describe("subnets CSV export", () => {
     assert.equal(body.error.code, "invalid_artifact");
     assert.equal(body.meta.artifact_path, "/metagraph/subnets.json");
     assert.equal(body.meta.collection, "subnets");
+  });
+});
+
+// --- Providers CSV export (#5665) --------------------------------------------
+// The named-download + contract assertions ride the shared CSV_ROUTES lists
+// above; these cover what's specific to this collection.
+describe("providers CSV export", () => {
+  test("?format=csv honours field projection", async () => {
+    const res = await handleRequest(
+      req("/api/v1/providers?format=csv&fields=id,name&limit=2"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    const lines = (await res.text()).split("\r\n").filter(Boolean);
+    assert.equal(lines[0], "id,name");
+    assert.equal(lines.length, 3);
+  });
+
+  test("the non-scalar provider fields (netuids array, social object) serialize into CSV cells", async () => {
+    const res = await handleRequest(
+      req("/api/v1/providers?format=csv&fields=id,netuids,social&limit=5"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    const text = await res.text();
+    const lines = text.split("\r\n").filter(Boolean);
+    assert.equal(lines[0], "id,netuids,social");
+    // Nothing leaks a raw "[object Object]" — the shared serializer joins arrays
+    // with ";" and JSON-encodes objects, so no `exclude` option is needed here.
+    assert.ok(
+      !text.includes("[object Object]"),
+      "non-scalar cells must be serialized, not stringified via toString()",
+    );
   });
 });
 
@@ -1487,6 +1525,7 @@ describe("registry list CSV export", () => {
 
   const CSV_ROUTES = [
     "economics",
+    "providers",
     "surfaces",
     "subnet-surfaces",
     "endpoints",
@@ -1512,7 +1551,7 @@ describe("registry list CSV export", () => {
   });
 
   test("list routes without a CSV contract stay JSON-only", () => {
-    for (const id of ["providers", "rpc-endpoints", "source-snapshots"]) {
+    for (const id of ["rpc-endpoints", "source-snapshots"]) {
       const entry = API_ROUTES.find((route) => route.id === id);
       assert.ok(entry, `route ${id} should exist`);
       assert.notEqual(entry.csv_response, true, `${id} must stay JSON-only`);
@@ -1523,6 +1562,7 @@ describe("registry list CSV export", () => {
   // a text/csv attachment named after the route id with a header row.
   for (const [path, filename] of [
     ["/api/v1/economics", "economics.csv"],
+    ["/api/v1/providers", "providers.csv"],
     ["/api/v1/surfaces", "surfaces.csv"],
     ["/api/v1/endpoints", "endpoints.csv"],
     ["/api/v1/candidates", "candidates.csv"],


### PR DESCRIPTION
Fixes #5665.

Providers was the last ranked-list page missing **both** backend CSV support and the export affordance. `GET /api/v1/providers` was registered with plain `listQuery("providers")`, so the contract-driven dispatcher never treated `?format=csv` as a CSV request no matter what the frontend sent.

## Backend
- `src/contracts.mjs`: `providers` now uses `csvListQuery("providers")`, matching the `subnets`/`candidates` precedent.
- **No `exclude` option is needed — verified against the real route rather than assumed.** The provider rows do carry two non-scalar fields (`netuids` array, `social` object), but the shared serializer (`workers/csv.mjs` `stringifyCell`) already joins arrays with `;` and JSON-encodes objects. `GET /api/v1/providers?format=csv` returns `200` + `text/csv; charset=utf-8` + `attachment; filename="providers.csv"` with all 16 projected columns and no `[object Object]` leakage.
- Regenerated the OpenAPI/type artifacts, which pick up the new `format` parameter and the `text/csv` response.

## Frontend
`providers.index.tsx`'s `PageHero actions` renders `DownloadCsvButton` between `ResetFiltersButton` and `ShareButton`, matching the sibling pages.

**The CSV URL deliberately forwards no page search state**, mirroring `endpoints.tsx` — the other list page that fetches once and filters client-side ("*the table filters client-side over the full fetched list; the CSV export hits the backend route directly*"). `providers.index.tsx` is the same shape: `providersQuery()` fetches `/api/v1/providers` with no params and the page filters/sorts entirely client-side. Its search state is **not** expressible as route query values — I probed each one:

| Page state | `/api/v1/providers?format=csv&…` |
| --- | --- |
| `authority=official\|community\|provider-claimed\|registry-observed` | 200 |
| `authority=high` (nav shortcut = official + provider-claimed) | **400 `invalid_query`** |
| `sort=name` | 200 |
| `sort=surfaces\|endpoints\|subnets\|updated` (client-only keys) | **400 `invalid_query`** |

So forwarding the page's own `sort`/`authority` would make Download CSV **error for most users**. Full-snapshot export is both correct here and the established precedent.

## Tests
`tests/api-coverage.test.mjs` — 258/258 green. Providers joins the shared `CSV_ROUTES` contract assertions and the named-download loop; added coverage for field projection and for the non-scalar (`netuids`/`social`) cells. Note this change also required updating the tests that used `/api/v1/providers` as the canonical *"list route with no CSV contract"* example — that role now goes to `/api/v1/gaps`.

Validators green: `validate:contract-drift`, `validate-api` (159 routes), `validate:openapi-examples` (159/159), `validate:schemas`, lint + prettier.

## Screenshots
Before/after are identical apart from the new **Download CSV** button in the actions bar.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5665-csv-after-mobile-dark.png)<br><sub>after</sub> |
