### PR TITLE
Fix #5736: remove duplicate Allways leaderboard registry surface

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -3,7 +3,7 @@
   "curation": {
     "gap_notes": [
       "No verified dashboard surface yet (no dashboard link found on the website as of 2026-07-15).",
-      "Data-artifact surface exists (sn-7-allways-data-artifact) but is community-submitted, not yet maintainer-verified."
+      "Removed duplicate leaderboard URL surface; kept allways-miners-leaderboard (subnet-api)."
     ],
     "level": "adapter-backed",
     "review_state": "maintainer-reviewed",
@@ -272,28 +272,6 @@
       "provider": "allways",
       "public_safe": true,
       "url": "https://api.all-ways.io/sse"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "id": "sn-7-allways-data-artifact",
-      "kind": "data-artifact",
-      "name": "Allways community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "allways",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.all-ways.io/swagger-json"],
-      "url": "https://api.all-ways.io/miners/leaderboard"
     },
     {
       "auth_required": false,

--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -44,7 +44,6 @@ const BASE_LAYER_KINDS = new Set(["subtensor-rpc", "subtensor-wss", "archive"]);
 // its underlying duplicate is actually resolved in the registry file.
 const GRANDFATHERED_DUPLICATE_URLS = new Set([
   "8-ball.json|https://github.com/Barbariandev/8Ball_miner",
-  "allways.json|https://api.all-ways.io/miners/leaderboard",
   "bitmind.json|https://api.bitmind.ai/health",
   "gradients.json|https://api.gradients.io/v1/network/status",
 ]);


### PR DESCRIPTION
## Summary
- Remove `sn-7-allways-data-artifact` (duplicate of `allways-miners-leaderboard`).
- Drop the matching `GRANDFATHERED_DUPLICATE_URLS` entry in `scripts/validate-surface.mjs`.
- Keep the correctly typed `subnet-api` surface.

## Test plan
- [x] `allways.json` has a single surface for the leaderboard URL
- [x] grandfather list no longer includes that URL

Fixes #5736
