### PR TITLE
fix(ui): extract testable threshold logic from use-mobile/use-scrolled

### DIFF
--- a/apps/ui/src/hooks/use-mobile.test.ts
+++ b/apps/ui/src/hooks/use-mobile.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { isMobileWidth } from "./use-mobile";
+
+describe("isMobileWidth", () => {
+  it("is mobile strictly below the 768px breakpoint", () => {
+    expect(isMobileWidth(0)).toBe(true);
+    expect(isMobileWidth(767)).toBe(true);
+  });
+
+  it("is not mobile at or above the breakpoint", () => {
+    expect(isMobileWidth(768)).toBe(false);
+    expect(isMobileWidth(1024)).toBe(false);
+  });
+
+  it("honors a custom breakpoint", () => {
+    expect(isMobileWidth(500, 480)).toBe(false);
+    expect(isMobileWidth(479, 480)).toBe(true);
+  });
+});

--- a/apps/ui/src/hooks/use-mobile.tsx
+++ b/apps/ui/src/hooks/use-mobile.tsx
@@ -2,16 +2,25 @@ import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;
 
+/**
+ * Whether a viewport `width` counts as mobile: strictly below `breakpoint`.
+ * Pure, so the breakpoint comparison is unit-testable without mounting a
+ * component or a real `matchMedia`.
+ */
+export function isMobileWidth(width: number, breakpoint: number = MOBILE_BREAKPOINT): boolean {
+  return width < breakpoint;
+}
+
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
 
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsMobile(isMobileWidth(window.innerWidth));
     };
     mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setIsMobile(isMobileWidth(window.innerWidth));
     return () => mql.removeEventListener("change", onChange);
   }, []);
 

--- a/apps/ui/src/hooks/use-scrolled.test.ts
+++ b/apps/ui/src/hooks/use-scrolled.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { isPastScrollThreshold } from "./use-scrolled";
+
+describe("isPastScrollThreshold", () => {
+  it("is past only strictly above the default threshold of 4", () => {
+    expect(isPastScrollThreshold(0, 4)).toBe(false);
+    expect(isPastScrollThreshold(4, 4)).toBe(false);
+    expect(isPastScrollThreshold(5, 4)).toBe(true);
+  });
+
+  it("honors a custom threshold", () => {
+    expect(isPastScrollThreshold(99, 100)).toBe(false);
+    expect(isPastScrollThreshold(100, 100)).toBe(false);
+    expect(isPastScrollThreshold(101, 100)).toBe(true);
+  });
+});

--- a/apps/ui/src/hooks/use-scrolled.ts
+++ b/apps/ui/src/hooks/use-scrolled.ts
@@ -1,6 +1,15 @@
 import { useEffect, useState } from "react";
 
 /**
+ * Whether `scrollY` is past `threshold` pixels: strictly greater than. Pure, so
+ * the threshold comparison is unit-testable without mounting a component or a
+ * real scroll event.
+ */
+export function isPastScrollThreshold(scrollY: number, threshold: number): boolean {
+  return scrollY > threshold;
+}
+
+/**
  * Returns `true` once the window (or a custom scroll root) has scrolled past
  * `threshold` pixels. Used to toggle scroll-shadows on sticky toolbars.
  * SSR-safe.
@@ -10,7 +19,7 @@ export function useScrolled(threshold = 4): boolean {
   useEffect(() => {
     if (typeof window === "undefined") return;
     const onScroll = () => {
-      setScrolled(window.scrollY > threshold);
+      setScrolled(isPastScrollThreshold(window.scrollY, threshold));
     };
     onScroll();
     window.addEventListener("scroll", onScroll, { passive: true });


### PR DESCRIPTION
## What

`use-mobile.tsx` and `use-scrolled.ts` were the only two hooks in `apps/ui/src/hooks` that inlined their numeric-threshold comparison directly in the `useEffect` body, leaving no pure function a unit test could target — and so the only two hooks in that directory with zero coverage.

This applies the same "extract the pure branch, test the pure branch" convention every sibling hook already follows (`resolveRefetchInterval`, `classifyEndpointLatency`, `COARSE_POINTER_MEDIA_QUERY`):

- `use-mobile.tsx`: extract `export function isMobileWidth(width, breakpoint = MOBILE_BREAKPOINT)` and call it from both `useEffect` call sites (initial `setIsMobile` and the `matchMedia` `onChange` handler).
- `use-scrolled.ts`: extract `export function isPastScrollThreshold(scrollY, threshold)` and call it from the `onScroll` handler.

Pure refactor — output is identical for every input; no hook runtime behavior changes, no `testing-library`/`renderHook` dependency added.

## Tests

- `use-mobile.test.ts` — `isMobileWidth` below / at / above the 768px breakpoint, plus a custom breakpoint (boundary-value style, mirroring `use-endpoint-health.test.ts`).
- `use-scrolled.test.ts` — `isPastScrollThreshold` below / at / above the default threshold and a custom threshold.

`npm test --workspace=apps/ui` → 135 files, 1028 tests pass. `eslint`, `prettier --check`, and `tsc --noEmit` all clean.

No visual output changes (logic-only, `apps/ui/src/hooks/**` + tests).

Closes #6241


## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/before__desktop_light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/before__desktop_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/after__desktop_light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/after__desktop_light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/before__desktop_dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/before__desktop_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/after__desktop_dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/after__desktop_dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/before__tablet_light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/before__tablet_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/after__tablet_light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/after__tablet_light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/before__tablet_dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/before__tablet_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/after__tablet_dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/after__tablet_dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/before__mobile_light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/before__mobile_light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/after__mobile_light.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/after__mobile_light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/before__mobile_dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/before__mobile_dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/after__mobile_dark.png" width="260">](https://raw.githubusercontent.com/nghetienhiep/metagraphed/screenshots-6241/after__mobile_dark.png)<br><sub>after</sub> |
