### PR TITLE
feat(ui): add a top-emitters leaderboard to /leaderboards (#6269)

### DIFF
--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -3,7 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useMemo } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { Scale, UserMinus } from "lucide-react";
+import { Scale, UserMinus, Zap } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
@@ -20,11 +20,12 @@ import {
 import {
   chainDeregistrationsQuery,
   chainWeightsQuery,
+  economicsQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
-import type { Subnet } from "@/lib/metagraphed/types";
+import type { Subnet, SubnetEconomics } from "@/lib/metagraphed/types";
 
 const leaderboardsSearchSchema = z.object({
   window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
@@ -115,8 +116,15 @@ function LeaderboardsPage() {
             <DeregistrationsLeaderboard win={win} />
           </Suspense>
         </QueryErrorBoundary>
+        <QueryErrorBoundary>
+          <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
+            <EmissionsLeaderboard />
+          </Suspense>
+        </QueryErrorBoundary>
       </div>
-      <ApiSourceFooter paths={["/api/v1/chain/weights", "/api/v1/chain/deregistrations"]} />
+      <ApiSourceFooter
+        paths={["/api/v1/chain/weights", "/api/v1/chain/deregistrations", "/api/v1/economics"]}
+      />
     </AppShell>
   );
 }
@@ -289,6 +297,160 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
                       </td>
                       <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
                         {row.sets_per_setter != null ? row.sets_per_setter.toFixed(2) : "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+// Top-emitters board (#6269) — subnets ranked by their share of network
+// emissions, from the already-live GET /api/v1/economics snapshot. Mirrors the
+// weight-setting/deregistrations board structure (summary tiles + desktop table
+// + < md card fallback); emission_share is not windowed, so this board has no
+// window selector.
+function EmissionsLeaderboard() {
+  const { data: ecoRes } = useSuspenseQuery(economicsQuery());
+  const subnetById = useSubnetById();
+  const ranked = useMemo(
+    () =>
+      ((ecoRes.data ?? []) as SubnetEconomics[])
+        .filter((s) => typeof s.emission_share === "number")
+        .sort((a, b) => (b.emission_share ?? 0) - (a.emission_share ?? 0)),
+    [ecoRes],
+  );
+  const pct = (v: number | undefined) =>
+    v != null && Number.isFinite(v) ? `${(v * 100).toFixed(2)}%` : "—";
+  const topShare = ranked.slice(0, 10).reduce((sum, s) => sum + (s.emission_share ?? 0), 0);
+  // Cap the ranked table at the top 20, matching the other boards' page size.
+  const top = ranked.slice(0, 20);
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+          Top emitters
+        </h2>
+        <p className="mt-1 text-sm text-ink-muted">
+          Subnets ranked by their share of network emissions — from the live economics snapshot.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatTile
+          icon={Zap}
+          eyebrow="Subnets emitting"
+          value={formatNumber(ranked.length)}
+          hint="with an emission share"
+          tone="accent"
+        />
+        <StatTile
+          icon={Zap}
+          eyebrow="Top emitter"
+          value={ranked.length > 0 ? pct(ranked[0].emission_share) : "—"}
+          hint={
+            ranked.length > 0
+              ? (subnetById.get(ranked[0].netuid)?.name ?? `Subnet ${ranked[0].netuid}`)
+              : "no data"
+          }
+        />
+        <StatTile
+          icon={Zap}
+          eyebrow="Top 10 share"
+          value={pct(topShare)}
+          hint="combined network emissions"
+        />
+      </div>
+
+      {ranked.length === 0 ? (
+        <EmptyState
+          title="No emission data yet"
+          description="The economics snapshot has no per-subnet emission share for this network yet."
+        />
+      ) : (
+        <section className="rounded-lg border border-border bg-card">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
+            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+              Per-subnet rankings
+            </span>
+            <span className="font-mono text-[11px] text-ink-muted">
+              top {top.length} of {formatNumber(ranked.length)} subnets
+            </span>
+          </div>
+          <div className="md:hidden space-y-2 p-3">
+            {top.map((row, i) => {
+              const subnet = subnetById.get(row.netuid);
+              const name = subnet?.name ?? row.name ?? `Subnet ${row.netuid}`;
+              return (
+                <div key={row.netuid} className="rounded border border-border bg-card p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: row.netuid }}
+                      className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
+                    >
+                      <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
+                        {i + 1}
+                      </span>
+                      <BrandIcon
+                        size={18}
+                        name={name}
+                        fallback={row.netuid}
+                        netuid={row.netuid}
+                        subnetSlug={typeof subnet?.slug === "string" ? subnet.slug : undefined}
+                      />
+                      <span className="truncate text-sm text-ink-strong">{name}</span>
+                    </Link>
+                    <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-strong">
+                      {pct(row.emission_share)}
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div className="hidden md:block overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr>
+                  <th className={TH}>Rank</th>
+                  <th className={TH}>Subnet</th>
+                  <th className={`${TH} text-right`}>Emission share</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {top.map((row, i) => {
+                  const subnet = subnetById.get(row.netuid);
+                  const name = subnet?.name ?? row.name ?? `Subnet ${row.netuid}`;
+                  return (
+                    <tr key={row.netuid} className="hover:bg-surface/40">
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
+                        {i + 1}
+                      </td>
+                      <td className="px-4 py-2.5">
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: row.netuid }}
+                          className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
+                        >
+                          <BrandIcon
+                            size={18}
+                            name={name}
+                            fallback={row.netuid}
+                            netuid={row.netuid}
+                            subnetSlug={typeof subnet?.slug === "string" ? subnet.slug : undefined}
+                          />
+                          <span className="truncate text-sm text-ink-strong">{name}</span>
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-strong">
+                        {pct(row.emission_share)}
                       </td>
                     </tr>
                   );


### PR DESCRIPTION
Closes #6269.

## What

`/leaderboards` had weight-setting and deregistrations boards but **no emissions board**, even though `emission_share` is a live per-subnet field (served by `GET /api/v1/economics`, already shown as a plain column on `/subnets`).

Adds an `EmissionsLeaderboard` component ranking subnets by `emission_share` from the **already-live** `GET /api/v1/economics` response — **no new backend** — mirroring the existing boards' structure:

- a 3-tile summary: subnets emitting, top emitter (with its name), and top-10 combined share;
- a desktop table (Rank · Subnet · Emission share) with the shared `BrandIcon` + subnet link;
- a `< md` stacked-card fallback, matching the other two boards.

Capped at the **top 20** to match the other boards' page size. `emission_share` is not windowed, so this board (correctly) has no window selector. Also added `/api/v1/economics` to the page's `ApiSourceFooter`.

## Screenshots (before / after)

Real `/leaderboards` (live economics data). **Before** = page tail (only the weight-setting + deregistrations boards; data-sources footer lists 2 endpoints). **After** = the new Top emitters board.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6269/before-desktop-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6269/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6269/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6269/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6269/before-tablet-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6269/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6269/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6269/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6269/before-mobile-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6269/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6269/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6269/after-mobile-dark.png) |

## Verify

- `prettier --check` + `eslint` (from apps/ui) + `tsc --noEmit`: clean (0 errors).
- Diff is exactly one file (`apps/ui/src/routes/leaderboards.tsx`, +165/-3).