### PR TITLE
feat(ui): surface network-wide total stake on /subnets (#6271)

### DIFF
--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -191,7 +191,7 @@ function SubnetsPage() {
       <QueryErrorBoundary>
         <Suspense
           fallback={
-            <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3 mb-6">
               <Skeleton className="h-20" />
               <Skeleton className="h-20" />
               <Skeleton className="h-20" />
@@ -248,12 +248,13 @@ function SubnetsStatStrip() {
   const totalH = health.total;
   const healthyOk = ok != null && totalH != null && totalH > 0 && ok / totalH > 0.9;
   return (
-    <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3 mb-6">
       <StatTile
         icon={Network}
         eyebrow="Active subnets"
         value={formatNumber(active)}
         hint={total ? `of ${formatNumber(total)}` : undefined}
+        truncate={false}
       />
       <StatTile
         icon={Radio}
@@ -261,19 +262,27 @@ function SubnetsStatStrip() {
         value={formatNumber(adapter)}
         hint="pilots"
         tone="accent"
+        truncate={false}
       />
-      <StatTile icon={Layers} eyebrow="Manifested surfaces" value={formatNumber(manifested)} />
+      <StatTile
+        icon={Layers}
+        eyebrow="Manifested surfaces"
+        value={formatNumber(manifested)}
+        truncate={false}
+      />
       <StatTile
         icon={Activity}
         eyebrow="Healthy"
         value={ok != null && totalH ? `${formatNumber(ok)}/${formatNumber(totalH)}` : "—"}
         tone={healthyOk ? "ok" : "default"}
+        truncate={false}
       />
       <StatTile
         icon={Coins}
         eyebrow="Total stake"
         value={formatTao(totalStake)}
         tooltip="Network-wide total stake across all subnets, from the latest daily snapshot."
+        truncate={false}
       />
     </div>
   );

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseInfiniteQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useEffect, useMemo } from "react";
 import { z } from "zod";
-import { Network, Radio, Layers, Activity } from "lucide-react";
+import { Network, Radio, Layers, Activity, Coins } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
@@ -49,6 +49,7 @@ import {
   subnetHealthMapQuery,
   agentCatalogMapQuery,
   economicsQuery,
+  economicsTrendsQuery,
 } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber, formatTao, isStaleFreshness } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
@@ -190,7 +191,8 @@ function SubnetsPage() {
       <QueryErrorBoundary>
         <Suspense
           fallback={
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+              <Skeleton className="h-20" />
               <Skeleton className="h-20" />
               <Skeleton className="h-20" />
               <Skeleton className="h-20" />
@@ -216,6 +218,13 @@ function SubnetsPage() {
 function SubnetsStatStrip() {
   const coverage = useSuspenseQuery(coverageQuery()).data.data ?? {};
   const health = useSuspenseQuery(healthQuery()).data.data ?? {};
+  // #6271: network-wide stake, reusing the /api/v1/economics/trends consumer the
+  // explorer trend chart already reads (#3365). The endpoint returns days
+  // newest-first (same assumption explorer.tsx makes before reversing for its
+  // sparkline), so days[0] is the latest snapshot; formatTao renders "—" when the
+  // series is empty or the day's stake is null.
+  const trends = useSuspenseQuery(economicsTrendsQuery()).data.data;
+  const totalStake = trends.days[0]?.total_stake_tao ?? null;
   // Wired to the live /api/v1/coverage shape (same as CoverageFunnel): the older
   // netuids_active/netuids_total/adapter_backed fields are null on the live payload.
   const active =
@@ -239,7 +248,7 @@ function SubnetsStatStrip() {
   const totalH = health.total;
   const healthyOk = ok != null && totalH != null && totalH > 0 && ok / totalH > 0.9;
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
       <StatTile
         icon={Network}
         eyebrow="Active subnets"
@@ -259,6 +268,12 @@ function SubnetsStatStrip() {
         eyebrow="Healthy"
         value={ok != null && totalH ? `${formatNumber(ok)}/${formatNumber(totalH)}` : "—"}
         tone={healthyOk ? "ok" : "default"}
+      />
+      <StatTile
+        icon={Coins}
+        eyebrow="Total stake"
+        value={formatTao(totalStake)}
+        tooltip="Network-wide total stake across all subnets, from the latest daily snapshot."
       />
     </div>
   );


### PR DESCRIPTION
## Summary

`/subnets` carried no stake figure of any kind, while `GET /api/v1/economics/trends` already computes a network-wide daily total-stake series from the `subnet_snapshots` rollup and is already consumed by the explorer trend chart (`explorer.tsx`, #3365).

This reuses that exact consumer as a **"Total stake"** headline `StatTile` on the `/subnets` stat strip. No new backend work, no new pipeline — a straight reuse of already-shipped, already-proven wiring in a new location.

Closes #6271

## What Changed

**`apps/ui/src/routes/subnets.index.tsx`** (1 file, +28/-4):

- `SubnetsStatStrip` now reads the existing `economicsTrendsQuery()` and takes the latest snapshot's `total_stake_tao`. The endpoint returns days newest-first — the same assumption `explorer.tsx` already makes before reversing for its sparkline — so `days[0]` is the latest day; this is documented inline rather than left implicit.
- Empty-series / null-stake both fall through `formatTao`, which renders `—` (verified in `format.ts`), matching the "Healthy" tile's existing placeholder behaviour.
- Stat strip goes `grid-cols-2 md:grid-cols-3 lg:grid-cols-5` (fallback skeletons match). A flat `md:grid-cols-5` is **not** viable: at the `md` breakpoint (768px) five tiles are ~137px wide, and `StatTile`'s value is `shrink-0` (deliberately, per the `#3940` comment), so `338.64M τ` cannot shrink and overflows the tile and the page. Tablet therefore gets 3 columns × 2 rows, and the 5-across row starts at `lg`.
- All five tiles get `truncate={false}` so the eyebrows wrap instead of clipping. This is the prop's documented purpose ("a label too long to reliably fit one line at every breakpoint ... in a 2-column mobile grid"). Previously mobile rendered `ACTIVE SUBN…` / `ADAPTER-BAC…` / `MANIFESTED …`; they now read in full.
- Context lives in the tile's `tooltip` rather than a `hint`. `StatTile` deliberately lets the hint absorb constrained width so the value never wraps (see the `#3940` comment in `stat-tile.tsx`), so at 5 columns a `hint="network-wide"` clips to `netw…` on desktop and `n.` on mobile. `tooltip` is the component's documented affordance for "what the statistic means" and renders `shrink-0`; this matches the existing usage in `emission-yield-panel.tsx`.

Beyond the issue's literal deliverable: the breakpoint ladder, the `truncate={false}` on the four pre-existing tiles, the Suspense-fallback column count, and the tooltip-over-hint choice. All four are consequences of fitting a 5th tile into this strip rather than additions of scope — calling them out explicitly per the contribution guide. The `truncate={false}` change also incidentally fixes pre-existing eyebrow clipping on the other four tiles at mobile.

## Screenshots (before / after)

Real `/subnets`, captured with `npm run screenshots --workspace=apps/ui` at fixed viewports (no full-page capture), themes forced via `mg-theme`. Before is this PR's merge-base. The stat strip gains a fifth tile: **Total stake · 338.64M τ**.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6271-total-stake-after-mobile-dark.png)<br><sub>after</sub> |

Verified with a scripted assertion at all 3 viewports × both themes: `document.scrollWidth <= clientWidth` and no stat tile's bounding box escapes the viewport (`pageOverflow=false, tileClipped=false` in all 6 combinations).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6271`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A — no generated artifacts touched.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A — consumes an already-live route; no contract change.)

## Validation

Scoped to the `ui` CI job's gates, run in CI's own order (Node 22.23.1):

- [x] `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui` — the exact CI step; lint 0 errors (235 pre-existing warnings, unchanged), Prettier clean on my file
- [x] `npm run typecheck --workspace=apps/ui` — 0 errors
- [x] `npm test --workspace=apps/ui` — 136 files / 1040 tests passed
- [x] `npm run test:e2e --workspace=apps/ui` — 24 passed (responsive-overflow, all routes)
- [x] `npm run build --workspace=apps/ui` — built clean
- [x] `git diff --check` — clean
- [x] Rebased onto `main` immediately before pushing; diff is 1 file.

`packages/client` / `packages/ui-kit` sources are untouched, so no `dist` rebuild is bundled here.

> **Note on the red `ui` check:** it fails at `Lint (ESLint + Prettier)` on `apps/ui/src/components/metagraphed/account-address.tsx`, which this PR does not touch. `main` is red on the same step independently of this PR — [run 29529107962](https://github.com/JSONbored/metagraphed/actions/runs/29529107962) on `ac2d669d`. #6280 added `compact={compact}` to a `<CopyButton>` line there, taking it to ~101 chars against `apps/ui`'s `printWidth: 100`. The one-line `prettier --write` fix is deliberately **not** bundled here to keep this PR single-purpose and avoid colliding with a maintainer fix; happy to add it if preferred. This PR's own files pass the step.

## Template Used

backend-code (frontend change; `apps/ui`-scoped — see the screenshot contract above)
