### PR TITLE
fix(ui-kit): give every copy/share control a focus ring and a copy announcement

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -1373,6 +1373,9 @@ function CopyIconToggle({ copied, size = 3, className }) {
     }
   );
 }
+function CopyStatusRegion({ children }) {
+  return /* @__PURE__ */ jsxRuntime.jsx("span", { role: "status", "aria-live": "polite", className: "sr-only", children });
+}
 function CopyButton({
   value,
   label,
@@ -1380,25 +1383,33 @@ function CopyButton({
   compact
 }) {
   const { copied, copy } = useCopy({ label });
-  return /* @__PURE__ */ jsxRuntime.jsx(
-    "button",
-    {
-      type: "button",
-      onClick: () => copy(value),
-      "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
-      title: copied ? "Copied!" : `Copy ${label ?? "value"}`,
-      className: classNames(
-        // min-h-11 min-w-11 gives the icon-only button the same 44px minimum
-        // touch target as every other header icon button in the shell (the
-        // convention list-shell.tsx documents); p-1 keeps the icon itself compact
-        // and centered within that hit area.
-        "shrink-0 inline-flex items-center justify-center rounded p-1 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong transition-colors",
-        compact && "-my-3.5",
-        className
-      ),
-      children: /* @__PURE__ */ jsxRuntime.jsx(CopyIconToggle, { copied })
-    }
-  );
+  return /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
+    /* @__PURE__ */ jsxRuntime.jsx(
+      "button",
+      {
+        type: "button",
+        onClick: () => copy(value),
+        "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
+        title: copied ? "Copied!" : `Copy ${label ?? "value"}`,
+        className: classNames(
+          // min-h-11 min-w-11 gives the icon-only button the same 44px minimum
+          // touch target as every other header icon button in the shell (the
+          // convention list-shell.tsx documents); p-1 keeps the icon itself compact
+          // and centered within that hit area.
+          "shrink-0 inline-flex items-center justify-center rounded p-1 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong transition-colors",
+          // Focus ring drawn inside the 44px box (ring-inset) so it stays visible
+          // rather than clipping against a `compact` row's -my-3.5 fold or a
+          // tight table cell. KeyChip's own ring-offset treatment can't be reused
+          // verbatim here for that reason (#6371).
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60",
+          compact && "-my-3.5",
+          className
+        ),
+        children: /* @__PURE__ */ jsxRuntime.jsx(CopyIconToggle, { copied })
+      }
+    ),
+    /* @__PURE__ */ jsxRuntime.jsx(CopyStatusRegion, { children: copied ? `${label ?? "Value"} copied to clipboard` : "" })
+  ] });
 }
 function CopyableCode({
   value,
@@ -1407,59 +1418,66 @@ function CopyableCode({
   truncate = true
 }) {
   const { copied, copy } = useCopy({ label: label ?? "value" });
-  return /* @__PURE__ */ jsxRuntime.jsxs(
-    "button",
-    {
-      type: "button",
-      onClick: () => copy(value),
-      title: value,
-      "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
-      className: classNames(
-        "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left font-mono text-[11px] text-ink hover:border-ink/30 transition-colors",
-        className
-      ),
-      children: [
-        label ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "shrink-0 text-ink-muted uppercase tracking-wider text-[10px]", children: label }) : null,
-        /* @__PURE__ */ jsxRuntime.jsx(
-          "code",
-          {
-            className: classNames(
-              "min-w-0 text-ink-strong",
-              truncate ? "truncate" : "truncate sm:whitespace-normal sm:break-all"
-            ),
-            children: value
-          }
+  return /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
+    /* @__PURE__ */ jsxRuntime.jsxs(
+      "button",
+      {
+        type: "button",
+        onClick: () => copy(value),
+        title: value,
+        "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
+        className: classNames(
+          "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left font-mono text-[11px] text-ink hover:border-ink/30 transition-colors",
+          // Matches KeyChip's ring treatment -- this one is a bordered chip like
+          // KeyChip (not an icon-only hit area), so the offset ring reads cleanly
+          // against the card behind it (#6371).
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card",
+          className
         ),
-        /* @__PURE__ */ jsxRuntime.jsxs(
-          "span",
-          {
-            className: "relative inline-flex size-3 shrink-0 items-center justify-center",
-            "aria-hidden": true,
-            children: [
-              /* @__PURE__ */ jsxRuntime.jsx(
-                lucideReact.Check,
-                {
-                  className: classNames(
-                    "absolute size-3 text-health-ok transition-all duration-150",
-                    copied ? "scale-100 opacity-100" : "scale-50 opacity-0"
-                  )
-                }
+        children: [
+          label ? /* @__PURE__ */ jsxRuntime.jsx("span", { className: "shrink-0 text-ink-muted uppercase tracking-wider text-[10px]", children: label }) : null,
+          /* @__PURE__ */ jsxRuntime.jsx(
+            "code",
+            {
+              className: classNames(
+                "min-w-0 text-ink-strong",
+                truncate ? "truncate" : "truncate sm:whitespace-normal sm:break-all"
               ),
-              /* @__PURE__ */ jsxRuntime.jsx(
-                lucideReact.Copy,
-                {
-                  className: classNames(
-                    "absolute size-3 text-ink-muted group-hover:text-ink transition-all duration-150",
-                    copied ? "scale-50 opacity-0" : "scale-100 opacity-100"
-                  )
-                }
-              )
-            ]
-          }
-        )
-      ]
-    }
-  );
+              children: value
+            }
+          ),
+          /* @__PURE__ */ jsxRuntime.jsxs(
+            "span",
+            {
+              className: "relative inline-flex size-3 shrink-0 items-center justify-center",
+              "aria-hidden": true,
+              children: [
+                /* @__PURE__ */ jsxRuntime.jsx(
+                  lucideReact.Check,
+                  {
+                    className: classNames(
+                      "absolute size-3 text-health-ok transition-all duration-150",
+                      copied ? "scale-100 opacity-100" : "scale-50 opacity-0"
+                    )
+                  }
+                ),
+                /* @__PURE__ */ jsxRuntime.jsx(
+                  lucideReact.Copy,
+                  {
+                    className: classNames(
+                      "absolute size-3 text-ink-muted group-hover:text-ink transition-all duration-150",
+                      copied ? "scale-50 opacity-0" : "scale-100 opacity-100"
+                    )
+                  }
+                )
+              ]
+            }
+          )
+        ]
+      }
+    ),
+    /* @__PURE__ */ jsxRuntime.jsx(CopyStatusRegion, { children: copied ? `${label ?? "Value"} copied to clipboard` : "" })
+  ] });
 }
 function SegmentedToggle({
   options,
@@ -1923,41 +1941,44 @@ function KeyChip({
   const short = value.length > head + tail + 1 ? `${value.slice(0, head)}\u2026${value.slice(-tail)}` : value;
   return (
     // Self-wrapped so KeyChip works outside AppShell's global provider.
-    /* @__PURE__ */ jsxRuntime.jsx(TooltipProvider, { children: /* @__PURE__ */ jsxRuntime.jsxs(Tooltip, { delayDuration: 120, children: [
-      /* @__PURE__ */ jsxRuntime.jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxRuntime.jsxs(
-        "button",
-        {
-          type: "button",
-          onClick: () => copy(value),
-          "aria-label": copied ? `${label} copied` : `Copy ${label}: ${value}`,
-          className: classNames(
-            "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left font-mono text-[11px] text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
-            className
-          ),
-          children: [
-            /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate tabular-nums", children: short }),
-            /* @__PURE__ */ jsxRuntime.jsx(
-              CopyIconToggle,
-              {
-                copied,
-                className: "text-ink-muted group-hover:text-ink"
-              }
-            )
-          ]
-        }
-      ) }),
-      /* @__PURE__ */ jsxRuntime.jsxs(
-        TooltipContent,
-        {
-          side: "top",
-          className: "max-w-[90vw] break-all font-mono text-[11px]",
-          children: [
-            /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mr-1 uppercase tracking-widest text-[9px] opacity-70", children: label }),
-            value
-          ]
-        }
-      )
-    ] }) })
+    /* @__PURE__ */ jsxRuntime.jsxs(TooltipProvider, { children: [
+      /* @__PURE__ */ jsxRuntime.jsxs(Tooltip, { delayDuration: 120, children: [
+        /* @__PURE__ */ jsxRuntime.jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxRuntime.jsxs(
+          "button",
+          {
+            type: "button",
+            onClick: () => copy(value),
+            "aria-label": copied ? `${label} copied` : `Copy ${label}: ${value}`,
+            className: classNames(
+              "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left font-mono text-[11px] text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
+              className
+            ),
+            children: [
+              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "truncate tabular-nums", children: short }),
+              /* @__PURE__ */ jsxRuntime.jsx(
+                CopyIconToggle,
+                {
+                  copied,
+                  className: "text-ink-muted group-hover:text-ink"
+                }
+              )
+            ]
+          }
+        ) }),
+        /* @__PURE__ */ jsxRuntime.jsxs(
+          TooltipContent,
+          {
+            side: "top",
+            className: "max-w-[90vw] break-all font-mono text-[11px]",
+            children: [
+              /* @__PURE__ */ jsxRuntime.jsx("span", { className: "mr-1 uppercase tracking-widest text-[9px] opacity-70", children: label }),
+              value
+            ]
+          }
+        )
+      ] }),
+      /* @__PURE__ */ jsxRuntime.jsx(CopyStatusRegion, { children: copied ? `${label} copied to clipboard` : "" })
+    ] })
   );
 }
 function ListShell({
@@ -2486,7 +2507,7 @@ function ShareButton({
         "aria-label": "Copy link with current filters, sort, and page",
         title: "Copy link with current filters, sort, and page",
         className: classNames(
-          bare ? "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors" : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors",
+          bare ? "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           className
         ),
         children: [
@@ -2495,7 +2516,7 @@ function ShareButton({
         ]
       }
     ),
-    /* @__PURE__ */ jsxRuntime.jsx("span", { role: "status", "aria-live": "polite", className: "sr-only", children: announcement })
+    /* @__PURE__ */ jsxRuntime.jsx(CopyStatusRegion, { children: announcement })
   ] });
 }
 function ActionBar({

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1344,6 +1344,9 @@ function CopyIconToggle({ copied, size = 3, className }) {
     }
   );
 }
