### PR TITLE
fix(ui): render the already-fetched max_validator_trust on the validator detail page

### DIFF
--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -353,6 +353,13 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
         />
         <StatTile
+          icon={Gauge}
+          eyebrow="Max validator trust"
+          value={scoreStr(detail.max_validator_trust)}
+          hint="best subnet"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+        />
+        <StatTile
           icon={Percent}
           eyebrow="Take rate"
           value={formatTakePct(detail.take)}


### PR DESCRIPTION
## What

`validatorDetailQuery` already normalizes `max_validator_trust` (`queries.ts:6036`), and it's a real, populated field — verified against live production data (e.g. hotkey `5E2LP6...TKeZ5u` returns `avg_validator_trust=0.937763`, `max_validator_trust=1`) — but `validators.$hotkey.tsx` only ever rendered `avg_validator_trust`.

Adds a "Max validator trust" `StatTile` immediately after the existing "Avg validator trust" one, same icon/styling, using the same `scoreStr` formatter already applied to the sibling metric.

## Scope

- 1 file, +7 lines. No new component, no layout change — same `StatTile` grid, one more tile.

## Screenshot evidence

Captured on `/validators/5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u` ("tao.bot"), confirmed against the actual dev server's SSR output before capturing.

| Viewport · Theme | Before | After |
| ---- | ---- | ---- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6254-validator-max-trust-after-mobile-dark.png)<br><sub>after</sub> |

## Verification

- `npx eslint` run from within `apps/ui`: 0 errors, 0 warnings.
- Confirmed the field is non-null on real live data (curled the public API), not just present in the type/normalizer.
- Rebased onto current `main`.

Closes #6254
