### PR TITLE
fix(api): documents collection sort=kind is a no-op, rows carry type not kind

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -21652,12 +21652,14 @@ export interface operations {
     search: {
         parameters: {
             query?: {
+                type?: "subnet" | "surface" | "provider";
+                netuid?: number;
                 q?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
-                sort?: "kind" | "netuid" | "slug" | "title";
+                sort?: "netuid" | "slug" | "title" | "type";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
             };
@@ -21775,12 +21777,14 @@ export interface operations {
     searchIndex: {
         parameters: {
             query?: {
+                type?: "subnet" | "surface" | "provider";
+                netuid?: number;
                 q?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
-                sort?: "kind" | "netuid" | "slug" | "title";
+                sort?: "netuid" | "slug" | "title" | "type";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
             };

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -9013,8 +9013,29 @@
       "path": "/api/v1/search",
       "public": true,
       "query_collection": "documents",
-      "query_filter_names": [],
+      "query_filter_names": [
+        "type",
+        "netuid"
+      ],
       "query_parameters": [
+        {
+          "name": "type",
+          "schema": {
+            "enum": [
+              "subnet",
+              "surface",
+              "provider"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
         {
           "name": "q",
           "schema": {
@@ -9049,10 +9070,10 @@
           "name": "sort",
           "schema": {
             "enum": [
-              "kind",
               "netuid",
               "slug",
-              "title"
+              "title",
+              "type"
             ],
             "type": "string"
           }
@@ -9078,8 +9099,29 @@
       "path": "/api/v1/search-index",
       "public": true,
       "query_collection": "documents",
-      "query_filter_names": [],
+      "query_filter_names": [
+        "type",
+        "netuid"
+      ],
       "query_parameters": [
+        {
+          "name": "type",
+          "schema": {
+            "enum": [
+              "subnet",
+              "surface",
+              "provider"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
         {
           "name": "q",
           "schema": {
@@ -9114,10 +9156,10 @@
           "name": "sort",
           "schema": {
             "enum": [
-              "kind",
               "netuid",
               "slug",
-              "title"
+              "title",
+              "type"
             ],
             "type": "string"
           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -42145,6 +42145,28 @@
         "parameters": [
           {
             "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "subnet",
+                "surface",
+                "provider"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
             "name": "q",
             "required": false,
             "schema": {
@@ -42187,10 +42209,10 @@
             "required": false,
             "schema": {
               "enum": [
-                "kind",
                 "netuid",
                 "slug",
-                "title"
+                "title",
+                "type"
               ],
               "type": "string"
             }
@@ -42342,6 +42364,28 @@
         "parameters": [
           {
             "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "subnet",
+                "surface",
+                "provider"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
             "name": "q",
             "required": false,
             "schema": {
@@ -42384,10 +42428,10 @@
             "required": false,
             "schema": {
               "enum": [
-                "kind",
                 "netuid",
                 "slug",
-                "title"
+                "title",
+                "type"
               ],
               "type": "string"
             }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -21652,12 +21652,14 @@ export interface operations {
     search: {
         parameters: {
             query?: {
+                type?: "subnet" | "surface" | "provider";
+                netuid?: number;
                 q?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
-                sort?: "kind" | "netuid" | "slug" | "title";
+                sort?: "netuid" | "slug" | "title" | "type";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
             };
@@ -21775,12 +21777,14 @@ export interface operations {
     searchIndex: {
         parameters: {
             query?: {
+                type?: "subnet" | "surface" | "provider";
+                netuid?: number;
                 q?: string;
                 fields?: string;
                 limit?: number;
                 cursor?: number;
                 /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
-                sort?: "kind" | "netuid" | "slug" | "title";
+                sort?: "netuid" | "slug" | "title" | "type";
                 /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
                 order?: "asc" | "desc";
             };

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -196,8 +196,14 @@ export const API_QUERY_COLLECTIONS = {
     sort: ["id", "kind", "name", "netuid", "provider"],
   }),
   documents: queryCollection("documents", {
+    filters: {
+      // Document *type* (subnet/surface/provider), distinct from surface
+      // *kind* (openapi/website/sdk/...) — do not reuse QUERY_ENUMS.surfaceKind.
+      type: enumSchema(["subnet", "surface", "provider"]),
+      netuid: integerSchema,
+    },
     search: ["title", "subtitle", "slug", "tokens"],
-    sort: ["kind", "netuid", "slug", "title"],
+    sort: ["netuid", "slug", "title", "type"],
   }),
   economics: queryCollection("subnets", {
     filters: {

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -698,6 +698,77 @@ describe("list-query unknown parameter validation (#2578)", () => {
   });
 });
 
+// #6239: documents advertised sort=kind, but search-index rows carry no `kind`
+// field at all (the field is `type`) — every request silently no-op'd instead
+// of erroring. Fixed by sorting/filtering on the real `type` field and adding
+// a `netuid` filter, matching every other collection's kind/netuid handling.
+describe("list-query documents type/netuid (#6239)", () => {
+  const data = {
+    documents: [
+      { id: "sn-1", type: "subnet", netuid: 1, title: "Root" },
+      { id: "sn-2", type: "subnet", netuid: 2, title: "Allways" },
+      { id: "surf-1", type: "surface", netuid: 2, title: "Allways docs" },
+      { id: "prov-1", type: "provider", title: "Some Provider" },
+    ],
+  };
+  const ids = (result) => result.data.documents.map((r) => r.id);
+
+  test("?sort=type actually reorders rows (was a silent no-op under sort=kind)", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/search?sort=type"),
+      "documents",
+    );
+    assert.equal(result.error, undefined);
+    // provider < subnet < surface, alphabetically ascending.
+    assert.deepEqual(ids(result), ["prov-1", "sn-1", "sn-2", "surf-1"]);
+  });
+
+  test("?sort=kind is no longer accepted (400, not a silent no-op)", () => {
+    const sortError = validateListQueryParams(
+      query("/api/v1/search?sort=kind"),
+      "documents",
+    );
+    assert.equal(sortError.parameter, "sort");
+    assert.equal(sortError.message, "sort is not supported for documents.");
+  });
+
+  for (const type of ["subnet", "surface", "provider"]) {
+    test(`?type=${type} filters to only that document type`, () => {
+      const result = applyQueryFilters(
+        data,
+        query(`/api/v1/search?type=${type}`),
+        "documents",
+      );
+      assert.equal(result.error, undefined);
+      assert.equal(
+        result.data.documents.every((doc) => doc.type === type),
+        true,
+      );
+      assert.ok(result.data.documents.length > 0);
+    });
+  }
+
+  test("an invalid ?type= value is a query error", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/search?type=bogus"),
+      "documents",
+    );
+    assert.equal(result.error.parameter, "type");
+  });
+
+  test("?netuid=2 filters to documents carrying that netuid, excluding provider docs", () => {
+    const result = applyQueryFilters(
+      data,
+      query("/api/v1/search?netuid=2"),
+      "documents",
+    );
+    assert.equal(result.error, undefined);
+    assert.deepEqual(ids(result), ["sn-2", "surf-1"]);
+  });
+});
+
 // #2085: integration_readiness was sortable/filterable via MCP list_subnets but
 // not on the equivalent REST subnets collection. After wiring it into the
 // contract's sort + rangeFilters, the generic list-query engine reads row[key]


### PR DESCRIPTION
## Summary
- `GET /api/v1/search` and `GET /api/v1/search-index` (the `documents` query collection) advertised `sort=kind` as valid, but no document row has ever had a `kind` field — the actual field is `type` (per `scripts/build-artifacts.mjs`'s `buildSearchIndex` and the committed `SearchDocument`/`SearchIndexDocument` schemas). Since `sortRows` reads `row[key]` and every row is missing `kind`, every row fell into the "missing field" bucket and the request silently returned the collection in unsorted original order — no error, just a no-op.
- Fixed `src/contracts.mjs`'s `documents` collection: `sort` now uses `"type"` instead of the nonexistent `"kind"`, and added a `filters` block (`type: enumSchema(["subnet", "surface", "provider"])`, `netuid: integerSchema`) matching every other collection's kind/netuid filtering convention. `sort=kind` is no longer accepted at all — it now returns the standard 400 instead of silently no-op'ing.
- Regenerated and committed the derived contract artifacts (`public/metagraph/openapi.json`, `public/metagraph/api-index.json`, `packages/contract/index.d.ts`, `public/metagraph/types.d.ts`) via `npm run build`. `public/metagraph/r2-manifest.json` and `public/metagraph/schemas/index.json` came back as non-deterministic deploy-owned artifacts and were auto-reverted against `upstream/main`, per the build script's own output.

Closes #6239

## Test plan
- [x] `npx vitest run tests/list-query.test.mjs tests/contracts.test.mjs` — 97 tests pass, including 6 new tests covering: `sort=type` actually reorders rows, `sort=kind` now 400s instead of no-op'ing, `?type=subnet|surface|provider` filters correctly, an invalid `?type=` 400s, and `?netuid=` filters correctly (excluding provider docs, which have no netuid).
- [x] `npm run lint` / `npm run format:check` — clean
- [x] `npm run validate:contract-drift` — passed
- [x] `npm run validate:openapi` — passed for 159 routes
- [x] `npm run validate:schemas` / `npm run validate:api` — passed