### PR TITLE
fix(ui): add ShareButton + ApiSourceFooter to subnet and provider detail pages

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -20,6 +20,7 @@ import {
   safeExternalUrl,
   CurationChip,
   HealthPill,
+  ShareButton,
   DailyRollupFreshness,
   StatWithSpark,
   MiniStack,
@@ -349,6 +350,7 @@ export function SubnetMasthead({
         <div className="ml-auto flex md:hidden items-center gap-1.5">
           <HealthPill state={probeHealth} />
           <CurationChip level={profile?.curation_level} />
+          <ShareButton />
         </div>
       </div>
 
@@ -451,6 +453,7 @@ export function SubnetMasthead({
         <div className="hidden md:flex shrink-0 flex-col items-end gap-1.5">
           <HealthPill state={probeHealth} />
           <CurationChip level={profile?.curation_level} />
+          <ShareButton />
         </div>
       </div>
 

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -16,7 +16,9 @@ import {
   PrimaryLinksRail,
   CopyableCode,
   SectionAnchor,
+  ShareButton,
 } from "@jsonbored/ui-kit";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { EndpointsGlance } from "@/components/metagraphed/endpoints-glance";
 import { EndpointList } from "@/components/metagraphed/endpoint-list";
@@ -148,6 +150,7 @@ function ProviderShell({ slug }: { slug: string }) {
             />
           ) : null
         }
+        actions={<ShareButton />}
       />
 
       <ProfileTabs
@@ -171,6 +174,10 @@ function ProviderShell({ slug }: { slug: string }) {
           {summary?.by_layer ? <BreakdownCard title="By layer" data={summary.by_layer} /> : null}
         </aside>
       </div>
+
+      <ApiSourceFooter
+        paths={[`/api/v1/providers/${slug}`, `/api/v1/providers/${slug}/endpoints`]}
+      />
     </>
   );
 }

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -105,6 +105,7 @@ import type {
 import { IncidentTimeline } from "@/components/metagraphed/incident-timeline";
 import { TimeRangeProvider } from "@/components/metagraphed/analytics/time-range-context";
 import { SubnetMasthead } from "@/components/metagraphed/subnet-masthead";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { OperationalPanel } from "@/components/metagraphed/operational-panel";
 import { ResourceExplorer } from "@/components/metagraphed/resource-explorer";
 import { GittensorRegisteredRepos } from "@/components/metagraphed/gittensor-registered-repos";
@@ -340,6 +341,8 @@ function ProfileShell({ netuid }: { netuid: number }) {
           ) : null}
           {tab === "api" ? <ApiPanel netuid={netuid} /> : null}
         </div>
+
+        <ApiSourceFooter paths={[`/api/v1/subnets/${netuid}/profile`]} />
       </SubnetFilterProvider>
     </TimeRangeProvider>
   );


### PR DESCRIPTION
Closes #5481

The subnet-detail and provider-detail pages were the only two entity-detail routes missing the `ShareButton` (copy-link affordance) and `ApiSourceFooter` (data-provenance footer) that `accounts.$ss58`, `blocks.$ref`, `extrinsics.$hash`, and `validators.$hotkey` all render. All four deliverables:

- **providers.$slug.tsx** — `actions={<ShareButton />}` on the existing `EntityHero` (it already supports the prop) + an `ApiSourceFooter` for `/api/v1/providers/{slug}` and `.../endpoints`.
- **subnet-masthead.tsx** — `ShareButton` in both the mobile status row and the desktop action column, beside the existing HealthPill/CurationChip.
- **subnets.$netuid.tsx** — `ApiSourceFooter` for `/api/v1/subnets/{netuid}/profile`.

### Primary matrix — subnet detail masthead ShareButton (3 viewports × 2 themes)

The masthead is a custom component (not `PageHero`), so this is the load-bearing integration; captured at the standard Phase C2 matrix. The "Share view" button appears in the header.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-top-after-mobile-dark.png)<br><sub>after</sub> |

### Supplementary — the other three deliverables (desktop, both themes)

Provider masthead `ShareButton` (via `EntityHero.actions`), and the `ApiSourceFooter` "DATA SOURCES" strip on both pages (scrolled to the page end).

| What | Before | After |
| ---- | ------ | ----- |
| Provider · ShareButton · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-top-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-top-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-top-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-top-after-desktop-light.png)<br><sub>after</sub> |
| Provider · ShareButton · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-top-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-top-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-top-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-top-after-desktop-dark.png)<br><sub>after</sub> |
| Subnet · ApiSourceFooter · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-footer-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-footer-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-footer-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-footer-after-desktop-light.png)<br><sub>after</sub> |
| Subnet · ApiSourceFooter · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-footer-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-footer-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-footer-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-subnet-footer-after-desktop-dark.png)<br><sub>after</sub> |
| Provider · ApiSourceFooter · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-footer-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-footer-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-footer-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-footer-after-desktop-light.png)<br><sub>after</sub> |
| Provider · ApiSourceFooter · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-footer-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-footer-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-footer-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/5481/5481-provider-footer-after-desktop-dark.png)<br><sub>after</sub> |

### Verification

`prettier` clean · `eslint` 0 errors · `tsc --noEmit` 0 · `vitest` 1023/1023 passing (133 files). `ShareButton` takes no required props (defaults to `window.location.href`); `ApiSourceFooter` paths were confirmed rendering in the live browser on both pages.
