### PR TITLE
fix(ui): distinguish real fetch errors from empty data in 3 network-wide widgets

### DIFF
--- a/apps/ui/src/components/metagraphed/emission-yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/emission-yield-panel.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { TrendingUp, Server, Users, Coins } from "lucide-react";
 import { chainYieldQuery } from "@/lib/metagraphed/queries";
 import { StatTile } from "@jsonbored/ui-kit";
-import { EmptyState } from "@/components/metagraphed/states";
+import { EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { formatNumber } from "@/lib/metagraphed/format";
 
 // #3472: network emission-yield summary — the return-rate companion to the
@@ -32,8 +32,12 @@ function Notice({ children }: { children: string }) {
  * chain-yield snapshot once and renders a KPI-tile grid.
  */
 export function EmissionYieldPanel() {
-  const { data: res, isPending } = useQuery(chainYieldQuery());
+  const { data: res, isPending, isError, error, refetch } = useQuery(chainYieldQuery());
   const y = res?.data;
+
+  if (isError) {
+    return <ErrorState error={error} onRetry={() => refetch()} context="network emission yield" />;
+  }
 
   if (isPending && !y) {
     return <Notice>Loading network emission yield…</Notice>;

--- a/apps/ui/src/components/metagraphed/recent-identity-changes.tsx
+++ b/apps/ui/src/components/metagraphed/recent-identity-changes.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { chainIdentityHistoryQuery } from "@/lib/metagraphed/queries";
-import { EmptyState } from "@/components/metagraphed/states";
+import { EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { TimeAgo } from "@jsonbored/ui-kit";
 
 // #3474: homepage widget — the live network-wide feed of recent subnet-identity
@@ -24,8 +24,12 @@ function Notice({ children }: { children: string }) {
  * names/descriptions never escape the row at mobile width.
  */
 export function RecentIdentityChanges() {
-  const { data: res, isPending } = useQuery(chainIdentityHistoryQuery(10));
+  const { data: res, isPending, isError, error, refetch } = useQuery(chainIdentityHistoryQuery(10));
   const changes = res?.data?.changes ?? [];
+
+  if (isError) {
+    return <ErrorState error={error} onRetry={() => refetch()} context="recent identity changes" />;
+  }
 
   if (isPending && !res) {
     return <Notice>Loading recent identity changes…</Notice>;

--- a/apps/ui/src/components/metagraphed/subnet-health-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-health-matrix.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { subnetsQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@jsonbored/ui-kit";
+import { ErrorState } from "@/components/metagraphed/states";
 import type { HealthState, Subnet } from "@/lib/metagraphed/types";
 
 const TONE: Record<HealthState, string> = {
@@ -28,10 +29,14 @@ const TONE_TEXT: Record<HealthState, string> = {
  * health state on hover. Falls back to a static skeleton on first paint.
  */
 export function SubnetHealthMatrix() {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     ...subnetsQuery({ limit: 256, sort: "netuid", order: "asc" }),
   });
   const rows = ((data?.data ?? []) as Subnet[]).slice().sort((a, b) => a.netuid - b.netuid);
+
+  if (isError) {
+    return <ErrorState error={error} onRetry={() => refetch()} context="subnet health matrix" />;
+  }
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## What

Second follow-up to #5863. `SubnetHealthMatrix` (renders on `/health`), `EmissionYieldPanel` (renders on `/status`), and `RecentIdentityChanges` (renders on the homepage) each destructured only `{ data, isLoading }` / `{ data, isPending }` from `useQuery` — no `isError` — so a real fetch failure fell through to the empty-data branch. `subnet-health-matrix.tsx` was worse than the others: it had **no error UI at all**, just an empty heatmap grid with zero indication anything failed.

Applies the `account-history-chart.tsx` pattern (`isError`/`error`/`refetch` + `ErrorState` with `onRetry`) to all 3, per the sibling issue #5863 (merged) and its subnet-detail-page follow-up #6248.

## Scope

- UI-only change under `apps/ui/src/components/metagraphed/{subnet-health-matrix,emission-yield-panel,recent-identity-changes}.tsx`.
- No change to loading-state or success-state rendering.

## Screenshot evidence

Captured on `/health`'s subnet health matrix — the most severe of the 3 instances (no error UI existed at all before this fix) — with `/api/v1/subnets` forced to return HTTP 500 (browser-layer network interception, not a mock). The identical `isError`/`ErrorState` wiring is applied to the other 2 files (`emission-yield-panel.tsx`, `recent-identity-changes.tsx`).

| Viewport · Theme | Before | After |
| ---- | ---- | ---- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6253-network-widgets-after-mobile-dark.png)<br><sub>after</sub> |

## Verification

- `npx eslint` run from within `apps/ui` (matching CI's actual invocation) on the 3 changed files: 0 errors, 0 warnings.
- Rebased onto current `main`.

Closes #6253

(Resubmission of #6266, closed for a lint failure the CI job's `eslint .` caught that a standalone `prettier --check` did not — fixed by collapsing the flagged destructure/JSX formatting.)
