### PR TITLE
fix(ui-kit): self-wrap TooltipProvider in the five components that require an ancestor

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1921,41 +1921,44 @@ function KeyChip({
 }) {
   const { copied, copy } = useCopy({ label });
   const short = value.length > head + tail + 1 ? `${value.slice(0, head)}\u2026${value.slice(-tail)}` : value;
-  return /* @__PURE__ */ jsxRuntime.jsxs(Tooltip, { delayDuration: 120, children: [
-    /* @__PURE__ */ jsxRuntime.jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxRuntime.jsxs(
-      "button",
-      {
-        type: "button",
-        onClick: () => copy(value),
-        "aria-label": copied ? `${label} copied` : `Copy ${label}: ${value}`,
-        className: classNames(
-          "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left font-mono text-[11px] text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
-          className
-        ),
-        children: [
-          /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate tabular-nums", children: short }),
-          /* @__PURE__ */ jsxRuntime.jsx(
-            CopyIconToggle,
-            {
-              copied,
-              className: "text-ink-muted group-hover:text-ink"
-            }
-          )
-        ]
-      }
-    ) }),
-    /* @__PURE__ */ jsxRuntime.jsxs(
-      TooltipContent,
-      {
-        side: "top",
-        className: "max-w-[90vw] break-all font-mono text-[11px]",
-        children: [
-          /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mr-1 uppercase tracking-widest text-[9px] opacity-70", children: label }),
-          value
-        ]
-      }
-    )
-  ] });
+  return (
+    // Self-wrapped so KeyChip works outside AppShell's global provider.
+    /* @__PURE__ */ jsxRuntime.jsx(TooltipProvider, { children: /* @__PURE__ */ jsxRuntime.jsxs(Tooltip, { delayDuration: 120, children: [
+      /* @__PURE__ */ jsxRuntime.jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxRuntime.jsxs(
+        "button",
+        {
+          type: "button",
+          onClick: () => copy(value),
+          "aria-label": copied ? `${label} copied` : `Copy ${label}: ${value}`,
+          className: classNames(
+            "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left font-mono text-[11px] text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
+            className
+          ),
+          children: [
+            /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate tabular-nums", children: short }),
+            /* @__PURE__ */ jsxRuntime.jsx(
+              CopyIconToggle,
+              {
+                copied,
+                className: "text-ink-muted group-hover:text-ink"
+              }
+            )
+          ]
+        }
+      ) }),
+      /* @__PURE__ */ jsxRuntime.jsxs(
+        TooltipContent,
+        {
+          side: "top",
+          className: "max-w-[90vw] break-all font-mono text-[11px]",
+          children: [
+            /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mr-1 uppercase tracking-widest text-[9px] opacity-70", children: label }),
+            value
+          ]
+        }
+      )
+    ] }) })
+  );
 }
 function ListShell({
   filters,
@@ -3421,50 +3424,53 @@ function SparkLegend({
 }) {
   const fresh = formatFreshness(updatedAt, windowLabel);
   const freshAbs = formatFreshnessAbsolute(updatedAt);
-  return /* @__PURE__ */ jsxRuntime.jsxs(Tooltip, { delayDuration: 200, children: [
-    /* @__PURE__ */ jsxRuntime.jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxRuntime.jsx(
-      "span",
-      {
-        tabIndex: 0,
-        className: "inline-flex max-w-full items-center focus:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded",
-        children
-      }
-    ) }),
-    /* @__PURE__ */ jsxRuntime.jsxs(
-      TooltipContent,
-      {
-        side,
-        sideOffset: 6,
-        collisionPadding: 8,
-        avoidCollisions: true,
-        className: "max-w-xs text-[11px] leading-relaxed",
-        children: [
-          /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "font-mono text-[10px] uppercase tracking-widest mb-1", children: [
-            metric,
-            windowLabel ? ` \xB7 ${windowLabel}` : ""
-          ] }),
-          /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mb-1", children: [
-            /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "font-mono text-[9.5px] uppercase tracking-widest opacity-70", children: [
-              "source \xB7",
-              " "
+  return (
+    // Self-wrapped so SparkLegend works outside AppShell's global provider.
+    /* @__PURE__ */ jsxRuntime.jsx(TooltipProvider, { children: /* @__PURE__ */ jsxRuntime.jsxs(Tooltip, { delayDuration: 200, children: [
+      /* @__PURE__ */ jsxRuntime.jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxRuntime.jsx(
+        "span",
+        {
+          tabIndex: 0,
+          className: "inline-flex max-w-full items-center focus:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded",
+          children
+        }
+      ) }),
+      /* @__PURE__ */ jsxRuntime.jsxs(
+        TooltipContent,
+        {
+          side,
+          sideOffset: 6,
+          collisionPadding: 8,
+          avoidCollisions: true,
+          className: "max-w-xs text-[11px] leading-relaxed",
+          children: [
+            /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "font-mono text-[10px] uppercase tracking-widest mb-1", children: [
+              metric,
+              windowLabel ? ` \xB7 ${windowLabel}` : ""
             ] }),
-            source
-          ] }),
-          staleness ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mb-1", children: [
-            /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "font-mono text-[9.5px] uppercase tracking-widest opacity-70", children: [
-              "staleness \xB7",
-              " "
+            /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mb-1", children: [
+              /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "font-mono text-[9.5px] uppercase tracking-widest opacity-70", children: [
+                "source \xB7",
+                " "
+              ] }),
+              source
             ] }),
-            staleness
-          ] }) : null,
-          fresh || freshAbs ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1 font-mono text-[10px] opacity-80", children: [
-            fresh ?? "",
-            freshAbs ? `${fresh ? " \xB7 " : ""}last checked ${freshAbs}` : ""
-          ] }) : null
-        ]
-      }
-    )
-  ] });
+            staleness ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mb-1", children: [
+              /* @__PURE__ */ jsxRuntime.jsxs("span", { className: "font-mono text-[9.5px] uppercase tracking-widest opacity-70", children: [
+                "staleness \xB7",
+                " "
+              ] }),
+              staleness
+            ] }) : null,
+            fresh || freshAbs ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1 font-mono text-[10px] opacity-80", children: [
+              fresh ?? "",
+              freshAbs ? `${fresh ? " \xB7 " : ""}last checked ${freshAbs}` : ""
+            ] }) : null
+          ]
+        }
+      )
+    ] }) })
+  );
 }
 function Sparkline({
   values,
@@ -3710,56 +3716,59 @@ function StatWithSpark({
 }) {
   const freshLine = formatFreshness(updatedAt, windowLabel);
   const freshAbs = formatFreshnessAbsolute(updatedAt);
-  return /* @__PURE__ */ jsxRuntime.jsxs(Tooltip, { delayDuration: 200, children: [
-    /* @__PURE__ */ jsxRuntime.jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxRuntime.jsxs(
-      "div",
-      {
-        tabIndex: 0,
-        className: classNames(
-          "group flex flex-col gap-1 px-3 py-2.5 min-w-0 focus:outline-none focus-visible:bg-surface/40 transition-colors",
-          className
-        ),
-        children: [
-          /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[9.5px] uppercase tracking-widest text-ink-muted truncate", children: label }),
-          /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "flex items-baseline gap-1.5 min-w-0", children: [
-            /* @__PURE__ */ jsxRuntime.jsx(
-              "span",
-              {
-                className: classNames(
-                  "font-display text-lg font-semibold tabular-nums leading-none truncate",
-                  tone === "ok" && "text-health-ok",
-                  tone === "warn" && "text-health-warn",
-                  tone === "down" && "text-health-down",
-                  tone === "default" && "text-ink-strong"
-                ),
-                children: value
-              }
-            ),
-            unit ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "shrink-0 font-mono text-[9px] uppercase tracking-widest text-ink-muted", children: unit }) : null,
-            delta
-          ] }),
-          viz ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mt-0.5 min-h-[18px]", children: viz }) : null,
-          hint ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[9.5px] text-ink-muted/80 truncate", children: hint }) : null,
-          freshLine ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[9px] tracking-wide text-ink-muted/70 truncate", children: freshLine }) : null
-        ]
-      }
-    ) }),
-    /* @__PURE__ */ jsxRuntime.jsxs(
-      TooltipContent,
-      {
-        side: "bottom",
-        className: "max-w-xs text-[11px] leading-relaxed",
-        children: [
-          /* @__PURE__ */ jsxRuntime.jsx("div", { children: full ?? hint ?? label }),
-          freshAbs || windowLabel ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1 font-mono text-[10px] text-primary-foreground/70", children: [
-            freshAbs ? `Last checked ${freshAbs}` : null,
-            freshAbs && windowLabel ? " \xB7 " : "",
-            windowLabel ? `${windowLabel} window` : null
-          ] }) : null
-        ]
-      }
-    )
-  ] });
+  return (
+    // Self-wrapped so StatWithSpark works outside AppShell's global provider.
+    /* @__PURE__ */ jsxRuntime.jsx(TooltipProvider, { children: /* @__PURE__ */ jsxRuntime.jsxs(Tooltip, { delayDuration: 200, children: [
+      /* @__PURE__ */ jsxRuntime.jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxRuntime.jsxs(
+        "div",
+        {
+          tabIndex: 0,
+          className: classNames(
+            "group flex flex-col gap-1 px-3 py-2.5 min-w-0 focus:outline-none focus-visible:bg-surface/40 transition-colors",
+            className
+          ),
+          children: [
+            /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[9.5px] uppercase tracking-widest text-ink-muted truncate", children: label }),
+            /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "flex items-baseline gap-1.5 min-w-0", children: [
+              /* @__PURE__ */ jsxRuntime.jsx(
+                "span",
+                {
+                  className: classNames(
+                    "font-display text-lg font-semibold tabular-nums leading-none truncate",
+                    tone === "ok" && "text-health-ok",
+                    tone === "warn" && "text-health-warn",
+                    tone === "down" && "text-health-down",
+                    tone === "default" && "text-ink-strong"
+                  ),
+                  children: value
+                }
+              ),
+              unit ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "shrink-0 font-mono text-[9px] uppercase tracking-widest text-ink-muted", children: unit }) : null,
+              delta
+            ] }),
+            viz ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "mt-0.5 min-h-[18px]", children: viz }) : null,
+            hint ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[9.5px] text-ink-muted/80 truncate", children: hint }) : null,
+            freshLine ? /* @__PURE__ */ jsxRuntime.jsx("div", { className: "font-mono text-[9px] tracking-wide text-ink-muted/70 truncate", children: freshLine }) : null
+          ]
+        }
+      ) }),
+      /* @__PURE__ */ jsxRuntime.jsxs(
+        TooltipContent,
+        {
+          side: "bottom",
+          className: "max-w-xs text-[11px] leading-relaxed",
+          children: [
+            /* @__PURE__ */ jsxRuntime.jsx("div", { children: full ?? hint ?? label }),
+            freshAbs || windowLabel ? /* @__PURE__ */ jsxRuntime.jsxs("div", { className: "mt-1 font-mono text-[10px] text-primary-foreground/70", children: [
+              freshAbs ? `Last checked ${freshAbs}` : null,
+              freshAbs && windowLabel ? " \xB7 " : "",
+              windowLabel ? `${windowLabel} window` : null
+            ] }) : null
+          ]
+        }
+      )
+    ] }) })
+  );
 }
 function MiniStack({
   segments,
@@ -3850,29 +3859,33 @@ function MiniRadial({
 function DotRow({
   dots
 }) {
-  return /* @__PURE__ */ jsxRuntime.jsx(
-    "div",
-    {
-      className: "flex items-center gap-1",
-      role: "img",
-      "aria-label": "Source coverage",
-      children: dots.map((d) => /* @__PURE__ */ jsxRuntime.jsxs(Tooltip, { delayDuration: 150, children: [
-        /* @__PURE__ */ jsxRuntime.jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxRuntime.jsx(
-          "span",
-          {
-            className: classNames(
-              "size-1.5 rounded-full",
-              d.on ? "bg-accent" : "bg-border"
-            )
-          }
-        ) }),
-        /* @__PURE__ */ jsxRuntime.jsxs(TooltipContent, { side: "top", className: "font-mono text-[10px]", children: [
-          d.label,
-          " ",
-          d.on ? "\u2713" : "\u2014"
-        ] })
-      ] }, d.label))
-    }
+  return (
+    // One provider for the row rather than one per dot -- self-wrapped so DotRow
+    // works outside AppShell's global provider.
+    /* @__PURE__ */ jsxRuntime.jsx(TooltipProvider, { children: /* @__PURE__ */ jsxRuntime.jsx(
+      "div",
+      {
+        className: "flex items-center gap-1",
+        role: "img",
+        "aria-label": "Source coverage",
+        children: dots.map((d) => /* @__PURE__ */ jsxRuntime.jsxs(Tooltip, { delayDuration: 150, children: [
+          /* @__PURE__ */ jsxRuntime.jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxRuntime.jsx(
+            "span",
+            {
+              className: classNames(
+                "size-1.5 rounded-full",
+                d.on ? "bg-accent" : "bg-border"
+              )
+            }
+          ) }),
+          /* @__PURE__ */ jsxRuntime.jsxs(TooltipContent, { side: "top", className: "font-mono text-[10px]", children: [
+            d.label,
+            " ",
+            d.on ? "\u2713" : "\u2014"
+          ] })
+        ] }, d.label))
+      }
+    ) })
   );
 }
 function NoDataSpark({
@@ -3883,41 +3896,44 @@ function NoDataSpark({
 }) {
   const freshAbs = formatFreshnessAbsolute(updatedAt);
   const freshLine = formatFreshness(updatedAt, windowLabel);
-  return /* @__PURE__ */ jsxRuntime.jsxs(Tooltip, { delayDuration: 150, children: [
-    /* @__PURE__ */ jsxRuntime.jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxRuntime.jsxs(
-      "div",
-      {
-        tabIndex: 0,
-        role: "img",
-        "aria-label": `${reason}${freshAbs ? `, last checked ${freshAbs}` : ""}`,
-        className: "flex w-full items-center gap-1.5 rounded-sm border border-dashed border-border/70 bg-paper/40 px-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-        style: { height },
-        children: [
-          /* @__PURE__ */ jsxRuntime.jsx(
-            "span",
-            {
-              "aria-hidden": true,
-              className: "inline-block size-1 rounded-full bg-ink-muted/60"
-            }
-          ),
-          /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate font-mono text-[9px] uppercase tracking-widest text-ink-muted/80", children: freshLine ?? reason })
-        ]
-      }
-    ) }),
-    /* @__PURE__ */ jsxRuntime.jsxs(
-      TooltipContent,
-      {
-        side: "top",
-        className: "max-w-xs text-[11px] leading-relaxed",
-        children: [
-          reason,
-          ".",
-          " ",
-          freshAbs ? `Last checked ${freshAbs}${windowLabel ? ` \xB7 ${windowLabel} window` : ""}.` : "No probe samples recorded yet."
-        ]
-      }
-    )
-  ] });
+  return (
+    // Self-wrapped so NoDataSpark works outside AppShell's global provider.
+    /* @__PURE__ */ jsxRuntime.jsx(TooltipProvider, { children: /* @__PURE__ */ jsxRuntime.jsxs(Tooltip, { delayDuration: 150, children: [
+      /* @__PURE__ */ jsxRuntime.jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxRuntime.jsxs(
+        "div",
+        {
+          tabIndex: 0,
+          role: "img",
+          "aria-label": `${reason}${freshAbs ? `, last checked ${freshAbs}` : ""}`,
+          className: "flex w-full items-center gap-1.5 rounded-sm border border-dashed border-border/70 bg-paper/40 px-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          style: { height },
+          children: [
+            /* @__PURE__ */ jsxRuntime.jsx(
+              "span",
+              {
+                "aria-hidden": true,
+                className: "inline-block size-1 rounded-full bg-ink-muted/60"
+              }
+            ),
+            /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate font-mono text-[9px] uppercase tracking-widest text-ink-muted/80", children: freshLine ?? reason })
+          ]
+        }
+      ) }),
+      /* @__PURE__ */ jsxRuntime.jsxs(
+        TooltipContent,
+        {
+          side: "top",
+          className: "max-w-xs text-[11px] leading-relaxed",
+          children: [
+            reason,
+            ".",
+            " ",
+            freshAbs ? `Last checked ${freshAbs}${windowLabel ? ` \xB7 ${windowLabel} window` : ""}.` : "No probe samples recorded yet."
+          ]
+        }
+      )
+    ] }) })
+  );
 }
 var sum = (ns) => ns.reduce((a, b) => a + b, 0);
 var MIN_TILE_W_FOR_LABEL = 16;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1892,41 +1892,44 @@ function KeyChip({
 }) {
   const { copied, copy } = useCopy({ label });
   const short = value.length > head + tail + 1 ? `${value.slice(0, head)}\u2026${value.slice(-tail)}` : value;
-  return /* @__PURE__ */ jsxs(Tooltip, { delayDuration: 120, children: [
-    /* @__PURE__ */ jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxs(
-      "button",
-      {
-        type: "button",
-        onClick: () => copy(value),
-        "aria-label": copied ? `${label} copied` : `Copy ${label}: ${value}`,
-        className: classNames(
-          "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left font-mono text-[11px] text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
-          className
-        ),
-        children: [
-          /* @__PURE__ */ jsx("span", { className: "truncate tabular-nums", children: short }),
-          /* @__PURE__ */ jsx(
-            CopyIconToggle,
-            {
-              copied,
-              className: "text-ink-muted group-hover:text-ink"
-            }
-          )
-        ]
-      }
-    ) }),
-    /* @__PURE__ */ jsxs(
-      TooltipContent,
-      {
-        side: "top",
-        className: "max-w-[90vw] break-all font-mono text-[11px]",
-        children: [
-          /* @__PURE__ */ jsx("span", { className: "mr-1 uppercase tracking-widest text-[9px] opacity-70", children: label }),
-          value
-        ]
-      }
-    )
-  ] });
+  return (
+    // Self-wrapped so KeyChip works outside AppShell's global provider.
+    /* @__PURE__ */ jsx(TooltipProvider, { children: /* @__PURE__ */ jsxs(Tooltip, { delayDuration: 120, children: [
+      /* @__PURE__ */ jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxs(
+        "button",
+        {
+          type: "button",
+          onClick: () => copy(value),
+          "aria-label": copied ? `${label} copied` : `Copy ${label}: ${value}`,
+          className: classNames(
+            "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left font-mono text-[11px] text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
+            className
+          ),
+          children: [
+            /* @__PURE__ */ jsx("span", { className: "truncate tabular-nums", children: short }),
+            /* @__PURE__ */ jsx(
+              CopyIconToggle,
+              {
+                copied,
+                className: "text-ink-muted group-hover:text-ink"
+              }
+            )
+          ]
+        }
+      ) }),
+      /* @__PURE__ */ jsxs(
+        TooltipContent,
+        {
+          side: "top",
+          className: "max-w-[90vw] break-all font-mono text-[11px]",
+          children: [
+            /* @__PURE__ */ jsx("span", { className: "mr-1 uppercase tracking-widest text-[9px] opacity-70", children: label }),
+            value
+          ]
+        }
+      )
+    ] }) })
+  );
 }
 function ListShell({
   filters,
@@ -3392,50 +3395,53 @@ function SparkLegend({
 }) {
   const fresh = formatFreshness(updatedAt, windowLabel);
   const freshAbs = formatFreshnessAbsolute(updatedAt);
-  return /* @__PURE__ */ jsxs(Tooltip, { delayDuration: 200, children: [
-    /* @__PURE__ */ jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsx(
-      "span",
-      {
-        tabIndex: 0,
-        className: "inline-flex max-w-full items-center focus:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded",
-        children
-      }
-    ) }),
-    /* @__PURE__ */ jsxs(
-      TooltipContent,
-      {
-        side,
-        sideOffset: 6,
-        collisionPadding: 8,
-        avoidCollisions: true,
-        className: "max-w-xs text-[11px] leading-relaxed",
-        children: [
-          /* @__PURE__ */ jsxs("div", { className: "font-mono text-[10px] uppercase tracking-widest mb-1", children: [
-            metric,
-            windowLabel ? ` \xB7 ${windowLabel}` : ""
-          ] }),
-          /* @__PURE__ */ jsxs("div", { className: "mb-1", children: [
-            /* @__PURE__ */ jsxs("span", { className: "font-mono text-[9.5px] uppercase tracking-widest opacity-70", children: [
-              "source \xB7",
-              " "
+  return (
+    // Self-wrapped so SparkLegend works outside AppShell's global provider.
+    /* @__PURE__ */ jsx(TooltipProvider, { children: /* @__PURE__ */ jsxs(Tooltip, { delayDuration: 200, children: [
+      /* @__PURE__ */ jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsx(
+        "span",
+        {
+          tabIndex: 0,
+          className: "inline-flex max-w-full items-center focus:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded",
+          children
+        }
+      ) }),
+      /* @__PURE__ */ jsxs(
+        TooltipContent,
+        {
+          side,
+          sideOffset: 6,
+          collisionPadding: 8,
+          avoidCollisions: true,
+          className: "max-w-xs text-[11px] leading-relaxed",
+          children: [
+            /* @__PURE__ */ jsxs("div", { className: "font-mono text-[10px] uppercase tracking-widest mb-1", children: [
+              metric,
+              windowLabel ? ` \xB7 ${windowLabel}` : ""
             ] }),
-            source
-          ] }),
-          staleness ? /* @__PURE__ */ jsxs("div", { className: "mb-1", children: [
-            /* @__PURE__ */ jsxs("span", { className: "font-mono text-[9.5px] uppercase tracking-widest opacity-70", children: [
-              "staleness \xB7",
-              " "
+            /* @__PURE__ */ jsxs("div", { className: "mb-1", children: [
+              /* @__PURE__ */ jsxs("span", { className: "font-mono text-[9.5px] uppercase tracking-widest opacity-70", children: [
+                "source \xB7",
+                " "
+              ] }),
+              source
             ] }),
-            staleness
-          ] }) : null,
-          fresh || freshAbs ? /* @__PURE__ */ jsxs("div", { className: "mt-1 font-mono text-[10px] opacity-80", children: [
-            fresh ?? "",
-            freshAbs ? `${fresh ? " \xB7 " : ""}last checked ${freshAbs}` : ""
-          ] }) : null
-        ]
-      }
-    )
-  ] });
+            staleness ? /* @__PURE__ */ jsxs("div", { className: "mb-1", children: [
+              /* @__PURE__ */ jsxs("span", { className: "font-mono text-[9.5px] uppercase tracking-widest opacity-70", children: [
+                "staleness \xB7",
+                " "
+              ] }),
+              staleness
+            ] }) : null,
+            fresh || freshAbs ? /* @__PURE__ */ jsxs("div", { className: "mt-1 font-mono text-[10px] opacity-80", children: [
+              fresh ?? "",
+              freshAbs ? `${fresh ? " \xB7 " : ""}last checked ${freshAbs}` : ""
+            ] }) : null
+          ]
+        }
+      )
+    ] }) })
+  );
 }
 function Sparkline({
   values,
@@ -3681,56 +3687,59 @@ function StatWithSpark({
 }) {
   const freshLine = formatFreshness(updatedAt, windowLabel);
   const freshAbs = formatFreshnessAbsolute(updatedAt);
-  return /* @__PURE__ */ jsxs(Tooltip, { delayDuration: 200, children: [
-    /* @__PURE__ */ jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxs(
-      "div",
-      {
-        tabIndex: 0,
-        className: classNames(
-          "group flex flex-col gap-1 px-3 py-2.5 min-w-0 focus:outline-none focus-visible:bg-surface/40 transition-colors",
-          className
-        ),
-        children: [
-          /* @__PURE__ */ jsx("div", { className: "font-mono text-[9.5px] uppercase tracking-widest text-ink-muted truncate", children: label }),
-          /* @__PURE__ */ jsxs("div", { className: "flex items-baseline gap-1.5 min-w-0", children: [
-            /* @__PURE__ */ jsx(
-              "span",
-              {
-                className: classNames(
-                  "font-display text-lg font-semibold tabular-nums leading-none truncate",
-                  tone === "ok" && "text-health-ok",
-                  tone === "warn" && "text-health-warn",
-                  tone === "down" && "text-health-down",
-                  tone === "default" && "text-ink-strong"
-                ),
-                children: value
-              }
-            ),
-            unit ? /* @__PURE__ */ jsx("span", { className: "shrink-0 font-mono text-[9px] uppercase tracking-widest text-ink-muted", children: unit }) : null,
-            delta
-          ] }),
-          viz ? /* @__PURE__ */ jsx("div", { className: "mt-0.5 min-h-[18px]", children: viz }) : null,
-          hint ? /* @__PURE__ */ jsx("div", { className: "font-mono text-[9.5px] text-ink-muted/80 truncate", children: hint }) : null,
-          freshLine ? /* @__PURE__ */ jsx("div", { className: "font-mono text-[9px] tracking-wide text-ink-muted/70 truncate", children: freshLine }) : null
-        ]
-      }
-    ) }),
-    /* @__PURE__ */ jsxs(
-      TooltipContent,
-      {
-        side: "bottom",
-        className: "max-w-xs text-[11px] leading-relaxed",
-        children: [
-          /* @__PURE__ */ jsx("div", { children: full ?? hint ?? label }),
-          freshAbs || windowLabel ? /* @__PURE__ */ jsxs("div", { className: "mt-1 font-mono text-[10px] text-primary-foreground/70", children: [
-            freshAbs ? `Last checked ${freshAbs}` : null,
-            freshAbs && windowLabel ? " \xB7 " : "",
-            windowLabel ? `${windowLabel} window` : null
-          ] }) : null
-        ]
-      }
-    )
-  ] });
+  return (
+    // Self-wrapped so StatWithSpark works outside AppShell's global provider.
+    /* @__PURE__ */ jsx(TooltipProvider, { children: /* @__PURE__ */ jsxs(Tooltip, { delayDuration: 200, children: [
+      /* @__PURE__ */ jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxs(
+        "div",
+        {
+          tabIndex: 0,
+          className: classNames(
+            "group flex flex-col gap-1 px-3 py-2.5 min-w-0 focus:outline-none focus-visible:bg-surface/40 transition-colors",
+            className
+          ),
+          children: [
+            /* @__PURE__ */ jsx("div", { className: "font-mono text-[9.5px] uppercase tracking-widest text-ink-muted truncate", children: label }),
+            /* @__PURE__ */ jsxs("div", { className: "flex items-baseline gap-1.5 min-w-0", children: [
+              /* @__PURE__ */ jsx(
+                "span",
+                {
+                  className: classNames(
+                    "font-display text-lg font-semibold tabular-nums leading-none truncate",
+                    tone === "ok" && "text-health-ok",
+                    tone === "warn" && "text-health-warn",
+                    tone === "down" && "text-health-down",
+                    tone === "default" && "text-ink-strong"
+                  ),
+                  children: value
+                }
+              ),
+              unit ? /* @__PURE__ */ jsx("span", { className: "shrink-0 font-mono text-[9px] uppercase tracking-widest text-ink-muted", children: unit }) : null,
+              delta
+            ] }),
+            viz ? /* @__PURE__ */ jsx("div", { className: "mt-0.5 min-h-[18px]", children: viz }) : null,
+            hint ? /* @__PURE__ */ jsx("div", { className: "font-mono text-[9.5px] text-ink-muted/80 truncate", children: hint }) : null,
+            freshLine ? /* @__PURE__ */ jsx("div", { className: "font-mono text-[9px] tracking-wide text-ink-muted/70 truncate", children: freshLine }) : null
+          ]
+        }
+      ) }),
+      /* @__PURE__ */ jsxs(
+        TooltipContent,
+        {
+          side: "bottom",
+          className: "max-w-xs text-[11px] leading-relaxed",
+          children: [
+            /* @__PURE__ */ jsx("div", { children: full ?? hint ?? label }),
+            freshAbs || windowLabel ? /* @__PURE__ */ jsxs("div", { className: "mt-1 font-mono text-[10px] text-primary-foreground/70", children: [
+              freshAbs ? `Last checked ${freshAbs}` : null,
+              freshAbs && windowLabel ? " \xB7 " : "",
+              windowLabel ? `${windowLabel} window` : null
+            ] }) : null
+          ]
+        }
+      )
+    ] }) })
+  );
 }
 function MiniStack({
   segments,
@@ -3821,29 +3830,33 @@ function MiniRadial({
 function DotRow({
   dots
 }) {
-  return /* @__PURE__ */ jsx(
-    "div",
-    {
-      className: "flex items-center gap-1",
-      role: "img",
-      "aria-label": "Source coverage",
-      children: dots.map((d) => /* @__PURE__ */ jsxs(Tooltip, { delayDuration: 150, children: [
-        /* @__PURE__ */ jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsx(
-          "span",
-          {
-            className: classNames(
-              "size-1.5 rounded-full",
-              d.on ? "bg-accent" : "bg-border"
-            )
-          }
-        ) }),
-        /* @__PURE__ */ jsxs(TooltipContent, { side: "top", className: "font-mono text-[10px]", children: [
-          d.label,
-          " ",
-          d.on ? "\u2713" : "\u2014"
-        ] })
-      ] }, d.label))
-    }
+  return (
+    // One provider for the row rather than one per dot -- self-wrapped so DotRow
+    // works outside AppShell's global provider.
+    /* @__PURE__ */ jsx(TooltipProvider, { children: /* @__PURE__ */ jsx(
+      "div",
+      {
+        className: "flex items-center gap-1",
+        role: "img",
+        "aria-label": "Source coverage",
+        children: dots.map((d) => /* @__PURE__ */ jsxs(Tooltip, { delayDuration: 150, children: [
+          /* @__PURE__ */ jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsx(
+            "span",
+            {
+              className: classNames(
+                "size-1.5 rounded-full",
+                d.on ? "bg-accent" : "bg-border"
+              )
+            }
+          ) }),
+          /* @__PURE__ */ jsxs(TooltipContent, { side: "top", className: "font-mono text-[10px]", children: [
+            d.label,
+            " ",
+            d.on ? "\u2713" : "\u2014"
+          ] })
+        ] }, d.label))
+      }
+    ) })
   );
 }
 function NoDataSpark({
@@ -3854,41 +3867,44 @@ function NoDataSpark({
 }) {
   const freshAbs = formatFreshnessAbsolute(updatedAt);
   const freshLine = formatFreshness(updatedAt, windowLabel);
-  return /* @__PURE__ */ jsxs(Tooltip, { delayDuration: 150, children: [
-    /* @__PURE__ */ jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxs(
-      "div",
-      {
-        tabIndex: 0,
-        role: "img",
-        "aria-label": `${reason}${freshAbs ? `, last checked ${freshAbs}` : ""}`,
-        className: "flex w-full items-center gap-1.5 rounded-sm border border-dashed border-border/70 bg-paper/40 px-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-        style: { height },
-        children: [
-          /* @__PURE__ */ jsx(
-            "span",
-            {
-              "aria-hidden": true,
-              className: "inline-block size-1 rounded-full bg-ink-muted/60"
-            }
-          ),
-          /* @__PURE__ */ jsx("span", { className: "truncate font-mono text-[9px] uppercase tracking-widest text-ink-muted/80", children: freshLine ?? reason })
-        ]
-      }
-    ) }),
-    /* @__PURE__ */ jsxs(
-      TooltipContent,
-      {
-        side: "top",
-        className: "max-w-xs text-[11px] leading-relaxed",
-        children: [
-          reason,
-          ".",
-          " ",
-          freshAbs ? `Last checked ${freshAbs}${windowLabel ? ` \xB7 ${windowLabel} window` : ""}.` : "No probe samples recorded yet."
-        ]
-      }
-    )
-  ] });
+  return (
+    // Self-wrapped so NoDataSpark works outside AppShell's global provider.
+    /* @__PURE__ */ jsx(TooltipProvider, { children: /* @__PURE__ */ jsxs(Tooltip, { delayDuration: 150, children: [
+      /* @__PURE__ */ jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxs(
+        "div",
+        {
+          tabIndex: 0,
+          role: "img",
+          "aria-label": `${reason}${freshAbs ? `, last checked ${freshAbs}` : ""}`,
+          className: "flex w-full items-center gap-1.5 rounded-sm border border-dashed border-border/70 bg-paper/40 px-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          style: { height },
+          children: [
+            /* @__PURE__ */ jsx(
+              "span",
+              {
+                "aria-hidden": true,
+                className: "inline-block size-1 rounded-full bg-ink-muted/60"
+              }
+            ),
+            /* @__PURE__ */ jsx("span", { className: "truncate font-mono text-[9px] uppercase tracking-widest text-ink-muted/80", children: freshLine ?? reason })
+          ]
+        }
+      ) }),
+      /* @__PURE__ */ jsxs(
+        TooltipContent,
+        {
+          side: "top",
+          className: "max-w-xs text-[11px] leading-relaxed",
+          children: [
+            reason,
+            ".",
+            " ",
+            freshAbs ? `Last checked ${freshAbs}${windowLabel ? ` \xB7 ${windowLabel} window` : ""}.` : "No probe samples recorded yet."
+          ]
+        }
+      )
+    ] }) })
+  );
 }
 var sum = (ns) => ns.reduce((a, b) => a + b, 0);
 var MIN_TILE_W_FOR_LABEL = 16;

--- a/packages/ui-kit/src/components/metagraphed/charts/spark-legend.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/spark-legend.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { formatFreshness, formatFreshnessAbsolute } from "@/lib/format";
@@ -36,47 +37,50 @@ export function SparkLegend({
   const fresh = formatFreshness(updatedAt, windowLabel);
   const freshAbs = formatFreshnessAbsolute(updatedAt);
   return (
-    <Tooltip delayDuration={200}>
-      <TooltipTrigger asChild>
-        <span
-          tabIndex={0}
-          className="inline-flex max-w-full items-center focus:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded"
-        >
-          {children}
-        </span>
-      </TooltipTrigger>
-      <TooltipContent
-        side={side}
-        sideOffset={6}
-        collisionPadding={8}
-        avoidCollisions
-        className="max-w-xs text-[11px] leading-relaxed"
-      >
-        <div className="font-mono text-[10px] uppercase tracking-widest mb-1">
-          {metric}
-          {windowLabel ? ` · ${windowLabel}` : ""}
-        </div>
-        <div className="mb-1">
-          <span className="font-mono text-[9.5px] uppercase tracking-widest opacity-70">
-            source ·{" "}
+    // Self-wrapped so SparkLegend works outside AppShell's global provider.
+    <TooltipProvider>
+      <Tooltip delayDuration={200}>
+        <TooltipTrigger asChild>
+          <span
+            tabIndex={0}
+            className="inline-flex max-w-full items-center focus:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded"
+          >
+            {children}
           </span>
-          {source}
-        </div>
-        {staleness ? (
+        </TooltipTrigger>
+        <TooltipContent
+          side={side}
+          sideOffset={6}
+          collisionPadding={8}
+          avoidCollisions
+          className="max-w-xs text-[11px] leading-relaxed"
+        >
+          <div className="font-mono text-[10px] uppercase tracking-widest mb-1">
+            {metric}
+            {windowLabel ? ` · ${windowLabel}` : ""}
+          </div>
           <div className="mb-1">
             <span className="font-mono text-[9.5px] uppercase tracking-widest opacity-70">
-              staleness ·{" "}
+              source ·{" "}
             </span>
-            {staleness}
+            {source}
           </div>
-        ) : null}
-        {fresh || freshAbs ? (
-          <div className="mt-1 font-mono text-[10px] opacity-80">
-            {fresh ?? ""}
-            {freshAbs ? `${fresh ? " · " : ""}last checked ${freshAbs}` : ""}
-          </div>
-        ) : null}
-      </TooltipContent>
-    </Tooltip>
+          {staleness ? (
+            <div className="mb-1">
+              <span className="font-mono text-[9.5px] uppercase tracking-widest opacity-70">
+                staleness ·{" "}
+              </span>
+              {staleness}
+            </div>
+          ) : null}
+          {fresh || freshAbs ? (
+            <div className="mt-1 font-mono text-[10px] opacity-80">
+              {fresh ?? ""}
+              {freshAbs ? `${fresh ? " · " : ""}last checked ${freshAbs}` : ""}
+            </div>
+          ) : null}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/packages/ui-kit/src/components/metagraphed/charts/stat-with-spark.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/stat-with-spark.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
@@ -48,64 +49,67 @@ export function StatWithSpark({
   const freshLine = formatFreshness(updatedAt, windowLabel);
   const freshAbs = formatFreshnessAbsolute(updatedAt);
   return (
-    <Tooltip delayDuration={200}>
-      <TooltipTrigger asChild>
-        <div
-          tabIndex={0}
-          className={classNames(
-            "group flex flex-col gap-1 px-3 py-2.5 min-w-0 focus:outline-none focus-visible:bg-surface/40 transition-colors",
-            className,
-          )}
-        >
-          <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted truncate">
-            {label}
-          </div>
-          <div className="flex items-baseline gap-1.5 min-w-0">
-            <span
-              className={classNames(
-                "font-display text-lg font-semibold tabular-nums leading-none truncate",
-                tone === "ok" && "text-health-ok",
-                tone === "warn" && "text-health-warn",
-                tone === "down" && "text-health-down",
-                tone === "default" && "text-ink-strong",
-              )}
-            >
-              {value}
-            </span>
-            {unit ? (
-              <span className="shrink-0 font-mono text-[9px] uppercase tracking-widest text-ink-muted">
-                {unit}
+    // Self-wrapped so StatWithSpark works outside AppShell's global provider.
+    <TooltipProvider>
+      <Tooltip delayDuration={200}>
+        <TooltipTrigger asChild>
+          <div
+            tabIndex={0}
+            className={classNames(
+              "group flex flex-col gap-1 px-3 py-2.5 min-w-0 focus:outline-none focus-visible:bg-surface/40 transition-colors",
+              className,
+            )}
+          >
+            <div className="font-mono text-[9.5px] uppercase tracking-widest text-ink-muted truncate">
+              {label}
+            </div>
+            <div className="flex items-baseline gap-1.5 min-w-0">
+              <span
+                className={classNames(
+                  "font-display text-lg font-semibold tabular-nums leading-none truncate",
+                  tone === "ok" && "text-health-ok",
+                  tone === "warn" && "text-health-warn",
+                  tone === "down" && "text-health-down",
+                  tone === "default" && "text-ink-strong",
+                )}
+              >
+                {value}
               </span>
+              {unit ? (
+                <span className="shrink-0 font-mono text-[9px] uppercase tracking-widest text-ink-muted">
+                  {unit}
+                </span>
+              ) : null}
+              {delta}
+            </div>
+            {viz ? <div className="mt-0.5 min-h-[18px]">{viz}</div> : null}
+            {hint ? (
+              <div className="font-mono text-[9.5px] text-ink-muted/80 truncate">
+                {hint}
+              </div>
             ) : null}
-            {delta}
+            {freshLine ? (
+              <div className="font-mono text-[9px] tracking-wide text-ink-muted/70 truncate">
+                {freshLine}
+              </div>
+            ) : null}
           </div>
-          {viz ? <div className="mt-0.5 min-h-[18px]">{viz}</div> : null}
-          {hint ? (
-            <div className="font-mono text-[9.5px] text-ink-muted/80 truncate">
-              {hint}
+        </TooltipTrigger>
+        <TooltipContent
+          side="bottom"
+          className="max-w-xs text-[11px] leading-relaxed"
+        >
+          <div>{full ?? hint ?? label}</div>
+          {freshAbs || windowLabel ? (
+            <div className="mt-1 font-mono text-[10px] text-primary-foreground/70">
+              {freshAbs ? `Last checked ${freshAbs}` : null}
+              {freshAbs && windowLabel ? " · " : ""}
+              {windowLabel ? `${windowLabel} window` : null}
             </div>
           ) : null}
-          {freshLine ? (
-            <div className="font-mono text-[9px] tracking-wide text-ink-muted/70 truncate">
-              {freshLine}
-            </div>
-          ) : null}
-        </div>
-      </TooltipTrigger>
-      <TooltipContent
-        side="bottom"
-        className="max-w-xs text-[11px] leading-relaxed"
-      >
-        <div>{full ?? hint ?? label}</div>
-        {freshAbs || windowLabel ? (
-          <div className="mt-1 font-mono text-[10px] text-primary-foreground/70">
-            {freshAbs ? `Last checked ${freshAbs}` : null}
-            {freshAbs && windowLabel ? " · " : ""}
-            {windowLabel ? `${windowLabel} window` : null}
-          </div>
-        ) : null}
-      </TooltipContent>
-    </Tooltip>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 
@@ -204,27 +208,31 @@ export function DotRow({
   dots: Array<{ label: string; on: boolean }>;
 }) {
   return (
-    <div
-      className="flex items-center gap-1"
-      role="img"
-      aria-label="Source coverage"
-    >
-      {dots.map((d) => (
-        <Tooltip key={d.label} delayDuration={150}>
-          <TooltipTrigger asChild>
-            <span
-              className={classNames(
-                "size-1.5 rounded-full",
-                d.on ? "bg-accent" : "bg-border",
-              )}
-            />
-          </TooltipTrigger>
-          <TooltipContent side="top" className="font-mono text-[10px]">
-            {d.label} {d.on ? "✓" : "—"}
-          </TooltipContent>
-        </Tooltip>
-      ))}
-    </div>
+    // One provider for the row rather than one per dot -- self-wrapped so DotRow
+    // works outside AppShell's global provider.
+    <TooltipProvider>
+      <div
+        className="flex items-center gap-1"
+        role="img"
+        aria-label="Source coverage"
+      >
+        {dots.map((d) => (
+          <Tooltip key={d.label} delayDuration={150}>
+            <TooltipTrigger asChild>
+              <span
+                className={classNames(
+                  "size-1.5 rounded-full",
+                  d.on ? "bg-accent" : "bg-border",
+                )}
+              />
+            </TooltipTrigger>
+            <TooltipContent side="top" className="font-mono text-[10px]">
+              {d.label} {d.on ? "✓" : "—"}
+            </TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+    </TooltipProvider>
   );
 }
 
@@ -247,33 +255,36 @@ export function NoDataSpark({
   const freshAbs = formatFreshnessAbsolute(updatedAt);
   const freshLine = formatFreshness(updatedAt, windowLabel);
   return (
-    <Tooltip delayDuration={150}>
-      <TooltipTrigger asChild>
-        <div
-          tabIndex={0}
-          role="img"
-          aria-label={`${reason}${freshAbs ? `, last checked ${freshAbs}` : ""}`}
-          className="flex w-full items-center gap-1.5 rounded-sm border border-dashed border-border/70 bg-paper/40 px-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          style={{ height }}
+    // Self-wrapped so NoDataSpark works outside AppShell's global provider.
+    <TooltipProvider>
+      <Tooltip delayDuration={150}>
+        <TooltipTrigger asChild>
+          <div
+            tabIndex={0}
+            role="img"
+            aria-label={`${reason}${freshAbs ? `, last checked ${freshAbs}` : ""}`}
+            className="flex w-full items-center gap-1.5 rounded-sm border border-dashed border-border/70 bg-paper/40 px-1.5 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            style={{ height }}
+          >
+            <span
+              aria-hidden
+              className="inline-block size-1 rounded-full bg-ink-muted/60"
+            />
+            <span className="truncate font-mono text-[9px] uppercase tracking-widest text-ink-muted/80">
+              {freshLine ?? reason}
+            </span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent
+          side="top"
+          className="max-w-xs text-[11px] leading-relaxed"
         >
-          <span
-            aria-hidden
-            className="inline-block size-1 rounded-full bg-ink-muted/60"
-          />
-          <span className="truncate font-mono text-[9px] uppercase tracking-widest text-ink-muted/80">
-            {freshLine ?? reason}
-          </span>
-        </div>
-      </TooltipTrigger>
-      <TooltipContent
-        side="top"
-        className="max-w-xs text-[11px] leading-relaxed"
-      >
-        {reason}.{" "}
-        {freshAbs
-          ? `Last checked ${freshAbs}${windowLabel ? ` · ${windowLabel} window` : ""}.`
-          : "No probe samples recorded yet."}
-      </TooltipContent>
-    </Tooltip>
+          {reason}.{" "}
+          {freshAbs
+            ? `Last checked ${freshAbs}${windowLabel ? ` · ${windowLabel} window` : ""}.`
+            : "No probe samples recorded yet."}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/packages/ui-kit/src/components/metagraphed/key-chip.tsx
+++ b/packages/ui-kit/src/components/metagraphed/key-chip.tsx
@@ -1,6 +1,7 @@
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useCopy } from "@/hooks/use-copy";
@@ -39,33 +40,36 @@ export function KeyChip({
       : value;
 
   return (
-    <Tooltip delayDuration={120}>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          onClick={() => copy(value)}
-          aria-label={copied ? `${label} copied` : `Copy ${label}: ${value}`}
-          className={classNames(
-            "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left font-mono text-[11px] text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
-            className,
-          )}
+    // Self-wrapped so KeyChip works outside AppShell's global provider.
+    <TooltipProvider>
+      <Tooltip delayDuration={120}>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => copy(value)}
+            aria-label={copied ? `${label} copied` : `Copy ${label}: ${value}`}
+            className={classNames(
+              "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left font-mono text-[11px] text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
+              className,
+            )}
+          >
+            <span className="truncate tabular-nums">{short}</span>
+            <CopyIconToggle
+              copied={copied}
+              className="text-ink-muted group-hover:text-ink"
+            />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent
+          side="top"
+          className="max-w-[90vw] break-all font-mono text-[11px]"
         >
-          <span className="truncate tabular-nums">{short}</span>
-          <CopyIconToggle
-            copied={copied}
-            className="text-ink-muted group-hover:text-ink"
-          />
-        </button>
-      </TooltipTrigger>
-      <TooltipContent
-        side="top"
-        className="max-w-[90vw] break-all font-mono text-[11px]"
-      >
-        <span className="mr-1 uppercase tracking-widest text-[9px] opacity-70">
-          {label}
-        </span>
-        {value}
-      </TooltipContent>
-    </Tooltip>
+          <span className="mr-1 uppercase tracking-widest text-[9px] opacity-70">
+            {label}
+          </span>
+          {value}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/packages/ui-kit/src/components/metagraphed/tooltip-provider-independence.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/tooltip-provider-independence.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import React, { type ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { KeyChip } from "@/components/metagraphed/key-chip";
+import { SparkLegend } from "@/components/metagraphed/charts/spark-legend";
+import {
+  DotRow,
+  NoDataSpark,
+  StatWithSpark,
+} from "@/components/metagraphed/charts/stat-with-spark";
+
+// Radix's Tooltip root calls useTooltipProviderContext with no `optional`
+// flag, so @radix-ui/react-context throws
+// "`Tooltip` must be used within `TooltipProvider`" the moment one renders
+// with no Provider ancestor. These components used to rely on
+// apps/ui's AppShell supplying a single global <TooltipProvider>, which made
+// them unusable anywhere else (a standalone embed, a design-sync preview, a
+// test harness). Each now self-wraps, matching InfoTooltip/EligibilityChip.
+//
+// Rendering on the server is enough to prove it: the throw happens during
+// render, before any effect or browser API is needed -- which is why this fits
+// the package's node-environment suite with no jsdom.
+const render = (element: ReactElement) => () => renderToStaticMarkup(element);
+
+describe("ui-kit tooltip components render without an ancestor TooltipProvider", () => {
+  const cases: Array<[string, ReactElement]> = [
+    [
+      "KeyChip",
+      React.createElement(KeyChip, {
+        value: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+        label: "hotkey",
+      }),
+    ],
+    [
+      "SparkLegend",
+      React.createElement(SparkLegend, {
+        metric: "Health trend",
+        source: "live-cron-prober",
+        children: "child",
+      }),
+    ],
+    [
+      "StatWithSpark",
+      React.createElement(StatWithSpark, { label: "Uptime", value: "99.9%" }),
+    ],
+    [
+      "DotRow",
+      React.createElement(DotRow, {
+        dots: [
+          { label: "registry", on: true },
+          { label: "probe", on: false },
+        ],
+      }),
+    ],
+    ["NoDataSpark", React.createElement(NoDataSpark, {})],
+  ];
+
+  for (const [name, element] of cases) {
+    it(`${name} does not throw with no provider ancestor`, () => {
+      expect(render(element)).not.toThrow();
+    });
+  }
+
+  // The regression these guard against: without a provider, Radix throws this
+  // exact message. If a future edit drops a component's own TooltipProvider,
+  // the assertion above fails with it.
+  it("a bare Radix Tooltip still throws without a provider (the guarded failure)", async () => {
+    const { Tooltip, TooltipContent, TooltipTrigger } =
+      await import("@/components/ui/tooltip");
+    expect(
+      render(
+        React.createElement(
+          Tooltip,
+          null,
+          React.createElement(TooltipTrigger, null, "trigger"),
+          React.createElement(TooltipContent, null, "content"),
+        ),
+      ),
+    ).toThrow(/must be used within `TooltipProvider`/);
+  });
+
+  // Nested Radix providers are safe, so self-wrapping cannot regress the
+  // components' existing use inside AppShell's global provider.
+  it("still renders when nested inside an outer provider, as AppShell does", async () => {
+    const { TooltipProvider } = await import("@/components/ui/tooltip");
+    for (const [, element] of cases) {
+      expect(
+        render(React.createElement(TooltipProvider, null, element)),
+      ).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## What

`KeyChip`, `SparkLegend`, `StatWithSpark`, `DotRow`, and `NoDataSpark` each render a bare Radix `<Tooltip>` with no `TooltipProvider`. Radix's `Tooltip` root calls `useTooltipProviderContext` with no `optional` flag, so it throws ``Tooltip` must be used within `TooltipProvider`` **during render** when no Provider ancestor exists.

They don't crash today only because `apps/ui`'s `AppShell` wraps every route in one global `<TooltipProvider>` — which silently couples these five to always being rendered inside it. Outside it (a standalone embed, a design-sync preview, a test harness) they throw.

Each now self-wraps, matching the `InfoTooltip`/`EligibilityChip` precedent already in the package.

**Confirmed the premise before fixing it** — rendering a bare `<Tooltip>` against this repo's installed `@radix-ui/react-tooltip@1.2.12` does throw exactly that error, so this is a real crash, not a theoretical one.

## Notes on the two judgement calls

- **`DotRow` takes one provider for the whole row**, not one per dot — its `<Tooltip>` sits inside a `.map()`, and a provider per dot would be pointless churn.
- **`delayDuration` is left on each `<Tooltip>`** rather than hoisted to the provider, so the existing per-tooltip delays (120/150/200ms) are preserved exactly.

## No visual change — proven, not asserted

`TooltipProvider` is context-only and emits no DOM. I rendered all five components **inside an outer provider (AppShell's current arrangement) before and after this change** and diffed the markup:

```
✅ BYTE-IDENTICAL — 2834 bytes both
```

`git diff -w` (ignoring whitespace) is **+19 lines, 0 deletions** — the wrappers and their comments. The rest of the line count is re-indentation from introducing a wrapper element.

Nested Radix providers are safe, so the components' existing use inside AppShell's global provider is unaffected — covered by a test below.

## Testing

Added `tooltip-provider-independence.test.ts` (7 tests). The package's suite is `environment: "node"` with `src/**/*.test.ts` only and no jsdom, so this renders via `react-dom/server` — sufficient because the throw happens during render, before any effect or browser API is needed.

- Each of the five components rendered with **no ancestor provider**, asserted not to throw.
- A guard asserting a **bare Radix `Tooltip` still does throw** — so if a future edit drops a component's own provider, this suite fails rather than silently regressing.
- Each component rendered **nested inside an outer provider**, asserting the AppShell path still works.

**Verified the test is meaningful**, not a rubber stamp: reverting `KeyChip` to its unwrapped form fails the suite with the exact Radix error, and it passes again once restored.

`packages/ui-kit`: 12 files / 64 tests pass, `typecheck` clean, `lint` clean, `format:check` clean.

Closes #6374
