### PR TITLE
feat(api): support ?format=csv on the identity-history endpoints

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -198,7 +198,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the append-only diff-tracking timeline for one account's personal chain identity (epic #4301/5.2): each entry is a snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the append-only diff-tracking timeline for one account's personal chain identity (epic #4301/5.2): each entry is a snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
         get: operations["accountIdentityHistory"];
         put?: never;
         post?: never;
@@ -2119,7 +2119,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the append-only on-chain identity timeline for one subnet (#1647): each entry is a SubnetIdentitiesV3 snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the append-only on-chain identity timeline for one subnet (#1647): each entry is a SubnetIdentitiesV3 snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
         get: operations["subnetIdentityHistory"];
         put?: never;
         post?: never;
@@ -9414,6 +9414,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -9423,7 +9425,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -9477,6 +9479,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountIdentityHistoryArtifact"];
                     };
+                    /**
+                     * @example observed_at,name,url,github,image,discord,description,additional,identity_hash
+                     *     2026-06-27T00:00:00.000Z,Alice,https://alice.example,https://github.com/alice,https://alice.example/avatar.png,https://discord.gg/alice,Sample account,extra,hash_sample
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -24920,6 +24927,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -24929,7 +24938,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -24983,6 +24992,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetIdentityHistoryArtifact"];
                     };
+                    /**
+                     * @example block_number,observed_at,subnet_name,symbol,description,github_repo,subnet_url,discord,logo_url,identity_hash
+                     *     8454388,2026-06-27T00:00:00.000Z,Apex,APEX,Sample subnet,https://github.com/example/apex,https://apex.example,https://discord.gg/apex,https://apex.example/logo.png,hash_sample
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -6142,7 +6142,7 @@
     {
       "artifact_path": "/metagraph/subnets/{netuid}/identity-history.json",
       "cache": "short",
-      "description": "Fetch the append-only on-chain identity timeline for one subnet (#1647): each entry is a SubnetIdentitiesV3 snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+      "description": "Fetch the append-only on-chain identity timeline for one subnet (#1647): each entry is a SubnetIdentitiesV3 snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
       "id": "subnet-identity-history",
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/identity-history",
@@ -6168,6 +6168,17 @@
         {
           "name": "cursor",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
             "type": "string"
           }
         }
@@ -6755,7 +6766,7 @@
     {
       "artifact_path": "/metagraph/accounts/{ss58}/identity-history.json",
       "cache": "short",
-      "description": "Fetch the append-only diff-tracking timeline for one account's personal chain identity (epic #4301/5.2): each entry is a snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+      "description": "Fetch the append-only diff-tracking timeline for one account's personal chain identity (epic #4301/5.2): each entry is a snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
       "id": "account-identity-history",
       "method": "GET",
       "path": "/api/v1/accounts/{ss58}/identity-history",
@@ -6781,6 +6792,17 @@
         {
           "name": "cursor",
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
             "type": "string"
           }
         }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -23986,6 +23986,19 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -24047,9 +24060,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "observed_at,name,url,github,image,discord,description,additional,identity_hash\r\n2026-06-27T00:00:00.000Z,Alice,https://alice.example,https://github.com/alice,https://alice.example/avatar.png,https://discord.gg/alice,Sample account,extra,hash_sample",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -24106,7 +24125,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the append-only diff-tracking timeline for one account's personal chain identity (epic #4301/5.2): each entry is a snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+        "summary": "Fetch the append-only diff-tracking timeline for one account's personal chain identity (epic #4301/5.2): each entry is a snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
         "tags": [
           "accounts",
           "analytics"
@@ -47334,6 +47353,19 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -47395,9 +47427,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "block_number,observed_at,subnet_name,symbol,description,github_repo,subnet_url,discord,logo_url,identity_hash\r\n8454388,2026-06-27T00:00:00.000Z,Apex,APEX,Sample subnet,https://github.com/example/apex,https://apex.example,https://discord.gg/apex,https://apex.example/logo.png,hash_sample",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -47454,7 +47492,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the append-only on-chain identity timeline for one subnet (#1647): each entry is a SubnetIdentitiesV3 snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+        "summary": "Fetch the append-only on-chain identity timeline for one subnet (#1647): each entry is a SubnetIdentitiesV3 snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
         "tags": [
           "subnets",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -198,7 +198,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the append-only diff-tracking timeline for one account's personal chain identity (epic #4301/5.2): each entry is a snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the append-only diff-tracking timeline for one account's personal chain identity (epic #4301/5.2): each entry is a snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
         get: operations["accountIdentityHistory"];
         put?: never;
         post?: never;
@@ -2119,7 +2119,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the append-only on-chain identity timeline for one subnet (#1647): each entry is a SubnetIdentitiesV3 snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. */
+        /** Fetch the append-only on-chain identity timeline for one subnet (#1647): each entry is a SubnetIdentitiesV3 snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV. */
         get: operations["subnetIdentityHistory"];
         put?: never;
         post?: never;
@@ -9414,6 +9414,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -9423,7 +9425,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -9477,6 +9479,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AccountIdentityHistoryArtifact"];
                     };
