### PR TITLE
feat(ui): validator-agnostic delegation UX + honest sponsor-slot disclosure

### DIFF
--- a/apps/ui/src/components/metagraphed/neuron-table.test.ts
+++ b/apps/ui/src/components/metagraphed/neuron-table.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { NUMERIC_FIELDS } from "./neuron-table";
+
+/**
+ * Disclosure guard for the sponsored-validator pin (#5166): the objective
+ * validator/miner ranking must never be sortable by `featured` (or any future
+ * sponsor field) — a paid placement can never distort the neutral comparison.
+ * `NUMERIC_FIELDS` is the single point NeuronTable consults to decide which
+ * columns are sortable, so pinning this set is the actual enforcement, not
+ * just documentation of intent.
+ */
+describe("NeuronTable sort-field invariant", () => {
+  it("never makes the sponsored-placement pin sortable", () => {
+    expect(NUMERIC_FIELDS.has("featured" as never)).toBe(false);
+  });
+
+  it("never makes any other likely sponsor/partnership field sortable", () => {
+    for (const field of ["sponsored", "partner", "partnership", "promoted"]) {
+      expect(NUMERIC_FIELDS.has(field as never)).toBe(false);
+    }
+  });
+
+  it("still sorts on the objective metrics it's meant to", () => {
+    for (const field of [
+      "uid",
+      "stake_tao",
+      "emission_tao",
+      "rank",
+      "trust",
+      "consensus",
+      "dividends",
+      "validator_trust",
+      "take",
+    ]) {
+      expect(NUMERIC_FIELDS.has(field as never)).toBe(true);
+    }
+  });
+});

--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -1,11 +1,17 @@
 import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
-import { Download } from "lucide-react";
+import { Coins, Download } from "lucide-react";
 import { CopyButton } from "@jsonbored/ui-kit";
 import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
 import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { buildUrl } from "@/lib/metagraphed/client";
+import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
+import {
+  annualizedDelegatorApyPct,
+  formatApyPct,
+  formatTakePct,
+} from "@/lib/metagraphed/validator-apy";
 import type { MetagraphNeuron } from "@/lib/metagraphed/types";
 
 /**
@@ -28,17 +34,21 @@ export function scoreStr(v?: number | null): string {
 }
 
 /**
- * Small pill marking a DB-toggled featured validator (#5166) — same visual
- * language as the "Validator" permit pill below. Shared with the global
- * validators leaderboard table (routes/validators.index.tsx).
+ * Small pill marking a DB-toggled featured-validator pin (#5166) — a paid/
+ * partner placement, not a quality or trust signal. Deliberately styled
+ * distinct from the "Validator" permit pill below (that one IS a chain-derived
+ * trust fact; this one is a disclosed sponsorship) so the two are never
+ * visually confused. Label is persistent (not hover-gated) — the disclosure
+ * has to be legible without any interaction. Shared with the global
+ * validators leaderboard table (validator-columns.tsx).
  */
