### PR TITLE
fix(ui): deep-link subnet-position rows to the neuron they already know

### DIFF
--- a/apps/ui/src/lib/metagraphed/subnet-position-link.test.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-position-link.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { subnetPositionSearch } from "@/lib/metagraphed/subnet-position-link";
+
+// #6431: AccountFootprintSection and SubnetPerformanceTable each render one row
+// per subnet membership and linked SN{netuid} to the bare subnet page, while the
+// row's own uid sat unlinked in the next cell -- even though subnets.$netuid.tsx
+// already reads `tab`/`uid` to render that neuron's detail card. Both rows now
+// build their search through this one helper, so they cannot drift apart again.
+describe("subnetPositionSearch (#6431)", () => {
+  it("deep-links to the row's neuron card when a uid is present", () => {
+    expect(subnetPositionSearch(3)).toEqual({ tab: "metagraph", uid: 3 });
+  });
+
+  it("keeps uid 0, which is a real neuron, not an absent one", () => {
+    // The guard is `!= null`, not truthiness -- uid 0 is the first neuron.
+    expect(subnetPositionSearch(0)).toEqual({ tab: "metagraph", uid: 0 });
+  });
+
+  it("falls back to the bare subnet link when the row has no uid", () => {
+    // accounts.$ss58.tsx renders "—" for a null uid; the link must stay as it
+    // was rather than deep-linking to a neuron that isn't there.
+    expect(subnetPositionSearch(null)).toBeUndefined();
+    expect(subnetPositionSearch(undefined)).toBeUndefined();
+  });
+
+  it("targets the metagraph tab, the one that renders the neuron card", () => {
+    expect(subnetPositionSearch(7)?.tab).toBe("metagraph");
+  });
+
+  // subnets.$netuid.tsx's validateSearch keeps `uid` only when
+  // Number.isInteger(uid) && uid >= 0 -- anything this helper emits must survive
+  // that, or the deep link silently degrades to the overview.
+  it("emits a uid that survives the target route's validateSearch", () => {
+    const validate = (uid: unknown) => {
+      const n = Number(uid);
+      return Number.isInteger(n) && n >= 0 ? n : undefined;
+    };
+    for (const uid of [0, 1, 255, 1024]) {
+      const search = subnetPositionSearch(uid);
+      expect(validate(search?.uid)).toBe(uid);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/subnet-position-link.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-position-link.ts
@@ -1,0 +1,20 @@
+/**
+ * Search params that deep-link a subnet-position row to its own neuron card
+ * (#6431).
+ *
+ * `AccountFootprintSection` (accounts.$ss58.tsx) and `SubnetPerformanceTable`
+ * (validators.$hotkey.tsx) both render one row per subnet membership, linking
+ * `SN{netuid}` to the subnet page while the row's `uid` sits unlinked in the
+ * next cell. `subnets.$netuid.tsx` already reads `tab`/`uid` from its search to
+ * render a "Neuron UID {uid}" detail card — its own MetagraphPanel/
+ * ValidatorsPanel navigate that way internally — so those rows can land on the
+ * exact neuron instead of the subnet overview.
+ *
+ * Returns `undefined` when the row has no uid, which leaves the link exactly as
+ * it was: a bare subnet link.
+ */
+export function subnetPositionSearch(
+  uid: number | null | undefined,
+): { tab: string; uid: number } | undefined {
+  return uid != null ? { tab: "metagraph", uid } : undefined;
+}

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -73,6 +73,7 @@ import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { accountFeedSectionPhase } from "@/lib/metagraphed/account-feed-section";
 import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
+import { subnetPositionSearch } from "@/lib/metagraphed/subnet-position-link";
 import type {
   AccountCounterparty,
   AccountStakeFlowSubnet,
@@ -2017,6 +2018,9 @@ function AccountFootprintSection({
                     <Link
                       to="/subnets/$netuid"
                       params={{ netuid: r.netuid }}
+                      // Same deep-link as SubnetPerformanceTable: this row already
+                      // knows its uid, so land on the neuron card, not the overview.
+                      search={subnetPositionSearch(r.uid)}
                       className="inline-flex items-center rounded-full border border-border bg-paper px-2.5 py-1 font-medium text-ink-strong transition-colors hover:border-accent/30 hover:text-accent"
                     >
                       SN{r.netuid}

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -33,6 +33,7 @@ import {
   formatTakePct,
 } from "@/lib/metagraphed/validator-apy";
 import type { ValidatorDetailSubnet } from "@/lib/metagraphed/types";
+import { subnetPositionSearch } from "@/lib/metagraphed/subnet-position-link";
 
 const validatorDetailSearchSchema = z.object({
   window: fallback(z.enum(["7d", "30d", "90d"]), "30d").default("30d"),
@@ -141,6 +142,10 @@ function SubnetPerformanceTable({
                 <Link
                   to="/subnets/$netuid"
                   params={{ netuid: s.netuid }}
+                  // Deep-link straight to this row's neuron card rather than the
+                  // subnet overview -- the uid is right here in the next cell, and
+                  // subnets.$netuid.tsx already reads `tab`/`uid` to render it.
+                  search={subnetPositionSearch(s.uid)}
                   className="text-ink-strong hover:text-accent hover:underline"
                 >
                   SN{s.netuid}


### PR DESCRIPTION
## What

`AccountFootprintSection` (`accounts.$ss58.tsx`) and `SubnetPerformanceTable` (`validators.$hotkey.tsx`) each render one row per subnet membership, linking `SN{netuid}` to the **bare subnet page** — while the row's own `uid` renders as plain unlinked text in the very next cell.

`subnets.$netuid.tsx` already has the deep-link mechanism for exactly this: its `MetagraphPanel`/`ValidatorsPanel` navigate with `search: { tab: "metagraph", uid }`, and the page reads it back to render a "Neuron UID {uid}" card. So both rows were **dropping a uid they already had** and landing the visitor on the overview.

Both links now carry that search. A row with no uid keeps the current bare-subnet link.

## Verified against the target, not just the issue

Before wiring it, I checked `subnets.$netuid.tsx` actually accepts these params:

```ts
type SearchParams = { tab?: string; sev?: string; uid?: number; ev_kind?: string };
validateSearch: (s) => ({ ..., uid: Number.isInteger(uidNum) && uidNum >= 0 ? uidNum : undefined })
```

It does — and note that `validateSearch` **silently drops** a uid that isn't a non-negative integer, which would degrade the link back to the overview with no error. There's a test pinning that every uid this helper emits survives that filter.

## One shared helper instead of two ternaries

The two tables had already drifted from `subnets.$netuid.tsx` by duplicating the same link-building independently, so I put the search construction in one `subnetPositionSearch()` helper both routes call, rather than copy-pasting the ternary a third and fourth time. It also gives the logic a home that this package's node-environment suite can test directly — rendering either route would need a full router context.

## No visual change

Only the link's *target* gains search params; the rendered row is byte-identical. Nothing moves, nothing is added — the same `SN{netuid}` chip now just lands on the neuron instead of the overview.

## Testing

`subnet-position-link.test.ts` (5 tests): the deep-link case; **uid 0 preserved** (the guard is `!= null`, not truthiness — uid 0 is a real neuron and truthiness would have silently skipped it); null/undefined falling back to the bare link; the `metagraph` tab pinned; and the `validateSearch`-survival case above.

`apps/ui`: **138 files / 1049 tests pass**, `tsc` clean, `format:check` clean. ESLint reports the same 23 pre-existing `react-refresh` warnings on `accounts.$ss58.tsx` as `upstream/main` does — unchanged by this diff (verified by linting main's copy of the file).

Closes #6431