+                    /**
+                     * @example observed_at,name,url,github,image,discord,description,additional,identity_hash
+                     *     2026-06-27T00:00:00.000Z,Alice,https://alice.example,https://github.com/alice,https://alice.example/avatar.png,https://discord.gg/alice,Sample account,extra,hash_sample
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */
@@ -24920,6 +24927,8 @@ export interface operations {
                 limit?: number;
                 offset?: number;
                 cursor?: string;
+                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                format?: "json" | "csv";
             };
             header?: never;
             path: {
@@ -24929,7 +24938,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -24983,6 +24992,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetIdentityHistoryArtifact"];
                     };
+                    /**
+                     * @example block_number,observed_at,subnet_name,symbol,description,github_repo,subnet_url,discord,logo_url,identity_hash
+                     *     8454388,2026-06-27T00:00:00.000Z,Apex,APEX,Sample subnet,https://github.com/example/apex,https://apex.example,https://discord.gg/apex,https://apex.example/logo.png,hash_sample
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2684,14 +2684,14 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/subnets/{netuid}/identity-history",
     "/metagraph/subnets/{netuid}/identity-history.json",
-    "Fetch the append-only on-chain identity timeline for one subnet (#1647): each entry is a SubnetIdentitiesV3 snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+    "Fetch the append-only on-chain identity timeline for one subnet (#1647): each entry is a SubnetIdentitiesV3 snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
     "short",
     ["subnets", "analytics"],
-    [
+    csvRouteQuery([
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "cursor", schema: { type: "string" } },
-    ],
+    ]),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(
@@ -3010,14 +3010,14 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/accounts/{ss58}/identity-history",
     "/metagraph/accounts/{ss58}/identity-history.json",
-    "Fetch the append-only diff-tracking timeline for one account's personal chain identity (epic #4301/5.2): each entry is a snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging.",
+    "Fetch the append-only diff-tracking timeline for one account's personal chain identity (epic #4301/5.2): each entry is a snapshot recorded when any tracked field changed. Newest first; ?limit (<=1000) / ?offset, or ?cursor= for stable keyset paging. Pass ?format=csv to download the page as CSV.",
     "short",
     ["accounts", "analytics"],
-    [
+    csvRouteQuery([
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 1000 } },
       { name: "offset", schema: { type: "integer", minimum: 0 } },
       { name: "cursor", schema: { type: "string" } },
-    ],
+    ]),
     [{ name: "ss58", schema: { type: "string" } }],
   ),
   route(

--- a/src/csv-route-examples.mjs
+++ b/src/csv-route-examples.mjs
@@ -29,6 +29,19 @@ export const ROUTE_CSV_EXAMPLES = {
     "block_number,observed_at,hyperparameters,hyperparams_hash",
     '8454388,2026-06-27T00:00:00.000Z,"{""kappa"":0.5}",hash_sample',
   ].join("\r\n"),
+  // The formatIdentityHistoryEntry row shape (src/subnet-identity-history.mjs):
+  // one SubnetIdentitiesV3 snapshot per row.
+  "subnet-identity-history": [
+    "block_number,observed_at,subnet_name,symbol,description,github_repo,subnet_url,discord,logo_url,identity_hash",
+    "8454388,2026-06-27T00:00:00.000Z,Apex,APEX,Sample subnet,https://github.com/example/apex,https://apex.example,https://discord.gg/apex,https://apex.example/logo.png,hash_sample",
+  ].join("\r\n"),
+  // The formatAccountIdentityHistoryEntry row shape
+  // (src/account-identity-history.mjs): keyed by account, so no block_number and
+  // the account_identity field names (name/url/github/image/additional).
+  "account-identity-history": [
+    "observed_at,name,url,github,image,discord,description,additional,identity_hash",
+    "2026-06-27T00:00:00.000Z,Alice,https://alice.example,https://github.com/alice,https://alice.example/avatar.png,https://discord.gg/alice,Sample account,extra,hash_sample",
+  ].join("\r\n"),
   "subnet-events": EVENTS_CSV_EXAMPLE,
   "account-events": EVENTS_CSV_EXAMPLE,
   // The Postgres all-events feed: flat scalar columns of each raw pallet.method

--- a/tests/identity-history-csv.test.mjs
+++ b/tests/identity-history-csv.test.mjs
@@ -1,0 +1,258 @@
+// CSV export tests for the two identity-history feeds —
+// GET /api/v1/subnets/{netuid}/identity-history and
+// GET /api/v1/accounts/{ss58}/identity-history. Kept in a dedicated file so this
+// PR does not contend with open entity-handler PRs on the shared
+// request-handlers-entities.test.mjs harness, mirroring
+// subnet-hyperparams-history-csv.test.mjs.
+
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildOpenApiArtifact } from "../src/contracts.mjs";
+import { loadOpenApiComponentSchemas } from "../scripts/openapi-components.mjs";
+import {
+  handleSubnetIdentityHistory,
+  handleAccountIdentityHistory,
+} from "../workers/request-handlers/entities.mjs";
+
+const NETUID = 7;
+const SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const SUBNET_CSV_HEADER =
+  "block_number,observed_at,subnet_name,symbol,description,github_repo,subnet_url,discord,logo_url,identity_hash";
+const ACCOUNT_CSV_HEADER =
+  "observed_at,name,url,github,image,discord,description,additional,identity_hash";
+
+function req(path) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+function url(path) {
+  return new URL(`https://api.metagraph.sh${path}`);
+}
+
+function postgresEnv(flag, body) {
+  return {
+    [flag]: "postgres",
+    DATA_API: { fetch: async () => Response.json(body) },
+  };
+}
+
+async function errorJson(res) {
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.ok, false);
+  return body;
+}
+
+describe("identity-history OpenAPI CSV contract", () => {
+  test("documents the CSV header on both identity-history routes", async () => {
+    const openapi = buildOpenApiArtifact(
+      "1970-01-01T00:00:00.000Z",
+      await loadOpenApiComponentSchemas(),
+    );
+    const subnetCsv =
+      openapi.paths["/api/v1/subnets/{netuid}/identity-history"].get.responses[
+        "200"
+      ].content["text/csv"];
+    assert.equal(subnetCsv.schema.type, "string");
+    assert.equal(subnetCsv.example.split("\r\n")[0], SUBNET_CSV_HEADER);
+
+    const accountCsv =
+      openapi.paths["/api/v1/accounts/{ss58}/identity-history"].get.responses[
+        "200"
+      ].content["text/csv"];
+    assert.equal(accountCsv.schema.type, "string");
+    assert.equal(accountCsv.example.split("\r\n")[0], ACCOUNT_CSV_HEADER);
+  });
+});
+
+describe("handleSubnetIdentityHistory CSV export", () => {
+  test("returns header-only CSV on cold D1", async () => {
+    const res = await handleSubnetIdentityHistory(
+      req(`/api/v1/subnets/${NETUID}/identity-history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/identity-history?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(lines[0], SUBNET_CSV_HEADER);
+    assert.equal(lines.length, 1);
+  });
+
+  test("exports the paginated timeline via the Postgres tier", async () => {
+    const env = postgresEnv("METAGRAPH_SUBNET_IDENTITY_SOURCE", {
+      schema_version: 1,
+      netuid: NETUID,
+      entry_count: 1,
+      limit: 50,
+      offset: 0,
+      next_cursor: null,
+      entries: [
+        {
+          block_number: 100,
+          observed_at: "2026-06-21T00:00:00.000Z",
+          subnet_name: "MIAO",
+          symbol: "α",
+          description: "old",
+          github_repo: null,
+          subnet_url: null,
+          discord: null,
+          logo_url: null,
+          identity_hash: "abc",
+        },
+      ],
+    });
+    const res = await handleSubnetIdentityHistory(
+      req(`/api/v1/subnets/${NETUID}/identity-history`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/identity-history?limit=50&format=csv`),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines[0], SUBNET_CSV_HEADER);
+    assert.equal(lines[1], "100,2026-06-21T00:00:00.000Z,MIAO,α,old,,,,,abc");
+    assert.equal(lines.length, 2);
+  });
+
+  test("keeps the JSON envelope when no CSV is requested", async () => {
+    const env = postgresEnv("METAGRAPH_SUBNET_IDENTITY_SOURCE", {
+      schema_version: 1,
+      netuid: NETUID,
+      entry_count: 0,
+      limit: 50,
+      offset: 0,
+      next_cursor: null,
+      entries: [],
+    });
+    const res = await handleSubnetIdentityHistory(
+      req(`/api/v1/subnets/${NETUID}/identity-history`),
+      env,
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/identity-history`),
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.netuid, NETUID);
+  });
+
+  test("rejects an unsupported format value", async () => {
+    const res = await handleSubnetIdentityHistory(
+      req(`/api/v1/subnets/${NETUID}/identity-history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/identity-history?format=pdf`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("rejects an empty format parameter", async () => {
+    const res = await handleSubnetIdentityHistory(
+      req(`/api/v1/subnets/${NETUID}/identity-history`),
+      {},
+      NETUID,
+      url(`/api/v1/subnets/${NETUID}/identity-history?format=`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+});
+
+describe("handleAccountIdentityHistory CSV export", () => {
+  test("returns header-only CSV on cold D1", async () => {
+    const res = await handleAccountIdentityHistory(
+      req(`/api/v1/accounts/${SS58}/identity-history`),
+      {},
+      SS58,
+      url(`/api/v1/accounts/${SS58}/identity-history?format=csv`),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).split("\r\n");
+    assert.equal(lines[0], ACCOUNT_CSV_HEADER);
+    assert.equal(lines.length, 1);
+  });
+
+  test("exports the paginated timeline via the Postgres tier", async () => {
+    const env = postgresEnv("METAGRAPH_ACCOUNT_IDENTITY_SOURCE", {
+      schema_version: 1,
+      account: SS58,
+      entry_count: 1,
+      limit: 50,
+      offset: 0,
+      next_cursor: null,
+      entries: [
+        {
+          observed_at: "2026-06-21T00:00:00.000Z",
+          name: "Alice",
+          url: "https://alice.example",
+          github: "https://github.com/alice",
+          image: null,
+          discord: null,
+          description: "hi",
+          additional: null,
+          identity_hash: "abc",
+        },
+      ],
+    });
+    const res = await handleAccountIdentityHistory(
+      req(`/api/v1/accounts/${SS58}/identity-history`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/identity-history?limit=50&format=csv`),
+    );
+    assert.equal(res.status, 200);
+    const lines = (await res.text()).trim().split("\r\n");
+    assert.equal(lines[0], ACCOUNT_CSV_HEADER);
+    assert.equal(
+      lines[1],
+      "2026-06-21T00:00:00.000Z,Alice,https://alice.example,https://github.com/alice,,,hi,,abc",
+    );
+    assert.equal(lines.length, 2);
+  });
+
+  test("keeps the JSON envelope when no CSV is requested", async () => {
+    const env = postgresEnv("METAGRAPH_ACCOUNT_IDENTITY_SOURCE", {
+      schema_version: 1,
+      account: SS58,
+      entry_count: 0,
+      limit: 50,
+      offset: 0,
+      next_cursor: null,
+      entries: [],
+    });
+    const res = await handleAccountIdentityHistory(
+      req(`/api/v1/accounts/${SS58}/identity-history`),
+      env,
+      SS58,
+      url(`/api/v1/accounts/${SS58}/identity-history`),
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.account, SS58);
+  });
+
+  test("rejects an unsupported format value", async () => {
+    const res = await handleAccountIdentityHistory(
+      req(`/api/v1/accounts/${SS58}/identity-history`),
+      {},
+      SS58,
+      url(`/api/v1/accounts/${SS58}/identity-history?format=pdf`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+
+  test("rejects an empty format parameter", async () => {
+    const res = await handleAccountIdentityHistory(
+      req(`/api/v1/accounts/${SS58}/identity-history`),
+      {},
+      SS58,
+      url(`/api/v1/accounts/${SS58}/identity-history?format=`),
+    );
+    const body = await errorJson(res);
+    assert.equal(body.meta.parameter, "format");
+  });
+});

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -491,6 +491,37 @@ const EVENTS_CSV_COLUMNS = [
   "observed_at",
   "extrinsic_index",
 ];
+// The formatIdentityHistoryEntry row shape (src/subnet-identity-history.mjs):
+// one SubnetIdentitiesV3 snapshot per row, stable so a CSV consumer's columns
+// never shift.
+const SUBNET_IDENTITY_HISTORY_CSV_COLUMNS = [
+  "block_number",
+  "observed_at",
+  "subnet_name",
+  "symbol",
+  "description",
+  "github_repo",
+  "subnet_url",
+  "discord",
+  "logo_url",
+  "identity_hash",
+];
+// The formatAccountIdentityHistoryEntry row shape
+// (src/account-identity-history.mjs): keyed by account, so it carries no
+// block_number (account_identity has no chain block height, only captured_at)
+// and uses the account_identity field names rather than the subnet identity
+// fields.
+const ACCOUNT_IDENTITY_HISTORY_CSV_COLUMNS = [
+  "observed_at",
+  "name",
+  "url",
+  "github",
+  "image",
+  "discord",
+  "description",
+  "additional",
+  "identity_hash",
+];
 
 function validateResponseFormat(url) {
   const raw = url.searchParams.get("format");
@@ -1155,10 +1186,11 @@ export async function handleSubnetHistory(request, env, netuid, url) {
 // GET /api/v1/subnets/{netuid}/identity-history (#1647): append-only on-chain
 // identity timeline, newest first. Cold/absent store → schema-stable zero.
 export async function handleSubnetIdentityHistory(request, env, netuid, url) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset, cursor } = parsePagination(url, FEED_PAGINATION);
@@ -1172,6 +1204,18 @@ export async function handleSubnetIdentityHistory(request, env, netuid, url) {
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_SUBNET_IDENTITY_SOURCE")) ??
     (await fromD1());
+  // CSV mirrors handleSubnetHyperparamsHistory: the page is already
+  // limit/offset/cursor-bounded, so the CSV path carries the identical page the
+  // JSON path would. Cold store -> empty entries -> header-only CSV.
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.entries,
+      `subnet-${netuid}-identity-history`,
+      "short",
+      request,
+      SUBNET_IDENTITY_HISTORY_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {
@@ -3426,10 +3470,11 @@ export async function handleAccountIdentity(request, env, ss58, url) {
 // exactly, keyed by ss58 instead of netuid. Cold/absent store → schema-stable
 // zero entries, never 404.
 export async function handleAccountIdentityHistory(request, env, ss58, url) {
-  const validationError = validateQueryParams(url, [
+  const validationError = validateEntityQuery(url, [
     "limit",
     "offset",
     "cursor",
+    "format",
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const { limit, offset, cursor } = parsePagination(url, FEED_PAGINATION);
@@ -3446,6 +3491,18 @@ export async function handleAccountIdentityHistory(request, env, ss58, url) {
       request,
       "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
     )) ?? (await fromD1());
+  // CSV mirrors handleSubnetHyperparamsHistory: the page is already
+  // limit/offset/cursor-bounded, so the CSV path carries the identical page the
+  // JSON path would. Cold store -> empty entries -> header-only CSV.
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.entries,
+      "account-identity-history",
+      "short",
+      request,
+      ACCOUNT_IDENTITY_HISTORY_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

`?format=csv` now works on both identity-history feeds — `GET /api/v1/subnets/{netuid}/identity-history` and `GET /api/v1/accounts/{ss58}/identity-history` — instead of returning a `400 invalid_query`. Both were the only append-only history feeds in `workers/request-handlers/entities.mjs` still on the JSON-only `validateQueryParams(url, ["limit","offset","cursor"])` allow-list, unlike their sibling `handleSubnetHyperparamsHistory` and every other paginated feed in the file.

Closes #6357.

## What Changed

- Switched both handlers to `validateEntityQuery` (adds `"format"` to the allow-list) and added a `csvRequested`/`csvResponse` branch mirroring `handleSubnetHyperparamsHistory`'s — the page is already limit/offset/cursor-bounded, so the CSV path ships the identical page the JSON path would; a cold store yields a header-only CSV.
- Added two column constants matching each entry's actual serialized shape:
  - `SUBNET_IDENTITY_HISTORY_CSV_COLUMNS` = `block_number, observed_at, subnet_name, symbol, description, github_repo, subnet_url, discord, logo_url, identity_hash` (the `formatIdentityHistoryEntry` shape — exactly the column list the issue specifies).
  - `ACCOUNT_IDENTITY_HISTORY_CSV_COLUMNS` = `observed_at, name, url, github, image, discord, description, additional, identity_hash`. The account feed's entry (`formatAccountIdentityHistoryEntry`) has a genuinely different shape — it carries **no `block_number`** (account identity has no chain block height, only `captured_at`) and uses the `account_identity` field names, as `src/account-identity-history.mjs`'s own header documents. Reusing the subnet column list here would have emitted an all-empty CSV, so each handler gets the column set that matches its rows — consistent with the file's per-feed column-list convention.
- Documented the CSV response in the OpenAPI contract for both routes (`csvRouteQuery` + a "Pass ?format=csv…" description) and added worked CSV examples in `src/csv-route-examples.mjs`. Regenerated `openapi.json` + generated types/client via `npm run build`.

## Validation

- `npm run test` — 9151 passed (adds `tests/identity-history-csv.test.mjs`, 11 tests: OpenAPI CSV contract for both routes, header-only cold CSV, Postgres-tier row export, JSON-envelope default, and the `format=pdf`/`format=` rejections, mirroring `subnet-hyperparams-history-csv.test.mjs`).
- `npm run lint` + `npm run format:check` — clean.
- `npm run validate:contract-drift`, `validate:openapi`, `validate:openapi-examples`, `validate:types`, `validate:generated-client`, `validate:api`, `validate:docs`, `validate:schemas`, `validate:artifact-budgets`, `worker:bundle:budget` — all pass.
- Patch coverage: every changed line and branch in `src/**`/`workers/**` is exercised by the new + existing entity tests.
- `git diff --check` — clean.
