### PR TITLE
refactor(scripts): extract README catalog helpers into scripts/lib for testability

### DIFF
--- a/scripts/generate-registry-readme-section.mjs
+++ b/scripts/generate-registry-readme-section.mjs
@@ -11,112 +11,22 @@
 // visibility → more contributions). Live health/readiness links out to the profile
 // rather than being inlined, so there are no per-view badge requests baked into git.
 //
+// The pure catalog-rendering helpers live in scripts/lib/readme-catalog.mjs (#6247);
+// this file is a thin CLI wrapper over them.
+//
 //   node scripts/generate-registry-readme-section.mjs           # write README.md
 //   node scripts/generate-registry-readme-section.mjs --check    # verify up-to-date
 
-import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { repoRoot } from "./lib.mjs";
+import {
+  injectedReadme,
+  loadOverlays,
+  renderCatalog,
+} from "./lib/readme-catalog.mjs";
 
-const BEGIN = "<!-- BEGIN:REGISTRY-CATALOG -->";
-const END = "<!-- END:REGISTRY-CATALOG -->";
 const README_PATH = path.join(repoRoot, "README.md");
-const OVERLAYS_DIR = path.join(repoRoot, "registry/subnets");
-const SITE = "https://metagraph.sh";
-const API = "https://api.metagraph.sh";
-
-// Provenance / process tags (how an entry was curated) are noise in a catalog —
-// keep only the use-case "focus" tags. Prefix-matched so new official-*/baseline-*
-// tags are filtered automatically.
-const PROVENANCE_PREFIX = /^(official|baseline|identity)-/;
-const PROVENANCE_EXACT = new Set([
-  "pilot",
-  "root",
-  "system",
-  "native-only",
-  "macrocosmos",
-]);
-
-function loadOverlays() {
-  return readdirSync(OVERLAYS_DIR)
-    .filter((file) => file.endsWith(".json"))
-    .map((file) =>
-      JSON.parse(readFileSync(path.join(OVERLAYS_DIR, file), "utf8")),
-    )
-    .filter((overlay) => Number.isInteger(overlay?.netuid))
-    .sort((a, b) => a.netuid - b.netuid);
-}
-
-function focusTags(overlay) {
-  return (overlay.categories || [])
-    .filter((tag) => !PROVENANCE_PREFIX.test(tag) && !PROVENANCE_EXACT.has(tag))
-    .sort();
-}
-
-function links(overlay) {
-  const out = [];
-  if (overlay.website_url) out.push(`[site](${overlay.website_url})`);
-  if (overlay.docs_url) out.push(`[docs](${overlay.docs_url})`);
-  if (overlay.source_repo) out.push(`[repo](${overlay.source_repo})`);
-  return out.join(" · ") || "—";
-}
-
-function renderCatalog(overlays) {
-  const focusCounts = new Map();
-  for (const overlay of overlays) {
-    for (const tag of focusTags(overlay)) {
-      focusCounts.set(tag, (focusCounts.get(tag) || 0) + 1);
-    }
-  }
-  const topFocus = [...focusCounts.entries()]
-    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-    .slice(0, 12)
-    .map(([tag, count]) => `\`${tag}\` ${count}`)
-    .join(" · ");
-
-  const withSite = overlays.filter((o) => o.website_url).length;
-  const withDocs = overlays.filter((o) => o.docs_url).length;
-  const withRepo = overlays.filter((o) => o.source_repo).length;
-
-  // A bulleted list (not a markdown table): Prettier pads table cells to the
-  // widest column, which at ~90 rows of long URLs explodes the diff — a list
-  // stays Prettier-stable and renders just as cleanly on GitHub.
-  const items = overlays.map((overlay) => {
-    const name = overlay.name || `Subnet ${overlay.netuid}`;
-    const focus = focusTags(overlay)
-      .map((tag) => `\`${tag}\``)
-      .join(" ");
-    const linkStr = links(overlay);
-    return (
-      `- **[${name}](${SITE}/subnets/${overlay.netuid})** \`SN${overlay.netuid}\`` +
-      (focus ? ` — ${focus}` : "") +
-      (linkStr !== "—" ? ` · ${linkStr}` : "")
-    );
-  });
-
-  return [
-    `**${overlays.length} curated subnets** — ${withSite} with a site, ${withDocs} with docs, ${withRepo} with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](${SITE})**; per-subnet JSON at \`${API}/api/v1/subnets/{netuid}\`.`,
-    "",
-    `**Focus areas:** ${topFocus}`,
-    "",
-    ...items,
-    "",
-    `<sub>Auto-generated from the curated overlays in \`registry/subnets/\` by \`scripts/generate-registry-readme-section.mjs\` — enrich a subnet (one PR) and it appears here. Not the live list; browse + monitor everything at [metagraph.sh](${SITE}).</sub>`,
-  ].join("\n");
-}
-
-function injectedReadme(readme, catalog) {
-  const beginAt = readme.indexOf(BEGIN);
-  const endAt = readme.indexOf(END);
-  if (beginAt === -1 || endAt === -1 || endAt < beginAt) {
-    throw new Error(
-      `README.md is missing the ${BEGIN} / ${END} markers (add them where the catalog should render).`,
-    );
-  }
-  const before = readme.slice(0, beginAt + BEGIN.length);
-  const after = readme.slice(endAt);
-  return `${before}\n\n${catalog}\n\n${after}`;
-}
 
 function main() {
   const check = process.argv.includes("--check");

--- a/scripts/lib/readme-catalog.mjs
+++ b/scripts/lib/readme-catalog.mjs
@@ -1,0 +1,109 @@
+// README subnet-catalog rendering helpers, extracted verbatim from
+// scripts/generate-registry-readme-section.mjs (#6247 testability decomposition).
+// Pure functions over plain overlay objects/strings (loadOverlays is the only
+// I/O boundary), so the catalog logic is unit-testable without invoking the CLI.
+// scripts/generate-registry-readme-section.mjs is now a thin wrapper that imports
+// from here — mirrors the scripts/lib/readme-links.mjs / scripts/lib.mjs split.
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { repoRoot } from "../lib.mjs";
+
+export const BEGIN = "<!-- BEGIN:REGISTRY-CATALOG -->";
+export const END = "<!-- END:REGISTRY-CATALOG -->";
+const OVERLAYS_DIR = path.join(repoRoot, "registry/subnets");
+const SITE = "https://metagraph.sh";
+const API = "https://api.metagraph.sh";
+
+// Provenance / process tags (how an entry was curated) are noise in a catalog —
+// keep only the use-case "focus" tags. Prefix-matched so new official-*/baseline-*
+// tags are filtered automatically.
+const PROVENANCE_PREFIX = /^(official|baseline|identity)-/;
+const PROVENANCE_EXACT = new Set([
+  "pilot",
+  "root",
+  "system",
+  "native-only",
+  "macrocosmos",
+]);
+
+export function loadOverlays() {
+  return readdirSync(OVERLAYS_DIR)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) =>
+      JSON.parse(readFileSync(path.join(OVERLAYS_DIR, file), "utf8")),
+    )
+    .filter((overlay) => Number.isInteger(overlay?.netuid))
+    .sort((a, b) => a.netuid - b.netuid);
+}
+
+export function focusTags(overlay) {
+  return (overlay.categories || [])
+    .filter((tag) => !PROVENANCE_PREFIX.test(tag) && !PROVENANCE_EXACT.has(tag))
+    .sort();
+}
+
+export function links(overlay) {
+  const out = [];
+  if (overlay.website_url) out.push(`[site](${overlay.website_url})`);
+  if (overlay.docs_url) out.push(`[docs](${overlay.docs_url})`);
+  if (overlay.source_repo) out.push(`[repo](${overlay.source_repo})`);
+  return out.join(" · ") || "—";
+}
+
+export function renderCatalog(overlays) {
+  const focusCounts = new Map();
+  for (const overlay of overlays) {
+    for (const tag of focusTags(overlay)) {
+      focusCounts.set(tag, (focusCounts.get(tag) || 0) + 1);
+    }
+  }
+  const topFocus = [...focusCounts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 12)
+    .map(([tag, count]) => `\`${tag}\` ${count}`)
+    .join(" · ");
+
+  const withSite = overlays.filter((o) => o.website_url).length;
+  const withDocs = overlays.filter((o) => o.docs_url).length;
+  const withRepo = overlays.filter((o) => o.source_repo).length;
+
+  // A bulleted list (not a markdown table): Prettier pads table cells to the
+  // widest column, which at ~90 rows of long URLs explodes the diff — a list
+  // stays Prettier-stable and renders just as cleanly on GitHub.
+  const items = overlays.map((overlay) => {
+    const name = overlay.name || `Subnet ${overlay.netuid}`;
+    const focus = focusTags(overlay)
+      .map((tag) => `\`${tag}\``)
+      .join(" ");
+    const linkStr = links(overlay);
+    return (
+      `- **[${name}](${SITE}/subnets/${overlay.netuid})** \`SN${overlay.netuid}\`` +
+      (focus ? ` — ${focus}` : "") +
+      (linkStr !== "—" ? ` · ${linkStr}` : "")
+    );
+  });
+
+  return [
+    `**${overlays.length} curated subnets** — ${withSite} with a site, ${withDocs} with docs, ${withRepo} with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](${SITE})**; per-subnet JSON at \`${API}/api/v1/subnets/{netuid}\`.`,
+    "",
+    `**Focus areas:** ${topFocus}`,
+    "",
+    ...items,
+    "",
+    `<sub>Auto-generated from the curated overlays in \`registry/subnets/\` by \`scripts/generate-registry-readme-section.mjs\` — enrich a subnet (one PR) and it appears here. Not the live list; browse + monitor everything at [metagraph.sh](${SITE}).</sub>`,
+  ].join("\n");
+}
+
+export function injectedReadme(readme, catalog) {
+  const beginAt = readme.indexOf(BEGIN);
+  const endAt = readme.indexOf(END);
+  if (beginAt === -1 || endAt === -1 || endAt < beginAt) {
+    throw new Error(
+      `README.md is missing the ${BEGIN} / ${END} markers (add them where the catalog should render).`,
+    );
+  }
+  const before = readme.slice(0, beginAt + BEGIN.length);
+  const after = readme.slice(endAt);
+  return `${before}\n\n${catalog}\n\n${after}`;
+}

