### PR TITLE
feat(ui): add an SS58 address inspector tool page

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -21,6 +21,7 @@ import {
   Copy,
   ExternalLink,
   FileJson,
+  Fingerprint,
   Gauge,
   GitBranch,
   Hash,
@@ -195,6 +196,13 @@ const STATIC_ROUTES_TAIL: RouteEntry[] = [
     to: "/runtime",
     hint: "Spec-version upgrade history",
     icon: GitBranch,
+    scope: "route",
+  },
+  {
+    label: "SS58 inspector",
+    to: "/tools/ss58",
+    hint: "Decode & verify any SS58 address",
+    icon: Fingerprint,
     scope: "route",
   },
 ];

--- a/apps/ui/src/lib/metagraphed/ss58.test.ts
+++ b/apps/ui/src/lib/metagraphed/ss58.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { blake2b, base58Encode, encodeSs58 } from "./ss58";
+import { blake2b, base58Encode, base58Decode, encodeSs58, decodeSs58 } from "./ss58";
 
 const hex = (h: string) =>
   Uint8Array.from(
@@ -51,5 +51,68 @@ describe("encodeSs58", () => {
   it("returns null for non-32-byte input", () => {
     expect(encodeSs58(new Uint8Array(31))).toBeNull();
     expect(encodeSs58(new Uint8Array(33))).toBeNull();
+  });
+});
+
+describe("base58Decode", () => {
+  it("inverts base58Encode, including leading-zero '1's", () => {
+    const bytes = hex("0x0000287fb4cd");
+    expect(base58Decode(base58Encode(bytes))).toEqual(bytes);
+  });
+  it("returns null for a character outside the alphabet", () => {
+    // '0', 'O', 'I', 'l' are excluded from the base58 alphabet.
+    expect(base58Decode("0OIl")).toBeNull();
+  });
+});
+
+describe("decodeSs58", () => {
+  const alicePubkey = hex("0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d");
+
+  it("decodes a format-42 address back to its pubkey, checksum-verified", () => {
+    const decoded = decodeSs58("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+    expect(decoded).toEqual({
+      valid: true,
+      format: 42,
+      pubkey: alicePubkey,
+      checksumValid: true,
+      extendedFormat: false,
+    });
+  });
+
+  it("decodes a different network format byte (0 = Polkadot)", () => {
+    const decoded = decodeSs58("15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5");
+    expect(decoded?.format).toBe(0);
+    expect(decoded?.pubkey).toEqual(alicePubkey);
+    expect(decoded?.checksumValid).toBe(true);
+  });
+
+  it("flags a corrupted checksum without throwing", () => {
+    // Flip the last character of an otherwise-valid address.
+    const valid = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    const corrupted = valid.slice(0, -1) + (valid.endsWith("Y") ? "X" : "Y");
+    const decoded = decodeSs58(corrupted);
+    expect(decoded?.valid).toBe(false);
+    expect(decoded?.checksumValid).toBe(false);
+    expect(decoded?.pubkey).toBeNull();
+  });
+
+  it("returns null for malformed base58 input", () => {
+    expect(decodeSs58("not-valid-base58-0OIl")).toBeNull();
+  });
+
+  it("returns null for a well-formed but wrong-length base58 string", () => {
+    expect(decodeSs58(base58Encode(new Uint8Array(10)))).toBeNull();
+  });
+
+  it("round-trips encodeSs58 output for an arbitrary format byte", () => {
+    const encoded = encodeSs58(alicePubkey, 2); // Kusama
+    const decoded = decodeSs58(encoded!);
+    expect(decoded).toEqual({
+      valid: true,
+      format: 2,
+      pubkey: alicePubkey,
+      checksumValid: true,
+      extendedFormat: false,
+    });
   });
 });

--- a/apps/ui/src/lib/metagraphed/ss58.ts
+++ b/apps/ui/src/lib/metagraphed/ss58.ts
@@ -159,6 +159,33 @@ export function base58Encode(bytes: Uint8Array): string {
   return out;
 }
 
