### PR TITLE
feat(ui): adopt one ranked-list interaction model across validators and leaderboards (#5344)

### DIFF
--- a/apps/ui/src/components/metagraphed/account-address.tsx
+++ b/apps/ui/src/components/metagraphed/account-address.tsx
@@ -38,7 +38,12 @@ export function AccountAddress({
             {shortHash(ss58, keep)}
           </Link>
         </EntityHoverCard>
-        <CopyButton value={ss58} label="account" className={copyButtonClassName} compact={compact} />
+        <CopyButton
+          value={ss58}
+          label="account"
+          className={copyButtonClassName}
+          compact={compact}
+        />
       </span>
     );
   }

--- a/apps/ui/src/components/metagraphed/validator-columns.test.ts
+++ b/apps/ui/src/components/metagraphed/validator-columns.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { VALIDATOR_COLUMNS } from "./validator-columns";
-import type { GlobalValidator } from "@/lib/metagraphed/types";
+import type { GlobalValidator, GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 // A fully-populated row so every column's cell renderer resolves a real value
 // rather than its null fallback.
@@ -74,6 +74,39 @@ describe("VALIDATOR_COLUMNS", () => {
       "Total emission",
     ]) {
       expect(headers).toContain(h);
+    }
+  });
+
+  // #5344: the table's `<select>` was replaced by clickable column headers, so a
+  // sort key with no column backing it would be unreachable from the UI — the
+  // exact regression that made avg/max trust select-only in the first place.
+  it("gives every /api/v1/validators sort key a column to sort from", () => {
+    const sortable = new Set(VALIDATOR_COLUMNS.map((c) => c.sort).filter(Boolean));
+    const apiSortKeys: GlobalValidatorSort[] = [
+      "avg_validator_trust",
+      "max_validator_trust",
+      "stake_dominance",
+      "subnet_count",
+      "total_emission",
+      "total_stake",
+      "uid_count",
+    ];
+    for (const key of apiSortKeys) {
+      expect(sortable).toContain(key);
+    }
+  });
+
+  it("maps each sort key to exactly one column (no ambiguous header)", () => {
+    const keys = VALIDATOR_COLUMNS.map((c) => c.sort).filter(Boolean);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  // Padding is the route's job (density-driven) -- a column baking in its own
+  // py-* would silently win or lose against it depending on CSS source order.
+  it("leaves cell padding to the route so the density toggle can own it", () => {
+    for (const col of VALIDATOR_COLUMNS) {
+      expect(col.thClassName).not.toMatch(/\bp[xy]?-/);
+      expect(col.tdClassName).not.toMatch(/\bp[xy]?-/);
     }
   });
 });

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -3,13 +3,16 @@ import { Link } from "@tanstack/react-router";
 import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
-import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
+import { taoCompact, scoreStr, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
 import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
-import type { GlobalValidator } from "@/lib/metagraphed/types";
+import type { GlobalValidator, GlobalValidatorSort } from "@/lib/metagraphed/types";
 
-const TH_BASE = "px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted";
-const TD_BASE = "px-3 py-2 font-mono text-[11px]";
+// Cell padding is NOT baked in here: the route owns it so one density choice can
+// drive every cell (classNames() plain-joins, so a route-side "py-1.5" would not
+// reliably beat a "py-2" baked in here -- CSS source order, not class order, wins).
+const TH_BASE = "font-mono text-[10px] uppercase tracking-widest text-ink-muted";
+const TD_BASE = "font-mono text-[11px]";
 const TD_NUM = `${TD_BASE} text-right tabular-nums`;
 
 /**
@@ -24,6 +27,14 @@ export interface ValidatorColumn {
   thClassName: string;
   tdClassName: string;
   cell: (v: GlobalValidator) => ReactNode;
+  /**
+   * The `/api/v1/validators` sort key this column ranks by, when it has one.
+   * Columns carrying it render a clickable SortHeader; the rest stay static
+   * text. Keeping the mapping on the column (rather than a parallel lookup in
+   * the route) is what makes "every sort key is reachable from a header" a
+   * property the tests can assert against the same array the table renders.
+   */
+  sort?: GlobalValidatorSort;
 }
 
 const numeric = (
@@ -95,10 +106,11 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     // apy_estimate (#2551) is a 0..1 fraction; formatApyPct takes a percentage.
     cell: (v) => formatApyPct(v.apy_estimate != null ? v.apy_estimate * 100 : null),
   },
