### PR TITLE
feat(api): add account_positions GraphQL query mirroring GET /api/v1/accounts/{ss58}/positions

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -172,6 +172,7 @@ import {
   STAKE_FLOW_DIRECTIONS,
 } from "./stake-flow.mjs";
 import { buildAccountPortfolio } from "./account-portfolio.mjs";
+import { buildAccountPositions } from "./account-nominator-positions.mjs";
 import {
   buildAccountRegistrations,
   REGISTRATION_WINDOWS,
@@ -399,6 +400,8 @@ export const SDL = `
     account_position_history(ss58: String!, netuid: Int!, window: String): AccountPositionHistory!
     "One wallet's cross-subnet neuron portfolio: every subnet where the hotkey is a registered neuron, each position's economics (stake, emission, rank, trust, incentive, dividends, role) and emission/stake yield, plus wallet-level aggregates (totals, counts, overall return, stake concentration). Richer than account.registrations (registration footprint only). An address with no registered neurons resolves to a schema-stable empty card, never null. Mirrors GET /api/v1/accounts/{ss58}/portfolio."
     account_portfolio(ss58: String!): AccountPortfolio!
+    "This account's reconstructed nominator-side positions: what it holds delegated across every hotkey/subnet, distinct from account_portfolio's hotkey-scoped view (a pure delegator shows near-zero there since its stake lives on someone ELSE's hotkey row). Root (netuid 0) stake is not covered -- root has no alpha pool, so an address that only holds root-delegated stake resolves to a schema-stable empty positions[], never null. Mirrors GET /api/v1/accounts/{ss58}/positions."
+    account_positions(ss58: String!): AccountPositions!
     "One account's live cross-subnet footprint: every subnet where the hotkey is currently registered as a neuron, each with its netuid, uid, stake, validator-permit and active flag, plus a subnet_count. The registration snapshot only (netuid/uid/stake/permit/active) -- account_portfolio is the richer economics view over the same neurons. An unregistered or never-seen address resolves to a schema-stable empty footprint (subnet_count 0, subnets []), never null. Mirrors GET /api/v1/accounts/{ss58}/subnets."
     account_subnets(ss58: String!): AccountSubnets!
     "One account's per-subnet axon-serving footprint over a 7d/30d/90d window (default 30d): AxonServed announcement count and first/last timestamps per subnet, an HHI concentration of where its serving activity is focused, and the dominant subnet; an address with no announcements in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/accounts/{ss58}/serving."
@@ -2701,6 +2704,25 @@ export const SDL = `
     yield: Float
   }
 
+  "This account's reconstructed nominator-side positions: what it holds delegated across every hotkey/subnet, distinct from AccountPortfolio's hotkey-scoped view. Mirrors GET /api/v1/accounts/{ss58}/positions."
+  type AccountPositions {
+    schema_version: Int!
+    ss58: String!
+    captured_at: String
+    position_count: Int!
+    total_stake_tao: Float!
+    positions: [NominatorPosition!]!
+  }
+
+  "One (hotkey, netuid) delegation this account holds, reconstructed from the nominator-positions ledger joined against the hotkey's live stake_tao for that netuid."
+  type NominatorPosition {
+    hotkey: String!
+    netuid: Int!
+    "This account's share of the hotkey's total alpha-pool shares on this subnet (0..1), not a TAO amount."
+    share_fraction: Float!
+    stake_tao: Float!
+  }
+
   # Realtime chain-event firehose (#4983, ADR 0015) -- a thin protocol adapter
   # over the SAME ChainFirehoseHub Durable Object connection #4982's SSE/WS
   # transports use, not a second event pipeline. Reached over WebSocket only
@@ -2913,6 +2935,7 @@ export const FIELD_COMPLEXITY = {
   account_stake_flow: RELATIONSHIP_FIELD_COMPLEXITY,
   account_position_history: RELATIONSHIP_FIELD_COMPLEXITY,
   account_portfolio: RELATIONSHIP_FIELD_COMPLEXITY,
+  account_positions: RELATIONSHIP_FIELD_COMPLEXITY,
   account_subnets: RELATIONSHIP_FIELD_COMPLEXITY,
   // Fans out into leaderboardProfilesProjection plus several D1 reads and the
   // economics tier -- same cost class as the other relationship fields.
@@ -4982,6 +5005,36 @@ const rootValue = {
       total_emission_tao: data.total_emission_tao ?? 0,
       overall_yield: data.overall_yield ?? null,
       stake_concentration: data.stake_concentration ?? null,
+      positions: data.positions || [],
+    };
+  },
+
+  async account_positions({ ss58 }, context) {
+    if (!SS58_ADDRESS_PATTERN.test(ss58)) {
+      throw new GraphQLError("ss58 must be a valid SS58 address.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) ->
+    // buildAccountPositions([], new Map(), ss58) fallback contract
+    // handleAccountPositions uses -- Postgres-only (no D1 predecessor), flat
+    // body (like account_portfolio's), not the { data, generatedAt } envelope
+    // the account-event-footprint family uses.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/accounts/${encodeURIComponent(ss58)}/positions`,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildAccountPositions([], new Map(), ss58);
+    return {
+      schema_version: data.schema_version ?? 1,
+      ss58: data.ss58 ?? ss58,
+      captured_at: data.captured_at ?? null,
+      position_count: data.position_count ?? 0,
+      total_stake_tao: data.total_stake_tao ?? 0,
       positions: data.positions || [],
     };
   },

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -4507,6 +4507,133 @@ describe("graphql — account_portfolio (#5702, Postgres-tier flat body + zeroed
   });
 });
 