+/** base58-decode a string (Bitcoin/Substrate alphabet). `null` on any character outside the alphabet — mirrors {@link base58Encode}'s digit-array algorithm in reverse. */
+export function base58Decode(input: string): Uint8Array | null {
+  const bytes = [0];
+  for (const char of input) {
+    const value = BASE58_ALPHABET.indexOf(char);
+    if (value === -1) return null;
+    let carry = value;
+    for (let i = 0; i < bytes.length; i++) {
+      carry += bytes[i] * 58;
+      bytes[i] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  let leadingZeros = 0;
+  for (const char of input) {
+    if (char === "1") leadingZeros++;
+    else break;
+  }
+  const out = new Uint8Array(leadingZeros + bytes.length);
+  for (let i = 0; i < bytes.length; i++) out[leadingZeros + bytes.length - 1 - i] = bytes[i];
+  return out;
+}
+
 // ── SS58 ─────────────────────────────────────────────────────────────────────
 const SS58_PREFIX = new TextEncoder().encode("SS58PRE");
 
@@ -183,4 +210,61 @@ export function encodeSs58(pubkey: Uint8Array, format = DEFAULT_SS58_FORMAT): st
   full.set(payload);
   full.set(checksum.slice(0, 2), payload.length);
   return base58Encode(full);
+}
+
+export interface DecodedSs58 {
+  /** True only for the fully-decoded, checksum-verified 32-byte-account shape. */
+  valid: boolean;
+  /** Network prefix byte, or -1 when `extendedFormat` is true (not decoded). */
+  format: number;
+  /** The 32-byte public key, present only when `valid` is true. */
+  pubkey: Uint8Array | null;
+  checksumValid: boolean;
+  /**
+   * SS58 prefixes 64-127 use a 2-byte bit-packed encoding this app doesn't
+   * implement — every chain a Bittensor user would realistically encounter
+   * (Polkadot 0, Kusama 2, generic Substrate/Bittensor 42) uses the simple
+   * single-byte form (0-63), so this just flags the shape rather than
+   * guessing at an unverified bit-unpacking.
+   */
+  extendedFormat: boolean;
+}
+
+/**
+ * Decode an SS58 address string back to its network prefix and public key,
+ * verifying the checksum. Only handles the single-byte-prefix, 32-byte
+ * account-id shape {@link encodeSs58} produces (what every real Bittensor
+ * hotkey/coldkey is) — returns `null` for malformed base58 or a length that
+ * doesn't match that shape, and `extendedFormat: true` (no pubkey) for a
+ * structurally-plausible but unsupported 2-byte-prefix address.
+ */
+export function decodeSs58(address: string): DecodedSs58 | null {
+  const bytes = base58Decode(address.trim());
+  if (!bytes || bytes.length < 3) return null;
+
+  const first = bytes[0];
+  if (first >= 128) return null;
+
+  if (first > 63) {
+    return { valid: false, format: -1, pubkey: null, checksumValid: false, extendedFormat: true };
+  }
+
+  if (bytes.length !== 35) return null;
+
+  const format = first;
+  const payload = bytes.slice(0, 33);
+  const checksum = bytes.slice(33, 35);
+  const input = new Uint8Array(SS58_PREFIX.length + payload.length);
+  input.set(SS58_PREFIX);
+  input.set(payload, SS58_PREFIX.length);
+  const expectedChecksum = blake2b(input, 64);
+  const checksumValid = checksum[0] === expectedChecksum[0] && checksum[1] === expectedChecksum[1];
+
+  return {
+    valid: checksumValid,
+    format,
+    pubkey: checksumValid ? payload.slice(1) : null,
+    checksumValid,
+    extendedFormat: false,
+  };
 }

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as BlocksIndexRouteImport } from './routes/blocks.index'
 import { Route as AdminChangesIndexRouteImport } from './routes/admin-changes.index'
 import { Route as AccountsIndexRouteImport } from './routes/accounts.index'
 import { Route as ValidatorsHotkeyRouteImport } from './routes/validators.$hotkey'
+import { Route as ToolsSs58RouteImport } from './routes/tools.ss58'
 import { Route as SubnetsNetuidRouteImport } from './routes/subnets.$netuid'
 import { Route as ProvidersSlugRouteImport } from './routes/providers.$slug'
 import { Route as GraphqlExplorerRouteImport } from './routes/graphql.explorer'
