### PR TITLE
fix(ui): add ShareButton + ApiSourceFooter to subnet/provider detail without inflating rows

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -26,6 +26,7 @@ import {
   MiniRadial,
   DotRow,
   NoDataSpark,
+  ShareButton,
   Sparkline,
 } from "@jsonbored/ui-kit";
 import {
@@ -349,6 +350,7 @@ export function SubnetMasthead({
         <div className="ml-auto flex md:hidden items-center gap-1.5">
           <HealthPill state={probeHealth} />
           <CurationChip level={profile?.curation_level} />
+          <ShareButton bare className="-my-3.5" />
         </div>
       </div>
 
@@ -451,6 +453,7 @@ export function SubnetMasthead({
         <div className="hidden md:flex shrink-0 flex-col items-end gap-1.5">
           <HealthPill state={probeHealth} />
           <CurationChip level={profile?.curation_level} />
+          <ShareButton bare className="-my-3.5" />
         </div>
       </div>
 

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -9,6 +9,7 @@ import {
   StaleBanner,
   RECOVERY,
 } from "@/components/metagraphed/states";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import {
   EntityHero,
@@ -16,6 +17,7 @@ import {
   PrimaryLinksRail,
   CopyableCode,
   SectionAnchor,
+  ShareButton,
 } from "@jsonbored/ui-kit";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { EndpointsGlance } from "@/components/metagraphed/endpoints-glance";
@@ -130,6 +132,7 @@ function ProviderShell({ slug }: { slug: string }) {
         title={p?.name ?? slug}
         subtitle={shouldShowProviderSlugSubtitle(p?.name, slug) ? <>· {slug}</> : null}
         description={p?.notes}
+        actions={<ShareButton />}
         links={<PrimaryLinksRail website={p?.website ?? p?.homepage} docs={p?.docs} />}
         stats={[
           { label: "Endpoints", value: formatNumber(summary?.endpoint_count) },
@@ -171,6 +174,10 @@ function ProviderShell({ slug }: { slug: string }) {
           {summary?.by_layer ? <BreakdownCard title="By layer" data={summary.by_layer} /> : null}
         </aside>
       </div>
+
+      <ApiSourceFooter
+        paths={[`/api/v1/providers/${slug}`, `/api/v1/providers/${slug}/endpoints`]}
+      />
     </>
   );
 }

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -104,6 +104,7 @@ import type {
 } from "@/lib/metagraphed/types";
 import { IncidentTimeline } from "@/components/metagraphed/incident-timeline";
 import { TimeRangeProvider } from "@/components/metagraphed/analytics/time-range-context";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { SubnetMasthead } from "@/components/metagraphed/subnet-masthead";
 import { OperationalPanel } from "@/components/metagraphed/operational-panel";
 import { ResourceExplorer } from "@/components/metagraphed/resource-explorer";
@@ -340,6 +341,13 @@ function ProfileShell({ netuid }: { netuid: number }) {
           ) : null}
           {tab === "api" ? <ApiPanel netuid={netuid} /> : null}
         </div>
+        <ApiSourceFooter
+          paths={[
+            `/api/v1/subnets/${netuid}/profile`,
+            `/api/v1/subnets/${netuid}/overview`,
+            `/api/v1/subnets/${netuid}/identity-history`,
+          ]}
+        />
       </SubnetFilterProvider>
     </TimeRangeProvider>
   );


### PR DESCRIPTION
Fixes #5481. Supersedes #6231, which was rejected as *"doesn't follow standardized implementation/adds unnecessary line usage + wastes space"* — this rebuild addresses each of those points directly.

Every other entity-detail route pairs a `ShareButton` (copy-current-URL) with an `ApiSourceFooter` (data provenance) — `accounts.$ss58`, `blocks.$ref`, `extrinsics.$hash` and `validators.$hotkey` all do. The subnet and provider detail pages were the only two exceptions.

## What changed vs the rejected attempt

| | #6231 (rejected) | This PR |
| --- | --- | --- |
| Placement | a bespoke slot invented in the status row, wrapped in a new `<div>` | dropped into the masthead's **two existing** chip clusters, beside `HealthPill`/`CurationChip` |
| Masthead diff | wrapper + comment block | **3 lines**, no wrapper, no new row |
| Row inflation | never measured | **measured — unchanged** (numbers below) |

## Implementation

- **`providers.$slug.tsx`** — `EntityHero` documents an `actions` prop (*"was PageHero's `actions`"*) but the call never passed one. It now passes `actions={<ShareButton />}` — the same slot its peers use, not a bespoke placement.
- **`subnets.$netuid.tsx` / `subnet-masthead.tsx`** — `SubnetMasthead` has no actions slot, so each `ShareButton` goes inside the masthead's existing chip clusters (the `md:hidden` status-row cluster and the `md:flex` identity-grid column), adding no wrapper, no new row, and no layout of its own. Duplicating across both clusters matches the file's own convention — `HealthPill`/`CurationChip` are already duplicated, one hidden per breakpoint.
- **No inflation.** The shared `ShareButton` carries a 44px (`min-h-11`/`min-w-11`) touch target; dropped into those dense clusters it would grow them, so each gets `-my-3.5` to fold that height back into the surrounding padding — the same technique `validator-columns.tsx` already uses for its `CopyButton`.
- Both routes also render an `ApiSourceFooter` citing the paths they actually read, traced through `@/lib/metagraphed/queries` rather than assumed: providers → `/api/v1/providers/{slug}` + `/endpoints`; subnets → the `profile`, `overview` and `identity-history` endpoints.

## Measured — layout is byte-identical

Rendered against the real API at both breakpoints; the button keeps its full 44px hit area:

| Viewport | Masthead status row | Identity grid |
| --- | --- | --- |
| Desktop 1280×800 | 21px → **21px** | 128px → **128px** |
| Mobile 375×812 | 48px → **48px** | 207px → **207px** |

## Validation

`tsc --noEmit`: 0 errors in the changed files · `eslint`: 0 errors · `prettier --check`: clean · diff is **+18 lines, purely additive** (no deletions, no behavior/query/table changes).

The app is client-rendered (SSR is a shell), so both affordances were verified in a real browser DOM rather than by grepping HTML:

| Route | ApiSourceFooter | ShareButton |
| --- | --- | --- |
| `/subnets/1` **after** | 1 | 2 (one per breakpoint cluster, one hidden) |
| `/subnets/1` **before** | 0 | 0 |
| `/providers/404-gen` **after** | 1 | 1 |
| `/providers/404-gen` **before** | 0 | 0 |

## UI Evidence

Fixed viewports (375×812 / 768×1024 / 1280×800), both themes, real API data. Before/after are identical apart from the added **Share view** control. (`ApiSourceFooter` sits below the fold; its rendering is proven by the DOM check above.)

**Subnet detail (`/subnets/1`) — ShareButton added to the masthead's existing chip cluster**

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-subnet-after-mobile-dark.png)<br><sub>after</sub> |

**Provider detail (`/providers/404-gen`) — ShareButton via EntityHero's own `actions` prop**

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5481v2-provider-after-mobile-dark.png)<br><sub>after</sub> |
