### PR TITLE
docs(ui): add 10 endpoint-group narrative guides (Phase 3)

### DIFF
--- a/apps/ui/content/docs/accounts.mdx
+++ b/apps/ui/content/docs/accounts.mdx
@@ -1,0 +1,103 @@
+---
+title: Accounts
+description: GET /api/v1/accounts/{ss58} and its 22 sub-resources — identity, balance, holdings, activity feeds, network participation, and stake movement for one SS58 address. No API key.
+---
+
+An SS58 address encodes a 32-byte public key plus a network-prefix byte and checksum — the same underlying key can be re-encoded for different Substrate chains, so an SS58 string is a chain-scoped representation, not the key itself. Every Bittensor wallet splits into two: a **coldkey** that holds TAO and has final authority (stake movement, transfers — keep it offline), and a **hotkey** used for day-to-day operational signing (registering a neuron, setting weights, serving an axon). One coldkey can own many hotkeys.
+
+```
+GET https://api.metagraph.sh/api/v1/accounts/{ss58}
+```
+
+## Identity & lookup
+
+| Path                                           | Purpose                                                                |
+| ---------------------------------------------- | ---------------------------------------------------------------------- |
+| `GET /api/v1/accounts`                         | Site-wide leaderboard of every registered hotkey, cross-subnet totals. |
+| `GET /api/v1/accounts/{ss58}`                  | Cross-subnet activity summary for one account.                         |
+| `GET /api/v1/accounts/{ss58}/identity`         | Latest on-chain identity (name, description, socials).                 |
+| `GET /api/v1/accounts/{ss58}/identity-history` | Diff timeline of identity changes.                                     |
+| `GET /api/v1/sudo/key`                         | Current holder of `Sudo::Key` — see the callout below.                 |
+
+An account's on-chain identity is a separate, optional pallet from its core neuron/stake data — most accounts never call `set_identity`, so `has_identity: false` is the common case.
+
+## Balance & holdings
+
+| Path                                                   | Purpose                                                               |
+| ------------------------------------------------------ | --------------------------------------------------------------------- |
+| `GET /api/v1/accounts/{ss58}/balance`                  | Live free + reserved TAO balance, RPC-sourced.                        |
+| `GET /api/v1/accounts/{ss58}/portfolio`                | Cross-subnet neuron positions (hotkey-scoped) with economics + yield. |
+| `GET /api/v1/accounts/{ss58}/positions`                | Nominator-side delegated positions — distinct from portfolio.         |
+| `GET /api/v1/accounts/{ss58}/subnets`                  | Subnets where the hotkey is currently registered.                     |
+| `GET /api/v1/accounts/{ss58}/subnets/{netuid}/history` | One wallet's position on one subnet over time.                        |
+
+## Activity feeds
+
+| Path                                         | Notes                                                                                                                                                |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/v1/accounts/{ss58}/events`         | Curated chain-event history. `limit` (1–1000, default 100), `offset`/`cursor`, `kind`, `netuid`, `block_start`/`block_end`, `format=csv`.            |
+| `GET /api/v1/accounts/{ss58}/extrinsics`     | Extrinsics signed by this account. Same pagination as `events`.                                                                                      |
+| `GET /api/v1/accounts/{ss58}/transfers`      | Native-TAO transfer feed. Same pagination.                                                                                                           |
+| `GET /api/v1/accounts/{ss58}/history`        | Durable per-day activity rollup. `from`/`to` (`YYYY-MM-DD`) — an inverted range returns an empty page rather than erroring.                          |
+| `GET /api/v1/accounts/{ss58}/counterparties` | Per-counterparty fund-flow rollup (`limit` 1–100, default 20), or pass `?counterparty=<ss58>` for one relationship's drilldown (`limit` default 50). |
+
+## Network participation
+
+Seven windowed footprint routes share one shape — a per-subnet count, first/last timestamp, HHI concentration, and dominant subnet — over `?window=7d|30d|90d` (default `30d`):
+
+| Path                                          | What it counts                                                                          |
+| --------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `GET /api/v1/accounts/{ss58}/registrations`   | Per-subnet neuron registrations.                                                        |
+| `GET /api/v1/accounts/{ss58}/deregistrations` | Per-subnet deregistrations/evictions.                                                   |
+| `GET /api/v1/accounts/{ss58}/serving`         | Axon-serving announcements — the endpoint a miner publishes so validators can reach it. |
+| `GET /api/v1/accounts/{ss58}/axon-removals`   | Axon teardown announcements.                                                            |
+| `GET /api/v1/accounts/{ss58}/prometheus`      | Telemetry-endpoint announcements.                                                       |
+| `GET /api/v1/accounts/{ss58}/weight-setters`  | Validator weight-setting activity.                                                      |
+| `GET /api/v1/accounts/{ss58}/stake-flow`      | Net/gross stake added vs. removed per subnet. Also takes `?direction=all\|in\|out`.     |
+
+<Callout title="weight-setters only supports 7d/30d">
+  Every other windowed route above also accepts `90d` — `weight-setters` is the one outlier
+  (`?window=7d|30d` only, default `7d`). An unsupported value 400s with the valid set listed.
+</Callout>
+
+## Stake movement
+
+`GET /api/v1/accounts/{ss58}/stake-moves` — stake re-delegation (`StakeMoved`, same coldkey, no unstake) footprint, same `?window=` shape as above.
+
+```bash
+curl -s https://api.metagraph.sh/api/v1/accounts/5F.../portfolio
+```
+
+```js tab="JavaScript"
+const res = await fetch("https://api.metagraph.sh/api/v1/accounts/5F.../events?limit=50");
+const { data } = await res.json();
+```
+
+```python tab="Python"
+import requests
+
+data = requests.get(
+    "https://api.metagraph.sh/api/v1/accounts/5F.../events", params={"limit": 50}
+).json()["data"]
+```
+
+<Callout title="Sudo::Key lives here, not with the extrinsics feed">
+  `GET /api/v1/sudo/key` returns `{ hotkey, queried_at }` — the account that currently holds root
+  authority (subtensor has no Council/Senate; sudo is the only remaining privileged key). It's an
+  account lookup, not an extrinsic — the extrinsics-shaped [`/api/v1/sudo`](/docs/extrinsics) feed
+  of Sudo-pallet calls is a separate, sibling route.
+</Callout>
+
+Unlisted query params 400 rather than being silently ignored. Feed routes clamp `limit` at 1000, `offset` at 1,000,000. `/balance` is the one rate-limited route in this group — 100 requests/60s per client IP; everything else is D1/Postgres-backed with no per-route limiter.
+
+<ApiSourceFooter
+  paths={[
+    "/api/v1/accounts",
+    "/api/v1/accounts/{ss58}",
+    "/api/v1/accounts/{ss58}/balance",
+    "/api/v1/accounts/{ss58}/portfolio",
+    "/api/v1/accounts/{ss58}/events",
+    "/api/v1/accounts/{ss58}/stake-flow",
+    "/api/v1/sudo/key",
+  ]}
+/>

--- a/apps/ui/content/docs/api-reference/index.mdx
+++ b/apps/ui/content/docs/api-reference/index.mdx
@@ -11,6 +11,10 @@ This reference is generated directly from the published [OpenAPI spec](/schemas)
 here disagrees with the API's actual behavior, the spec (not this page) is what needs fixing.
 
 <Callout type="info">
-  Looking for prose walkthroughs instead of a per-endpoint reference? See the [GraphQL](/docs/graphql),
-  [RPC](/docs/rpc), and [chain events](/docs/chain-events) guides.
+  Looking for prose walkthroughs instead of a per-endpoint reference? [Blocks](/docs/blocks),
+  [Extrinsics](/docs/extrinsics), [Accounts](/docs/accounts), [Subnets](/docs/subnets),
+  [Metagraph & validators](/docs/metagraph), [Economics](/docs/economics), [Health](/docs/health),
+  [Chain analytics](/docs/chain-analytics), [Chain events](/docs/chain-events),
+  [Webhooks](/docs/webhooks), [Search & AI](/docs/search-ai), [Feeds](/docs/feeds),
+  [GraphQL](/docs/graphql), and [RPC](/docs/rpc) each cover one endpoint group in prose.
 </Callout>

--- a/apps/ui/content/docs/blocks.mdx
+++ b/apps/ui/content/docs/blocks.mdx
@@ -1,0 +1,91 @@
+---
+title: Blocks
+description: GET /api/v1/blocks, block detail/extrinsics/events, block-production analytics, and the runtime-version transition timeline — the base layer everything else is anchored to. No API key.
+---
+
+Bittensor's subtensor chain is a Substrate chain, producing a finalized block roughly every 12 seconds. Each block has a header (a parent hash linking it to the one before, plus a state root and extrinsics root committing to what changed) and a body — the ordered extrinsics it carried. This page covers the block-level surface everything else (extrinsics, chain events, account activity) is anchored to.
+
+```
+GET https://api.metagraph.sh/api/v1/blocks
+```
+
+## GET /api/v1/blocks
+
+Recent-block feed, newest first.
+
+| Param                           | Notes                                                                 |
+| ------------------------------- | --------------------------------------------------------------------- |
+| `limit`                         | 1–100, default 50.                                                    |
+| `offset` / `cursor`             | Offset or keyset paging. Out-of-range values clamp rather than error. |
+| `author`                        | Scope to one block-authoring validator.                               |
+| `spec_version`                  | Scope to one runtime spec version.                                    |
+| `block_start` / `block_end`     | Block-number range.                                                   |
+| `from` / `to`                   | Epoch-ms observed-at range.                                           |
+| `min_extrinsics` / `min_events` | Floor filters — numeric input, 400s on non-integer.                   |
+| `format`                        | `csv`.                                                                |
+
+```bash
+curl -s 'https://api.metagraph.sh/api/v1/blocks?min_extrinsics=5&limit=10'
+```
+
+## GET /api/v1/blocks/\{ref\}
+
+One block's header — `{ref}` accepts either a decimal block number or a `0x` + 64-hex block hash. An unknown block never 404s: it returns `{ block: null }` with a 200. The response includes the nearest stored `prev`/`next_block_number` for chain-walk navigation.
+
+```bash
+curl -s https://api.metagraph.sh/api/v1/blocks/5000000
+```
+
+## Extrinsics & events in one block
+
+| Path                                    | Returns                                                                                                   | Params                                    |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `GET /api/v1/blocks/{ref}/extrinsics`   | The extrinsics in this block, index-ascending.                                                            | `limit` (≤100), `offset`, `format=csv`    |
+| `GET /api/v1/blocks/{ref}/events`       | Curated, account-attributed events (a fixed allowlist of "interesting" kinds).                            | `limit` (≤1000), `offset`, `format=csv`   |
+| `GET /api/v1/blocks/{ref}/chain-events` | **Every** raw `pallet.method` event in this block, unfiltered — no limit/offset, returns the whole block. | numeric `block_number` only, no hash form |
+
+<Callout title="chain-events is a proxy with its own rate limit">
+  `/blocks/{ref}/chain-events` forwards to a separate deep-history Worker over a service binding,
+  the same tier documented in full on the [chain events reference](/docs/chain-events) — including
+  its own 60 req/60s rate limiter and the 503 you'll get if that binding isn't wired into a
+  deployment. See that page rather than duplicating it here.
+</Callout>
+
+## Block-production analytics & runtime versions
+
+| Path                         | Purpose                                                                                                     |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `GET /api/v1/blocks/summary` | Inter-block timing, throughput, author decentralization, spec-version spread.                               |
+| `GET /api/v1/runtime`        | The runtime spec-version transition timeline — every distinct `spec_version` seen, earliest block for each. |
+
+`/api/v1/runtime` reports only `spec_version` (not the full Substrate `RuntimeVersion` struct), read directly off each block's own `spec_version` column — that column only started being captured from a fixed point on, so `coverage_from_block`/`coverage_from_at` mark where the recorded history actually begins. It's grouped with Blocks rather than a general "chain" surface because it's a pure aggregate over the same block-header data `/blocks/summary`'s `latest_spec_version` field also derives from.
+
+<Callout title="current_spec_version isn't just the last transition">
+  Grouping by spec version collapses each one to its *earliest* block — so if a version were ever
+  superseded and then reappeared, naively reading the last transition would report the wrong one as
+  current. `current_spec_version` is computed as a separate query instead.
+</Callout>
+
+```js tab="JavaScript"
+const res = await fetch("https://api.metagraph.sh/api/v1/blocks/summary");
+const { data } = await res.json();
+```
+
+```python tab="Python"
+import requests
+
+data = requests.get("https://api.metagraph.sh/api/v1/blocks/summary").json()["data"]
+```
+
+`/blocks/{ref}` caches 600s once resolved (finalized blocks are immutable) and 60s while unknown; every other route here caches 60s.
+
+<ApiSourceFooter
+  paths={[
+    "/api/v1/blocks",
+    "/api/v1/blocks/summary",
+    "/api/v1/blocks/{ref}",
+    "/api/v1/blocks/{ref}/extrinsics",
+    "/api/v1/blocks/{ref}/events",
+    "/api/v1/runtime",
+  ]}
+/>

--- a/apps/ui/content/docs/chain-analytics.mdx
+++ b/apps/ui/content/docs/chain-analytics.mdx
@@ -1,0 +1,98 @@
+---
+title: Chain analytics
+description: GET /api/v1/chain/* — chain-wide rollups and leaderboards over activity, transfers, stake movement, weights, and concentration. Distinct from the raw /chain-events firehose. No API key.
+---
+
+The [chain events reference](/docs/chain-events) covers the raw, unfiltered `pallet.method` event firehose. This page is the other `/api/v1/chain/*` surface — pre-aggregated, chain-wide rollups and leaderboards, built from the same curated event/neuron stores that back the per-account and per-subnet analytics elsewhere in the API. Where chain events answers "what happened, unfiltered," these routes answer "what happened, ranked and summed across every subnet."
+
+```
+GET https://api.metagraph.sh/api/v1/chain/activity
+```
+
+All 21 routes below are mainnet-only (no `/{network}/` prefix support). Most share one windowed-leaderboard shape: `?window=7d|30d` (default `7d`), `?limit=` (varies by route, capped at 100), `?format=csv` for the row-level leaderboard only — network rollups and distributions stay JSON-only.
+
+## Activity & liveness
+
+| Path                         | Purpose                                                                      | Extra params                                      |
+| ---------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------- |
+| `GET /api/v1/chain/activity` | Daily block/extrinsic/event counts, success rate, unique signers.            | —                                                 |
+| `GET /api/v1/chain/calls`    | Extrinsic call-mix — count and share per pallet module (or module.function). | `call_module`, `group_by=module\|module_function` |
+| `GET /api/v1/chain/signers`  | Most-active-account leaderboard, by tx count or total fee paid.              | `call_module`, `sort=tx_count\|total_fee_tao`     |
+| `GET /api/v1/chain/fees`     | Daily fee/tip series + top fee payers + median fee.                          | `call_module`                                     |
+
+## Transfers & relationships
+
+| Path                               | Purpose                                                                         | Extra params         |
+| ---------------------------------- | ------------------------------------------------------------------------------- | -------------------- |
+| `GET /api/v1/chain/transfers`      | Network-wide TAO transfer volume + top senders/receivers + concentration share. | —                    |
+| `GET /api/v1/chain/transfer-pairs` | Top sender→receiver TAO corridors, ranked by volume or count.                   | `sort=volume\|count` |
+
+## Stake movement & market
+
+| Path                                | Purpose                                                                      | Params                                             |
+| ----------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------- |
+| `GET /api/v1/chain/stake-flow`      | Net stake added minus removed per subnet — capital flow.                     | window/limit                                       |
+| `GET /api/v1/chain/stake-moves`     | Stake re-delegation churn per subnet (same coldkey, no unstake).             | window/limit                                       |
+| `GET /api/v1/chain/stake-transfers` | Stake ownership moved to a _different_ coldkey — origin side only.           | window/limit                                       |
+| `GET /api/v1/chain/alpha-volume`    | Rolling 24h buy/sell alpha-volume leaderboard + network sentiment.           | fixed 24h window, `limit`, `format` — no `?window` |
+| `GET /api/v1/chain/yield`           | Network-wide emission/stake return rate, validator vs miner, p10–p90 spread. | none                                               |
+
+```bash
+curl -s 'https://api.metagraph.sh/api/v1/chain/stake-flow?window=30d&limit=20'
+```
+
+## Registration & serving churn
+
+| Path                                | What it counts                                                              |
+| ----------------------------------- | --------------------------------------------------------------------------- |
+| `GET /api/v1/chain/registrations`   | `NeuronRegistered` leaderboard — registration demand per subnet.            |
+| `GET /api/v1/chain/deregistrations` | `NeuronDeregistered` leaderboard — exit/eviction activity per subnet.       |
+| `GET /api/v1/chain/axon-removals`   | `AxonInfoRemoved` leaderboard — serving-infrastructure teardown per subnet. |
+| `GET /api/v1/chain/serving`         | `AxonServed` leaderboard — which subnets are announcing serving endpoints.  |
+| `GET /api/v1/chain/prometheus`      | `PrometheusServed` leaderboard — which subnets run telemetry endpoints.     |
+
+## Weights & network state
+
+| Path                                 | Purpose                                                                                       | Params                                       |
+| ------------------------------------ | --------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `GET /api/v1/chain/weights`          | `WeightsSet` leaderboard per subnet — aggregate only, doesn't name setters.                   | window/limit                                 |
+| `GET /api/v1/chain/weights/setters`  | The individual validators behind the above, ranked by total `WeightsSet` events network-wide. | window/limit                                 |
+| `GET /api/v1/chain/concentration`    | Network-wide stake/emission concentration across five lenses.                                 | none — pure snapshot                         |
+| `GET /api/v1/chain/performance`      | Network-wide reward-distribution concentration + trust-score spread.                          | none                                         |
+| `GET /api/v1/chain/identity-history` | Most-recent on-chain identity changes across every subnet, newest-first.                      | `limit` (default 50, max 200)                |
+| `GET /api/v1/chain/turnover`         | Validator-set churn between window-boundary snapshots.                                        | `window=7d\|30d\|90d` (default 30d), `limit` |
+
+<Callout title="Chain-scope concentration isn't just the per-subnet view summed">
+  The per-subnet `/subnets/{netuid}/concentration` route measures a subnet's own neuron set.
+  Chain-scope `concentration` adds two lenses the per-subnet view structurally can't compute —
+  `entity_emission`/`entity_stake` — which collapse an operator's hotkeys *across every subnet*
+  before measuring concentration. An operator diversified across five subnets looks decentralized in
+  each one individually but concentrated at network scale; only this route sees that.
+</Callout>
+
+```js tab="JavaScript"
+const res = await fetch(
+  "https://api.metagraph.sh/api/v1/chain/signers?sort=total_fee_tao&limit=20",
+);
+const { data } = await res.json();
+```
+
+```python tab="Python"
+import requests
+
+data = requests.get(
+    "https://api.metagraph.sh/api/v1/chain/signers", params={"sort": "total_fee_tao", "limit": 20}
+).json()["data"]
+```
+
+Only `/chain/fees` carries a dedicated rate limit (60 req/60s, when it runs through the deep-history Postgres tier) — every other route here relies on edge caching alone. All are cached 60s, keyed on the shared health-cron snapshot stamp.
+
+<ApiSourceFooter
+  paths={[
+    "/api/v1/chain/activity",
+    "/api/v1/chain/transfers",
+    "/api/v1/chain/stake-flow",
+    "/api/v1/chain/concentration",
+    "/api/v1/chain/weights",
+  ]}
+/>

--- a/apps/ui/content/docs/economics.mdx
+++ b/apps/ui/content/docs/economics.mdx
@@ -1,0 +1,67 @@
+---
+title: Economics
+description: GET /api/v1/economics and /economics/trends — the dynamic-TAO per-subnet snapshot and network-wide daily time series. Alpha pools, emission share, FDV. No API key.
+---
+
+Bittensor runs a dynamic-TAO (dTAO) model: every subnet mints its own "alpha" token and runs a constant-product AMM pool holding TAO and alpha reserves. Staking TAO into a subnet buys alpha from that pool, and the reserve ratio sets the alpha price in TAO — each subnet's share of newly minted TAO is proportional to its alpha price relative to every other subnet's, a market-priced allocation rather than a vote-based one. These two routes expose that model as data.
+
+```
+GET https://api.metagraph.sh/api/v1/economics
+```
+
+## GET /api/v1/economics
+
+Per-subnet economic/validator snapshot — one row per subnet, live at the current moment.
+
+| Param                  | Notes                                                                                                                                                                       |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `netuid`               | Scope to one subnet.                                                                                                                                                        |
+| `registration_allowed` | `true` / `false`.                                                                                                                                                           |
+| `q`                    | Name/slug search, ≤200 chars.                                                                                                                                               |
+| `fields`               | Comma-separated partial field selection.                                                                                                                                    |
+| `limit` / `cursor`     | 1–1000, keyset paging.                                                                                                                                                      |
+| `sort` / `order`       | Sort key (`alpha_fdv_tao`, `alpha_price_tao`, `emission_share`, `total_stake_tao`, `netuid`, and more) + `asc`/`desc` (default `desc`, and default sort is emission share). |
+| `format`               | `csv` for a flat export.                                                                                                                                                    |
+
+**Response fields** worth knowing: `alpha_price_tao` (the AMM's current TAO/alpha exchange rate), `tao_in_pool_tao` / `alpha_in_pool` / `alpha_out_pool` (the pool reserves), `emission_share` (this subnet's cut of new TAO issuance), `alpha_market_cap_tao` / `alpha_fdv_tao` (derived, not on-chain — FDV is alpha price × the fixed 21,000,000 per-subnet alpha max supply, the same cap structure as TAO's own 21M), `registration_cost_tao` (the current dynamic recycle-burn cost to register a new UID), and `total_stake_tao`.
+
+```bash
+curl -s 'https://api.metagraph.sh/api/v1/economics?sort=alpha_fdv_tao&order=desc&limit=10'
+```
+
+## GET /api/v1/economics/trends
+
+A network-wide daily time series — the aggregate across every subnet, one point per UTC day, not a per-subnet breakdown.
+
+| Param    | Notes                                                   |
+| -------- | ------------------------------------------------------- |
+| `window` | `7d` \| `30d` \| `90d` \| `1y` \| `all`, default `30d`. |
+| `format` | `csv`.                                                  |
+
+Each day rolls up summed `total_stake_tao`, a stake-weighted mean alpha price, an unweighted median alpha price, summed validator/miner counts, and mean emission share — network-wide, not per subnet. A cold rollup returns `{ day_count: 0, days: [] }` rather than erroring.
+
+```bash
+curl -s https://api.metagraph.sh/api/v1/economics/trends?window=90d
+```
+
+<Callout title="60000-row cap on window=all">
+  `/economics/trends?window=all` is bounded to 60,000 raw rows — sized for roughly 129 subnets × 365
+  days. Hitting the cap drops the oldest day rather than serving a truncated one silently.
+</Callout>
+
+```js tab="JavaScript"
+const res = await fetch("https://api.metagraph.sh/api/v1/economics?sort=emission_share&limit=20");
+const { data } = await res.json();
+```
+
+```python tab="Python"
+import requests
+
+data = requests.get(
+    "https://api.metagraph.sh/api/v1/economics", params={"sort": "emission_share", "limit": 20}
+).json()["data"]
+```
+
+Both routes are cached 60s. `/economics` prefers a live KV snapshot (falling back to the last published R2 artifact, so it never 404s); `/economics/trends` is edge-cached and busts on the same publish stamp as the sibling history/trajectory routes.
+
+<ApiSourceFooter paths={["/api/v1/economics", "/api/v1/economics/trends"]} />

--- a/apps/ui/content/docs/extrinsics.mdx
+++ b/apps/ui/content/docs/extrinsics.mdx
@@ -1,0 +1,100 @@
+---
+title: Extrinsics
+description: GET /api/v1/extrinsics, /extrinsics/{hash}, /governance/config-changes, and /sudo — the on-chain call feed, root-origin hyperparameter changes, and why governance/sudo are just filtered views of the same table. No API key.
+---
+
+An extrinsic is Substrate's term for anything that originates outside the chain's runtime and ends up in a block — signed (a user submits and pays for it), unsigned, or inherent (inserted by the block author itself, like the per-block timestamp). Every on-chain action on Bittensor's subtensor chain — a stake move, a weight-set, a subnet registration, a hyperparameter change — is one, decoded here into `call_module` (the pallet, e.g. `SubtensorModule`) and `call_function` (the specific call, e.g. `add_stake`).
+
+```
+GET https://api.metagraph.sh/api/v1/extrinsics
+```
+
+## GET /api/v1/extrinsics
+
+Recent-extrinsic feed, newest first, across every pallet. Filters compose (AND-ed, never OR).
+
+| Param                           | Notes                                                                                                    |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `limit`                         | 1–100, default 50.                                                                                       |
+| `offset` / `cursor`             | Offset paging or keyset paging (`cursor`, an opaque token, preferred for stable deep paging).            |
+| `block`                         | Scope to one block number.                                                                               |
+| `signer`                        | Scope to one SS58 signer.                                                                                |
+| `call_module` / `call_function` | Scope to one pallet / one call within it.                                                                |
+| `call_hash`                     | `0x` + 64 hex. Requires `call_module` also be set — keeps the decoded-args scan bounded, 400s otherwise. |
+| `success`                       | `true` or `false`.                                                                                       |
+| `block_start` / `block_end`     | Block-number range.                                                                                      |
+| `from` / `to`                   | Epoch-ms time range.                                                                                     |
+| `format`                        | `csv` downloads a narrow projection instead of the JSON envelope.                                        |
+
+**Response** — `{ schema_version, extrinsic_count, limit, offset, next_cursor, extrinsics: Extrinsic[] }`. Each `Extrinsic` is `{ block_number, extrinsic_index, extrinsic_hash, signer, call_module, call_function, call_args, success, fee_tao, tip_tao, observed_at }` — `call_args` is the decoded call payload (nested calls, EVM addresses, large u64/u128 values all normalized server-side), never raw SCALE.
+
+```bash
+curl -s 'https://api.metagraph.sh/api/v1/extrinsics?call_module=SubtensorModule&call_function=add_stake&limit=5'
+```
+
+## GET /api/v1/extrinsics/\{hash\}
+
+Single-extrinsic detail, plus its emitted `account_events` (bounded to 50).
+
+`{hash}` accepts either a `0x…` extrinsic hash or the composite `<block_number>-<extrinsic_index>` id — the hash is best-effort in the decoder, so the composite id is the identifier guaranteed to always be present. An unknown ref never 404s: it returns `{ extrinsic: null, events: [] }` with a 200.
+
+```bash
+curl -s https://api.metagraph.sh/api/v1/extrinsics/5000000-3
+```
+
+## Root-origin calls: governance & sudo
+
+Bittensor originally had a bicameral governance structure — a Triumvirate that proposed changes and a Senate of top-K delegates that approved them by majority vote. That structure was removed from subtensor; what's left of on-chain governance today is a single privileged root key (the `Sudo` pallet) plus `AdminUtils`, subtensor's own pallet for root-origin hyperparameter and network-config changes (tempo, max UIDs, burn bounds, immunity period, and similar — mostly `sudo_set_*` calls).
+
+`/api/v1/governance/config-changes` and `/api/v1/sudo` aren't a different store or shape — they're the same extrinsics feed above, pre-filtered to `call_module = 'AdminUtils'` and `call_module = 'Sudo'` respectively. They get dedicated routes because most `AdminUtils` calls don't emit a dedicated chain event: the extrinsic and its decoded `call_args` are the only reliable record of what changed and to what value, so this surface can't be derived from an events feed the way most "what happened" questions can.
+
+## GET /api/v1/governance/config-changes
+
+Root-origin hyperparameter and network-config changes. Same params as the general feed above, minus `signer` / `call_module` / `call_hash` (module is fixed).
+
+```bash
+curl -s 'https://api.metagraph.sh/api/v1/governance/config-changes?call_function=sudo_set_tempo&limit=10'
+```
+
+## GET /api/v1/sudo
+
+The root-key call table — every extrinsic where `call_module = 'Sudo'`. Same param set as `config-changes` above.
+
+```bash
+curl -s https://api.metagraph.sh/api/v1/sudo?limit=10
+```
+
+<Callout title="Related: GET /api/v1/sudo/key">
+  A separate, RPC-live route (1h cache) returning the account that currently holds `Sudo::Key` — not
+  an extrinsics-shaped route, so it isn't covered above, but it's the account you'll see as `signer`
+  on every row `/api/v1/sudo` returns.
+</Callout>
+
+## Limits & caching
+
+None of the four routes above are individually rate-limited. All are cached 60s with a weak ETag (`Cache-Control: public, max-age=60, stale-while-revalidate=300`) and support `?format=csv` for a narrow row export.
+
+```js tab="JavaScript"
+const res = await fetch(
+  "https://api.metagraph.sh/api/v1/extrinsics?call_module=SubtensorModule&limit=5",
+);
+const { data } = await res.json();
+```
+
+```python tab="Python"
+import requests
+
+data = requests.get(
+    "https://api.metagraph.sh/api/v1/extrinsics",
+    params={"call_module": "SubtensorModule", "limit": 5},
+).json()["data"]
+```
+
+<ApiSourceFooter
+  paths={[
+    "/api/v1/extrinsics",
+    "/api/v1/extrinsics/{hash}",
+    "/api/v1/governance/config-changes",
+    "/api/v1/sudo",
+  ]}
+/>

--- a/apps/ui/content/docs/health.mdx
+++ b/apps/ui/content/docs/health.mdx
@@ -1,0 +1,79 @@
+---
+title: Health & readiness
+description: GET /api/v1/health, /health/history/{date}, /health/trends, /incidents, and the per-subnet health/uptime/percentile/incident routes — probe-derived, never hand-set. No API key.
+---
+
+Every surface metagraphed tracks (an archive node, an SDK, a subnet API, a dashboard) gets checked on a live 15-minute cron sweep. Status here is never self-reported or manually set — it comes exclusively from that probe, classified `ok`, `degraded`, `failed`, or `unknown`.
+
+```
+GET https://api.metagraph.sh/api/v1/health
+```
+
+## Live status
+
+| Path                                  | Scope         | Notes                                                                                         |
+| ------------------------------------- | ------------- | --------------------------------------------------------------------------------------------- |
+| `GET /api/v1/health`                  | Registry-wide | `netuid`, `status`, `fields`, `limit` (≤1000), `cursor`, `sort`, `order`.                     |
+| `GET /api/v1/subnets/{netuid}/health` | One subnet    | `kind`, `provider`, `status`, `classification`, `fields`, `limit`, `cursor`, `sort`, `order`. |
+
+Both are live-only — a cold store returns an explicit `unknown` payload, never a stale baked value and never a 404. `kind` scopes to a surface type (`archive`, `subtensor-rpc`, `subnet-api`, `docs`, and similar); `classification` narrows to the probe's own outcome (`live`, `dead`, `timeout`, `rate-limited`, `wrong-chain`, and similar).
+
+```bash
+curl -s 'https://api.metagraph.sh/api/v1/subnets/7/health?status=failed'
+```
+
+## Incidents
+
+Reconstructed from raw probe history with a gap-island SQL query, not stored as discrete rows: consecutive failing checks group into one incident when the gap between them is under 30 minutes (cadence plus one missed-run buffer), and a lone failed probe that recovers on the next tick doesn't count — only ≥2 consecutive failures (roughly 4+ minutes sustained) become a real incident.
+
+| Path                                            | Scope      | Params                                                                                             |
+| ----------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------- |
+| `GET /api/v1/incidents`                         | Global     | `window` (`7d`\|`30d`)                                                                             |
+| `GET /api/v1/subnets/{netuid}/health/incidents` | One subnet | `window` (`7d`\|`30d`) — also returns a per-surface SLA (uptime ratio) alongside the incident list |
+
+<Callout title="A single missed probe isn't an incident">
+  The ≥2-consecutive threshold is deliberate — roughly three-quarters of raw failure rows are a lone
+  probe recovering on the very next 15-minute tick. Don't treat one failed check in the history
+  endpoints below as downtime; check `/incidents` for what actually cleared the threshold.
+</Callout>
+
+## History, trends, percentiles, uptime
+
+| Path                                              | Window / notes                                                                                                                                                 |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/v1/health/history/{date}`               | `date` = `YYYY-MM-DD`. Filters: `netuid`, `kind`, `provider`, `status`, `classification`, `fields`, `limit`, `cursor`, `sort`, `order`.                        |
+| `GET /api/v1/health/trends`                       | Bulk 7d/30d uptime + latency trend for every subnet, fixed windows.                                                                                            |
+| `GET /api/v1/subnets/{netuid}/health/trends`      | Same, one subnet, both windows returned together.                                                                                                              |
+| `GET /api/v1/subnets/{netuid}/health/percentiles` | p50/p95/p99 + avg/min/max latency per surface. `window` = `7d`\|`30d`. Successful checks only.                                                                 |
+| `GET /api/v1/subnets/{netuid}/uptime`             | Long-term daily uptime from the durable rollup table (raw checks prune after 30d, this survives). `window` = `90d`\|`1y`. `min_samples` drops low-sample days. |
+
+```js tab="JavaScript"
+const res = await fetch("https://api.metagraph.sh/api/v1/subnets/7/health/percentiles?window=30d");
+const { data } = await res.json();
+```
+
+```python tab="Python"
+import requests
+
+data = requests.get(
+    "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles", params={"window": "30d"}
+).json()["data"]
+```
+
+Every route on this page is mainnet-only — none accept a `/{network}/` prefix. All are cached 60s and edge-cached keyed on the health cron's own `last_run_at` stamp, so repeated requests within the same 15-minute window are served without re-running the aggregation.
+
+<Callout title="This is registry health, not a readiness probe">
+  The bare `GET /health` (no `/api/v1` prefix) is a different thing entirely — a lightweight
+  liveness/readiness check for this API's own infrastructure (bindings, data-publish freshness, cron
+  staleness), not registry content. Don't confuse the two when wiring up a monitor.
+</Callout>
+
+<ApiSourceFooter
+  paths={[
+    "/api/v1/health",
+    "/api/v1/health/history/{date}",
+    "/api/v1/health/trends",
+    "/api/v1/incidents",
+    "/api/v1/subnets/{netuid}/health",
+  ]}
+/>

--- a/apps/ui/content/docs/metagraph.mdx
+++ b/apps/ui/content/docs/metagraph.mdx
@@ -1,0 +1,96 @@
+---
+title: Subnet metagraph & validators
+description: GET /api/v1/subnets/{netuid}/metagraph, /validators, /neurons/{uid}, and the global /api/v1/validators surface — trust, incentive, consensus, dividends, and nominators explained. No API key.
+---
+
+A metagraph is the on-chain snapshot of everything happening in one subnet at a given block: every registered neuron (miner or validator), its stake, and the weight relationships between them — the data structure this API reads so you don't need to run a node to see a subnet's current state.
+
+Both miners and validators are "neurons" — a `uid` (a per-subnet slot number, not a global identity) paired with a hotkey/coldkey. Miners produce the subnet's actual output and earn **incentive**; validators periodically submit a weight vector scoring that output and earn **dividends** for doing so credibly. A validator needs a stake-gated "validator permit" for its weights to count.
+
+```
+GET https://api.metagraph.sh/api/v1/subnets/{netuid}/metagraph
+```
+
+## Per-subnet metagraph & neurons
+
+| Path                                                 | Purpose                                               | Params                                  |
+| ---------------------------------------------------- | ----------------------------------------------------- | --------------------------------------- |
+| `GET /api/v1/subnets/{netuid}/metagraph`             | Full per-UID metagraph — every neuron on this subnet. | `?validator_permit=true`, `?format=csv` |
+| `GET /api/v1/subnets/{netuid}/validators`            | Just the validator-permit rows, ranked by stake.      | `?format=csv`                           |
+| `GET /api/v1/subnets/{netuid}/neurons/{uid}`         | One neuron's full state.                              | —                                       |
+| `GET /api/v1/subnets/{netuid}/neurons/{uid}/history` | Daily time series of one UID's fields.                | `?window=7d\|30d\|90d\|1y\|all`         |
+
+## What each field means
+
+| Field             | Meaning                                                                                                                                                                                                    |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `trust`           | How much a neuron's contributions are relied on by others, built up from behavior over time.                                                                                                               |
+| `validator_trust` | For validators specifically: how closely a validator's weight-settings track what the rest of the (stake-weighted) validator set agrees on.                                                                |
+| `incentive`       | A miner's share of the subnet's emission pool, from how validators scored its work. Sums to 1 across a subnet's miners.                                                                                    |
+| `consensus`       | How much validators agree on a miner's score. Yuma Consensus down-weights any validator whose weights diverge too far from the group, so this also acts as a check against one validator skewing outcomes. |
+| `dividends`       | A validator's share of emissions, from its stake and how well its weights align with consensus. Sums to 1 across a subnet's validators — this is the pool nominators draw their cut from.                  |
+| `emission`        | The actual per-epoch reward (in the subnet's alpha token), computed from incentive or dividends × the subnet's emission budget. An epoch is ~360 blocks, roughly 72 minutes on mainnet.                    |
+| `rank`            | A raw, pre-consensus weighted score — an intermediate Yuma Consensus signal, not the same as final standing.                                                                                               |
+
+<Callout title="subnetValidators vs globalValidators aren't the same question">
+  `subnetValidators` answers "who validates inside subnet N, ranked by stake?" — plain per-subnet
+  rows. `globalValidators` below answers "which hotkeys validate anywhere, and how big is their
+  total footprint?" — one row per hotkey, grouped across every subnet it holds a permit on. Don't
+  expect the two to line up 1:1.
+</Callout>
+
+```bash
+curl -s 'https://api.metagraph.sh/api/v1/subnets/7/metagraph?validator_permit=true'
+```
+
+## Global validators
+
+| Path                                         | Purpose                                                            | Params                                                                                       |
+| -------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `GET /api/v1/validators`                     | Cross-subnet validator/operator leaderboard.                       | `?sort=` (7 options, default `subnet_count`), `?limit=1-100` (default 20), `?format=csv`     |
+| `GET /api/v1/validators/{hotkey}`            | One validator's aggregated cross-subnet totals + per-subnet table. | — (a cold hotkey returns a zeroed 200, never 404)                                            |
+| `GET /api/v1/validators/{hotkey}/history`    | Daily cross-subnet staked/rewards history.                         | `?window=7d\|30d\|90d\|1y\|all`                                                              |
+| `GET /api/v1/validators/{hotkey}/nominators` | Who has staked to this validator's hotkey, cross-subnet.           | `?window=7d\|30d\|90d` (default `30d`), `?sort=`, `?limit=1-100`, `?coldkey=`, `?format=csv` |
+
+Each `globalValidators` row carries `subnet_count`, `uid_count`, `total_stake_tao`/`total_emission_tao` summed across memberships, a `root_stake_tao` vs `alpha_stake_tao` split, `stake_dominance`, average/max `validator_trust`, an APY estimate, and a self-declared identity.
+
+## Nominators
+
+Nominators (sometimes called delegators) are TAO holders who stake to a validator's hotkey instead of running their own. `validatorNominators` isn't a stake-position snapshot — it's a **windowed flow** derived from raw stake-add/-remove events: each row is one nominator that staked or unstaked against this hotkey during the window, with `staked_tao`, `unstaked_tao`, `net_staked_tao` (can be negative), and `event_count`.
+
+```bash
+curl -s 'https://api.metagraph.sh/api/v1/validators/5F.../nominators?window=30d'
+```
+
+<Callout title="Two different nominator counts — they won't reconcile">
+  `validatorNominators` is a windowed flow. The separate `nominator_count` field on
+  `globalValidators`/`validatorDetail` rows is an all-time, unwindowed count of distinct coldkeys
+  currently holding nonzero stake, from a lower-frequency full-chain scan — `null` (not `0`) when
+  that side table hasn't captured the hotkey yet. Don't expect the two numbers to match.
+</Callout>
+
+```js tab="JavaScript"
+const res = await fetch("https://api.metagraph.sh/api/v1/validators?sort=total_stake_tao&limit=20");
+const { data } = await res.json();
+```
+
+```python tab="Python"
+import requests
+
+data = requests.get(
+    "https://api.metagraph.sh/api/v1/validators", params={"sort": "total_stake_tao", "limit": 20}
+).json()["data"]
+```
+
+None of these eight routes have a dedicated rate limiter; all are cached 60s and edge-cached on the shared health-cron snapshot stamp.
+
+<ApiSourceFooter
+  paths={[
+    "/api/v1/subnets/{netuid}/metagraph",
+    "/api/v1/subnets/{netuid}/validators",
+    "/api/v1/subnets/{netuid}/neurons/{uid}",
+    "/api/v1/validators",
+    "/api/v1/validators/{hotkey}",
+    "/api/v1/validators/{hotkey}/nominators",
+  ]}
+/>

--- a/apps/ui/content/docs/search-ai.mdx
+++ b/apps/ui/content/docs/search-ai.mdx
@@ -1,0 +1,88 @@
+---
+title: Search & AI
+description: GET /api/v1/search, /search/semantic, and POST /api/v1/ask — keyword search, vector search, and grounded question-answering over the registry. 503s cleanly when AI isn't enabled. No API key.
+---
+
+Two ways to search the registry, plus a question-answering endpoint built on top of the same index. Keyword search matches literal substrings; semantic search encodes your query into a vector and finds conceptually related results even with zero shared words — the standard keyword-vs-embedding distinction from information retrieval.
+
+```
+GET https://api.metagraph.sh/api/v1/search?q=inference
+```
+
+## Keyword search
+
+| Path                       | Difference                                                                    |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| `GET /api/v1/search`       | Full search-index artifact, including per-document match tokens.              |
+| `GET /api/v1/search-index` | The slim artifact — identical documents, no tokens. Meant for fast typeahead. |
+
+Both share one query engine: `q` (≤200 chars) splits on whitespace and requires every term to appear (AND, not OR) across a document's title/subtitle/slug/tokens; plus `fields` (projection), `limit` (1–1000), `cursor`, `sort` (`kind`\|`netuid`\|`slug`\|`title`), `order`. This is a static-artifact scan — refreshes on the registry's normal 6h publish cycle, not live per-request.
+
+```bash
+curl -s 'https://api.metagraph.sh/api/v1/search?q=inference&limit=10'
+```
+
+## Semantic search
+
+`GET /api/v1/search/semantic` — embeds your query (`q`, required, ≤1000 chars) and finds registry documents whose own pre-computed embeddings are nearest in vector space, live on every request via Cloudflare Vectorize.
+
+| Param   | Notes                                                               |
+| ------- | ------------------------------------------------------------------- |
+| `q`     | Required, ≤1000 chars.                                              |
+| `limit` | 1–20, default 10.                                                   |
+| `type`  | Repeatable — `subnet`, `surface`, or `provider`. Omit for no scope. |
+
+```bash
+curl -s 'https://api.metagraph.sh/api/v1/search/semantic?q=cross-lingual+translation&type=subnet'
+```
+
+## Ask (grounded question-answering)
+
+`POST /api/v1/ask` doesn't let the model answer from its own training knowledge — it first runs the same semantic retrieval above to pull real, current registry documents as context, then instructs the model to answer only from that context, with numbered citations, or say plainly it doesn't know.
+
+```json title="Request body"
+{ "question": "which subnets expose an inference API?", "topK": 6, "type": "subnet" }
+```
+
+| Field      | Notes                                                       |
+| ---------- | ----------------------------------------------------------- |
+| `question` | Required, ≤1000 chars.                                      |
+| `topK`     | 1–6, default 6 — how many sources the model sees.           |
+| `type`     | Same three-value scope as semantic search, string or array. |
+
+What actually feeds the grounding: the same embedded registry documents semantic search uses, **live-probed health status** (not a build-time snapshot — fetched fresh per request so "is subnet X's API up right now" reflects real-time state), and the agent-catalog artifact for actionability facets (callable service count, base URL, health).
+
+<Callout title="Reliable for registry facts, not general Bittensor knowledge">
+  `/ask` answers well when the question is groundable in the registry's own data — which subnets
+  expose an API, whether a given endpoint is healthy, what a provider runs. Questions about chain
+  mechanics or tokenomics theory outside what's in the registry correctly get "I don't know" rather
+  than a guess — that's the point of grounding it.
+</Callout>
+
+```js tab="JavaScript"
+const res = await fetch("https://api.metagraph.sh/api/v1/ask", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ question: "which subnets expose an inference API?", type: "subnet" }),
+});
+const { data } = await res.json();
+```
+
+```python tab="Python"
+import requests
+
+data = requests.post(
+    "https://api.metagraph.sh/api/v1/ask",
+    json={"question": "which subnets expose an inference API?", "type": "subnet"},
+).json()["data"]
+```
+
+<Callout title="503 when AI isn't enabled">
+  `/search/semantic` and `/ask` both require an AI-enabled deployment. Off by default in local dev
+  and CI — every request gets a uniform `503 ai_unavailable` regardless of query. Keyword search
+  (`/search`, `/search-index`) has no such dependency and always works.
+</Callout>
+
+Both AI routes share a 20 requests/60s per-client-IP rate limit — tighter than the general API since `/ask` drives an LLM call. `/ask`'s body caps at 4 KB.
+
+<ApiSourceFooter paths={["/api/v1/search", "/api/v1/search/semantic", "/api/v1/ask"]} />

--- a/apps/ui/content/docs/subnets.mdx
+++ b/apps/ui/content/docs/subnets.mdx
@@ -1,0 +1,124 @@
+---
+title: Subnets
+description: GET /api/v1/subnets and its structure, lifecycle, market, decentralization, and curation sub-resources — everything about a subnet except who's currently on its metagraph. No API key.
+---
+
+A Bittensor subnet is an independent incentive mechanism — its own miners, validators, and reward rules — identified on-chain by a `netuid`. Since the February 2025 dynamic-TAO upgrade, every subnet runs a constant-product AMM between TAO and its own alpha token: price moves with every stake/unstake, and a subnet's share of new TAO issuance is set by that market rather than a root-validator vote.
+
+This page covers what a subnet _is_ and how it's _behaved_ — structure, activity, market data, decentralization metrics, curated metadata. For who's registered on it right now (the live neuron table), see [Subnet metagraph & validators](/docs/metagraph).
+
+```
+GET https://api.metagraph.sh/api/v1/subnets/{netuid}
+```
+
+## Structure & configuration
+
+| Path                                                   | Purpose                                                            |
+| ------------------------------------------------------ | ------------------------------------------------------------------ |
+| `GET /api/v1/subnets`                                  | List/filter/sort every subnet.                                     |
+| `GET /api/v1/subnets/movers`                           | Cross-subnet stake/emission/validator/neuron momentum leaderboard. |
+| `GET /api/v1/subnets/{netuid}`                         | Full subnet detail.                                                |
+| `GET /api/v1/subnets/{netuid}/overview`                | Composed profile + health + curation + gaps summary.               |
+| `GET /api/v1/subnets/{netuid}/hyperparameters`         | Current consensus/economic/governance knobs.                       |
+| `GET /api/v1/subnets/{netuid}/hyperparameters/history` | Append-only hyperparameter-change timeline.                        |
+| `GET /api/v1/subnets/{netuid}/identity-history`        | Append-only on-chain identity change timeline.                     |
+
+`/subnets` takes 25+ filter params — `domain`, `subnet_type`, `curation_level`, `coverage_level`, `q` (free text), `fields` (sparse fieldset), and `min_*`/`max_*` range filters on tempo/participant count/surface count and similar — plus `cursor`/`limit` (≤1000)/`sort`/`order`/`format=csv`.
+
+A subnet's **hyperparameters** are its owner-tunable knobs: `tempo` (blocks per epoch — default 360, sets weight-update cadence), `immunity_period` (blocks a freshly-registered neuron is shielded from deregistration), `kappa` (softmax steepness turning validator weights into incentive), `commit_reveal_enabled` (encrypts weights for a window to stop weight-copying), and roughly two dozen more.
+
+```bash
+curl -s 'https://api.metagraph.sh/api/v1/subnets?domain=inference&sort=participant_count&order=desc'
+```
+
+## Lifecycle & activity
+
+Raw chain-event churn, mostly windowed `?window=7d|30d|90d`:
+
+| Path                                           | Purpose                                                                           |
+| ---------------------------------------------- | --------------------------------------------------------------------------------- |
+| `GET /api/v1/subnets/{netuid}/registrations`   | Neuron registration activity.                                                     |
+| `GET /api/v1/subnets/{netuid}/deregistrations` | Neuron deregistration activity.                                                   |
+| `GET /api/v1/subnets/{netuid}/axon-removals`   | Axon teardown announcements.                                                      |
+| `GET /api/v1/subnets/{netuid}/serving`         | Axon-serving announcements.                                                       |
+| `GET /api/v1/subnets/{netuid}/prometheus`      | Telemetry-endpoint announcements.                                                 |
+| `GET /api/v1/subnets/{netuid}/recycled`        | Live cumulative TAO recycled for registration on this subnet.                     |
+| `GET /api/v1/subnets/{netuid}/event-summary`   | Windowed activity summary.                                                        |
+| `GET /api/v1/subnets/{netuid}/events`          | Raw curated event feed, CSV-exportable.                                           |
+| `GET /api/v1/subnets/{netuid}/history`         | Per-day neuron/validator/stake/emission rollup — `?window=7d\|30d\|90d\|1y\|all`. |
+| `GET /api/v1/subnets/{netuid}/turnover`        | Validator-set churn + stability score between window snapshots.                   |
+
+Registration on a subnet costs TAO that's **recycled**, not burned — returned to the pool that funds future block emissions rather than destroyed. The price decays over time and rises with each successful registration.
+
+## Market & economics-adjacent
+
+| Path                                           | Purpose                                                                                 |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `GET /api/v1/subnets/{netuid}/ohlc`            | Alpha-price OHLCV candles. `?interval=1h\|1d` (default 1h), `?days=1-365` (default 90). |
+| `GET /api/v1/subnets/{netuid}/volume`          | Rolling 24h buy/sell alpha volume + sentiment.                                          |
+| `GET /api/v1/subnets/{netuid}/stake-flow`      | Net stake in/out.                                                                       |
+| `GET /api/v1/subnets/{netuid}/stake-moves`     | Re-delegation churn.                                                                    |
+| `GET /api/v1/subnets/{netuid}/stake-transfers` | Cross-account stake-ownership transfers.                                                |
+| `GET /api/v1/subnets/{netuid}/stake-quote`     | Read-only AMM slippage quote for a hypothetical stake/unstake.                          |
+| `GET /api/v1/subnets/{netuid}/trajectory`      | Weekly structural completeness/surface-count trend.                                     |
+| `GET /api/v1/subnets/{netuid}/yield`           | Per-UID emission-yield ranking.                                                         |
+| `GET /api/v1/subnets/{netuid}/yield/history`   | Daily yield trend.                                                                      |
+
+OHLC candles are reconstructed from the same stake-add/-remove event stream, not a separate price oracle — price per trade is `amount_tao / alpha_amount`. Root (netuid 0) has no AMM and is excluded.
+
+```bash
+curl -s 'https://api.metagraph.sh/api/v1/subnets/64/ohlc?interval=1d&days=30'
+```
+
+## Decentralization & consensus-weight metrics
+
+| Path                                                 | Purpose                                                                                             |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `GET /api/v1/subnets/{netuid}/concentration`         | Gini, HHI, Nakamoto coefficient, entropy across three lenses (per-UID, per-entity, validator-only). |
+| `GET /api/v1/subnets/{netuid}/concentration/history` | Daily trend of the above.                                                                           |
+| `GET /api/v1/subnets/{netuid}/performance`           | Reward-concentration + trust/consensus score spread.                                                |
+| `GET /api/v1/subnets/{netuid}/performance/history`   | Daily trend of the above.                                                                           |
+| `GET /api/v1/subnets/{netuid}/weights`               | Weight-setting activity aggregate for this subnet.                                                  |
+| `GET /api/v1/subnets/{netuid}/weights/setters`       | Per-validator weight-setting leaderboard for this subnet.                                           |
+
+<Callout title="Nakamoto coefficient and entropy, not just top-N%">
+  Concentration here isn't just a top-holder percentage — it includes the Nakamoto coefficient (the
+  minimum number of colluding parties needed to control the subnet) and Shannon entropy alongside
+  Gini and HHI, the same toolkit used in published Bittensor decentralization research. Independent
+  analysis of live subnets has found wide variance — some controllable by coalitions as small as
+  1-2%.
+</Callout>
+
+## Curated metadata
+
+Registry-native metadata, not chain-derived:
+
+| Path                                      | Purpose                                                           |
+| ----------------------------------------- | ----------------------------------------------------------------- |
+| `GET /api/v1/subnets/{netuid}/profile`    | Public-safe curated subnet profile.                               |
+| `GET /api/v1/subnets/{netuid}/surfaces`   | Curated, promoted public surfaces (docs, repo, API, and similar). |
+| `GET /api/v1/subnets/{netuid}/candidates` | Unpromoted candidate surfaces awaiting review.                    |
+
+```js tab="JavaScript"
+const res = await fetch("https://api.metagraph.sh/api/v1/subnets/64/concentration");
+const { data } = await res.json();
+```
+
+```python tab="Python"
+import requests
+
+data = requests.get("https://api.metagraph.sh/api/v1/subnets/64/concentration").json()["data"]
+```
+
+No route in this group has a dedicated per-IP rate limiter. `limit` caps at 1000 for most list/history routes (100 for `movers`, 50 for `event-summary`'s recent events), `days` caps at 365 for OHLC, and `recycled` carries its own 600s cache.
+
+<ApiSourceFooter
+  paths={[
+    "/api/v1/subnets",
+    "/api/v1/subnets/{netuid}",
+    "/api/v1/subnets/{netuid}/hyperparameters",
+    "/api/v1/subnets/{netuid}/ohlc",
+    "/api/v1/subnets/{netuid}/concentration",
+    "/api/v1/subnets/{netuid}/profile",
+  ]}
+/>

--- a/apps/ui/content/docs/webhooks.mdx
+++ b/apps/ui/content/docs/webhooks.mdx
@@ -1,0 +1,104 @@
+---
+title: Webhooks
+description: POST/GET/DELETE /api/v1/webhooks/subscriptions — subscribe to the registry's publish change feed with HMAC-signed, at-least-once delivery. No API key required beyond a subscription secret.
+---
+
+Subscribe to metagraphed's own publish cycle: every time the registry rebuilds and publishes (a push to a human-input registry path, or a daily floor schedule), subscribers get an HMAC-signed POST describing what changed. This is a separate system from anything on-chain — it's this app's own change-feed infrastructure.
+
+```
+POST https://api.metagraph.sh/api/v1/webhooks/subscriptions
+```
+
+## Create a subscription
+
+`POST /api/v1/webhooks/subscriptions`, authenticated with a shared token in the `x-metagraph-webhook-subscription-token` header (contact the maintainers for one — the route 503s with a distinct code if creation is disabled entirely).
+
+```json title="Request body"
+{
+  "url": "https://example.com/hooks/metagraphed",
+  "filters": { "kinds": ["subnets"], "netuids": [7, 64] },
+  "secret": "optional — a 16-256 char string; generated for you if omitted"
+}
+```
+
+`url` must be `https://`, no embedded credentials, no localhost/private/link-local address, and (for a hostname) contain at least one dot — re-checked at delivery time too, as SSRF defense-in-depth. `filters` is optional; omitting it (or sending `{}`) matches every event.
+
+<Callout title="An explicit empty array means match nothing, not match all">
+  `{"filters": {"kinds": []}}` is not the same as omitting `kinds` — an explicitly empty array
+  for a present key means "match nothing" on that facet. Only *omitting* the key means unrestricted.
+</Callout>
+
+The response (`201`) includes your subscription `id`, the `secret` — **returned once, here only, never echoed by GET** — and a `delivery` block describing exactly how signed payloads will arrive:
+
+```json title="201 response (excerpt)"
+{
+  "id": "…",
+  "secret": "…",
+  "delivery": {
+    "method": "POST",
+    "signature_header": "x-metagraph-signature",
+    "signature_algorithm": "hmac-sha256-hex",
+    "idempotency_header": "x-metagraph-idempotency-key"
+  }
+}
+```
+
+## Inspect or remove a subscription
+
+| Path                                         | Auth                                                                                                                                  | Notes                                                                                                                                                                     |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/v1/webhooks/subscriptions/{id}`    | None — the id itself is the lookup key.                                                                                               | Returns the subscription (no secret) plus a `delivery` health block: `status` (`ok`\|`retrying`\|`dead_letter`), pending/dead-letter counts, and the last failure if any. |
+| `DELETE /api/v1/webhooks/subscriptions/{id}` | `x-metagraph-webhook-secret` header, matching _this subscription's own_ secret — a different credential from the shared create token. | `403` on mismatch, `404` if the id doesn't exist.                                                                                                                         |
+
+```bash
+curl -s https://api.metagraph.sh/api/v1/webhooks/subscriptions/<id>
+```
+
+## How delivery works
+
+Delivery isn't a fixed interval — it fires from the publish pipeline itself, right after a build's R2/KV upload completes. Every subscription whose `filters` match the resulting change event gets an HMAC-SHA256-signed POST, headers:
+
+| Header                        | Content                                                                                                                                                                                              |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `x-metagraph-signature`       | Hex HMAC-SHA256 of the raw request body, keyed by your subscription's secret. Verify by recomputing over the raw bytes and comparing in constant time — the same pattern Stripe/GitHub webhooks use. |
+| `x-metagraph-event-id`        | Stable across every subscriber and redelivery of the same event content.                                                                                                                             |
+| `x-metagraph-idempotency-key` | Stable per (subscriber, event) pair across retries — dedupe on this, not the event id alone.                                                                                                         |
+
+Delivery is **at-least-once**: up to 3 fresh attempts with exponential backoff, then a failure is parked and swept on later publish runs with backoff up to 12h, dead-lettering after 8 rounds. A non-retryable failure (any 4xx other than a timeout, or a redirect — redirects aren't followed) fails immediately without parking; a 5xx, 429, network error, or timeout retries.
+
+<Callout title="Two different 503s, two different causes">
+  If the subscription store itself isn't configured, every route 503s `webhooks_unavailable` — the
+  whole feature is off. If only the shared create token is unset, `POST` specifically returns
+  `webhook_subscriptions_disabled` — creation is off, but `GET`/`DELETE` on subscriptions that
+  already exist may still work.
+</Callout>
+
+```js tab="JavaScript"
+const res = await fetch("https://api.metagraph.sh/api/v1/webhooks/subscriptions", {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+    "x-metagraph-webhook-subscription-token": token,
+  },
+  body: JSON.stringify({
+    url: "https://example.com/hooks/metagraphed",
+    filters: { kinds: ["subnets"] },
+  }),
+});
+const { data } = await res.json();
+```
+
+```python tab="Python"
+import requests
+
+res = requests.post(
+    "https://api.metagraph.sh/api/v1/webhooks/subscriptions",
+    headers={"x-metagraph-webhook-subscription-token": token},
+    json={"url": "https://example.com/hooks/metagraphed", "filters": {"kinds": ["subnets"]}},
+)
+data = res.json()["data"]
+```
+
+Create/delete share one rate limit — 10 requests/60s per client IP. Subscription bodies cap at 8 KB; `filters.netuids` caps at 64 entries, `filters.kinds` at 8. Subscriptions expire 180 days after creation.
+
+<ApiSourceFooter paths={["/api/v1/webhooks/subscriptions"]} />

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -338,7 +338,7 @@ function SiteFooter() {
         aria-hidden
         className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-accent/60 to-transparent"
       />
-      <div className="max-w-shell-max mx-auto px-4 md:px-10 py-14 grid gap-10 md:grid-cols-4 text-[12px] text-ink-muted">
+      <div className="max-w-shell-max mx-auto px-4 md:px-10 py-14 grid gap-10 md:grid-cols-5 text-[12px] text-ink-muted">
         <div className="md:col-span-2">
           <div className="font-display text-base font-semibold text-ink-strong inline-flex items-baseline gap-1">
             Metagraphed
@@ -400,13 +400,25 @@ function SiteFooter() {
           <FooterLink to="/health">Health</FooterLink>
           <FooterLink to="/status">Status</FooterLink>
           <FooterLink to="/schemas">Schemas</FooterLink>
-          <FooterLink to="/docs/graphql">GraphQL</FooterLink>
-          <FooterLink to="/docs/rpc">RPC</FooterLink>
-          <FooterLink to="/docs/feeds">Feeds</FooterLink>
           <FooterLink to="/gaps">Gaps</FooterLink>
-          <FooterLink to="/docs/chain-events">Chain events reference</FooterLink>
           <FooterLink to="/agents">For agents</FooterLink>
           <FooterLink to="/about">About</FooterLink>
+        </FooterCol>
+        <FooterCol title="Guides">
+          <FooterLink to="/docs/blocks">Blocks</FooterLink>
+          <FooterLink to="/docs/extrinsics">Extrinsics</FooterLink>
+          <FooterLink to="/docs/accounts">Accounts</FooterLink>
+          <FooterLink to="/docs/subnets">Subnets</FooterLink>
+          <FooterLink to="/docs/metagraph">Metagraph & validators</FooterLink>
+          <FooterLink to="/docs/economics">Economics</FooterLink>
+          <FooterLink to="/docs/health">Health & readiness</FooterLink>
+          <FooterLink to="/docs/chain-analytics">Chain analytics</FooterLink>
+          <FooterLink to="/docs/chain-events">Chain events</FooterLink>
+          <FooterLink to="/docs/webhooks">Webhooks</FooterLink>
+          <FooterLink to="/docs/search-ai">Search & AI</FooterLink>
+          <FooterLink to="/docs/feeds">Feeds</FooterLink>
+          <FooterLink to="/docs/graphql">GraphQL</FooterLink>
+          <FooterLink to="/docs/rpc">RPC</FooterLink>
         </FooterCol>
       </div>
       <div className="border-t border-border/70">


### PR DESCRIPTION
## Summary

Phase 3 of the docs migration ([plan](https://github.com/JSONbored/metagraphed/pull/6210)): adds a narrative prose guide for every endpoint group that didn't already have one, closing out the remaining queued docs issues.

Closes #3504, Closes #3505, Closes #3506, Closes #3507, Closes #3508, Closes #3509, Closes #3510, Closes #3511, Closes #3514, Closes #3516

| Page | Route |
| --- | --- |
| [Blocks](apps/ui/content/docs/blocks.mdx) | `/api/v1/blocks`, block detail/extrinsics/events, `/api/v1/runtime` |
| [Extrinsics](apps/ui/content/docs/extrinsics.mdx) | `/api/v1/extrinsics`, `/governance/config-changes`, `/sudo` |
| [Accounts](apps/ui/content/docs/accounts.mdx) | `/api/v1/accounts/{ss58}` + 22 sub-resources |
| [Subnets](apps/ui/content/docs/subnets.mdx) | `/api/v1/subnets` + structure/lifecycle/market/decentralization/curation |
| [Subnet metagraph & validators](apps/ui/content/docs/metagraph.mdx) | `/subnets/{netuid}/metagraph`, `/validators`, `/neurons/{uid}` |
| [Economics](apps/ui/content/docs/economics.mdx) | `/api/v1/economics`, `/economics/trends` |
| [Health & readiness](apps/ui/content/docs/health.mdx) | `/api/v1/health`, `/incidents`, per-subnet health/uptime/percentiles |
| [Chain analytics](apps/ui/content/docs/chain-analytics.mdx) | `/api/v1/chain/*` (21 rollup/leaderboard routes) |
| [Webhooks](apps/ui/content/docs/webhooks.mdx) | `/api/v1/webhooks/subscriptions` (POST/GET/DELETE) |
| [Search & AI](apps/ui/content/docs/search-ai.mdx) | `/api/v1/search`, `/search/semantic`, `/ask` |

Two of these (Webhooks, Search & AI) document real, implemented routes that have **no OpenAPI-generated reference page at all** — `/api/v1/webhooks/subscriptions`, `/api/v1/search/semantic`, and `/api/v1/ask` aren't in the published spec, so these pages are the sole documentation surface for them.

## How this was built

Every route, parameter, limit, and cache TTL was verified against the real implementation (`workers/api.mjs`, `src/*.mjs`, and the published OpenAPI spec) — not assumed from the spec's own (sometimes stale) summaries. Domain concepts (SS58/hotkey/coldkey, Yuma Consensus fields, dTAO/alpha pools, subnet hyperparameters, Substrate extrinsics/governance) are paraphrased from official Bittensor/Substrate documentation, cited and cross-checked, never copied verbatim.

A few things worth flagging that came out of that verification pass:
- The "Chain analytics" page deliberately covers only `/api/v1/chain/*` — the existing `chain-events.mdx` already documents `/api/v1/chain-events*`, and the two are genuinely different surfaces (raw firehose vs. pre-aggregated rollups), not a duplicate.
- The "Subnets" and "Subnet metagraph & validators" pages have an explicit scope boundary — subnet-level aggregates/config/history vs. the live neuron table — cross-linked in both directions.
- Bittensor's governance/sudo extrinsics are just the general extrinsics feed pre-filtered by pallet, not a separate store — subtensor has no Council/Senate anymore (removed upstream), which the Extrinsics page explains rather than glossing over.

## Wiring

- The API reference's Callout (`content/docs/api-reference/index.mdx`) now links all 14 narrative guides (previously only listed 3, missing even the already-shipped `/docs/feeds`).
- The site footer's "Operations" column would have been unreadable at 14 links crammed in — split into a dedicated "Guides" column (`app-shell.tsx`, `md:grid-cols-4` → `md:grid-cols-5`). Before/after below.
- No route registration needed for the new pages themselves — `docs.$.tsx`'s catch-all + fumadocs' page-tree auto-discovery already pick up anything under `content/docs/`.

## Screenshots

Footer restructuring (the one pre-existing-component visual change in this PR):

| Viewport | Theme | Before | After |
| --- | --- | --- | --- |
| Desktop | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/endpoint-group-guides/before-footer-desktop-light.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/endpoint-group-guides/after-footer-desktop-light.png) |
| Desktop | Dark | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/endpoint-group-guides/before-footer-desktop-dark.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/endpoint-group-guides/after-footer-desktop-dark.png) |
| Mobile | Light | ![before](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/endpoint-group-guides/before-footer-mobile.png) | ![after](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/endpoint-group-guides/after-footer-mobile.png) |

Sample of the 10 new pages (all 10 render cleanly — verified via Playwright, zero console errors, HTTP 200 on every route):

| Page | Preview |
| --- | --- |
| Subnets (desktop, light) | ![subnets light](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/endpoint-group-guides/page-subnets-desktop-light.png) |
| Subnets (desktop, dark) | ![subnets dark](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/endpoint-group-guides/page-subnets-desktop-dark.png) |
| Webhooks (desktop, light) | ![webhooks light](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/endpoint-group-guides/page-webhooks-desktop-light.png) |
| Accounts (mobile, light) | ![accounts mobile](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/endpoint-group-guides/page-accounts-mobile-light.png) |

## Test plan

- [x] `npx tsc --noEmit -p apps/ui` clean
- [x] `npx eslint`/`npx prettier --check` clean on every touched/new file
- [x] `npm run test --workspace=apps/ui` — 133 files / 1023 tests pass
- [x] Real production build (`LOVABLE_SANDBOX=1 NITRO_PRESET=cloudflare-module npm run build`) succeeds
- [x] All 10 new routes verified via Playwright: HTTP 200, correct `<title>`, zero console errors
- [x] Manually verified in-browser: sidebar auto-discovers all 10 pages, tables/Callouts/code-tabs/`ApiSourceFooter` render correctly, footer restructuring holds across desktop/mobile × light/dark
