### PR TITLE
chore(enrich): taostats identity gap-fills

### DIFF
--- a/registry/subnets/glyph.json
+++ b/registry/subnets/glyph.json
@@ -65,5 +65,8 @@
       "url": "https://github.com/glyph-research/glyph-subnet"
     }
   ],
+  "social": {
+    "x": "https://x.com/glyphresearch"
+  },
   "website_url": "https://glyph-research.org"
 }


### PR DESCRIPTION
## Summary

Third-party taostats gap-fills for human review — sourced from the SubnetIdentitiesV3 identity API.

| Subnet | Netuid | Field | Value | Provenance |
|--------|--------|-------|-------|------------|
| Glyph | 117 | `social.x` | `https://x.com/glyphresearch` | taostats SubnetIdentitiesV3 |

## Notes

- Gap-fill only: no existing fields were overwritten.
- Name-matched: taostats `subnet_name="glyph"` aligns with registry `name="Glyph"`.
- URL verified live (HTTP 200) before inclusion.
- Other candidates (10 raw gaps) were dropped due to subnet name mismatches, dead URLs (404), or placeholder repo names.
- Values are third-party taostats data — held for human review before merge.