### PR TITLE
test(scripts): extract + unit-test the README registry-catalog generator (#6247)

### DIFF
--- a/scripts/generate-registry-readme-section.mjs
+++ b/scripts/generate-registry-readme-section.mjs
@@ -11,112 +11,24 @@
 // visibility → more contributions). Live health/readiness links out to the profile
 // rather than being inlined, so there are no per-view badge requests baked into git.
 //
+// The pure catalog logic (loadOverlays / focusTags / links / renderCatalog /
+// injectedReadme) lives in scripts/lib/registry-readme-section.mjs (#6247) so it
+// is unit-tested directly; this entrypoint keeps only the README read/write and
+// the --check wiring.
+//
 //   node scripts/generate-registry-readme-section.mjs           # write README.md
 //   node scripts/generate-registry-readme-section.mjs --check    # verify up-to-date
 
-import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { repoRoot } from "./lib.mjs";
+import {
+  loadOverlays,
+  renderCatalog,
+  injectedReadme,
+} from "./lib/registry-readme-section.mjs";
 
-const BEGIN = "<!-- BEGIN:REGISTRY-CATALOG -->";
-const END = "<!-- END:REGISTRY-CATALOG -->";
 const README_PATH = path.join(repoRoot, "README.md");
-const OVERLAYS_DIR = path.join(repoRoot, "registry/subnets");
-const SITE = "https://metagraph.sh";
-const API = "https://api.metagraph.sh";
-
-// Provenance / process tags (how an entry was curated) are noise in a catalog —
-// keep only the use-case "focus" tags. Prefix-matched so new official-*/baseline-*
-// tags are filtered automatically.
-const PROVENANCE_PREFIX = /^(official|baseline|identity)-/;
-const PROVENANCE_EXACT = new Set([
-  "pilot",
-  "root",
-  "system",
-  "native-only",
-  "macrocosmos",
-]);
-
-function loadOverlays() {
-  return readdirSync(OVERLAYS_DIR)
-    .filter((file) => file.endsWith(".json"))
-    .map((file) =>
-      JSON.parse(readFileSync(path.join(OVERLAYS_DIR, file), "utf8")),
-    )
-    .filter((overlay) => Number.isInteger(overlay?.netuid))
-    .sort((a, b) => a.netuid - b.netuid);
-}
-
-function focusTags(overlay) {
-  return (overlay.categories || [])
-    .filter((tag) => !PROVENANCE_PREFIX.test(tag) && !PROVENANCE_EXACT.has(tag))
-    .sort();
-}
-
-function links(overlay) {
-  const out = [];
-  if (overlay.website_url) out.push(`[site](${overlay.website_url})`);
-  if (overlay.docs_url) out.push(`[docs](${overlay.docs_url})`);
-  if (overlay.source_repo) out.push(`[repo](${overlay.source_repo})`);
-  return out.join(" · ") || "—";
-}
-
-function renderCatalog(overlays) {
-  const focusCounts = new Map();
-  for (const overlay of overlays) {
-    for (const tag of focusTags(overlay)) {
-      focusCounts.set(tag, (focusCounts.get(tag) || 0) + 1);
-    }
-  }
-  const topFocus = [...focusCounts.entries()]
-    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-    .slice(0, 12)
-    .map(([tag, count]) => `\`${tag}\` ${count}`)
-    .join(" · ");
-
-  const withSite = overlays.filter((o) => o.website_url).length;
-  const withDocs = overlays.filter((o) => o.docs_url).length;
-  const withRepo = overlays.filter((o) => o.source_repo).length;
-
-  // A bulleted list (not a markdown table): Prettier pads table cells to the
-  // widest column, which at ~90 rows of long URLs explodes the diff — a list
-  // stays Prettier-stable and renders just as cleanly on GitHub.
-  const items = overlays.map((overlay) => {
-    const name = overlay.name || `Subnet ${overlay.netuid}`;
-    const focus = focusTags(overlay)
-      .map((tag) => `\`${tag}\``)
-      .join(" ");
-    const linkStr = links(overlay);
-    return (
-      `- **[${name}](${SITE}/subnets/${overlay.netuid})** \`SN${overlay.netuid}\`` +
-      (focus ? ` — ${focus}` : "") +
-      (linkStr !== "—" ? ` · ${linkStr}` : "")
-    );
-  });
-
-  return [
-    `**${overlays.length} curated subnets** — ${withSite} with a site, ${withDocs} with docs, ${withRepo} with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](${SITE})**; per-subnet JSON at \`${API}/api/v1/subnets/{netuid}\`.`,
-    "",
-    `**Focus areas:** ${topFocus}`,
-    "",
-    ...items,
-    "",
-    `<sub>Auto-generated from the curated overlays in \`registry/subnets/\` by \`scripts/generate-registry-readme-section.mjs\` — enrich a subnet (one PR) and it appears here. Not the live list; browse + monitor everything at [metagraph.sh](${SITE}).</sub>`,
-  ].join("\n");
-}
-
-function injectedReadme(readme, catalog) {
-  const beginAt = readme.indexOf(BEGIN);
-  const endAt = readme.indexOf(END);
-  if (beginAt === -1 || endAt === -1 || endAt < beginAt) {
-    throw new Error(
-      `README.md is missing the ${BEGIN} / ${END} markers (add them where the catalog should render).`,
-    );
-  }
-  const before = readme.slice(0, beginAt + BEGIN.length);
-  const after = readme.slice(endAt);
-  return `${before}\n\n${catalog}\n\n${after}`;
-}
 
 function main() {
   const check = process.argv.includes("--check");

--- a/scripts/lib/registry-readme-section.mjs
+++ b/scripts/lib/registry-readme-section.mjs
@@ -1,0 +1,109 @@
+// Pure rendering helpers for the README subnet catalog (#1020), extracted from
+// scripts/generate-registry-readme-section.mjs (#6247 testability decomposition)
+// so the catalog logic — focus-tag filtering, link composition, ranking, and
+// marker injection — is unit-tested directly, matching the convention every
+// other scripts/lib/*.mjs helper follows. The generator keeps only the README
+// read/write + --check wiring; everything here is a pure function over plain
+// objects/strings (loadOverlays takes its directory as an argument, so it too
+// is testable against a fixture dir).
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { repoRoot } from "../lib.mjs";
+
+export const BEGIN = "<!-- BEGIN:REGISTRY-CATALOG -->";
+export const END = "<!-- END:REGISTRY-CATALOG -->";
+export const OVERLAYS_DIR = path.join(repoRoot, "registry/subnets");
+export const SITE = "https://metagraph.sh";
+export const API = "https://api.metagraph.sh";
+
+// Provenance / process tags (how an entry was curated) are noise in a catalog —
+// keep only the use-case "focus" tags. Prefix-matched so new official-*/baseline-*
+// tags are filtered automatically.
+export const PROVENANCE_PREFIX = /^(official|baseline|identity)-/;
+export const PROVENANCE_EXACT = new Set([
+  "pilot",
+  "root",
+  "system",
+  "native-only",
+  "macrocosmos",
+]);
+
+export function loadOverlays(dir = OVERLAYS_DIR) {
+  return readdirSync(dir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => JSON.parse(readFileSync(path.join(dir, file), "utf8")))
+    .filter((overlay) => Number.isInteger(overlay?.netuid))
+    .sort((a, b) => a.netuid - b.netuid);
+}
+
+export function focusTags(overlay) {
+  return (overlay.categories || [])
+    .filter((tag) => !PROVENANCE_PREFIX.test(tag) && !PROVENANCE_EXACT.has(tag))
+    .sort();
+}
+
+export function links(overlay) {
+  const out = [];
+  if (overlay.website_url) out.push(`[site](${overlay.website_url})`);
+  if (overlay.docs_url) out.push(`[docs](${overlay.docs_url})`);
+  if (overlay.source_repo) out.push(`[repo](${overlay.source_repo})`);
+  return out.join(" · ") || "—";
+}
+
+export function renderCatalog(overlays) {
+  const focusCounts = new Map();
+  for (const overlay of overlays) {
+    for (const tag of focusTags(overlay)) {
+      focusCounts.set(tag, (focusCounts.get(tag) || 0) + 1);
+    }
+  }
+  const topFocus = [...focusCounts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 12)
+    .map(([tag, count]) => `\`${tag}\` ${count}`)
+    .join(" · ");
+
+  const withSite = overlays.filter((o) => o.website_url).length;
+  const withDocs = overlays.filter((o) => o.docs_url).length;
+  const withRepo = overlays.filter((o) => o.source_repo).length;
+
+  // A bulleted list (not a markdown table): Prettier pads table cells to the
+  // widest column, which at ~90 rows of long URLs explodes the diff — a list
+  // stays Prettier-stable and renders just as cleanly on GitHub.
+  const items = overlays.map((overlay) => {
+    const name = overlay.name || `Subnet ${overlay.netuid}`;
+    const focus = focusTags(overlay)
+      .map((tag) => `\`${tag}\``)
+      .join(" ");
+    const linkStr = links(overlay);
+    return (
+      `- **[${name}](${SITE}/subnets/${overlay.netuid})** \`SN${overlay.netuid}\`` +
+      (focus ? ` — ${focus}` : "") +
+      (linkStr !== "—" ? ` · ${linkStr}` : "")
+    );
+  });
+
+  return [
+    `**${overlays.length} curated subnets** — ${withSite} with a site, ${withDocs} with docs, ${withRepo} with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](${SITE})**; per-subnet JSON at \`${API}/api/v1/subnets/{netuid}\`.`,
+    "",
+    `**Focus areas:** ${topFocus}`,
+    "",
+    ...items,
+    "",
+    `<sub>Auto-generated from the curated overlays in \`registry/subnets/\` by \`scripts/generate-registry-readme-section.mjs\` — enrich a subnet (one PR) and it appears here. Not the live list; browse + monitor everything at [metagraph.sh](${SITE}).</sub>`,
+  ].join("\n");
+}
+
+export function injectedReadme(readme, catalog) {
+  const beginAt = readme.indexOf(BEGIN);
+  const endAt = readme.indexOf(END);
+  if (beginAt === -1 || endAt === -1 || endAt < beginAt) {
+    throw new Error(
+      `README.md is missing the ${BEGIN} / ${END} markers (add them where the catalog should render).`,
+    );
+  }
+  const before = readme.slice(0, beginAt + BEGIN.length);
+  const after = readme.slice(endAt);
+  return `${before}\n\n${catalog}\n\n${after}`;
+}

--- a/tests/registry-readme-section.test.mjs
+++ b/tests/registry-readme-section.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, test } from "vitest";
+import {
+  BEGIN,
+  END,
+  PROVENANCE_EXACT,
+  loadOverlays,
+  focusTags,
+  links,
+  renderCatalog,
+  injectedReadme,
+} from "../scripts/lib/registry-readme-section.mjs";
+
+// --- focusTags: keep use-case tags, drop provenance/process noise -----------
+
+describe("focusTags", () => {
+  test("drops PROVENANCE_PREFIX (official-/baseline-/identity-) and PROVENANCE_EXACT tags, keeps the rest sorted", () => {
+    const overlay = {
+      categories: [
+        "inference",
+        "official-verified",
+        "pilot",
+        "baseline-seed",
+        "training",
+        "root",
+        "identity-linked",
+      ],
+    };
+    assert.deepEqual(focusTags(overlay), ["inference", "training"]);
+  });
+
+  test("every PROVENANCE_EXACT tag is filtered", () => {
+    const overlay = { categories: [...PROVENANCE_EXACT, "compute"] };
+    assert.deepEqual(focusTags(overlay), ["compute"]);
+  });
+
+  test("a missing categories array yields no tags", () => {
+    assert.deepEqual(focusTags({}), []);
+  });
+});
+
+// --- links: compose site/docs/repo, em-dash fallback ------------------------
+
+describe("links", () => {
+  test("joins the present links with ' · ' in site/docs/repo order", () => {
+    assert.equal(
+      links({
+        website_url: "https://x.io",
+        docs_url: "https://x.io/docs",
+        source_repo: "https://github.com/x/x",
+      }),
+      "[site](https://x.io) · [docs](https://x.io/docs) · [repo](https://github.com/x/x)",
+    );
+  });
+
+  test("omits absent links and keeps order", () => {
+    assert.equal(
+      links({ source_repo: "https://github.com/x/x" }),
+      "[repo](https://github.com/x/x)",
+    );
+  });
+
+  test("falls back to an em dash when no links exist", () => {
+    assert.equal(links({}), "—");
+  });
+});
+
+// --- renderCatalog: header stats, focus ranking, per-subnet bullets ---------
+
+describe("renderCatalog", () => {
+  const overlays = [
+    {
+      netuid: 1,
+      name: "Alpha",
+      categories: ["inference", "official-verified"],
+      website_url: "https://alpha.io",
+    },
+    {
+      netuid: 2,
+      name: "Beta",
+      categories: ["inference", "training"],
+      docs_url: "https://beta.io/docs",
+      source_repo: "https://github.com/beta/beta",
+    },
+    { netuid: 3, categories: ["pilot"] },
+  ];
+
+  test("counts subnets and site/docs/repo coverage in the header line", () => {
+    const out = renderCatalog(overlays);
+    assert.match(
+      out,
+      /\*\*3 curated subnets\*\* — 1 with a site, 1 with docs, 1 with a public repo\./,
+    );
+  });
+
+  test("ranks focus areas by count then name (provenance tags excluded)", () => {
+    const out = renderCatalog(overlays);
+    assert.match(out, /\*\*Focus areas:\*\* `inference` 2 · `training` 1/);
+    assert.doesNotMatch(out, /official-verified|pilot/);
+  });
+
+  test("renders one bullet per subnet, falling back to 'Subnet N' when unnamed", () => {
+    const out = renderCatalog(overlays);
+    assert.match(
+      out,
+      /- \*\*\[Alpha\]\(https:\/\/metagraph\.sh\/subnets\/1\)\*\* `SN1` — `inference` · \[site\]\(https:\/\/alpha\.io\)/,
+    );
+    // Unnamed netuid 3 falls back to "Subnet 3" with the em-dash link (no focus).
+    assert.match(
+      out,
+      /- \*\*\[Subnet 3\]\(https:\/\/metagraph\.sh\/subnets\/3\)\*\* `SN3`\n/,
+    );
+  });
+});
+
+// --- injectedReadme: splice between markers, throw when malformed -----------
+
+describe("injectedReadme", () => {
+  test("replaces the content between the markers, preserving surrounding text", () => {
+    const readme = `# Title\n\n${BEGIN}\nOLD\n${END}\n\nfooter`;
+    const result = injectedReadme(readme, "NEW CATALOG");
+    assert.equal(
+      result,
+      `# Title\n\n${BEGIN}\n\nNEW CATALOG\n\n${END}\n\nfooter`,
+    );
+    assert.match(result, /^# Title/);
+    assert.match(result, /footer$/);
+  });
+
+  test("throws when a marker is missing", () => {
+    assert.throws(
+      () => injectedReadme(`no markers here`, "x"),
+      /missing the .* markers/,
+    );
+  });
+
+  test("throws when the end marker precedes the begin marker", () => {
+    assert.throws(
+      () => injectedReadme(`${END} ... ${BEGIN}`, "x"),
+      /missing the .* markers/,
+    );
+  });
+});
+
+// --- loadOverlays: parse a directory of overlays, filter, sort by netuid ----
+
+describe("loadOverlays", () => {
+  test("parses *.json, drops entries without an integer netuid, sorts ascending", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "readme-overlays-"));
+    try {
+      writeFileSync(
+        path.join(dir, "b.json"),
+        JSON.stringify({ netuid: 7, name: "Seven" }),
+      );
+      writeFileSync(
+        path.join(dir, "a.json"),
+        JSON.stringify({ netuid: 2, name: "Two" }),
+      );
+      // No netuid -> filtered out.
+      writeFileSync(path.join(dir, "c.json"), JSON.stringify({ name: "Nope" }));
+      // Non-.json -> ignored entirely.
+      writeFileSync(path.join(dir, "notes.txt"), "ignore me");
+
+      const overlays = loadOverlays(dir);
+      assert.deepEqual(
+        overlays.map((o) => o.netuid),
+        [2, 7],
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds the missing unit-test coverage for the README subnet-catalog generator (`scripts/generate-registry-readme-section.mjs`) — the one outlier in the codebase's own convention, where every other `scripts/lib/*.mjs` helper already has a matching `tests/*.test.mjs` (`readme-links.mjs` being the closest sibling).

## How

Its logic lived inline in `scripts/`, so nothing was exported and nothing was testable. This extracts the pure functions **verbatim** into `scripts/lib/registry-readme-section.mjs`:
- `loadOverlays` (now takes its directory as an argument so it's testable against a fixture dir), `focusTags`, `links`, `renderCatalog`, `injectedReadme`, plus the marker/provenance constants.
- The generator is reduced to the `README.md` read/write + `--check` wiring, importing from the lib. **Output is byte-identical** (`git diff README.md` is empty after regenerating; the catalog itself is unchanged and stays owned out-of-band by `.github/workflows/readme-catalog-refresh.yml`).

## Tests

`tests/registry-readme-section.test.mjs` — 13 cases:
- `focusTags`: `PROVENANCE_PREFIX` + `PROVENANCE_EXACT` filtering, missing-categories
- `links`: site/docs/repo composition + order + em-dash fallback
- `renderCatalog`: header coverage stats, focus-area ranking (by count then name, provenance excluded), per-subnet bullets incl. the unnamed→`Subnet N` fallback
- `injectedReadme`: splice between markers + both malformed-marker throws
- `loadOverlays`: parse a fixture dir, drop non-integer `netuid`, ignore non-`.json`, sort ascending

Closes #6247.