### PR TITLE
fix(ui): add DownloadCsvButton to providers.index.tsx

### DIFF
--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -20,6 +20,7 @@ import {
   type ProviderCounts,
 } from "@/lib/metagraphed/queries";
 import { classNames, isStaleFreshness } from "@/lib/metagraphed/format";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { matchesQuery } from "@/lib/metagraphed/url-state";
 import { matchesProviderAuthority } from "@/lib/metagraphed/providers-url-state";
 import { resolveProviderCard } from "@/lib/metagraphed/provider-card-fields";
@@ -30,6 +31,7 @@ import {
   PageHero,
   ViewModeToggle,
   ShareButton,
+  DownloadCsvButton,
   TimeAgo,
   ActionBar,
   Donut,
@@ -78,6 +80,7 @@ function ProvidersPage() {
     search.q || search.kind || search.authority || (search.sort && search.sort !== "name"),
   );
   const onReset = () => navigate({ search: { view: search.view } as never, replace: true });
+  const providersCsvUrl = buildUrl("/api/v1/providers");
   return (
     <AppShell>
       <PageHero
@@ -99,6 +102,7 @@ function ProvidersPage() {
             />
             <ActionBar>
               <ResetFiltersButton active={filtersActive} onReset={onReset} bare />
+              <DownloadCsvButton url={providersCsvUrl} bare />
               <ShareButton bare />
             </ActionBar>
           </>

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -19237,6 +19237,8 @@ export interface operations {
                 sort?: "authority" | "id" | "kind" | "name";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -19244,7 +19246,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19300,6 +19302,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProvidersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2648,6 +2648,17 @@
               "desc"
             ]
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -37984,6 +37984,19 @@
                 "desc"
               ]
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -38047,9 +38060,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -19237,6 +19237,8 @@ export interface operations {
                 sort?: "authority" | "id" | "kind" | "name";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path?: never;
@@ -19244,7 +19246,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -19300,6 +19302,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProvidersArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1823,7 +1823,7 @@ export const API_ROUTES = [
     "List providers and sources.",
     "standard",
     ["providers"],
-    listQuery("providers"),
+    csvListQuery("providers"),
   ),
   route(
     "provider-detail",

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1263,10 +1263,10 @@ describe("subnets CSV export", () => {
   });
 
   test("Accept: text/csv is ignored for collection routes without CSV contracts", async () => {
-    // /api/v1/providers is a list route that intentionally has no CSV contract,
-    // so content negotiation must fall through to the JSON envelope.
+    // /api/v1/source-snapshots is a list route that intentionally has no CSV
+    // contract, so content negotiation must fall through to the JSON envelope.
     const res = await handleRequest(
-      req("/api/v1/providers?limit=1", {
+      req("/api/v1/source-snapshots?limit=1", {
         headers: { accept: "text/csv" },
       }),
       createLocalArtifactEnv(),
@@ -1277,7 +1277,6 @@ describe("subnets CSV export", () => {
 
     const body = await res.json();
     assert.equal(body.ok, true);
-    assert.equal(Array.isArray(body.data.providers), true);
   });
 
   test("empty projected CSV exports retain the requested header row", async () => {
@@ -1434,6 +1433,7 @@ describe("registry list CSV export", () => {
     "subnet-candidates",
     "profiles",
     "coverage-depth",
+    "providers",
   ];
 
   test("every wired registry route advertises the CSV contract", () => {
@@ -1450,7 +1450,7 @@ describe("registry list CSV export", () => {
   });
 
   test("list routes without a CSV contract stay JSON-only", () => {
-    for (const id of ["providers", "rpc-endpoints", "source-snapshots"]) {
+    for (const id of ["rpc-endpoints", "source-snapshots"]) {
       const entry = API_ROUTES.find((route) => route.id === id);
       assert.ok(entry, `route ${id} should exist`);
       assert.notEqual(entry.csv_response, true, `${id} must stay JSON-only`);
@@ -1466,6 +1466,7 @@ describe("registry list CSV export", () => {
     ["/api/v1/candidates", "candidates.csv"],
     ["/api/v1/profiles", "profiles.csv"],
     ["/api/v1/coverage-depth", "coverage-depth.csv"],
+    ["/api/v1/providers", "providers.csv"],
   ]) {
     test(`${path}?format=csv returns a named text/csv download`, async () => {
       const res = await handleRequest(


### PR DESCRIPTION
## Summary

`providers.index.tsx` was the only directory/list route without a CSV-export action — every comparable route (`subnets.index.tsx`, `validators.index.tsx`, `blocks.index.tsx`, `extrinsics.index.tsx`, `endpoints.tsx`, `surfaces.tsx`, `sudo.index.tsx`, `admin-changes.index.tsx`, `accounts.$ss58.tsx`) already exposes `DownloadCsvButton`.

Closes #5864

## Scope note (backend + frontend, not UI-only)

Wiring just the button wasn't enough to make it *work*: `/api/v1/providers` had no CSV contract on the backend. That wasn't an oversight — a dedicated test since #2794 explicitly asserted `providers` (along with `rpc-endpoints` and `source-snapshots`) must stay JSON-only. Shipping only the frontend half would have produced a "Download CSV" button that silently downloads a JSON payload instead of a real CSV.

I checked whether that exclusion reflected a real data-shape problem (e.g. nested arrays that don't flatten to CSV) — it doesn't. The existing flat column set for providers (`id, name, kind, authority, github_url, website_url`, from the static dataset exporter) is exactly as CSV-friendly as subnets/validators. So this reads as a rollout-scope gap from #2794, not a permanent constraint, and enabling it now is the right call — but it does mean this PR touches `src/contracts.mjs` in addition to `apps/**`.

## What Changed

- **Frontend**: `providers.index.tsx` — added `DownloadCsvButton` to the `PageHero`'s `ActionBar`, wired to `buildUrl("/api/v1/providers")` (no server-side filter params exist for this collection, matching how `providersQuery()` already fetches it).
- **Backend**: `src/contracts.mjs` — flipped the `providers` route from `listQuery("providers")` to `csvListQuery("providers")`.
- **Tests**: `tests/api-coverage.test.mjs` — removed `providers` from the "stays JSON-only" guard list (swapped the "Accept: text/csv is ignored" test to use `source-snapshots` instead, which is still JSON-only), added `providers` to the CSV-contract-advertised list, and added a dedicated `/api/v1/providers?format=csv returns a named text/csv download` test matching the other registry list routes.
- **Regenerated**: `openapi.json`, `api-index.json`, `types.d.ts`, `packages/contract/index.d.ts` (via `npm run build`) to reflect the new `format` query param and `text/csv` response on the providers route.

## Validation

- [x] `npx eslint apps/ui/src/routes/providers.index.tsx` — clean (0 errors; pre-existing fast-refresh warnings unrelated to this change)
- [x] `npm run typecheck --workspace=apps/ui` — clean
- [x] `npm test --workspace=apps/ui` — 1027/1027 passed
- [x] `npm run build --workspace=apps/ui` — clean
- [x] `npx vitest run tests/api-coverage.test.mjs` — 256/256 passed
- [x] `npm run validate` / `validate:contract-drift` / `validate:openapi` / `node scripts/validate-openapi-examples.mjs` — all clean
- [x] Full repo `npx vitest run` — 8685/8710 passed; the 25 failures are pre-existing, unrelated to this change (Windows path-separator assertions in `tests/script-utils.test.mjs`, a `wrangler` CLI dependency missing in this environment, and test timeouts — none touch `contracts.mjs`, `providers`, or CSV export, and none are in files this PR modifies)

## Screenshots

Adding `DownloadCsvButton` changes the `PageHero` action row, so this counts as a visual change. Captured before/after at `/providers`.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://github.com/user-attachments/assets/22626bb2-673f-420b-b074-36f5e839e8b7" width="260">](https://github.com/user-attachments/assets/22626bb2-673f-420b-b074-36f5e839e8b7)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/a044a67a-d76c-4465-bced-21372a912335" width="260">](https://github.com/user-attachments/assets/a044a67a-d76c-4465-bced-21372a912335)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://github.com/user-attachments/assets/cc8ff1d8-087d-43cf-89a4-27d34f2c12c2" width="260">](https://github.com/user-attachments/assets/cc8ff1d8-087d-43cf-89a4-27d34f2c12c2)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/c91e5a01-eaf4-4697-a0b7-29648dcf80db" width="260">](https://github.com/user-attachments/assets/c91e5a01-eaf4-4697-a0b7-29648dcf80db)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://github.com/user-attachments/assets/4cb01e54-38f2-4085-a6b4-9fa7e4a25209" width="260">](https://github.com/user-attachments/assets/4cb01e54-38f2-4085-a6b4-9fa7e4a25209)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/b613c50c-56bd-4d6c-9b5d-7d7417fa978d" width="260">](https://github.com/user-attachments/assets/b613c50c-56bd-4d6c-9b5d-7d7417fa978d)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://github.com/user-attachments/assets/2f695a3f-66f8-4fc9-8c56-24c50d20ea13" width="260">](https://github.com/user-attachments/assets/2f695a3f-66f8-4fc9-8c56-24c50d20ea13)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/b31ee461-cfcb-4acf-a698-1b6a775a1c61" width="260">](https://github.com/user-attachments/assets/b31ee461-cfcb-4acf-a698-1b6a775a1c61)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://github.com/user-attachments/assets/ad7e2d61-3137-4715-a6de-8cf68ed008c3" width="260">](https://github.com/user-attachments/assets/ad7e2d61-3137-4715-a6de-8cf68ed008c3)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/74494115-b59e-4162-834e-efe244be7fba" width="260">](https://github.com/user-attachments/assets/74494115-b59e-4162-834e-efe244be7fba)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://github.com/user-attachments/assets/7ca8e99d-e05f-4ff0-853b-cee7ae7b44d3" width="260">](https://github.com/user-attachments/assets/7ca8e99d-e05f-4ff0-853b-cee7ae7b44d3)<br><sub>before</sub> | [<img src="https://github.com/user-attachments/assets/9a5f1242-dfff-4df8-8b6f-f3a3a87032c4" width="260">](https://github.com/user-attachments/assets/9a5f1242-dfff-4df8-8b6f-f3a3a87032c4)<br><sub>after</sub> |