+describe("graphql — account_positions (#6324, Postgres-tier flat body + empty-card fallback)", () => {
+  const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  function query(argsClause) {
+    return `{ account_positions${argsClause} {
+      schema_version ss58 captured_at position_count total_stake_tao
+      positions { hotkey netuid share_fraction stake_tao }
+    } }`;
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty card, never null", async () => {
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`));
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.account_positions, {
+      schema_version: 1,
+      ss58: SS58,
+      captured_at: null,
+      position_count: 0,
+      total_stake_tao: 0,
+      positions: [],
+    });
+  });
+
+  test("resolves the Postgres-tier positions (flat body, matches GET /api/v1/accounts/{ss58}/positions parity)", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            ss58: SS58,
+            captured_at: "2026-07-10T00:00:00.000Z",
+            position_count: 2,
+            total_stake_tao: 1500,
+            positions: [
+              {
+                hotkey: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+                netuid: 3,
+                share_fraction: 0.5,
+                stake_tao: 1000,
+              },
+              {
+                hotkey: "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
+                netuid: 7,
+                share_fraction: 0.25,
+                stake_tao: 500,
+              },
+            ],
+          }),
+      },
+    };
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    const p = body.data.account_positions;
+    assert.equal(p.position_count, 2);
+    assert.equal(p.total_stake_tao, 1500);
+    assert.equal(p.positions[0].netuid, 3);
+    assert.equal(p.positions[0].share_fraction, 0.5);
+    assert.equal(
+      p.positions[1].hotkey,
+      "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
+    );
+  });
+
+  test("ss58 is forwarded on the Postgres-tier request path", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            ss58: SS58,
+            positions: [],
+          });
+        },
+      },
+    };
+    await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(capturedUrl.pathname, `/api/v1/accounts/${SS58}/positions`);
+  });
+
+  test("a malformed Postgres-tier body degrades to a schema-stable empty card", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.account_positions, {
+      schema_version: 1,
+      ss58: SS58,
+      captured_at: null,
+      position_count: 0,
+      total_stake_tao: 0,
+      positions: [],
+    });
+  });
+
+  test("an invalid ss58 is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      query('(ss58: "not-a-valid-address")'),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+    assert.equal(called, false);
+  });
+
+  test("account_positions is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.account_positions, 5);
+  });
+});
+
 describe("graphql — account_subnets (#5894, Postgres-tier flat body + empty-card fallback)", () => {
   const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 


### PR DESCRIPTION
## Summary

- Adds an `account_positions` GraphQL query mirroring `GET /api/v1/accounts/{ss58}/positions`, closing the GraphQL-surface gap called out in #6324 (the same gap already existed for the REST/MCP pairing filed separately in #6323).

## What Changed

- `src/graphql.mjs`: added `account_positions(ss58: String!): AccountPositions!` to the Query type, new `AccountPositions`/`NominatorPosition` GraphQL types mirroring `AccountPositionsArtifact`/`NominatorPosition` in `schemas/`, a resolver following `account_portfolio`'s exact `tryPostgresTier(..., "METAGRAPH_NEURONS_SOURCE") ?? buildAccountPositions([], new Map(), ss58)` fallback contract (reusing `buildAccountPositions` from `src/account-nominator-positions.mjs`, the same function `handleAccountPositions` uses), and a `RELATIONSHIP_FIELD_COMPLEXITY` weight entry.
- `tests/graphql.test.mjs`: added a parity test suite (cold-store empty card, Postgres-tier resolution, ss58 forwarded on the request path, malformed-body fallback, invalid-ss58 `BAD_USER_INPUT`, complexity weight) matching the sibling `account_portfolio`/`account_subnets` suites.

No `schemas/` changes — the GraphQL SDL is embedded in `src/graphql.mjs` and built at runtime, so no OpenAPI/contract regeneration applies here.

Closes #6324

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6324`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No OpenAPI change — GraphQL-only addition.)

## Validation

- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`