-  { ...numeric("Active subnets"), cell: (v) => formatNumber(v.subnet_count) },
+  { ...numeric("Active subnets"), sort: "subnet_count", cell: (v) => formatNumber(v.subnet_count) },
   {
     ...numeric("UIDs"),
     tdClassName: `${TD_NUM} text-ink-muted`,
+    sort: "uid_count",
     cell: (v) => formatNumber(v.uid_count),
   },
   {
@@ -108,12 +120,30 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
   },
   {
     ...numeric("Dominance"),
+    sort: "stake_dominance",
     cell: (v) => (v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"),
   },
-  { ...numeric("Total stake"), cell: (v) => taoCompact(v.total_stake_tao) },
+  { ...numeric("Total stake"), sort: "total_stake", cell: (v) => taoCompact(v.total_stake_tao) },
   {
     ...numeric("Total emission"),
     tdClassName: `${TD_NUM} text-ink-muted`,
+    sort: "total_emission",
     cell: (v) => taoCompact(v.total_emission_tao),
+  },
+  // Trust closes the gap the `<select>` used to cover on its own: avg/max trust
+  // were sortable but had no column, so a header-driven table would have made
+  // both keys unreachable. Same 3-dp convention the per-subnet neuron table
+  // renders "Val Trust" with.
+  {
+    ...numeric("Avg trust"),
+    tdClassName: `${TD_NUM} text-ink-muted`,
+    sort: "avg_validator_trust",
+    cell: (v) => scoreStr(v.avg_validator_trust),
+  },
+  {
+    ...numeric("Max trust"),
+    tdClassName: `${TD_NUM} text-ink-muted`,
+    sort: "max_validator_trust",
+    cell: (v) => scoreStr(v.max_validator_trust),
   },
 ];

