### PR TITLE
fix(registry): dedupe api.all-ways.io/miners/leaderboard duplicate surface (#5736)

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -2,8 +2,7 @@
   "categories": ["defi", "bitcoin", "subnet-api", "pilot"],
   "curation": {
     "gap_notes": [
-      "No verified dashboard surface yet (no dashboard link found on the website as of 2026-07-15).",
-      "Data-artifact surface exists (sn-7-allways-data-artifact) but is community-submitted, not yet maintainer-verified."
+      "No verified dashboard surface yet (no dashboard link found on the website as of 2026-07-15)."
     ],
     "level": "adapter-backed",
     "review_state": "maintainer-reviewed",
@@ -272,28 +271,6 @@
       "provider": "allways",
       "public_safe": true,
       "url": "https://api.all-ways.io/sse"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "id": "sn-7-allways-data-artifact",
-      "kind": "data-artifact",
-      "name": "Allways community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "allways",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.all-ways.io/swagger-json"],
-      "url": "https://api.all-ways.io/miners/leaderboard"
     },
     {
       "auth_required": false,


### PR DESCRIPTION
Closes #5736.

## What

`registry/subnets/allways.json` registered `https://api.all-ways.io/miners/leaderboard` **twice** under two surface kinds:

- `allways-miners-leaderboard` — `kind: subnet-api`, `GET`, `expect: json`, `authority: provider-claimed`
- `sn-7-allways-data-artifact` — `kind: data-artifact`, `HEAD`, `expect: any`, `authority: community` (community-submitted)

The endpoint returns a live JSON leaderboard response — it is a subnet API surface, not a downloadable data artifact (like a HuggingFace dataset). Per the issue guidance (keep whichever `kind` most accurately describes what the endpoint actually returns), I kept `allways-miners-leaderboard` (subnet-api) and removed the redundant `sn-7-allways-data-artifact`. I also dropped the now-dangling `curation.gap_notes` entry that referenced the removed surface by id; the removed surface carried no unique notes/attribution that needed folding into the survivor.

## The other two deliverables are already satisfied in `main`

- `bitmind.json` (SN34): `https://api.bitmind.ai/health` is registered once (`sn-34-bitmind-subnet-api`); no `data-artifact` duplicate remains.
- `gradients.json` (SN56): `https://api.gradients.io/v1/network/status` is registered once (`sn-56-gradients-subnet-api`); no `data-artifact` duplicate remains.

A duplicate-URL scan across all three files confirms allways was the only one still double-registering. No other surface in any file was touched.

## Verify

- `npm run validate:surface` → passes (1121 surfaces across 129 files).
- Diff is 1 file, `-24/+1` (one surface object + one stale gap_note removed).