### PR TITLE
fix(ui): split pure neuron formatters out of neuron-table.tsx to fix bundle budget

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-subnet-heatmap.tsx
@@ -4,7 +4,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@jsonbored/ui-kit";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { shortHash } from "@/lib/metagraphed/blocks";
-import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { classNames } from "@/lib/metagraphed/format";
 
 // #3495: validator (row) × subnet (column) participation matrix from the global

--- a/apps/ui/src/components/metagraphed/metagraph-panel.tsx
+++ b/apps/ui/src/components/metagraphed/metagraph-panel.tsx
@@ -3,7 +3,8 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Boxes, Layers, ShieldCheck } from "lucide-react";
 import { subnetMetagraphQuery } from "@/lib/metagraphed/queries";
 import { TableState, RealtimeFreshness, StatTile, BarMini } from "@jsonbored/ui-kit";
-import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
+import { NeuronTable } from "@/components/metagraphed/neuron-table";
+import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { classNames } from "@/lib/metagraphed/format";
 import type { MetagraphNeuron } from "@/lib/metagraphed/types";
 

--- a/apps/ui/src/components/metagraphed/movers-band.tsx
+++ b/apps/ui/src/components/metagraphed/movers-band.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { subnetMoversQuery } from "@/lib/metagraphed/queries";
-import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { SelectFilter } from "@/components/metagraphed/table-controls";
 import { formatNumber } from "@/lib/metagraphed/format";
 import type { SubnetMover } from "@/lib/metagraphed/types";

--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -4,7 +4,7 @@ import { Coins, Flame, Award, Server, X } from "lucide-react";
 import { subnetNeuronQuery } from "@/lib/metagraphed/queries";
 import { RealtimeFreshness, StatTile } from "@jsonbored/ui-kit";
 import { EmptyState } from "@/components/metagraphed/states";
-import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 

--- a/apps/ui/src/components/metagraphed/neuron-format.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-format.tsx
@@ -1,0 +1,46 @@
+/**
+ * Pure neuron/validator formatting helpers, deliberately split out of
+ * `neuron-table.tsx`. That file also pulls in `StakeUnstakeModal` (wallet
+ * connect + signing flow), which is fine for the table itself but was
+ * leaking into the homepage's initial bundle via `movers-band.tsx` ->
+ * `taoCompact` -> the whole `neuron-table.tsx` module graph, blowing the
+ * gzip budget. Anything that only needs a formatter should import from
+ * here, not from `neuron-table.tsx`.
+ */
+
+/** Format a TAO value compactly. Stake can run into the millions; emission and
+ * incentive are sub-unit. Null/non-finite collapses to an em-dash. */
+export function taoCompact(v?: number | null): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M`;
+  if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  if (Math.abs(v) >= 1) return v.toFixed(2);
+  if (v === 0) return "0";
+  return v.toFixed(4);
+}
+
+/** Format a 0..1 score (trust, consensus, incentive) to three decimals. */
+export function scoreStr(v?: number | null): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return v.toFixed(3);
+}
+
+/**
+ * Small pill marking a DB-toggled featured-validator pin (#5166) — a paid/
+ * partner placement, not a quality or trust signal. Deliberately styled
+ * distinct from the "Validator" permit pill (that one IS a chain-derived
+ * trust fact; this one is a disclosed sponsorship) so the two are never
+ * visually confused. Label is persistent (not hover-gated) — the disclosure
+ * has to be legible without any interaction. Shared across the metagraph/
+ * validator tables and cards.
+ */
+export function SponsoredBadge() {
+  return (
+    <span
+      className="inline-flex items-center rounded border border-ink-muted/40 bg-surface px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-wider text-ink-muted"
+      title="Sponsored placement — this validator paid for visibility here. It is not ranked or endorsed; see the validator directory's own stake/trust/APY columns for objective standing."
+    >
+      Sponsored
+    </span>
+  );
+}

--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -7,51 +7,13 @@ import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
+import { taoCompact, scoreStr, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import {
   annualizedDelegatorApyPct,
   formatApyPct,
   formatTakePct,
 } from "@/lib/metagraphed/validator-apy";
 import type { MetagraphNeuron } from "@/lib/metagraphed/types";
-
-/**
- * Format a TAO value compactly. Stake can run into the millions; emission and
- * incentive are sub-unit. Null/non-finite collapses to an em-dash.
- */
-export function taoCompact(v?: number | null): string {
-  if (v == null || !Number.isFinite(v)) return "—";
-  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M`;
-  if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
-  if (Math.abs(v) >= 1) return v.toFixed(2);
-  if (v === 0) return "0";
-  return v.toFixed(4);
-}
-
-/** Format a 0..1 score (trust, consensus, incentive) to three decimals. */
-export function scoreStr(v?: number | null): string {
-  if (v == null || !Number.isFinite(v)) return "—";
-  return v.toFixed(3);
-}
-
-/**
- * Small pill marking a DB-toggled featured-validator pin (#5166) — a paid/
- * partner placement, not a quality or trust signal. Deliberately styled
- * distinct from the "Validator" permit pill below (that one IS a chain-derived
- * trust fact; this one is a disclosed sponsorship) so the two are never
- * visually confused. Label is persistent (not hover-gated) — the disclosure
- * has to be legible without any interaction. Shared with the global
- * validators leaderboard table (validator-columns.tsx).
- */
-export function SponsoredBadge() {
-  return (
-    <span
-      className="inline-flex items-center rounded border border-ink-muted/40 bg-surface px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-wider text-ink-muted"
-      title="Sponsored placement — this validator paid for visibility here. It is not ranked or endorsed; see the validator directory's own stake/trust/APY columns for objective standing."
-    >
-      Sponsored
-    </span>
-  );
-}
 
 type SortField =
   | "uid"

