### PR TITLE
fix(api): bound chain-firehose ingest body before Durable Object forward

### DIFF
--- a/tests/chain-firehose-routes.test.mjs
+++ b/tests/chain-firehose-routes.test.mjs
@@ -8,6 +8,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.mjs";
+import { CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES } from "../workers/chain-firehose-hub.mjs";
 
 function stubHub(fetchImpl) {
   return {
@@ -275,4 +276,93 @@ test("ingest: relays a non-2xx upstream status (e.g. 400 from an invalid payload
     {},
   );
   assert.equal(res.status, 400);
+});
+
+// The Durable Object rejects bodies over CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES,
+// but that only helps after the Worker has already buffered + forwarded the
+// payload. Bound the body at the auth edge so an authenticated caller (or a
+// leaked sync secret) cannot force unbounded memory/CPU on the public Worker.
+test("ingest: 413s on an oversized Content-Length before the hub is reached", async () => {
+  let forwarded = false;
+  const env = {
+    CHAIN_FIREHOSE_SYNC_SECRET: "shh",
+    CHAIN_FIREHOSE_HUB: stubHub(() => {
+      forwarded = true;
+      return new Response("{}", { status: 202 });
+    }),
+  };
+  const res = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/internal/chain-firehose-ingest",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES + 1),
+          "x-chain-firehose-sync-token": "shh",
+        },
+        // Body may be empty/short -- the declared length alone must trip the
+        // guard before any Durable Object call.
+        body: "{}",
+      },
+    ),
+    env,
+    {},
+  );
+  assert.equal(res.status, 413);
+  assert.equal((await res.json()).error.code, "payload_too_large");
+  assert.equal(forwarded, false, "oversized ingest must not reach the hub");
+});
+
+test("ingest: 413s on a chunked body that crosses the ingest byte cap before the hub is reached", async () => {
+  let forwarded = false;
+  const env = {
+    CHAIN_FIREHOSE_SYNC_SECRET: "shh",
+    CHAIN_FIREHOSE_HUB: stubHub(() => {
+      forwarded = true;
+      return new Response("{}", { status: 202 });
+    }),
+  };
+  // Omit Content-Length so the Worker must stream-bound the body (the
+  // Content-Length short-circuit is covered above).
+  const res = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/internal/chain-firehose-ingest",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-chain-firehose-sync-token": "shh",
+        },
+        body: new Blob([
+          " ".repeat(CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES + 1),
+        ]).stream(),
+        duplex: "half",
+      },
+    ),
+    env,
+    {},
+  );
+  assert.equal(res.status, 413);
+  assert.equal((await res.json()).error.code, "payload_too_large");
+  assert.equal(forwarded, false, "oversized ingest must not reach the hub");
+});
+
+test("ingest: a body at the ingest byte cap is still forwarded to the hub", async () => {
+  let forwardedBody;
+  const env = {
+    CHAIN_FIREHOSE_SYNC_SECRET: "shh",
+    CHAIN_FIREHOSE_HUB: stubHub((_input, init) => {
+      forwardedBody = init.body;
+      return new Response(JSON.stringify({ ok: true }), { status: 202 });
+    }),
+  };
+  const body = "x".repeat(CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES);
+  const res = await handleRequest(
+    ingestRequest(body, { token: "shh" }),
+    env,
+    {},
+  );
+  assert.equal(res.status, 202);
+  assert.equal(forwardedBody, body);
 });

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -28,7 +28,7 @@ import { CHAIN_DEREGISTRATIONS_WINDOWS } from "../src/chain-deregistrations.mjs"
 import { CHAIN_REGISTRATIONS_WINDOWS } from "../src/chain-registrations.mjs";
 import { CHAIN_AXON_REMOVALS_WINDOWS } from "../src/chain-axon-removals.mjs";
 import { handleRequest } from "../workers/api.mjs";
