### PR TITLE
feat(ui): add a root-subnet inclusion toggle to the /subnets filter bar (#6270)

### DIFF
--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -135,6 +135,10 @@ export interface Subnet {
   name?: string;
   symbol?: string;
   type?: "root" | "application";
+  // Wire field the /api/v1/subnets list already returns (SubnetIndexEntry),
+  // typed here so the #6270 root filter reads it without casting through the
+  // index signature below.
+  subnet_type?: "root" | "application" | string;
   participants?: number;
   tempo?: number;
   registration_block?: number;

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -22,6 +22,19 @@ export const tableSearchSchema = z.object({
   // #9: agent-catalog capability filters (applied client-side over joined rows).
   serviceKind: fallback(z.string(), "").default(""),
   readiness: fallback(z.string(), "").default(""),
+  // #6270: root-subnet inclusion toggle for /subnets, applied client-side over
+  // the `subnet_type` the list response already returns. A boolean defaulting
+  // to true (the endpoints route's `callable` toggle shape) rather than the ""
+  // string filters above: it includes/excludes a slice of the set instead of
+  // selecting one value, and defaulting to true keeps the unfiltered list
+  // byte-identical to today's for anyone without the param.
+  //
+  // No companion `includeInactive`: GET /api/v1/subnets is documented as "List
+  // active Finney subnets" and only ever returns status=active rows (verified
+  // live — ?status=inactive returns 0). A client-side inactive filter could
+  // only narrow rows the server already sent, so it would be inert by
+  // construction; it belongs here only once that route serves non-active rows.
+  includeRoot: fallback(z.boolean(), true).default(true),
   // Layout state for list routes that support multiple views + row density.
   // Additive + optional with safe fallbacks so the toggles persist in the URL.
   view: fallback(z.enum(["table", "grid", "matrix"]), "table").default("table"),

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -139,7 +139,10 @@ function SubnetsPage() {
     !!search.readiness ||
     !!search.kind ||
     !!search.stale ||
-    !!search.cursor;
+    !!search.cursor ||
+    // #6270: defaults to true, so hiding the root is what makes it "active" —
+    // without this the Reset button stays disabled while a filter is applied.
+    !search.includeRoot;
   const onReset = () =>
     navigate({
       search: { limit: search.limit, view: search.view } as never,
@@ -261,6 +264,45 @@ function SubnetsStatStrip() {
   );
 }
 
+/**
+ * Exclude-a-slice toggle for the /subnets list (#6270). Mirrors the /endpoints
+ * "Callable only" toggle's shape and accent convention: the accent is lit only
+ * while the toggle is NARROWING the list, so the default (everything included)
+ * stays visually quiet. `hidden` is the pressed state — the slice is excluded.
+ */
+function ExcludeToggle({
+  hidden,
+  onToggle,
+  label,
+  count,
+  title,
+}: {
+  hidden: boolean;
+  onToggle: () => void;
+  label: string;
+  count: number;
+  title: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={hidden}
+      title={title}
+      className={classNames(
+        "inline-flex min-h-9 items-center gap-1.5 rounded border px-2 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+        hidden
+          ? "border-accent/40 bg-accent/10 text-accent"
+          : "border-border bg-card text-ink-muted hover:text-ink-strong",
+      )}
+    >
+      <span className={classNames("size-1.5 rounded-full", hidden && "bg-accent")} />
+      {label}
+      {count > 0 ? <span className="text-ink-muted">· {count}</span> : null}
+    </button>
+  );
+}
+
 function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; density?: Density }) {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
@@ -329,6 +371,15 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
       ),
     [pages, healthMap, catalogMap, economicsMap],
   );
+
+  // #6270: how many rows each inclusion toggle would drop, surfaced on the
+  // toggle itself so it answers "what am I hiding?" before you press it — the
+  // same affordance /endpoints' callable toggle gives with directoryCount.
+  // Counted over the full joined set, independent of the other filters.
+  const rootCount = useMemo(
+    () => all.filter((s) => s.subnet_type === "root" || s.netuid === 0).length,
+    [all],
+  );
   const total = pages[0]?.meta?.pagination?.total ?? pages[0]?.meta?.total;
 
   // Treat the URL cursor as the immutable starting point for this infinite query.
@@ -361,7 +412,10 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
     search.readiness ||
     search.kind ||
     search.stale ||
-    search.sort
+    search.sort ||
+    // #6270: defaults to true (include everything), so it only counts as an
+    // active filter once the user has switched it OFF.
+    !search.includeRoot
   );
 
   // Client-side filter + sort (the list API only honors q + cursor/limit).
@@ -391,6 +445,11 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
         // doesn't emit a `freshness` field on these rows — `updated_at` is what's
         // actually populated (confirmed against the live response).
         if (search.stale && !isStaleFreshness(s.updated_at, 24 * 60 * 60_000)) return false;
+        // #6270: root inclusion. Defaults to true, so the unfiltered list is
+        // unchanged; switching it off drops the root netuid. Identified by the
+        // wire `subnet_type` (netuid 0 is the root subnet by definition, so
+        // it's accepted either way).
+        if (!search.includeRoot && (s.subnet_type === "root" || s.netuid === 0)) return false;
         return true;
       }),
     [
@@ -402,6 +461,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
       search.readiness,
       search.kind,
       search.stale,
+      search.includeRoot,
     ],
   );
   const rows = useMemo(
@@ -491,6 +551,17 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
           { value: "identity-only", label: "identity-only" },
           { value: "dormant", label: "dormant" },
         ]}
