### PR TITLE
fix(ui): add missing compact prop to 2 AccountAddress call sites

### DIFF
--- a/apps/ui/src/components/metagraphed/account-address.tsx
+++ b/apps/ui/src/components/metagraphed/account-address.tsx
@@ -38,7 +38,12 @@ export function AccountAddress({
             {shortHash(ss58, keep)}
           </Link>
         </EntityHoverCard>
-        <CopyButton value={ss58} label="account" className={copyButtonClassName} compact={compact} />
+        <CopyButton
+          value={ss58}
+          label="account"
+          className={copyButtonClassName}
+          compact={compact}
+        />
       </span>
     );
   }

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -460,6 +460,7 @@ function BlocksTable() {
                 >
                   <AccountAddress
                     ss58={b.author}
+                    compact
                     fallback={
                       b.author ? <CopyableCode value={b.author} className="max-w-full" /> : "—"
                     }

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -377,6 +377,7 @@ function ExtrinsicsTable() {
                 <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
                   <AccountAddress
                     ss58={x.signer}
+                    compact
                     fallback={
                       x.signer ? <CopyableCode value={x.signer} className="max-w-full" /> : "—"
                     }

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -28,7 +28,7 @@ import { CHAIN_DEREGISTRATIONS_WINDOWS } from "../src/chain-deregistrations.mjs"
 import { CHAIN_REGISTRATIONS_WINDOWS } from "../src/chain-registrations.mjs";
 import { CHAIN_AXON_REMOVALS_WINDOWS } from "../src/chain-axon-removals.mjs";
 import { handleRequest } from "../workers/api.mjs";
-import { resolveClientIp } from "../workers/config.mjs";
+import { resolveClientIp, DAY_MS } from "../workers/config.mjs";
 import {
   KV_ECONOMICS_CURRENT,
   KV_HEALTH_CURRENT,
@@ -10667,11 +10667,25 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
   });
 
   test("no Postgres tier flag: aggregates surface_uptime_daily rows straight off D1", async () => {
+    // Relative to Date.now(), not a hardcoded literal -- a fixed past date
+    // drifts outside the resolver's real "7d" window as wall-clock time
+    // moves on, making this fail independent of any code change once it
+    // does (it just did: the literal was "2026-07-09", fixed for real in
+    // #6319 against main). loadBulkHealthTrends (src/bulk-health-trends.mjs)
+    // computes the window cutoff from the real Date.now() by default, so the
+    // fixture must track it the same way
+    // tests/request-handlers-analytics.test.mjs's `recentDay` already does
+    // for the identical surface_uptime_daily shape. Carried here too so this
+    // PR's own CI isn't blocked waiting on #6319 to merge separately --
+    // collapses to a no-op once this branch rebases onto that fix.
+    const recentDay = new Date(Date.now() - 2 * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
     const env = {
       METAGRAPH_HEALTH_DB: bulkTrendsD1([
         {
           netuid: 7,
-          date: "2026-07-09",
+          date: recentDay,
           total: 10,
           ok_count: 9,
           avg_latency_ms: 50,


### PR DESCRIPTION
## Summary

`AccountAddress`'s inner `CopyButton` in two table cells — `blocks.index.tsx`'s "Author" column and `extrinsics.index.tsx`'s "Signer" column — never got the `compact` prop, so both cells kept forcing the same 44px `min-h-11` touch target that #6280 removed from every other table-row `CopyButton`/`AccountAddress` in the app. These two call sites didn't exist on #6280's branch when it diverged from `main`, so they were out of scope there.

Because the sibling hash column in the same row (block hash / extrinsic hash) is now fixed by #6280, the account/signer cell was left as the sole remaining forcing constraint on these two rows — so the bug is still real and visible on current `main`, not just latent.

## Fix

Adds `compact` to the two `AccountAddress` call sites:
- `apps/ui/src/routes/blocks.index.tsx` — the `Author` column (`b.author`)
- `apps/ui/src/routes/extrinsics.index.tsx` — the `Signer` column (`x.signer`)

No component changes needed — `AccountAddress`'s `compact` prop (forwarded to its inner `CopyButton`) already exists on `main` via #6280.

## Measured effect

Verified with Playwright against a real dev server (live chain data), measuring `getBoundingClientRect()` on the first several table rows, before and after:

| Page | Row height before | Row height after |
| --- | --- | --- |
| `/blocks` | 65px | 38px |
| `/extrinsics` | 65px | 38px |

(65px = 44px CopyButton min-height + 20px cell padding; 38px matches the natural height of every other row.)

## Screenshots

Both captured against a running dev server with live chain data — "before" is current `main` (post-#6280), "after" is this branch.

| Page | Before | After |
| --- | --- | --- |
| `/blocks` — Author column | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/account-address-compact-followup/blocks-before.png" width="420">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/account-address-compact-followup/blocks-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/account-address-compact-followup/blocks-after.png" width="420">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/account-address-compact-followup/blocks-after.png) |
| `/extrinsics` — Signer column | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/account-address-compact-followup/extrinsics-before.png" width="420">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/account-address-compact-followup/extrinsics-before.png) | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/account-address-compact-followup/extrinsics-after.png" width="420">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/account-address-compact-followup/extrinsics-after.png) |

## Context

Small follow-up to #6280 (`fix(ui-kit): add a compact CopyButton variant so table rows stop silently inflating to 44px`), found while resolving that PR's merge conflict — not linked with `Closes #` since there's no tracked issue for this and the contributor skill's own rules say a linked issue is never required.

## Test plan

- [x] `npx tsc --noEmit -p apps/ui` clean
- [x] `npx eslint` on both touched files — 0 errors (pre-existing `react-refresh/only-export-components` warnings only, unrelated to this change)
- [x] `npx prettier --check` on both touched files — clean
- [x] `npm run test --workspace=apps/ui` — 136 files / 1040 tests pass
- [x] Verified against a running dev server with live chain data on both `/blocks` and `/extrinsics`, before (current `main`) and after (this branch) — row height 65px → 38px on both, measured via `getBoundingClientRect()` and confirmed visually (screenshots above)

## Update: unrelated pre-existing CI failure, fixed here too

CI's `ui` job failed here first on an unrelated `prettier/prettier` formatting issue in `account-address.tsx` (a single-line JSX prop list Prettier wants wrapped) — fixed.

After that, the `test` job failed on `tests/graphql.test.mjs`'s `health_trends` D1-path case — completely unrelated to this PR's files. Root cause: that test hardcodes a fixture date (`"2026-07-09"`) that's checked against a live `Date.now()`-relative 7-day window in `loadBulkHealthTrends`; wall-clock time has now carried it outside that window, so it was failing on unmodified `main` too — confirmed by running it in isolation against `main` directly, not assumed. This blocks CI on every PR right now, not just this one. Opened [#6319](https://github.com/JSONbored/metagraphed/pull/6319) with the real fix against `main`, and carried the identical change onto this branch so this PR isn't stuck waiting on that one to merge first — it'll collapse to a no-op once this branch rebases past #6319.

