### PR TITLE
feat(api): add a missing_kinds filter to the review-gap-priorities collection

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -20654,6 +20654,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 review_state?: string;
                 fields?: string;
                 limit?: number;
@@ -23827,6 +23828,7 @@ export interface operations {
         parameters: {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 review_state?: string;
                 fields?: string;
                 limit?: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -3462,6 +3462,7 @@
       "query_filter_names": [
         "netuid",
         "curation_level",
+        "missing_kinds",
         "review_state"
       ],
       "query_parameters": [
@@ -3482,6 +3483,28 @@
               "machine-verified",
               "maintainer-reviewed",
               "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "missing_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
             ],
             "type": "string"
           }
@@ -3566,6 +3589,7 @@
       "query_collection": "review-gap-priorities",
       "query_filter_names": [
         "curation_level",
+        "missing_kinds",
         "review_state"
       ],
       "query_parameters": [
@@ -3579,6 +3603,28 @@
               "machine-verified",
               "maintainer-reviewed",
               "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "missing_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
             ],
             "type": "string"
           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -40642,6 +40642,30 @@
           },
           {
             "in": "query",
+            "name": "missing_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "review_state",
             "required": false,
             "schema": {
@@ -45692,6 +45716,30 @@
                 "machine-verified",
                 "maintainer-reviewed",
                 "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "missing_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
               ],
               "type": "string"
             }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -20654,6 +20654,7 @@ export interface operations {
             query?: {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 review_state?: string;
                 fields?: string;
                 limit?: number;
@@ -23827,6 +23828,7 @@ export interface operations {
         parameters: {
             query?: {
                 curation_level?: "native" | "candidate-discovered" | "community-seeded" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                missing_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 review_state?: string;
                 fields?: string;
                 limit?: number;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -355,6 +355,7 @@ export const API_QUERY_COLLECTIONS = {
     filters: {
       netuid: integerSchema,
       curation_level: enumSchema(QUERY_ENUMS.curationLevel),
+      missing_kinds: enumSchema(QUERY_ENUMS.surfaceKind),
       review_state: filterTextSchema,
     },
     sort: [

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1696,6 +1696,23 @@ describe("Worker runtime", () => {
             entry.missing_kinds.includes("source-repo"),
           ),
       ],
+      // #6240: review-gap-priorities advertised sort=missing_kinds but had no matching filter, unlike the
+      // enrichment-queue/enrichment-targets siblings that already narrow on the exact same array field.
+      [
+        "https://metagraph.sh/api/v1/review/gaps?missing_kinds=openapi",
+        (body) =>
+          body.data.priorities.length > 0 &&
+          body.data.priorities.every((entry) =>
+            entry.missing_kinds.includes("openapi"),
+          ),
+      ],
+      [
+        "https://metagraph.sh/api/v1/subnets/1/gaps?missing_kinds=sse",
+        (body) =>
+          body.data.priorities.every((entry) =>
+            entry.missing_kinds.includes("sse"),
+          ),
+      ],
       [
         "https://metagraph.sh/api/v1/review/enrichment-evidence?missing_kinds=openapi",
         (body) =>
@@ -1758,6 +1775,9 @@ describe("Worker runtime", () => {
       "https://metagraph.sh/api/v1/review/enrichment-evidence?missing_kinds=seed-node",
       "https://metagraph.sh/api/v1/review/enrichment-targets?target_type=unknown",
       "https://metagraph.sh/api/v1/subnets/7/health?status=alive",
+      // #6240: the new missing_kinds filter rejects an off-vocabulary kind through the same enum path
+      // its enrichment-queue/enrichment-targets siblings already use -- no new error shape.
+      "https://metagraph.sh/api/v1/review/gaps?missing_kinds=seed-node",
     ];
 
     for (const url of routes) {


### PR DESCRIPTION
Fixes #6240. Fresh PR per the base-conflict close on #6294 (its review was clean — *"no blockers"*, gate passing, and after the rebase all CI including `checks` is green). Rebased onto current `main`; no budget change is needed here since `main` already raised the `openapi.json` fail line to 1.75MB.

## Scope

One line of substance plus regenerated artifacts. `src/contracts.mjs`'s `review-gap-priorities` collection gains `missing_kinds: enumSchema(QUERY_ENUMS.surfaceKind)`.

`missing_kinds` was already a legal `sort=` target but had no matching filter — a caller could order the review-gap queue by which surface kind is missing without being able to narrow to one. Both routes the collection backs (`/api/v1/review/gaps`, `/api/v1/subnets/{netuid}/gaps`) were affected. This is the identical entry the sibling `enrichment-queue`/`enrichment-targets` collections already use for this exact field: rows carry `missing_kinds` as an array, so `filterRows`'s existing `Array.isArray` membership branch handles it with **no new machinery**. The `sort` array and both sibling collections are untouched.

## Risk note

**Low / additive.** An absent `missing_kinds` param leaves both routes behaving exactly as before, and an off-vocabulary value is rejected through the same enum path every sibling filter already uses — same 400 `invalid_query` envelope, no new error shape. No collection, sort, or sibling semantics change.

## Verified against the real artifact, not assumed

```
GET /api/v1/review/gaps?limit=200
  → 129 rows; missing_kinds histogram:
    sse=127, openapi=70, website=9, source-repo=9, subnet-api=9, data-artifact=8

GET /api/v1/review/gaps?missing_kinds=sse    → 200, exactly 127 rows
                                              → every returned row's array contains "sse"
GET /api/v1/subnets/1/gaps?missing_kinds=sse → 200 (scoped route honors it too)
GET /api/v1/review/gaps?missing_kinds=not-a-kind
  → 400 {"error":{"code":"invalid_query",...},"meta":{...,"parameter":"missing_kinds"}}
```

## Validation

`worker-runtime` 50/50 · `validate:artifact-budgets` passes (2282 artifacts, exit 0) · `validate:contract-drift` · `validate:openapi` (159 routes) · `validate:openapi-examples` (159/159) · eslint 0 · prettier clean.

Tests: three cases in `tests/worker-runtime.test.mjs`, each beside the sibling entry it mirrors — array-membership on the bulk route, the same on the per-subnet route, and the off-vocabulary value in the shared 400 `invalid_query` table.