### PR TITLE
fix(ui): stop #evidence deep links bouncing off the Evidence tab (#6434)

### DIFF
--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -210,7 +210,11 @@ const SECTION_TO_TAB: Record<string, string> = {
   "stake-quote": "overview",
   reliability: "overview",
   lineage: "overview",
-  evidence: "overview",
+  // #6434: the Overview embed is a preview and owns `evidence-preview`; the
+  // bare `evidence` id belongs to the dedicated Evidence tab below, like every
+  // other tab-owning section. Mirrors the preview-vs-full id split in
+  // providers.$slug.tsx (`subnets-served-preview` vs `subnets-served`).
+  "evidence-preview": "overview",
   metagraph: "metagraph",
   neuron: "metagraph",
   concentration: "metagraph",
@@ -228,6 +232,7 @@ const SECTION_TO_TAB: Record<string, string> = {
   "schema-drift": "schemas",
   candidates: "candidates",
   gaps: "gaps",
+  evidence: "evidence",
   api: "api",
 };
 
@@ -332,8 +337,8 @@ function ProfileShell({ netuid }: { netuid: number }) {
             <SectionAnchor
               id="evidence"
               title="Evidence & sources"
-              subtitle="Every claim should be traceable."
-              info="Source URLs and timestamps for verified registry entries."
+              subtitle="Primary links and recorded evidence backing this profile."
+              info="GET /api/v1/evidence — source URLs and timestamps for verified registry entries."
             >
               <EvidencePanel netuid={netuid} />
             </SectionAnchor>
@@ -493,12 +498,14 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
       {/* 7 — Cross-network lineage (#1113): renders only when paired. */}
       <SubnetLineageSection netuid={netuid} />
 
-      {/* 8 — Sources & evidence — UI's wired EvidencePanel (NOT evidence-clusters). */}
+      {/* 8 — Evidence & sources — UI's wired EvidencePanel (NOT evidence-clusters).
+          Preview embed of the dedicated Evidence tab: same copy, own
+          `evidence-preview` id, muted rail marking it as lower-density context. */}
       <SectionAnchor
-        id="evidence"
-        title="Sources & evidence"
+        id="evidence-preview"
+        title="Evidence & sources"
         subtitle="Primary links and recorded evidence backing this profile."
-        info="GET /api/v1/evidence"
+        info="GET /api/v1/evidence — source URLs and timestamps for verified registry entries."
         tone="muted"
       >
         <EvidencePanel netuid={netuid} />

--- a/apps/ui/tests/e2e/capture-evidence-section-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-evidence-section-screenshots.mjs
@@ -1,0 +1,98 @@
+/**
+ * Capture /subnets/:netuid Evidence section headers for #6434.
+ *
+ * The change is the SectionAnchor header copy (title / subtitle / info) on two
+ * instances of the same panel, so the evidence that matters is a tight crop of
+ * each header -- a full-page shot buries a two-line diff. Both tabs are shot:
+ * the Overview embed (whose title changes) and the dedicated Evidence tab
+ * (whose subtitle + info change).
+ *
+ * The Overview selector matches either id on purpose: before the fix that embed
+ * is `#evidence`, after it is `#evidence-preview`, and the same script has to
+ * shoot both variants.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8080 VARIANT=before node tests/e2e/capture-evidence-section-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8080 VARIANT=after  node tests/e2e/capture-evidence-section-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/evidence-section-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8080";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const NETUID = process.env.NETUID ?? "1";
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 900 },
+];
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function open(page, route) {
+  await page.goto(`${BASE_URL}${route}`, { waitUntil: "networkidle", timeout: 90_000 });
+  await page.waitForTimeout(800);
+}
+
+/** The SectionAnchor header (title + info + subtitle) -- the changed region. */
+function header(section) {
+  return section.locator("xpath=./div[1]");
+}
+
+async function shotHeader(page, selector, file) {
+  const section = page.locator(selector).first();
+  await section.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(250);
+  await header(section).screenshot({ path: file });
+  console.log(`wrote ${file}`);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await setTheme(page, theme);
+
+      // Overview tab: the embedded preview (#evidence before, #evidence-preview after).
+      await open(page, `/subnets/${NETUID}`);
+      await shotHeader(
+        page,
+        "section#evidence-preview, section#evidence",
+        path.join(OUT_DIR, `${VARIANT}-overview-${viewport.name}-${theme}.png`),
+      );
+
+      // Dedicated Evidence tab: keeps #evidence in both variants.
+      await open(page, `/subnets/${NETUID}?tab=evidence`);
+      await shotHeader(
+        page,
+        "section#evidence",
+        path.join(OUT_DIR, `${VARIANT}-evidence-tab-${viewport.name}-${theme}.png`),
+      );
+
+      await context.close();
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/ui/tests/e2e/evidence-deep-link.spec.ts
+++ b/apps/ui/tests/e2e/evidence-deep-link.spec.ts
@@ -1,0 +1,75 @@
+import { existsSync } from "node:fs";
+import { test, expect } from "@playwright/test";
+import { harPathForRoute, DATED_ENDPOINT_PATTERNS, findHarFixture } from "./har-path.js";
+
+// #6434: /subnets/:netuid renders EvidencePanel twice -- a preview embedded in
+// the Overview tab and the full section under the dedicated Evidence tab. Both
+// used to claim id="evidence", and SECTION_TO_TAB mapped that id to "overview",
+// so useHashScroll bounced a reader who opened the Evidence tab with #evidence
+// straight back to Overview: the tab's own SectionAnchor "copy link" button
+// produced a URL that navigated away from the tab it was copied from.
+//
+// The fix gives the Overview embed its own `evidence-preview` id (the
+// preview-vs-full split providers.$slug.tsx already uses for
+// `subnets-served-preview` vs `subnets-served`) and points the bare `evidence`
+// id at the tab that actually owns it. These two tests pin both directions of
+// that mapping -- the first one fails on the pre-fix code, which is the point.
+//
+// Deterministic by design, mirroring responsive-overflow.spec.ts: the route
+// replays tests/e2e/har/subnets-1.har rather than hitting live chain data, so
+// a subnet's evidence changing shape can never make this flap.
+const ROUTE = "/subnets/1";
+const harPath = harPathForRoute(ROUTE);
+
+if (!existsSync(harPath)) {
+  throw new Error(
+    `Missing HAR fixture for ${ROUTE}: ${harPath}. Run ` +
+      `\`npm run test:e2e:record-har --workspace=apps/ui\` against a live dev server first.`,
+  );
+}
+
+/** Replay recorded API traffic + settle, matching responsive-overflow.spec.ts. */
+async function openWithHar(page: import("@playwright/test").Page, url: string) {
+  await page.routeFromHAR(harPath, {
+    url: "**/api.metagraph.sh/**",
+    notFound: "fallback",
+    update: false,
+  });
+  // Registered after routeFromHAR so date-stamped endpoints still resolve to
+  // the recorded fixture rather than falling through to live data.
+  for (const pattern of DATED_ENDPOINT_PATTERNS) {
+    const fixture = findHarFixture(harPath, pattern);
+    if (fixture) {
+      await page.route(pattern, (route) => route.fulfill(fixture));
+    }
+  }
+  await page.goto(url);
+  // HAR responses resolve instantly, which starves "networkidle" of the quiet
+  // window it needs on a route with recurring refetches -- fall back to a fixed
+  // settle rather than hanging (same rationale as responsive-overflow.spec.ts).
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 5000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+}
+
+test.describe("#6434 evidence deep links", () => {
+  test("#evidence resolves to the dedicated Evidence tab", async ({ page }) => {
+    await openWithHar(page, `${ROUTE}#evidence`);
+
+    // useHashScroll rewrites the tab search param when the hash's owning tab
+    // isn't active, so landing on Overview with #evidence must switch tabs.
+    await expect(page).toHaveURL(/[?&]tab=evidence/);
+    await expect(page.locator("section#evidence")).toBeVisible();
+  });
+
+  test("#evidence-preview stays on the Overview tab", async ({ page }) => {
+    await openWithHar(page, `${ROUTE}#evidence-preview`);
+
+    // The preview lives on Overview (the default tab), so the hash must not
+    // drag the reader onto the Evidence tab.
+    await expect(page).not.toHaveURL(/[?&]tab=evidence/);
+    await expect(page.locator("section#evidence-preview")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

`/subnets/:netuid` wrapped the same `<EvidencePanel />` in two `SectionAnchor`s that
both claimed `id="evidence"` — one embedded in Overview, one under the dedicated
Evidence tab — while `SECTION_TO_TAB` mapped that id to `"overview"`.

The copy drift the issue describes is real, but the mapping is the sharper bug.
`useHashScroll` navigates whenever a hash's mapped tab isn't the active one:

```ts
const expectedTab = sectionToTab[id];
if (expectedTab && expectedTab !== activeTab) navigate({ tab: expectedTab, hash: id })
```

So opening the **Evidence tab** with `#evidence` redirected to Overview. Since
`SectionAnchor`'s copy-link button writes `#${id}`, the Evidence tab's own "copy
link" button produced a URL that navigated away from the tab it was copied from,
and the dedicated tab was unreachable by deep link.

`evidence` was also the **only** tab-owning section in the map not pointed at its
own tab — `metagraph`, `endpoints`, `gaps` and the rest all are, and there is a
real `{ id: "evidence", label: "Evidence" }` tab — so the mapping was the bug
rather than the intent.

## What Changed

Took the issue's second option — distinct ids, following the `providers.$slug.tsx`
convention (`subnets-served-preview` vs `subnets-served`):

| | Overview embed | Evidence tab |
| --- | --- | --- |
| `id` | `evidence-preview` (new) | `evidence` (kept) |
| `SECTION_TO_TAB` | → `overview` | → `evidence` (was `overview`) |
| `title` | "Evidence & sources" (unified) | "Evidence & sources" |
| `subtitle` | "Primary links and recorded evidence backing this profile." | unified (was "Every claim should be traceable.") |
| `info` | merged: `GET /api/v1/evidence — source URLs and timestamps for verified registry entries.` | same |
| `tone` | `muted` — kept | none |

Both instances now read identically, matching the reference, where the preview and
full sections share title/subtitle. The merged `info` keeps the endpoint *and* the
prose the two copies had split between them, matching the `GET /path — prose` form
its sibling sections already use (`volume-24h`, `stake-quote`, `identity`). The
preview keeps its `muted` rail as the lower-density affordance it already had —
the one intentional difference, and what the distinct id exists to express.

`evidence-preview` is mapped to `overview` because every overview section in this
file's map is; the unmapped-preview variant in `providers.$slug.tsx` would silently
no-op from another tab.

## Verification

`#evidence` deep links now resolve to the tab that owns the section, pinned in both
directions by a HAR-replayed e2e spec (`tests/e2e/evidence-deep-link.spec.ts`,
deterministic via `har/subnets-1.har`, mirroring `responsive-overflow.spec.ts`):

- `#evidence` → switches to the Evidence tab
- `#evidence-preview` → stays on Overview

**The spec fails on the pre-fix code** (verified by stashing the route change: 2/2
failed, then 2/2 passed with it restored), so it is a real regression test rather
than a restatement of current behaviour.

- `npm run lint --workspace=apps/ui` — clean (0 errors)
- `npm run format:check --workspace=apps/ui` — clean
- `npm run typecheck --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 1044/1044 passed
- `npm run test:e2e --workspace=apps/ui` — 26/26 passed, incl. all 24
  `responsive-overflow` checks (the title swap is character-count-neutral, so the
  baseline is unaffected)
- `npm run build --workspace=apps/ui` — clean

## Screenshots

Header crops — the changed region — for both tabs. Before, the same panel
contradicted itself across tabs; after, both read the same.

### Overview tab (title changes)

| Viewport | Before | After |
| --- | --- | --- |
| Mobile (375) light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/before-overview-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/after-overview-mobile-light.png) |
| Mobile (375) dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/before-overview-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/after-overview-mobile-dark.png) |
| Tablet (768) light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/before-overview-tablet-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/after-overview-tablet-light.png) |
| Tablet (768) dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/before-overview-tablet-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/after-overview-tablet-dark.png) |
| Desktop (1280) light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/before-overview-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/after-overview-desktop-light.png) |
| Desktop (1280) dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/before-overview-desktop-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/after-overview-desktop-dark.png) |

### Evidence tab (subtitle + info change)

| Viewport | Before | After |
| --- | --- | --- |
| Mobile (375) light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/before-evidence-tab-mobile-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/after-evidence-tab-mobile-light.png) |
| Mobile (375) dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/before-evidence-tab-mobile-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/after-evidence-tab-mobile-dark.png) |
| Tablet (768) light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/before-evidence-tab-tablet-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/after-evidence-tab-tablet-light.png) |
| Tablet (768) dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/before-evidence-tab-tablet-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/after-evidence-tab-tablet-dark.png) |
| Desktop (1280) light | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/before-evidence-tab-desktop-light.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/after-evidence-tab-desktop-light.png) |
| Desktop (1280) dark | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/before-evidence-tab-desktop-dark.png) | ![](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6434-evidence/after-evidence-tab-desktop-dark.png) |

Captured with `tests/e2e/capture-evidence-section-screenshots.mjs` (included), which
crops each `SectionAnchor` header.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6434`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched — `apps/ui/**` only, 3 files.
- [x] `routeTree.gen.ts` untouched.
- [x] `git diff --check` clean.

Closes #6434
