### PR TITLE
test(ui): extract + test use-mobile/use-scrolled's inlined threshold logic

### DIFF
--- a/apps/ui/src/hooks/use-mobile.test.ts
+++ b/apps/ui/src/hooks/use-mobile.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isMobileWidth, MOBILE_BREAKPOINT } from "./use-mobile";
+
+describe("isMobileWidth", () => {
+  it("is true below the breakpoint", () => {
+    expect(isMobileWidth(MOBILE_BREAKPOINT - 1)).toBe(true);
+    expect(isMobileWidth(320)).toBe(true);
+  });
+
+  it("is false at or above the breakpoint", () => {
+    expect(isMobileWidth(MOBILE_BREAKPOINT)).toBe(false);
+    expect(isMobileWidth(1280)).toBe(false);
+  });
+
+  it("respects a custom breakpoint", () => {
+    expect(isMobileWidth(900, 1024)).toBe(true);
+    expect(isMobileWidth(1024, 1024)).toBe(false);
+  });
+});

--- a/apps/ui/src/hooks/use-mobile.tsx
+++ b/apps/ui/src/hooks/use-mobile.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
 
-const MOBILE_BREAKPOINT = 768;
+export const MOBILE_BREAKPOINT = 768;
+
+/** Pure width-vs-breakpoint comparison, extracted so it's testable without a DOM. */
+export function isMobileWidth(width: number, breakpoint: number = MOBILE_BREAKPOINT): boolean {
+  return width < breakpoint;
+}
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
@@ -8,10 +13,10 @@ export function useIsMobile() {
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsMobile(isMobileWidth(window.innerWidth));
     };
     mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setIsMobile(isMobileWidth(window.innerWidth));
     return () => mql.removeEventListener("change", onChange);
   }, []);
 

--- a/apps/ui/src/hooks/use-scrolled.test.ts
+++ b/apps/ui/src/hooks/use-scrolled.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isScrolledPast } from "./use-scrolled";
+
+describe("isScrolledPast", () => {
+  it("is false at or below the threshold", () => {
+    expect(isScrolledPast(0, 4)).toBe(false);
+    expect(isScrolledPast(4, 4)).toBe(false);
+  });
+
+  it("is true once past the threshold", () => {
+    expect(isScrolledPast(5, 4)).toBe(true);
+    expect(isScrolledPast(200, 4)).toBe(true);
+  });
+
+  it("respects a custom threshold", () => {
+    expect(isScrolledPast(50, 100)).toBe(false);
+    expect(isScrolledPast(101, 100)).toBe(true);
+  });
+});

--- a/apps/ui/src/hooks/use-scrolled.ts
+++ b/apps/ui/src/hooks/use-scrolled.ts
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
 
+/** Pure scrollY-vs-threshold comparison, extracted so it's testable without a DOM. */
+export function isScrolledPast(scrollY: number, threshold: number): boolean {
+  return scrollY > threshold;
+}
+
 /**
  * Returns `true` once the window (or a custom scroll root) has scrolled past
  * `threshold` pixels. Used to toggle scroll-shadows on sticky toolbars.
@@ -10,7 +15,7 @@ export function useScrolled(threshold = 4): boolean {
   useEffect(() => {
     if (typeof window === "undefined") return;
     const onScroll = () => {
-      setScrolled(window.scrollY > threshold);
+      setScrolled(isScrolledPast(window.scrollY, threshold));
     };
     onScroll();
     window.addEventListener("scroll", onScroll, { passive: true });


### PR DESCRIPTION
## What

`use-mobile.tsx` and `use-scrolled.ts` inlined their width-vs-breakpoint and scrollY-vs-threshold comparisons directly inside `useEffect`, with no test coverage — unlike most sibling hooks (`use-refetch-interval.ts`'s `resolveRefetchInterval`, `use-coarse-pointer.tsx`'s shared media-query contract), which extract the pure decision logic into a standalone, directly-testable function.

Extracts `isMobileWidth(width, breakpoint)` and `isScrolledPast(scrollY, threshold)` as named exports, wires them into the existing hooks unchanged (same public `useIsMobile()`/`useScrolled(n)` signatures, no consumer changes needed), and adds focused unit tests for both — following the `resolveRefetchInterval` pattern rather than mocking `matchMedia`/`window.scrollY`.

## Scope

- 4 files (2 hooks + 2 new test files), +52/-4 lines. No behavior change, no consumer changes.
- Confined to `apps/ui/src/hooks/**` + test files — no visual change, so this PR is exempt from the repo's screenshot-evidence contract per its own stated exception.

## Verification

- `npx eslint` run from within `apps/ui` on all 4 files: 0 errors, 0 warnings.
- `npx vitest run` on both new test files: 6/6 tests pass.
- Rebased onto current `main`.

Closes #6241