--- a/apps/ui/src/components/metagraphed/sponsored-validator-callout.tsx
+++ b/apps/ui/src/components/metagraphed/sponsored-validator-callout.tsx
@@ -2,7 +2,7 @@ import { Coins } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
-import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-table";
+import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
 import {
   annualizedDelegatorApyPct,

--- a/apps/ui/src/components/metagraphed/subnet-validators-preview.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-validators-preview.tsx
@@ -6,7 +6,7 @@ import { CopyButton } from "@jsonbored/ui-kit";
 import { subnetValidatorsQuery } from "@/lib/metagraphed/queries";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { Skeleton } from "@/components/metagraphed/states";
-import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
 import { SponsoredValidatorCallout } from "@/components/metagraphed/sponsored-validator-callout";
 import { annualizedDelegatorApyPct, formatApyPct } from "@/lib/metagraphed/validator-apy";

--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { CopyButton } from "@jsonbored/ui-kit";
 
-import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-table";
+import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
 

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -3,7 +3,7 @@ import { Link } from "@tanstack/react-router";
 import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
-import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-table";
+import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
 import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
 import type { GlobalValidator } from "@/lib/metagraphed/types";

--- a/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
+++ b/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
@@ -8,7 +8,7 @@ import {
   SearchInput,
   SelectFilter,
 } from "@/components/metagraphed/table-controls";
-import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { formatNumber } from "@/lib/metagraphed/format";
 import type { validatorNominatorsQuery } from "@/lib/metagraphed/queries";
 import type { ValidatorNominatorEntry } from "@/lib/metagraphed/types";

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -8,7 +8,8 @@ import {
   TreemapMini,
   type TreemapMiniDatum,
 } from "@jsonbored/ui-kit";
-import { NeuronTable, taoCompact } from "@/components/metagraphed/neuron-table";
+import { NeuronTable } from "@/components/metagraphed/neuron-table";
+import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { SponsoredValidatorCallout } from "@/components/metagraphed/sponsored-validator-callout";
 
 const TOP_N = 10;

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -12,7 +12,7 @@ import {
   Sparkline,
   CopyButton,
 } from "@jsonbored/ui-kit";
-import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { Skeleton, EmptyState } from "@/components/metagraphed/states";
 import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -42,7 +42,7 @@ import {
   StatTile,
   RealtimeFreshness,
 } from "@jsonbored/ui-kit";
-import { taoCompact } from "@/components/metagraphed/neuron-table";
+import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { ReadinessScorecard } from "@/components/metagraphed/readiness-scorecard";
 import { EndpointList } from "@/components/metagraphed/endpoint-list";
 import { SearchInput } from "@/components/metagraphed/table-controls";

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -21,7 +21,7 @@ import {
   ValidatorNominatorsTable,
   type ValidatorNominatorsSearch,
 } from "@/components/metagraphed/validator-nominators-table";
-import { taoCompact, scoreStr } from "@/components/metagraphed/neuron-table";
+import { taoCompact, scoreStr } from "@/components/metagraphed/neuron-format";
 import { validatorDetailQuery, validatorNominatorsQuery } from "@/lib/metagraphed/queries";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -14,7 +14,7 @@ import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { ValidatorDominanceChart } from "@/components/metagraphed/charts/validator-dominance-chart";
-import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-table";
+import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import { ValidatorCardList } from "@/components/metagraphed/validator-card-list";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { VALIDATOR_COLUMNS } from "@/components/metagraphed/validator-columns";


### PR DESCRIPTION
## Summary

Main's `Validate / ui` (bundle-size budget) check has been red since #6219 merged — every subsequent commit is still failing it:

```
Initial client JS (entry + static-import closure, gzipped): 303 KB / budget 300 KB
```

Root cause: `movers-band.tsx` (rendered directly on the homepage) imports `taoCompact` from `neuron-table.tsx`. `neuron-table.tsx` now also imports `StakeUnstakeModal` (wallet-connect + signing flow) for the new per-row Delegate action added in #6219. Because ES module imports execute the whole module, that pulled `StakeUnstakeModal`'s entire dependency chain into the homepage's initial bundle even though the homepage never renders a Delegate button — pushing the gzip total 3 KB over budget.

## Fix

Split the pure formatting helpers (`taoCompact`, `scoreStr`, `SponsoredBadge`) out of `neuron-table.tsx` into a new `neuron-format.tsx` with no heavy imports, and repointed every consumer (~15 files) at it. `NeuronTable` itself, its exports (`NUMERIC_FIELDS`, `SortField`), and all rendered markup are unchanged — this is a pure module-graph fix, not a behavior or visual change.

## Verification

- `npm run build --workspace=apps/ui` with `LOVABLE_SANDBOX=1 NITRO_PRESET=cloudflare-module` (matches CI) + the CI bundle-budget script locally: **293 KB / 300 KB** (was 303 KB)
- `npm run lint --workspace=apps/ui`: 0 errors (233 pre-existing unrelated warnings, untouched)
- `npm run format:check --workspace=apps/ui`: clean
- `npm run typecheck --workspace=apps/ui`: 0 errors
- `npm run test --workspace=apps/ui`: 1023/1023 passed, including `neuron-table.test.ts`'s sort-invariant guard
- No `apps/ui` visual output changes (same JSX, same styling, just relocated pure functions) — does not require the before/after screenshot table per house rule 5.

Closes the bundle-budget regression introduced by #6219.