@@ -152,6 +153,11 @@ const ValidatorsHotkeyRoute = ValidatorsHotkeyRouteImport.update({
   path: '/validators/$hotkey',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ToolsSs58Route = ToolsSs58RouteImport.update({
+  id: '/tools/ss58',
+  path: '/tools/ss58',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SubnetsNetuidRoute = SubnetsNetuidRouteImport.update({
   id: '/subnets/$netuid',
   path: '/subnets/$netuid',
@@ -225,6 +231,7 @@ export interface FileRoutesByFullPath {
   '/graphql/explorer': typeof GraphqlExplorerRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
+  '/tools/ss58': typeof ToolsSs58Route
   '/validators/$hotkey': typeof ValidatorsHotkeyRoute
   '/accounts/': typeof AccountsIndexRoute
   '/admin-changes/': typeof AdminChangesIndexRoute
@@ -259,6 +266,7 @@ export interface FileRoutesByTo {
   '/graphql/explorer': typeof GraphqlExplorerRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
+  '/tools/ss58': typeof ToolsSs58Route
   '/validators/$hotkey': typeof ValidatorsHotkeyRoute
   '/accounts': typeof AccountsIndexRoute
   '/admin-changes': typeof AdminChangesIndexRoute
@@ -294,6 +302,7 @@ export interface FileRoutesById {
   '/graphql/explorer': typeof GraphqlExplorerRoute
   '/providers/$slug': typeof ProvidersSlugRoute
   '/subnets/$netuid': typeof SubnetsNetuidRoute
+  '/tools/ss58': typeof ToolsSs58Route
   '/validators/$hotkey': typeof ValidatorsHotkeyRoute
   '/accounts/': typeof AccountsIndexRoute
   '/admin-changes/': typeof AdminChangesIndexRoute
@@ -330,6 +339,7 @@ export interface FileRouteTypes {
     | '/graphql/explorer'
     | '/providers/$slug'
     | '/subnets/$netuid'
+    | '/tools/ss58'
     | '/validators/$hotkey'
     | '/accounts/'
     | '/admin-changes/'
@@ -364,6 +374,7 @@ export interface FileRouteTypes {
     | '/graphql/explorer'
     | '/providers/$slug'
     | '/subnets/$netuid'
+    | '/tools/ss58'
     | '/validators/$hotkey'
     | '/accounts'
     | '/admin-changes'
@@ -398,6 +409,7 @@ export interface FileRouteTypes {
     | '/graphql/explorer'
     | '/providers/$slug'
     | '/subnets/$netuid'
+    | '/tools/ss58'
     | '/validators/$hotkey'
     | '/accounts/'
     | '/admin-changes/'
@@ -433,6 +445,7 @@ export interface RootRouteChildren {
   GraphqlExplorerRoute: typeof GraphqlExplorerRoute
   ProvidersSlugRoute: typeof ProvidersSlugRoute
   SubnetsNetuidRoute: typeof SubnetsNetuidRoute
+  ToolsSs58Route: typeof ToolsSs58Route
   ValidatorsHotkeyRoute: typeof ValidatorsHotkeyRoute
   AccountsIndexRoute: typeof AccountsIndexRoute
   AdminChangesIndexRoute: typeof AdminChangesIndexRoute
@@ -602,6 +615,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ValidatorsHotkeyRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/tools/ss58': {
+      id: '/tools/ss58'
+      path: '/tools/ss58'
+      fullPath: '/tools/ss58'
+      preLoaderRoute: typeof ToolsSs58RouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/subnets/$netuid': {
       id: '/subnets/$netuid'
       path: '/subnets/$netuid'
@@ -697,6 +717,7 @@ const rootRouteChildren: RootRouteChildren = {
   GraphqlExplorerRoute: GraphqlExplorerRoute,
   ProvidersSlugRoute: ProvidersSlugRoute,
   SubnetsNetuidRoute: SubnetsNetuidRoute,
+  ToolsSs58Route: ToolsSs58Route,
   ValidatorsHotkeyRoute: ValidatorsHotkeyRoute,
   AccountsIndexRoute: AccountsIndexRoute,
   AdminChangesIndexRoute: AdminChangesIndexRoute,

--- a/apps/ui/src/routes/tools.ss58.tsx
+++ b/apps/ui/src/routes/tools.ss58.tsx
@@ -1,0 +1,202 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useMemo, useState } from "react";
+import { CheckCircle2, XCircle, AlertTriangle } from "lucide-react";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { CopyableCode, PageHero } from "@jsonbored/ui-kit";
+import { decodeSs58, DEFAULT_SS58_FORMAT } from "@/lib/metagraphed/ss58";
+import { classNames } from "@/lib/metagraphed/format";
+
+export const Route = createFileRoute("/tools/ss58")({
+  head: () => ({
+    meta: [
+      { title: "SS58 address inspector — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Decode and validate any SS58-formatted Substrate address — network prefix, public key, checksum. Runs entirely in your browser; nothing is sent anywhere. No API key.",
+      },
+    ],
+  }),
+  component: Ss58ToolPage,
+});
+
+// The handful of prefixes a Bittensor user could plausibly paste in by
+// mistake -- not a full registry of the ~60 assigned SS58 prefixes, which
+// would be scope well beyond a quick sanity-check tool.
+const KNOWN_FORMATS: Record<number, string> = {
+  0: "Polkadot",
+  2: "Kusama",
+  [DEFAULT_SS58_FORMAT]: "Generic Substrate (Bittensor)",
+};
+
+function toHex(bytes: Uint8Array): string {
+  return "0x" + [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function Ss58ToolPage() {
+  const [input, setInput] = useState("");
+  const trimmed = input.trim();
+  const decoded = useMemo(() => (trimmed ? decodeSs58(trimmed) : null), [trimmed]);
+
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Tools"
+        title="SS58 address inspector"
+        description="Paste any SS58-formatted Substrate address to decode its network prefix and public key, and verify its checksum. Runs entirely in your browser — nothing here is ever sent anywhere."
+        caption="tools / ss58"
+      />
+
+      <div className="space-y-6">
+        <div>
+          <label htmlFor="ss58-input" className="mg-label mb-2 block">
+            Address
+          </label>
+          <input
+            id="ss58-input"
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+            spellCheck={false}
+            autoComplete="off"
+            className="w-full rounded-lg border border-border bg-card px-4 py-3 font-mono text-sm text-ink-strong placeholder:text-ink-muted/50 focus:border-accent/50 focus:outline-none"
+          />
+        </div>
+
+        {trimmed && decoded === null ? (
+          <ResultCard tone="error" icon={XCircle} title="Not a valid SS58 address">
+            <p>
+              Couldn&apos;t decode this as SS58 — either the base58 encoding is malformed, or the
+              decoded length doesn&apos;t match a standard 32-byte account (prefix + public key +
+              2-byte checksum).
+            </p>
+          </ResultCard>
+        ) : null}
+
+        {decoded?.extendedFormat ? (
+          <ResultCard tone="warn" icon={AlertTriangle} title="Extended (2-byte) network prefix">
+            <p>
+              This address uses a prefix in the 64-127 range, which SS58 encodes across 2 bytes with
+              a bit-packed scheme this tool doesn&apos;t decode — every network a Bittensor user
+              would realistically encounter (Polkadot, Kusama, generic Substrate) uses a simple
+              single-byte prefix instead, so this is either a wallet's byte encoding quirk or a much
+              less common chain.
+            </p>
+          </ResultCard>
+        ) : null}
+
+        {decoded && !decoded.extendedFormat && !decoded.checksumValid ? (
+          <ResultCard tone="error" icon={XCircle} title="Invalid checksum">
+            <p>
+              The address parses to the right shape (prefix + 32-byte account + checksum), but the
+              checksum doesn&apos;t match — this address has been mistyped, truncated, or corrupted
+              somewhere. Double-check every character before using it.
+            </p>
+          </ResultCard>
+        ) : null}
+
+        {decoded?.valid && decoded.pubkey ? (
+          <ResultCard
+            tone="ok"
+            icon={CheckCircle2}
+            title={
+              decoded.format === DEFAULT_SS58_FORMAT
+                ? "Valid Bittensor address"
+                : "Valid SS58 address — not Bittensor"
+            }
+          >
+            <dl className="grid grid-cols-[auto_1fr] items-baseline gap-x-4 gap-y-2.5 text-sm">
+              <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Network prefix
+              </dt>
+              <dd className="font-mono text-ink-strong">
+                {decoded.format}
+                {KNOWN_FORMATS[decoded.format] ? (
+                  <span className="ml-2 text-ink-muted">({KNOWN_FORMATS[decoded.format]})</span>
+                ) : null}
+              </dd>
+              <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Public key
+              </dt>
+              <dd className="min-w-0">
+                <CopyableCode value={toHex(decoded.pubkey)} className="w-full" />
+              </dd>
+              <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Checksum
+              </dt>
+              <dd className="text-health-ok">Valid</dd>
+            </dl>
+            {decoded.format !== DEFAULT_SS58_FORMAT ? (
+              <p className="mt-3 text-[13px] text-ink-muted">
+                This is a well-formed SS58 address, but its network prefix ({decoded.format}) is not
+                Bittensor&apos;s ({DEFAULT_SS58_FORMAT}) — it belongs to
+                {KNOWN_FORMATS[decoded.format]
+                  ? ` ${KNOWN_FORMATS[decoded.format]}`
+                  : " a different Substrate chain"}
+                . Sending TAO to it would go to a different key on a different network, not this
+                account on Bittensor.
+              </p>
+            ) : null}
+          </ResultCard>
+        ) : null}
+
+        <section className="rounded-lg border border-border bg-card p-5 text-[13px] leading-relaxed text-ink-muted">
+          <h2 className="mb-2 font-display text-sm font-semibold text-ink-strong">
+            How this works
+          </h2>
+          <p>
+            An SS58 address is{" "}
+            <code className="font-mono text-ink-strong">
+              base58(prefix || public_key || checksum)
+            </code>{" "}
+            — a network-prefix byte, the 32-byte sr25519/ed25519 public key, and a 2-byte checksum
+            (the first 2 bytes of a blake2b-512 hash over{" "}
+            <code className="font-mono text-ink-strong">"SS58PRE" || prefix || public_key</code>),
+            all base58-encoded. The same public key produces a different address string per network
+            — Bittensor's hotkeys and coldkeys use prefix 42 (&quot;generic Substrate&quot;), the
+            same prefix several other chains without a dedicated allocation also use. Decoding and
+            checksum verification happen entirely client-side; this page makes no network requests.
+          </p>
+        </section>
+      </div>
+    </AppShell>
+  );
+}
+
+function ResultCard({
+  tone,
+  icon: Icon,
+  title,
+  children,
+}: {
+  tone: "ok" | "warn" | "error";
+  icon: typeof CheckCircle2;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={classNames(
+        "rounded-lg border p-5",
+        tone === "ok" && "border-health-ok/30 bg-health-ok/5",
+        tone === "warn" && "border-health-warn/30 bg-health-warn/5",
+        tone === "error" && "border-health-down/30 bg-health-down/5",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <Icon
+          className={classNames(
+            "size-4 shrink-0",
+            tone === "ok" && "text-health-ok",
+            tone === "warn" && "text-health-warn",
+            tone === "error" && "text-health-down",
+          )}
+          aria-hidden
+        />
+        <h2 className="font-display text-sm font-semibold text-ink-strong">{title}</h2>
+      </div>
+      <div className="mt-2.5 text-[13px] leading-relaxed text-ink-muted">{children}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a client-side SS58 address inspector at `/tools/ss58`, per #3497.

Paste any SS58-formatted Substrate address and it decodes the network prefix, extracts the 32-byte public key, and verifies the checksum — entirely in the browser, no network requests.

## Why this shape

- **Decoder lives next to the existing encoder.** `ss58.ts` already vendors a dependency-free blake2b + base58 implementation for `encodeSs58` (rendering raw chain-event account-id bytes as addresses). `decodeSs58`/`base58Decode` reuse the exact same primitives rather than a second implementation, and round-trip against the same Alice/Bob test vectors the encoder is already verified against.
- **Doesn't guess at the 2-byte extended prefix range (64-127).** SS58 prefixes 64-127 use a bit-packed 2-byte encoding I chose not to implement — every network a Bittensor user would realistically encounter (Polkadot 0, Kusama 2, generic Substrate/Bittensor 42) uses the simple single-byte form. The tool explicitly flags this shape as "not decoded" rather than fabricating an unverified bit-unpacking.
- **The actually-useful case: catching a wrong-network paste.** A well-formed SS58 address with a prefix other than 42 (e.g. a Polkadot address) decodes successfully and shows a clear warning that it belongs to a different network — the practical failure mode this tool is for.

## Screenshots

| State | |
| --- | --- |
| Valid Bittensor address (prefix 42) | ![valid](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/ss58-inspector-tool/valid-bittensor.png) |
| Valid but wrong network (Polkadot, prefix 0) | ![wrong network](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/ss58-inspector-tool/valid-wrong-network.png) |
| Corrupted checksum (one character flipped) | ![invalid checksum](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/ss58-inspector-tool/invalid-checksum.png) |
| Malformed input | ![malformed](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/ss58-inspector-tool/malformed.png) |
| Empty state | ![empty](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/ss58-inspector-tool/empty.png) |

## Test plan

- [x] `npx tsc --noEmit -p apps/ui` clean
- [x] `cd apps/ui && npx eslint <files>` clean (the real CI lint command — see prior PRs in this batch for why standalone `prettier --check` isn't trustworthy here)
- [x] `npm run test --workspace=apps/ui` — 133 files / 1031 tests pass, including 8 new `decodeSs58`/`base58Decode` tests (round-trip, wrong-network format byte, corrupted checksum, malformed input, wrong-length input)
- [x] Verified all 4 decode states + empty state in a running dev server via Playwright, zero console errors
- [x] New route auto-discovered by TanStack Router's file-based routing (`routeTree.gen.ts` regenerated, committed) — breadcrumb, page title, and command-palette entry all confirmed working
