### PR TITLE
fix(ui): show a StaleBanner on the validator detail page (#5861)

### DIFF
--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -6,7 +6,7 @@ import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { Boxes, Coins, Gauge, Percent, Users, Zap } from "lucide-react";
 import { useWallet } from "@/hooks/use-wallet";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
+import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
@@ -25,7 +25,7 @@ import { taoCompact, scoreStr } from "@/components/metagraphed/neuron-table";
 import { validatorDetailQuery, validatorNominatorsQuery } from "@/lib/metagraphed/queries";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { hasValidatorIdentity } from "@/lib/metagraphed/validator-identity";
 import {
   annualizedDelegatorApyPct,
@@ -241,6 +241,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
   const sourceRef = ss58PathSegment(hotkey);
   const detailRes = useSuspenseQuery(validatorDetailQuery(hotkey)).data;
   const detail = detailRes.data;
+  const generatedAt = detailRes.meta?.generated_at ?? null;
   const identity = detail.coldkey_identity;
   const hasIdentity = hasValidatorIdentity(identity);
   const displayName =
@@ -310,6 +311,13 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         }
         caption="explorer / v1"
       />
+
+      {isStaleFreshness(generatedAt) ? (
+        <StaleBanner
+          generatedAt={generatedAt}
+          refreshQueryKeys={[validatorDetailQuery(hotkey).queryKey]}
+        />
+      ) : null}
 
       <div className="mb-12 grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6">
         <StatTile


### PR DESCRIPTION
## What

Adds a `StaleBanner` to the validator detail page (`validators.$hotkey.tsx`), which had no staleness indicator at all — unlike its own list view (`validators.index.tsx:168`) and the structurally-identical detail routes `subnets.$netuid.tsx:280` / `providers.$slug.tsx:142`, which all surface one.

## How

Display-layer only, mirroring the sibling pattern exactly:
- `isStaleFreshness(detailRes.meta?.generated_at)` gates a `StaleBanner` (both already used across the app), rendered right below the `PageHero`.
- `refreshQueryKeys` points at `validatorDetailQuery(hotkey)`'s key so the banner's "Refresh now" action revalidates the detail data.
- The `meta` field already exists on `validatorDetailQuery` — the query and tables are untouched.

## Screenshots

The banner only renders when the snapshot is stale (`isStaleFreshness` → >12h). Live data is currently fresh, so the **after** shots below show the stale state forced with an aged snapshot timestamp (banner: *"Snapshot from 3d ago — may be lagging behind live"* + Refresh now); **before** is `main` (no banner). Full viewport × theme matrix:

| View | Before | After |
|------|--------|-------|
| Desktop · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861-after-desktop-light.png) |
| Desktop · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861-after-desktop-dark.png) |
| Tablet · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861-after-tablet-light.png) |
| Tablet · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861-after-tablet-dark.png) |
| Mobile · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861-after-mobile-light.png) |
| Mobile · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861-after-mobile-dark.png) |

Closes #5861.