### PR TITLE
fix(ui): add copy affordance to neuron detail card's hotkey/coldkey (#6339)

### DIFF
--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -2,7 +2,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { Coins, Flame, Award, Server, X } from "lucide-react";
 import { subnetNeuronQuery } from "@/lib/metagraphed/queries";
-import { RealtimeFreshness, StatTile } from "@jsonbored/ui-kit";
+import { RealtimeFreshness, StatTile, CopyButton } from "@jsonbored/ui-kit";
 import { EmptyState } from "@/components/metagraphed/states";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { shortHash } from "@/lib/metagraphed/blocks";
@@ -145,14 +145,17 @@ function KeyRow({ label, value }: { label: string; value?: string }) {
         {label}
       </span>
       {value ? (
-        <Link
-          to="/accounts/$ss58"
-          params={{ ss58: value }}
-          className="font-mono text-[12px] text-ink hover:text-accent hover:underline"
-          title={value}
-        >
-          {shortHash(value) ?? value}
-        </Link>
+        <span className="inline-flex items-center gap-1">
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58: value }}
+            className="font-mono text-[12px] text-ink hover:text-accent hover:underline"
+            title={value}
+          >
+            {shortHash(value) ?? value}
+          </Link>
+          <CopyButton value={value} label={label} />
+        </span>
       ) : (
         <span className="font-mono text-[12px] text-ink-muted">—</span>
       )}


### PR DESCRIPTION
Closes #6339.

## What

The subnet detail page's per-UID drill-down card (`neuron-detail-card.tsx`'s `KeyRow`) rendered Hotkey/Coldkey as a plain `<Link>` with **no copy affordance** — unlike every other identifier display in the app, including the metagraph/validators table this card drills down from (`neuron-table.tsx`, `validator-columns.tsx`).

Added a `<CopyButton value={value} label={label} />` next to the `KeyRow` link (wrapped in an `inline-flex` span), so both the Hotkey and Coldkey rows can be copied without navigating away.

## Screenshots (before / after)

Subnet detail per-UID card (`/subnets/1?tab=metagraph&uid=0`). The copy icon appears next to Hotkey + Coldkey in the after column.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6339/before-desktop-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6339/after-desktop-light.png) |
| Desktop · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6339/before-desktop-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6339/after-desktop-dark.png) |
| Tablet · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6339/before-tablet-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6339/after-tablet-light.png) |
| Tablet · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6339/before-tablet-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6339/after-tablet-dark.png) |
| Mobile · Light | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6339/before-mobile-light.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6339/after-mobile-light.png) |
| Mobile · Dark | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6339/before-mobile-dark.png) | ![](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6339/after-mobile-dark.png) |

## Verify

- `prettier --check` + `eslint` (from apps/ui) + `tsc --noEmit`: clean (0 errors).
- Diff is 1 file, +12/-9.