### PR TITLE
feat(mcp): add get_account_positions tool mirroring GET /api/v1/accounts/{ss58}/positions

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -476,6 +476,7 @@ import {
   DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW,
 } from "./subnet-deregistrations.mjs";
 import { buildAccountPortfolio } from "./account-portfolio.mjs";
+import { buildAccountPositions } from "./account-nominator-positions.mjs";
 import {
   buildNeuronHistory,
   buildSubnetHistory,
@@ -6107,6 +6108,43 @@ export const MCP_TOOLS = [
           mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/portfolio`),
           "METAGRAPH_NEURONS_SOURCE",
         )) ?? buildAccountPortfolio([], ss58)
+      );
+    },
+  },
+  {
+    name: "get_account_positions",
+    title: "Get an account's nominator-side positions",
+    description:
+      "This account's reconstructed nominator-side positions (by SS58 coldkey): " +
+      "what it holds delegated across every hotkey/subnet — hotkey, netuid, " +
+      "share_fraction (0-1, this account's share of that hotkey's alpha-pool " +
+      "shares on that subnet), and the derived stake_tao. Distinct from " +
+      "get_account_portfolio's hotkey-scoped view — a pure delegator shows " +
+      "near-zero there since its stake lives on someone ELSE's hotkey row. Root " +
+      "(netuid 0) stake is not covered — root has no alpha pool. An address with " +
+      "no delegated positions returns an empty card, not an error. Mirrors " +
+      "GET /api/v1/accounts/{ss58}/positions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ss58: {
+          type: "string",
+          description:
+            "The account's coldkey SS58 address, base58, 47-48 chars.",
+          pattern: SS58_PATTERN_SOURCE,
+        },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const ss58 = requireSs58(args);
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/positions`),
+          "METAGRAPH_NEURONS_SOURCE",
+        )) ?? buildAccountPositions([], new Map(), ss58)
       );
     },
   },
@@ -12322,6 +12360,19 @@ const TOOL_OUTPUT_SCHEMAS = {
       total_emission_tao: { type: "number" },
       overall_yield: { type: ["number", "null"] },
       stake_concentration: { type: ["object", "null"] },
+      positions: { type: "array", items: { type: "object" } },
+    },
+  },
+  get_account_positions: {
+    type: "object",
+    additionalProperties: true,
+    required: ["ss58", "position_count", "total_stake_tao", "positions"],
+    properties: {
+      schema_version: { type: "integer" },
+      ss58: { type: "string" },
+      captured_at: NULLABLE_STRING,
+      position_count: { type: "integer" },
+      total_stake_tao: { type: "number" },
       positions: { type: "array", items: { type: "object" } },
     },
   },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -16267,6 +16267,27 @@ describe("MCP account identity/position-history tools (#5225 parity)", () => {
     });
     assert.equal(badWindow.body.result.isError, true);
   });
+
+  // nominator_positions never had a D1-era predecessor (#6323), same
+  // no-D1-fallback shape as get_account_position_history above -- flag
+  // absent means straight to the schema-stable empty card, no D1 query at all.
+  test("get_account_positions returns a schema-stable empty card with no Postgres flag", async () => {
+    const res = await callTool("get_account_positions", { ss58: SS58 });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.ss58, SS58);
+    assert.equal(out.captured_at, null);
+    assert.equal(out.position_count, 0);
+    assert.equal(out.total_stake_tao, 0);
+    assert.deepEqual(out.positions, []);
+  });
+
+  test("get_account_positions rejects a malformed ss58", async () => {
+    const res = await callTool("get_account_positions", {
+      ss58: "not-an-address",
+    });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /ss58/);
+  });
 });
 
 describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () => {
@@ -16703,6 +16724,11 @@ describe("MCP chain-*/subnet-* analytics tools — Postgres tier wiring", () => 
       tool: "get_account_portfolio",
       args: { ss58: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5" },
       path: "/api/v1/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5/portfolio",
+    },
+    {
+      tool: "get_account_positions",
+      args: { ss58: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5" },
+      path: "/api/v1/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5/positions",
     },
     {
       tool: "get_account_position_history",


### PR DESCRIPTION
## Summary

- Adds a `get_account_positions` MCP tool mirroring `GET /api/v1/accounts/{ss58}/positions`, closing the MCP-surface gap called out in #6323 (the REST/GraphQL pairing already exists; the sibling GraphQL-surface gap was #6324).

## What Changed

- `src/mcp-server.mjs`: added `get_account_positions` to `MCP_TOOLS`, with a required `ss58` (SS58-pattern) input, following `get_account_portfolio`'s exact `tryPostgresTier(..., "METAGRAPH_NEURONS_SOURCE") ?? buildAccountPositions([], new Map(), ss58)` fallback contract (reusing `buildAccountPositions` from `src/account-nominator-positions.mjs`, the same function `handleAccountPositions` uses — Postgres-only, no D1-era predecessor). Also added the tool's output JSON Schema entry to `TOOL_OUTPUT_SCHEMAS`.
- `tests/mcp-server.test.mjs`: added `get_account_positions` to the shared Postgres-tier-wiring `CASES` table (parity test asserting the tool forwards to the exact REST-equivalent path, falls back to the schema-stable empty shape on failure, and ignores `DATA_API` without the flag), plus dedicated cold-empty-card and malformed-ss58 tests.

No `schemas/`/OpenAPI changes — this is an MCP-only addition; `npm run validate:mcp` passes at 177 tools (was 176).

Closes #6323

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6323`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No OpenAPI change — MCP-only addition.)

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate`
- [x] `npm run validate:mcp`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npx vitest run tests/mcp-server.test.mjs` (1090/1090 passed, covers the new tool's cold/error/Postgres-tier/malformed-ss58 paths)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`