### PR TITLE
feat(schema): add exchange_listings to the subnet manifest schema (#6274)

### DIFF
--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -70,6 +70,13 @@
         "$ref": "#/$defs/link"
       }
     },
+    "exchange_listings": {
+      "type": "array",
+      "description": "Centralized-exchange listings where this subnet's token trades (Taostats-parity metadata, #6274). Display-only registry metadata like `social` — not a live-verified surface, so it carries no probe/verification machinery.",
+      "items": {
+        "$ref": "#/$defs/exchange_listing"
+      }
+    },
     "contact": {
       "type": "string",
       "description": "Curated operator support contact (email or public URL, harvested from SubnetIdentitiesV3 subnet_contact) — sanitized at build via subnetContact. Display-only; never feeds completeness."
@@ -416,6 +423,28 @@
         "source_url": {
           "type": "string",
           "format": "uri"
+        }
+      }
+    },
+    "exchange_listing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exchange", "url"],
+      "properties": {
+        "exchange": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Exchange name, e.g. \"MEXC\", \"Kraken\"."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Link to the market/listing page for this token on the exchange."
+        },
+        "pair": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional traded pair identifier, e.g. \"TAO/USDT\"."
         }
       }
     },

--- a/tests/subnet-manifest-exchange-listings.test.mjs
+++ b/tests/subnet-manifest-exchange-listings.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { describe, test } from "vitest";
+import { repoRoot } from "../scripts/lib.mjs";
+
+// #6274: exchange_listings is additive registry metadata on the subnet manifest,
+// following the links[]/social pattern (an array of structured objects, no
+// probe/verification machinery). These validate the new field's shape against
+// the real schema.
+
+const schema = JSON.parse(
+  readFileSync(
+    path.join(repoRoot, "schemas/subnet-manifest.schema.json"),
+    "utf8",
+  ),
+);
+const ajv = addFormats(new Ajv2020({ allErrors: true, strict: false }));
+const validate = ajv.compile(schema);
+
+// A minimal manifest carrying every required field, so a test only exercises the
+// exchange_listings field it overrides.
+function manifest(overrides = {}) {
+  return {
+    schema_version: 1,
+    netuid: 1,
+    name: "Example",
+    slug: "example",
+    status: "active",
+    categories: [],
+    surfaces: [],
+    ...overrides,
+  };
+}
+
+describe("subnet-manifest schema: exchange_listings (#6274)", () => {
+  test("accepts valid entries (exchange + url, optional pair)", () => {
+    const ok = validate(
+      manifest({
+        exchange_listings: [
+          { exchange: "MEXC", url: "https://www.mexc.com/x", pair: "TAO/USDT" },
+          { exchange: "Kraken", url: "https://pro.kraken.com/app/trade/x" },
+        ],
+      }),
+    );
+    assert.equal(ok, true, JSON.stringify(validate.errors));
+  });
+
+  test("is optional/additive — a manifest without it still validates", () => {
+    assert.equal(validate(manifest()), true, JSON.stringify(validate.errors));
+    assert.equal(validate(manifest({ exchange_listings: [] })), true);
+  });
+
+  test("requires both exchange and url on each entry", () => {
+    assert.equal(
+      validate(manifest({ exchange_listings: [{ url: "https://x.com" }] })),
+      false,
+    );
+    assert.equal(
+      validate(manifest({ exchange_listings: [{ exchange: "MEXC" }] })),
+      false,
+    );
+  });
+
+  test("rejects a non-uri url, an empty exchange, and unknown properties", () => {
+    assert.equal(
+      validate(
+        manifest({ exchange_listings: [{ exchange: "MEXC", url: "nope" }] }),
+      ),
+      false,
+    );
+    assert.equal(
+      validate(
+        manifest({
+          exchange_listings: [{ exchange: "", url: "https://x.com" }],
+        }),
+      ),
+      false,
+    );
+    assert.equal(
+      validate(
+        manifest({
+          exchange_listings: [
+            { exchange: "MEXC", url: "https://x.com", ticker: "TAO" },
+          ],
+        }),
+      ),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds an optional `exchange_listings` field to `schemas/subnet-manifest.schema.json`, closing the Taostats-parity gap so a subnet's registry manifest can record where its token trades.

## How

Follows the existing `links[]` / `social` pattern exactly:
- New `$defs/exchange_listing` mirroring `$defs/link` — an object with `additionalProperties: false`, `required: [exchange, url]`, plus an optional `pair` (e.g. `"TAO/USDT"`). Each property is documented (schema-as-docs, like the other manifest fields).
- `exchange_listings` property = `{ type: "array", items: { $ref: "#/$defs/exchange_listing" } }`, mirroring `links`.
- Display-only registry metadata like `social` — **no probe/verification machinery**, additive/optional (no migration for the 129 existing overlays).

## On the "regenerate artifacts" deliverable

This is registry-**input** metadata: the manifest schema doesn't feed the API contract schemas (`api-components` / OpenAPI / generated types are derived from `schemas/components/*`, not the manifest), so **nothing regenerates and `validate:contract-drift` stays green** (verified). Surfacing `exchange_listings` on the `/subnets` API *response* — `schemas/components/05-subnets.schema.json` + the manifest→response copy in `build-artifacts.mjs`, mirroring how `social` flows — is a clean, separable follow-up; happy to do it in this PR or a next one, whichever you prefer.

## Tests

`tests/subnet-manifest-exchange-listings.test.mjs` validates the new field against the real schema via Ajv: valid entries accepted, field optional, `exchange`+`url` required, and non-uri url / empty exchange / unknown property all rejected.

Closes #6274.