### PR TITLE
fix(ui): add copy buttons to explorer address/signer tables without inflating rows

### DIFF
--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -19,6 +19,7 @@ import {
   Sparkline,
   BarMini,
   Donut,
+  CopyButton,
 } from "@jsonbored/ui-kit";
 import { EXPLORER_LEADERBOARD_IDS } from "@/components/metagraphed/explorer-leaderboard-layout";
 import { ExplorerLeaderboardTableShell } from "@/components/metagraphed/explorer-leaderboard-table-shell";
@@ -1126,14 +1127,17 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
                   {transfers.top_senders.map((s) => (
                     <tr key={s.address} className="hover:bg-surface/40">
                       <td className="px-4 py-2 font-mono text-[11px]">
-                        <Link
-                          to="/accounts/$ss58"
-                          params={{ ss58: s.address }}
-                          className="text-ink-strong hover:text-accent hover:underline"
-                          title={s.address}
-                        >
-                          {shortHash(s.address) ?? s.address}
-                        </Link>
+                        <span className="flex items-center gap-1.5">
+                          <Link
+                            to="/accounts/$ss58"
+                            params={{ ss58: s.address }}
+                            className="text-ink-strong hover:text-accent hover:underline"
+                            title={s.address}
+                          >
+                            {shortHash(s.address) ?? s.address}
+                          </Link>
+                          <CopyButton value={s.address} label="address" className="-my-4" />
+                        </span>
                       </td>
                       <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
                         {formatTao(s.volume_tao)}
@@ -1169,14 +1173,17 @@ function TransfersLeaderboardSection({ transfers }: { transfers: ChainTransfers 
                   {transfers.top_receivers.map((r) => (
                     <tr key={r.address} className="hover:bg-surface/40">
                       <td className="px-4 py-2 font-mono text-[11px]">
-                        <Link
-                          to="/accounts/$ss58"
-                          params={{ ss58: r.address }}
-                          className="text-ink-strong hover:text-accent hover:underline"
-                          title={r.address}
-                        >
-                          {shortHash(r.address) ?? r.address}
-                        </Link>
+                        <span className="flex items-center gap-1.5">
+                          <Link
+                            to="/accounts/$ss58"
+                            params={{ ss58: r.address }}
+                            className="text-ink-strong hover:text-accent hover:underline"
+                            title={r.address}
+                          >
+                            {shortHash(r.address) ?? r.address}
+                          </Link>
+                          <CopyButton value={r.address} label="address" className="-my-4" />
+                        </span>
                       </td>
                       <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
                         {formatTao(r.volume_tao)}
@@ -1450,14 +1457,17 @@ function ExplorerDashboard() {
                     {signers.signers.slice(0, 12).map((s) => (
                       <tr key={s.signer} className="hover:bg-surface/40">
                         <td className="px-4 py-2 font-mono text-[11px]">
-                          <Link
-                            to="/accounts/$ss58"
-                            params={{ ss58: s.signer }}
-                            className="text-ink-strong hover:text-accent hover:underline"
-                            title={s.signer}
-                          >
-                            {shortHash(s.signer) ?? s.signer}
-                          </Link>
+                          <span className="flex items-center gap-1.5">
+                            <Link
+                              to="/accounts/$ss58"
+                              params={{ ss58: s.signer }}
+                              className="text-ink-strong hover:text-accent hover:underline"
+                              title={s.signer}
+                            >
+                              {shortHash(s.signer) ?? s.signer}
+                            </Link>
+                            <CopyButton value={s.signer} label="signer" className="-my-4" />
+                          </span>
                         </td>
                         <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
                           {formatNumber(s.tx_count)}
@@ -1565,14 +1575,17 @@ function ExplorerDashboard() {
                   {fees.top_fee_payers.map((p) => (
                     <tr key={p.signer} className="hover:bg-surface/40">
                       <td className="px-4 py-2 font-mono text-[11px]">
-                        <Link
-                          to="/accounts/$ss58"
-                          params={{ ss58: p.signer }}
-                          className="text-ink-strong hover:text-accent hover:underline"
-                          title={p.signer}
-                        >
-                          {shortHash(p.signer) ?? p.signer}
-                        </Link>
+                        <span className="flex items-center gap-1.5">
+                          <Link
+                            to="/accounts/$ss58"
+                            params={{ ss58: p.signer }}
+                            className="text-ink-strong hover:text-accent hover:underline"
+                            title={p.signer}
+                          >
+                            {shortHash(p.signer) ?? p.signer}
+                          </Link>
+                          <CopyButton value={p.signer} label="signer" className="-my-4" />
+                        </span>
                       </td>
                       <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
                         {formatTao(p.total_fee_tao)}
@@ -1722,14 +1735,17 @@ function ExplorerDashboard() {
                       <tr key={weightSetterKey(setter)} className="hover:bg-surface/40">
                         <td className="px-4 py-2 font-mono text-[11px]">
                           {setter.hotkey ? (
-                            <Link
-                              to="/accounts/$ss58"
-                              params={{ ss58: setter.hotkey }}
-                              className="text-ink-strong hover:text-accent hover:underline"
-                              title={setter.hotkey}
-                            >
-                              {shortHash(setter.hotkey) ?? setter.hotkey}
-                            </Link>
+                            <span className="flex items-center gap-1.5">
+                              <Link
+                                to="/accounts/$ss58"
+                                params={{ ss58: setter.hotkey }}
+                                className="text-ink-strong hover:text-accent hover:underline"
+                                title={setter.hotkey}
+                              >
+                                {shortHash(setter.hotkey) ?? setter.hotkey}
+                              </Link>
+                              <CopyButton value={setter.hotkey} label="hotkey" className="-my-4" />
+                            </span>
                           ) : (
                             <span
                               className="text-ink-muted"
@@ -1835,24 +1851,30 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
                     {i + 1}
                   </td>
                   <td className="px-4 py-2 font-mono text-[11px]">
-                    <Link
-                      to="/accounts/$ss58"
-                      params={{ ss58: p.from }}
-                      className="text-ink-strong hover:text-accent hover:underline"
-                      title={p.from}
-                    >
-                      {shortHash(p.from) ?? p.from}
-                    </Link>
+                    <span className="flex items-center gap-1.5">
+                      <Link
+                        to="/accounts/$ss58"
+                        params={{ ss58: p.from }}
+                        className="text-ink-strong hover:text-accent hover:underline"
+                        title={p.from}
+                      >
+                        {shortHash(p.from) ?? p.from}
+                      </Link>
+                      <CopyButton value={p.from} label="address" className="-my-4" />
+                    </span>
                   </td>
                   <td className="px-4 py-2 font-mono text-[11px]">
-                    <Link
-                      to="/accounts/$ss58"
-                      params={{ ss58: p.to }}
-                      className="text-ink-strong hover:text-accent hover:underline"
-                      title={p.to}
-                    >
-                      {shortHash(p.to) ?? p.to}
-                    </Link>
+                    <span className="flex items-center gap-1.5">
+                      <Link
+                        to="/accounts/$ss58"
+                        params={{ ss58: p.to }}
+                        className="text-ink-strong hover:text-accent hover:underline"
+                        title={p.to}
+                      >
+                        {shortHash(p.to) ?? p.to}
+                      </Link>
+                      <CopyButton value={p.to} label="address" className="-my-4" />
+                    </span>
                   </td>
                   <td className="px-4 py-2 text-right font-mono text-[11px] tabular-nums text-ink">
                     {formatTao(p.volume_tao)}


### PR DESCRIPTION
Closes #5857

`explorer.tsx` rendered every address/signer in its seven tables (top senders, top receivers, pair signers ×2, weight-setters, largest transfers from/to) as a tooltip-only `title=` link — no copy affordance, and no `CopyButton` import in the file at all.

Each is now paired with a `CopyButton`. These rows are the compact `py-2` variant, so each button is given `-my-4`, which folds the button's 44px height back into the row's existing padding — the button keeps its full 44px hit area and the row height is unchanged (measured 32px → 32px on `/explorer`). Same no-grow approach that landed in #6160/#6166/#6179 (`-my-3.5` there for the `py-2.5` rows; `-my-4` here for the shorter `py-2` rows).

Captured at the Phase C2 matrix — fixed viewports (375×812 / 768×1024 / 1280×800), each theme forced via `mg-theme`. The before/after show the same signer table with and without the copy buttons.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5857/5857-after-mobile-dark.png)<br><sub>after</sub> |

### Verification

`prettier` clean · `eslint` 0 errors · `tsc --noEmit` 0 · `vitest` 1013/1013 passing (129 files). The zero row-height delta was measured in the browser via `getBoundingClientRect()` with the button toggled on/off across all 12 rendered copy buttons.
