### PR TITLE
test: cover llms.txt / llms-full.txt generation from build-artifacts.mjs (#6250)

### DIFF
--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -27,8 +27,13 @@ import {
   r2StagingRoot,
   registrySurfaceKey,
   isSurfaceStale,
+  loadSubnets,
 } from "../scripts/lib.mjs";
-import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import {
+  CONTRACT_VERSION,
+  API_ROUTES,
+  PRIMARY_DOMAIN,
+} from "../src/contracts.mjs";
 import { handleRequest } from "../workers/api.mjs";
 
 // The committed digests the forged-build tests snapshot + restore (so a forged
@@ -98,6 +103,63 @@ beforeAll(() => {
 afterAll(() => {
   restorePublicTree(publicTreeSnapshot);
 });
+
+// #6250: the llms.txt family (public/llms.txt, public/llms-full.txt,
+// public/.well-known/llms.txt) is .gitignored — never committed, regenerated on
+// every build — so the committed-artifact freshness gate can't see it and there
+// is no reviewable diff. Tests that run the real build are the only regression
+// net. This is the natural home: the build+snapshot/restore harness above is the
+// only place a generated-but-uncommitted artifact can be read safely.
+test("llms.txt family is generated with the expected structure", async () => {
+  const subnets = await loadSubnets();
+  let short, wellKnown, full;
+  try {
+    runNode("scripts/build-artifacts.mjs");
+    const read = (rel) => readFileSync(path.join(PUBLIC_TREE, rel), "utf8");
+    short = read("llms.txt");
+    wellKnown = read(".well-known/llms.txt");
+    full = read("llms-full.txt");
+  } finally {
+    // build-artifacts.mjs regenerates the whole public/ tree from current
+    // source (which drifts from the committed seed), so restore it before the
+    // next test — otherwise tree-reading tests like "registry validates" run
+    // against the regenerated tree and fail. (afterAll restores again; the
+    // sibling build-running tests below restore in their own finally too.)
+    restorePublicTree(publicTreeSnapshot);
+  }
+  const base = `https://${PRIMARY_DOMAIN}`;
+
+  // public/.well-known/llms.txt is a byte-identical copy of the short index.
+  assert.equal(wellKnown, short);
+
+  // The short index carries "## Machine entrypoints" with the OpenAPI,
+  // agent-catalog, and MCP-server links.
+  assert.match(short, /^## Machine entrypoints$/m);
+  assert.ok(short.includes(`${base}/metagraph/openapi.json`), "openapi link");
+  assert.ok(
+    short.includes(`${base}/api/v1/agent-catalog`),
+    "agent-catalog link",
+  );
+  assert.ok(short.includes(`${base}/mcp`), "MCP server link");
+
+  // llms-full.txt has one "## Subnets" bullet per subnet in the registry ...
+  assert.match(full, /^## Subnets$/m);
+  const subnetsSection = full
+    .split("## Subnets")[1]
+    .split("## All API routes")[0];
+  const subnetBullets = subnetsSection.match(/^- SN\d+ /gm) ?? [];
+  assert.equal(subnetBullets.length, subnets.length);
+
+  // ... and a "## All API routes" section listing every API_ROUTES entry.
+  assert.match(full, /^## All API routes$/m);
+  const routesSection = full.split("## All API routes")[1];
+  for (const entry of API_ROUTES) {
+    assert.ok(
+      routesSection.includes(`\`${entry.method} ${entry.path}\``),
+      `llms-full.txt missing API route: ${entry.method} ${entry.path}`,
+    );
+  }
+}, 30_000);
 
 test("registry validates", () => {
   runNode("scripts/validate.mjs");


### PR DESCRIPTION
Closes #6250.

## What

The llms.txt family — `public/llms.txt`, `public/llms-full.txt`, `public/.well-known/llms.txt` — is generated by `scripts/build-artifacts.mjs` but **`.gitignored`** (regenerated on every build, never committed). So the "verify committed derived artifacts are fresh" CI gate can never see it, and there is no committed diff for a reviewer. A test that runs the real build is the only regression net.

Adds one test to `tests/artifacts.test.mjs` — the one file with the build + `public/` snapshot/restore harness, so a **generated-but-uncommitted** artifact can be read in-test. It runs `build-artifacts.mjs` and asserts:

- `public/.well-known/llms.txt` is **byte-identical** to `public/llms.txt`.
- `llms.txt` has the `## Machine entrypoints` section with the **OpenAPI**, **agent-catalog**, and **MCP-server** links.
- `llms-full.txt` has **one `## Subnets` bullet per subnet** returned by `loadSubnets()`, and a `## All API routes` section listing **every** `API_ROUTES` entry from `src/contracts.mjs`.

The build + reads are wrapped in `try/finally` that calls `restorePublicTree(...)` — the restore discipline every other build-running test in this file uses — so tree-reading siblings (`registry validates`) are unaffected.

Assertions track the generator sources (`loadSubnets()`, `API_ROUTES`, `PRIMARY_DOMAIN`) rather than hardcoding, so they follow the generator instead of going stale.

**Diff is exactly one file (`tests/artifacts.test.mjs`, +63/-1). Backend test-coverage only — no `docs.*.tsx` route, no `apps/ui` changes.**

## Verify

- Full `vitest run tests/artifacts.test.mjs` on a clean tree: `llms.txt family` ✓ and `registry validates` ✓.
- `prettier --check` + `eslint` on the file: clean.