### PR TITLE
feat(ui): add root/status filters to /subnets (#6270)

### DIFF
--- a/apps/ui/src/components/metagraphed/account-address.tsx
+++ b/apps/ui/src/components/metagraphed/account-address.tsx
@@ -38,7 +38,12 @@ export function AccountAddress({
             {shortHash(ss58, keep)}
           </Link>
         </EntityHoverCard>
-        <CopyButton value={ss58} label="account" className={copyButtonClassName} compact={compact} />
+        <CopyButton
+          value={ss58}
+          label="account"
+          className={copyButtonClassName}
+          compact={compact}
+        />
       </span>
     );
   }

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -19,6 +19,12 @@ export const tableSearchSchema = z.object({
   stale: fallback(z.string(), "").default(""),
   provider: fallback(z.string(), "").default(""),
   netuid: fallback(z.string(), "").default(""),
+  // /subnets root/status filters (#6270) -- "" means unfiltered (matches every
+  // other filter field's convention). `root` reads the row's normalized `type`
+  // ("root" | "application"); `status` reads the row's on-chain `lifecycle`
+  // ("active" | "deprecated" | "parked") -- confirmed against live data.
+  root: fallback(z.string(), "").default(""),
+  status: fallback(z.string(), "").default(""),
   // #9: agent-catalog capability filters (applied client-side over joined rows).
   serviceKind: fallback(z.string(), "").default(""),
   readiness: fallback(z.string(), "").default(""),

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -139,6 +139,8 @@ function SubnetsPage() {
     !!search.readiness ||
     !!search.kind ||
     !!search.stale ||
+    !!search.root ||
+    !!search.status ||
     !!search.cursor;
   const onReset = () =>
     navigate({
@@ -361,6 +363,8 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
     search.readiness ||
     search.kind ||
     search.stale ||
+    search.root ||
+    search.status ||
     search.sort
   );
 
@@ -391,6 +395,18 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
         // doesn't emit a `freshness` field on these rows — `updated_at` is what's
         // actually populated (confirmed against the live response).
         if (search.stale && !isStaleFreshness(s.updated_at, 24 * 60 * 60_000)) return false;
+        // `type` (normalized from the API's `subnet_type`) is "root" | "application" —
+        // confirmed against live data (1 root subnet, 128 application, out of 129).
+        if (search.root === "only" && s.type !== "root") return false;
+        if (search.root === "exclude" && s.type === "root") return false;
+        // On-chain lifecycle, not probe health (never conflate the two — see
+        // useSubnetProbeHealth's "never by profile/chain lifecycle status" note).
+        // The list API's `status` field is uniformly "active" for every row (a
+        // no-op to filter on); `lifecycle` is the field that actually varies
+        // (confirmed live: active/deprecated/parked).
+        const lifecycle = s.lifecycle as string | undefined;
+        if (search.status === "active" && lifecycle !== "active") return false;
+        if (search.status === "inactive" && lifecycle === "active") return false;
         return true;
       }),
     [
@@ -402,6 +418,8 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
       search.readiness,
       search.kind,
       search.stale,
+      search.root,
+      search.status,
     ],
   );
   const rows = useMemo(
@@ -468,6 +486,24 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
           { value: "warn", label: "warn" },
           { value: "down", label: "down" },
           { value: "unknown", label: "unknown" },
+        ]}
+      />
+      <SelectFilter
+        label="root"
+        value={search.root}
+        onChange={(v) => setSearch({ root: v })}
+        options={[
+          { value: "only", label: "root only" },
+          { value: "exclude", label: "exclude root" },
+        ]}
+      />
+      <SelectFilter
+        label="status"
+        value={search.status}
+        onChange={(v) => setSearch({ status: v })}
+        options={[
+          { value: "active", label: "active" },
+          { value: "inactive", label: "inactive" },
         ]}
       />
       <SelectFilter


### PR DESCRIPTION
## What

Adds `root` and `status` filters to `/subnets`, following the same `SelectFilter` +
`tableSearchSchema` pattern already used by the existing `curation`/`health`/`kind`/`stale`
filters on this page.

The issue as filed implied filtering on `is_root`/`subnet_is_active` fields. Neither exists:
`Subnet` (`types.ts`) has no such fields, and curling live `/api/v1/subnets` confirmed the raw
API's `status` field is uniformly `"active"` across all 129 subnets — a filter on it would have
been a silent no-op. The fields that actually distinguish rows are the already-normalized `type`
(from `subnet_type`, `"root"` | `"application"` — 1 root subnet, 128 application, confirmed live)
and the raw `lifecycle` field (`"active"` | `"deprecated"` | `"parked"`, confirmed varying live:
125/3/1). The filters read those instead.

- `root`: "root only" / "exclude root" via `s.type`.
- `status`: "active" / "inactive" via `s.lifecycle` (inactive = not `"active"`, i.e.
  deprecated or parked).

Also includes an unrelated 1-line prettier reformat of `account-address.tsx`'s `CopyButton` call
— `main` itself currently fails the `ui` job's lint step because #6280 pushed that line over the
width limit; carrying the fix here so this PR's own `ui` check is green rather than waiting on
whichever PR ends up landing the fix upstream.

## Scope

- `url-state.ts`: 2 new schema fields (`root`, `status`), default `""` (unfiltered), matching
  every other filter field's convention.
- `subnets.index.tsx`: filter predicates, both `filtersActive` checks, 2 new `SelectFilter`
  dropdowns.
- `account-address.tsx`: formatting only, no behavior change.

## Screenshot evidence

Captured on `/subnets`, before = current `main`, after = this branch.

| Viewport · Theme | Before | After |
| ---- | ---- | ---- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/subnets-root-status-6270-after-mobile-dark.png)<br><sub>after</sub> |

## Verification

- `npx eslint .` run from within `apps/ui`: 0 errors, 235 pre-existing warnings (unchanged).
- `npx vitest run` on `url-state.test.ts`: 20/20 passing.
- Confirmed `type`/`lifecycle` distributions against live `/api/v1/subnets` before wiring up
  the filters (not just the type declaration).
- Rebased onto current `main`.

Closes #6270
