### PR TITLE
feat(ui): give chain events its own /events section (#6268)

### DIFF
--- a/apps/ui/src/components/metagraphed/chain-events-feed.test.ts
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { CHAIN_EVENTS_PAGE_SIZE, chainEventsBaseParams } from "./chain-events-feed";
+
+describe("chainEventsBaseParams", () => {
+  it("sends only the page size when no filters are set", () => {
+    expect(chainEventsBaseParams("", "")).toEqual({ limit: CHAIN_EVENTS_PAGE_SIZE });
+  });
+
+  it("includes the pallet when set", () => {
+    expect(chainEventsBaseParams("System", "")).toEqual({
+      limit: CHAIN_EVENTS_PAGE_SIZE,
+      pallet: "System",
+    });
+  });
+
+  it("includes method only alongside a pallet (API conjunctive contract)", () => {
+    // method without a pallet is meaningless to the API, so it's dropped.
+    expect(chainEventsBaseParams("", "ExtrinsicSuccess")).toEqual({
+      limit: CHAIN_EVENTS_PAGE_SIZE,
+    });
+    expect(chainEventsBaseParams("System", "ExtrinsicSuccess")).toEqual({
+      limit: CHAIN_EVENTS_PAGE_SIZE,
+      pallet: "System",
+      method: "ExtrinsicSuccess",
+    });
+  });
+
+  it("trims surrounding whitespace before deciding what to send", () => {
+    expect(chainEventsBaseParams("  System  ", "  ExtrinsicSuccess  ")).toEqual({
+      limit: CHAIN_EVENTS_PAGE_SIZE,
+      pallet: "System",
+      method: "ExtrinsicSuccess",
+    });
+    // whitespace-only pallet collapses to "no filters" and drops the method too.
+    expect(chainEventsBaseParams("   ", "ExtrinsicSuccess")).toEqual({
+      limit: CHAIN_EVENTS_PAGE_SIZE,
+    });
+  });
+});

--- a/apps/ui/src/components/metagraphed/chain-events-feed.tsx
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.tsx
@@ -1,0 +1,197 @@
+import { Link } from "@tanstack/react-router";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { SearchInput } from "@/components/metagraphed/table-controls";
+import { TimeAgo, ListShell, LoadMore } from "@jsonbored/ui-kit";
+import { chainEventsInfiniteQuery } from "@/lib/metagraphed/queries";
+import { formatNumber } from "@/lib/metagraphed/format";
+import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
+import type { ChainEvent } from "@/lib/metagraphed/types";
+
+const TH = "px-4 py-2.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
+
+/** Page size for the raw all-events feed, shared by /events and /explorer. */
+export const CHAIN_EVENTS_PAGE_SIZE = 50;
+
+/**
+ * Build the `/api/v1/chain-events` query params from filter state. `method` is
+ * only meaningful alongside a `pallet`, so it's dropped when `pallet` is empty —
+ * mirroring the API's conjunctive filter contract.
+ */
+export function chainEventsBaseParams(
+  pallet: string,
+  method: string,
+): Record<string, string | number> {
+  const p = pallet.trim();
+  const m = method.trim();
+  const params: Record<string, string | number> = { limit: CHAIN_EVENTS_PAGE_SIZE };
+  if (p) params.pallet = p;
+  if (p && m) params.method = m;
+  return params;
+}
+
+interface Props {
+  pallet: string;
+  method: string;
+  cursor: string;
+  /**
+   * Patch the pallet/method filter state. The caller owns URL state and is
+   * responsible for resetting its own cursor param so a new filter restarts
+   * from the newest page.
+   */
+  onFilter: (patch: { pallet?: string; method?: string }) => void;
+}
+
+/**
+ * The raw all-events feed (ADR 0013) — cursor-paginated, newest-first, with
+ * pallet/method filters. Rendered both as an embedded section on /explorer and
+ * as the standalone /events route, so it lives here as one shared component to
+ * keep the two in sync.
+ */
+export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
+  const baseParams = chainEventsBaseParams(pallet, method);
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isFetchNextPageError,
+    error,
+    isPending,
+    isFetching,
+    refetch,
+  } = useInfiniteQuery(chainEventsInfiniteQuery(baseParams, cursor));
+
+  const pages = data?.pages ?? [];
+  const lastPage = pages[pages.length - 1];
+  const cursorInvalid = !!(lastPage as { cursorInvalid?: boolean } | undefined)?.cursorInvalid;
+  const events = pages.flatMap((p) => (p.data ?? []) as ChainEvent[]);
+  const filtersActive = !!(pallet.trim() || method.trim());
+
+  const filters = (
+    <>
+      <SearchInput
+        value={pallet}
+        onChange={(v) => onFilter({ pallet: v, method: v.trim() ? method : "" })}
+        placeholder="Filter by pallet"
+        className="min-w-[140px] flex-none font-mono text-[11px]"
+      />
+      <SearchInput
+        value={method}
+        onChange={(v) => onFilter({ method: v })}
+        placeholder={pallet.trim() ? "Filter by method" : "Method (requires pallet)"}
+        className="min-w-[140px] flex-none font-mono text-[11px]"
+      />
+    </>
+  );
+
+  const emptyNode = (
+    <EmptyState
+      title={
+        filtersActive
+          ? "No chain events match these filters."
+          : "No chain events indexed yet — the all-events backfill fills this feed."
+      }
+    />
+  );
+
+  const table = (
+    <table className="w-full text-left text-sm">
+      <thead className="bg-surface/40">
+        <tr>
+          <th className={TH}>Pallet.method</th>
+          <th className={TH}>Block</th>
+          <th className={`${TH} text-right`}>Observed</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-border">
+        {events.map((event) => (
+          <tr key={`${event.block_number}-${event.event_index}`} className="hover:bg-surface/40">
+            <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
+              {extrinsicCall(event.pallet, event.method)}
+            </td>
+            <td className="px-4 py-2.5 font-mono text-[11px]">
+              {event.block_number != null ? (
+                <Link
+                  to="/blocks/$ref"
+                  params={{ ref: String(event.block_number) }}
+                  className="text-ink-strong hover:text-accent hover:underline"
+                >
+                  #{formatNumber(event.block_number)}
+                </Link>
+              ) : (
+                "—"
+              )}
+            </td>
+            <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
+              <TimeAgo at={event.observed_at} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+  const cards = events.map((event) => (
+    <div
+      key={`${event.block_number}-${event.event_index}-card`}
+      className="rounded border border-border bg-card p-3 min-h-11"
+    >
+      <div className="font-mono text-[11px] text-ink-strong">
+        {extrinsicCall(event.pallet, event.method)}
+      </div>
+      <div className="mt-1 flex items-center justify-between gap-2 font-mono text-[10px] text-ink-muted">
+        {event.block_number != null ? (
+          <Link
+            to="/blocks/$ref"
+            params={{ ref: String(event.block_number) }}
+            className="hover:text-accent hover:underline"
+          >
+            #{formatNumber(event.block_number)}
+          </Link>
+        ) : (
+          <span>—</span>
+        )}
+        <TimeAgo at={event.observed_at} />
+      </div>
+    </div>
+  ));
+
+  if (isPending) return <Skeleton className="h-56 w-full" />;
+  if (error && !data)
+    return (
+      <ErrorState
+        error={error}
+        context="chain events feed"
+        onRetry={() => {
+          void refetch();
+        }}
+      />
+    );
+
+  return (
+    <ListShell
+      filters={filters}
+      table={table}
+      cards={cards}
+      isEmpty={events.length === 0 && !isFetching}
+      empty={emptyNode}
+      isStale={isFetching && !isPending && !isFetchingNextPage}
+      footer={
+        events.length > 0 ? (
+          <LoadMore
+            hasMore={!!hasNextPage}
+            isLoading={isFetchingNextPage}
+            onLoadMore={() => {
+              void fetchNextPage();
+            }}
+            shown={events.length}
+            error={isFetchNextPageError ? error : null}
+            cursorInvalid={cursorInvalid}
+          />
+        ) : undefined
+      }
+    />
+  );
+}

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -170,6 +170,13 @@ const STATIC_ROUTES_TAIL: RouteEntry[] = [
     scope: "route",
   },
   {
+    label: "Events",
+    to: "/events",
+    hint: "Chain event feed",
+    icon: Rss,
+    scope: "route",
+  },
+  {
     label: "Accounts",
     to: "/accounts",
     hint: "Hotkey & coldkey activity",

--- a/apps/ui/src/components/metagraphed/nav-omnibox.tsx
+++ b/apps/ui/src/components/metagraphed/nav-omnibox.tsx
@@ -9,6 +9,7 @@ import {
   Hash,
   Layers,
   Network,
+  Rss,
   Search,
   User,
   Wifi,
@@ -81,6 +82,12 @@ const NAV_LINKS = [
     label: "Blocks",
     hint: "Chain block explorer",
     Icon: Hash,
+  },
+  {
+    to: "/events",
+    label: "Events",
+    hint: "Chain event feed",
+    Icon: Rss,
   },
   {
     to: "/accounts",

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as SubnetsIndexRouteImport } from './routes/subnets.index'
 import { Route as RuntimeIndexRouteImport } from './routes/runtime.index'
 import { Route as ProvidersIndexRouteImport } from './routes/providers.index'
 import { Route as ExtrinsicsIndexRouteImport } from './routes/extrinsics.index'
+import { Route as EventsIndexRouteImport } from './routes/events.index'
 import { Route as BlocksIndexRouteImport } from './routes/blocks.index'
 import { Route as AdminChangesIndexRouteImport } from './routes/admin-changes.index'
 import { Route as AccountsIndexRouteImport } from './routes/accounts.index'
@@ -132,6 +133,11 @@ const ExtrinsicsIndexRoute = ExtrinsicsIndexRouteImport.update({
   path: '/extrinsics/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const EventsIndexRoute = EventsIndexRouteImport.update({
+  id: '/events/',
+  path: '/events/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BlocksIndexRoute = BlocksIndexRouteImport.update({
   id: '/blocks/',
   path: '/blocks/',
@@ -229,6 +235,7 @@ export interface FileRoutesByFullPath {
   '/accounts/': typeof AccountsIndexRoute
   '/admin-changes/': typeof AdminChangesIndexRoute
   '/blocks/': typeof BlocksIndexRoute
+  '/events/': typeof EventsIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/runtime/': typeof RuntimeIndexRoute
@@ -263,6 +270,7 @@ export interface FileRoutesByTo {
   '/accounts': typeof AccountsIndexRoute
   '/admin-changes': typeof AdminChangesIndexRoute
   '/blocks': typeof BlocksIndexRoute
+  '/events': typeof EventsIndexRoute
   '/extrinsics': typeof ExtrinsicsIndexRoute
   '/providers': typeof ProvidersIndexRoute
   '/runtime': typeof RuntimeIndexRoute
@@ -298,6 +306,7 @@ export interface FileRoutesById {
   '/accounts/': typeof AccountsIndexRoute
   '/admin-changes/': typeof AdminChangesIndexRoute
   '/blocks/': typeof BlocksIndexRoute
+  '/events/': typeof EventsIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/runtime/': typeof RuntimeIndexRoute
@@ -334,6 +343,7 @@ export interface FileRouteTypes {
     | '/accounts/'
     | '/admin-changes/'
     | '/blocks/'
+    | '/events/'
     | '/extrinsics/'
     | '/providers/'
     | '/runtime/'
@@ -368,6 +378,7 @@ export interface FileRouteTypes {
     | '/accounts'
     | '/admin-changes'
     | '/blocks'
+    | '/events'
     | '/extrinsics'
     | '/providers'
     | '/runtime'
@@ -402,6 +413,7 @@ export interface FileRouteTypes {
     | '/accounts/'
     | '/admin-changes/'
     | '/blocks/'
+    | '/events/'
     | '/extrinsics/'
     | '/providers/'
     | '/runtime/'
@@ -437,6 +449,7 @@ export interface RootRouteChildren {
   AccountsIndexRoute: typeof AccountsIndexRoute
   AdminChangesIndexRoute: typeof AdminChangesIndexRoute
   BlocksIndexRoute: typeof BlocksIndexRoute
+  EventsIndexRoute: typeof EventsIndexRoute
   ExtrinsicsIndexRoute: typeof ExtrinsicsIndexRoute
   ProvidersIndexRoute: typeof ProvidersIndexRoute
   RuntimeIndexRoute: typeof RuntimeIndexRoute
@@ -574,6 +587,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ExtrinsicsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/events/': {
+      id: '/events/'
+      path: '/events'
+      fullPath: '/events/'
+      preLoaderRoute: typeof EventsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/blocks/': {
       id: '/blocks/'
       path: '/blocks'
@@ -701,6 +721,7 @@ const rootRouteChildren: RootRouteChildren = {
   AccountsIndexRoute: AccountsIndexRoute,
   AdminChangesIndexRoute: AdminChangesIndexRoute,
   BlocksIndexRoute: BlocksIndexRoute,
+  EventsIndexRoute: EventsIndexRoute,
   ExtrinsicsIndexRoute: ExtrinsicsIndexRoute,
   ProvidersIndexRoute: ProvidersIndexRoute,
   RuntimeIndexRoute: RuntimeIndexRoute,

--- a/apps/ui/src/routes/events.index.tsx
+++ b/apps/ui/src/routes/events.index.tsx
@@ -1,0 +1,76 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { z } from "zod";
+import { fallback, zodValidator } from "@tanstack/zod-adapter";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { ChainEventsFeed, chainEventsBaseParams } from "@/components/metagraphed/chain-events-feed";
+import { PageHero, ShareButton, DownloadCsvButton, ActionBar } from "@jsonbored/ui-kit";
+import { buildUrl } from "@/lib/metagraphed/client";
+
+const eventsSearchSchema = z.object({
+  // Server-side filters wired to the /api/v1/chain-events feed. `method` is only
+  // meaningful alongside a `pallet`, matching the embedded explorer feed (#6268).
+  pallet: fallback(z.string(), "").default(""),
+  method: fallback(z.string(), "").default(""),
+  cursor: fallback(z.string(), "").default(""),
+});
+
+export const Route = createFileRoute("/events/")({
+  validateSearch: zodValidator(eventsSearchSchema),
+  head: () => ({
+    meta: [
+      { title: "Chain events — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Recent Bittensor pallet events indexed from the chain — pallet.method, block, and observation time, newest first.",
+      },
+      { property: "og:title", content: "Chain events — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "Recent Bittensor pallet events indexed from the chain — pallet.method, block, and observation time, newest first.",
+      },
+    ],
+  }),
+  component: EventsPage,
+});
+
+function EventsPage() {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const eventsCsvUrl = buildUrl(
+    "/api/v1/chain-events",
+    chainEventsBaseParams(search.pallet, search.method),
+  );
+
+  const onFilter = (patch: { pallet?: string; method?: string }) =>
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch, cursor: "" }) as never,
+      resetScroll: false,
+    });
+
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Explorer"
+        live
+        title="Chain events"
+        description="Individual Bittensor pallet events indexed directly from the chain — newest first, distinct from aggregate activity stats."
+        actions={
+          <ActionBar>
+            <DownloadCsvButton url={eventsCsvUrl} bare />
+            <ShareButton bare />
+          </ActionBar>
+        }
+      />
+      <ChainEventsFeed
+        pallet={search.pallet}
+        method={search.method}
+        cursor={search.cursor}
+        onFilter={onFilter}
+      />
+      <ApiSourceFooter paths={["/api/v1/chain-events", "/api/v1/chain-events/stats"]} />
+    </AppShell>
+  );
+}

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useInfiniteQuery, useQuery, useSuspenseQueries } from "@tanstack/react-query";
+import { useQuery, useSuspenseQueries } from "@tanstack/react-query";
 import { Suspense, useMemo, useState } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
@@ -13,7 +13,6 @@ import {
   ShareButton,
   ActionBar,
   ListShell,
-  LoadMore,
   TimeAgo,
   StatTile,
   Sparkline,
@@ -23,12 +22,11 @@ import {
 } from "@jsonbored/ui-kit";
 import { EXPLORER_LEADERBOARD_IDS } from "@/components/metagraphed/explorer-leaderboard-layout";
 import { ExplorerLeaderboardTableShell } from "@/components/metagraphed/explorer-leaderboard-table-shell";
-import { SearchInput } from "@/components/metagraphed/table-controls";
+import { ChainEventsFeed } from "@/components/metagraphed/chain-events-feed";
 import {
   blocksQuery,
   chainActivityQuery,
   chainCallsQuery,
-  chainEventsInfiniteQuery,
   chainEventsStatsQuery,
   chainFeesQuery,
   chainSignersQuery,
@@ -47,10 +45,8 @@ import {
 } from "@/lib/metagraphed/queries";
 import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
-import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import type {
   ChainCalls,
-  ChainEvent,
   ChainEventsStats,
   ChainStakeFlow,
   ChainStakeMoves,
@@ -1915,128 +1911,12 @@ function ChainEventsFeedSection() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
 
-  const baseParams = useMemo(
-    () => ({
-      pallet: search.pallet.trim() || undefined,
-      method: search.pallet.trim() && search.method.trim() ? search.method.trim() : undefined,
-      limit: 50,
-    }),
-    [search.pallet, search.method],
-  );
-
-  const {
-    data,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-    isFetchNextPageError,
-    error,
-    isPending,
-    isFetching,
-    refetch,
-  } = useInfiniteQuery(chainEventsInfiniteQuery(baseParams, search.events_cursor));
-
-  const setSearch = (patch: Record<string, unknown>) =>
+  const onFilter = (patch: { pallet?: string; method?: string }) =>
     navigate({
       search: (prev: Record<string, unknown>) =>
         ({ ...prev, ...patch, events_cursor: "" }) as never,
       resetScroll: false,
     });
-
-  const pages = data?.pages ?? [];
-  const lastPage = pages[pages.length - 1];
-  const cursorInvalid = !!(lastPage as { cursorInvalid?: boolean } | undefined)?.cursorInvalid;
-  const events = pages.flatMap((p) => (p.data ?? []) as ChainEvent[]);
-  const filtersActive = !!(search.pallet.trim() || search.method.trim());
-
-  const filters = (
-    <>
-      <SearchInput
-        value={search.pallet}
-        onChange={(v) => setSearch({ pallet: v, method: v.trim() ? search.method : "" })}
-        placeholder="Filter by pallet"
-        className="min-w-[140px] flex-none font-mono text-[11px]"
-      />
-      <SearchInput
-        value={search.method}
-        onChange={(v) => setSearch({ method: v })}
-        placeholder={search.pallet.trim() ? "Filter by method" : "Method (requires pallet)"}
-        className="min-w-[140px] flex-none font-mono text-[11px]"
-      />
-    </>
-  );
-
-  const emptyNode = (
-    <EmptyState
-      title={
-        filtersActive
-          ? "No chain events match these filters."
-          : "No chain events indexed yet — the all-events backfill fills this feed."
-      }
-    />
-  );
-
-  const table = (
-    <table className="w-full text-left text-sm">
-      <thead className="bg-surface/40">
-        <tr>
-          <th className={TH}>Pallet.method</th>
-          <th className={TH}>Block</th>
-          <th className={`${TH} text-right`}>Observed</th>
-        </tr>
-      </thead>
-      <tbody className="divide-y divide-border">
-        {events.map((event) => (
-          <tr key={`${event.block_number}-${event.event_index}`} className="hover:bg-surface/40">
-            <td className="px-4 py-2.5 font-mono text-[11px] text-ink-strong">
-              {extrinsicCall(event.pallet, event.method)}
-            </td>
-            <td className="px-4 py-2.5 font-mono text-[11px]">
-              {event.block_number != null ? (
-                <Link
-                  to="/blocks/$ref"
-                  params={{ ref: String(event.block_number) }}
-                  className="text-ink-strong hover:text-accent hover:underline"
-                >
-                  #{formatNumber(event.block_number)}
-                </Link>
-              ) : (
-                "—"
-              )}
-            </td>
-            <td className="px-4 py-2.5 text-right font-mono text-[11px] text-ink-muted">
-              <TimeAgo at={event.observed_at} />
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
-
-  const cards = events.map((event) => (
-    <div
-      key={`${event.block_number}-${event.event_index}-card`}
-      className="rounded border border-border bg-card p-3 min-h-11"
-    >
-      <div className="font-mono text-[11px] text-ink-strong">
-        {extrinsicCall(event.pallet, event.method)}
-      </div>
-      <div className="mt-1 flex items-center justify-between gap-2 font-mono text-[10px] text-ink-muted">
-        {event.block_number != null ? (
-          <Link
-            to="/blocks/$ref"
-            params={{ ref: String(event.block_number) }}
-            className="hover:text-accent hover:underline"
-          >
-            #{formatNumber(event.block_number)}
-          </Link>
-        ) : (
-          <span>—</span>
-        )}
-        <TimeAgo at={event.observed_at} />
-      </div>
-    </div>
-  ));
 
   return (
     <section className="mt-10 rounded-lg border border-border bg-card p-5">
@@ -2048,41 +1928,12 @@ function ChainEventsFeedSection() {
           Browse individual pallet events newest-first — distinct from aggregate activity stats.
         </p>
       </div>
-
-      {isPending ? (
-        <Skeleton className="h-56 w-full" />
-      ) : error && !data ? (
-        <ErrorState
-          error={error}
-          context="chain events feed"
-          onRetry={() => {
-            void refetch();
-          }}
-        />
-      ) : (
-        <ListShell
-          filters={filters}
-          table={table}
-          cards={cards}
-          isEmpty={events.length === 0 && !isFetching}
-          empty={emptyNode}
-          isStale={isFetching && !isPending && !isFetchingNextPage}
-          footer={
-            events.length > 0 ? (
-              <LoadMore
-                hasMore={!!hasNextPage}
-                isLoading={isFetchingNextPage}
-                onLoadMore={() => {
-                  void fetchNextPage();
-                }}
-                shown={events.length}
-                error={isFetchNextPageError ? error : null}
-                cursorInvalid={cursorInvalid}
-              />
-            ) : undefined
-          }
-        />
-      )}
+      <ChainEventsFeed
+        pallet={search.pallet}
+        method={search.method}
+        cursor={search.events_cursor}
+        onFilter={onFilter}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Chain events get their own first-class `/events` section, matching the standalone treatment Blocks and Extrinsics already have. Previously the live chain-events feed was only reachable by scrolling `/explorer`; now it's browsable directly and reachable from the main nav and ⌘K.

> Resubmit of #6304, addressing the two review gaps that closed it: **(1)** the feed logic is now a shared component instead of duplicated, and **(2)** it has test coverage.

### What changed

- **`apps/ui/src/components/metagraphed/chain-events-feed.tsx`** (new) — the filters/table/cards/empty/error/pagination logic extracted into **one shared `ChainEventsFeed` component**, plus a `chainEventsBaseParams` helper and `CHAIN_EVENTS_PAGE_SIZE` constant. Consumes the already-live `GET /api/v1/chain-events` (+ `/chain-events/stats`) — no backend work.
- **`apps/ui/src/routes/explorer.tsx`** — `ChainEventsFeedSection` now renders the shared `<ChainEventsFeed>` instead of its own inline copy (net **−158 lines**). `/explorer` is visually unchanged (same markup, same query).
- **`apps/ui/src/routes/events.index.tsx`** (new) — standalone `/events` route: `PageHero` + Download CSV + Share, wrapping the same shared `<ChainEventsFeed>` and `ApiSourceFooter`.
- **`nav-omnibox.tsx` / `command-palette-body.tsx`** — `Events` entries added to `NAV_LINKS` (after Blocks) and the ⌘K route list (after Extrinsics).

### Addressing the #6304 review

- **Duplication → shared component.** `/events` and `/explorer` now render the *same* `ChainEventsFeed`; there's no more line-for-line copy to keep in sync.
- **No tests → coverage added.** `chain-events-feed.test.ts` (4 cases) covers the extracted `chainEventsBaseParams` contract (page-size only, pallet-only, method-requires-pallet, whitespace trimming). The shared render path is additionally exercised by the existing `/explorer` responsive-overflow e2e.

## Validation

Ran locally (Node 22, `--workspace=apps/ui`): `lint` (0 errors) · `format:check` · `typecheck` · `test` (**1027 passing**, incl. the 4 new) · `test:e2e` (**24 passing**, incl. `/explorer` at all viewports — confirms no regression from the refactor) · `build` (bundle under budget).

## Screenshots

Before = the Chain events feed embedded in `/explorer` (its only prior home, rendered by the shared component post-refactor — unchanged); After = the new standalone `/events` page.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-desktop-light-before.png)<br><sub>before · /explorer embedded</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-desktop-light-after.png)<br><sub>after · /events</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-desktop-dark-before.png)<br><sub>before · /explorer embedded</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-desktop-dark-after.png)<br><sub>after · /events</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-tablet-light-before.png)<br><sub>before · /explorer embedded</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-tablet-light-after.png)<br><sub>after · /events</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-tablet-dark-before.png)<br><sub>before · /explorer embedded</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-tablet-dark-after.png)<br><sub>after · /events</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-mobile-light-before.png)<br><sub>before · /explorer embedded</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-mobile-light-after.png)<br><sub>after · /events</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-mobile-dark-before.png)<br><sub>before · /explorer embedded</sub> | [<img src="https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/nickmopen/metagraphed/screenshots/6268-events-mobile-dark-after.png)<br><sub>after · /events</sub> |

Closes #6268
