### PR TITLE
feat(mcp): extend list_subnets range bounds to match REST

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -2298,22 +2298,26 @@ export const MCP_TOOLS = [
         },
         min_candidate_count: {
           type: "integer",
-          description: "Only subnets with at least this many surface candidates.",
+          description:
+            "Only subnets with at least this many surface candidates.",
           minimum: 0,
         },
         max_candidate_count: {
           type: "integer",
-          description: "Only subnets with at most this many surface candidates.",
+          description:
+            "Only subnets with at most this many surface candidates.",
           minimum: 0,
         },
         min_mechanism_count: {
           type: "integer",
-          description: "Only subnets with at least this many registered mechanisms.",
+          description:
+            "Only subnets with at least this many registered mechanisms.",
           minimum: 0,
         },
         max_mechanism_count: {
           type: "integer",
-          description: "Only subnets with at most this many registered mechanisms.",
+          description:
+            "Only subnets with at most this many registered mechanisms.",
           minimum: 0,
         },
         min_participant_count: {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -1949,6 +1949,18 @@ const LIST_SUBNETS_RANGE_BOUNDS = [
   { arg: "max_readiness", field: "integration_readiness", op: "max" },
   { arg: "min_surface_count", field: "surface_count", op: "min" },
   { arg: "max_surface_count", field: "surface_count", op: "max" },
+  { arg: "min_block", field: "block", op: "min" },
+  { arg: "max_block", field: "block", op: "max" },
+  { arg: "min_candidate_count", field: "candidate_count", op: "min" },
+  { arg: "max_candidate_count", field: "candidate_count", op: "max" },
+  { arg: "min_mechanism_count", field: "mechanism_count", op: "min" },
+  { arg: "max_mechanism_count", field: "mechanism_count", op: "max" },
+  { arg: "min_participant_count", field: "participant_count", op: "min" },
+  { arg: "max_participant_count", field: "participant_count", op: "max" },
+  { arg: "min_probed_surface_count", field: "probed_surface_count", op: "min" },
+  { arg: "max_probed_surface_count", field: "probed_surface_count", op: "max" },
+  { arg: "min_tempo", field: "tempo", op: "min" },
+  { arg: "max_tempo", field: "tempo", op: "max" },
   { arg: "min_netuid", field: "netuid", op: "min" },
   { arg: "max_netuid", field: "netuid", op: "max" },
 ];
@@ -2274,6 +2286,66 @@ export const MCP_TOOLS = [
         max_surface_count: {
           type: "integer",
           description: "Only subnets with at most this many callable surfaces.",
+          minimum: 0,
+        },
+        min_block: {
+          type: "number",
+          description: "Only subnets whose current block is >= this.",
+        },
+        max_block: {
+          type: "number",
+          description: "Only subnets whose current block is <= this.",
+        },
+        min_candidate_count: {
+          type: "integer",
+          description: "Only subnets with at least this many surface candidates.",
+          minimum: 0,
+        },
+        max_candidate_count: {
+          type: "integer",
+          description: "Only subnets with at most this many surface candidates.",
+          minimum: 0,
+        },
+        min_mechanism_count: {
+          type: "integer",
+          description: "Only subnets with at least this many registered mechanisms.",
+          minimum: 0,
+        },
+        max_mechanism_count: {
+          type: "integer",
+          description: "Only subnets with at most this many registered mechanisms.",
+          minimum: 0,
+        },
+        min_participant_count: {
+          type: "integer",
+          description: "Only subnets with at least this many participants.",
+          minimum: 0,
+        },
+        max_participant_count: {
+          type: "integer",
+          description: "Only subnets with at most this many participants.",
+          minimum: 0,
+        },
+        min_probed_surface_count: {
+          type: "integer",
+          description:
+            "Only subnets with at least this many probed (health-checked) surfaces.",
+          minimum: 0,
+        },
+        max_probed_surface_count: {
+          type: "integer",
+          description:
+            "Only subnets with at most this many probed (health-checked) surfaces.",
+          minimum: 0,
+        },
+        min_tempo: {
+          type: "integer",
+          description: "Only subnets whose tempo is >= this.",
+          minimum: 0,
+        },
+        max_tempo: {
+          type: "integer",
+          description: "Only subnets whose tempo is <= this.",
           minimum: 0,
         },
         min_netuid: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -7252,6 +7252,7 @@ describe("list_subnets", () => {
           status: "active",
           integration_readiness: 15,
           surface_count: 17,
+          tempo: 100,
           categories: [],
         },
         {
@@ -7262,6 +7263,7 @@ describe("list_subnets", () => {
           status: "active",
           integration_readiness: 90,
           surface_count: 4,
+          tempo: 360,
           categories: ["inference"],
         },
         {
@@ -7272,6 +7274,7 @@ describe("list_subnets", () => {
           status: "deprecated",
           integration_readiness: 0,
           surface_count: 0,
+          tempo: 50,
           derived_categories: ["data"],
         },
       ],
@@ -7444,6 +7447,18 @@ describe("list_subnets", () => {
       await callTool("list_subnets", { min_netuid: 1, max_netuid: 7 }, { deps })
     ).body.result.structuredContent;
     assert.deepEqual(rangeNetuids(out), [7]); // 0 below, 8 above
+  });
+
+  test("min_/max_tempo bound the subnet tempo (REST range-filter parity)", async () => {
+    const atLeast200 = (
+      await callTool("list_subnets", { min_tempo: 200 }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(atLeast200), [7]); // only 360 >= 200
+
+    const atMost99 = (
+      await callTool("list_subnets", { max_tempo: 99 }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(rangeNetuids(atMost99), [8]); // only 50 <= 99
   });
 
   test("a row whose bounded field is absent or non-numeric is excluded", async () => {


### PR DESCRIPTION
## Summary

- Extend `LIST_SUBNETS_RANGE_BOUNDS` with `block`, `candidate_count`, `mechanism_count`, `participant_count`, `probed_surface_count`, and `tempo` (min/max each), matching REST `/api/v1/subnets` range filters.
- Add the twelve corresponding optional properties to `list_subnets` `inputSchema`.
- Existing `min_readiness`/`max_readiness`/`min_surface_count`/`max_surface_count`/`min_netuid`/`max_netuid` args unchanged; `rangeFilterSubnets` logic untouched.

Closes #6246

## Test plan

- [x] `npm test -- tests/mcp-server.test.mjs -t "min_/max_tempo"` — new bound narrows rows
- [x] Full `tests/mcp-server.test.mjs` suite green
- [ ] CI `test` + `checks` on PR
