### PR TITLE
feat(api): add missing_kinds filter to review-gap-priorities collection

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -20654,6 +20654,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 review_state?: string;
                 fields?: string;
                 limit?: number;
@@ -23827,6 +23828,7 @@ export interface operations {
         parameters: {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 review_state?: string;
                 fields?: string;
                 limit?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -3462,6 +3462,7 @@
       "query_filter_names": [
         "netuid",
         "curation_level",
+        "missing_kinds",
         "review_state"
       ],
       "query_parameters": [
@@ -3482,6 +3483,28 @@
               "machine-verified",
               "maintainer-reviewed",
               "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "missing_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
             ],
             "type": "string"
           }
@@ -3566,6 +3589,7 @@
       "query_collection": "review-gap-priorities",
       "query_filter_names": [
         "curation_level",
+        "missing_kinds",
         "review_state"
       ],
       "query_parameters": [
@@ -3579,6 +3603,28 @@
               "machine-verified",
               "maintainer-reviewed",
               "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "missing_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
             ],
             "type": "string"
           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -40642,6 +40642,30 @@
           },
           {
             "in": "query",
+            "name": "missing_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "review_state",
             "required": false,
             "schema": {
@@ -45692,6 +45716,30 @@
                 "machine-verified",
                 "maintainer-reviewed",
                 "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "missing_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
               ],
               "type": "string"
             }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -20654,6 +20654,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 review_state?: string;
                 fields?: string;
                 limit?: number;
@@ -23827,6 +23828,7 @@ export interface operations {
         parameters: {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 review_state?: string;
                 fields?: string;
                 limit?: number;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -355,6 +355,7 @@ export const API_QUERY_COLLECTIONS = {
     filters: {
       netuid: integerSchema,
       curation_level: enumSchema(QUERY_ENUMS.curationLevel),
+      missing_kinds: enumSchema(QUERY_ENUMS.surfaceKind),
       review_state: filterTextSchema,
     },
     sort: [

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1715,6 +1715,23 @@ describe("Worker runtime", () => {
           ),
       ],
       [
+        "https://metagraph.sh/api/v1/review/gaps?missing_kinds=openapi",
+        (body) =>
+          body.data.priorities.length > 0 &&
+          body.data.priorities.every((entry) =>
+            entry.missing_kinds.includes("openapi"),
+          ),
+      ],
+      [
+        "https://metagraph.sh/api/v1/subnets/103/gaps?missing_kinds=openapi",
+        (body) =>
+          body.data.priorities.length > 0 &&
+          body.data.priorities.every(
+            (entry) =>
+              entry.netuid === 103 && entry.missing_kinds.includes("openapi"),
+          ),
+      ],
+      [
         "https://metagraph.sh/api/v1/subnets/7/health?status=ok",
         (body) =>
           body.data.surfaces.every(
@@ -1756,6 +1773,7 @@ describe("Worker runtime", () => {
       "https://metagraph.sh/api/v1/review/enrichment-queue?direct_submission_kinds=seed-node",
       "https://metagraph.sh/api/v1/review/enrichment-queue?identity_level=unknown",
       "https://metagraph.sh/api/v1/review/enrichment-evidence?missing_kinds=seed-node",
+      "https://metagraph.sh/api/v1/review/gaps?missing_kinds=seed-node",
       "https://metagraph.sh/api/v1/review/enrichment-targets?target_type=unknown",
       "https://metagraph.sh/api/v1/subnets/7/health?status=alive",
     ];


### PR DESCRIPTION
## Summary

`missing_kinds` was already a legal `sort=` target on the `review-gap-priorities` collection but had no matching `filters` entry — a caller could order the review-gap queue by which surface kind is missing without being able to narrow it to one. Both routes the collection backs (`GET /api/v1/review/gaps` and `GET /api/v1/subnets/{netuid}/gaps`) were affected.

## Change

Adds the identical `missing_kinds: enumSchema(QUERY_ENUMS.surfaceKind)` filter entry that the sibling `enrichment-queue` and `enrichment-targets` collections already use for this exact field. Rows carry `missing_kinds` as an array, so `filterRows`'s existing `Array.isArray` membership branch handles it — no new filter machinery. The `sort` array and both sibling collections are untouched.

Regenerated the OpenAPI / api-index / type artifacts, which pick up the new optional query parameter on both routes.

Closes #6240

## Verified against the built artifact

```
GET /api/v1/review/gaps?limit=200
  → 129 rows; missing_kinds histogram:
    sse=127, openapi=70, website=9, source-repo=9, subnet-api=9, data-artifact=8

GET /api/v1/review/gaps?missing_kinds=openapi        → 200, 70 rows, every row's array contains "openapi"
GET /api/v1/subnets/103/gaps?missing_kinds=openapi   → 200, scoped route honors it (netuid 103)
GET /api/v1/review/gaps?missing_kinds=seed-node
  → 400 {"error":{"code":"invalid_query"}, "meta":{"parameter":"missing_kinds"}}
```

That 400 envelope is byte-identical to the sibling collections' — same code, same `meta.parameter`.

## Tests

Three cases added to `tests/worker-runtime.test.mjs`, each beside the sibling entry it mirrors: the array-membership filter on the bulk route (`?missing_kinds=openapi`), the same on the per-subnet route (`?missing_kinds=openapi`, netuid 103), and the off-vocabulary value in the shared 400 `invalid_query` table.

## Validation

- `npx vitest run tests/worker-runtime.test.mjs` — 50/50 passed
- `npm run test:coverage` — full suite green; all modified/coverable lines covered
- `npm run lint` · `npm run format:check` — clean
- `npm run validate:contract-drift` · `validate:openapi` (159 routes) · `validate:openapi-examples` (159/159) · `validate:types` · `validate:api`
