### PR TITLE
fix(ui): show an error state when a history chart's query fails

### DIFF
--- a/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { accountPositionHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { AccountPositionHistoryPoint } from "@/lib/metagraphed/types";
@@ -30,7 +30,13 @@ function yieldStr(v?: number) {
  * this position has no history yet (e.g. a freshly-registered neuron). */
 export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; netuid: number }) {
   const [win, setWin] = useState<Win>("90d");
-  const { data: res, isLoading } = useQuery(accountPositionHistoryQuery(ss58, netuid, win));
+  const {
+    data: res,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(accountPositionHistoryQuery(ss58, netuid, win));
   const points = useMemo<AccountPositionHistoryPoint[]>(
     () => res?.data?.points ?? [],
     [res?.data?.points],
@@ -79,6 +85,8 @@ export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; ne
       <div className="flex items-center justify-end">{windowSelector}</div>
       {isLoading ? (
         <Skeleton className="h-32 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} context="position history" />
       ) : !hasData ? (
         <EmptyState
           title="No history yet"

--- a/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { subnetNeuronHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetNeuronHistoryPoint } from "@/lib/metagraphed/types";
 
@@ -22,7 +22,13 @@ function scoreStr(v?: number) {
  */
 export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: number }) {
   const [win, setWin] = useState<Win>("90d");
-  const { data: res, isLoading } = useQuery(subnetNeuronHistoryQuery(netuid, uid, win));
+  const {
+    data: res,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(subnetNeuronHistoryQuery(netuid, uid, win));
   const points = useMemo<SubnetNeuronHistoryPoint[]>(
     () => res?.data?.points ?? [],
     [res?.data?.points],
@@ -79,6 +85,8 @@ export function NeuronHistoryChart({ netuid, uid }: { netuid: number; uid: numbe
       </div>
       {isLoading ? (
         <Skeleton className="h-32 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} context="neuron history" />
       ) : !hasData ? (
         <EmptyState
           title="No per-UID history"

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
@@ -20,7 +20,13 @@ const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
  */
 export function SubnetHistoryChart({ netuid }: { netuid: number }) {
   const [win, setWin] = useState<Win>("90d");
-  const { data: res, isLoading } = useQuery(subnetHistoryQuery(netuid, win));
+  const {
+    data: res,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(subnetHistoryQuery(netuid, win));
   const points = useMemo<SubnetHistoryPoint[]>(() => res?.data?.points ?? [], [res?.data?.points]);
 
   const series = useMemo(() => {
@@ -72,6 +78,8 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
       <div className="flex items-center justify-end">{windowSelector}</div>
       {isLoading ? (
         <Skeleton className="h-32 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} context="subnet history" />
       ) : !hasData ? (
         <EmptyState
           title="No on-chain history"

--- a/apps/ui/src/components/metagraphed/validator-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/validator-history-chart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { validatorHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { ValidatorHistoryPoint } from "@/lib/metagraphed/types";
@@ -29,7 +29,13 @@ function rewardsStr(v?: number) {
  * the validator has no history yet (e.g. a freshly-registered hotkey). */
 export function ValidatorHistoryChart({ hotkey }: { hotkey: string }) {
   const [win, setWin] = useState<Win>("90d");
-  const { data: res, isLoading } = useQuery(validatorHistoryQuery(hotkey, win));
+  const {
+    data: res,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(validatorHistoryQuery(hotkey, win));
   const points = useMemo<ValidatorHistoryPoint[]>(
     () => res?.data?.points ?? [],
     [res?.data?.points],
@@ -77,6 +83,8 @@ export function ValidatorHistoryChart({ hotkey }: { hotkey: string }) {
       <div className="flex items-center justify-end">{windowSelector}</div>
       {isLoading ? (
         <Skeleton className="h-32 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} context="validator history" />
       ) : !hasData ? (
         <EmptyState
           title="No history yet"


### PR DESCRIPTION
### What

The four history-chart components each destructured only `{ data, isLoading }` from `useQuery`, with no `isError`. When the request actually fails, `data` stays `undefined`, `points` ends up empty, and the component renders its `EmptyState` — so a genuine API failure looks like "no data yet". The sibling `account-history-chart.tsx` already handles this correctly.

### Fix

In `neuron-history-chart.tsx`, `validator-history-chart.tsx`, `subnet-history-chart.tsx`, and `account-position-history-chart.tsx`: destructure `isError`/`error`/`refetch` and render the shared `ErrorState` (with `onRetry={() => refetch()}`) on error, mirroring `account-history-chart.tsx` exactly. Loading and success rendering are untouched.

### Screenshots

Captured on `/subnets/1` (SubnetHistoryChart) with the `/history` endpoint forced to **HTTP 500** — before, the failure shows the misleading "No on-chain history" empty state; after, it shows a real error card with a Retry button. The other three charts receive the identical mechanical change to the same shared pattern, so they render the same `ErrorState`.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/subnet-history-mobile-dark-after.png)<br><sub>after</sub> |

### Local checks

`typecheck` (0 errors on the 4 files), full `test` suite (1010 pass), `lint` clean.

Closes #5863