-export function FeaturedBadge() {
+export function SponsoredBadge() {
   return (
     <span
-      className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-wider text-accent-text"
-      title="Featured validator"
+      className="inline-flex items-center rounded border border-ink-muted/40 bg-surface px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-wider text-ink-muted"
+      title="Sponsored placement — this validator paid for visibility here. It is not ranked or endorsed; see the validator directory's own stake/trust/APY columns for objective standing."
     >
-      Featured
+      Sponsored
     </span>
   );
 }
@@ -51,12 +61,19 @@ type SortField =
   | "trust"
   | "consensus"
   | "dividends"
-  | "validator_trust";
+  | "validator_trust"
+  | "take";
 
 /** Which scoring columns each variant surfaces, in render order. */
 type NeuronTableVariant = "miner" | "validator";
 
-const NUMERIC_FIELDS = new Set<SortField>([
+// `featured` (the sponsored-placement pin, #5166) must NEVER be sortable —
+// sort/rank stays strictly objective (stake, trust, consensus, etc.) so a
+// paid placement can never distort the neutral comparison. `SortField` simply
+// has no `featured` member, so it can't be added here without a type error;
+// neuron-table.test.ts also asserts this set never contains "featured" at
+// runtime as a second line of defense if that type is ever loosened.
+export const NUMERIC_FIELDS = new Set<SortField>([
   "uid",
   "stake_tao",
   "emission_tao",
@@ -65,6 +82,7 @@ const NUMERIC_FIELDS = new Set<SortField>([
   "consensus",
   "dividends",
   "validator_trust",
+  "take",
 ]);
 
 /**
@@ -170,6 +188,10 @@ export function NeuronTable({
                 <>
                   {col("dividends", "Dividends")}
                   {col("validator_trust", "Val Trust")}
+                  {col("take", "Take")}
+                  <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
+                    Est. APY
+                  </th>
                 </>
               ) : (
                 <>
@@ -181,6 +203,11 @@ export function NeuronTable({
               <th className="px-3 py-2.5 text-center font-mono text-[10px] uppercase tracking-widest">
                 Permit
               </th>
+              {isValidator ? (
+                <th className="px-3 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest">
+                  Delegate
+                </th>
+              ) : null}
             </tr>
           </thead>
           <tbody>
@@ -209,7 +236,7 @@ export function NeuronTable({
                   </td>
                   <td className="px-3 py-2.5 font-mono text-[11px]">
                     <div className="flex items-center gap-1.5">
-                      {n.featured ? <FeaturedBadge /> : null}
+                      {n.featured ? <SponsoredBadge /> : null}
                       {n.hotkey ? (
                         <>
                           {isValidator ? (
@@ -252,6 +279,14 @@ export function NeuronTable({
                       <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
                         {scoreStr(validatorTrustValue(n))}
                       </td>
+                      <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                        {formatTakePct(n.take)}
+                      </td>
+                      <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                        {formatApyPct(
+                          annualizedDelegatorApyPct(n.emission_tao ?? 0, n.stake_tao ?? 0, n.take),
+                        )}
+                      </td>
                     </>
                   ) : (
                     <>
@@ -275,6 +310,26 @@ export function NeuronTable({
                       <span className="font-mono text-[10px] text-ink-subtle-text">—</span>
                     )}
                   </td>
+                  {isValidator ? (
+                    <td className="px-3 py-2.5 text-right">
+                      {n.hotkey ? (
+                        <StakeUnstakeModal
+                          hotkey={n.hotkey}
+                          netuid={netuid}
+                          trigger={(open) => (
+                            <button
+                              type="button"
+                              onClick={open}
+                              className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong transition-colors hover:border-accent/50 hover:text-accent"
+                            >
+                              <Coins className="size-3 text-ink-muted" aria-hidden />
+                              Delegate
+                            </button>
+                          )}
+                        />
+                      ) : null}
+                    </td>
+                  ) : null}
                 </tr>
               );
             })}

--- a/apps/ui/src/components/metagraphed/sponsored-validator-callout.tsx
+++ b/apps/ui/src/components/metagraphed/sponsored-validator-callout.tsx
@@ -1,0 +1,98 @@
+import { Coins } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { CopyButton } from "@jsonbored/ui-kit";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-table";
+import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
+import {
+  annualizedDelegatorApyPct,
+  formatApyPct,
+  formatTakePct,
+} from "@/lib/metagraphed/validator-apy";
+import type { MetagraphNeuron } from "@/lib/metagraphed/types";
+
+/**
+ * Renders a `featured: true` (#5166) validator as its own honestly-disclosed
+ * slot — never as an unmarked row inside the objective, stake-ranked list.
+ *
+ * Deliberately its own component/card, not a table row: the objective
+ * NeuronTable below (or beside) this always sorts by real chain metrics only
+ * (see NUMERIC_FIELDS in neuron-table.tsx, which structurally excludes
+ * `featured`), so a paid placement can be shown prominently without ever
+ * being counted as rank #1. This mirrors how search/marketplace "Sponsored"
+ * results work: prominent placement is fine, blending into the organic count
+ * is not. The featured validator may also appear in the objective list below
+ * at its own true, unfavored position — this callout doesn't hide it there.
+ */
+export function SponsoredValidatorCallout({
+  netuid,
+  subnetName,
+  validator,
+}: {
+  netuid: number;
+  subnetName?: string;
+  validator: MetagraphNeuron;
+}) {
+  if (!validator.hotkey) return null;
+  const apy = formatApyPct(
+    annualizedDelegatorApyPct(
+      validator.emission_tao ?? 0,
+      validator.stake_tao ?? 0,
+      validator.take,
+    ),
+  );
+
+  return (
+    <div className="rounded-xl border border-ink-muted/30 bg-surface/40 p-4">
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <SponsoredBadge />
+        <span className="font-mono text-[10px] text-ink-muted">
+          Paid placement — not ranked or endorsed by Metagraphed.
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <Link
+            to="/validators/$hotkey"
+            params={{ hotkey: validator.hotkey }}
+            className="truncate font-mono text-[13px] text-ink-strong hover:text-accent hover:underline"
+            title={validator.hotkey}
+          >
+            {shortHash(validator.hotkey, 6) ?? validator.hotkey}
+          </Link>
+          <CopyButton value={validator.hotkey} label="hotkey" />
+        </div>
+        <div className="flex flex-wrap items-center gap-4 font-mono text-[11px] text-ink-muted">
+          <span>
+            Stake{" "}
+            <span className="text-ink-strong tabular-nums">
+              {taoCompact(validator.stake_tao)} τ
+            </span>
+          </span>
+          <span>
+            Take{" "}
+            <span className="text-ink-strong tabular-nums">{formatTakePct(validator.take)}</span>
+          </span>
+          <span>
+            Est. APY <span className="text-ink-strong tabular-nums">{apy}</span>
+          </span>
+        </div>
+        <StakeUnstakeModal
+          hotkey={validator.hotkey}
+          netuid={netuid}
+          subnetName={subnetName}
+          trigger={(open) => (
+            <button
+              type="button"
+              onClick={open}
+              className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-3 py-1.5 text-[11px] font-medium text-ink-strong transition-colors hover:border-accent/50 hover:text-accent"
+            >
+              <Coins className="size-3 text-ink-muted" aria-hidden />
+              Delegate
+            </button>
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/subnet-validators-preview.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-validators-preview.tsx
@@ -1,0 +1,139 @@
+import { Suspense } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { Coins, ArrowRight } from "lucide-react";
+import { CopyButton } from "@jsonbored/ui-kit";
+import { subnetValidatorsQuery } from "@/lib/metagraphed/queries";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { Skeleton } from "@/components/metagraphed/states";
+import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
+import { SponsoredValidatorCallout } from "@/components/metagraphed/sponsored-validator-callout";
+import { annualizedDelegatorApyPct, formatApyPct } from "@/lib/metagraphed/validator-apy";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import type { MetagraphNeuron } from "@/lib/metagraphed/types";
+
+const PREVIEW_N = 3;
+
+/**
+ * Hero-adjacent validator preview (#5903 follow-up): the "as few clicks as
+ * possible" delegation entry point — a visitor can compare the top few
+ * validators and delegate without leaving the masthead. Reads the same
+ * subnetValidatorsQuery the Validators tab uses (React Query dedupes the
+ * fetch), so this never issues a second network request.
+ *
+ * Ranking here is always by stake_tao, computed fresh from `validators` —
+ * it never reads `featured`. A sponsored validator (if any) renders in its
+ * own SponsoredValidatorCallout above this ranked list, never blended into
+ * it; see that component's own doc comment for why.
+ */
+export function SubnetValidatorsPreview({ netuid }: { netuid: number }) {
+  return (
+    <QueryErrorBoundary fallback={() => null}>
+      <Suspense fallback={<Skeleton className="h-32 w-full" />}>
+        <SubnetValidatorsPreviewLoader netuid={netuid} />
+      </Suspense>
+    </QueryErrorBoundary>
+  );
+}
+
+function SubnetValidatorsPreviewLoader({ netuid }: { netuid: number }) {
+  const { data } = useSuspenseQuery(subnetValidatorsQuery(netuid));
+  const validators = data.data.validators;
+  const navigate = useNavigate();
+
+  if (validators.length === 0) return null;
+
+  const sponsored = validators.find((v) => v.featured && v.hotkey);
+  const topByStake = [...validators]
+    .filter((v) => v.hotkey)
+    .sort((a, b) => (b.stake_tao ?? 0) - (a.stake_tao ?? 0))
+    .slice(0, PREVIEW_N);
+
+  return (
+    <div className="mt-6 space-y-3">
+      {sponsored ? <SponsoredValidatorCallout netuid={netuid} validator={sponsored} /> : null}
+      <div className="rounded-xl border border-border bg-card p-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+            Top validators · by stake
+          </span>
+          <button
+            type="button"
+            onClick={() =>
+              navigate({
+                to: ".",
+                search: (prev: Record<string, unknown>) => ({ ...prev, tab: "validators" }),
+                replace: true,
+              })
+            }
+            className="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-wider text-ink-muted transition-colors hover:text-accent"
+          >
+            View all validators
+            <ArrowRight className="size-3" aria-hidden />
+          </button>
+        </div>
+        <ul className="divide-y divide-border/60">
+          {topByStake.map((v) => (
+            <ValidatorPreviewRow key={v.uid} netuid={netuid} validator={v} />
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function ValidatorPreviewRow({
+  netuid,
+  validator,
+}: {
+  netuid: number;
+  validator: MetagraphNeuron;
+}) {
+  if (!validator.hotkey) return null;
+  const apy = formatApyPct(
+    annualizedDelegatorApyPct(
+      validator.emission_tao ?? 0,
+      validator.stake_tao ?? 0,
+      validator.take,
+    ),
+  );
+
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-3 py-2.5">
+      <div className="flex min-w-0 items-center gap-1.5">
+        <Link
+          to="/validators/$hotkey"
+          params={{ hotkey: validator.hotkey }}
+          className="truncate font-mono text-[12px] text-ink-strong hover:text-accent hover:underline"
+          title={validator.hotkey}
+        >
+          {shortHash(validator.hotkey, 6) ?? validator.hotkey}
+        </Link>
+        <CopyButton value={validator.hotkey} label="hotkey" />
+      </div>
+      <div className="flex flex-wrap items-center gap-3 font-mono text-[11px] text-ink-muted">
+        <span>
+          <span className="text-ink-strong tabular-nums">{taoCompact(validator.stake_tao)}</span> τ
+        </span>
+        <span>
+          <span className="text-ink-strong tabular-nums">{apy}</span> APY
+        </span>
+        <StakeUnstakeModal
+          hotkey={validator.hotkey}
+          netuid={netuid}
+          trigger={(open) => (
+            <button
+              type="button"
+              onClick={open}
+              className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2.5 py-1 text-[11px] font-medium text-ink-strong transition-colors hover:border-accent/50 hover:text-accent"
+            >
+              <Coins className="size-3 text-ink-muted" aria-hidden />
+              Delegate
+            </button>
+          )}
+        />
+      </div>
+    </li>
+  );
+}

--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { CopyButton } from "@jsonbored/ui-kit";
 
-import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
+import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-table";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
 
@@ -29,7 +29,7 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
             className="min-w-0 space-y-2 rounded-lg border border-border bg-card p-3"
           >
             <div className="flex min-w-0 items-center gap-1.5">
-              {v.featured ? <FeaturedBadge /> : null}
+              {v.featured ? <SponsoredBadge /> : null}
               <Link
                 to="/validators/$hotkey"
                 params={{ hotkey: v.hotkey }}

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -3,7 +3,7 @@ import { Link } from "@tanstack/react-router";
 import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
-import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
+import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-table";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
 import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
@@ -41,7 +41,7 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     tdClassName: TD_BASE,
     cell: (v) => (
       <div className="flex items-center gap-1.5">
-        {v.featured ? <FeaturedBadge /> : null}
+        {v.featured ? <SponsoredBadge /> : null}
         <ValidatorIdentityChip hotkey={v.hotkey} identity={v.coldkey_identity} size={20} />
       </div>
     ),

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -9,6 +9,7 @@ import {
   type TreemapMiniDatum,
 } from "@jsonbored/ui-kit";
 import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
+import { SponsoredValidatorCallout } from "@/components/metagraphed/sponsored-validator-callout";
 
 const TOP_N = 10;
 
@@ -29,6 +30,7 @@ export function ValidatorsTableLoader({
   const { data } = useSuspenseQuery(subnetValidatorsQuery(netuid));
   const meta = data.meta;
   const validators = data.data.validators;
+  const sponsored = validators.find((v) => v.featured && v.hotkey);
 
   const stakeBars = useMemo(() => {
     return [...validators]
@@ -67,6 +69,7 @@ export function ValidatorsTableLoader({
 
   return (
     <div className="space-y-4">
+      {sponsored ? <SponsoredValidatorCallout netuid={netuid} validator={sponsored} /> : null}
       {stakeBars.length > 0 ? (
         <div className="rounded-xl border border-border bg-card p-4">
           <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -5616,6 +5616,7 @@ function normalizeMetagraphNeuron(raw: unknown): MetagraphNeuron | undefined {
     registered_at_block: coerceFiniteNumber(raw.registered_at_block),
     is_immunity_period: booleanValue(raw.is_immunity_period),
     axon: coerceString(raw.axon) ?? null,
+    take: coerceFiniteNumber(raw.take) ?? null,
     // Only /validators rows carry this (#5166); booleanValue already maps an
     // absent/non-boolean cell to undefined, so metagraph/neuron-detail rows
     // (which never send it) keep the field genuinely absent, not a false.

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2086,7 +2086,10 @@ export interface MetagraphNeuron {
   registered_at_block?: number;
   is_immunity_period?: boolean;
   axon?: string | null;
-  /** DB-toggled maintainer pin (#5166) — only set on /validators rows, absent elsewhere. */
+  /** Validator commission (0..1 fraction) — only set on /validators rows, absent elsewhere. */
+  take?: number | null;
+  /** DB-toggled maintainer pin (#5166) — a disclosed sponsored placement, not a
+   * trust signal. Only set on /validators rows, absent elsewhere. */
   featured?: boolean;
   [key: string]: unknown;
 }

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -110,8 +110,10 @@ import { ResourceExplorer } from "@/components/metagraphed/resource-explorer";
 import { GittensorRegisteredRepos } from "@/components/metagraphed/gittensor-registered-repos";
 import { SubnetProfilePanel } from "@/components/metagraphed/subnet-profile-panel";
 import { SubnetPulseStrip } from "@/components/metagraphed/subnet-pulse-strip";
+import { SubnetValidatorsPreview } from "@/components/metagraphed/subnet-validators-preview";
 import { SubnetFilterProvider } from "@/components/metagraphed/subnet-filter-context";
 import { SubnetCompareDrawer } from "@/components/metagraphed/subnet-compare-drawer";
+import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 
 type SearchParams = {
   tab?: string;
@@ -291,6 +293,8 @@ function ProfileShell({ netuid }: { netuid: number }) {
             ) : null
           }
         />
+
+        <SubnetValidatorsPreview netuid={netuid} />
 
         <SubnetPulseStrip netuid={netuid} />
 
@@ -1557,6 +1561,7 @@ function ValidatorsPanel({ netuid }: { netuid: number }) {
       subtitle="Active validator set ranked by stake — emission, trust, and consensus."
       info="GET /api/v1/subnets/{netuid}/validators — the permitted, stake-ranked validator set from the latest snapshot. Select a UID to open it in the Metagraph tab."
     >
+      <ValidatorGuide />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-64 w-full" />}>
           <ValidatorsTableLoader

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -14,7 +14,7 @@ import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { ValidatorDominanceChart } from "@/components/metagraphed/charts/validator-dominance-chart";
-import { taoCompact, FeaturedBadge } from "@/components/metagraphed/neuron-table";
+import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-table";
 import { ValidatorCardList } from "@/components/metagraphed/validator-card-list";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { VALIDATOR_COLUMNS } from "@/components/metagraphed/validator-columns";

--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -173,6 +173,20 @@ CREATE INDEX IF NOT EXISTS idx_neurons_hotkey        ON neurons (hotkey);
 -- reassignment cycles, so this small side table sidesteps the hazard entirely.
 -- Toggled by a direct SQL UPDATE/INSERT -- no code deploy needed to change
 -- which validator is featured.
+--
+-- Disclosure requirement (added when this pin became a real, sold sponsored-
+-- placement product rather than dormant infra): a hotkey in this table is a
+-- PAID placement, not an editorial/quality signal. The frontend must always
+-- render it as SponsoredBadge (apps/ui/src/components/metagraphed/
+-- neuron-table.tsx) with a persistent, non-hover-gated "Sponsored" label --
+-- and, on the subnet/validator listing surfaces, as its own separate
+-- SponsoredValidatorCallout card ABOVE the objectively stake-ranked list,
+-- never as an unmarked row inside it. NUMERIC_FIELDS in neuron-table.tsx
+-- structurally excludes `featured` from every sort option, so a placement
+-- here can never distort the neutral ranking those surfaces show. Toggling
+-- this table is a maintainer-only operational action (direct SQL, like this
+-- comment says above) -- treat it the same as any other paid/disclosed
+-- placement decision, not a data-quality judgment.
 CREATE TABLE IF NOT EXISTS featured_validators (
   hotkey      TEXT PRIMARY KEY,
   featured_at BIGINT NOT NULL


### PR DESCRIPTION
## Summary

Two related pieces, both scoped from the same design conversation:

**A. Validator-agnostic delegation UX (subnet detail page)**
- New `SubnetValidatorsPreview` widget rendered above the fold (between the masthead and pulse strip on every `/subnets/$netuid` page): top-3 validators by stake with a real **Delegate** action per row, reusing the already-shipped `StakeUnstakeModal` wallet-connect/stake flow -- no new transaction UI built.
- The Validators tab (`NeuronTable`'s validator variant) gains **Take%** (sortable) and **Est. APY** (computed client-side via the existing `annualizedDelegatorApyPct` helper, same one already used on `/validators/:hotkey`) columns, plus a per-row **Delegate** action.
- Wires in the existing, previously-unused-here `ValidatorGuide` explainer ("How to evaluate a validator") on the Validators tab.
- Ranking is always by objective on-chain metrics. `NUMERIC_FIELDS` in `neuron-table.tsx` has no `featured` member -- a paid placement can structurally never become sortable/rankable. Backed by a new test (`neuron-table.test.ts`).
- Since `subnets.$netuid.tsx` is one shared route for all 129 subnets, this is one implementation, not a per-subnet change.

**B. Honest disclosure fix for the existing sponsored-placement pin**
- `featured_validators` (#5166/#5211) is an already-shipped, DB-backed pin that reorders a validator to the front of validator listings -- currently unused in production (verified live: zero `featured:true` rows). Its badge said only **"Featured"**, reused the trust/permit pill's accent color, and never disclosed *why* a validator was pinned.
- Renamed `FeaturedBadge` -> `SponsoredBadge`: persistent (non-hover), explicit **"Sponsored"** label with its own neutral styling, distinct from the trust-signal color language.
- Added `SponsoredValidatorCallout` -- when a validator is pinned, it now renders as its own clearly-labeled card **above and separate from** the neutral ranked list, never as an unmarked row inside it (same pattern as disclosed search/marketplace sponsored results).
- Documented the disclosure requirement directly in `deploy/postgres/schema.sql`'s `featured_validators` comment so it can't quietly regress in a future PR.
- No schema/registry changes needed -- this reuses existing, already-shipped infrastructure rather than adding a parallel mechanism.

## Test plan
- [x] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (1013/1013 passed, incl. new `neuron-table.test.ts`)
- [x] `npm run build --workspace=apps/ui`
- [x] Manually verified against a real dev server + live API data (`/subnets/1`): masthead widget renders 3 validators with working Delegate/copy actions; Validators tab renders Take/Est. APY columns and Delegate actions correctly; `ValidatorGuide` loads; no console errors.

## Screenshots

### Masthead validators-preview widget (`/subnets/1`)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-masthead-after-mobile-dark.png)<br><sub>after</sub> |

### Validators tab upgrade (`/subnets/1?tab=validators`, scrolled to `#validators`)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/delegation-ux-validators-tab-after-mobile-dark.png)<br><sub>after</sub> |