--- a/tests/readme-catalog.test.mjs
+++ b/tests/readme-catalog.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+
+import {
+  BEGIN,
+  END,
+  focusTags,
+  injectedReadme,
+  links,
+  renderCatalog,
+} from "../scripts/lib/readme-catalog.mjs";
+
+describe("readme-catalog focusTags", () => {
+  test("strips provenance prefix + exact tags, keeps real focus tags (sorted)", () => {
+    const tags = focusTags({
+      categories: [
+        "inference",
+        "official-source-repo", // PROVENANCE_PREFIX official-
+        "baseline-curated", // PROVENANCE_PREFIX baseline-
+        "identity-reviewed", // PROVENANCE_PREFIX identity-
+        "pilot", // PROVENANCE_EXACT
+        "root", // PROVENANCE_EXACT
+        "system", // PROVENANCE_EXACT
+        "native-only", // PROVENANCE_EXACT
+        "macrocosmos", // PROVENANCE_EXACT
+        "agents",
+      ],
+    });
+    assert.deepEqual(tags, ["agents", "inference"]);
+  });
+
+  test("tolerates a missing categories array", () => {
+    assert.deepEqual(focusTags({}), []);
+  });
+});
+
+describe("readme-catalog links", () => {
+  test("renders site/docs/repo in order when all three are present", () => {
+    assert.equal(
+      links({
+        website_url: "https://s",
+        docs_url: "https://d",
+        source_repo: "https://r",
+      }),
+      "[site](https://s) · [docs](https://d) · [repo](https://r)",
+    );
+  });
+
+  test("includes only the present links, preserving order", () => {
+    assert.equal(links({ docs_url: "https://d" }), "[docs](https://d)");
+    assert.equal(
+      links({ website_url: "https://s", source_repo: "https://r" }),
+      "[site](https://s) · [repo](https://r)",
+    );
+  });
+
+  test("falls back to an em-dash when an overlay has none of the three", () => {
+    assert.equal(links({}), "—");
+  });
+});
+
+describe("readme-catalog renderCatalog", () => {
+  test("ranks focus areas by count, breaking ties alphabetically", () => {
+    const overlays = [
+      { netuid: 1, categories: ["b-focus", "a-focus"] },
+      { netuid: 2, categories: ["b-focus"] },
+      { netuid: 3, categories: ["c-focus"] },
+    ];
+    const focusLine = renderCatalog(overlays)
+      .split("\n")
+      .find((line) => line.startsWith("**Focus areas:**"));
+    // b-focus (2) leads; a-focus and c-focus tie at 1 -> alphabetical (a before c).
+    assert.equal(
+      focusLine,
+      "**Focus areas:** `b-focus` 2 · `a-focus` 1 · `c-focus` 1",
+    );
+  });
+
+  test("truncates the Focus areas line to 12 entries", () => {
+    const overlays = Array.from({ length: 20 }, (_, index) => ({
+      netuid: index + 1,
+      categories: [`focus-${String(index).padStart(2, "0")}`],
+    }));
+    const focusLine = renderCatalog(overlays)
+      .split("\n")
+      .find((line) => line.startsWith("**Focus areas:**"));
+    assert.equal((focusLine.match(/`focus-\d+`/g) || []).length, 12);
+  });
+});
+
+describe("readme-catalog injectedReadme", () => {
+  const catalog = "CATALOG_BODY";
+
+  test("splices the catalog between the markers without mutating outside content", () => {
+    const readme = `intro text\n${BEGIN}\nOLD\n${END}\ntrailer text`;
+    const out = injectedReadme(readme, catalog);
+    assert.ok(out.startsWith("intro text\n"));
+    assert.ok(out.endsWith("trailer text"));
+    assert.ok(out.includes(`${BEGIN}\n\n${catalog}\n\n${END}`));
+    assert.ok(!out.includes("OLD"));
+  });
+
+  test("throws when a marker is missing", () => {
+    assert.throws(
+      () => injectedReadme(`only ${BEGIN} here`, catalog),
+      /missing/,
+    );
+    assert.throws(
+      () => injectedReadme("no markers at all", catalog),
+      /missing/,
+    );
+  });
+
+  test("throws when the markers are out of order (END before BEGIN)", () => {
+    assert.throws(
+      () => injectedReadme(`${END} preamble ${BEGIN}`, catalog),
+      /missing/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the pure catalog-rendering functions out of `scripts/generate-registry-readme-section.mjs` into a new `scripts/lib/readme-catalog.mjs` module (mirroring the existing `scripts/lib/readme-links.mjs` / `scripts/lib.mjs` split), so the catalog logic is unit-testable without invoking the CLI. `generate-registry-readme-section.mjs` becomes a thin CLI wrapper that imports from it.

## Changes

- **`scripts/lib/readme-catalog.mjs`** (new): exports `loadOverlays`, `focusTags`, `links`, `renderCatalog`, `injectedReadme` (plus the `BEGIN`/`END` markers) — extracted verbatim, no behavior change.
- **`scripts/generate-registry-readme-section.mjs`**: now a thin CLI wrapper (`main()` + `README_PATH`) importing from the module.
- **`tests/readme-catalog.test.mjs`** (new): covers
  - `focusTags` strips `PROVENANCE_PREFIX` (`official-*`/`baseline-*`/`identity-*`) and `PROVENANCE_EXACT` (`pilot`/`root`/`system`/`native-only`/`macrocosmos`) tags while keeping real focus tags (sorted), and tolerates a missing `categories`;
  - `links()` renders site/docs/repo in order, includes only present links, and falls back to `—`;
  - `renderCatalog` ranks focus areas by count with alphabetical tie-break and truncates the Focus-areas line to 12;
  - `injectedReadme` splices between the markers without mutating outside content, and throws on missing / out-of-order markers.

## Verification

Internal extraction only — no behavior change. `npm run validate:readme-catalog` (`--check`) still passes (README byte-identical, 129 curated subnets), so `.github/workflows/readme-catalog-refresh.yml` keeps working unchanged. No `apps/ui` change, no new route. 10 new unit tests pass.

Closes #6247