-import { resolveClientIp } from "../workers/config.mjs";
+import { DAY_MS, resolveClientIp } from "../workers/config.mjs";
 import {
   KV_ECONOMICS_CURRENT,
   KV_HEALTH_CURRENT,
@@ -10667,11 +10667,14 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
   });
 
   test("no Postgres tier flag: aggregates surface_uptime_daily rows straight off D1", async () => {
+    // Relative to now — a hardcoded day falls out of the 7d window and the
+    // assertion rots (same class as the chain-fees median date-rot fix).
+    const recentDay = new Date(Date.now() - DAY_MS).toISOString().slice(0, 10);
     const env = {
       METAGRAPH_HEALTH_DB: bulkTrendsD1([
         {
           netuid: 7,
-          date: "2026-07-09",
+          date: recentDay,
           total: 10,
           ok_count: 9,
           avg_latency_ms: 50,

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -264,6 +264,7 @@ import {
 import { loadGlobalOperationalHealth } from "../src/global-operational-health.mjs";
 import {
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
+  CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES,
   ChainFirehoseHub,
 } from "./chain-firehose-hub.mjs";
 import { McpSessionHub } from "./mcp-session-hub.mjs";
@@ -1268,13 +1269,33 @@ async function handleChainFirehoseIngest(request, env) {
       503,
     );
   }
-  const body = await request.text();
+  // Enforce the DO's 16 KB ingest ceiling HERE, before buffering/forwarding.
+  // request.text() alone would let an authenticated caller (or a leaked
+  // sync secret) force the Worker to materialize an arbitrarily large body
+  // and copy it into the Durable Object binding, only for the DO to reject
+  // it after the cost was already paid. Mirror /ask's streaming bound so a
+  // chunked oversize body is cancelled as soon as it crosses the cap.
+  const boundedBody = await readBoundedRequestText(
+    request,
+    CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES,
+  );
+  if (!boundedBody.ok) {
+    return errorResponse(
+      "payload_too_large",
+      `Chain-firehose ingest body exceeds ${CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES} bytes.`,
+      413,
+    );
+  }
   const stub = env.CHAIN_FIREHOSE_HUB.get(
     env.CHAIN_FIREHOSE_HUB.idFromName("global"),
   );
   const upstream = await stub.fetch(
     "https://chain-firehose-hub.internal/ingest",
-    { method: "POST", body, headers: { "content-type": "application/json" } },
+    {
+      method: "POST",
+      body: boundedBody.text,
+      headers: { "content-type": "application/json" },
+    },
   );
   return new Response(await upstream.text(), {
     status: upstream.status,


### PR DESCRIPTION
## Summary
- `handleChainFirehoseIngest` authenticated callers and then called `request.text()` with no byte cap before forwarding to `ChainFirehoseHub`.
- The Durable Object already rejects bodies over `CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES` (16 KB), but only after the Worker had buffered and copied the entire payload — so a leaked `CHAIN_FIREHOSE_SYNC_SECRET` could still force unbounded Worker memory/CPU (chunked uploads bypass `Content-Length`).
- Reuse the existing `readBoundedRequestText` helper (same pattern as `/ask`) to enforce the 16 KB ceiling at the Worker auth edge and return `413 payload_too_large` without invoking the DO.

## Root cause
Auth + rate-limit protected request count, but not request size. The DO's size validator could not prevent the Worker from paying the buffering cost first.

## Fix approach
- Import `CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES` from `workers/chain-firehose-hub.mjs`.
- Stream-bound the ingest body in `handleChainFirehoseIngest` before `stub.fetch`.
- Add regression tests for oversized `Content-Length`, chunked oversize bodies, and at-cap forwarding.

## Impact
- Prevents unbounded memory use on the public Worker ingest path when the sync secret leaks or is abused.
- Preserves valid relay payloads at/under the existing 16 KB contract; no protocol change for legitimate box-side relays.

## Risk / tradeoffs
- Low: same constant the DO already enforces; callers that previously paid for a doomed oversized forward now get a faster 413 from the Worker instead.
- Bodies exactly at the cap still forward (unchanged from DO semantics).

## Test plan
- [x] `npx vitest run tests/chain-firehose-routes.test.mjs` (17 passed)
- [x] `npx vitest run tests/chain-firehose-hub.test.mjs` (118 passed)
- [x] `npx eslint workers/api.mjs tests/chain-firehose-routes.test.mjs --quiet`
- [ ] CI Validate workflow green

Made with [Cursor](https://cursor.com)