### PR TITLE
fix(ui-kit): stop ListCard silently dropping onClick on its link branch

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2035,7 +2035,7 @@ function ListCard({
 }) {
   const cls = "block rounded border border-border bg-card p-3 min-h-11 hover:border-ink/30 active:bg-surface transition-colors";
   if (to) {
-    return /* @__PURE__ */ jsxRuntime.jsx("a", { href: to, className: cls, children });
+    return /* @__PURE__ */ jsxRuntime.jsx("a", { href: to, onClick, className: cls, children });
   }
   return /* @__PURE__ */ jsxRuntime.jsx(
     "button",

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2006,7 +2006,7 @@ function ListCard({
 }) {
   const cls = "block rounded border border-border bg-card p-3 min-h-11 hover:border-ink/30 active:bg-surface transition-colors";
   if (to) {
-    return /* @__PURE__ */ jsx("a", { href: to, className: cls, children });
+    return /* @__PURE__ */ jsx("a", { href: to, onClick, className: cls, children });
   }
   return /* @__PURE__ */ jsx(
     "button",

--- a/packages/ui-kit/src/components/metagraphed/list-card-onclick.test.ts
+++ b/packages/ui-kit/src/components/metagraphed/list-card-onclick.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ReactElement } from "react";
+import { ListCard } from "@/components/metagraphed/list-shell";
+
+// #6376: ListCard takes independently-optional `to`/`onClick`, but the link
+// branch returned <a href={to}> without ever attaching onClick -- passing both
+// silently swallowed the handler, with nothing in the JSDoc saying they were
+// mutually exclusive. A caller wiring click-tracking alongside navigation got no
+// warning and no handler.
+//
+// ListCard is a plain function, so calling it returns the element to inspect
+// directly -- no DOM needed, which suits this package's node-environment suite
+// (a click can't be dispatched without jsdom, but the wiring is what regressed).
+type CardElementProps = {
+  href?: string;
+  type?: string;
+  onClick?: () => void;
+  className?: string;
+};
+
+const render = (props: Parameters<typeof ListCard>[0]) =>
+  ListCard(props) as ReactElement<CardElementProps>;
+
+describe("ListCard wires onClick on both branches (#6376)", () => {
+  it("attaches onClick to the link branch instead of dropping it", () => {
+    const onClick = vi.fn();
+    const el = render({ to: "/subnets/1", onClick, children: "row" });
+
+    expect(el.type).toBe("a");
+    expect(el.props.href).toBe("/subnets/1");
+    // The regression: this used to be undefined.
+    expect(el.props.onClick).toBe(onClick);
+
+    el.props.onClick?.();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("still navigates -- the handler is additive, not a replacement", () => {
+    // No preventDefault wrapper: the <a> keeps its href so the browser
+    // navigates, and onClick runs alongside it (the click-tracking case).
+    const el = render({ to: "/accounts/x", onClick: vi.fn(), children: "row" });
+    expect(el.props.href).toBe("/accounts/x");
+    expect(String(el.props.onClick)).not.toMatch(/preventDefault/);
+  });
+
+  it("link branch without onClick stays undefined, not a stub", () => {
+    const el = render({ to: "/subnets/1", children: "row" });
+    expect(el.type).toBe("a");
+    expect(el.props.onClick).toBeUndefined();
+  });
+
+  it("without `to` it is still a button carrying onClick", () => {
+    const onClick = vi.fn();
+    const el = render({ onClick, children: "row" });
+
+    expect(el.type).toBe("button");
+    expect(el.props.type).toBe("button");
+    expect(el.props.onClick).toBe(onClick);
+  });
+
+  it("both branches keep the 44px tap-target class the JSDoc promises", () => {
+    const link = render({ to: "/x", children: "row" });
+    const button = render({ onClick: vi.fn(), children: "row" });
+    expect(link.props.className).toContain("min-h-11");
+    expect(button.props.className).toContain("min-h-11");
+  });
+});

--- a/packages/ui-kit/src/components/metagraphed/list-shell.tsx
+++ b/packages/ui-kit/src/components/metagraphed/list-shell.tsx
@@ -91,6 +91,15 @@ export function ListShell({
 /**
  * Tap-friendly card row used by mobile card fallbacks.
  * Targets a 44px minimum height for accessible tap targets.
+ *
+ * `to` and `onClick` are independent and may be combined: with `to` the card is
+ * a link, and `onClick` (if given) fires on activation *in addition to*
+ * navigation -- the click-tracking-alongside-navigation case. It does not
+ * preventDefault, so the link still navigates. With no `to`, the card is a
+ * button and `onClick` is its only behaviour.
+ *
+ * (#6376: the link branch used to drop `onClick` silently -- no warning, no
+ * navigation change, the handler simply never ran.)
  */
 export function ListCard({
   to,
@@ -105,7 +114,7 @@ export function ListCard({
     "block rounded border border-border bg-card p-3 min-h-11 hover:border-ink/30 active:bg-surface transition-colors";
   if (to) {
     return (
-      <a href={to} className={cls}>
+      <a href={to} onClick={onClick} className={cls}>
         {children}
       </a>
     );


### PR DESCRIPTION
## What

`ListCard` takes independently-optional `to`/`onClick`, but the link branch returned `<a href={to}>` **without ever attaching `onClick`**:

```tsx
if (to) {
  return <a href={to} className={cls}>{children}</a>;   // onClick dropped
}
```

Passing both swallowed the handler silently — no warning, no type error, and nothing in the JSDoc saying the two were mutually exclusive. A caller wiring click-tracking alongside navigation got no handler and no clue why.

## Which of the two options, and why

The issue offered either **attaching `onClick` on the `<a>` branch** or **narrowing the props into a discriminated union** so passing both is a compile-time error.

I took the first. An `<a>` with an `onClick` is an ordinary React pattern, and the click-tracking-alongside-navigation case the issue itself names is a *legitimate* use — a union would forbid it outright rather than fix it. There's also no `preventDefault`: the handler is **additive**, and the link still navigates.

The JSDoc now states that contract explicitly instead of leaving it unsaid, which is the other half of the issue's ask ("update the JSDoc to state the actual contract, whichever is chosen").

## Testing

`list-card-onclick.test.ts` (5 tests). `ListCard` is a plain function, so the test **calls it and inspects the returned element** — dispatching a real click needs a DOM this package's node-environment suite doesn't have, and the wiring is what regressed, not the browser's dispatch.

- The link branch carries the handler **and invokes it** (`el.props.onClick` was `undefined` before).
- The `href` survives, so navigation isn't replaced — the handler is additive.
- An omitted `onClick` stays `undefined` rather than becoming a stub.
- The button branch (no `to`) still carries it.
- Both branches keep the `min-h-11` tap target the JSDoc promises.

**Verified meaningful:** reverting `list-shell.tsx` to its upstream form fails the dropped-handler assertion; restored, 5/5 pass.

`packages/ui-kit`: 15 files / 87 tests pass, `typecheck` clean, `lint` clean, repo `format:check` clean. `dist` regenerated and committed.

## Note on #6379

#6379 asks whether `ListCard` should be wired into a real route or dropped from the barrel, and says *"if kept, fix the `onClick`-dropped defect in the same component first"*. This is that fix — it stands on its own and doesn't pre-empt that decision either way.

Closes #6376
