### PR TITLE
fix(ui): add CopyButton to explorer.tsx address/signer tables

### DIFF
--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -19,6 +19,7 @@ import {
   Sparkline,
   BarMini,
   Donut,
+  CopyButton,
 } from "@jsonbored/ui-kit";
 import { EXPLORER_LEADERBOARD_IDS } from "@/components/metagraphed/explorer-leaderboard-layout";
 import { ExplorerLeaderboardTableShell } from "@/components/metagraphed/explorer-leaderboard-table-shell";
@@ -1126,14 +1127,17 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
                   {transfers.top_senders.map((s) => (
                     <tr key={s.address} className="hover:bg-surface/40">
                       <td className="px-4 py-2 font-mono text-[11px]">
-                        <Link
-                          to="/accounts/$ss58"
-                          params={{ ss58: s.address }}
-                          className="text-ink-strong hover:text-accent hover:underline"
-                          title={s.address}
-                        >
-                          {shortHash(s.address) ?? s.address}
-                        </Link>
+                        <span className="inline-flex items-center gap-1">
+                          <Link
+                            to="/accounts/$ss58"
+                            params={{ ss58: s.address }}
+                            className="text-ink-strong hover:text-accent hover:underline"
+                            title={s.address}
+                          >
+                            {shortHash(s.address) ?? s.address}
+                          </Link>
+                          <CopyButton value={s.address} label="address" />
+                        </span>
                       </td>
                       <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
                         {formatTao(s.volume_tao)}
@@ -1169,14 +1173,17 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
                   {transfers.top_receivers.map((r) => (
                     <tr key={r.address} className="hover:bg-surface/40">
                       <td className="px-4 py-2 font-mono text-[11px]">
-                        <Link
-                          to="/accounts/$ss58"
-                          params={{ ss58: r.address }}
-                          className="text-ink-strong hover:text-accent hover:underline"
-                          title={r.address}
-                        >
-                          {shortHash(r.address) ?? r.address}
-                        </Link>
+                        <span className="inline-flex items-center gap-1">
+                          <Link
+                            to="/accounts/$ss58"
+                            params={{ ss58: r.address }}
+                            className="text-ink-strong hover:text-accent hover:underline"
+                            title={r.address}
+                          >
+                            {shortHash(r.address) ?? r.address}
+                          </Link>
+                          <CopyButton value={r.address} label="address" />
+                        </span>
                       </td>
                       <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
                         {formatTao(r.volume_tao)}
@@ -1450,14 +1457,17 @@ function ExplorerDashboard() {
                     {signers.signers.slice(0, 12).map((s) => (
                       <tr key={s.signer} className="hover:bg-surface/40">
                         <td className="px-4 py-2 font-mono text-[11px]">
-                          <Link
-                            to="/accounts/$ss58"
-                            params={{ ss58: s.signer }}
-                            className="text-ink-strong hover:text-accent hover:underline"
-                            title={s.signer}
-                          >
-                            {shortHash(s.signer) ?? s.signer}
-                          </Link>
+                          <span className="inline-flex items-center gap-1">
+                            <Link
+                              to="/accounts/$ss58"
+                              params={{ ss58: s.signer }}
+                              className="text-ink-strong hover:text-accent hover:underline"
+                              title={s.signer}
+                            >
+                              {shortHash(s.signer) ?? s.signer}
+                            </Link>
+                            <CopyButton value={s.signer} label="address" />
+                          </span>
                         </td>
                         <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
                           {formatNumber(s.tx_count)}
@@ -1565,14 +1575,17 @@ function ExplorerDashboard() {
                   {fees.top_fee_payers.map((p) => (
                     <tr key={p.signer} className="hover:bg-surface/40">
                       <td className="px-4 py-2 font-mono text-[11px]">
-                        <Link
-                          to="/accounts/$ss58"
-                          params={{ ss58: p.signer }}
-                          className="text-ink-strong hover:text-accent hover:underline"
-                          title={p.signer}
-                        >
-                          {shortHash(p.signer) ?? p.signer}
-                        </Link>
+                        <span className="inline-flex items-center gap-1">
+                          <Link
+                            to="/accounts/$ss58"
+                            params={{ ss58: p.signer }}
+                            className="text-ink-strong hover:text-accent hover:underline"
+                            title={p.signer}
+                          >
+                            {shortHash(p.signer) ?? p.signer}
+                          </Link>
+                          <CopyButton value={p.signer} label="address" />
+                        </span>
                       </td>
                       <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
                         {formatTao(p.total_fee_tao)}
@@ -1722,14 +1735,17 @@ function ExplorerDashboard() {
                       <tr key={weightSetterKey(setter)} className="hover:bg-surface/40">
                         <td className="px-4 py-2 font-mono text-[11px]">
                           {setter.hotkey ? (
-                            <Link
-                              to="/accounts/$ss58"
-                              params={{ ss58: setter.hotkey }}
-                              className="text-ink-strong hover:text-accent hover:underline"
-                              title={setter.hotkey}
-                            >
-                              {shortHash(setter.hotkey) ?? setter.hotkey}
-                            </Link>
+                            <span className="inline-flex items-center gap-1">
+                              <Link
+                                to="/accounts/$ss58"
+                                params={{ ss58: setter.hotkey }}
+                                className="text-ink-strong hover:text-accent hover:underline"
+                                title={setter.hotkey}
+                              >
+                                {shortHash(setter.hotkey) ?? setter.hotkey}
+                              </Link>
+                              <CopyButton value={setter.hotkey} label="address" />
+                            </span>
                           ) : (
                             <span
                               className="text-ink-muted"
@@ -1835,24 +1851,30 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
                     {i + 1}
                   </td>
                   <td className="px-4 py-2 font-mono text-[11px]">
-                    <Link
-                      to="/accounts/$ss58"
-                      params={{ ss58: p.from }}
-                      className="text-ink-strong hover:text-accent hover:underline"
-                      title={p.from}
-                    >
-                      {shortHash(p.from) ?? p.from}
-                    </Link>
+                    <span className="inline-flex items-center gap-1">
+                      <Link
+                        to="/accounts/$ss58"
+                        params={{ ss58: p.from }}
+                        className="text-ink-strong hover:text-accent hover:underline"
+                        title={p.from}
+                      >
+                        {shortHash(p.from) ?? p.from}
+                      </Link>
+                      <CopyButton value={p.from} label="address" />
+                    </span>
                   </td>
                   <td className="px-4 py-2 font-mono text-[11px]">
-                    <Link
-                      to="/accounts/$ss58"
-                      params={{ ss58: p.to }}
-                      className="text-ink-strong hover:text-accent hover:underline"
-                      title={p.to}
-                    >
-                      {shortHash(p.to) ?? p.to}
-                    </Link>
+                    <span className="inline-flex items-center gap-1">
+                      <Link
+                        to="/accounts/$ss58"
+                        params={{ ss58: p.to }}
+                        className="text-ink-strong hover:text-accent hover:underline"
+                        title={p.to}
+                      >
+                        {shortHash(p.to) ?? p.to}
+                      </Link>
+                      <CopyButton value={p.to} label="address" />
+                    </span>
                   </td>
                   <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
                     {formatTao(p.volume_tao)}


### PR DESCRIPTION
## Summary

`apps/ui/src/routes/explorer.tsx` renders 7 address/signer tables — top senders, top receivers, pair signers (×2), weight-setter hotkeys, and largest transfers from/to — each as a plain account `<Link>` with **no copy affordance**, unlike the rest of the app's identifier tables (`blocks.index.tsx`, `extrinsics.index.tsx`, `AccountCell`).

## Fix

Pair each of the 7 address/signer links with a `<CopyButton value={…} label="address" />` (imported from `@jsonbored/ui-kit`, matching the established `blocks.index.tsx` pattern), wrapped in an `inline-flex` span. Link destinations, sort/filter behavior, and column layout are unchanged.

## Screenshots

The "Most active accounts" table (representative of all 7); each Account cell now carries a copy button.

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5857/before-desktop-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5857/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5857/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5857/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5857/before-tablet-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5857/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5857/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5857/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5857/before-mobile-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5857/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5857/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/5857/after-mobile-dark.png) |

Closes #5857
