### PR TITLE
fix(ui): add 'Open API' action to validators + chain-events empty states (#6340)

### DIFF
--- a/apps/ui/src/components/metagraphed/chain-events-feed.tsx
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.tsx
@@ -4,6 +4,7 @@ import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/state
 import { SearchInput } from "@/components/metagraphed/table-controls";
 import { TimeAgo, ListShell, LoadMore } from "@jsonbored/ui-kit";
 import { chainEventsInfiniteQuery } from "@/lib/metagraphed/queries";
+import { API_BASE } from "@/lib/metagraphed/config";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import type { ChainEvent } from "@/lib/metagraphed/types";
@@ -92,6 +93,15 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
         filtersActive
           ? "No chain events match these filters."
           : "No chain events indexed yet — the all-events backfill fills this feed."
+      }
+      action={
+        filtersActive
+          ? undefined
+          : {
+              label: "Open /api/v1/chain-events",
+              href: `${API_BASE}/api/v1/chain-events`,
+              external: true,
+            }
       }
     />
   );

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -7,6 +7,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { PageHero, ShareButton, DownloadCsvButton, ActionBar } from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
+import { API_BASE } from "@/lib/metagraphed/config";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
@@ -207,6 +208,11 @@ function ValidatorsTable({
         <EmptyState
           title="No validators indexed yet"
           description="The global validator directory is empty for this window."
+          action={{
+            label: "Open /api/v1/validators",
+            href: `${API_BASE}/api/v1/validators`,
+            external: true,
+          }}
         />
       )}
 


### PR DESCRIPTION
Closes #6340.

## What

Every other single-feed list page's genuinely-empty `EmptyState` offers an `action` link to the underlying API (`blocks.index.tsx`, `extrinsics.index.tsx`, `providers.index.tsx`, `call-module-extrinsics-table.tsx`), but the **Validators index** and the **Chain events feed** did not.

- `validators.index.tsx`: added `action={{ label: "Open /api/v1/validators", href: \`\${API_BASE}/api/v1/validators\`, external: true }}` to its `EmptyState`.
- `chain-events-feed.tsx`: added the equivalent action citing `/api/v1/chain-events` to the **unfiltered** empty branch only — the filtered-empty branch ("No chain events match these filters") stays without an action, matching the filter-empty convention used elsewhere.

Left `leaderboards.tsx` (distinct `lastChecked` pattern) untouched, per the issue.

## Screenshots (before / after)

Empty states forced by an empty API response. The "Open API" link (with external-link icon) appears in the after column.

### Validators index — `/validators`
| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/before-validators-desktop-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/after-validators-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/before-validators-desktop-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/after-validators-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/before-validators-tablet-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/after-validators-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/before-validators-tablet-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/after-validators-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/before-validators-mobile-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/after-validators-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/before-validators-mobile-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/after-validators-mobile-dark.png) |

### Chain events feed — `/explorer`
| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/before-events-desktop-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/after-events-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/before-events-desktop-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/after-events-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/before-events-tablet-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/after-events-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/before-events-tablet-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/after-events-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/before-events-mobile-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/after-events-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/before-events-mobile-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6340/after-events-mobile-dark.png) |

## Verify

- `prettier --check` + `eslint` (from apps/ui) + `tsc --noEmit`: clean (0 errors).
- Diff is 2 files, +16.