### PR TITLE
fix(ui): extract testable threshold logic from use-mobile/use-scrolled

### DIFF
--- a/apps/ui/src/hooks/use-mobile.test.ts
+++ b/apps/ui/src/hooks/use-mobile.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { isMobileWidth } from "./use-mobile";
+
+describe("isMobileWidth", () => {
+  it("is mobile below the default 768px breakpoint", () => {
+    expect(isMobileWidth(767)).toBe(true);
+  });
+
+  it("is not mobile at the default 768px breakpoint", () => {
+    expect(isMobileWidth(768)).toBe(false);
+  });
+
+  it("is not mobile above the default 768px breakpoint", () => {
+    expect(isMobileWidth(1280)).toBe(false);
+  });
+
+  it("honors a custom breakpoint", () => {
+    expect(isMobileWidth(1023, 1024)).toBe(true);
+    expect(isMobileWidth(1024, 1024)).toBe(false);
+  });
+});

--- a/apps/ui/src/hooks/use-mobile.tsx
+++ b/apps/ui/src/hooks/use-mobile.tsx
@@ -2,16 +2,21 @@ import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;
 
+/** Pure breakpoint comparison for useIsMobile; exported for unit tests. */
+export function isMobileWidth(width: number, breakpoint: number = MOBILE_BREAKPOINT): boolean {
+  return width < breakpoint;
+}
+
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
 
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsMobile(isMobileWidth(window.innerWidth));
     };
     mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setIsMobile(isMobileWidth(window.innerWidth));
     return () => mql.removeEventListener("change", onChange);
   }, []);
 

--- a/apps/ui/src/hooks/use-scrolled.test.ts
+++ b/apps/ui/src/hooks/use-scrolled.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { isPastScrollThreshold } from "./use-scrolled";
+
+describe("isPastScrollThreshold", () => {
+  it("is not past the default 4px threshold below it", () => {
+    expect(isPastScrollThreshold(3, 4)).toBe(false);
+  });
+
+  it("is not past the default 4px threshold at it", () => {
+    expect(isPastScrollThreshold(4, 4)).toBe(false);
+  });
+
+  it("is past the default 4px threshold above it", () => {
+    expect(isPastScrollThreshold(5, 4)).toBe(true);
+  });
+
+  it("honors a custom threshold", () => {
+    expect(isPastScrollThreshold(100, 200)).toBe(false);
+    expect(isPastScrollThreshold(200, 200)).toBe(false);
+    expect(isPastScrollThreshold(201, 200)).toBe(true);
+  });
+});

--- a/apps/ui/src/hooks/use-scrolled.ts
+++ b/apps/ui/src/hooks/use-scrolled.ts
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
 
+/** Pure threshold comparison for useScrolled; exported for unit tests. */
+export function isPastScrollThreshold(scrollY: number, threshold: number): boolean {
+  return scrollY > threshold;
+}
+
 /**
  * Returns `true` once the window (or a custom scroll root) has scrolled past
  * `threshold` pixels. Used to toggle scroll-shadows on sticky toolbars.
@@ -10,7 +15,7 @@ export function useScrolled(threshold = 4): boolean {
   useEffect(() => {
     if (typeof window === "undefined") return;
     const onScroll = () => {
-      setScrolled(window.scrollY > threshold);
+      setScrolled(isPastScrollThreshold(window.scrollY, threshold));
     };
     onScroll();
     window.addEventListener("scroll", onScroll, { passive: true });


### PR DESCRIPTION
## Summary
- `use-mobile.tsx` (`useIsMobile`) and `use-scrolled.ts` (`useScrolled`) each inlined a plain numeric-threshold comparison directly in the hook body, unlike every other stateful hook in `apps/ui/src/hooks` (`use-refetch-interval.ts`'s `resolveRefetchInterval`, `use-endpoint-health.ts`'s `classifyEndpointLatency`), which all extract the pure decision logic as an exported, independently-testable function.
- Extracted `isMobileWidth(width, breakpoint = 768)` from `use-mobile.tsx` and `isPastScrollThreshold(scrollY, threshold)` from `use-scrolled.ts`, and call them from the existing `useEffect`/`onScroll` call sites. No runtime behavior change — output is identical for every input.
- Added `use-mobile.test.ts` and `use-scrolled.test.ts` unit-testing both pure functions at their boundary values (below/at/above threshold, plus a custom non-default threshold), following the boundary-value style of `use-endpoint-health.test.ts`.

This PR is confined to `apps/ui/src/hooks/**` and test files with no visual/rendered-output change, so it isn't a guarded path per the repo's own contribution guide.

Closes #6241

## Test plan
- [x] `npx vitest run apps/ui/src/hooks/use-mobile.test.ts apps/ui/src/hooks/use-scrolled.test.ts` — 8 new tests pass
- [x] `npx vitest run` (apps/ui, full suite) — 135 files / 1031 tests pass
- [x] `npx tsc --noEmit -p apps/ui` — clean
- [x] `npx eslint apps/ui/src/hooks/use-mobile.tsx apps/ui/src/hooks/use-scrolled.ts apps/ui/src/hooks/use-mobile.test.ts apps/ui/src/hooks/use-scrolled.test.ts` — clean
- [x] `npm run format:check --workspace=apps/ui` — clean