### PR TITLE
fix(ui): collapse price-ticker sparkline slot when there's no trend

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
@@ -126,16 +126,20 @@ export function SubnetPriceTicker({ limit = 12 }: { limit?: number }) {
                 <span className="font-display font-semibold tabular-nums text-ink-strong">
                   {priceStr(it.price)}
                 </span>
-                <span className="inline-block w-[44px] align-middle">
-                  <Sparkline
-                    values={t.values}
-                    width={44}
-                    height={14}
-                    interactive={false}
-                    fill={false}
-                    color={t.color}
-                  />
-                </span>
+                {/* A single-point series paints nothing (#6038) -- collapse the 44px slot
+                    instead of reserving dead space until trajectory history backfills. */}
+                {t.values.length >= 2 ? (
+                  <span className="inline-block w-[44px] align-middle">
+                    <Sparkline
+                      values={t.values}
+                      width={44}
+                      height={14}
+                      interactive={false}
+                      fill={false}
+                      color={t.color}
+                    />
+                  </span>
+                ) : null}
                 {t.changePct != null ? (
                   <span className="font-mono tabular-nums text-[10px]" style={{ color: t.color }}>
                     {arrow} {t.changePct >= 0 ? "+" : ""}


### PR DESCRIPTION
## Summary

`SubnetPriceTicker` (the homepage stock-ticker marquee) reserves a fixed 44px slot per subnet for a price sparkline. When there are fewer than 2 real trajectory points, `Sparkline` paints nothing (a single-point polyline has no line to draw), but the 44px slot still renders — a dead gap next to every subnet's price.

Closes #6038.

## Context

Root cause investigated in #6038: `/api/v1/subnets/{netuid}/trajectory` was returning zero points for every subnet — traced to two stale `METAGRAPH_*_SOURCE` feature flags never having been flipped to Postgres, leaving the read path on a D1 tier whose write had silently been failing. That's being fixed separately (backend cutover, in progress). This PR is the complementary frontend fix: don't show dead space while there's no trend to draw, regardless of why — also relevant for any genuinely-new subnet that hasn't accumulated 2 days of trajectory history yet, independent of the backend issue.

## Fix

Collapse the sparkline slot entirely when `t.values.length < 2`, instead of rendering an empty fixed-width span.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6038-ticker-sparkline-collapse-after-mobile-dark.png)<br><sub>after</sub> |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint`/`npx prettier --check` clean on the touched file
- [x] Before/after captured via the repo's automated screenshot tool against live production data (still showing the empty-trend state at capture time)
