### PR TITLE
fix(turnover): don't score a single snapshot against itself

### DIFF
--- a/src/turnover.mjs
+++ b/src/turnover.mjs
@@ -122,7 +122,8 @@ const EMPTY_TURNOVER_CHANGES = {
 // Compare a subnet's start-of-window vs end-of-window neuron_daily snapshots into a
 // turnover scorecard. `rows` carries both dates' rows (the handler reads exactly
 // the two boundary snapshot_dates); `startDate`/`endDate` name them. Null-safe: no
-// data, or no resolvable boundary dates, yields the schema-stable empty block.
+// data, no resolvable boundary dates, or a single snapshot date, yields the
+// schema-stable empty block.
 export function buildTurnover(
   rows,
   netuid,
@@ -136,7 +137,18 @@ export function buildTurnover(
     start_date: startDate ?? null,
     end_date: endDate ?? null,
   };
-  if (startDate == null || endDate == null || list.length === 0) {
+  // A single snapshot (start === end) can't show change: comparing it to itself
+  // would report a flawless retention/stability_score of 100 for a populated
+  // subnet while comparable is false (#6352). The handler resolves the bounds
+  // via MIN/MAX(snapshot_date), so a subnet with one stored day in the window --
+  // a newly-registered one, say -- lands here with non-null equal dates and
+  // non-empty rows. Mirrors buildChainTurnover's guard.
+  if (
+    startDate == null ||
+    endDate == null ||
+    startDate === endDate ||
+    list.length === 0
+  ) {
     return { ...base, ...EMPTY_TURNOVER };
   }
 
@@ -220,7 +232,15 @@ export function buildTurnoverChanges(
     start_date: startDate ?? null,
     end_date: endDate ?? null,
   };
-  if (startDate == null || endDate == null || list.length === 0) {
+  // Mirror buildTurnover's single-snapshot guard (#6352): comparing a snapshot
+  // to itself yields zero entered/exited/reassigned, which reads as "no churn
+  // observed" rather than "not comparable".
+  if (
+    startDate == null ||
+    endDate == null ||
+    startDate === endDate ||
+    list.length === 0
+  ) {
     return { ...base, ...EMPTY_TURNOVER_CHANGES };
   }
 

--- a/tests/turnover.test.mjs
+++ b/tests/turnover.test.mjs
@@ -7,6 +7,21 @@ import {
 } from "../src/turnover.mjs";
 
 describe("buildTurnover", () => {
+  test("two distinct snapshot dates still compute a real score (the #6352 guard is not over-broad)", () => {
+    const rows = [
+      { snapshot_date: "2026-06-01", hotkey: "A", uid: 1, validator_permit: 1 },
+      { snapshot_date: "2026-06-30", hotkey: "A", uid: 1, validator_permit: 1 },
+    ];
+    const data = buildTurnover(rows, 7, {
+      window: "30d",
+      startDate: "2026-06-01",
+      endDate: "2026-06-30",
+    });
+    assert.equal(data.comparable, true);
+    assert.equal(data.validator_retention, 1);
+    assert.equal(data.stability_score, 100);
+  });
+
   test("cold / empty / non-array / no-window inputs yield a schema-stable empty block", () => {
     const cases = [
       { rows: [], opts: { window: "30d" } },
@@ -141,7 +156,11 @@ describe("buildTurnover", () => {
     assert.equal(data.stability_score, 42); // round((0.3333 + 0.5)/2 * 100)
   });
 
-  test("a single snapshot (start === end) is flagged not comparable but trivially stable", () => {
+  // #6352: this case previously asserted the fabricated scores the guard now
+  // prevents (validator_retention 1 / neuron_retention 1 / stability_score 100
+  // from scoring a snapshot against itself). comparable:false was already set,
+  // but a caller not checking that flag read a flawless subnet.
+  test("a single snapshot (start === end) is not comparable and scores null, not a trivial 100", () => {
     const rows = [
       {
         snapshot_date: "2026-06-30",
@@ -164,10 +183,10 @@ describe("buildTurnover", () => {
     assert.equal(data.comparable, false);
     assert.equal(data.validators_entered, 0);
     assert.equal(data.validators_exited, 0);
-    assert.equal(data.validator_retention, 1);
+    assert.equal(data.validator_retention, null);
     assert.equal(data.uids_deregistered, 0);
-    assert.equal(data.neuron_retention, 1);
-    assert.equal(data.stability_score, 100);
+    assert.equal(data.neuron_retention, null);
+    assert.equal(data.stability_score, null);
   });
 
   test("blank uid cells are skipped (not counted as uid 0)", () => {
@@ -277,6 +296,29 @@ describe("buildTurnover", () => {
 });
 
 describe("buildTurnoverChanges", () => {
+  // #6352: same missing guard. Comparing a snapshot to itself yields zero
+  // entered/exited/reassigned, which reads as "no churn observed" rather than
+  // "not comparable".
+  test("a single snapshot (start === end) with rows yields the empty changes block", () => {
+    const day = "2026-06-30";
+    const rows = [
+      { snapshot_date: day, hotkey: "A", uid: 1, validator_permit: 1 },
+      { snapshot_date: day, hotkey: "B", uid: 2, validator_permit: 1 },
+    ];
+    const data = buildTurnoverChanges(rows, 7, {
+      window: "30d",
+      startDate: day,
+      endDate: day,
+    });
+    assert.equal(data.comparable, false);
+    assert.deepEqual(data.validators_entered, []);
+    assert.deepEqual(data.validators_exited, []);
+    assert.deepEqual(data.uid_reassignments, []);
+    assert.equal(data.validators_entered_count, 0);
+    assert.equal(data.validators_exited_count, 0);
+    assert.equal(data.uid_reassignment_count, 0);
+  });
+
   test("cold / empty / non-array inputs yield schema-stable empty detail", () => {
     for (const rows of [[], null, undefined]) {
       const data = buildTurnoverChanges(rows, 7, { window: "30d" });


### PR DESCRIPTION
Closes #6352

## The bug

`buildTurnover` guarded only `startDate == null || endDate == null || list.length === 0` — never `startDate === endDate`. The handler resolves the bounds via `MIN`/`MAX(snapshot_date)`, so a subnet with a single stored `neuron_daily` day in the window (a newly-registered one, say) arrives with **non-null equal dates and non-empty rows**, falls through both guards, and scores the snapshot against itself.

Reproduced against the real builder before fixing:

```
buildTurnover(oneDayRows, 7, { startDate: '2026-07-16', endDate: '2026-07-16' })
  -> comparable: false | validator_retention: 1 | stability_score: 100 | neuron_retention: 1
```

`comparable: false` was already set, but a caller not specifically checking that flag reads a **flawless subnet**. The network-wide sibling `buildChainTurnover` has always had this guard — its comment describes this exact failure ("comparing it to itself would report a flawless retention for populated subnets while comparable is false").

## The fix

Adds the `startDate === endDate` early-return to **`buildTurnover`** and **`buildTurnoverChanges`**, mirroring `buildChainTurnover`'s guard shape. After:

```
single snapshot -> comparable: false | validator_retention: null | stability_score: null | neuron_retention: null
two dates       -> comparable: true  | stability_score: 100          (still computes)
```

## A test asserted the bug

`tests/turnover.test.mjs` had a case literally titled *"a single snapshot (start === end) is flagged not comparable but **trivially stable**"*, asserting `validator_retention: 1` / `neuron_retention: 1` / `stability_score: 100` — the fabricated scores this issue calls a bug.

I **updated that test to the corrected contract** rather than adding a contradictory duplicate beside it. It now asserts `null` retention/stability, which is exactly the regression test the issue's deliverables ask for.

Also added:
- **two distinct snapshot dates still compute a real score** — pins that the guard isn't over-broad.
- **`buildTurnoverChanges` single-snapshot** → empty changes block (the issue's `?changes=true` requirement). Comparing a snapshot to itself yields zero entered/exited/reassigned, which reads as *"no churn observed"* rather than *"not comparable"*.

## Verification

`buildTurnover` is a shared builder, so I ran every consumer, not just its own suite:

```
tests/turnover.test.mjs                  passed
tests/chain-turnover.test.mjs            passed   (the sibling guard)
tests/graphql.test.mjs                   passed   (subnet_turnover resolver)
tests/mcp-server.test.mjs                passed   (get_subnet_turnover)
tests/request-handlers-entities.test.mjs passed   (REST handler)
tests/analytics.test.mjs                 passed
tests/movers.test.mjs                    passed
```

Patch coverage measured locally the way codecov measures it — every added line mapped against `coverage-final.json`'s `statementMap`/`branchMap`: **14/14 covered statements and branch arms = 100%** (target 99%), no partials. `eslint` clean, `prettier --check` clean, rebased to `behind: 0` immediately before pushing.
