### PR TITLE
fix(ui): add ShareButton + ApiSourceFooter to the subnet and provider detail pages

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -26,6 +26,7 @@ import {
   MiniRadial,
   DotRow,
   NoDataSpark,
+  ShareButton,
   Sparkline,
 } from "@jsonbored/ui-kit";
 import {
@@ -346,9 +347,15 @@ export function SubnetMasthead({
             stale
           </span>
         ) : null}
-        <div className="ml-auto flex md:hidden items-center gap-1.5">
-          <HealthPill state={probeHealth} />
-          <CurationChip level={profile?.curation_level} />
+        <div className="ml-auto flex items-center gap-1.5">
+          {/* #5481: the subnet-detail masthead was one of only two entity-detail headers with no
+              copy-current-URL affordance. It lives in the status row (not the identity grid's md+ only
+              health column) so it is reachable at every viewport, like every peer detail page's. */}
+          <div className="flex md:hidden items-center gap-1.5">
+            <HealthPill state={probeHealth} />
+            <CurationChip level={profile?.curation_level} />
+          </div>
+          <ShareButton bare />
         </div>
       </div>
 

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -9,6 +9,7 @@ import {
   StaleBanner,
   RECOVERY,
 } from "@/components/metagraphed/states";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import {
   EntityHero,
@@ -16,6 +17,7 @@ import {
   PrimaryLinksRail,
   CopyableCode,
   SectionAnchor,
+  ShareButton,
 } from "@jsonbored/ui-kit";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { EndpointsGlance } from "@/components/metagraphed/endpoints-glance";
@@ -130,6 +132,7 @@ function ProviderShell({ slug }: { slug: string }) {
         title={p?.name ?? slug}
         subtitle={shouldShowProviderSlugSubtitle(p?.name, slug) ? <>· {slug}</> : null}
         description={p?.notes}
+        actions={<ShareButton />}
         links={<PrimaryLinksRail website={p?.website ?? p?.homepage} docs={p?.docs} />}
         stats={[
           { label: "Endpoints", value: formatNumber(summary?.endpoint_count) },
@@ -171,6 +174,10 @@ function ProviderShell({ slug }: { slug: string }) {
           {summary?.by_layer ? <BreakdownCard title="By layer" data={summary.by_layer} /> : null}
         </aside>
       </div>
+
+      <ApiSourceFooter
+        paths={[`/api/v1/providers/${slug}`, `/api/v1/providers/${slug}/endpoints`]}
+      />
     </>
   );
 }

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -104,6 +104,7 @@ import type {
 } from "@/lib/metagraphed/types";
 import { IncidentTimeline } from "@/components/metagraphed/incident-timeline";
 import { TimeRangeProvider } from "@/components/metagraphed/analytics/time-range-context";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { SubnetMasthead } from "@/components/metagraphed/subnet-masthead";
 import { OperationalPanel } from "@/components/metagraphed/operational-panel";
 import { ResourceExplorer } from "@/components/metagraphed/resource-explorer";
@@ -340,6 +341,13 @@ function ProfileShell({ netuid }: { netuid: number }) {
           ) : null}
           {tab === "api" ? <ApiPanel netuid={netuid} /> : null}
         </div>
+        <ApiSourceFooter
+          paths={[
+            `/api/v1/subnets/${netuid}/profile`,
+            `/api/v1/subnets/${netuid}/overview`,
+            `/api/v1/subnets/${netuid}/identity-history`,
+          ]}
+        />
       </SubnetFilterProvider>
     </TimeRangeProvider>
   );


### PR DESCRIPTION
Fixes #5481.

Every other entity-detail route already renders both a `ShareButton` (the copy-current-URL affordance) and an `ApiSourceFooter` (the data-provenance footer) — `accounts.$ss58.tsx`, `blocks.$ref.tsx`, `extrinsics.$hash.tsx` and `validators.$hotkey.tsx` all do. The subnet and provider detail pages — the two busiest — were the only exceptions.

## What

- **`providers.$slug.tsx`** renders `EntityHero` but never passed its `actions` prop, even though `EntityHero` explicitly supports one (*"was PageHero's `actions`"*). It now passes `actions={<ShareButton />}` — a drop-in already used by its peers — plus an `ApiSourceFooter`.
- **`subnets.$netuid.tsx`** renders `SubnetMasthead` rather than `PageHero`/`EntityHero`, so the `ShareButton` is dropped into the masthead's own status row instead, self-contained, the same way every peer does it. The route now also renders an `ApiSourceFooter`.
- No query, table or masthead layout behavior changes — these are additive affordances only.

## Two things worth flagging for review

**ShareButton placement on the subnet masthead.** The obvious spot was the identity grid's action column (beside `HealthPill`/`CurationChip`) — but that column is `hidden md:flex`, so the button would silently disappear on mobile. It's in the status row instead, which renders at every viewport, with a comment recording why.

**The cited API paths are the ones each route actually reads**, traced through `@/lib/metagraphed/queries` rather than assumed:
- providers: `/api/v1/providers/{slug}` (`providerQuery`) + `/api/v1/providers/{slug}/endpoints` (`providerEndpointsQuery`)
- subnets: `/api/v1/subnets/{netuid}/profile` (`subnetProfileQuery`), `/overview`, `/identity-history`

## Validation

`tsc --noEmit`: 0 errors in the changed files · `eslint`: 0 errors · `prettier --check`: clean.

Both affordances were additionally verified rendering in a real browser DOM (the app is client-rendered, so an SSR HTML check proves nothing):

| Route | ApiSourceFooter | ShareButton |
| --- | --- | --- |
| `/subnets/1` **after** | 1 | 1 |
| `/subnets/1` **before** | 0 | 0 |
| `/providers/404-gen` **after** | 1 | 1 |
| `/providers/404-gen` **before** | 0 | 0 |

## UI Evidence

Captured at fixed viewports (375×812 / 768×1024 / 1280×800), both themes, against real API data — before/after are identical apart from the added **Share view** control. (`ApiSourceFooter` sits below the fold on both pages; its rendering is proven by the DOM check above.)

**Subnet detail (`/subnets/1`) — ShareButton added to the masthead status row**

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-subnet-after-mobile-dark.png)<br><sub>after</sub> |

**Provider detail (`/providers/404-gen`) — ShareButton added via EntityHero's `actions` prop**

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481-provider-after-mobile-dark.png)<br><sub>after</sub> |