--- a/apps/ui/src/lib/metagraphed/leaderboard-sort.test.ts
+++ b/apps/ui/src/lib/metagraphed/leaderboard-sort.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { withRank, sortRanked } from "./leaderboard-sort";
+
+const board = [
+  { netuid: 1, weight_sets: 100, per_setter: 2.5 },
+  { netuid: 2, weight_sets: 50, per_setter: null },
+  { netuid: 3, weight_sets: 75, per_setter: 1.5 },
+];
+
+describe("withRank", () => {
+  it("stamps the API's delivery order as the rank", () => {
+    expect(withRank(board).map((r) => [r.netuid, r.rank])).toEqual([
+      [1, 1],
+      [2, 2],
+      [3, 3],
+    ]);
+  });
+
+  it("does not mutate the source rows", () => {
+    const rows = [{ netuid: 9 }];
+    withRank(rows);
+    expect(rows[0]).not.toHaveProperty("rank");
+  });
+});
+
+describe("sortRanked", () => {
+  const ranked = withRank(board);
+
+  it("sorts descending by a numeric column", () => {
+    expect(sortRanked(ranked, (r) => r.weight_sets, "desc").map((r) => r.netuid)).toEqual([
+      1, 3, 2,
+    ]);
+  });
+
+  it("sorts ascending by a numeric column", () => {
+    expect(sortRanked(ranked, (r) => r.weight_sets, "asc").map((r) => r.netuid)).toEqual([2, 3, 1]);
+  });
+
+  it("keeps the API rank on the row when re-sorted (Rank column stays truthful)", () => {
+    const byWeight = sortRanked(ranked, (r) => r.weight_sets, "asc");
+    expect(byWeight.map((r) => r.rank)).toEqual([2, 3, 1]);
+  });
+
+  it("sorts rows with no value last in BOTH directions", () => {
+    expect(sortRanked(ranked, (r) => r.per_setter, "desc").map((r) => r.netuid)).toEqual([1, 3, 2]);
+    // netuid 2 has a null metric — ascending must not float it to the top as if
+    // it were the smallest value.
+    expect(sortRanked(ranked, (r) => r.per_setter, "asc").map((r) => r.netuid)).toEqual([3, 1, 2]);
+  });
+
+  it("treats a non-finite number as missing, not as a value", () => {
+    const rows = withRank([{ v: 1 }, { v: Number.NaN }, { v: 3 }]);
+    expect(sortRanked(rows, (r) => r.v, "desc").map((r) => r.rank)).toEqual([3, 1, 2]);
+  });
+
+  it("breaks ties by the API rank, so the order is stable and total", () => {
+    const rows = withRank([{ v: 5 }, { v: 5 }, { v: 5 }]);
+    expect(sortRanked(rows, (r) => r.v, "desc").map((r) => r.rank)).toEqual([1, 2, 3]);
+    expect(sortRanked(rows, (r) => r.v, "asc").map((r) => r.rank)).toEqual([1, 2, 3]);
+  });
+
+  it("sorts strings alphabetically", () => {
+    const rows = withRank([{ name: "Zeus" }, { name: "Apex" }, { name: "Mars" }]);
+    expect(sortRanked(rows, (r) => r.name, "asc").map((r) => r.name)).toEqual([
+      "Apex",
+      "Mars",
+      "Zeus",
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const before = ranked.map((r) => r.netuid);
+    sortRanked(ranked, (r) => r.weight_sets, "asc");
+    expect(ranked.map((r) => r.netuid)).toEqual(before);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/leaderboard-sort.ts
+++ b/apps/ui/src/lib/metagraphed/leaderboard-sort.ts
@@ -1,0 +1,59 @@
+/**
+ * Client-side ranked-list sorting for the /leaderboards boards (#5344).
+ *
+ * The boards arrive already ranked by their primary metric and are delivered
+ * whole (no cursor), so re-sorting them is a pure view concern — unlike
+ * /validators, whose ranking is a server-side query over a top-N slice and so
+ * cannot be reordered client-side without changing what the rows mean.
+ */
+
+export type SortOrder = "asc" | "desc";
+
+/** A board row carrying the API's own ranking, pinned before any re-sort. */
+export interface RankedRow {
+  rank: number;
+}
+
+/**
+ * Stamp each row with the rank implied by the order the API delivered it in.
+ *
+ * The Rank column has to keep reporting the board's ranking, not the row's
+ * current display position — otherwise sorting by a secondary metric would
+ * relabel the #1 subnet as #7 and quietly destroy the only piece of information
+ * the board exists to convey.
+ */
+export function withRank<T>(rows: readonly T[]): Array<T & RankedRow> {
+  return rows.map((row, i) => ({ ...row, rank: i + 1 }));
+}
+
+/**
+ * Sort ranked rows by one column's value.
+ *
+ * Two deliberate properties:
+ * - **Null-last in both directions.** A subnet with no `sets_per_setter` is
+ *   "unknown", not "lowest" — floating it to the top of an ascending sort would
+ *   read as a real ranking. Absent values stay at the bottom either way.
+ * - **Ties break by the API's rank**, so the sort is total and stable: equal
+ *   values keep the board's own ordering instead of the engine's arbitrary one.
+ */
+export function sortRanked<T extends RankedRow>(
+  rows: readonly T[],
+  value: (row: T) => number | string | null | undefined,
+  order: SortOrder,
+): T[] {
+  const dir = order === "asc" ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const av = value(a);
+    const bv = value(b);
+    const aMissing = av == null || (typeof av === "number" && !Number.isFinite(av));
+    const bMissing = bv == null || (typeof bv === "number" && !Number.isFinite(bv));
+    if (aMissing && bMissing) return a.rank - b.rank;
+    if (aMissing) return 1;
+    if (bMissing) return -1;
+    const cmp =
+      typeof av === "string" || typeof bv === "string"
+        ? String(av).localeCompare(String(bv))
+        : (av as number) - (bv as number);
+    return cmp !== 0 ? Math.sign(cmp) * dir : a.rank - b.rank;
+  });
+}

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -17,20 +17,56 @@ import {
   DownloadCsvButton,
   ActionBar,
 } from "@jsonbored/ui-kit";
+import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
 import {
   chainDeregistrationsQuery,
   chainWeightsQuery,
   subnetsQuery,
 } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { withRank, sortRanked, type SortOrder } from "@/lib/metagraphed/leaderboard-sort";
 import { buildUrl } from "@/lib/metagraphed/client";
 import type { Subnet } from "@/lib/metagraphed/types";
 
+// Each board owns its own sort so the two are independently rankable and the
+// whole view stays shareable in one URL — the same search-param-backed model
+// /subnets uses, rather than component-local state that a shared link drops.
+const weightsSortFields = [
+  "rank",
+  "subnet",
+  "weight_sets",
+  "distinct_setters",
+  "sets_per_setter",
+] as const;
+const deregsSortFields = [
+  "rank",
+  "subnet",
+  "deregistrations",
+  "distinct_deregistered_hotkeys",
+  "deregistrations_per_hotkey",
+] as const;
+
+type WeightsSortField = (typeof weightsSortFields)[number];
+type DeregsSortField = (typeof deregsSortFields)[number];
+
 const leaderboardsSearchSchema = z.object({
   window: fallback(z.enum(["7d", "30d"]), "7d").default("7d"),
+  weights_sort: fallback(z.enum(weightsSortFields), "rank").default("rank"),
+  weights_order: fallback(z.enum(["asc", "desc"]), "asc").default("asc"),
+  deregs_sort: fallback(z.enum(deregsSortFields), "rank").default("rank"),
+  deregs_order: fallback(z.enum(["asc", "desc"]), "asc").default("asc"),
 });
 
 type LeaderboardWindow = z.infer<typeof leaderboardsSearchSchema>["window"];
+
+/**
+ * Sort toggle shared by both boards: a new column starts ascending, the active
+ * column flips — identical to /subnets' onSort, so the interaction transfers
+ * between ranked-list pages instead of being re-learned per page.
+ */
+function nextOrder(prevField: string | undefined, prevOrder: SortOrder | undefined, field: string) {
+  return prevField === field && prevOrder === "asc" ? "desc" : "asc";
+}
 
 export const Route = createFileRoute("/leaderboards")({
   validateSearch: zodValidator(leaderboardsSearchSchema),
@@ -135,9 +171,52 @@ function useSubnetById(): Map<number, Subnet> {
 function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
   const { data: boardRes } = useSuspenseQuery(chainWeightsQuery(win));
   const subnetById = useSubnetById();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const search = Route.useSearch();
+  const sort: WeightsSortField = search.weights_sort;
+  const order: SortOrder = search.weights_order;
   const board = boardRes.data;
   const network = board.network;
   const dist = board.intensity_distribution;
+
+  // Resolve the subnet name onto the row before sorting so the Subnet column
+  // ranks by what it displays, not by netuid.
+  const rows = useMemo(() => {
+    const named = withRank(board.subnets).map((row) => ({
+      ...row,
+      name: subnetById.get(row.netuid)?.name ?? `Subnet ${row.netuid}`,
+    }));
+    if (sort === "rank") return sortRanked(named, (r) => r.rank, order);
+    if (sort === "subnet") return sortRanked(named, (r) => r.name, order);
+    return sortRanked(named, (r) => r[sort], order);
+  }, [board.subnets, subnetById, sort, order]);
+
+  const onSort = (field: string) =>
+    navigate({
+      search: (prev: Record<string, unknown>) =>
+        ({
+          ...prev,
+          weights_sort: field,
+          weights_order: nextOrder(sort, order, field),
+        }) as never,
+      replace: true,
+    });
+
+  const col = (field: WeightsSortField, label: string, align: "left" | "right" = "right") => (
+    <th
+      className={classNames(TH, align === "right" && "text-right")}
+      aria-sort={ariaSort(sort === field, order)}
+    >
+      <SortHeader
+        label={label}
+        field={field}
+        active={sort === field}
+        order={order}
+        onSort={onSort}
+        align={align}
+      />
+    </th>
+  );
 
   return (
     <div className="space-y-8">
@@ -208,9 +287,9 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
               stacked card per subnet instead — mirrors the cards/desktop-only
               split the explorer leaderboards use for the same static boards. */}
           <div className="md:hidden space-y-2 p-3">
-            {board.subnets.map((row, i) => {
+            {rows.map((row) => {
               const subnet = subnetById.get(row.netuid);
-              const name = subnet?.name ?? `Subnet ${row.netuid}`;
+              const name = row.name;
               return (
                 <div key={row.netuid} className="rounded border border-border bg-card p-3">
                   <div className="flex items-center justify-between gap-2">
@@ -220,7 +299,7 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
                       className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
                     >
                       <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
-                        {i + 1}
+                        {row.rank}
                       </span>
                       <BrandIcon
                         size={18}
@@ -249,21 +328,21 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
             <table className="w-full text-left text-sm">
               <thead>
                 <tr>
-                  <th className={TH}>Rank</th>
-                  <th className={TH}>Subnet</th>
-                  <th className={`${TH} text-right`}>Weight-sets</th>
-                  <th className={`${TH} text-right`}>Distinct setters</th>
-                  <th className={`${TH} text-right`}>Per setter</th>
+                  {col("rank", "Rank")}
+                  {col("subnet", "Subnet", "left")}
+                  {col("weight_sets", "Weight-sets")}
+                  {col("distinct_setters", "Distinct setters")}
+                  {col("sets_per_setter", "Per setter")}
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
-                {board.subnets.map((row, i) => {
+                {rows.map((row) => {
                   const subnet = subnetById.get(row.netuid);
-                  const name = subnet?.name ?? `Subnet ${row.netuid}`;
+                  const name = row.name;
                   return (
                     <tr key={row.netuid} className="hover:bg-surface/40">
                       <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                        {i + 1}
+                        {row.rank}
                       </td>
                       <td className="px-4 py-2.5">
                         <Link
@@ -305,8 +384,49 @@ function WeightSettingLeaderboard({ win }: { win: LeaderboardWindow }) {
 function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
   const { data: boardRes } = useSuspenseQuery(chainDeregistrationsQuery(win));
   const subnetById = useSubnetById();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const search = Route.useSearch();
+  const sort: DeregsSortField = search.deregs_sort;
+  const order: SortOrder = search.deregs_order;
   const board = boardRes.data;
   const network = board.network;
+
+  const rows = useMemo(() => {
+    const named = withRank(board.subnets).map((row) => ({
+      ...row,
+      name: subnetById.get(row.netuid)?.name ?? `Subnet ${row.netuid}`,
+    }));
+    if (sort === "rank") return sortRanked(named, (r) => r.rank, order);
+    if (sort === "subnet") return sortRanked(named, (r) => r.name, order);
+    return sortRanked(named, (r) => r[sort], order);
+  }, [board.subnets, subnetById, sort, order]);
+
+  const onSort = (field: string) =>
+    navigate({
+      search: (prev: Record<string, unknown>) =>
+        ({
+          ...prev,
+          deregs_sort: field,
+          deregs_order: nextOrder(sort, order, field),
+        }) as never,
+      replace: true,
+    });
+
+  const col = (field: DeregsSortField, label: string, align: "left" | "right" = "right") => (
+    <th
+      className={classNames(TH, align === "right" && "text-right")}
+      aria-sort={ariaSort(sort === field, order)}
+    >
+      <SortHeader
+        label={label}
+        field={field}
+        active={sort === field}
+        order={order}
+        onSort={onSort}
+        align={align}
+      />
+    </th>
+  );
 
   return (
     <div className="space-y-8">
@@ -370,9 +490,9 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
           </div>
           {/* < md: card fallback per subnet (see the weight-setting board). */}
           <div className="md:hidden space-y-2 p-3">
-            {board.subnets.map((row, i) => {
+            {rows.map((row) => {
               const subnet = subnetById.get(row.netuid);
-              const name = subnet?.name ?? `Subnet ${row.netuid}`;
+              const name = row.name;
               return (
                 <div key={row.netuid} className="rounded border border-border bg-card p-3">
                   <div className="flex items-center justify-between gap-2">
@@ -382,7 +502,7 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
                       className="inline-flex min-w-0 items-center gap-2 hover:text-accent"
                     >
                       <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-muted">
-                        {i + 1}
+                        {row.rank}
                       </span>
                       <BrandIcon
                         size={18}
@@ -411,21 +531,21 @@ function DeregistrationsLeaderboard({ win }: { win: LeaderboardWindow }) {
             <table className="w-full text-left text-sm">
               <thead>
                 <tr>
-                  <th className={TH}>Rank</th>
-                  <th className={TH}>Subnet</th>
-                  <th className={`${TH} text-right`}>Deregistrations</th>
-                  <th className={`${TH} text-right`}>Distinct hotkeys</th>
-                  <th className={`${TH} text-right`}>Per hotkey</th>
+                  {col("rank", "Rank")}
+                  {col("subnet", "Subnet", "left")}
+                  {col("deregistrations", "Deregistrations")}
+                  {col("distinct_deregistered_hotkeys", "Distinct hotkeys")}
+                  {col("deregistrations_per_hotkey", "Per hotkey")}
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
-                {board.subnets.map((row, i) => {
+                {rows.map((row) => {
                   const subnet = subnetById.get(row.netuid);
-                  const name = subnet?.name ?? `Subnet ${row.netuid}`;
+                  const name = row.name;
                   return (
                     <tr key={row.netuid} className="hover:bg-surface/40">
                       <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink-muted">
-                        {i + 1}
+                        {row.rank}
                       </td>
                       <td className="px-4 py-2.5">
                         <Link

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -146,6 +146,39 @@ function ValidatorsPage() {
   );
 }
 
+function SortSelect({
+  value,
+  onChange,
+  className,
+}: {
+  value: GlobalValidatorSort;
+  onChange: (v: GlobalValidatorSort) => void;
+  className?: string;
+}) {
+  return (
+    <label
+      className={classNames(
+        "inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs",
+        className,
+      )}
+    >
+      <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">Sort</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value as GlobalValidatorSort)}
+        className="bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label="Sort validators"
+      >
+        {validatorSortKeys.map((k) => (
+          <option key={k} value={k}>
+            {SORT_LABELS[k]}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
 function ValidatorsTable({
   sort,
   density,
@@ -159,7 +192,10 @@ function ValidatorsTable({
   const validators = res.data.validators;
   const generatedAt = res.meta?.generated_at ?? null;
   const compact = density === "compact";
-  const cellPad = compact ? "px-3 py-1.5" : "px-4 py-2.5";
+  // "comfortable" keeps this table's existing px-3 py-2 exactly, so the default
+  // view is unchanged and compact is purely opt-in; a wider px-4 (as /subnets
+  // uses) would squeeze this table's much longer column set for no benefit.
+  const cellPad = compact ? "px-3 py-1.5" : "px-3 py-2";
 
   return (
     <div className="space-y-3">
@@ -174,6 +210,12 @@ function ValidatorsTable({
         <span className="font-mono text-[11px] text-ink-muted">
           {formatNumber(validators.length)} validators · ranked by {SORT_LABELS[sort]}
         </span>
+        {/* < md this page renders the card list, not the table, so there are no
+            column headers to click — the select stays as the mobile sort
+            affordance rather than leaving small viewports unable to sort at
+            all. /subnets can drop straight to headers because its view toggle
+            can put a real table on screen; this page has no such toggle. */}
+        <SortSelect value={sort} onChange={onSortChange} className="md:hidden" />
       </div>
 
       {validators.length > 0 ? (

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -4,13 +4,22 @@ import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { PageHero, ShareButton, DownloadCsvButton, ActionBar } from "@jsonbored/ui-kit";
+import {
+  PageHero,
+  ShareButton,
+  DownloadCsvButton,
+  ActionBar,
+  DensityToggle,
+  type Density,
+} from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
-import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
+import { classNames, formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { ValidatorDominanceChart } from "@/components/metagraphed/charts/validator-dominance-chart";
@@ -46,6 +55,7 @@ const SORT_LABELS: Record<GlobalValidatorSort, string> = {
 
 const validatorsSearchSchema = z.object({
   sort: fallback(z.enum(validatorSortKeys), "subnet_count").default("subnet_count"),
+  density: fallback(z.enum(["comfortable", "compact"]), "comfortable").optional(),
 });
 
 export const Route = createFileRoute("/validators/")({
@@ -76,6 +86,15 @@ function ValidatorsPage() {
   // current view as CSV. DownloadCsvButton appends `format=csv`; the backend's
   // handleGlobalValidators already serves it (#5482).
   const validatorsCsvUrl = buildUrl("/api/v1/validators", { sort });
+  const isMobile = useIsMobile();
+  // Same resolution order as /subnets: an explicit choice wins, otherwise mobile
+  // defaults to compact so the row height suits the viewport.
+  const effectiveDensity: Density = search.density ?? (isMobile ? "compact" : "comfortable");
+  const setDensity = (d: Density) =>
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, density: d }) as never,
+      replace: true,
+    });
   return (
     <AppShell>
       <PageHero
@@ -85,6 +104,7 @@ function ValidatorsPage() {
         description="Network-wide validator directory — hotkeys ranked across all Bittensor subnets, computed live from the chain-direct metagraph."
         actions={
           <>
+            <DensityToggle value={effectiveDensity} onChange={setDensity} />
             <ActionBar>
               <DownloadCsvButton url={validatorsCsvUrl} bare />
               <ShareButton bare />
@@ -97,6 +117,7 @@ function ValidatorsPage() {
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>
           <ValidatorsTable
             sort={sort}
+            density={effectiveDensity}
             onSortChange={(v) =>
               navigate({
                 search: (prev: Record<string, unknown>) => ({ ...prev, sort: v }) as never,
@@ -125,42 +146,20 @@ function ValidatorsPage() {
   );
 }
 
-function SortSelect({
-  value,
-  onChange,
-}: {
-  value: GlobalValidatorSort;
-  onChange: (v: GlobalValidatorSort) => void;
-}) {
-  return (
-    <label className="inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs">
-      <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">Sort</span>
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value as GlobalValidatorSort)}
-        className="bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        aria-label="Sort validators"
-      >
-        {validatorSortKeys.map((k) => (
-          <option key={k} value={k}>
-            {SORT_LABELS[k]}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
 function ValidatorsTable({
   sort,
+  density,
   onSortChange,
 }: {
   sort: GlobalValidatorSort;
+  density: Density;
   onSortChange: (v: GlobalValidatorSort) => void;
 }) {
   const res = useSuspenseQuery(validatorsQuery({ sort })).data;
   const validators = res.data.validators;
   const generatedAt = res.meta?.generated_at ?? null;
+  const compact = density === "compact";
+  const cellPad = compact ? "px-3 py-1.5" : "px-4 py-2.5";
 
   return (
     <div className="space-y-3">
@@ -175,7 +174,6 @@ function ValidatorsTable({
         <span className="font-mono text-[11px] text-ink-muted">
           {formatNumber(validators.length)} validators · ranked by {SORT_LABELS[sort]}
         </span>
-        <SortSelect value={sort} onChange={onSortChange} />
       </div>
 
       {validators.length > 0 ? (
@@ -184,8 +182,29 @@ function ValidatorsTable({
             <thead className="bg-surface/50">
               <tr>
                 {VALIDATOR_COLUMNS.map((col) => (
-                  <th key={col.header} className={col.thClassName}>
-                    {col.header}
+                  <th
+                    key={col.header}
+                    className={classNames(cellPad, col.thClassName)}
+                    // Only a sortable column reports a sort state; the rest stay "none"
+                    // by omission rather than claiming an unsortable columnheader.
+                    aria-sort={col.sort ? ariaSort(sort === col.sort, "desc") : undefined}
+                  >
+                    {col.sort ? (
+                      <SortHeader
+                        label={col.header}
+                        field={col.sort}
+                        active={sort === col.sort}
+                        // /api/v1/validators ranks each key server-side, descending, and
+                        // takes no order param -- so a header selects the key and the
+                        // arrow always reads "desc". Flipping it client-side would only
+                        // reverse the fetched top-N, which is not the same query.
+                        order="desc"
+                        onSort={(field) => onSortChange(field as GlobalValidatorSort)}
+                        align={col.thClassName.includes("text-right") ? "right" : "left"}
+                      />
+                    ) : (
+                      col.header
+                    )}
                   </th>
                 ))}
               </tr>
@@ -194,7 +213,7 @@ function ValidatorsTable({
               {validators.map((v) => (
                 <tr key={v.hotkey} className="hover:bg-surface/40">
                   {VALIDATOR_COLUMNS.map((col) => (
-                    <td key={col.header} className={col.tdClassName}>
+                    <td key={col.header} className={classNames(cellPad, col.tdClassName)}>
                       {col.cell(v)}
                     </td>
                   ))}


### PR DESCRIPTION
## What

Three structurally-similar ranked-list pages had three different interaction models: `/subnets` used clickable `SortHeader` column headers plus a density toggle, `/validators` used a standalone `<select>` with non-interactive `<th>`s and no density control, and `/leaderboards` had no sort UI at all beyond the 7d/30d window switch.

Per the issue's first deliverable, **`/subnets`' existing model is adopted as the canonical one** (clickable `SortHeader` + `aria-sort` on the `<th>` + density toggle), and `/validators` and `/leaderboards` are brought up to it. Both already had the shared primitives available — `SortHeader`/`ariaSort` from `table-controls.tsx` and `DensityToggle` from `@jsonbored/ui-kit` — so this composes them rather than adding new one-off styling. (Saved views stay `/subnets`-specific: `SubnetsSavedViews` is bound to that route's filter set, and the issue scopes deliverables 2 and 3 to sort + density.)

## What changed

**`/validators`** — `<select>` → clickable column headers, plus a density toggle:

- Each column now carries its own `/api/v1/validators` sort key (`ValidatorColumn.sort`), so the `<thead>` and the sort mapping come from the same array the rows render from — the invariant that already makes header/cell misalignment (#5307) structurally impossible.
- **Added `Avg trust` / `Max trust` columns.** `avg_validator_trust` and `max_validator_trust` are sortable on the API but had no column, so a header-driven table would have made both keys **unreachable** — deleting the `<select>` without them would have been a silent functional regression. Both fields were already on `GlobalValidator` and normalized; they render with the same 3-dp `scoreStr` convention the per-subnet neuron table uses for "Val Trust". This is called out explicitly as the one addition beyond the issue's literal text — it exists to keep the migration lossless, and a test now asserts every API sort key has a column.
- **Sorting stays server-side and descending.** `/api/v1/validators` ranks each key itself over a top-N slice and takes no `order` param, so a header selects the key and the arrow always reads "desc". Flipping direction client-side would only reverse the fetched top-20, which is not the same query — so it isn't offered rather than being offered dishonestly.
- Cell padding moved out of the column defs into the route so one density choice drives every cell. `classNames()` plain-joins (no tailwind-merge), so a route-side `py-1.5` could not have reliably beaten a `py-2` baked into the column — a test now pins that. **"Comfortable" keeps this table's existing `px-3 py-2` exactly**, so the default view's density is unchanged and compact is purely opt-in.
- **The `<select>` is retained below `md`.** This page renders the card list, not the table, on small viewports and has no view toggle that could put a table on screen — so deleting the select outright would have left mobile unable to sort at all. Headers where there are headers, select where there are cards. (`/subnets` can drop straight to headers precisely because its view toggle can surface a real table at any width.)

**`/leaderboards`** — sort UI for both boards:

- Both boards get clickable headers over Rank / Subnet / their three metrics, with each board owning its own search params (`weights_sort`/`weights_order`, `deregs_sort`/`deregs_order`) so they sort independently and the whole view stays shareable in one URL.
- These boards arrive whole and pre-ranked, so unlike `/validators` they sort **client-side** with the same new-column-ascending / active-column-flips toggle `/subnets` uses.
- **The Rank column keeps the API's ranking after a re-sort** rather than relabelling rows 1,2,3 by display position — otherwise sorting by a secondary metric would quietly destroy the only thing the board exists to convey. Sorting logic lives in `lib/metagraphed/leaderboard-sort.ts` (pure, 10 unit tests): missing metrics sort last in **both** directions (absent ≠ smallest), and ties break by the API rank so the sort is total and stable.

## Scope

- `apps/ui/**` only — 7 files, +422/−38. No API, schema, or contract change.
- **Known tradeoff, called out deliberately:** the two trust columns take the desktop table from 11 to 13 columns, so at 1280 the headers and the hotkey/coldkey cells now wrap to two lines (rows ~37px → ~49px). That is the same wrapping this table already does at tablet today (see the Tablet · Before shot), not a new rendering — but it is the honest price of keeping every sort key reachable from a header. If a reviewer would rather keep 11 columns, the alternative is dropping `avg_validator_trust`/`max_validator_trust` from the sort set entirely; I chose not to remove working functionality unasked.
- **One out-of-scope file, and why:** `account-address.tsx` is a 1-line Prettier reformat. `main` (`ac2d669d`, #6280) left that line at 101 chars against `apps/ui`'s `printWidth: 100`, which the `ui` job's `eslint .` fails on as a `prettier/prettier` **error** — so *every* `apps/ui` PR is currently red through no fault of its own (JSONbored's own #6311 included). This PR cannot be green without it. It's the exact fix ESLint's own `--fix` output prescribes, and it's the same class of failure that closed #6266. Happy to drop it the moment `main` is fixed independently.

## Screenshot evidence

Captured with the repo's own `npm run screenshots` tool against `upstream/main` as the base ref, at fixed viewports (no full-page capture), with the theme forced via `mg-theme`.

### `/validators` — `<select>` → clickable headers + density toggle

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-validators-after-mobile-dark.png)<br><sub>after</sub> |

**Mobile rows are intentionally identical**: `< md` renders the card list, not the table, so the sort `<select>` is retained there — the shots are the evidence that no mobile sort affordance was lost. On desktop the select is gone and `Active subnets` carries the active-sort arrow; `Avg trust` / `Max trust` are the two new columns. Tablet already wrapped headers/hotkeys and scrolled horizontally before this PR — that rendering is pre-existing, not introduced here.

### `/leaderboards` — sort headers on both boards

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/5344-leaderboards-after-mobile-dark.png)<br><sub>after</sub> |

The deregistrations board renders its `EmptyState` in both refs (no `NeuronDeregistered` events in the live 7d window at capture time), so the weight-setting board is what the shots show. Default order is unchanged — `Rank` simply becomes the active ascending sort.


## Verification

Full `ui` job run locally, in CI's order — all green:

- `npm run lint --workspace=apps/ui` · `npm run format:check --workspace=apps/ui` (workspace-scoped — `apps/ui` has its own `.prettierrc`)
- `npm run typecheck --workspace=apps/ui` · `npm run typecheck --workspace=packages/ui-kit`
- `npm test --workspace=apps/ui` — **1053 passed** (137 files), including 13 new tests
- `npm test --workspace=packages/ui-kit` — 57 passed
- `npm run test:e2e --workspace=apps/ui` — 24/24 responsive-overflow checks passed
- `npm run build --workspace=apps/ui` · `packages/client` + `packages/ui-kit` dist drift checks clean
- `git diff --check` clean

Behaviour driven in a real browser against a dev server (the e2e overflow check covers neither `/validators` nor `/leaderboards`, so these were asserted directly):

- header click re-queries the server (`?sort=total_stake`) and `aria-sort` follows the clicked column; the row order genuinely changes (the top row stays `tao.bot` only because it is the maintainer-pinned `featured` validator from #5166)
- density toggle: row padding 10px → 6px, persisted as `density=compact`
- mobile (375px): the table is hidden, the select is visible and still drives the sort (`?sort=total_stake`); desktop is the inverse — select hidden, 7 header buttons live
- leaderboards: default order is the API ranking; after re-sorting, the Rank column still reads `20,10,8,4` rather than `1,2,3,4`; re-sorting board 1 leaves `deregs_sort` untouched
- `document.scrollWidth <= clientWidth` asserted on both routes at 375 / 768 / 1280 × light + dark — 12/12 clean

Closes #5344
