### PR TITLE
fix(ui): add ShareButton + ApiSourceFooter to subnet/provider detail pages

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -27,6 +27,7 @@ import {
   DotRow,
   NoDataSpark,
   Sparkline,
+  ShareButton,
 } from "@jsonbored/ui-kit";
 import {
   subnetEndpointsQuery,
@@ -346,7 +347,8 @@ export function SubnetMasthead({
             stale
           </span>
         ) : null}
-        <div className="ml-auto flex md:hidden items-center gap-1.5">
+        <ShareButton className="ml-auto" />
+        <div className="flex md:hidden items-center gap-1.5">
           <HealthPill state={probeHealth} />
           <CurationChip level={profile?.curation_level} />
         </div>

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -10,12 +10,14 @@ import {
   RECOVERY,
 } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import {
   EntityHero,
   BrandIcon,
   PrimaryLinksRail,
   CopyableCode,
   SectionAnchor,
+  ShareButton,
 } from "@jsonbored/ui-kit";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { EndpointsGlance } from "@/components/metagraphed/endpoints-glance";
@@ -131,6 +133,7 @@ function ProviderShell({ slug }: { slug: string }) {
         subtitle={shouldShowProviderSlugSubtitle(p?.name, slug) ? <>· {slug}</> : null}
         description={p?.notes}
         links={<PrimaryLinksRail website={p?.website ?? p?.homepage} docs={p?.docs} />}
+        actions={<ShareButton />}
         stats={[
           { label: "Endpoints", value: formatNumber(summary?.endpoint_count) },
           { label: "Monitored", value: formatNumber(summary?.monitored_count) },
@@ -171,6 +174,10 @@ function ProviderShell({ slug }: { slug: string }) {
           {summary?.by_layer ? <BreakdownCard title="By layer" data={summary.by_layer} /> : null}
         </aside>
       </div>
+
+      <ApiSourceFooter
+        paths={[`/api/v1/providers/${slug}`, `/api/v1/providers/${slug}/endpoints`]}
+      />
     </>
   );
 }

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -25,6 +25,7 @@ import {
   RECOVERY,
 } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EvidencePanel } from "@/components/metagraphed/evidence-panel";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { SchemaDriftSummary } from "@/components/metagraphed/schema-drift";
@@ -340,6 +341,8 @@ function ProfileShell({ netuid }: { netuid: number }) {
           ) : null}
           {tab === "api" ? <ApiPanel netuid={netuid} /> : null}
         </div>
+
+        <ApiSourceFooter paths={[`/api/v1/subnets/${netuid}/profile`]} />
       </SubnetFilterProvider>
     </TimeRangeProvider>
   );


### PR DESCRIPTION
## What

Every other entity-detail route (`accounts.$ss58.tsx`, `blocks.$ref.tsx`, `extrinsics.$hash.tsx`, `validators.$hotkey.tsx`) renders both a `ShareButton` and an `ApiSourceFooter`. The two busiest detail pages — `subnets.$netuid.tsx` and `providers.$slug.tsx` — rendered neither.

- `providers.$slug.tsx`: pass `actions={<ShareButton />}` to the existing `EntityHero` call (the prop already exists on `EntityHeroProps`, just wasn't used here); add an `ApiSourceFooter` citing the provider/endpoints API paths.
- `subnet-masthead.tsx`: add a `ShareButton` to the status row's action area — self-contained, no hero-layout migration needed (per the issue's explicit scope note).
- `subnets.$netuid.tsx`: add an `ApiSourceFooter` citing the subnet profile API path.

## Scope

- UI-only change across 3 files under `apps/ui/src/{routes,components/metagraphed}/**`.
- No layout redesign — both additions use the existing `actions`/status-row slots the way every sibling detail page already does.

## Screenshot evidence

Captured on `/subnets/1`'s masthead status row, where the new `ShareButton` appears (previously absent). The identical `actions={<ShareButton />}` pattern is applied to `providers.$slug.tsx`'s `EntityHero`. `ApiSourceFooter` (added to both routes, citing the respective detail API paths) renders at the bottom of each page, below the fold on this viewport — not re-captured separately since it's the exact same component/usage pattern already screenshotted in other merged PRs on this repo (e.g. plain `paths={[...]}` citation, no custom rendering).

| Viewport · Theme | Before | After |
| ---- | ---- | ---- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/5481-subnet-share-after-mobile-dark.png)<br><sub>after</sub> |

## Verification

- `npx eslint` on the 3 changed files: 0 errors, 0 warnings (pre-existing `react-refresh` warnings only, unrelated).
- `npx prettier --check`: passes.
- Rebased onto current `main` (includes #6233).

Closes #5481
