### PR TITLE
feat(api): add missing_kinds filter to review-gap-priorities (#6240)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -20651,6 +20651,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 review_state?: string;
                 fields?: string;
                 limit?: number;
@@ -23818,6 +23819,7 @@ export interface operations {
         parameters: {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 review_state?: string;
                 fields?: string;
                 limit?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -3391,6 +3391,7 @@
       "query_filter_names": [
         "netuid",
         "curation_level",
+        "missing_kinds",
         "review_state"
       ],
       "query_parameters": [
@@ -3411,6 +3412,28 @@
               "machine-verified",
               "maintainer-reviewed",
               "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "missing_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
             ],
             "type": "string"
           }
@@ -3495,6 +3518,7 @@
       "query_collection": "review-gap-priorities",
       "query_filter_names": [
         "curation_level",
+        "missing_kinds",
         "review_state"
       ],
       "query_parameters": [
@@ -3508,6 +3532,28 @@
               "machine-verified",
               "maintainer-reviewed",
               "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "missing_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
             ],
             "type": "string"
           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -40604,6 +40604,30 @@
           },
           {
             "in": "query",
+            "name": "missing_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "review_state",
             "required": false,
             "schema": {
@@ -45588,6 +45612,30 @@
                 "machine-verified",
                 "maintainer-reviewed",
                 "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "missing_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
               ],
               "type": "string"
             }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -20651,6 +20651,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 review_state?: string;
                 fields?: string;
                 limit?: number;
@@ -23818,6 +23819,7 @@ export interface operations {
         parameters: {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 review_state?: string;
                 fields?: string;
                 limit?: number;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -339,6 +339,9 @@ export const API_QUERY_COLLECTIONS = {
     filters: {
       netuid: integerSchema,
       curation_level: enumSchema(QUERY_ENUMS.curationLevel),
+      // Same array-membership filter as enrichment-queue / enrichment-targets
+      // (#6240) — missing_kinds was already a legal sort key on this collection.
+      missing_kinds: enumSchema(QUERY_ENUMS.surfaceKind),
       review_state: filterTextSchema,
     },
     sort: [

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -1238,3 +1238,52 @@ describe("list-query string filter excludes rows missing the field", () => {
     });
   });
 });
+
+// #6240: review-gap-priorities could sort by missing_kinds but could not filter
+// on it, unlike enrichment-queue / enrichment-targets.
+describe("review-gap-priorities missing_kinds filter (#6240)", () => {
+  const data = {
+    priorities: [
+      {
+        netuid: 1,
+        name: "Has OpenAPI gap",
+        missing_kinds: ["openapi", "sse"],
+      },
+      {
+        netuid: 2,
+        name: "Has website gap",
+        missing_kinds: ["website"],
+      },
+      {
+        netuid: 3,
+        name: "No gaps",
+        missing_kinds: [],
+      },
+    ],
+  };
+  const netuids = (result) => result.data.priorities.map((r) => r.netuid);
+
+  test("?missing_kinds=<kind> keeps rows whose missing_kinds array contains that kind", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/review/gaps?missing_kinds=openapi"),
+      "review-gap-priorities",
+    );
+    assert.equal(result.error, undefined);
+    assert.deepEqual(netuids(result), [1]);
+    assert.ok(
+      result.data.priorities.every((row) =>
+        row.missing_kinds.includes("openapi"),
+      ),
+    );
+  });
+
+  test("an invalid missing_kinds value returns invalid_query on that parameter", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/review/gaps?missing_kinds=not-a-kind"),
+      "review-gap-priorities",
+    );
+    assert.equal(result.error.parameter, "missing_kinds");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `missing_kinds` to the `review-gap-priorities` query collection filters so `GET /api/v1/review/gaps` and `GET /api/v1/subnets/{netuid}/gaps` can narrow rows by missing surface kind (same enum + array-membership semantics as enrichment-queue / enrichment-targets).
- Regenerate OpenAPI / api-index / types so the new query parameter is documented.
- Cover the happy path and invalid-value `invalid_query` case in `tests/list-query.test.mjs`.

Closes #6240

## What Changed

- **`src/contracts.mjs`**: `review-gap-priorities.filters.missing_kinds = enumSchema(QUERY_ENUMS.surfaceKind)`.
- **Generated**: `public/metagraph/openapi.json`, `public/metagraph/api-index.json`, `public/metagraph/types.d.ts`, `packages/contract/index.d.ts`.
- **Tests**: `tests/list-query.test.mjs` — valid `?missing_kinds=openapi` filter + invalid value → `parameter: "missing_kinds"`.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6240`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (New optional query filter on existing review-gaps routes.)

## Validation

- [x] `npx vitest run tests/list-query.test.mjs` (85 passed)
- [x] `npx prettier --check` on touched source/test files
- [x] `npm run lint`
- [x] `git diff --check`
- [x] `npm run build` (regenerated OpenAPI/types; deploy-owned artifacts auto-reverted)
- [x] `npm run validate:contract-drift`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:upvote`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`

## Template Used

backend-code