+function CopyStatusRegion({ children }) {
+  return /* @__PURE__ */ jsx("span", { role: "status", "aria-live": "polite", className: "sr-only", children });
+}
 function CopyButton({
   value,
   label,
@@ -1351,25 +1354,33 @@ function CopyButton({
   compact
 }) {
   const { copied, copy } = useCopy({ label });
-  return /* @__PURE__ */ jsx(
-    "button",
-    {
-      type: "button",
-      onClick: () => copy(value),
-      "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
-      title: copied ? "Copied!" : `Copy ${label ?? "value"}`,
-      className: classNames(
-        // min-h-11 min-w-11 gives the icon-only button the same 44px minimum
-        // touch target as every other header icon button in the shell (the
-        // convention list-shell.tsx documents); p-1 keeps the icon itself compact
-        // and centered within that hit area.
-        "shrink-0 inline-flex items-center justify-center rounded p-1 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong transition-colors",
-        compact && "-my-3.5",
-        className
-      ),
-      children: /* @__PURE__ */ jsx(CopyIconToggle, { copied })
-    }
-  );
+  return /* @__PURE__ */ jsxs(Fragment, { children: [
+    /* @__PURE__ */ jsx(
+      "button",
+      {
+        type: "button",
+        onClick: () => copy(value),
+        "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
+        title: copied ? "Copied!" : `Copy ${label ?? "value"}`,
+        className: classNames(
+          // min-h-11 min-w-11 gives the icon-only button the same 44px minimum
+          // touch target as every other header icon button in the shell (the
+          // convention list-shell.tsx documents); p-1 keeps the icon itself compact
+          // and centered within that hit area.
+          "shrink-0 inline-flex items-center justify-center rounded p-1 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong transition-colors",
+          // Focus ring drawn inside the 44px box (ring-inset) so it stays visible
+          // rather than clipping against a `compact` row's -my-3.5 fold or a
+          // tight table cell. KeyChip's own ring-offset treatment can't be reused
+          // verbatim here for that reason (#6371).
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60",
+          compact && "-my-3.5",
+          className
+        ),
+        children: /* @__PURE__ */ jsx(CopyIconToggle, { copied })
+      }
+    ),
+    /* @__PURE__ */ jsx(CopyStatusRegion, { children: copied ? `${label ?? "Value"} copied to clipboard` : "" })
+  ] });
 }
 function CopyableCode({
   value,
@@ -1378,59 +1389,66 @@ function CopyableCode({
   truncate = true
 }) {
   const { copied, copy } = useCopy({ label: label ?? "value" });
-  return /* @__PURE__ */ jsxs(
-    "button",
-    {
-      type: "button",
-      onClick: () => copy(value),
-      title: value,
-      "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
-      className: classNames(
-        "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left font-mono text-[11px] text-ink hover:border-ink/30 transition-colors",
-        className
-      ),
-      children: [
-        label ? /* @__PURE__ */ jsx("span", { className: "shrink-0 text-ink-muted uppercase tracking-wider text-[10px]", children: label }) : null,
-        /* @__PURE__ */ jsx(
-          "code",
-          {
-            className: classNames(
-              "min-w-0 text-ink-strong",
-              truncate ? "truncate" : "truncate sm:whitespace-normal sm:break-all"
-            ),
-            children: value
-          }
+  return /* @__PURE__ */ jsxs(Fragment, { children: [
+    /* @__PURE__ */ jsxs(
+      "button",
+      {
+        type: "button",
+        onClick: () => copy(value),
+        title: value,
+        "aria-label": copied ? "Copied" : `Copy ${label ?? "value"}`,
+        className: classNames(
+          "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left font-mono text-[11px] text-ink hover:border-ink/30 transition-colors",
+          // Matches KeyChip's ring treatment -- this one is a bordered chip like
+          // KeyChip (not an icon-only hit area), so the offset ring reads cleanly
+          // against the card behind it (#6371).
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card",
+          className
         ),
-        /* @__PURE__ */ jsxs(
-          "span",
-          {
-            className: "relative inline-flex size-3 shrink-0 items-center justify-center",
-            "aria-hidden": true,
-            children: [
-              /* @__PURE__ */ jsx(
-                Check,
-                {
-                  className: classNames(
-                    "absolute size-3 text-health-ok transition-all duration-150",
-                    copied ? "scale-100 opacity-100" : "scale-50 opacity-0"
-                  )
-                }
+        children: [
+          label ? /* @__PURE__ */ jsx("span", { className: "shrink-0 text-ink-muted uppercase tracking-wider text-[10px]", children: label }) : null,
+          /* @__PURE__ */ jsx(
+            "code",
+            {
+              className: classNames(
+                "min-w-0 text-ink-strong",
+                truncate ? "truncate" : "truncate sm:whitespace-normal sm:break-all"
               ),
-              /* @__PURE__ */ jsx(
-                Copy,
-                {
-                  className: classNames(
-                    "absolute size-3 text-ink-muted group-hover:text-ink transition-all duration-150",
-                    copied ? "scale-50 opacity-0" : "scale-100 opacity-100"
-                  )
-                }
-              )
-            ]
-          }
-        )
-      ]
-    }
-  );
+              children: value
+            }
+          ),
+          /* @__PURE__ */ jsxs(
+            "span",
+            {
+              className: "relative inline-flex size-3 shrink-0 items-center justify-center",
+              "aria-hidden": true,
+              children: [
+                /* @__PURE__ */ jsx(
+                  Check,
+                  {
+                    className: classNames(
+                      "absolute size-3 text-health-ok transition-all duration-150",
+                      copied ? "scale-100 opacity-100" : "scale-50 opacity-0"
+                    )
+                  }
+                ),
+                /* @__PURE__ */ jsx(
+                  Copy,
+                  {
+                    className: classNames(
+                      "absolute size-3 text-ink-muted group-hover:text-ink transition-all duration-150",
+                      copied ? "scale-50 opacity-0" : "scale-100 opacity-100"
+                    )
+                  }
+                )
+              ]
+            }
+          )
+        ]
+      }
+    ),
+    /* @__PURE__ */ jsx(CopyStatusRegion, { children: copied ? `${label ?? "Value"} copied to clipboard` : "" })
+  ] });
 }
 function SegmentedToggle({
   options,
@@ -1894,41 +1912,44 @@ function KeyChip({
   const short = value.length > head + tail + 1 ? `${value.slice(0, head)}\u2026${value.slice(-tail)}` : value;
   return (
     // Self-wrapped so KeyChip works outside AppShell's global provider.
-    /* @__PURE__ */ jsx(TooltipProvider, { children: /* @__PURE__ */ jsxs(Tooltip, { delayDuration: 120, children: [
-      /* @__PURE__ */ jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxs(
-        "button",
-        {
-          type: "button",
-          onClick: () => copy(value),
-          "aria-label": copied ? `${label} copied` : `Copy ${label}: ${value}`,
-          className: classNames(
-            "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left font-mono text-[11px] text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
-            className
-          ),
-          children: [
-            /* @__PURE__ */ jsx("span", { className: "truncate tabular-nums", children: short }),
-            /* @__PURE__ */ jsx(
-              CopyIconToggle,
-              {
-                copied,
-                className: "text-ink-muted group-hover:text-ink"
-              }
-            )
-          ]
-        }
-      ) }),
-      /* @__PURE__ */ jsxs(
-        TooltipContent,
-        {
-          side: "top",
-          className: "max-w-[90vw] break-all font-mono text-[11px]",
-          children: [
-            /* @__PURE__ */ jsx("span", { className: "mr-1 uppercase tracking-widest text-[9px] opacity-70", children: label }),
-            value
-          ]
-        }
-      )
-    ] }) })
+    /* @__PURE__ */ jsxs(TooltipProvider, { children: [
+      /* @__PURE__ */ jsxs(Tooltip, { delayDuration: 120, children: [
+        /* @__PURE__ */ jsx(TooltipTrigger, { asChild: true, children: /* @__PURE__ */ jsxs(
+          "button",
+          {
+            type: "button",
+            onClick: () => copy(value),
+            "aria-label": copied ? `${label} copied` : `Copy ${label}: ${value}`,
+            className: classNames(
+              "group inline-flex min-w-0 max-w-full items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-left font-mono text-[11px] text-ink-strong hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card transition-colors",
+              className
+            ),
+            children: [
+              /* @__PURE__ */ jsx("span", { className: "truncate tabular-nums", children: short }),
+              /* @__PURE__ */ jsx(
+                CopyIconToggle,
+                {
+                  copied,
+                  className: "text-ink-muted group-hover:text-ink"
+                }
+              )
+            ]
+          }
+        ) }),
+        /* @__PURE__ */ jsxs(
+          TooltipContent,
+          {
+            side: "top",
+            className: "max-w-[90vw] break-all font-mono text-[11px]",
+            children: [
+              /* @__PURE__ */ jsx("span", { className: "mr-1 uppercase tracking-widest text-[9px] opacity-70", children: label }),
+              value
+            ]
+          }
+        )
+      ] }),
+      /* @__PURE__ */ jsx(CopyStatusRegion, { children: copied ? `${label} copied to clipboard` : "" })
+    ] })
   );
 }
 function ListShell({
@@ -2457,7 +2478,7 @@ function ShareButton({
         "aria-label": "Copy link with current filters, sort, and page",
         title: "Copy link with current filters, sort, and page",
         className: classNames(
-          bare ? "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors" : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors",
+          bare ? "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring" : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           className
         ),
         children: [
@@ -2466,7 +2487,7 @@ function ShareButton({
         ]
       }
     ),
-    /* @__PURE__ */ jsx("span", { role: "status", "aria-live": "polite", className: "sr-only", children: announcement })
+    /* @__PURE__ */ jsx(CopyStatusRegion, { children: announcement })
   ] });
 }
 function ActionBar({

--- a/packages/ui-kit/src/components/metagraphed/copy-a11y.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/copy-a11y.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { CopyButton } from "@/components/metagraphed/copy-button";
+import { CopyableCode } from "@/components/metagraphed/copyable-code";
+import { KeyChip } from "@/components/metagraphed/key-chip";
+import { ShareButton } from "@/components/metagraphed/share-button";
+import { DownloadCsvButton } from "@/components/metagraphed/download-csv-button";
+
+// #6370/#6371/#6372: every copy/share control should be keyboard-focus-visible
+// and should announce the copy result to a screen reader. Before this, only
+// ShareButton had the live region and only DownloadCsvButton/KeyChip had a
+// focus ring -- so tabbing an ActionBar lit up the CSV button and skipped
+// Share, and a screen reader confirmed a copy from Share but from nothing else.
+//
+// Rendered via react-dom/server: this package's suite is node-environment with
+// no jsdom, and class lists + the live region are both present in static markup.
+const html = (element: React.ReactElement) =>
+  renderToStaticMarkup(React.createElement(TooltipProvider, null, element));
+
+const VALUE = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+describe("copy/share controls are keyboard-focus-visible (#6370, #6371)", () => {
+  const cases: Array<[string, React.ReactElement]> = [
+    ["CopyButton", React.createElement(CopyButton, { value: VALUE })],
+    [
+      "CopyButton (compact)",
+      React.createElement(CopyButton, { value: VALUE, compact: true }),
+    ],
+    ["CopyableCode", React.createElement(CopyableCode, { value: VALUE })],
+    ["KeyChip", React.createElement(KeyChip, { value: VALUE })],
+    ["ShareButton", React.createElement(ShareButton, { url: "/subnets" })],
+    [
+      "ShareButton (bare)",
+      React.createElement(ShareButton, { url: "/subnets", bare: true }),
+    ],
+  ];
+
+  for (const [name, element] of cases) {
+    it(`${name} renders a focus-visible utility`, () => {
+      expect(html(element)).toMatch(/focus-visible:ring-2/);
+    });
+  }
+
+  // The regression #6370 describes concretely: this exact toolbar composition
+  // ships in apps/ui/src/routes/subnets.index.tsx, and Share used to be the one
+  // control that lit up nothing on Tab.
+  it("ShareButton bare matches its ActionBar sibling DownloadCsvButton", () => {
+    const share = html(
+      React.createElement(ShareButton, { url: "/subnets", bare: true }),
+    );
+    const csv = html(
+      React.createElement(DownloadCsvButton, {
+        // Absolute: buildCsvDownloadUrl parses this with `new URL`.
+        url: "https://api.metagraph.sh/api/v1/subnets",
+        bare: true,
+      }),
+    );
+    for (const utility of [
+      "focus:outline-none",
+      "focus-visible:ring-2",
+      "focus-visible:ring-ring",
+    ]) {
+      expect(csv).toContain(utility);
+      expect(share).toContain(utility);
+    }
+  });
+});
+
+describe("copy controls announce the result to screen readers (#6372)", () => {
+  const cases: Array<[string, React.ReactElement]> = [
+    ["CopyButton", React.createElement(CopyButton, { value: VALUE })],
+    ["CopyableCode", React.createElement(CopyableCode, { value: VALUE })],
+    ["KeyChip", React.createElement(KeyChip, { value: VALUE })],
+    ["ShareButton", React.createElement(ShareButton, { url: "/subnets" })],
+  ];
+
+  for (const [name, element] of cases) {
+    it(`${name} renders a polite sr-only status region`, () => {
+      const markup = html(element);
+      expect(markup).toMatch(
+        /<span role="status" aria-live="polite" class="sr-only">/,
+      );
+    });
+  }
+
+  // The region must stay mounted while idle: assistive tech announces a
+  // CONTENT CHANGE inside a live region, so a region that only appears on
+  // success may never be announced at all. Idle renders it empty, not absent.
+  it("keeps the region mounted and empty before any copy", () => {
+    const markup = html(React.createElement(CopyButton, { value: VALUE }));
+    expect(markup).toContain(
+      '<span role="status" aria-live="polite" class="sr-only"></span>',
+    );
+  });
+
+  // sr-only is absolutely positioned, so adding the region beside a button
+  // inside a flex row cannot shift layout.
+  it("uses sr-only so the region adds no layout", () => {
+    for (const [, element] of cases) {
+      expect(html(element)).toContain('class="sr-only"');
+    }
+  });
+});

--- a/packages/ui-kit/src/components/metagraphed/copy-button.tsx
+++ b/packages/ui-kit/src/components/metagraphed/copy-button.tsx
@@ -1,6 +1,7 @@
 import { classNames } from "@/lib/format";
 import { useCopy } from "@/hooks/use-copy";
 import { CopyIconToggle } from "./copy-icon-toggle";
+import { CopyStatusRegion } from "./copy-status-region";
 
 /**
  * Icon-only copy button with the same green-check microinteraction as
@@ -32,22 +33,34 @@ export function CopyButton({
 }) {
   const { copied, copy } = useCopy({ label });
   return (
-    <button
-      type="button"
-      onClick={() => copy(value)}
-      aria-label={copied ? "Copied" : `Copy ${label ?? "value"}`}
-      title={copied ? "Copied!" : `Copy ${label ?? "value"}`}
-      className={classNames(
-        // min-h-11 min-w-11 gives the icon-only button the same 44px minimum
-        // touch target as every other header icon button in the shell (the
-        // convention list-shell.tsx documents); p-1 keeps the icon itself compact
-        // and centered within that hit area.
-        "shrink-0 inline-flex items-center justify-center rounded p-1 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong transition-colors",
-        compact && "-my-3.5",
-        className,
-      )}
-    >
-      <CopyIconToggle copied={copied} />
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={() => copy(value)}
+        aria-label={copied ? "Copied" : `Copy ${label ?? "value"}`}
+        title={copied ? "Copied!" : `Copy ${label ?? "value"}`}
+        className={classNames(
+          // min-h-11 min-w-11 gives the icon-only button the same 44px minimum
+          // touch target as every other header icon button in the shell (the
+          // convention list-shell.tsx documents); p-1 keeps the icon itself compact
+          // and centered within that hit area.
+          "shrink-0 inline-flex items-center justify-center rounded p-1 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong transition-colors",
+          // Focus ring drawn inside the 44px box (ring-inset) so it stays visible
+          // rather than clipping against a `compact` row's -my-3.5 fold or a
+          // tight table cell. KeyChip's own ring-offset treatment can't be reused
+          // verbatim here for that reason (#6371).
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60",
+          compact && "-my-3.5",
+          className,
+        )}
+      >
+        <CopyIconToggle copied={copied} />
+      </button>
+      {/* #6372: the swapped aria-label above is not reliably re-announced on an
+        already-focused button, so the outcome gets its own live region. */}
+      <CopyStatusRegion>
+        {copied ? `${label ?? "Value"} copied to clipboard` : ""}
+      </CopyStatusRegion>
+    </>
   );
 }

--- a/packages/ui-kit/src/components/metagraphed/copy-status-region.tsx
+++ b/packages/ui-kit/src/components/metagraphed/copy-status-region.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+/**
+ * The shared screen-reader status line for copy affordances (#6372): a
+ * visually-hidden polite live region announcing the result of a copy.
+ *
+ * Every copy control consumes the same `useCopy` hook, but a swapped
+ * `aria-label` on an already-focused button is not reliably re-announced by
+ * most assistive tech — so the outcome needs its own live region. ShareButton
+ * shipped one; CopyButton/CopyableCode/KeyChip did not. This centralizes the
+ * markup so all four announce identically instead of duplicating (or omitting)
+ * it per component.
+ *
+ * `sr-only` is absolutely positioned, so this adds no layout: it can sit beside
+ * a button inside a flex row without shifting it.
+ *
+ * Render an empty child to say nothing — the region must stay mounted for a
+ * later content change to be announced, so callers clear the text rather than
+ * unmounting the region.
+ */
+export function CopyStatusRegion({ children }: { children: ReactNode }) {
+  return (
+    <span role="status" aria-live="polite" className="sr-only">
+      {children}
+    </span>
+  );
+}

--- a/packages/ui-kit/src/components/metagraphed/copyable-code.tsx
+++ b/packages/ui-kit/src/components/metagraphed/copyable-code.tsx
@@ -1,5 +1,6 @@
 import { Check, Copy } from "lucide-react";
 import { classNames } from "@/lib/format";
+import { CopyStatusRegion } from "./copy-status-region";
 import { useCopy } from "@/hooks/use-copy";
 
 interface Props {
@@ -18,46 +19,58 @@ export function CopyableCode({
   const { copied, copy } = useCopy({ label: label ?? "value" });
 
   return (
-    <button
-      type="button"
-      onClick={() => copy(value)}
-      title={value}
-      aria-label={copied ? "Copied" : `Copy ${label ?? "value"}`}
-      className={classNames(
-        "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left font-mono text-[11px] text-ink hover:border-ink/30 transition-colors",
-        className,
-      )}
-    >
-      {label ? (
-        <span className="shrink-0 text-ink-muted uppercase tracking-wider text-[10px]">
-          {label}
-        </span>
-      ) : null}
-      <code
+    <>
+      <button
+        type="button"
+        onClick={() => copy(value)}
+        title={value}
+        aria-label={copied ? "Copied" : `Copy ${label ?? "value"}`}
         className={classNames(
-          "min-w-0 text-ink-strong",
-          truncate ? "truncate" : "truncate sm:whitespace-normal sm:break-all",
+          "group inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-card px-2 py-1 text-left font-mono text-[11px] text-ink hover:border-ink/30 transition-colors",
+          // Matches KeyChip's ring treatment -- this one is a bordered chip like
+          // KeyChip (not an icon-only hit area), so the offset ring reads cleanly
+          // against the card behind it (#6371).
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-card",
+          className,
         )}
       >
-        {value}
-      </code>
-      <span
-        className="relative inline-flex size-3 shrink-0 items-center justify-center"
-        aria-hidden
-      >
-        <Check
+        {label ? (
+          <span className="shrink-0 text-ink-muted uppercase tracking-wider text-[10px]">
+            {label}
+          </span>
+        ) : null}
+        <code
           className={classNames(
-            "absolute size-3 text-health-ok transition-all duration-150",
-            copied ? "scale-100 opacity-100" : "scale-50 opacity-0",
+            "min-w-0 text-ink-strong",
+            truncate
+              ? "truncate"
+              : "truncate sm:whitespace-normal sm:break-all",
           )}
-        />
-        <Copy
-          className={classNames(
-            "absolute size-3 text-ink-muted group-hover:text-ink transition-all duration-150",
-            copied ? "scale-50 opacity-0" : "scale-100 opacity-100",
-          )}
-        />
-      </span>
-    </button>
+        >
+          {value}
+        </code>
+        <span
+          className="relative inline-flex size-3 shrink-0 items-center justify-center"
+          aria-hidden
+        >
+          <Check
+            className={classNames(
+              "absolute size-3 text-health-ok transition-all duration-150",
+              copied ? "scale-100 opacity-100" : "scale-50 opacity-0",
+            )}
+          />
+          <Copy
+            className={classNames(
+              "absolute size-3 text-ink-muted group-hover:text-ink transition-all duration-150",
+              copied ? "scale-50 opacity-0" : "scale-100 opacity-100",
+            )}
+          />
+        </span>
+      </button>
+      {/* #6372: same live region as every other copy control. */}
+      <CopyStatusRegion>
+        {copied ? `${label ?? "Value"} copied to clipboard` : ""}
+      </CopyStatusRegion>
+    </>
   );
 }

--- a/packages/ui-kit/src/components/metagraphed/key-chip.tsx
+++ b/packages/ui-kit/src/components/metagraphed/key-chip.tsx
@@ -7,6 +7,7 @@ import {
 import { useCopy } from "@/hooks/use-copy";
 import { classNames } from "@/lib/format";
 import { CopyIconToggle } from "./copy-icon-toggle";
+import { CopyStatusRegion } from "./copy-status-region";
 
 interface Props {
   /** Full value (e.g. coldkey/hotkey/long hash). */
@@ -70,6 +71,11 @@ export function KeyChip({
           {value}
         </TooltipContent>
       </Tooltip>
+      {/* #6372: the tooltip is pointer/focus affordance only -- the copy result
+          still needs its own live region, same as every sibling control. */}
+      <CopyStatusRegion>
+        {copied ? `${label} copied to clipboard` : ""}
+      </CopyStatusRegion>
     </TooltipProvider>
   );
 }

--- a/packages/ui-kit/src/components/metagraphed/share-button.tsx
+++ b/packages/ui-kit/src/components/metagraphed/share-button.tsx
@@ -3,6 +3,7 @@ import { Check, Share2 } from "lucide-react";
 import { toast } from "sonner";
 import { classNames } from "@/lib/format";
 import { useCopy } from "@/hooks/use-copy";
+import { CopyStatusRegion } from "./copy-status-region";
 
 interface Props {
   /** Optional explicit URL; defaults to current window.location.href. */
@@ -61,8 +62,8 @@ export function ShareButton({
         title="Copy link with current filters, sort, and page"
         className={classNames(
           bare
-            ? "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors"
-            : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors",
+            ? "inline-flex items-center gap-1.5 rounded px-2 py-1 min-h-8 text-[11px] font-medium text-ink-muted hover:text-ink-strong hover:bg-surface transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            : "inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink hover:border-ink/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           className,
         )}
       >
@@ -73,10 +74,8 @@ export function ShareButton({
         )}
         {copied ? "Link copied" : label}
       </button>
-      {/* Screen-reader status — visually hidden, polite live region. */}
-      <span role="status" aria-live="polite" className="sr-only">
-        {announcement}
-      </span>
+      {/* Screen-reader status — the shared region every copy control now uses. */}
+      <CopyStatusRegion>{announcement}</CopyStatusRegion>
     </>
   );
 }


### PR DESCRIPTION
## What

The copy/share affordances all consume the same `useCopy` hook, but had drifted apart on accessibility — each missing something a sibling already ships:

| Control | Focus ring | Copy announced |
|---|---|---|
| `DownloadCsvButton` | ✅ both branches | — (not a copy control) |
| `KeyChip` | ✅ | ❌ → **fixed** |
| `ShareButton` | ❌ → **fixed** (#6370) | ✅ (the reference) |
| `CopyButton` (59 usages in `apps/ui`) | ❌ → **fixed** (#6371) | ❌ → **fixed** |
| `CopyableCode` | ❌ → **fixed** (#6371) | ❌ → **fixed** |

The #6370 case is concrete: `apps/ui/src/routes/subnets.index.tsx:182-186` composes `<ActionBar><ResetFiltersButton /><DownloadCsvButton bare /><ShareButton bare /></ActionBar>` — tabbing that exact toolbar showed a ring on the CSV button and nothing on Share.

## The centralization #6372 asked for

#6372 suggested centralizing the announcement in `useCopy` "so every consumer gets it for free". `useCopy` itself can't host it — it's a `.ts` hook and renders nothing — so the shared piece is a small **`CopyStatusRegion`** component, and **ShareButton is reconciled onto it** rather than keeping its own copy (exactly the "instead of duplicating it" the issue asks for). ShareButton keeps its custom text and failure-path announcement; only the markup is shared.

It's **deliberately not barrel-exported** — a new unused public export is the precise smell #6377/#6379 are tracking.

## Two deliberate details

- **`CopyButton` takes `ring-inset`, not KeyChip's `ring-offset`.** #6371 asks to confirm the ring doesn't clip inside the `min-h-11 min-w-11` compact touch-target math — it would, against a `compact` row's `-my-3.5` fold and in tight table cells. Drawing the ring inside the box survives both. `CopyableCode` is a bordered chip like KeyChip, so it keeps the offset treatment.
- **The live region stays mounted and empty while idle.** Assistive tech announces a *content change* within a live region — a region that only appears on success may never be announced at all. There's a test pinning this.

## No visual change in the default state

The new utilities are `:focus-visible`-only (keyboard focus), and `sr-only` is absolutely positioned — so the status region adds no layout inside the flex rows these controls sit in. Nothing changes until a keyboard user tabs to a control, which is the point.

## Testing

`copy-a11y.test.ts` (13 tests), rendered via `react-dom/server` — this package's suite is node-environment with no jsdom, and both class lists and the live region are present in static markup.

- Focus-visible asserted on all six control/variant combinations (including `CopyButton compact` and `ShareButton bare`).
- `ShareButton bare` asserted to carry the **same three utilities** as `DownloadCsvButton bare` — the sibling parity #6370 is about.
- The live region asserted on all four copy controls, plus the mounted-and-empty-while-idle case.

**Verified meaningful, not a rubber stamp:** reverting all four components to their upstream form fails **11 of the 13** tests; restoring the fix passes 13/13.

`packages/ui-kit`: 13 files / 77 tests pass, `typecheck` clean, `lint` clean, repo `format:check` clean. `packages/ui-kit/dist` regenerated and committed (it's tracked, and the `ui` job fails on drift).

Closes #6370
Closes #6371
Closes #6372
