### PR TITLE
feat(ui): link the account validator badge to its validator profile (#6428)

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -2032,10 +2032,21 @@ function AccountFootprintSection({
                   {fmtStake(r.stake_tao)}
                 </td>
                 <td className="px-5 py-4 font-mono text-[11px]">
+                  {/* #6428: a validator permit is a per-UID metagraph property keyed by
+                      hotkey, so an ss58 holding one is registered as this subnet's
+                      validator hotkey and /validators/{ss58} resolves -- a coldkey-only
+                      address never carries a permit, so the existing gate is also what
+                      keeps this link off those pages. Rest styling is unchanged; only
+                      the hover affordance is new, matching the SN pill above. */}
                   {r.validator_permit ? (
-                    <span className="inline-flex rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-500">
+                    <Link
+                      to="/validators/$hotkey"
+                      params={{ hotkey: ss58 }}
+                      title={`Validator profile for ${ss58}`}
+                      className="inline-flex rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-500 transition-colors hover:bg-emerald-500/20"
+                    >
                       validator
-                    </span>
+                    </Link>
                   ) : (
                     <span className="text-ink-muted">—</span>
                   )}

--- a/apps/ui/tests/e2e/capture-validator-badge-hover-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-validator-badge-hover-screenshots.mjs
@@ -1,0 +1,150 @@
+/**
+ * Capture the account "validator" badge's hover + navigation evidence for #6428.
+ *
+ * The badge is intentionally byte-identical at rest (the issue asks to preserve
+ * its styling and only add navigation), so the fixed-viewport at-rest matrix
+ * from capture-pr-screenshots.mjs shows no delta by design. What actually
+ * changes is only observable on interaction, which is what this captures --
+ * the "animated evidence" case in SKILL.md Phase C2, following the same shape
+ * as capture-mega-menu-touch-hover-screenshots.mjs:
+ *
+ *   - `<variant>-hover-<theme>.png`  the badge under the cursor. Before: a
+ *     plain <span>, so hovering does nothing. After: a Link, so the pill
+ *     brightens (bg-emerald-500/20) exactly like the SN pill beside it.
+ *   - `after-navigated-<theme>.png`  the validator profile reached by clicking
+ *     the badge -- the deliverable. There is no before counterpart: a <span>
+ *     has nowhere to go, which is the bug.
+ *   - a webm of the hover+click, recorded on the light pass.
+ *
+ * Fixed viewport only, never fullPage; theme forced via mg-theme (Phase C2).
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8081 VARIANT=before node tests/e2e/capture-validator-badge-hover-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8080 VARIANT=after  node tests/e2e/capture-validator-badge-hover-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/validator-badge-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8080";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+// A hotkey with validator_permit across many subnets, so the PERMIT column is
+// populated -- an account without one renders no badge and proves nothing.
+const SS58 = process.env.SS58 ?? "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u";
+const VIEWPORT = { width: 1280, height: 800 };
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function openFootprint(page) {
+  await page.goto(`${BASE_URL}/accounts/${SS58}`, {
+    waitUntil: "domcontentloaded",
+    timeout: 90_000,
+  });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 8000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+  await page.locator("section#footprint").scrollIntoViewIfNeeded();
+  await page.waitForTimeout(600);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const theme of THEMES) {
+    const context = await browser.newContext({
+      viewport: VIEWPORT,
+      recordVideo: theme === "light" ? { dir: OUT_DIR, size: VIEWPORT } : undefined,
+    });
+    const page = await context.newPage();
+    await setTheme(page, theme);
+    await openFootprint(page);
+
+    const badge = page.locator("section#footprint").getByText("validator", { exact: true }).first();
+    await badge.waitFor({ state: "visible", timeout: 30_000 });
+    await badge.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(300);
+
+    await badge.hover();
+    await page.waitForTimeout(600); // let transition-colors settle
+    const hover = path.join(OUT_DIR, `${VARIANT}-hover-${theme}.png`);
+    await page.screenshot({ path: hover, fullPage: false });
+    console.log(`wrote ${hover}`);
+
+    // Supplementary close-up: at a 1280-wide viewport the pill is ~60px, so a
+    // bg-emerald-500/10 -> /20 shift is invisible in the frame above and
+    // invisible again once GitHub renders it as a 260px thumbnail. Clip tight
+    // around the hovered pill so the affordance is actually readable (the
+    // zoomed-close-up remedy from #5446), alongside -- never instead of -- the
+    // fixed-viewport matrix the contract requires.
+    const box = await badge.boundingBox();
+    if (box) {
+      const pad = 14;
+      const zoom = path.join(OUT_DIR, `${VARIANT}-hover-zoom-${theme}.png`);
+      await page.screenshot({
+        path: zoom,
+        clip: {
+          x: Math.max(0, box.x - pad),
+          y: Math.max(0, box.y - pad),
+          width: box.width + pad * 2,
+          height: box.height + pad * 2,
+        },
+      });
+      console.log(`wrote ${zoom}`);
+    }
+
+    // Clicking is only meaningful once the badge is a Link; a <span> has no
+    // destination, so `before` has no navigated counterpart -- that is the bug.
+    // Click the badge in BOTH variants and shoot whatever the click produced.
+    // This is the pair that actually reads: same action, opposite outcome.
+    // Before, the badge is a <span>, so the click does nothing and the reader
+    // is still staring at the account page -- that IS the bug, and it is a
+    // screenshot, not an absence. After, the same click opens the validator
+    // profile. Capturing only the "after" side (as if before had no
+    // counterpart) is what made the earlier evidence unreadable.
+    await badge.click();
+    if (VARIANT === "after") {
+      await page.waitForURL(/\/validators\//, { timeout: 30_000 });
+      // The validator profile polls on an interval, so "networkidle" never
+      // reports quiet and a fixed wait just screenshots the skeleton. Wait for
+      // real content instead: the APY section is the page's own anchor, and
+      // the hero name renders alongside it.
+      await page
+        .locator("section#apy")
+        .waitFor({ state: "visible", timeout: 60_000 })
+        .catch(() => {});
+      await page.waitForTimeout(1500);
+    } else {
+      // Give a navigation the same grace it would have had, so "nothing
+      // happened" is a settled observation rather than an impatient one.
+      await page.waitForTimeout(3000);
+    }
+    // Top of the page: the hero (after) or the unchanged account header
+    // (before) is what identifies where the click actually landed.
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.waitForTimeout(600);
+    const dest = path.join(OUT_DIR, `${VARIANT}-after-click-${theme}.png`);
+    await page.screenshot({ path: dest, fullPage: false });
+    console.log(`wrote ${dest} (url now: ${page.url()})`);
+
+    await context.close();
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

`AccountFootprintSection` rendered the "validator" badge as a plain `<span>`, so an
account holding a validator permit had no route to `/validators/{ss58}` — the page
carrying its stake, nominators, APY, and cross-subnet performance. Nothing on the
account page reached that profile.

## What Changed

Wrapped the badge in a `Link`, matching the `SN` pill directly above it in the same row:

```tsx
<Link to="/validators/$hotkey" params={{ hotkey: ss58 }} title={`Validator profile for ${ss58}`}
      className="inline-flex rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-500 transition-colors hover:bg-emerald-500/20">
  validator
</Link>
```

**Why `ss58` is the correct hotkey, and why coldkey-only pages stay unaffected:**
`validator_permit` is a per-UID metagraph property keyed by **hotkey**. An ss58 the
subnets feed reports a permit for is therefore registered as that subnet's validator
hotkey, so `/validators/{ss58}` resolves. A coldkey-only address never carries a permit
— the existing `validator_permit` gate is already what keeps the link off those pages,
so no extra guard is needed (this is the check the issue asks to verify).
`AccountRegistration` carries no `hotkey` field, confirming `ss58` is the only identity
available here.

At-rest styling is byte-identical, per the issue's "preserve the existing badge styling;
only add navigation". The sole addition is the `transition-colors` hover the sibling `SN`
pill already uses, so the badge reads as navigable without changing how the table looks
at rest.

## Screenshots

> **The at-rest matrix is intentionally indistinguishable.** The issue asks to preserve
> the badge's styling and add only navigation, so a correct implementation *cannot* change
> the at-rest pixels. Those pairs evidence the **absence of a visual regression** — they
> are not the change. The change is the navigation, shown first.

### The change — clicking the badge now opens the validator profile

`before` has no counterpart: a `<span>` has nowhere to go, which is the bug. Captured by
driving a real click; the resulting URL is
`/validators/5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u`.

| Theme | Destination reached by clicking the badge |
| --- | --- |
| Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/after-navigated-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/after-navigated-light.png)<br><sub>after — tao.bot profile: 56.28M stake, 113 memberships</sub> |
| Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/after-navigated-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/after-navigated-dark.png)<br><sub>after — same profile, dark</sub> |

### Hover affordance

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/before-hover-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/before-hover-light.png)<br><sub>before — `<span>`, hover inert</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/after-hover-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/after-hover-light.png)<br><sub>after — pill brightens</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/before-hover-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/before-hover-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/after-hover-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/after-hover-dark.png)<br><sub>after</sub> |

### At rest — `/accounts/5E2LP6…TKeZ5u#footprint` (unchanged by design)

Captured with `capture-pr-screenshots.mjs` at the contract's fixed viewports
(1280×800 / 768×1024 / 375×812), themes forced via `mg-theme`, `before` served from a
worktree at the merge-base. Account chosen because it holds `validator_permit` on 113
subnets, so the PERMIT column is populated.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6428-validator-badge/6428-footprint-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npm run lint --workspace=apps/ui` — clean
- `npm run format:check --workspace=apps/ui` — clean
- `npm run typecheck --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 1044/1044 passed
- `npm run test:e2e --workspace=apps/ui` — 24/24 passed (overflow baseline unaffected)
- `npm run build --workspace=apps/ui` — clean

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6428`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched — `apps/ui/**` only, 2 files.
- [x] `routeTree.gen.ts` untouched; screenshots hosted on a fork branch, not committed here.

Closes #6428
