### PR TITLE
feat(api): add curation_level filter to the curation collection (#6238)

### DIFF
--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -166,6 +166,10 @@ export const API_QUERY_COLLECTIONS = {
     filters: {
       netuid: integerSchema,
       coverage_level: enumSchema(QUERY_ENUMS.coverageLevel),
+      // #6238: curation_level is already a sort target here and a real filter on
+      // the sibling gaps collection; expose it as a filter too so callers can
+      // narrow, not just order, by it. Same shared enum gaps uses.
+      curation_level: enumSchema(QUERY_ENUMS.curationLevel),
     },
     sort: ["coverage_level", "curation_level", "name", "netuid"],
   }),

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -353,6 +353,53 @@ describe("list-query case-insensitive enum/string filters (#2073)", () => {
   });
 });
 
+// #6238: the curation collection could sort=curation_level but not filter on it,
+// unlike the sibling gaps collection. It's now a real filter using the same
+// shared QUERY_ENUMS.curationLevel vocabulary.
+describe("list-query curation curation_level filter (#6238)", () => {
+  const data = {
+    curation: [
+      { netuid: 1, curation_level: "native" },
+      { netuid: 2, curation_level: "maintainer-reviewed" },
+    ],
+  };
+
+  test("?curation_level=native narrows the curation list to matching rows", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/curation?curation_level=native"),
+      "curation",
+    );
+    assert.equal(result.error, undefined);
+    assert.deepEqual(
+      result.data.curation.map((r) => r.netuid),
+      [1],
+    );
+  });
+
+  test("the filter is case-insensitive, like every other enum filter (#2073)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/curation?curation_level=Maintainer-Reviewed"),
+      "curation",
+    );
+    assert.equal(result.error, undefined);
+    assert.deepEqual(
+      result.data.curation.map((r) => r.netuid),
+      [2],
+    );
+  });
+
+  test("an invalid curation_level errors with parameter curation_level (400 invalid_query)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/curation?curation_level=bogus"),
+      "curation",
+    );
+    assert.equal(result.error.parameter, "curation_level");
+  });
+});
+
 describe("list-query numeric range filters", () => {
   const data = {
     subnets: [


### PR DESCRIPTION
## What

Adds the missing `curation_level` filter to the `curation` query collection. `GET /api/v1/curation` already lists `curation_level` as a valid `sort` target, but had no matching `filters` entry — so callers could order by curation level but not narrow to one. The sibling `gaps` collection already exposes this exact field as a real filter.

## How

One line in `src/contracts.mjs` — add `curation_level: enumSchema(QUERY_ENUMS.curationLevel)` to the `curation` collection's `filters`, reusing the identical shared enum the `gaps` collection uses. No new vocabulary; `gaps` untouched; `sort` unchanged.

Behaviour comes for free from the existing route machinery: `GET /api/v1/curation?curation_level=<value>` now filters case-insensitively (per `#2073`), and an invalid value returns the standard `400 invalid_query` envelope with `parameter: "curation_level"` — exactly like the already-supported `?coverage_level=` filter and every other enum filter in the table.

## Tests

`tests/list-query.test.mjs` (following the existing `applyQueryFilters` per-collection pattern): the valid filter narrows rows, a mixed-case value matches case-insensitively (#2073), and an invalid value errors with `parameter: "curation_level"`. Full `list-query` + `contracts` suites green.

Closes #6238.