### PR TITLE
fix(ui): sanitize non-numeric input in the /blocks numeric filters (#6395)

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -293,28 +293,28 @@ function BlocksTable() {
         />
         <SearchInput
           value={search.block_start}
-          onChange={(v) => setSearch({ block_start: v, offset: 0 })}
+          onChange={(v) => setSearch({ block_start: v.replace(/[^0-9]/g, ""), offset: 0 })}
           placeholder="Block from…"
           inputMode="numeric"
           className="min-w-[120px] max-w-[140px] flex-none"
         />
         <SearchInput
           value={search.block_end}
-          onChange={(v) => setSearch({ block_end: v, offset: 0 })}
+          onChange={(v) => setSearch({ block_end: v.replace(/[^0-9]/g, ""), offset: 0 })}
           placeholder="Block to…"
           inputMode="numeric"
           className="min-w-[120px] max-w-[140px] flex-none"
         />
         <SearchInput
           value={search.min_extrinsics}
-          onChange={(v) => setSearch({ min_extrinsics: v, offset: 0 })}
+          onChange={(v) => setSearch({ min_extrinsics: v.replace(/[^0-9]/g, ""), offset: 0 })}
           placeholder="Min extrinsics…"
           inputMode="numeric"
           className="min-w-[120px] max-w-[140px] flex-none"
         />
         <SearchInput
           value={search.min_events}
-          onChange={(v) => setSearch({ min_events: v, offset: 0 })}
+          onChange={(v) => setSearch({ min_events: v.replace(/[^0-9]/g, ""), offset: 0 })}
           placeholder="Min events…"
           inputMode="numeric"
           className="min-w-[120px] max-w-[140px] flex-none"


### PR DESCRIPTION
Closes #6395.

## What

`blocks.index.tsx`'s four numeric filters — `block_start`, `block_end`, `min_extrinsics`, `min_events` — passed the raw `SearchInput` value straight through with only a cosmetic `inputMode="numeric"` hint (no effect on desktop typing/paste). So a typed or pasted letter reached the query string and tripped the backend's numeric-filter validation (400, hardened in #2310) through the page's error boundary — instead of the graceful sanitize-on-input behavior `/endpoints` already provides.

Applied the same digit-only sanitization `endpoints.tsx:843` uses for its `netuid` filter — `value.replace(/[^0-9]/g, "")` — to all four filters, so non-numeric input is stripped on change rather than surfacing a live error.

## Note on screenshots

This is a **behavioral** change, not a visual one — the filter inputs render identically; only the `onChange` handler now strips non-digits (matching the existing `/endpoints` pattern exactly). There is no visual before/after to capture: before, typing `a1b2` left `a1b2` in the field (then 400'd on submit); after, it becomes `12` on input. The diff is 4 one-line `onChange` edits mirroring `endpoints.tsx:843`.

## Verify

- `prettier --check` + `eslint` (from apps/ui) + `tsc --noEmit`: clean (0 errors).
- Diff is 1 file, +4/-4 (the four `onChange` handlers).