### PR TITLE
fix(ui): render max_validator_trust on the validator detail page (#6254)

### DIFF
--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -3,7 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { Boxes, Coins, Gauge, Percent, Users, Zap } from "lucide-react";
+import { Boxes, Coins, Gauge, Percent, TrendingUp, Users, Zap } from "lucide-react";
 import { useWallet } from "@/hooks/use-wallet";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
@@ -350,6 +350,13 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           eyebrow="Avg validator trust"
           value={scoreStr(detail.avg_validator_trust)}
           hint="mean across subnets"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+        />
+        <StatTile
+          icon={TrendingUp}
+          eyebrow="Max validator trust"
+          value={scoreStr(detail.max_validator_trust)}
+          hint="peak across subnets"
           className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
         />
         <StatTile


### PR DESCRIPTION
Closes #6254.

## What

`apps/ui/src/routes/validators.$hotkey.tsx` fetches `max_validator_trust` as part of the `ValidatorDetail` payload (`types.ts:2228`) but never renders it — only `avg_validator_trust` gets a `StatTile`. This adds a companion **"Max validator trust"** tile immediately next to the existing "Avg validator trust" tile, using:

- the same `scoreStr(...)` formatter as the avg tile, for consistent formatting;
- a distinct `TrendingUp` icon (avg uses `Gauge`), added to the existing `lucide-react` import;
- the same tile `className` as its siblings.

This matches the avg/max trust pairing already surfaced on the global validators list (`validators.index.tsx`, "Max trust" column). No other tile, page, or the existing avg tile was changed.

## Screenshots (before / after)

Real validator detail page (`/validators/5E2LP6…KeZ5u`), showing the new "Max validator trust · 1.000 · peak across subnets" tile appear between "Avg validator trust" and "Take rate".

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6254/before-desktop-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6254/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6254/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6254/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6254/before-tablet-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6254/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6254/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6254/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6254/before-mobile-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6254/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6254/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6254/after-mobile-dark.png) |

## Verify

- `prettier --check` and `eslint` (from apps/ui) on the changed file: clean (0 errors).
- Diff is 1 file, +8/-1.