### PR TITLE
fix(scripts): accept both --prefix forms in r2-download and correct the printed command

### DIFF
--- a/scripts/endpoint-ops-brief.mjs
+++ b/scripts/endpoint-ops-brief.mjs
@@ -23,7 +23,7 @@ export class MissingEndpointArtifactsError extends Error {
     super(
       [
         "Endpoint operations brief artifacts are missing.",
-        "Run `npm run artifacts:prepare-local` to build local R2 staging, or `npm run r2:download -- --prefix latest/` when R2 credentials are available, then retry `npm run endpoint:brief`.",
+        "Run `npm run artifacts:prepare-local` to build local R2 staging, or `npm run r2:download -- --prefix=latest/` when R2 credentials are available, then retry `npm run endpoint:brief`.",
         "Missing artifacts:",
         formattedPaths,
       ].join("\n"),

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -171,6 +171,34 @@ export function netuidFromEvidenceSubject(subject) {
   return null;
 }
 
+/**
+ * Read a CLI flag's value, accepting both `--flag=value` and `--flag value`.
+ *
+ * `scripts/` grew both conventions independently: some parsers match `--flag=`
+ * only (r2-download.mjs), while others take the next argv entry (subnet-new.mjs,
+ * curation-brief.mjs, and endpoint-ops-brief.mjs's own `valueAfter`). A parser
+ * that accepts only one form silently ignores the other -- no error, no warning,
+ * the flag is simply dropped and the default applies instead. That is exactly
+ * how endpoint-ops-brief.mjs came to document `--prefix latest/` for a script
+ * that only reads `--prefix=` (#6365).
+ *
+ * Accepting both is what enrichment-issues.mjs's `getOpt` already does; this is
+ * that behaviour, shared and unit-tested.
+ *
+ * A following token starting with `--` is treated as the next flag rather than
+ * this one's value, so `--prefix --write` falls back instead of silently
+ * downloading a prefix literally named "--write".
+ */
+export function flagValue(argv, flag, fallback = undefined) {
+  const equals = argv.find((arg) => arg.startsWith(`${flag}=`));
+  if (equals !== undefined) return equals.slice(flag.length + 1);
+  const index = argv.indexOf(flag);
+  if (index < 0) return fallback;
+  const next = argv[index + 1];
+  if (next === undefined || next.startsWith("--")) return fallback;
+  return next;
+}
+
 export async function readJson(filePath) {
   const raw = await fs.readFile(filePath, "utf8");
   return JSON.parse(raw);

--- a/scripts/r2-download.mjs
+++ b/scripts/r2-download.mjs
@@ -1,7 +1,13 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { mkdir, readFile } from "node:fs/promises";
-import { readJson, repoRoot, sha256Hex, stableStringify } from "./lib.mjs";
+import {
+  flagValue,
+  readJson,
+  repoRoot,
+  sha256Hex,
+  stableStringify,
+} from "./lib.mjs";
 import {
   R2_STAGING_RELATIVE_ROOT,
   artifactStorageTierForPath,
@@ -12,14 +18,15 @@ const write = args.has("--write");
 const manifest = await readJson(
   path.join(repoRoot, R2_STAGING_RELATIVE_ROOT, "r2-manifest.json"),
 );
-const prefixArg = process.argv.find((arg) => arg.startsWith("--prefix="));
+// Both `--prefix=latest/` and `--prefix latest/` are accepted: the equals-only
+// parser this used to have silently dropped the space-separated form and fell
+// back to manifest.latest_prefix, which is how endpoint-ops-brief.mjs's
+// remediation command came to be wrong for over a release (#6365).
+const prefixArg = flagValue(process.argv, "--prefix");
 const prefix = prefixArg
-  ? prefixArg.slice("--prefix=".length).replace(/^\/+|\/+$/g, "") + "/"
+  ? prefixArg.replace(/^\/+|\/+$/g, "") + "/"
   : manifest.latest_prefix;
-const outputDirArg = process.argv.find((arg) => arg.startsWith("--out="));
-const outputDir = outputDirArg
-  ? outputDirArg.slice("--out=".length)
-  : "tmp/r2-download";
+const outputDir = flagValue(process.argv, "--out", "tmp/r2-download");
 const planned = manifest.artifacts.map((artifact) => ({
   key: `${prefix}${artifact.path.replace(/^\/metagraph\//, "")}`,
   local_path: localArtifactPath(outputDir, artifact.path),

--- a/tests/script-flag-value.test.mjs
+++ b/tests/script-flag-value.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { flagValue } from "../scripts/lib.mjs";
+
+// #6365: scripts/ grew two flag conventions independently. r2-download.mjs read
+// `--prefix=` only, while endpoint-ops-brief.mjs -- which has its own
+// space-separated `valueAfter` parser -- printed `npm run r2:download --
+// --prefix latest/` as its remediation command. Following that printed command
+// dropped the flag silently: no token started with "--prefix=", so prefixArg was
+// undefined and the download fell back to manifest.latest_prefix with no error
+// and no warning. flagValue accepts both forms so neither convention can
+// silently lose a flag again.
+describe("flagValue accepts both CLI flag conventions (#6365)", () => {
+  test("reads the equals form", () => {
+    assert.equal(flagValue(["--prefix=latest/"], "--prefix"), "latest/");
+  });
+
+  test("reads the space-separated form (the one that used to be dropped)", () => {
+    assert.equal(flagValue(["--prefix", "latest/"], "--prefix"), "latest/");
+  });
+
+  test("both forms agree, whatever the surrounding argv", () => {
+    const equals = ["--write", "--prefix=2026-07-17/", "--out=tmp/x"];
+    const spaced = ["--write", "--prefix", "2026-07-17/", "--out", "tmp/x"];
+    assert.equal(
+      flagValue(equals, "--prefix"),
+      flagValue(spaced, "--prefix"),
+      "the two conventions must resolve identically",
+    );
+    assert.equal(flagValue(equals, "--out"), flagValue(spaced, "--out"));
+  });
+
+  test("falls back when the flag is absent", () => {
+    assert.equal(flagValue(["--write"], "--prefix", "latest/"), "latest/");
+    assert.equal(flagValue([], "--prefix", "latest/"), "latest/");
+    assert.equal(flagValue(["--write"], "--prefix"), undefined);
+  });
+
+  test("a following flag is not swallowed as the value", () => {
+    // `--prefix --write` must fall back, not download a prefix named "--write".
+    assert.equal(
+      flagValue(["--prefix", "--write"], "--prefix", "latest/"),
+      "latest/",
+    );
+    // Trailing flag with nothing after it.
+    assert.equal(
+      flagValue(["--write", "--prefix"], "--prefix", "latest/"),
+      "latest/",
+    );
+  });
+
+  test("an explicit empty value stays empty rather than falling back", () => {
+    // `--prefix=` is a caller saying "empty", which is distinct from omitting it.
+    assert.equal(flagValue(["--prefix="], "--prefix", "latest/"), "");
+  });
+
+  test("the equals form wins when both are somehow present", () => {
+    assert.equal(
+      flagValue(["--prefix=a/", "--prefix", "b/"], "--prefix"),
+      "a/",
+    );
+  });
+
+  test("matches only the requested flag, not a prefix of another", () => {
+    // `--out` must not be satisfied by `--output=...`.
+    assert.equal(
+      flagValue(["--outfile=x"], "--out", "tmp/r2-download"),
+      "tmp/r2-download",
+    );
+  });
+});


### PR DESCRIPTION
## What

`endpoint-ops-brief.mjs` told a user with missing local artifacts to run:

```
npm run r2:download -- --prefix latest/
```

But `r2-download.mjs` parsed the prefix with `argv.find((arg) => arg.startsWith("--prefix="))` — **equals-sign form only**. Expanding the documented command yields argv `["--write", "--prefix", "latest/"]`; no token starts with `--prefix=`, so `prefixArg` was `undefined` and the download **silently fell back to `manifest.latest_prefix`**. No error, no warning — the flag is just dropped, and the user gets a different prefix than the one the tool told them to ask for.

Verified against the old logic before changing anything:

```
OLD parser, --prefix=latest/ -> latest/
OLD parser, --prefix latest/ -> MANIFEST_DEFAULT   <-- the documented command
```

## Root cause: a split convention

`scripts/` grew both flag styles independently. `endpoint-ops-brief.mjs` has its **own space-separated `valueAfter` parser** (as do `subnet-new.mjs` and `curation-brief.mjs`) — so its author documented `r2-download` in the form *their own file* accepts, while `r2-download` reads equals-only. The docs weren't careless; the two halves just never agreed.

That's why I fixed both halves rather than only the message — correcting the string alone would leave the next person to hit the same trap from the other direction.

## Changes

- **`scripts/lib.mjs` gains `flagValue(argv, flag, fallback)`**, accepting both forms. This is exactly what `enrichment-issues.mjs`'s `getOpt` already does — lifted into the shared lib so it's importable and unit-tested rather than hand-rolled a fifth time. The issue suggested "a space-separated fallback ... matching the `valueAfter`-style convention most other scripts use"; sharing it seemed better than adding a sixth private copy.
- **`r2-download.mjs`** uses it for `--prefix` **and** `--out` (the issue flags both), so neither form is dropped.
- **`endpoint-ops-brief.mjs`**'s remediation command now reads `--prefix=latest/`.

One hardening detail beyond `getOpt`: a following token starting with `--` is treated as the next flag, so `--prefix --write` falls back rather than downloading a prefix literally named `--write`.

## Testing

`tests/script-flag-value.test.mjs` (8 tests): both forms; the two forms asserted to **resolve identically** whatever the surrounding argv; absent-flag fallback; a following flag not swallowed (and a trailing flag with nothing after it); `--prefix=` treated as an explicit empty rather than a fallback; equals-wins if both appear; and `--out` not satisfied by `--outfile=`.

`lint` clean, `format:check` clean, and the existing suites that import `scripts/lib.mjs` (`raw-artifact-freshness`, `contract-staleness`, `safe-fetch`) pass — 21 tests total.

Closes #6365
