### PR TITLE
fix(mcp): name the offending argument in optionalDayArg's error

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -5719,7 +5719,9 @@ const rootValue = {
     // straight through: the Postgres tier re-parses and rejects it, but the D1
     // fallback binds it into `day >= ?` / `day <= ?` against a TEXT column,
     // which silently yields a wrong (typically empty) series instead of an
-    // error. The message is REST's and MCP's verbatim, so all three agree.
+    // error. The message is REST's parseDateRange verbatim, so the two HTTP
+    // surfaces agree. (MCP's optionalDayArg names the offending argument
+    // instead -- its own file's validator convention, see #6355.)
     if (
       (from != null && !DAY_PATTERN.test(from)) ||
       (to != null && !DAY_PATTERN.test(to))

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -1753,7 +1753,14 @@ function optionalDayArg(args, key) {
   const value = optionalString(args, key);
   if (value === null) return null;
   if (!DAY_PATTERN.test(value)) {
-    throw toolError("invalid_params", "from/to must be YYYY-MM-DD dates.");
+    // Name the offending argument, like every sibling validator here (#6355):
+    // get_account_history validates both `from` and `to` through this helper,
+    // so a hardcoded "from/to" message left the caller guessing which one it
+    // rejected.
+    throw toolError(
+      "invalid_params",
+      `Argument \`${key}\` must be a YYYY-MM-DD date.`,
+    );
   }
   return value;
 }

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -12405,6 +12405,32 @@ describe("MCP account tail tools (history, extrinsics, transfers)", () => {
     assert.match(res.body.result.content[0].text, /YYYY-MM-DD/i);
   });
 
+  // #6355: optionalDayArg took a `key` but threw a hardcoded "from/to must be
+  // YYYY-MM-DD dates.", so mistyping `from` and mistyping `to` produced
+  // identical text. Every sibling validator in this file names its argument.
+  test("a malformed from names `from` -- not the other bound", async () => {
+    const res = await callTool("get_account_history", {
+      ss58: SS58,
+      from: "June",
+    });
+    assert.equal(res.body.result.isError, true);
+    const text = res.body.result.content[0].text;
+    assert.match(text, /`from`/);
+    assert.doesNotMatch(text, /`to`/);
+  });
+
+  test("a malformed to names `to`, even when from is valid", async () => {
+    const res = await callTool("get_account_history", {
+      ss58: SS58,
+      from: "2026-07-01",
+      to: "07/16/2026",
+    });
+    assert.equal(res.body.result.isError, true);
+    const text = res.body.result.content[0].text;
+    assert.match(text, /`to`/);
+    assert.doesNotMatch(text, /`from`/);
+  });
+
   test("get_account_history rejects a non-integer netuid filter", async () => {
     const res = await callTool("get_account_history", {
       ss58: SS58,


### PR DESCRIPTION
Closes #6355

## The bug

`optionalDayArg(args, key)` takes a `key`, uses it correctly for the lookup — then throws a **hardcoded** message:

```js
throw toolError("invalid_params", "from/to must be YYYY-MM-DD dates.");
```

`get_account_history` validates **both** bounds through this helper (`optionalDayArg(args, "from")` / `optionalDayArg(args, "to")`), so a caller who mistypes `from` and one who mistypes `to` get byte-identical error text and no way to tell which was rejected.

Every sibling validator in the same file already interpolates its argument name — `optionalPositiveInt`, `optionalBoolean`, `requireString`, `optionalString` all emit `` Argument `${key}` must be … ``. `optionalDayArg` was the lone exception.

## The fix

Interpolates `key`, matching that convention exactly:

```
Argument `from` must be a YYYY-MM-DD date.
```

## A knock-on I fixed rather than left to rot

My earlier #6353 fix left a comment in `graphql.mjs` claiming the GraphQL message was *"REST's and MCP's verbatim, so all three agree"*. This change makes that false, so I corrected it in the same PR: GraphQL still matches **REST's `parseDateRange`** verbatim (the two HTTP surfaces agree), while MCP now names the argument per **its own file's** validator convention. That edit is comment-only — one line of prose, no behaviour.

## Tests

2 regression cases added beside the existing `get_account_history` date test. They are real regression tests — **I reverted the fix and confirmed both fail without it**:

```
× a malformed from names `from` -- not the other bound
× a malformed to names `to`, even when from is valid
```

Each asserts the message names **its own** bound and explicitly `doesNotMatch` the other — which is precisely the bug (identical text for both). The pre-existing `rejects malformed from/to dates before D1` test still passes, since the message keeps the `YYYY-MM-DD` token it matches on.

```
tests/mcp-server.test.mjs      passed
tests/graphql.test.mjs         passed   (the #6353 guard unaffected)
tests/request-params.test.mjs  passed   (REST's parseDateRange untouched)
tests/account-history.test.mjs passed
```

Patch coverage measured locally the way codecov measures it: **1/1 covered = 100%** (target 99%) — the `graphql.mjs` hunk is comment-only, so it carries no coverable lines. `eslint` clean, `prettier --check` clean, rebased to `behind: 0` immediately before pushing.
