### PR TITLE
fix(ui): normalizeProvider never mapped github_url to repo, so the detail page's repo link was always empty

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -7464,6 +7464,7 @@ export function normalizeProvider(raw: unknown, slug: string): Provider {
   const summary = (root.endpoint_summary as Record<string, unknown> | undefined) ?? undefined;
   const website = pickStr(inner.website_url, inner.homepage, inner.website);
   const docs = pickStr(inner.docs_url, inner.docs);
+  const repo = pickStr(inner.github_url, inner.repo, inner.repository);
   return {
     // Spread raw fields FIRST so the normalized/computed fields below win on
     // collision (mirrors normalizeProviderListItem). Spreading `...inner` last
@@ -7476,6 +7477,7 @@ export function normalizeProvider(raw: unknown, slug: string): Provider {
     homepage: website,
     website,
     docs,
+    repo,
     notes: pickStr(inner.notes),
     endpoint_summary: summary as ProviderEndpointSummary | undefined,
     // Normalize singular API field names (endpoint_count / surface_count) to

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -130,7 +130,9 @@ function ProviderShell({ slug }: { slug: string }) {
         title={p?.name ?? slug}
         subtitle={shouldShowProviderSlugSubtitle(p?.name, slug) ? <>· {slug}</> : null}
         description={p?.notes}
-        links={<PrimaryLinksRail website={p?.website ?? p?.homepage} docs={p?.docs} />}
+        links={
+          <PrimaryLinksRail website={p?.website ?? p?.homepage} docs={p?.docs} repo={p?.repo} />
+        }
         stats={[
           { label: "Endpoints", value: formatNumber(summary?.endpoint_count) },
           { label: "Monitored", value: formatNumber(summary?.monitored_count) },


### PR DESCRIPTION
## What

The issue as filed assumed `p?.repo` was already populated and just needed wiring into `PrimaryLinksRail`'s `links={}` call. It wasn't: `normalizeProviderListItem` (used by the `/providers` list page) already computes `repo = pickStr(github_url, repo, repository)`, but `normalizeProvider` (used by this detail page) never did — so `p?.repo` was `undefined` for every provider. Verified against live production data: **0 of 100 providers** have a literal `repo` field; 80 have `github_url`. `BrandIcon`'s existing `repoUrl={p?.repo}` was silently a no-op too.

- `queries.ts`: `normalizeProvider` now mirrors the list-page normalizer's `repo` mapping.
- `providers.$slug.tsx`: wires the now-real `repo` value into `PrimaryLinksRail` (which already fully supports a `repo` prop and renders a "Repository" pill).

## Scope

- 2 files, +5/-1 lines. No layout/design changes.

## Screenshot evidence

Captured on `/providers/404-gen`, verified against the actual dev server's SSR output before capturing.

| Viewport · Theme | Before | After |
| ---- | ---- | ---- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6243-provider-repo-link-after-mobile-dark.png)<br><sub>after</sub> |

## Verification

- `npx eslint` run from within `apps/ui`: 0 errors, 0 warnings.
- Confirmed the fix against live production data and the actual dev server's rendered HTML.
- Rebased onto current `main`.

Closes #6243

(Resubmission of #6289, closed by an unrelated repo-wide `checks` gate failure (`openapi.json` artifact-budget) that also failed on the maintainer's own already-merged commits at the time — confirmed cleared on current `main` before resubmitting.)
