### PR TITLE
fix(graphql): validate account_history's from/to date format

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -94,6 +94,7 @@ import {
 } from "../workers/request-handlers/analytics.mjs";
 import {
   BLOCK_PAGINATION,
+  DAY_PATTERN,
   FEED_PAGINATION,
   clampLimit,
   clampOffset,
@@ -5713,9 +5714,23 @@ const rootValue = {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
+    // Same DAY_PATTERN guard REST's parseDateRange and MCP's optionalDayArg
+    // apply to this capability (#6353). Without it a malformed bound is passed
+    // straight through: the Postgres tier re-parses and rejects it, but the D1
+    // fallback binds it into `day >= ?` / `day <= ?` against a TEXT column,
+    // which silently yields a wrong (typically empty) series instead of an
+    // error. The message is REST's and MCP's verbatim, so all three agree.
+    if (
+      (from != null && !DAY_PATTERN.test(from)) ||
+      (to != null && !DAY_PATTERN.test(to))
+    ) {
+      throw new GraphQLError("from/to must be YYYY-MM-DD dates.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
     // Same FEED_PAGINATION bounds the /history route's clamp applies, so a
     // GraphQL caller cannot request a wider page than REST allows;
-    // netuid/from/to/cursor are forwarded verbatim for the route to re-parse,
+    // netuid/cursor are forwarded verbatim for the route to re-parse,
     // matching account_events and the sibling feed resolvers.
     const safeLimit = clampLimit(limit, FEED_PAGINATION);
     const safeOffset = clampOffset(offset);

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -8629,6 +8629,91 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
     } }`;
   }
 
+  // #6353: from/to were declared as plain String and forwarded unvalidated. On
+  // a Postgres-tier miss loadAccountHistory binds them straight into
+  // `day >= ?` / `day <= ?` against a TEXT column, so a malformed bound
+  // silently produced an empty series instead of an error -- while REST
+  // (parseDateRange) and MCP (optionalDayArg) both rejected it.
+  test("a malformed from is BAD_USER_INPUT, not a silently empty series", async () => {
+    let called = false;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    };
+    const { status, body } = await gql(
+      query(`(ss58: "${SS58}", from: "not-a-date")`),
+      env,
+    );
+    assert.equal(status, 200);
+    const err = body.errors.find(
+      (e) => e.extensions?.code === "BAD_USER_INPUT",
+    );
+    assert.ok(err, "expected a BAD_USER_INPUT error");
+    // The same message REST's parseDateRange and MCP's optionalDayArg emit.
+    assert.equal(err.message, "from/to must be YYYY-MM-DD dates.");
+    assert.equal(body.data, null);
+    assert.equal(called, false, "must not reach the tier");
+  });
+
+  test("a malformed to is BAD_USER_INPUT even when from is valid", async () => {
+    const { status, body } = await gql(
+      query(`(ss58: "${SS58}", from: "2026-07-01", to: "07/16/2026")`),
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data, null);
+  });
+
+  test("a date-shaped but non-YYYY-MM-DD bound is still rejected", async () => {
+    const { status, body } = await gql(
+      query(`(ss58: "${SS58}", from: "2026-7-1")`),
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+  });
+
+  test("well-formed from/to bounds are accepted and forwarded to the tier", async () => {
+    const capture = {};
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({ days: [] }), capture),
+    };
+    const { status, body } = await gql(
+      query(`(ss58: "${SS58}", from: "2026-07-01", to: "2026-07-16")`),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(capture.url.searchParams.get("from"), "2026-07-01");
+    assert.equal(capture.url.searchParams.get("to"), "2026-07-16");
+  });
+
+  test("the D1 fallback path rejects a malformed bound before it reaches the query", async () => {
+    // The regression the issue describes: with a D1 tier available, a bad bound
+    // used to reach `day >= ?` and return days: [] rather than erroring.
+    let prepared = false;
+    const env = {
+      METAGRAPH_HEALTH_DB: {
+        prepare: () => {
+          prepared = true;
+          return { bind: () => ({ all: async () => ({ results: [] }) }) };
+        },
+      },
+    };
+    const { status, body } = await gql(
+      query(`(ss58: "${SS58}", to: "not-a-date")`),
+      env,
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(prepared, false, "must not reach D1");
+  });
+
   // loadAccountHistory issues exactly one SELECT per call, so the mock ignores
   // the SQL text and always returns the given rows.
   function accountHistoryD1(rows = []) {


### PR DESCRIPTION
Closes #6353

## The bug

`account_history` declared `from`/`to` as plain `String` and forwarded them with **no format check**. That mattered on the D1 path: on a Postgres-tier miss the resolver calls `loadAccountHistory` directly, which binds the value straight into `day >= ?` / `day <= ?` against a **TEXT** column — so a malformed bound silently produced a wrong (typically empty) series instead of an error.

REST and MCP already rejected the identical input for the identical capability. Confirmed against the live handler:

```
GET /api/v1/accounts/{ss58}/history?from=not-a-date
  -> 400 {"code":"invalid_param","message":"from/to must be YYYY-MM-DD dates."}
```

Only GraphQL accepted it. The SDL doc-comment already promised *"from/to are YYYY-MM-DD bounds"* — this makes that contract real rather than aspirational.

## The fix

Validates `from`/`to` against the shared `DAY_PATTERN` before use and raises `GraphQLError` with `extensions: { code: "BAD_USER_INPUT" }` — the same guard style the sibling `account_*` resolvers already apply to `ss58`/`counterparty`, as the issue asks.

- The message is **REST's and MCP's verbatim** (`"from/to must be YYYY-MM-DD dates."`), so all three surfaces now agree character-for-character rather than inventing a third wording.
- `DAY_PATTERN` joins the **existing** `workers/request-params.mjs` import — the same module this resolver already takes `FEED_PAGINATION`/`clampLimit`/`clampOffset` from, so there's no new dependency edge.
- 16 lines changed, confined to the one resolver.

## Tests

5 regression cases added **inside** the existing `account_history` suite. They are real regression tests — **I reverted the fix and confirmed they fail without it**:

```
× a malformed from is BAD_USER_INPUT, not a silently empty series
× a malformed to is BAD_USER_INPUT even when from is valid
× the D1 fallback path rejects a malformed bound before it reaches the query
```

Covering:
- the issue's exact case — `account_history(ss58: "...", from: "not-a-date")` → error, not `days: []`, and the tier is never reached
- a malformed `to` when `from` is valid (the right arm of the guard)
- a date-shaped but non-conforming bound (`2026-7-1`) — still rejected
- well-formed bounds still accepted and forwarded to the tier as query params
- **the D1 path specifically**: asserts `prepare()` is never called, i.e. the bad bound can no longer reach `day >= ?`

```
tests/graphql.test.mjs               passed (14 account_history cases)
tests/request-handlers-entities.test.mjs passed   (REST unregressed)
tests/mcp-server.test.mjs            passed   (MCP unregressed)
tests/account-history-csv.test.mjs   passed
```

Patch coverage measured locally the way codecov measures it — every added line mapped against `coverage-final.json`'s `statementMap`/`branchMap`: **8/8 covered statements and branch arms = 100%** (target 99%), no partials — both arms of the compound guard exercised. `eslint` clean, `prettier --check` clean, rebased to `behind: 0` immediately before pushing.