+      />
+      <ExcludeToggle
+        hidden={!search.includeRoot}
+        onToggle={() => setSearch({ includeRoot: !search.includeRoot })}
+        label="Hide root"
+        count={rootCount}
+        title={
+          search.includeRoot
+            ? `Showing the root subnet — click to hide ${rootCount} root netuid${rootCount === 1 ? "" : "s"}`
+            : "Root subnet hidden — click to show it again"
+        }
       />
       <PageSizeSelect value={search.limit} onChange={(n) => setSearch({ limit: n })} />
     </>

--- a/apps/ui/tests/e2e/capture-subnets-filters-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-subnets-filters-screenshots.mjs
@@ -1,0 +1,81 @@
+/**
+ * Capture /subnets screenshots for the root inclusion toggle (#6270).
+ *
+ * Before captures show the filter toolbar without the toggle; after captures
+ * show it in its default (all-inclusive, unlit) state, plus one engaged shot
+ * proving the filter drops the root netuid.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8080 VARIANT=before node tests/e2e/capture-subnets-filters-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8080 VARIANT=after  node tests/e2e/capture-subnets-filters-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/subnets-filters-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8080";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const ALL_VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 900 },
+];
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function open(page, route) {
+  await page.goto(`${BASE_URL}${route}`, { waitUntil: "networkidle", timeout: 90_000 });
+  await page.waitForTimeout(800);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of ALL_VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await setTheme(page, theme);
+      await open(page, "/subnets");
+      const file = path.join(OUT_DIR, `${VARIANT}-subnets-${viewport.name}-${theme}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+      await context.close();
+    }
+  }
+
+  // Engaged state: only meaningful once the toggle exists, so it is an
+  // after-only shot. Desktop + both themes -- the grid above already covers
+  // responsive layout of the toolbar itself.
+  if (VARIANT === "after") {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+      const page = await context.newPage();
+      await setTheme(page, theme);
+      await open(page, "/subnets?includeRoot=false");
+      const file = path.join(OUT_DIR, `after-subnets-root-hidden-desktop-${theme}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+      await context.close();
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

`/subnets` already filters client-side on curation/health/service/readiness, and the list response already returns `subnet_type` (root|application) per subnet — but there was no way to exclude the root netuid, so the list was always the unfiltered set.

Adds one toggle to the existing filter bar, applied client-side over data already fetched (no new backend field or route):

- **`includeRoot`** in `tableSearchSchema` (`url-state.ts`) as a boolean defaulting to `true` — the `/endpoints` `callable` toggle's shape. Defaulting to true keeps the unfiltered list byte-identical for anyone without the param; it only counts toward `filtersActive` (which drives Reset) once switched off.
- An **`ExcludeToggle`** control mirroring the `/endpoints` "Callable only" toggle's markup and accent convention: the accent lights only while the toggle is *narrowing* the list, so the default all-inclusive view stays visually quiet. It shows the row count it would drop — the same "what am I hiding?" affordance `directoryCount` gives on `/endpoints`.
- Root is matched on the wire `subnet_type` (netuid 0 accepted either way). `subnet_type` is typed on the `Subnet` row — it was already returned, just reaching the filter through the index signature.

### Scope note — `includeInactive` deliberately omitted

The issue also asked for an `includeInactive` companion. `GET /api/v1/subnets` is documented as **"List active Finney subnets"** and only ever returns `status=active` rows — verified live: all 129 rows are `active`, and `?status=inactive` returns 0 (`meta.total: 0`). A client-side inactive filter can only narrow rows the server already sent, so it would be **inert by construction** — a control that can never do anything. It belongs here only once that route serves non-active rows. Happy to add it if you'd rather have the forward-looking control.

## Screenshots

| Viewport | Before | After |
| --- | --- | --- |
| Mobile 375 · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/before-subnets-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/after-subnets-mobile-light.png) |
| Mobile 375 · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/before-subnets-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/after-subnets-mobile-dark.png) |
| Tablet 768 · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/before-subnets-tablet-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/after-subnets-tablet-light.png) |
| Tablet 768 · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/before-subnets-tablet-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/after-subnets-tablet-dark.png) |
| Desktop 1280 · Light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/before-subnets-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/after-subnets-desktop-light.png) |
| Desktop 1280 · Dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/before-subnets-desktop-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/after-subnets-desktop-dark.png) |

**Engaged state** (`?includeRoot=false` — toggle lit, root hidden, Reset becomes available):

| Light | Dark |
| --- | --- |
| ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/after-subnets-root-hidden-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6270-subnets-root-toggle/after-subnets-root-hidden-desktop-dark.png) |

## Testing

- `typecheck`, `eslint` (0 errors), `prettier` — clean
- **1023 unit tests pass**
- **responsive-overflow e2e: 24/24 pass**, including `/subnets` at 375/768/1024/1280 — the added button introduces no overflow
- `vite build` succeeds

Closes #6270
