### PR TITLE
fix(ui-kit): remove the dead SearchScopeChip export (#6378)

### DIFF
--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2805,6 +2805,8 @@ function DiscordIcon({ className, ...props }) {
     }
   );
 }
+
+// src/components/metagraphed/search-scope.tsx
 var SCOPES = [
   { key: "all", label: "All" },
   { key: "subnet", label: "Subnets" },
@@ -2813,38 +2815,6 @@ var SCOPES = [
   { key: "provider", label: "Providers" },
   { key: "schema", label: "Schemas" }
 ];
-function SearchScopeChip({
-  value,
-  onChange
-}) {
-  const current = SCOPES.find((s) => s.key === value) ?? SCOPES[0];
-  return /* @__PURE__ */ jsxRuntime.jsxs(Popover, { children: [
-    /* @__PURE__ */ jsxRuntime.jsx(PopoverTrigger, { asChild: true, children: /* @__PURE__ */ jsxRuntime.jsxs(
-      "button",
-      {
-        type: "button",
-        "aria-label": `Search scope: ${current.label}`,
-        className: "inline-flex items-center gap-1 rounded-full border border-border bg-paper px-2.5 py-1 text-[11px] font-mono uppercase tracking-widest text-ink-muted hover:text-ink-strong hover:border-accent/40 transition-colors shrink-0",
-        children: [
-          current.label,
-          /* @__PURE__ */ jsxRuntime.jsx(lucideReact.ChevronDown, { className: "size-3 opacity-70" })
-        ]
-      }
-    ) }),
-    /* @__PURE__ */ jsxRuntime.jsx(PopoverContent, { align: "start", className: "w-44 p-1", children: /* @__PURE__ */ jsxRuntime.jsx("ul", { children: SCOPES.map((s) => /* @__PURE__ */ jsxRuntime.jsx("li", { children: /* @__PURE__ */ jsxRuntime.jsx(
-      "button",
-      {
-        type: "button",
-        onClick: () => onChange(s.key),
-        className: classNames(
-          "w-full text-left px-2 py-1.5 rounded text-[12px] transition-colors",
-          s.key === value ? "bg-surface text-ink-strong" : "text-ink hover:bg-surface/60"
-        ),
-        children: s.label
-      }
-    ) }, s.key)) }) })
-  ] });
-}
 var PREVIEW_COUNT = 24;
 function visibleTools(tools, open) {
   return open ? tools : tools.slice(0, PREVIEW_COUNT);
@@ -4145,7 +4115,6 @@ exports.RealtimeFreshness = RealtimeFreshness;
 exports.ReviewChip = ReviewChip;
 exports.SCOPES = SCOPES;
 exports.ScrollReveal = ScrollReveal;
-exports.SearchScopeChip = SearchScopeChip;
 exports.SectionAnchor = SectionAnchor;
 exports.SectionHeading = SectionHeading;
 exports.ShareButton = ShareButton;

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -2776,6 +2776,8 @@ function DiscordIcon({ className, ...props }) {
     }
   );
 }
