### PR TITLE
fix(test): stop the health_trends D1 fixture drifting out of its own window

### DIFF
--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -28,7 +28,7 @@ import { CHAIN_DEREGISTRATIONS_WINDOWS } from "../src/chain-deregistrations.mjs"
 import { CHAIN_REGISTRATIONS_WINDOWS } from "../src/chain-registrations.mjs";
 import { CHAIN_AXON_REMOVALS_WINDOWS } from "../src/chain-axon-removals.mjs";
 import { handleRequest } from "../workers/api.mjs";
-import { resolveClientIp } from "../workers/config.mjs";
+import { resolveClientIp, DAY_MS } from "../workers/config.mjs";
 import {
   KV_ECONOMICS_CURRENT,
   KV_HEALTH_CURRENT,
@@ -10667,11 +10667,22 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
   });
 
   test("no Postgres tier flag: aggregates surface_uptime_daily rows straight off D1", async () => {
+    // Relative to Date.now(), not a hardcoded literal -- a fixed past date
+    // drifts outside the resolver's real "7d" window as wall-clock time
+    // moves on, making this fail independent of any code change once it
+    // does (it just did: the literal was "2026-07-09"). loadBulkHealthTrends
+    // (src/bulk-health-trends.mjs) computes the window cutoff from the real
+    // Date.now() by default, so the fixture must track it the same way
+    // tests/request-handlers-analytics.test.mjs's `recentDay` already does
+    // for the identical surface_uptime_daily shape.
+    const recentDay = new Date(Date.now() - 2 * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
     const env = {
       METAGRAPH_HEALTH_DB: bulkTrendsD1([
         {
           netuid: 7,
-          date: "2026-07-09",
+          date: recentDay,
           total: 10,
           ok_count: 9,
           avg_latency_ms: 50,


### PR DESCRIPTION
## Summary

The `health_trends` GraphQL test's D1-path case ("no Postgres tier flag: aggregates surface_uptime_daily rows straight off D1") hardcoded `date: "2026-07-09"` as its only fixture row and asserted it inside the `7d` window. `loadBulkHealthTrends` (`src/bulk-health-trends.mjs`) computes that window from the real `Date.now()` by default -- so a fixed past date only passes until wall-clock time carries it past the 7-day cutoff. It just did, breaking this test on `main` and on every PR's CI run regardless of what the PR actually changes -- found while investigating an apparently-unrelated CI failure on #6311.

## Fix

Compute the fixture date relative to `Date.now()` (2 days ago) instead of a literal, matching the existing `recentDay` pattern already used in `tests/request-handlers-analytics.test.mjs` for the identical `surface_uptime_daily` row shape -- so this doesn't just push the same failure a few months out.

## Test plan

- [x] Reproduced the failure on unmodified `main` in isolation (`npx vitest run tests/graphql.test.mjs -t "health_trends"`) to confirm this is a pre-existing, date-triggered issue and not caused by any pending PR
- [x] `npx vitest run tests/graphql.test.mjs` -- 584/584 pass after the fix
- [x] `npx eslint`/`npx prettier --check` clean on the touched file