### PR TITLE
feat(mcp): add min_/max_latency_ms and min_/max_score to list_endpoints

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -8657,8 +8657,9 @@ export const MCP_TOOLS = [
       "with its kind, layer, provider, subnet (netuid), publication state, and " +
       "probe-derived status/latency/score. Use it to discover live endpoints " +
       "network-wide. Optionally filter by kind/layer/netuid/provider/" +
-      "publication_state/status/pool_eligible and page with limit/offset — the " +
-      "full catalog can be large. Mirrors GET /api/v1/endpoints.",
+      "publication_state/status/pool_eligible, bound by min_/max_latency_ms " +
+      "and min_/max_score, and page with limit/offset — the full catalog can " +
+      "be large. Mirrors GET /api/v1/endpoints.",
     inputSchema: {
       type: "object",
       properties: {
@@ -8692,6 +8693,22 @@ export const MCP_TOOLS = [
           type: "boolean",
           description: "Only endpoints eligible (or not) for RPC pooling.",
         },
+        min_latency_ms: {
+          type: "number",
+          description: "Only endpoints with probe-derived latency_ms >= this.",
+        },
+        max_latency_ms: {
+          type: "number",
+          description: "Only endpoints with probe-derived latency_ms <= this.",
+        },
+        min_score: {
+          type: "number",
+          description: "Only endpoints with probe-derived score >= this.",
+        },
+        max_score: {
+          type: "number",
+          description: "Only endpoints with probe-derived score <= this.",
+        },
         limit: {
           type: "integer",
           description: "Max endpoints to return. Omit for the full list.",
@@ -8717,6 +8734,17 @@ export const MCP_TOOLS = [
       );
       const status = optionalEnum(args, "status", QUERY_ENUMS.healthStatus);
       const poolEligible = optionalNullableBoolean(args, "pool_eligible");
+      // Inclusive numeric range bounds, the MCP mirror of REST's
+      // rangeFilters: ["latency_ms", "score"] on the endpoints collection
+      // (contracts.mjs) — same shape as LIST_SUBNETS_RANGE_BOUNDS.
+      const rangeBounds = [
+        { arg: "min_latency_ms", field: "latency_ms", op: "min" },
+        { arg: "max_latency_ms", field: "latency_ms", op: "max" },
+        { arg: "min_score", field: "score", op: "min" },
+        { arg: "max_score", field: "score", op: "max" },
+      ]
+        .filter(({ arg }) => Number.isFinite(args?.[arg]))
+        .map(({ field, op, arg }) => ({ field, op, limit: args[arg] }));
       const limit = optionalPositiveInt(args, "limit");
       const offset = optionalNonNegativeInt(args, "offset") ?? 0;
       let data = await loadArtifactData(ctx, "/metagraph/endpoints.json");
@@ -8724,6 +8752,7 @@ export const MCP_TOOLS = [
       // artifact serving path): the build-time endpoints.json bakes stale
       // operational health, so replace it from the 15-minute cron snapshot
       // before filtering/pagination -- status/pool_eligible filters below
+      // (and the latency_ms/score bounds, which come from this same overlay)
       // must see live values, not the baked ones.
       if (
         Array.isArray(data?.endpoints) &&
@@ -8745,7 +8774,12 @@ export const MCP_TOOLS = [
           (publicationState === null ||
             e.publication_state === publicationState) &&
           (status === null || e.status === status) &&
-          (poolEligible === null || e.pool_eligible === poolEligible),
+          (poolEligible === null || e.pool_eligible === poolEligible) &&
+          rangeBounds.every(({ field, op, limit: bound }) => {
+            const value = e[field];
+            if (typeof value !== "number") return false;
+            return op === "min" ? value >= bound : value <= bound;
+          }),
       );
       const page =
         limit === null

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14565,6 +14565,73 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.returned, 0);
   });
 
+  // #6244: min_/max_latency_ms and min_/max_score mirror REST's rangeFilters
+  // on the endpoints collection (contracts.mjs). A row missing the bounded
+  // field must be excluded, not silently pass, once a bound is set.
+  function endpointsRangeDeps() {
+    return makeDeps({
+      "/metagraph/endpoints.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        endpoints: [
+          { netuid: 1, provider: "datura", latency_ms: 50, score: 0.9 },
+          { netuid: 2, provider: "chutes", latency_ms: 400, score: 0.4 },
+          { netuid: 3, provider: "nova", latency_ms: 900, score: 0.1 },
+          // No latency_ms/score at all — must be excluded once any bound
+          // on either field is set, matching rangeFilterRows semantics.
+          { netuid: 4, provider: "no-metrics" },
+        ],
+      },
+    });
+  }
+
+  test("list_endpoints min_latency_ms/max_latency_ms bound latency_ms inclusively", async () => {
+    const deps = endpointsRangeDeps();
+    const min = (
+      await callTool("list_endpoints", { min_latency_ms: 400 }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(min.endpoints.map((e) => e.netuid).sort(), [2, 3]);
+
+    const max = (
+      await callTool("list_endpoints", { max_latency_ms: 400 }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(max.endpoints.map((e) => e.netuid).sort(), [1, 2]);
+
+    const missing = (
+      await callTool("list_endpoints", { min_latency_ms: 0 }, { deps })
+    ).body.result.structuredContent;
+    assert.deepEqual(
+      missing.endpoints.map((e) => e.netuid).sort(),
+      [1, 2, 3],
+      "the row with no latency_ms at all must be excluded once a bound is set",
+    );
+  });
+
+  test("list_endpoints min_score/max_score bound score inclusively", async () => {
+    const deps = endpointsRangeDeps();
+    const min = (await callTool("list_endpoints", { min_score: 0.5 }, { deps }))
+      .body.result.structuredContent;
+    assert.deepEqual(
+      min.endpoints.map((e) => e.netuid),
+      [1],
+    );
+
+    const max = (await callTool("list_endpoints", { max_score: 0.4 }, { deps }))
+      .body.result.structuredContent;
+    assert.deepEqual(max.endpoints.map((e) => e.netuid).sort(), [2, 3]);
+  });
+
+  test("list_endpoints composes range bounds with existing filters (AND)", async () => {
+    const deps = endpointsRangeDeps();
+    const res = await callTool(
+      "list_endpoints",
+      { provider: "chutes", min_score: 0.3, max_latency_ms: 500 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 1);
+    assert.equal(out.endpoints[0].netuid, 2);
+  });
+
   test("list_evidence returns filtered claim rows", async () => {
     const deps = makeDeps({
       "/metagraph/evidence-ledger.json": {


### PR DESCRIPTION
## Summary
- `GET /api/v1/endpoints` (the `endpoints` query collection) already accepts inclusive `min_latency_ms`/`max_latency_ms`/`min_score`/`max_score` bounds via `workers/list-query.mjs`'s generic range-filter mechanism, but the `list_endpoints` MCP tool — which explicitly says it "Mirrors GET /api/v1/endpoints" — never exposed these two numeric fields at all, only the categorical filters.
- Added `min_latency_ms`/`max_latency_ms`/`min_score`/`max_score` to `list_endpoints`'s `inputSchema` and applied them as inclusive bounds in the handler, using the identical "absent/non-numeric field excludes the row" semantics `rangeFilterRows` uses, composed (AND) with the tool's existing filters — mirroring the established `LIST_SUBNETS_RANGE_BOUNDS`/`rangeFilterSubnets` pattern already used by `list_subnets`.
- The bounds are evaluated after the existing live-health overlay (`overlayArtifactEndpoints`) runs, since `latency_ms`/`score` come from that overlay, not the baked artifact.
- Updated the tool's `description` string to mention the new range args.

Closes #6244

## Test plan
- [x] `npx vitest run tests/mcp-server.test.mjs -t "list_endpoints"` — 13 tests pass, including 3 new ones covering: `min_/max_latency_ms` bounding inclusively, `min_/max_score` bounding inclusively, a row missing both fields being excluded once any bound is set, and range bounds composing (AND) with an existing categorical filter.
- [x] `npx vitest run tests/mcp-server.test.mjs` (full file) — 1086 tests pass
- [x] `npm run test:coverage` (full suite) — 298 test files / 9050 tests pass
- [x] `npm run lint` / `npx prettier --check src/mcp-server.mjs tests/mcp-server.test.mjs` — clean
- [x] `npm run validate:mcp` — passed (176 tools, full lifecycle + tools/call + resources round trips)
- [x] `npm run validate` — passed