### PR TITLE
fix(api): honor ?format=csv on the per-subnet gaps route

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -23826,6 +23826,8 @@ export interface operations {
                 sort?: "candidate_count" | "curation_level" | "missing_kinds" | "name" | "netuid" | "priority_score" | "surface_count" | "verified_candidate_count";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -23835,7 +23837,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -23973,6 +23975,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetGapsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -3567,6 +3567,17 @@
               "desc"
             ]
           }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
         }
       ]
     },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -45659,6 +45659,19 @@
                 "desc"
               ]
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -45804,9 +45817,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -23826,6 +23826,8 @@ export interface operations {
                 sort?: "candidate_count" | "curation_level" | "missing_kinds" | "name" | "netuid" | "priority_score" | "surface_count" | "verified_candidate_count";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -23835,7 +23837,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -23973,6 +23975,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetGapsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1985,7 +1985,7 @@ export const API_ROUTES = [
     "Fetch interface gap priorities and enrichment queue for one subnet.",
     "standard",
     ["registry", "review", "subnets"],
-    listQuery("review-gap-priorities", { exclude: ["netuid"] }),
+    csvListQuery("review-gap-priorities", { exclude: ["netuid"] }),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1460,6 +1460,48 @@ describe("review enrichment list CSV export", () => {
     assert.ok(rows.every((row) => row.priority_score !== ""));
   });
 
+  // #6237: subnets/{netuid}/gaps is the netuid-scoped view of the SAME review-gap-priorities
+  // collection as review/gaps above, but was the one bulk/per-subnet pair whose per-subnet half
+  // never advertised the CSV contract, so ?format=csv silently returned JSON.
+  test("subnets/{netuid}/gaps ?format=csv returns the same CSV contract as its bulk sibling", async () => {
+    const res = await handleRequest(
+      req(
+        "/api/v1/subnets/1/gaps?format=csv&fields=netuid,priority_score,curation_level&limit=5",
+      ),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^text\/csv/);
+    assert.equal(
+      res.headers.get("content-disposition"),
+      'attachment; filename="subnet-gaps.csv"',
+    );
+    const { header, rows } = await parseCsv(res);
+    assert.equal(header.join(","), "netuid,priority_score,curation_level");
+    assert.ok(rows.length > 0);
+    // netuid is simply constant for the one subnet -- the scoped view of the same row shape.
+    assert.ok(rows.every((row) => row.netuid === "1"));
+    assert.ok(rows.every((row) => row.priority_score !== ""));
+  });
+
+  test("subnets/{netuid}/gaps without format= keeps its existing JSON envelope", async () => {
+    // Strictly additive: the default path must be untouched by the CSV wiring.
+    const res = await handleRequest(
+      req("/api/v1/subnets/1/gaps"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /^application\/json/);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(
+      Array.isArray(body.data.rows ?? body.data.gaps ?? body.data.priorities),
+      true,
+    );
+  });
+
   test("review/profile-completeness ?format=csv exports priority_score and honors identity_level", async () => {
     const res = await handleRequest(
       req(


### PR DESCRIPTION
Fixes #6237.

`GET /api/v1/review/gaps` and `GET /api/v1/subnets/{netuid}/gaps` serve the **exact same** `review-gap-priorities` collection — the per-subnet route is just the netuid-scoped view, passing `{ exclude: ["netuid"] }` to drop the now-redundant filter and nothing else. But only the bulk route was wired with `csvListQuery(...)`, which is what sets `csv_response` on the entry. `handleApiRequest` reads that single flag to decide whether `?format=csv` is honored, so the per-subnet route **silently ignored `format=csv`** and returned JSON for the identical row shape.

Every other bulk/per-subnet pair in the route table (`surfaces`/`subnet-surfaces`, `endpoints`/`subnet-endpoints`, `candidates`/`subnet-candidates`) keeps `csvListQuery` on **both** halves — `review-gaps`/`subnet-gaps` was the one pair that didn't. This wires the per-subnet route the same way.

## Verified against the real route, not assumed

```
GET /api/v1/subnets/1/gaps?format=csv
  → 200, content-type: text/csv; charset=utf-8
  → content-disposition: attachment; filename="subnet-gaps.csv"
  → candidate_count,curation_level,missing_kinds,name,netuid,priority_score,review_state,slug,suggested_next_action,surface_count,verified_candidate_count
  → 12,maintainer-reviewed,sse,Apex,1,27,maintainer-reviewed,sn-1,evaluate for subnet-specific adapter,18,5
```

Same columns its bulk sibling produces, with `netuid` simply constant for the one subnet. The no-`format` path still returns the unchanged JSON envelope — **strictly additive**.

## Changes

- `src/contracts.mjs`: the `subnet-gaps` route uses `csvListQuery("review-gap-priorities", { exclude: ["netuid"] })`, matching `review-gaps`' wiring exactly. The collection definition and every other route are untouched.
- Regenerated the OpenAPI/type artifacts, which pick up the new `format` parameter and the `text/csv` response for the route.

## Tests

Two cases in `tests/api-coverage.test.mjs`, beside the existing `review/gaps ?format=csv` test they mirror: the CSV contract (status/content-type/filename/columns/constant-netuid) and a regression that the default JSON envelope is unchanged.

Green: `api-coverage` 260/260 · `validate:contract-drift` · `validate:openapi` (159 routes) · `validate:openapi-examples` (159/159) · `validate-api` (159) · eslint 0 · prettier clean.