### PR TITLE
fix(ui): add StaleBanner to accounts.$ss58.tsx, matching subnets/validators/providers

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -28,7 +28,7 @@ import {
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
+import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { SelectFilter, FilterChip } from "@/components/metagraphed/table-controls";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import {
@@ -66,7 +66,7 @@ import {
   accountSubnetsQuery,
   accountTransfersQuery,
 } from "@/lib/metagraphed/queries";
-import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, formatTao, isStaleFreshness } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
@@ -160,7 +160,9 @@ function AccountDetail({ ss58 }: { ss58: string }) {
 
 function ValidAccountDetail({ ss58 }: { ss58: string }) {
   const sourceRef = ss58PathSegment(ss58);
-  const account = useSuspenseQuery(accountQuery(ss58)).data.data as AccountSummary;
+  const accountResult = useSuspenseQuery(accountQuery(ss58)).data;
+  const account = accountResult.data as AccountSummary;
+  const generatedAt = accountResult.meta?.generated_at ?? null;
   // Balance is a separate live-RPC call: fetched non-blocking so a slow/failed
   // RPC never stalls or errors the rest of the entity page.
   const balanceResult = useQuery(accountBalanceQuery(ss58));
@@ -229,6 +231,13 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
             >
               API endpoints
             </a>
+            {isStaleFreshness(generatedAt) ? (
+              <StaleBanner
+                compact
+                generatedAt={generatedAt}
+                refreshQueryKeys={[accountQuery(ss58).queryKey]}
+              />
+            ) : null}
           </>
         }
         aside={


### PR DESCRIPTION
## What

`accounts.$ss58.tsx` discarded `accountQuery`'s `.meta` entirely (only kept `.data`), so it had no way to know or show when its snapshot was stale — unlike the other "live aggregate" entity-detail pages (`subnets.$netuid.tsx`, `validators.$hotkey.tsx`, `providers.$slug.tsx`), which all check `meta?.generated_at` via `isStaleFreshness` and render a compact `StaleBanner` with a refresh action when the snapshot exceeds the freshness threshold.

**Note on scope**: the linked issue's framing ("the only entity-detail page without a StaleBanner") isn't quite accurate — `blocks.$ref.tsx` and `extrinsics.$hash.tsx` also lack it, but those are immutable finalized chain records where "staleness" doesn't apply the same way; `accounts` is the genuine odd one out among the mutable, live-aggregate detail pages. Scoped this fix to accounts only, matching the issue's concrete deliverable.

## Scope

- 1 file, +12/-3 lines. Mirrors `validators.$hotkey.tsx`'s exact `StaleBanner` usage pattern.

## Screenshot evidence

Since the banner is conditional on real staleness (12h threshold), captured with `accountQuery`'s response `meta.generated_at` deterministically rewritten to a stale timestamp via browser-layer response interception (not a mock — the real API response, one field altered) so the fix is provably exercised rather than relying on production data happening to be stale at capture time.

| Viewport · Theme | Before | After |
| ---- | ---- | ---- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6245-account-stale-banner-after-mobile-dark.png)<br><sub>after</sub> |

## Verification

- `npx eslint` run from within `apps/ui`: 0 errors, 0 warnings.
- Rebased onto current `main`.

Closes #6245