+
+// src/components/metagraphed/search-scope.tsx
 var SCOPES = [
   { key: "all", label: "All" },
   { key: "subnet", label: "Subnets" },
@@ -2784,38 +2786,6 @@ var SCOPES = [
   { key: "provider", label: "Providers" },
   { key: "schema", label: "Schemas" }
 ];
-function SearchScopeChip({
-  value,
-  onChange
-}) {
-  const current = SCOPES.find((s) => s.key === value) ?? SCOPES[0];
-  return /* @__PURE__ */ jsxs(Popover, { children: [
-    /* @__PURE__ */ jsx(PopoverTrigger, { asChild: true, children: /* @__PURE__ */ jsxs(
-      "button",
-      {
-        type: "button",
-        "aria-label": `Search scope: ${current.label}`,
-        className: "inline-flex items-center gap-1 rounded-full border border-border bg-paper px-2.5 py-1 text-[11px] font-mono uppercase tracking-widest text-ink-muted hover:text-ink-strong hover:border-accent/40 transition-colors shrink-0",
-        children: [
-          current.label,
-          /* @__PURE__ */ jsx(ChevronDown, { className: "size-3 opacity-70" })
-        ]
-      }
-    ) }),
-    /* @__PURE__ */ jsx(PopoverContent, { align: "start", className: "w-44 p-1", children: /* @__PURE__ */ jsx("ul", { children: SCOPES.map((s) => /* @__PURE__ */ jsx("li", { children: /* @__PURE__ */ jsx(
-      "button",
-      {
-        type: "button",
-        onClick: () => onChange(s.key),
-        className: classNames(
-          "w-full text-left px-2 py-1.5 rounded text-[12px] transition-colors",
-          s.key === value ? "bg-surface text-ink-strong" : "text-ink hover:bg-surface/60"
-        ),
-        children: s.label
-      }
-    ) }, s.key)) }) })
-  ] });
-}
 var PREVIEW_COUNT = 24;
 function visibleTools(tools, open) {
   return open ? tools : tools.slice(0, PREVIEW_COUNT);
@@ -4041,4 +4011,4 @@ function TreemapMini({
   );
 }
 
-export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EntityHero, ExternalLink, FreshnessBadge, FreshnessIndicator, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, InfoTooltip, Kbd, KeyChip, ListCard, ListShell, LoadMore, McpToolsList, MethodologyCallout, MiniRadial, MiniStack, NoDataSpark, PageHero, PageSection, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, RealtimeFreshness, ReviewChip, SCOPES, ScrollReveal, SearchScopeChip, SectionAnchor, SectionHeading, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, fmtYield, freshnessBadgeTimeCopy, freshnessDotClass, freshnessTierLabel, prefetchBrandIcon, safeExternalUrl, tierFreshnessLabel };
+export { AccentBand, Accordion, AccordionContent, AccordionItem, AccordionTrigger, ActionBar, AnimatedNumber, BackToTop, BarMini, BrandIcon, CandidateChip, CandlestickMini, Command, CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut, CopyButton, CopyIconToggle, CopyableCode, CurationChip, DailyRollupFreshness, DensityToggle, Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger, DiscordIcon, Donut, DonutLegend, DotRow, DownloadCsvButton, EligibilityChip, EntityHero, ExternalLink, FreshnessBadge, FreshnessIndicator, HealthDot, HealthPill, HoverCard, HoverCardContent, HoverCardTrigger, HoverPreview, InfoTooltip, Kbd, KeyChip, ListCard, ListShell, LoadMore, McpToolsList, MethodologyCallout, MiniRadial, MiniStack, NoDataSpark, PageHero, PageSection, Popover, PopoverAnchor, PopoverContent, PopoverTrigger, PrimaryLinksRail, RealtimeFreshness, ReviewChip, SCOPES, ScrollReveal, SectionAnchor, SectionHeading, ShareButton, Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetOverlay, SheetPortal, SheetTitle, SheetTrigger, Skeleton, SparkLegend, Sparkline, StatTile, StatWithSpark, TableState, TimeAgo, Toaster, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, TreemapMini, ViewModeToggle, Wordmark, YieldPercentileStrip, fmtYield, freshnessBadgeTimeCopy, freshnessDotClass, freshnessTierLabel, prefetchBrandIcon, safeExternalUrl, tierFreshnessLabel };

--- a/packages/ui-kit/src/components/metagraphed/search-scope.tsx
+++ b/packages/ui-kit/src/components/metagraphed/search-scope.tsx
@@ -1,11 +1,10 @@
-import { ChevronDown } from "lucide-react";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { classNames } from "@/lib/format";
-
+// The search-scope vocabulary shared by the command palette. The popover-based
+// SearchScopeChip that used to live here was removed as dead code (#6378): it
+// had zero call sites, and its one plausible home -- command-palette-body.tsx's
+// scope row -- deliberately renders every scope as a one-click button instead,
+// which is the right affordance inside an already-overlaid palette (a popover
+// there would hide the options behind an extra click). Only the vocabulary is
+// shared; each surface owns its own presentation.
 export const SCOPES = [
   { key: "all", label: "All" },
   { key: "subnet", label: "Subnets" },
@@ -16,47 +15,3 @@ export const SCOPES = [
 ] as const;
 
 export type SearchScope = (typeof SCOPES)[number]["key"];
-
-export function SearchScopeChip({
-  value,
-  onChange,
-}: {
-  value: SearchScope;
-  onChange: (v: SearchScope) => void;
-}) {
-  const current = SCOPES.find((s) => s.key === value) ?? SCOPES[0];
-  return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          aria-label={`Search scope: ${current.label}`}
-          className="inline-flex items-center gap-1 rounded-full border border-border bg-paper px-2.5 py-1 text-[11px] font-mono uppercase tracking-widest text-ink-muted hover:text-ink-strong hover:border-accent/40 transition-colors shrink-0"
-        >
-          {current.label}
-          <ChevronDown className="size-3 opacity-70" />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent align="start" className="w-44 p-1">
-        <ul>
-          {SCOPES.map((s) => (
-            <li key={s.key}>
-              <button
-                type="button"
-                onClick={() => onChange(s.key)}
-                className={classNames(
-                  "w-full text-left px-2 py-1.5 rounded text-[12px] transition-colors",
-                  s.key === value
-                    ? "bg-surface text-ink-strong"
-                    : "text-ink hover:bg-surface/60",
-                )}
-              >
-                {s.label}
-              </button>
-            </li>
-          ))}
-        </ul>
-      </PopoverContent>
-    </Popover>
-  );
-}

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -140,7 +140,6 @@ export { DiscordIcon } from "@/components/metagraphed/discord-icon";
 export {
   SCOPES,
   type SearchScope,
-  SearchScopeChip,
 } from "@/components/metagraphed/search-scope";
 export { McpToolsList } from "@/components/metagraphed/mcp-tools-list";
 export { fmtYield } from "@/components/metagraphed/yield-format";


### PR DESCRIPTION
`search-scope.tsx` exported a popover-based `SearchScopeChip` that **nothing ever imported** — a full-repo grep finds exactly one reference: the barrel export itself. Its constants (`SCOPES` / `SearchScope`) *are* live — `command-palette-body.tsx` imports them and renders its own scope row from the same array.

## Decision: remove the chip, don't adopt it
The two are **not interchangeable affordances**:
- The palette renders **every scope as a one-click button**, active one accented, with an inline "searching…" indicator. Inside an already-overlaid palette that's the right call.
- The chip is a **popover** — it would hide the options behind an extra click and nest a popover inside an overlay.

Adopting it would **regress the UX to justify keeping unused code**. The *vocabulary* is what's genuinely shared; each surface owns its presentation.

## Change
- Drop `SearchScopeChip` (and the imports only it used: `ChevronDown`, `Popover*`, `classNames`) from `search-scope.tsx`.
- Drop it from the barrel; **keep `SCOPES` / `SearchScope`**.
- Rebuild + commit `packages/ui-kit/dist` (`index.js` / `index.cjs`) since CI diffs it against a fresh build. `dist/index.css` is unchanged (its only local churn was line endings).

**No consumer changes and no rendered output changes** — the component had no call sites, so nothing that renders today is affected (no screenshot table applies).

## Testing
`typecheck` (ui-kit + apps/ui) clean · `apps/ui` 1044 tests pass · `ui-kit` 82 tests pass · `lint`/`format` clean.

Closes #6378
