### PR TITLE
fix(ui): distinguish real fetch errors from empty data in 7 subnet-detail-page panels

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/uptime-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/uptime-timeline.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/lib/metagraphed/queries";
 import { classNames, durationLabel, formatNumber, formatRelative } from "@/lib/metagraphed/format";
 import { formatFreshness } from "@/lib/metagraphed/freshness";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { Tooltip, TooltipContent, TooltipTrigger, InfoTooltip, TimeAgo } from "@jsonbored/ui-kit";
 import { useTimeRange, RANGE_LABEL } from "./time-range-context";
 import type { FlatSurfaceIncident, HealthTrendSurface } from "@/lib/metagraphed/types";
@@ -69,7 +69,13 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
   // 1h/24h have no sub-7d window upstream; surface that the bars are a 7d view.
   const usingFallbackWindow = range === "1h" || range === "24h";
 
-  const { data: tRes, isLoading } = useQuery(subnetHealthTrendsQuery(netuid));
+  const {
+    data: tRes,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(subnetHealthTrendsQuery(netuid));
   const { data: iRes } = useQuery(subnetHealthIncidentsQuery(netuid, winKey));
 
   const window = tRes?.data?.windows?.[winKey];
@@ -99,6 +105,14 @@ export function UptimeTimeline({ netuid, className }: { netuid: number; classNam
 
   if (isLoading) {
     return <Skeleton className="h-48 w-full" />;
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-xl border border-border bg-card p-6">
+        <ErrorState error={error} onRetry={() => refetch()} context="uptime timeline" />
+      </div>
+    );
   }
 
   if (surfaces.length === 0) {

--- a/apps/ui/src/components/metagraphed/concentration-panel.tsx
+++ b/apps/ui/src/components/metagraphed/concentration-panel.tsx
@@ -8,7 +8,7 @@ import {
   subnetPerformanceHistoryQuery,
 } from "@/lib/metagraphed/queries";
 import { StatTile, BarMini, Sparkline } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames } from "@/lib/metagraphed/format";
 import { PROFILE_KPI_GRID_CLASS } from "@/components/metagraphed/profile-kpi-grid";
 import type {
@@ -163,7 +163,13 @@ function Fact({ label, value }: { label: string; value: ReactNode }) {
 
 function DriftCard({ netuid }: { netuid: number }) {
   const [win, setWin] = useState<Win>("30d");
-  const { data: res, isLoading } = useQuery(subnetConcentrationHistoryQuery(netuid, win));
+  const {
+    data: res,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(subnetConcentrationHistoryQuery(netuid, win));
   const points = useMemo<ConcentrationHistoryPoint[]>(
     () => res?.data?.points ?? [],
     [res?.data?.points],
@@ -226,6 +232,8 @@ function DriftCard({ netuid }: { netuid: number }) {
       </div>
       {isLoading ? (
         <Skeleton className="h-28 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} context="concentration drift" />
       ) : !hasData ? (
         <EmptyState
           title="No drift history"
@@ -384,7 +392,13 @@ function PerformanceLoader({ netuid }: { netuid: number }) {
 
 function RewardDriftCard({ netuid }: { netuid: number }) {
   const [win, setWin] = useState<Win>("30d");
-  const { data: res, isLoading } = useQuery(subnetPerformanceHistoryQuery(netuid, win));
+  const {
+    data: res,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(subnetPerformanceHistoryQuery(netuid, win));
   const points = useMemo<PerformanceHistoryPoint[]>(
     () => res?.data?.points ?? [],
     [res?.data?.points],
@@ -447,6 +461,8 @@ function RewardDriftCard({ netuid }: { netuid: number }) {
       </div>
       {isLoading ? (
         <Skeleton className="h-28 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} context="reward drift" />
       ) : !hasData ? (
         <EmptyState
           title="No reward-drift history"

--- a/apps/ui/src/components/metagraphed/evidence-panel.tsx
+++ b/apps/ui/src/components/metagraphed/evidence-panel.tsx
@@ -83,11 +83,7 @@ export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
   if (query.isLoading) return <Skeleton className="h-24 w-full" />;
   if (query.error) {
     return (
-      <ErrorState
-        error={query.error}
-        onRetry={() => query.refetch()}
-        context="evidence index"
-      />
+      <ErrorState error={query.error} onRetry={() => query.refetch()} context="evidence index" />
     );
   }
   if (allRows.length === 0) return <EmptyState title="No evidence recorded" />;

--- a/apps/ui/src/components/metagraphed/evidence-panel.tsx
+++ b/apps/ui/src/components/metagraphed/evidence-panel.tsx
@@ -3,7 +3,7 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/metagraphed/client";
 import { metagraphedQueryKey } from "@/lib/metagraphed/queries";
 import { ExternalLink, HoverPreview, TimeAgo } from "@jsonbored/ui-kit";
-import { EmptyState, Skeleton } from "./states";
+import { EmptyState, ErrorState, Skeleton } from "./states";
 import { formatRelative } from "@/lib/metagraphed/format";
 import type { ApiMeta, EvidenceItem } from "@/lib/metagraphed/types";
 
@@ -83,9 +83,10 @@ export function EvidencePanel({ netuid, pageSize = 50 }: Props) {
   if (query.isLoading) return <Skeleton className="h-24 w-full" />;
   if (query.error) {
     return (
-      <EmptyState
-        title="No evidence index available"
-        description="The evidence endpoint did not respond. Source links may appear on individual resources instead."
+      <ErrorState
+        error={query.error}
+        onRetry={() => query.refetch()}
+        context="evidence index"
       />
     );
   }

--- a/apps/ui/src/components/metagraphed/incident-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/incident-timeline.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { AlertOctagon, AlertTriangle, Info } from "lucide-react";
 import { subnetHealthIncidentsQuery, flattenSurfaceIncidents } from "@/lib/metagraphed/queries";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { TimeAgo, SectionAnchor } from "@jsonbored/ui-kit";
 import { classNames } from "@/lib/metagraphed/format";
 import { incidentDurationLabel } from "@/lib/metagraphed/incident-duration";
@@ -18,7 +18,9 @@ function shortSurfaceId(id: string, netuid: number): string {
 }
 
 export function IncidentTimeline({ netuid }: { netuid: number }) {
-  const { data, isLoading } = useQuery(subnetHealthIncidentsQuery(netuid));
+  const { data, isLoading, isError, error, refetch } = useQuery(
+    subnetHealthIncidentsQuery(netuid),
+  );
   const incidents = flattenSurfaceIncidents(data?.data ?? []);
 
   return (
@@ -30,6 +32,8 @@ export function IncidentTimeline({ netuid }: { netuid: number }) {
     >
       {isLoading ? (
         <Skeleton className="h-24 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} context="incident history" />
       ) : incidents.length === 0 ? (
         <EmptyState
           title="No incidents recorded"

--- a/apps/ui/src/components/metagraphed/incident-timeline.tsx
+++ b/apps/ui/src/components/metagraphed/incident-timeline.tsx
@@ -18,9 +18,7 @@ function shortSurfaceId(id: string, netuid: number): string {
 }
 
 export function IncidentTimeline({ netuid }: { netuid: number }) {
-  const { data, isLoading, isError, error, refetch } = useQuery(
-    subnetHealthIncidentsQuery(netuid),
-  );
+  const { data, isLoading, isError, error, refetch } = useQuery(subnetHealthIncidentsQuery(netuid));
   const incidents = flattenSurfaceIncidents(data?.data ?? []);
 
   return (

--- a/apps/ui/src/components/metagraphed/reliability-panel.tsx
+++ b/apps/ui/src/components/metagraphed/reliability-panel.tsx
@@ -5,6 +5,7 @@ import {
   subnetHealthIncidentsQuery,
 } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
+import { ErrorState } from "@/components/metagraphed/states";
 import type { SurfaceLatencyPercentiles, SurfaceSla } from "@/lib/metagraphed/types";
 
 // #1114: per-surface reliability — uptime SLA + latency percentiles (p50/p95/p99)
@@ -47,12 +48,20 @@ function uptimeTone(u?: number): string {
 
 export function ReliabilityPanel({ netuid }: { netuid: number }) {
   const [window, setWindow] = useState<WindowKey>("7d");
-  const { data: pctRes, isPending: pctPending } = useQuery(
-    subnetHealthPercentilesQuery(netuid, window),
-  );
-  const { data: slaRes, isPending: slaPending } = useQuery(
-    subnetHealthIncidentsQuery(netuid, window),
-  );
+  const {
+    data: pctRes,
+    isPending: pctPending,
+    isError: pctError,
+    error: pctErrorObj,
+    refetch: refetchPct,
+  } = useQuery(subnetHealthPercentilesQuery(netuid, window));
+  const {
+    data: slaRes,
+    isPending: slaPending,
+    isError: slaIsError,
+    error: slaErrorObj,
+    refetch: refetchSla,
+  } = useQuery(subnetHealthIncidentsQuery(netuid, window));
 
   const percentiles: SurfaceLatencyPercentiles[] = pctRes?.data ?? [];
   const slas: SurfaceSla[] = slaRes?.data ?? [];
@@ -75,6 +84,8 @@ export function ReliabilityPanel({ netuid }: { netuid: number }) {
   }
   const rows = [...byId.values()].sort((a, b) => (a.uptime ?? 1) - (b.uptime ?? 1));
   const loading = pctPending || slaPending;
+  const isError = pctError || slaIsError;
+  const errorObj = pctErrorObj ?? slaErrorObj;
 
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-card">
@@ -102,6 +113,17 @@ export function ReliabilityPanel({ netuid }: { netuid: number }) {
       </div>
       {loading && rows.length === 0 ? (
         <div className="p-4 text-xs text-ink-muted">Loading reliability…</div>
+      ) : isError ? (
+        <div className="p-4">
+          <ErrorState
+            error={errorObj}
+            onRetry={() => {
+              void refetchPct();
+              void refetchSla();
+            }}
+            context="reliability"
+          />
+        </div>
       ) : rows.length === 0 ? (
         <div className="p-4 text-xs text-ink-muted">
           No probe history for this subnet in the {window} window yet.

--- a/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { subnetOhlcQuery } from "@/lib/metagraphed/queries";
 import { CandlestickMini, type CandlestickDatum } from "@jsonbored/ui-kit";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames, formatTao } from "@/lib/metagraphed/format";
 
 const INTERVALS = ["1h", "1d"] as const;
@@ -27,7 +27,13 @@ function fmtOhlcPrice(v: number): string {
  */
 export function SubnetOhlcChart({ netuid }: { netuid: number }) {
   const [interval, setIntervalState] = useState<Interval>("1h");
-  const { data: res, isLoading } = useQuery(subnetOhlcQuery(netuid, { interval }));
+  const {
+    data: res,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(subnetOhlcQuery(netuid, { interval }));
   const data = res?.data;
 
   const candles = useMemo<CandlestickDatum[]>(() => {
@@ -64,6 +70,10 @@ export function SubnetOhlcChart({ netuid }: { netuid: number }) {
       ))}
     </div>
   );
+
+  if (isError) {
+    return <ErrorState error={error} onRetry={() => refetch()} context="subnet OHLC" />;
+  }
 
   if (data?.root_excluded) {
     return (

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -13,7 +13,7 @@ import {
   CopyButton,
 } from "@jsonbored/ui-kit";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
-import { Skeleton, EmptyState } from "@/components/metagraphed/states";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { PROFILE_KPI_GRID_CLASS } from "@/components/metagraphed/profile-kpi-grid";
@@ -259,7 +259,13 @@ export function YieldLoader({ netuid }: { netuid: number }) {
 
 function YieldDriftCard({ netuid }: { netuid: number }) {
   const [win, setWin] = useState<Win>("30d");
-  const { data: res, isLoading } = useQuery(subnetYieldHistoryQuery(netuid, win));
+  const {
+    data: res,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(subnetYieldHistoryQuery(netuid, win));
   const points = useMemo<YieldHistoryPoint[]>(() => res?.data?.points ?? [], [res?.data?.points]);
 
   const series = useMemo(() => {
@@ -313,6 +319,8 @@ function YieldDriftCard({ netuid }: { netuid: number }) {
       </div>
       {isLoading ? (
         <Skeleton className="h-28 w-full" />
+      ) : isError ? (
+        <ErrorState error={error} onRetry={() => refetch()} context="yield drift" />
       ) : !hasData ? (
         <EmptyState
           title="No yield history"


### PR DESCRIPTION
## What

#5863 fixed 4 history-chart components that misrepresented a real fetch error as "no data yet." This closes out the same bug class for the 7 remaining instances on the busiest detail page in the explorer (`subnets.$netuid.tsx`):

- `subnet-ohlc-chart.tsx`, `yield-panel.tsx` (`YieldDriftCard`), `concentration-panel.tsx` (`DriftCard` + `RewardDriftCard`, two call sites), `incident-timeline.tsx`, `analytics/uptime-timeline.tsx`: destructured only `{ data, isLoading }` from `useQuery` — no `isError` — so a real fetch failure fell through to the `EmptyState` branch.
- `evidence-panel.tsx`: already checked `query.error`, but rendered it via `EmptyState` ("No evidence index available") instead of `ErrorState`, so it offered no retry affordance.
- `reliability-panel.tsx`: two `useQuery` calls (percentiles + SLA), neither checked; now shows `ErrorState` if **either** fails, with a combined retry that refetches both.

Applies the `account-history-chart.tsx` / #5863 pattern (`isError`/`error`/`refetch` + `ErrorState` with `onRetry`) throughout.

## Scope

- UI-only change across 7 files under `apps/ui/src/components/metagraphed/**`.
- No change to loading-state or success-state rendering.

## Screenshot evidence

Captured on `/subnets/1`'s "Incident history" section, with `/api/v1/subnets/1/health/incidents` forced to return HTTP 500 (browser-layer network interception, not a mock). The identical `isError`/`ErrorState` wiring is applied identically at the other 6 files/8 call sites.

**Before**: a real API failure silently renders "No incidents recorded" — indistinguishable from a genuinely clean history.
**After**: a real error state with the HTTP status, the failing URL, and a working Retry button.

| Viewport · Theme | Before | After |
| ---- | ---- | ---- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6248-subnet-panels-after-mobile-dark.png)<br><sub>after</sub> |

## Verification

- `npx eslint` on the 7 changed files: 0 errors, 0 warnings.
- `npx prettier --check`: passes.
- Rebased onto current `main`.

Closes #6248
