### PR TITLE
fix(ui-kit): give Sparkline and CandlestickMini's empty state an accessible name

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3098,6 +3098,8 @@ function synthesizeDonutAriaLabel(segments) {
   if (total <= 0) return "Donut chart with no data";
   return chartSegmentsAriaLabel(segments);
 }
+var SPARKLINE_EMPTY_ARIA_LABEL = "Sparkline chart with no data";
+var CANDLESTICK_MINI_EMPTY_ARIA_LABEL = "Candlestick chart with no data";
 function BarMini({
   data,
   max,
@@ -3168,7 +3170,8 @@ function CandlestickMini({
         preserveAspectRatio: "none",
         className: `block max-w-full ${className ?? ""}`,
         style: { maxWidth: width },
-        "aria-label": ariaLabel,
+        role: "img",
+        "aria-label": ariaLabel ?? CANDLESTICK_MINI_EMPTY_ARIA_LABEL,
         children: /* @__PURE__ */ jsxRuntime.jsx(
           "line",
           {
@@ -3518,7 +3521,8 @@ function Sparkline({
         preserveAspectRatio: "none",
         className: `block max-w-full ${className ?? ""}`,
         style: { maxWidth: width },
-        "aria-label": ariaLabel,
+        role: "img",
+        "aria-label": ariaLabel ?? SPARKLINE_EMPTY_ARIA_LABEL,
         children: /* @__PURE__ */ jsxRuntime.jsx(
           "line",
           {

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3069,6 +3069,8 @@ function synthesizeDonutAriaLabel(segments) {
   if (total <= 0) return "Donut chart with no data";
   return chartSegmentsAriaLabel(segments);
 }
+var SPARKLINE_EMPTY_ARIA_LABEL = "Sparkline chart with no data";
+var CANDLESTICK_MINI_EMPTY_ARIA_LABEL = "Candlestick chart with no data";
 function BarMini({
   data,
   max,
@@ -3139,7 +3141,8 @@ function CandlestickMini({
         preserveAspectRatio: "none",
         className: `block max-w-full ${className ?? ""}`,
         style: { maxWidth: width },
-        "aria-label": ariaLabel,
+        role: "img",
+        "aria-label": ariaLabel ?? CANDLESTICK_MINI_EMPTY_ARIA_LABEL,
         children: /* @__PURE__ */ jsx(
           "line",
           {
@@ -3489,7 +3492,8 @@ function Sparkline({
         preserveAspectRatio: "none",
         className: `block max-w-full ${className ?? ""}`,
         style: { maxWidth: width },
-        "aria-label": ariaLabel,
+        role: "img",
+        "aria-label": ariaLabel ?? SPARKLINE_EMPTY_ARIA_LABEL,
         children: /* @__PURE__ */ jsx(
           "line",
           {

--- a/packages/ui-kit/src/components/metagraphed/charts/candlestick-mini.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/candlestick-mini.tsx
@@ -4,6 +4,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
+import { CANDLESTICK_MINI_EMPTY_ARIA_LABEL } from "./chart-aria";
 
 export interface CandlestickDatum {
   /** Timestamp label, e.g. an ISO string or a formatted "12:00 UTC". */
@@ -76,7 +77,10 @@ export function CandlestickMini({
         preserveAspectRatio="none"
         className={`block max-w-full ${className ?? ""}`}
         style={{ maxWidth: width }}
-        aria-label={ariaLabel}
+        // #6375: same gap as Sparkline's empty branch -- no role, and no name
+        // at all when ariaLabel is omitted.
+        role="img"
+        aria-label={ariaLabel ?? CANDLESTICK_MINI_EMPTY_ARIA_LABEL}
       >
         <line
           x1={0}

--- a/packages/ui-kit/src/components/metagraphed/charts/chart-aria.ts
+++ b/packages/ui-kit/src/components/metagraphed/charts/chart-aria.ts
@@ -20,3 +20,18 @@ export function synthesizeDonutAriaLabel(segments: ChartAriaDatum[]): string {
   if (total <= 0) return "Donut chart with no data";
   return chartSegmentsAriaLabel(segments);
 }
+
+/**
+ * Fallback accessible names for the line-series primitives' empty states
+ * (#6375). BarMini/Donut synthesize a label from their data; Sparkline and
+ * CandlestickMini have no data to describe when empty, so their fallback is a
+ * constant.
+ *
+ * The phrasing keeps both existing conventions: "<chart> with no data" matches
+ * synthesizeBarMiniAriaLabel/synthesizeDonutAriaLabel above, and the chart noun
+ * matches each component's own `ariaLabel ?? "..."` fallback for its keyboard
+ * hint (sparkline.tsx, candlestick-mini.tsx).
+ */
+export const SPARKLINE_EMPTY_ARIA_LABEL = "Sparkline chart with no data";
+export const CANDLESTICK_MINI_EMPTY_ARIA_LABEL =
+  "Candlestick chart with no data";

--- a/packages/ui-kit/src/components/metagraphed/charts/chart-empty-aria.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/charts/chart-empty-aria.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Sparkline } from "@/components/metagraphed/charts/sparkline";
+import { CandlestickMini } from "@/components/metagraphed/charts/candlestick-mini";
+import {
+  CANDLESTICK_MINI_EMPTY_ARIA_LABEL,
+  SPARKLINE_EMPTY_ARIA_LABEL,
+} from "@/components/metagraphed/charts/chart-aria";
+
+// #6375: both primitives' empty-data branch rendered an <svg> with no
+// role="img" and, when ariaLabel was omitted, no accessible name at all -- while
+// their own populated branches set both, and every sibling primitive
+// (BarMini/Donut via chart-aria, NoDataSpark, MiniStack) has a safety net. A
+// screen-reader user hit an unlabeled graphic.
+const html = (element: React.ReactElement) => renderToStaticMarkup(element);
+
+const CANDLE = {
+  label: "12:00 UTC",
+  open: 1,
+  high: 2,
+  low: 0.5,
+  close: 1.5,
+};
+
+describe("chart primitives' empty state keeps an accessible name (#6375)", () => {
+  const empties: Array<[string, React.ReactElement, string]> = [
+    [
+      "Sparkline",
+      React.createElement(Sparkline, { values: [] }),
+      SPARKLINE_EMPTY_ARIA_LABEL,
+    ],
+    [
+      "CandlestickMini",
+      React.createElement(CandlestickMini, { data: [] }),
+      CANDLESTICK_MINI_EMPTY_ARIA_LABEL,
+    ],
+  ];
+
+  for (const [name, element, fallback] of empties) {
+    it(`${name}'s empty state is a named role="img"`, () => {
+      const markup = html(element);
+      expect(markup).toContain('role="img"');
+      expect(markup).toContain(`aria-label="${fallback}"`);
+    });
+  }
+
+  it("an explicit ariaLabel still wins over the synthesized fallback", () => {
+    expect(
+      html(
+        React.createElement(Sparkline, { values: [], ariaLabel: "Emission" }),
+      ),
+    ).toContain('aria-label="Emission"');
+    expect(
+      html(
+        React.createElement(CandlestickMini, {
+          data: [],
+          ariaLabel: "TAO price",
+        }),
+      ),
+    ).toContain('aria-label="TAO price"');
+  });
+
+  // The empty branch is now no worse than the populated one, which is the
+  // parity the issue asks for -- both are named graphics.
+  it("matches the populated branch, which already set role + label", () => {
+    const populatedSpark = html(
+      React.createElement(Sparkline, { values: [1, 2, 3], ariaLabel: "Trend" }),
+    );
+    expect(populatedSpark).toContain('role="img"');
+    expect(populatedSpark).toContain('aria-label="Trend"');
+
+    const populatedCandles = html(
+      React.createElement(CandlestickMini, {
+        data: [CANDLE, { ...CANDLE, label: "13:00 UTC" }],
+        ariaLabel: "Price",
+      }),
+    );
+    expect(populatedCandles).toContain('role="img"');
+    expect(populatedCandles).toContain('aria-label="Price"');
+  });
+
+  // Phrasing is pinned so the fallbacks keep matching chart-aria's existing
+  // synthesizeBarMiniAriaLabel/synthesizeDonutAriaLabel convention.
+  it("fallback phrasing matches the sibling helpers' convention", () => {
+    expect(SPARKLINE_EMPTY_ARIA_LABEL).toMatch(/ with no data$/);
+    expect(CANDLESTICK_MINI_EMPTY_ARIA_LABEL).toMatch(/ with no data$/);
+  });
+});

--- a/packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx
@@ -4,6 +4,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
+import { SPARKLINE_EMPTY_ARIA_LABEL } from "./chart-aria";
 
 export interface SparklinePoint {
   /** Timestamp label, e.g. "12:40 UTC" */
@@ -63,7 +64,11 @@ export function Sparkline({
         preserveAspectRatio="none"
         className={`block max-w-full ${className ?? ""}`}
         style={{ maxWidth: width }}
-        aria-label={ariaLabel}
+        // #6375: without role="img" the aria-label here was not reliably
+        // exposed, and an omitted ariaLabel left the placeholder an unnamed
+        // graphic -- the populated branch below has always set both.
+        role="img"
+        aria-label={ariaLabel ?? SPARKLINE_EMPTY_ARIA_LABEL}
       >
         <line
           x1={0}


### PR DESCRIPTION
## What

`Sparkline` and `CandlestickMini`'s empty-data branch rendered an `<svg>` with **no `role="img"`**, and with `aria-label` bound to a prop that is optional — so an omitted `ariaLabel` left the placeholder an entirely **unnamed graphic**.

Their own populated branches have always set `role="img"` plus a label, and every sibling primitive has a safety net:

| Primitive | Empty-state treatment |
|---|---|
| `MiniStack` | `aria-hidden` |
| `NoDataSpark` | `role="img"` + always-present synthesized reason |
| `BarMini` / `Donut` | synthesized fallback via `chart-aria.ts` |
| **`Sparkline` / `CandlestickMini`** | **neither → fixed here** |

## Following the existing conventions rather than inventing phrasing

The issue suggests e.g. "Sparkline chart, no data". I used the codebase's own two conventions instead:

- **`"<chart> with no data"`** matches `chart-aria.ts`'s existing `synthesizeBarMiniAriaLabel` / `synthesizeDonutAriaLabel`.
- **The chart nouns** (`"Sparkline chart"`, `"Candlestick chart"`) match each component's *own* `ariaLabel ?? "..."` fallback for its keyboard hint (`sparkline.tsx:145`, `candlestick-mini.tsx:177`).

The constants live in `chart-aria.ts` beside those helpers. They're constants rather than functions because BarMini/Donut synthesize *from their data*, whereas an empty chart has no data to describe — a zero-arg synthesizer would just be a constant with extra steps.

An explicit `ariaLabel` still wins; only the omitted case changes.

## Scope note

The **populated** branches bind `aria-label={ariaLabel}` unguarded too, so a populated chart rendered without the prop is likewise an unnamed `role="img"`. That's outside this issue's empty-state scope, so I left it alone rather than widening the diff — flagging it here in case it's worth its own issue.

## Testing

`chart-empty-aria.test.ts` (5 tests), rendered via `react-dom/server` (this package's suite is node-environment, no jsdom; role/aria are in static markup):

- Both empty states asserted to be a **named `role="img"`**.
- The explicit-`ariaLabel`-wins override.
- Parity with the populated branch, which already set both.
- The fallback phrasing pinned to the sibling helpers' `/ with no data$/` convention, so it can't drift.

**Verified meaningful:** reverting both components to their upstream form fails **2 of the 5**; restored, 5/5 pass.

`packages/ui-kit`: 14 files / 82 tests pass, `typecheck` clean, `lint` clean, repo `format:check` clean. `dist` regenerated and committed (it's tracked, and the `ui` job fails on drift).

Closes #6375
