### PR TITLE
feat(api): add curation_level filter to the curation collection (#6238)

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -16323,6 +16323,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
+                curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -3216,7 +3216,8 @@
       "query_collection": "curation",
       "query_filter_names": [
         "netuid",
-        "coverage_level"
+        "coverage_level",
+        "curation_level"
       ],
       "query_parameters": [
         {
@@ -3233,6 +3234,20 @@
               "native-only",
               "manifested",
               "probed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "curation_level",
+          "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "community-seeded",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
             ],
             "type": "string"
           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -33290,6 +33290,22 @@
           },
           {
             "in": "query",
+            "name": "curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "community-seeded",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "fields",
             "required": false,
             "schema": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -16323,6 +16323,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 coverage_level?: "native-only" | "manifested" | "probed";
+                curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 fields?: string;
                 limit?: number;
                 cursor?: number;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -166,6 +166,10 @@ export const API_QUERY_COLLECTIONS = {
     filters: {
       netuid: integerSchema,
       coverage_level: enumSchema(QUERY_ENUMS.coverageLevel),
+      // #6238: curation_level is already a sort target here and a real filter on
+      // the sibling gaps collection; expose it as a filter too so callers can
+      // narrow, not just order, by it. Same shared enum gaps uses.
+      curation_level: enumSchema(QUERY_ENUMS.curationLevel),
     },
     sort: ["coverage_level", "curation_level", "name", "netuid"],
   }),

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -353,6 +353,53 @@ describe("list-query case-insensitive enum/string filters (#2073)", () => {
   });
 });
 
+// #6238: the curation collection could sort=curation_level but not filter on it,
+// unlike the sibling gaps collection. It's now a real filter using the same
+// shared QUERY_ENUMS.curationLevel vocabulary.
+describe("list-query curation curation_level filter (#6238)", () => {
+  const data = {
+    curation: [
+      { netuid: 1, curation_level: "native" },
+      { netuid: 2, curation_level: "maintainer-reviewed" },
+    ],
+  };
+
+  test("?curation_level=native narrows the curation list to matching rows", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/curation?curation_level=native"),
+      "curation",
+    );
+    assert.equal(result.error, undefined);
+    assert.deepEqual(
+      result.data.curation.map((r) => r.netuid),
+      [1],
+    );
+  });
+
+  test("the filter is case-insensitive, like every other enum filter (#2073)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/curation?curation_level=Maintainer-Reviewed"),
+      "curation",
+    );
+    assert.equal(result.error, undefined);
+    assert.deepEqual(
+      result.data.curation.map((r) => r.netuid),
+      [2],
+    );
+  });
+
+  test("an invalid curation_level errors with parameter curation_level (400 invalid_query)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/curation?curation_level=bogus"),
+      "curation",
+    );
+    assert.equal(result.error.parameter, "curation_level");
+  });
+});
+
 describe("list-query numeric range filters", () => {
   const data = {
     subnets: [


### PR DESCRIPTION
## What

Adds the missing `curation_level` filter to the `curation` query collection. `GET /api/v1/curation` already listed `curation_level` as a valid `sort` target but had no matching `filters` entry — callers could order by curation level but not narrow to one. The sibling `gaps` collection already filters on this exact field.

## How

- `src/contracts.mjs`: `curation_level: enumSchema(QUERY_ENUMS.curationLevel)` added to the `curation` collection's `filters`, reusing the identical shared enum `gaps` uses. No new vocabulary; `gaps` untouched; `sort` unchanged.
- Regenerated + committed the gated contract artifacts (`public/metagraph/openapi.json`, `public/metagraph/api-index.json`, `public/metagraph/types.d.ts`, `packages/contract/index.d.ts`) so the new query parameter propagates. `validate:contract-drift` passes and a fresh build leaves the committed artifacts unchanged.

Filtering, case-insensitivity (`#2073`), and the `400 invalid_query` (`parameter: "curation_level"`) all come for free from the existing route machinery, exactly like the already-supported `?coverage_level=`.

## Tests

`tests/list-query.test.mjs` (existing `applyQueryFilters` per-collection pattern): valid filter narrows rows, mixed-case value matches case-insensitively, invalid value errors with `parameter: "curation_level"`.

Closes #6238.