### PR TITLE
feat(api): add id/confidence filters to candidates and surfaces (#6242)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -12205,6 +12205,8 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                id?: string;
+                confidence?: "low" | "medium" | "high";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -22712,6 +22714,8 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                id?: string;
+                confidence?: "low" | "medium" | "high";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -27337,6 +27341,7 @@ export interface operations {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                id?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -28972,6 +28977,7 @@ export interface operations {
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                id?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1737,7 +1737,8 @@
       "query_filter_names": [
         "netuid",
         "kind",
-        "provider"
+        "provider",
+        "id"
       ],
       "query_parameters": [
         {
@@ -1771,6 +1772,13 @@
         },
         {
           "name": "provider",
+          "schema": {
+            "maxLength": 100,
+            "type": "string"
+          }
+        },
+        {
+          "name": "id",
           "schema": {
             "maxLength": 100,
             "type": "string"
@@ -1846,7 +1854,8 @@
       "query_collection": "curated-surfaces",
       "query_filter_names": [
         "kind",
-        "provider"
+        "provider",
+        "id"
       ],
       "query_parameters": [
         {
@@ -1873,6 +1882,13 @@
         },
         {
           "name": "provider",
+          "schema": {
+            "maxLength": 100,
+            "type": "string"
+          }
+        },
+        {
+          "name": "id",
           "schema": {
             "maxLength": 100,
             "type": "string"
@@ -2324,7 +2340,9 @@
         "netuid",
         "kind",
         "provider",
-        "state"
+        "state",
+        "id",
+        "confidence"
       ],
       "query_parameters": [
         {
@@ -2373,6 +2391,24 @@
               "verified",
               "stale",
               "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "id",
+          "schema": {
+            "maxLength": 100,
+            "type": "string"
+          }
+        },
+        {
+          "name": "confidence",
+          "schema": {
+            "enum": [
+              "low",
+              "medium",
+              "high"
             ],
             "type": "string"
           }
@@ -2450,7 +2486,9 @@
       "query_filter_names": [
         "kind",
         "provider",
-        "state"
+        "state",
+        "id",
+        "confidence"
       ],
       "query_parameters": [
         {
@@ -2492,6 +2530,24 @@
               "verified",
               "stale",
               "rejected"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "id",
+          "schema": {
+            "maxLength": 100,
+            "type": "string"
+          }
+        },
+        {
+          "name": "confidence",
+          "schema": {
+            "enum": [
+              "low",
+              "medium",
+              "high"
             ],
             "type": "string"
           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -27681,6 +27681,28 @@
           },
           {
             "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "maxLength": 100,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "confidence",
+            "required": false,
+            "schema": {
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -43860,6 +43882,28 @@
           },
           {
             "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "maxLength": 100,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "confidence",
+            "required": false,
+            "schema": {
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -50286,6 +50330,15 @@
           },
           {
             "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "maxLength": 100,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {
@@ -52587,6 +52640,15 @@
           {
             "in": "query",
             "name": "provider",
+            "required": false,
+            "schema": {
+              "maxLength": 100,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "id",
             "required": false,
             "schema": {
               "maxLength": 100,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -12205,6 +12205,8 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                id?: string;
+                confidence?: "low" | "medium" | "high";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -22712,6 +22714,8 @@ export interface operations {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
                 state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
+                id?: string;
+                confidence?: "low" | "medium" | "high";
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -27337,6 +27341,7 @@ export interface operations {
             query?: {
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                id?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
@@ -28972,6 +28977,7 @@ export interface operations {
                 netuid?: number;
                 kind?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
+                id?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -155,6 +155,10 @@ export const API_QUERY_COLLECTIONS = {
       kind: enumSchema(QUERY_ENUMS.surfaceKind),
       provider: filterTextSchema,
       state: enumSchema(QUERY_ENUMS.candidateState),
+      // Same exact-match id filter as pools / endpoint-pools; confidence enum
+      // matches profiles (#6242).
+      id: filterTextSchema,
+      confidence: enumSchema(["low", "medium", "high"]),
     },
     sort: ["confidence", "id", "kind", "name", "netuid", "provider", "state"],
   }),
@@ -192,6 +196,8 @@ export const API_QUERY_COLLECTIONS = {
       netuid: integerSchema,
       kind: enumSchema(QUERY_ENUMS.surfaceKind),
       provider: filterTextSchema,
+      // Same exact-match id filter as pools / endpoint-pools (#6242).
+      id: filterTextSchema,
     },
     sort: ["id", "kind", "name", "netuid", "provider"],
   }),

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -1238,3 +1238,122 @@ describe("list-query string filter excludes rows missing the field", () => {
     });
   });
 });
+
+// #6242: candidates and curated-surfaces were sortable by id (and candidates by
+// confidence) but could not filter on those fields.
+describe("candidates id/confidence filters (#6242)", () => {
+  const data = {
+    candidates: [
+      {
+        id: "sn-7-openapi",
+        netuid: 7,
+        kind: "openapi",
+        confidence: "high",
+        provider: "allways",
+        state: "verified",
+      },
+      {
+        id: "sn-7-website",
+        netuid: 7,
+        kind: "website",
+        confidence: "low",
+        provider: "allways",
+        state: "schema-valid",
+      },
+      {
+        id: "sn-8-openapi",
+        netuid: 8,
+        kind: "openapi",
+        confidence: "medium",
+        provider: "beta",
+        state: "verified",
+      },
+    ],
+  };
+  const ids = (result) => result.data.candidates.map((r) => r.id);
+
+  test("?id=<value> keeps rows whose id exactly matches (case-insensitive)", () => {
+    const lower = applyQueryFilters(
+      data,
+      query("/api/v1/candidates?id=sn-7-openapi"),
+      "candidates",
+    );
+    const upper = applyQueryFilters(
+      data,
+      query("/api/v1/candidates?id=SN-7-OPENAPI"),
+      "candidates",
+    );
+    assert.equal(lower.error, undefined);
+    assert.equal(upper.error, undefined);
+    assert.deepEqual(ids(lower), ["sn-7-openapi"]);
+    assert.deepEqual(ids(upper), ids(lower));
+  });
+
+  test("?confidence=<low|medium|high> filters to rows with that confidence", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/candidates?confidence=medium"),
+      "candidates",
+    );
+    assert.equal(result.error, undefined);
+    assert.deepEqual(ids(result), ["sn-8-openapi"]);
+    assert.ok(
+      result.data.candidates.every((row) => row.confidence === "medium"),
+    );
+  });
+
+  test("an invalid confidence value returns invalid_query on that parameter", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/candidates?confidence=extreme"),
+      "candidates",
+    );
+    assert.equal(result.error.parameter, "confidence");
+  });
+});
+
+describe("curated-surfaces id filter (#6242)", () => {
+  const data = {
+    surfaces: [
+      {
+        id: "sn-7-openapi",
+        netuid: 7,
+        kind: "openapi",
+        provider: "allways",
+        name: "OpenAPI",
+      },
+      {
+        id: "sn-7-website",
+        netuid: 7,
+        kind: "website",
+        provider: "allways",
+        name: "Website",
+      },
+      {
+        id: "sn-8-openapi",
+        netuid: 8,
+        kind: "openapi",
+        provider: "beta",
+        name: "OpenAPI",
+      },
+    ],
+  };
+  const ids = (result) => result.data.surfaces.map((r) => r.id);
+
+  test("?id=<value> keeps rows whose id exactly matches (case-insensitive)", () => {
+    const lower = applyQueryFilters(
+      data,
+      query("/api/v1/surfaces?id=sn-7-website"),
+      "curated-surfaces",
+    );
+    const upper = applyQueryFilters(
+      data,
+      query("/api/v1/surfaces?id=SN-7-WEBSITE"),
+      "curated-surfaces",
+    );
+    assert.equal(lower.error, undefined);
+    assert.equal(upper.error, undefined);
+    assert.deepEqual(ids(lower), ["sn-7-website"]);
+    assert.deepEqual(ids(upper), ids(lower));
+  });
+});


### PR DESCRIPTION
## Summary

- Add `id` and `confidence` filters to the `candidates` query collection so `GET /api/v1/candidates` (and per-subnet candidates) can narrow rows by exact `id` and confidence enum — matching pools/endpoint-pools and profiles precedent.
- Add `id` filter to `curated-surfaces` so `GET /api/v1/surfaces` (and per-subnet surfaces) can target one surface by id.
- Regenerate OpenAPI / api-index / types so the new query parameters are documented.
- Cover valid filters and invalid `confidence` in `tests/list-query.test.mjs`.

Closes #6242

## What Changed

- **`src/contracts.mjs`**: `candidates.filters` gains `id: filterTextSchema` and `confidence: enumSchema(["low", "medium", "high"])`; `curated-surfaces.filters` gains `id: filterTextSchema`.
- **Generated**: `public/metagraph/openapi.json`, `public/metagraph/api-index.json`, `public/metagraph/types.d.ts`, `packages/contract/index.d.ts`.
- **Tests**: `tests/list-query.test.mjs` — `?id=` on candidates + surfaces (case-insensitive), `?confidence=` valid + invalid.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6242`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (New optional query filters on existing list routes.)

## Validation

- [x] `npx vitest run tests/list-query.test.mjs` (87 passed)
- [x] `npx prettier --check` on touched source/test files
- [x] `npm run lint`
- [x] `git diff --check`
- [x] `npm run build` (regenerated OpenAPI/types; deploy-owned artifacts auto-reverted)
- [x] `npm run validate:contract-drift`
- [ ] `npm run check`
- [ ] `npm run validate`
- [ ] `npm run validate:schemas`
- [ ] `npm run validate:api`
- [ ] `npm run validate:openapi`
- [ ] `npm run validate:types`
- [ ] `npm run validate:artifact-budgets`
- [ ] `npm run validate:docs`
- [ ] `npm run validate:upvote`
- [ ] `npm run validate:workflows`
- [ ] `npm run worker:test`
- [ ] `npm run test:coverage`
- [ ] `npm run scan:public-safety`

## Template Used

backend-code
