### PR TITLE
fix(ui): compact StaleBanner in the validator detail hero actions (#5861)

### DIFF
--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -206,11 +206,17 @@ export function StaleBanner({
   generatedAt,
   refreshQueryKeys,
   refreshLabel = "Refresh now",
+  compact = false,
 }: {
   generatedAt?: string | null;
   /** When provided, renders a button that invalidates these query keys. */
   refreshQueryKeys?: QueryKey[];
   refreshLabel?: string;
+  /**
+   * Compact single-line variant for tight contexts (e.g. a hero actions row):
+   * shorter copy and an icon-only refresh button whose label moves to a tooltip.
+   */
+  compact?: boolean;
 }) {
   const queryClient = useQueryClient();
   const [state, setState] = useState<"idle" | "pending" | "ok" | "error">("idle");
@@ -250,14 +256,24 @@ export function StaleBanner({
     <div
       role="status"
       aria-live="polite"
-      className="flex flex-wrap items-center gap-x-3 gap-y-1.5 font-mono text-[10px] text-ink-muted"
+      className={`flex items-center font-mono text-[10px] text-ink-muted ${
+        compact ? "gap-2" : "flex-wrap gap-x-3 gap-y-1.5"
+      }`}
     >
       <span className="inline-flex items-center gap-1.5 min-w-0">
         <Clock className="size-3 shrink-0" aria-hidden />
-        Snapshot from <TimeAgo at={generatedAt} /> — may be lagging behind live.
+        {compact ? (
+          <>
+            Snapshot <TimeAgo at={generatedAt} />
+          </>
+        ) : (
+          <>
+            Snapshot from <TimeAgo at={generatedAt} /> — may be lagging behind live.
+          </>
+        )}
       </span>
       {refreshQueryKeys?.length ? (
-        <span className="ml-auto flex items-center gap-2">
+        <span className={`flex items-center gap-2 ${compact ? "" : "ml-auto"}`}>
           {state === "error" && errorMsg ? (
             <span className="text-health-down truncate max-w-[18rem]" title={errorMsg}>
               {errorMsg}
@@ -265,18 +281,22 @@ export function StaleBanner({
           ) : null}
           {state === "ok" ? (
             <span className="inline-flex items-center gap-1 text-health-ok">
-              <CheckCircle2 className="size-3" /> Refreshed
+              <CheckCircle2 className="size-3" />
+              {compact ? null : " Refreshed"}
             </span>
           ) : null}
           <button
             type="button"
             onClick={onRefresh}
             disabled={state === "pending"}
-            className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2 py-1 font-medium text-ink-strong hover:border-ink/30 disabled:opacity-60 disabled:cursor-progress"
+            title={refreshLabel}
             aria-label={refreshLabel}
+            className={`inline-flex items-center gap-1.5 rounded border border-border bg-card font-medium text-ink-strong hover:border-ink/30 disabled:opacity-60 disabled:cursor-progress ${
+              compact ? "p-1" : "px-2 py-1"
+            }`}
           >
             <RefreshCw className={`size-3 ${state === "pending" ? "animate-spin" : ""}`} />
-            {state === "pending" ? "Refreshing…" : refreshLabel}
+            {compact ? null : state === "pending" ? "Refreshing…" : refreshLabel}
           </button>
         </span>
       ) : null}

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -6,7 +6,7 @@ import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { Boxes, Coins, Gauge, Percent, Users, Zap } from "lucide-react";
 import { useWallet } from "@/hooks/use-wallet";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
+import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
@@ -25,7 +25,7 @@ import { taoCompact, scoreStr } from "@/components/metagraphed/neuron-table";
 import { validatorDetailQuery, validatorNominatorsQuery } from "@/lib/metagraphed/queries";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { hasValidatorIdentity } from "@/lib/metagraphed/validator-identity";
 import {
   annualizedDelegatorApyPct,
@@ -241,6 +241,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
   const sourceRef = ss58PathSegment(hotkey);
   const detailRes = useSuspenseQuery(validatorDetailQuery(hotkey)).data;
   const detail = detailRes.data;
+  const generatedAt = detailRes.meta?.generated_at ?? null;
   const identity = detail.coldkey_identity;
   const hasIdentity = hasValidatorIdentity(identity);
   const displayName =
@@ -287,7 +288,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           </span>
         }
         actions={
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             {isOwner ? (
               <TakeManagementModal
                 hotkey={hotkey}
@@ -306,6 +307,13 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
               />
             ) : null}
             <ShareButton />
+            {isStaleFreshness(generatedAt) ? (
+              <StaleBanner
+                compact
+                generatedAt={generatedAt}
+                refreshQueryKeys={[validatorDetailQuery(hotkey).queryKey]}
+              />
+            ) : null}
           </div>
         }
         caption="explorer / v1"


### PR DESCRIPTION
## What

Adds a staleness indicator to the validator detail page (`validators.$hotkey.tsx`), which had none — unlike its own list view and the `subnets.$netuid` / `providers.$slug` detail pages.

## Addressing the prior review

The earlier attempt placed a full-width `StaleBanner` after the `PageHero`, which (per @JSONbored's review) floated in the hero's bottom-margin with too much spacing and a clunky text-plus-button layout. This revision takes the suggested direction — *"an icon and no 'refresh' text, and a tooltip or much shorter text"*:

- **New opt-in `compact` variant on the shared `StaleBanner`**: shorter copy ("Snapshot 3d ago" instead of "Snapshot from 3d ago — may be lagging behind live") and an **icon-only refresh button** whose "Refresh now" label moves to a `title` tooltip. Existing `StaleBanner` usages are unchanged.
- **Placed inline in the `PageHero` actions row** next to *Share view*, so it's integrated with the hero instead of floating in the section's bottom margin — removing the spacing issue entirely.

Gated on `isStaleFreshness(detailRes.meta?.generated_at)`; display-layer only, query/tables untouched.

## Screenshots

Compact indicator sits inline next to *Share view* (the `meta` field is fresh live, so **after** shows the stale state forced with an aged snapshot; **before** is `main`):

| View | Before | After |
|------|--------|-------|
| Desktop · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861v2-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861v2-after-desktop-light.png) |
| Desktop · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861v2-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861v2-after-desktop-dark.png) |
| Tablet · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861v2-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861v2-after-tablet-light.png) |
| Tablet · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861v2-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861v2-after-tablet-dark.png) |
| Mobile · Light | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861v2-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861v2-after-mobile-light.png) |
| Mobile · Dark | ![before](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861v2-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/shinkaito-ai/metagraphed/screenshots/5861v2-after-mobile-dark.png) |

Closes #5861.