### PR TITLE
feat(schema): add an exchange_listings field to the subnet manifest

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4863,6 +4863,18 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        /** @description A single exchange the subnet's token trades on (curated registry metadata, Taostats parity). Display-only — never a probed surface and never feeds completeness. */
+        ExchangeListing: {
+            /** @description Exchange name, e.g. "MEXC" or "Gate.io". */
+            exchange: string;
+            /** @description Optional trading pair identifier, e.g. "TAO/USDT". */
+            pair?: string;
+            /**
+             * Format: uri
+             * @description Public listing or trade URL for the token on this exchange.
+             */
+            url: string;
+        };
         /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); tip_tao is the priority tip in TAO (#1855, separate from fee_tao; nullable, commonly 0); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
         Extrinsic: {
             block_number: number | null;
@@ -6623,6 +6635,8 @@ export interface components {
             description?: string | null;
             /** Format: uri */
             docs_url?: string | null;
+            /** @description Curated exchanges where the subnet's token trades (Taostats parity, #6274). Display-only registry metadata — never a probed surface and never feeds completeness. */
+            exchange_listings?: components["schemas"]["ExchangeListing"][];
             gap_count?: number;
             gaps: components["schemas"]["Gaps"];
             /** @enum {string} */
@@ -22458,6 +22472,12 @@ export interface operations {
                      *           ],
                      *           "description": "Example description.",
                      *           "docs_url": "https://api.metagraph.sh/example",
+                     *           "exchange_listings": [
+                     *             {
+                     *               "exchange": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "gap_count": 1,
                      *           "gaps": {
                      *             "gap_notes": [
@@ -26332,6 +26352,12 @@ export interface operations {
                      *           ],
                      *           "description": "Example description.",
                      *           "docs_url": "https://api.metagraph.sh/example",
+                     *           "exchange_listings": [
+                     *             {
+                     *               "exchange": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "gap_count": 1,
                      *           "gaps": {
                      *             "gap_notes": [

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9100,6 +9100,30 @@
           }
         ]
       },
+      "ExchangeListing": {
+        "additionalProperties": false,
+        "description": "A single exchange the subnet's token trades on (curated registry metadata, Taostats parity). Display-only — never a probed surface and never feeds completeness.",
+        "properties": {
+          "exchange": {
+            "description": "Exchange name, e.g. \"MEXC\" or \"Gate.io\".",
+            "type": "string"
+          },
+          "pair": {
+            "description": "Optional trading pair identifier, e.g. \"TAO/USDT\".",
+            "type": "string"
+          },
+          "url": {
+            "description": "Public listing or trade URL for the token on this exchange.",
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "exchange",
+          "url"
+        ],
+        "type": "object"
+      },
       "Extrinsic": {
         "additionalProperties": false,
         "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); tip_tao is the priority tip in TAO (#1855, separate from fee_tao; nullable, commonly 0); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
@@ -16299,6 +16323,13 @@
               "string",
               "null"
             ]
+          },
+          "exchange_listings": {
+            "description": "Curated exchanges where the subnet's token trades (Taostats parity, #6274). Display-only registry metadata — never a probed surface and never feeds completeness.",
+            "items": {
+              "$ref": "#/components/schemas/ExchangeListing"
+            },
+            "type": "array"
           },
           "gap_count": {
             "minimum": 0,
@@ -43557,6 +43588,12 @@
                       ],
                       "description": "Example description.",
                       "docs_url": "https://api.metagraph.sh/example",
+                      "exchange_listings": [
+                        {
+                          "exchange": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "gap_count": 1,
                       "gaps": {
                         "gap_notes": [
@@ -48996,6 +49033,12 @@
                       ],
                       "description": "Example description.",
                       "docs_url": "https://api.metagraph.sh/example",
+                      "exchange_listings": [
+                        {
+                          "exchange": "example",
+                          "url": "https://api.metagraph.sh/example"
+                        }
+                      ],
                       "gap_count": 1,
                       "gaps": {
                         "gap_notes": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4863,6 +4863,18 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        /** @description A single exchange the subnet's token trades on (curated registry metadata, Taostats parity). Display-only — never a probed surface and never feeds completeness. */
+        ExchangeListing: {
+            /** @description Exchange name, e.g. "MEXC" or "Gate.io". */
+            exchange: string;
+            /** @description Optional trading pair identifier, e.g. "TAO/USDT". */
+            pair?: string;
+            /**
+             * Format: uri
+             * @description Public listing or trade URL for the token on this exchange.
+             */
+            url: string;
+        };
         /** @description One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); tip_tao is the priority tip in TAO (#1855, separate from fee_tao; nullable, commonly 0); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time. */
         Extrinsic: {
             block_number: number | null;
@@ -6623,6 +6635,8 @@ export interface components {
             description?: string | null;
             /** Format: uri */
             docs_url?: string | null;
+            /** @description Curated exchanges where the subnet's token trades (Taostats parity, #6274). Display-only registry metadata — never a probed surface and never feeds completeness. */
+            exchange_listings?: components["schemas"]["ExchangeListing"][];
             gap_count?: number;
             gaps: components["schemas"]["Gaps"];
             /** @enum {string} */
@@ -22458,6 +22472,12 @@ export interface operations {
                      *           ],
                      *           "description": "Example description.",
                      *           "docs_url": "https://api.metagraph.sh/example",
+                     *           "exchange_listings": [
+                     *             {
+                     *               "exchange": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "gap_count": 1,
                      *           "gaps": {
                      *             "gap_notes": [
@@ -26332,6 +26352,12 @@ export interface operations {
                      *           ],
                      *           "description": "Example description.",
                      *           "docs_url": "https://api.metagraph.sh/example",
+                     *           "exchange_listings": [
+                     *             {
+                     *               "exchange": "example",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             }
+                     *           ],
                      *           "gap_count": 1,
                      *           "gaps": {
                      *             "gap_notes": [

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -9086,6 +9086,30 @@
           }
         ]
       },
+      "ExchangeListing": {
+        "additionalProperties": false,
+        "description": "A single exchange the subnet's token trades on (curated registry metadata, Taostats parity). Display-only — never a probed surface and never feeds completeness.",
+        "properties": {
+          "exchange": {
+            "description": "Exchange name, e.g. \"MEXC\" or \"Gate.io\".",
+            "type": "string"
+          },
+          "pair": {
+            "description": "Optional trading pair identifier, e.g. \"TAO/USDT\".",
+            "type": "string"
+          },
+          "url": {
+            "description": "Public listing or trade URL for the token on this exchange.",
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "exchange",
+          "url"
+        ],
+        "type": "object"
+      },
       "Extrinsic": {
         "additionalProperties": false,
         "description": "One decoded extrinsic (transaction) from the first-party extrinsics D1 tier (#1345 block explorer). signer is the ss58 of a signed extrinsic (null for inherents); extrinsic_hash/call_module/call_function are best-effort (nullable); call_args is the decoded call arguments (a list of {name,value} descriptors, or an object, or null); fee_tao is the paid inclusion fee in TAO (nullable); tip_tao is the priority tip in TAO (#1855, separate from fee_tao; nullable, commonly 0); success is true/false from the block's ExtrinsicSuccess/Failed event (null when undeterminable); observed_at is the block time.",
@@ -16277,6 +16301,13 @@
               "string",
               "null"
             ]
+          },
+          "exchange_listings": {
+            "description": "Curated exchanges where the subnet's token trades (Taostats parity, #6274). Display-only registry metadata — never a probed surface and never feeds completeness.",
+            "items": {
+              "$ref": "#/components/schemas/ExchangeListing"
+            },
+            "type": "array"
           },
           "gap_count": {
             "minimum": 0,

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -116,6 +116,27 @@
         },
         "additionalProperties": false
       },
+      "ExchangeListing": {
+        "type": "object",
+        "required": ["exchange", "url"],
+        "description": "A single exchange the subnet's token trades on (curated registry metadata, Taostats parity). Display-only — never a probed surface and never feeds completeness.",
+        "properties": {
+          "exchange": {
+            "type": "string",
+            "description": "Exchange name, e.g. \"MEXC\" or \"Gate.io\"."
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Public listing or trade URL for the token on this exchange."
+          },
+          "pair": {
+            "type": "string",
+            "description": "Optional trading pair identifier, e.g. \"TAO/USDT\"."
+          }
+        },
+        "additionalProperties": false
+      },
       "Gaps": {
         "type": "object",
         "required": ["missing_kinds", "supported_kinds", "gap_notes"],
@@ -490,6 +511,13 @@
             "items": {
               "type": "object",
               "additionalProperties": true
+            }
+          },
+          "exchange_listings": {
+            "type": "array",
+            "description": "Curated exchanges where the subnet's token trades (Taostats parity, #6274). Display-only registry metadata — never a probed surface and never feeds completeness.",
+            "items": {
+              "$ref": "#/components/schemas/ExchangeListing"
             }
           },
           "native_slug": {

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -70,6 +70,22 @@
         "$ref": "#/$defs/link"
       }
     },
+    "exchange_listings": {
+      "type": "array",
+      "description": "Curated exchanges where the subnet's token trades — plain registry metadata (Taostats parity), like `links`/`social`. Display-only; never a live-verified surface (no probe/verification) and never feeds completeness.",
+      "items": {
+        "$ref": "#/$defs/exchange_listing"
+      },
+      "examples": [
+        [
+          {
+            "exchange": "MEXC",
+            "url": "https://www.mexc.com/exchange/TAO_USDT",
+            "pair": "TAO/USDT"
+          }
+        ]
+      ]
+    },
     "contact": {
       "type": "string",
       "description": "Curated operator support contact (email or public URL, harvested from SubnetIdentitiesV3 subnet_contact) — sanitized at build via subnetContact. Display-only; never feeds completeness."
@@ -416,6 +432,29 @@
         "source_url": {
           "type": "string",
           "format": "uri"
+        }
+      }
+    },
+    "exchange_listing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exchange", "url"],
+      "description": "A single exchange the subnet's token is listed on. Curated metadata, not a probed surface — the exchange name plus a public listing/trade URL, with an optional trading pair.",
+      "properties": {
+        "exchange": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Exchange name, e.g. \"MEXC\" or \"Gate.io\"."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Public listing or trade URL for the token on this exchange."
+        },
+        "pair": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional trading pair identifier, e.g. \"TAO/USDT\"."
         }
       }
     },

--- a/scripts/artifact-budgets.mjs
+++ b/scripts/artifact-budgets.mjs
@@ -9,7 +9,7 @@ export const ARTIFACT_SIZE_BUDGETS = [
   budget("health/latest.json", 1_000_000, 3_000_000),
   budget("health/history/*.json", 650_000, 1_250_000),
   budget("search.json", 750_000, 2_000_000),
-  budget("openapi.json", 1_400_000, 1_700_000),
+  budget("openapi.json", 1_400_000, 1_800_000),
   // Per-surface schema snapshots now embed the full upstream OpenAPI document.
   budget("schemas/*.json", 1_500_000, 5_000_000),
   budget("profiles.json", 700_000, 1_000_000),

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -2781,6 +2781,10 @@ function mergeSubnet(nativeSubnet, overlay, candidateCount) {
     // drives placement (docs/adr/0008-subnet-data-model.md).
     partnership: overlay?.partnership || null,
     links: overlay?.links || [],
+    // Curated exchange listings (#6274): where the subnet's token trades.
+    // Plain overlay passthrough like links — display-only registry metadata
+    // (Taostats parity), never a probed surface and never feeds completeness.
+    exchange_listings: overlay?.exchange_listings || [],
     // Structured social handles (#745): curated overlay wins over on-chain
     // SubnetIdentitiesV3 `additional` extraction. Display/search-only — never
     // feeds completeness (the #343 flywheel gate). Lives on the canonical

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -804,6 +804,9 @@ function buildExpectedGeneratedSubnet(nativeSnapshot, overlay, candidateCount) {
     // detail artifact reproducibility check matches the generator.
     partnership: overlay?.partnership || null,
     links: overlay?.links || [],
+    // Mirror mergeSubnet's #6274 exchange_listings passthrough so the per-subnet
+    // detail artifact reproducibility check matches the generator.
+    exchange_listings: overlay?.exchange_listings || [],
     // Mirror mergeSubnet's #745 social backfill (overlay wins, else sanitized
     // on-chain `additional`) so the reproducibility check matches the generator.
     social: socialAccounts(


### PR DESCRIPTION
## What

Adds an optional `exchange_listings` array to the subnet manifest so a subnet's
registry file can record where its token trades — closing the Taostats parity
gap described in #6274. It is plain, display-only registry metadata modelled on
the existing `links[]`/`social` fields: no probe/verification machinery, and it
never feeds completeness.

## Changes

- **`schemas/subnet-manifest.schema.json`** — new optional `exchange_listings`
  array plus an `$defs/exchange_listing` object (`exchange` + `url` required,
  optional `pair`, `additionalProperties: false`), following the `links`/`link`
  pattern. Documented with descriptions and a worked `examples` value.
- **`schemas/components/05-subnets.schema.json`** — new `ExchangeListing`
  component and an `exchange_listings` array on `SubnetDetail`, so the field is
  part of the served subnet-detail contract.
- **`scripts/build-artifacts.mjs` / `scripts/validate.mjs`** — carry
  `exchange_listings` through `mergeSubnet` and its `buildExpectedGeneratedSubnet`
  reproducibility mirror as a curated overlay passthrough (`overlay?.exchange_listings || []`),
  exactly like `links`.
- **Regenerated artifacts** — `schemas/api-components.schema.json`,
  `public/metagraph/openapi.json`, `public/metagraph/types.d.ts`, and
  `packages/contract/index.d.ts` rebuilt from the schema change.

No existing registry file needs migrating — the field is additive/optional.

## Validation

Ran with Node 22.23.1:

- `npm run build` — passed (local pipeline: bundle-schemas, build-artifacts,
  generate-types, generate-client, r2-manifest).
- `npm run validate:contract-drift` — passed (api-components bundle, openapi,
  types, contract, generated client all in sync).
- `npm run validate:openapi` / `validate:openapi-examples` — passed (159/159
  routes ship a schema-valid worked example, including the new
  `exchange_listings` sample).
- `npm run validate:types` / `validate:generated-client` /
  `validate:client-sdk-sync` / `validate:schema-enums` — passed.
- `npm run test:ci:artifacts` — passed (66 tests, incl. the per-subnet
  detail-artifact reproducibility check that now covers the passthrough).
- `npm run lint` and `npm run format:check` — clean.

Closes #6274
