### PR TITLE
fix(chain-firehose-relay): fix rate-limit thundering-herd incident, add Sentry

### DIFF
--- a/deploy/chain-firehose-relay.Dockerfile
+++ b/deploy/chain-firehose-relay.Dockerfile
@@ -20,10 +20,11 @@ FROM node:22.23.1-alpine
 RUN adduser -D -u 10001 relay
 WORKDIR /app
 
-# Single pinned dependency (matches the root package.json's own postgres.js
-# pin, the same driver workers/data-api.mjs uses) -- never auto-pull a future
-# release independently of the rest of the repo.
-RUN npm install --no-audit --no-fund postgres@3.4.9
+# Pinned dependencies (postgres.js matches the root package.json's own pin,
+# the same driver workers/data-api.mjs uses) -- never auto-pull a future
+# release independently of the rest of the repo. @sentry/node also matches
+# the root package.json pin.
+RUN npm install --no-audit --no-fund postgres@3.4.9 @sentry/node@10.66.0
 
 COPY scripts/chain-firehose-relay.mjs ./scripts/chain-firehose-relay.mjs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "dependencies": {
         "@duckdb/node-api": "^1.5.4-r.1",
         "@noble/hashes": "^2.2.0",
+        "@sentry/node": "^10.66.0",
         "graphql": "^17.0.2",
         "graphql-ws": "^6.1.0",
         "postgres": "^3.4.9",
@@ -566,6 +567,58 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.0.tgz",
+      "integrity": "sha512-aN3Oq8r1J3gPJtCwErP664gM0+HhM1I1lujPr9TMTCcEl/joQQbpGpeMdts9B1+W2wHMsvioDMv5F4PvMWE6gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.6.2.tgz",
+      "integrity": "sha512-5vBrtIEL+UVbO0YWWoyYG4QMgR+ZfnIL3xlteIkAmU7YaAPhc28k3md/NM14tnkfXKjKOn9yUzEA9AYUmNpvJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3015,6 +3068,119 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@orama/orama": {
@@ -5803,6 +5969,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@sentry/core": {
       "version": "10.63.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.63.0.tgz",
@@ -5819,6 +5994,119 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/core": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.66.0.tgz",
+      "integrity": "sha512-5Ow7iQiRjaSaEOmqEIkYV368hFFzShIZCXPoj+wX3JtOmKFrsNu6lr8/VJlQs7cyjFS6tzE50PrLrD8iAPS/8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0",
+        "@sentry/node-core": "10.66.0",
+        "@sentry/opentelemetry": "10.66.0",
+        "@sentry/server-utils": "10.66.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.66.0.tgz",
+      "integrity": "sha512-SUnXHROqSdSetKgZC1goDEKCuMz3OmQ1h4rxzWeexLyqan+pensZXfLouP6jzZXlA8e/HP7uQg78LnfqYDcZlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0",
+        "@sentry/opentelemetry": "10.66.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/node-core/node_modules/@sentry/core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.66.0.tgz",
+      "integrity": "sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.66.0.tgz",
+      "integrity": "sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.66.0.tgz",
+      "integrity": "sha512-K5Y9IettN9yIOnpqCs40HRLGqaGUoaQ50+ZsLqX2kPCk3TzJVpKZ9icKwaJ4Nxm72QgGVT5Ovfr/9FXbgd3b/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/opentelemetry/node_modules/@sentry/core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.66.0.tgz",
+      "integrity": "sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
       },
       "engines": {
         "node": ">=18"
@@ -5845,6 +6133,34 @@
       "dependencies": {
         "@sentry/core": "10.63.0",
         "@sentry/replay": "10.63.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.66.0.tgz",
+      "integrity": "sha512-h9EM9Wz9Mc6w2Vn7Fyh6ozjy4JC2UbUvWf9Ra1HYA4KMeYqjFA5/o0oB4pg4w/TF+rb+9OF/HNqxjuczxpudpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.6.1",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/server-utils/node_modules/@sentry/core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.66.0.tgz",
+      "integrity": "sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
       },
       "engines": {
         "node": ">=18"
@@ -8160,6 +8476,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -8665,10 +8987,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "dev": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "license": "MIT"
     },
     "node_modules/esast-util-from-estree": {
@@ -8979,7 +9300,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -9005,7 +9325,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -10128,6 +10447,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.1.tgz",
+      "integrity": "sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -11238,6 +11571,15 @@
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "license": "MIT"
     },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/meros": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/meros/-/meros-1.3.2.tgz",
@@ -12038,6 +12380,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/motion": {
       "version": "12.42.2",
@@ -13280,6 +13628,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
@@ -13433,6 +13794,12 @@
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
+    },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
     },
     "node_modules/semver": {
       "version": "7.8.5",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
   "dependencies": {
     "@duckdb/node-api": "^1.5.4-r.1",
     "@noble/hashes": "^2.2.0",
+    "@sentry/node": "^10.66.0",
     "graphql": "^17.0.2",
     "graphql-ws": "^6.1.0",
     "postgres": "^3.4.9",

--- a/scripts/chain-firehose-relay.mjs
+++ b/scripts/chain-firehose-relay.mjs
@@ -34,6 +34,86 @@
 //      CHAIN_FIREHOSE_SYNC_SECRET=... node scripts/chain-firehose-relay.mjs
 
 import postgres from "postgres";
+import * as Sentry from "@sentry/node";
+
+// Reports to the consolidated `metagraphed` Sentry project. Silently no-ops
+// if SENTRY_DSN is unset, matching this relay's own best-effort design.
+//
+// Deliberately NOT one captureMessage per dropped payload -- a real 2026-07
+// incident (a rate-limit thundering-herd loop this same fix addresses) hit
+// millions of drops over ~40 hours; naive per-drop capture would have blown
+// through the free-tier event quota in minutes and then been silently
+// SAMPLED AWAY by Sentry itself, hiding the incident rather than surfacing
+// it -- the opposite of the point. computeDropWindowUpdate() below (called
+// from main()'s poll loop, which owns the actual Sentry.captureMessage call)
+// aggregates instead: one event per CHAIN_FIREHOSE_DROP_REPORT_THRESHOLD
+// drops accumulated, or after CHAIN_FIREHOSE_DROP_REPORT_INTERVAL_MS of any
+// nonzero drop rate, whichever comes first (so a persistent-but-low-volume
+// problem is never silent forever either) -- the same "escalate
+// periodically, don't spam" shape as roles/validator-ops/watchdog.py's own
+// re-alert logic in metagraphed-infra. Exported for direct testing rather
+// than only indirectly via main()'s own /* v8 ignore */ boundary.
+export function initSentry() {
+  const dsn = process.env.SENTRY_DSN;
+  if (!dsn) return;
+  Sentry.init({
+    dsn,
+    environment: process.env.SENTRY_ENVIRONMENT || "production",
+    release: process.env.SENTRY_RELEASE, // deployed git SHA
+    tracesSampleRate: 0,
+  });
+  Sentry.setTag("component", "chain-firehose-relay");
+}
+
+export const CHAIN_FIREHOSE_DROP_REPORT_THRESHOLD = 500;
+export const CHAIN_FIREHOSE_DROP_REPORT_INTERVAL_MS = 5 * 60 * 1000;
+
+// Pure state-transition function: given the current drop-reporting window
+// (or null, before any drops this run) and a new batch's drop count, returns
+// whether the window's count/time threshold is now crossed and what the next
+// window state should be. Deliberately holds NO module-level mutable state
+// itself (unlike an earlier draft of this function) -- main()'s poll loop
+// owns the actual `dropWindow` variable in its own closure (the same
+// pattern it already uses for `lastCleanupAt`/`shuttingDown`), and is the
+// only caller that actually invokes Sentry.captureMessage when `report` is
+// true. That split is what makes this fully pure and testable with plain
+// input/output assertions, no Sentry mocking or test-order dependence
+// needed -- module-level mutable state here would leak between unit tests
+// unless every test carefully reset it first, which is exactly the bug this
+// design avoids.
+export function computeDropWindowUpdate(
+  window,
+  count,
+  lastStatus,
+  now = Date.now(),
+) {
+  const startedAt = window?.startedAt ?? now;
+  const totalCount = (window?.count ?? 0) + count;
+  const elapsedMs = now - startedAt;
+  const report =
+    totalCount >= CHAIN_FIREHOSE_DROP_REPORT_THRESHOLD ||
+    elapsedMs >= CHAIN_FIREHOSE_DROP_REPORT_INTERVAL_MS;
+  return {
+    report,
+    count: totalCount,
+    elapsedMs,
+    lastStatus,
+    // null (not a zeroed window) once reported -- the NEXT drop starts a
+    // fresh window from scratch, matching "resets after reporting."
+    nextWindow: report ? null : { startedAt, count: totalCount },
+  };
+}
+
+// A rate-limit pause is naturally low-frequency (each pause is itself at
+// least tens of seconds long -- see CHAIN_FIREHOSE_DEFAULT_RATE_LIMIT_PAUSE_MS),
+// so unlike drops this is safe to capture directly, one event per pause,
+// with no separate aggregation window needed.
+export function reportRateLimitPause(pauseMs) {
+  Sentry.captureMessage(
+    `chain-firehose-relay: rate limited by the ingest endpoint, pausing ${pauseMs}ms`,
+    { level: "warning", extra: { pauseMs } },
+  );
+}
 
 export const CHAIN_FIREHOSE_INGEST_TOKEN_HEADER = "x-chain-firehose-sync-token";
 export const DEFAULT_CHAIN_FIREHOSE_INGEST_URL =
@@ -139,11 +219,44 @@ export function computeBackoffDelayMs(
   return Math.min(baseMs * 2 ** attempt, maxMs);
 }
 
+// Ceiling on how long a single retry-after value can pause the relay for --
+// protects against a pathological/misconfigured server value stalling the
+// relay indefinitely (a real incident's own root cause was the OPPOSITE
+// problem -- not respecting retry-after at all -- but an unbounded value
+// would just trade one outage shape for another).
+export const CHAIN_FIREHOSE_MAX_RATE_LIMIT_PAUSE_MS = 5 * 60 * 1000;
+// Used when a 429 response has no (or an unparseable) retry-after header --
+// generous over the ingest endpoint's own 60s rate-limit window
+// (CHAIN_FIREHOSE_INGEST_RATE_LIMIT in workers/api.mjs) so a fallback pause
+// still clears the window rather than immediately re-triggering it.
+export const CHAIN_FIREHOSE_DEFAULT_RATE_LIMIT_PAUSE_MS = 65 * 1000;
+
+// Parses a standard `retry-after` header (either an integer number of
+// seconds, or an HTTP-date) into a millisecond delay from now. Returns null
+// if absent or unparseable -- callers fall back to
+// CHAIN_FIREHOSE_DEFAULT_RATE_LIMIT_PAUSE_MS in that case, never to zero
+// (silently not backing off at all was the actual root cause of a real
+// 2026-07 incident: 429s were retried with the same short generic backoff
+// as any other failure, so the relay kept re-triggering the same rate limit
+// indefinitely instead of ever recovering).
+export function parseRetryAfterMs(headerValue) {
+  if (!headerValue) return null;
+  const seconds = Number(headerValue);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const dateMs = Date.parse(headerValue);
+  if (Number.isFinite(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+  return null;
+}
+
 // Forwards one payload to the hub's ingest endpoint. `fetchImpl` is injected
 // so this is testable without a real network call -- the poll loop below is
 // the only caller in production. `payload` is the JSON-serialized string
 // body, not the parsed object (the caller stringifies chain_firehose_outbox's
-// already-parsed JSONB column once, up front).
+// already-parsed JSONB column once, up front). retryAfterMs is only present
+// on the result when the response actually carried a retry-after header
+// (i.e. never on a 2xx) -- keeps the common-case return shape unchanged.
 export async function forwardChainFirehoseNotification(
   payload,
   { ingestUrl, syncSecret },
@@ -164,7 +277,14 @@ export async function forwardChainFirehoseNotification(
       body: payload,
       signal: abortController.signal,
     });
-    const result = { ok: response.ok, status: response.status };
+    const retryAfterMs = parseRetryAfterMs(
+      response.headers?.get?.("retry-after"),
+    );
+    const result = {
+      ok: response.ok,
+      status: response.status,
+      ...(retryAfterMs !== null && { retryAfterMs }),
+    };
     await response.body?.cancel();
     return result;
   } finally {
@@ -175,7 +295,12 @@ export async function forwardChainFirehoseNotification(
 // Forwards one payload with bounded retry/backoff. Returns true if the
 // payload was forwarded successfully, false if it was dropped after
 // exhausting CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS -- never throws (a
-// forwarding failure must never crash the relay's poll loop).
+// forwarding failure must never crash the relay's poll loop). onRateLimited
+// (new) fires with the pause duration whenever a 429 is seen, independent of
+// whether this particular payload eventually succeeds or gets dropped --
+// forwardBatch uses it to pause the WHOLE poll loop, not just this one row's
+// own retries, which is the actual fix for the thundering-herd failure mode
+// (see forwardBatch's own comment).
 export async function forwardWithRetry(
   payload,
   config,
@@ -183,15 +308,18 @@ export async function forwardWithRetry(
     fetchImpl = fetch,
     sleepImpl = (ms) => new Promise((r) => setTimeout(r, ms)),
     onDrop,
+    onRateLimited,
   } = {},
 ) {
+  let result;
   for (
     let attempt = 0;
     attempt < CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS;
     attempt += 1
   ) {
+    result = undefined; // reset per attempt -- a thrown network error must not let a PRIOR attempt's stale status leak into this one's 429 check below
     try {
-      const result = await forwardChainFirehoseNotification(
+      result = await forwardChainFirehoseNotification(
         payload,
         config,
         fetchImpl,
@@ -200,11 +328,32 @@ export async function forwardWithRetry(
     } catch {
       // network error -- fall through to retry/backoff below
     }
+    if (result?.status === 429) {
+      const pauseMs = Math.min(
+        result.retryAfterMs ?? CHAIN_FIREHOSE_DEFAULT_RATE_LIMIT_PAUSE_MS,
+        CHAIN_FIREHOSE_MAX_RATE_LIMIT_PAUSE_MS,
+      );
+      onRateLimited?.(pauseMs);
+      // Do NOT also apply the generic exponential backoff below -- a 429
+      // means "you are over the limit right now," not "this one request
+      // had a transient blip." Retrying again within the same rate-limit
+      // window (which the generic 500ms/1s backoff would do) just adds
+      // another rejected request, never recovers anything.
+      if (attempt < CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS - 1) {
+        await sleepImpl(pauseMs);
+      }
+      continue;
+    }
     if (attempt < CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS - 1) {
       await sleepImpl(computeBackoffDelayMs(attempt));
     }
   }
-  onDrop?.(payload);
+  // lastStatus is the last-observed HTTP status across all attempts (undefined
+  // if every attempt threw a network error rather than getting a response) --
+  // extra context for onDrop's aggregate reporting, not part of the original
+  // (payload)-only contract, so existing callers that ignore the second
+  // argument are unaffected.
+  onDrop?.(payload, result?.status);
   return false;
 }
 
@@ -214,14 +363,37 @@ export async function forwardWithRetry(
 // caller's UPDATE ... RETURNING before this runs -- forwarding failure after
 // exhausting retries still counts as "handled" (best-effort, not
 // at-least-once, same as the old design), not re-queued.
+//
+// rateLimitedForMs (new): the MAX pause duration reported by any row in this
+// batch, if any hit a 429 -- the caller (main()'s poll loop) sleeps this long
+// before its NEXT poll rather than immediately re-claiming a fresh batch and
+// firing CHAIN_FIREHOSE_FORWARD_CONCURRENCY more requests straight into the
+// same rate limit. This is the actual fix for the real 2026-07 incident: 16
+// concurrent requests times however many batches per second the old
+// immediate-reloop behavior fired is trivially over the ingest endpoint's
+// own 120-req/60s limit the moment there's any real backlog, and every prior
+// design only backed off PER ROW, never paused the batch/poll level that was
+// the true source of the overload.
 export async function forwardBatch(rows, config, options = {}) {
+  let rateLimitedForMs = 0;
   const results = await mapBounded(
     rows,
     CHAIN_FIREHOSE_FORWARD_CONCURRENCY,
-    (row) => forwardWithRetry(JSON.stringify(row.payload), config, options),
+    (row) =>
+      forwardWithRetry(JSON.stringify(row.payload), config, {
+        ...options,
+        onRateLimited: (pauseMs) => {
+          rateLimitedForMs = Math.max(rateLimitedForMs, pauseMs);
+          options.onRateLimited?.(pauseMs);
+        },
+      }),
   );
   const forwarded = results.filter(Boolean).length;
-  return { forwarded, dropped: results.length - forwarded };
+  return {
+    forwarded,
+    dropped: results.length - forwarded,
+    ...(rateLimitedForMs > 0 && { rateLimitedForMs }),
+  };
 }
 
 /* v8 ignore start -- the long-running poll/cleanup loop needs a real
@@ -234,9 +406,11 @@ export async function forwardBatch(rows, config, options = {}) {
    tested via `node --test` instead) -- see that config's own comment for the
    convention. */
 async function main() {
+  initSentry();
   const config = parseRelayConfig(process.env);
   const sql = postgres(config.databaseUrl);
   let shuttingDown = false;
+  let dropWindow = null; // owned here, not module-level -- see computeDropWindowUpdate's own comment
 
   const shutdown = async () => {
     shuttingDown = true;
@@ -248,7 +422,10 @@ async function main() {
   // UPDATE ... RETURNING (SKIP LOCKED so a concurrently-running second relay
   // instance -- a brief overlap during a redeploy -- claims disjoint rows
   // instead of racing on the same ones), stamping delivered_at as the claim
-  // marker before any HTTP forwarding happens.
+  // marker before any HTTP forwarding happens. Returns the pause duration
+  // (ms) the caller should sleep before the NEXT poll if this batch hit the
+  // ingest endpoint's rate limit -- see forwardBatch's own comment for why
+  // this is the actual fix, not just per-row retry backoff.
   async function pollOnce() {
     const rows = await sql`
       UPDATE chain_firehose_outbox
@@ -261,14 +438,43 @@ async function main() {
         FOR UPDATE SKIP LOCKED
       )
       RETURNING id, payload`;
-    if (rows.length === 0) return 0;
-    await forwardBatch(rows, config, {
-      onDrop: () =>
-        console.error(
-          `[chain-firehose-relay] dropped a payload after ${CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS} attempts`,
-        ),
+    if (rows.length === 0) return { claimed: 0, rateLimitedForMs: 0 };
+    let droppedInBatch = 0;
+    let lastDropStatus;
+    const result = await forwardBatch(rows, config, {
+      onDrop: (_payload, status) => {
+        droppedInBatch += 1;
+        lastDropStatus = status;
+      },
     });
-    return rows.length;
+    if (droppedInBatch > 0) {
+      console.error(
+        `[chain-firehose-relay] dropped ${droppedInBatch}/${rows.length} payloads this batch after ${CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS} attempts each (last status: ${lastDropStatus ?? "network error"})`,
+      );
+      const update = computeDropWindowUpdate(
+        dropWindow,
+        droppedInBatch,
+        lastDropStatus,
+      );
+      dropWindow = update.nextWindow;
+      if (update.report) {
+        Sentry.captureMessage(
+          `chain-firehose-relay: ${update.count} payload(s) dropped in the last ${Math.round(update.elapsedMs / 1000)}s (last status: ${update.lastStatus ?? "network error"})`,
+          {
+            level: "warning",
+            extra: {
+              count: update.count,
+              lastStatus: update.lastStatus,
+              windowMs: update.elapsedMs,
+            },
+          },
+        );
+      }
+    }
+    return {
+      claimed: rows.length,
+      rateLimitedForMs: result.rateLimitedForMs ?? 0,
+    };
   }
 
   async function cleanupOnce() {
@@ -284,26 +490,45 @@ async function main() {
     `[chain-firehose-relay] polling chain_firehose_outbox every ${CHAIN_FIREHOSE_POLL_INTERVAL_MS}ms, forwarding to ${config.ingestUrl}`,
   );
   while (!shuttingDown) {
-    const claimed = await pollOnce();
+    const { claimed, rateLimitedForMs } = await pollOnce();
     if (Date.now() - lastCleanupAt >= CHAIN_FIREHOSE_CLEANUP_INTERVAL_MS) {
       await cleanupOnce();
       lastCleanupAt = Date.now();
     }
-    if (claimed === 0) {
+    if (rateLimitedForMs > 0) {
+      // The actual fix for the real 2026-07 incident: pause the WHOLE poll
+      // loop for the ingest endpoint's own stated recovery window instead of
+      // immediately claiming and firing another CHAIN_FIREHOSE_FORWARD_CONCURRENCY
+      // batch straight into the same rate limit. Reported once per pause
+      // (not per dropped row -- see reportRateLimitPause's own comment) so
+      // this is visible without becoming its own flood.
+      console.error(
+        `[chain-firehose-relay] rate limited by the ingest endpoint -- pausing ${rateLimitedForMs}ms before the next poll`,
+      );
+      reportRateLimitPause(rateLimitedForMs);
+      await new Promise((resolve) => setTimeout(resolve, rateLimitedForMs));
+    } else if (claimed === 0) {
       await new Promise((resolve) =>
         setTimeout(resolve, CHAIN_FIREHOSE_POLL_INTERVAL_MS),
       );
     }
-    // claimed > 0: loop again immediately to drain a backlog faster than
-    // one CHAIN_FIREHOSE_POLL_INTERVAL_MS per batch would.
+    // claimed > 0 and not rate limited: loop again immediately to drain a
+    // backlog faster than one CHAIN_FIREHOSE_POLL_INTERVAL_MS per batch would.
   }
   await sql.end({ timeout: 5 });
   process.exit(0);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((error) => {
+  main().catch(async (error) => {
     console.error("[chain-firehose-relay] fatal:", error);
+    // Explicitly caught here, so @sentry/node's default
+    // OnUnhandledRejection integration never sees this -- Node does not
+    // consider a promise "unhandled" once something calls .catch() on it.
+    // flush() before process.exit(1) is required: process.exit() is
+    // synchronous and does not wait for Sentry's background network send.
+    Sentry.captureException(error);
+    await Sentry.flush(2000);
     process.exit(1);
   });
 }

--- a/tests/chain-firehose-relay.test.mjs
+++ b/tests/chain-firehose-relay.test.mjs
@@ -7,18 +7,47 @@
 // directly here instead.
 import assert from "node:assert/strict";
 import { test, vi } from "vitest";
+
+// Hoisted spies -- mocked the same way apps/ui/src/lib/error-reporting.test.ts
+// mocks @sentry/browser. reportRateLimitPause and main()'s own fatal catch
+// are the only two call sites that actually invoke Sentry directly in this
+// file; computeDropWindowUpdate is a pure state-transition function with no
+// Sentry dependency at all (main()'s poll loop is the one that calls
+// Sentry.captureMessage when it reports === true) -- see that function's own
+// comment for why it's deliberately NOT the one holding module-level state
+// or calling Sentry itself.
+const captureMessage = vi.hoisted(() => vi.fn());
+const captureException = vi.hoisted(() => vi.fn());
+const sentryInit = vi.hoisted(() => vi.fn());
+const setTag = vi.hoisted(() => vi.fn());
+vi.mock("@sentry/node", () => ({
+  init: sentryInit,
+  setTag,
+  captureMessage,
+  captureException,
+  flush: vi.fn(async () => true),
+}));
+
 import {
   CHAIN_FIREHOSE_BACKOFF_BASE_MS,
   CHAIN_FIREHOSE_BACKOFF_MAX_MS,
+  CHAIN_FIREHOSE_DEFAULT_RATE_LIMIT_PAUSE_MS,
+  CHAIN_FIREHOSE_DROP_REPORT_INTERVAL_MS,
+  CHAIN_FIREHOSE_DROP_REPORT_THRESHOLD,
   CHAIN_FIREHOSE_FORWARD_TIMEOUT_MS,
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
   CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS,
+  CHAIN_FIREHOSE_MAX_RATE_LIMIT_PAUSE_MS,
   computeBackoffDelayMs,
+  computeDropWindowUpdate,
   forwardBatch,
   forwardChainFirehoseNotification,
   forwardWithRetry,
+  initSentry,
   mapBounded,
   parseRelayConfig,
+  parseRetryAfterMs,
+  reportRateLimitPause,
 } from "../scripts/chain-firehose-relay.mjs";
 
 // --- mapBounded ---------------------------------------------------------------
@@ -332,4 +361,360 @@ test("forwardBatch: counts a row dropped after exhausting retries separately fro
 test("forwardBatch: an empty batch forwards nothing and drops nothing", async () => {
   const result = await forwardBatch([], { ingestUrl: "u", syncSecret: "s" });
   assert.deepEqual(result, { forwarded: 0, dropped: 0 });
+});
+
+// --- parseRetryAfterMs -------------------------------------------------------
+// Real 2026-07 incident regression coverage: the relay's own rate-limit
+// backoff is only as correct as this parsing.
+
+test("parseRetryAfterMs: a plain integer-seconds header", () => {
+  assert.equal(parseRetryAfterMs("60"), 60_000);
+  assert.equal(parseRetryAfterMs("0"), 0);
+});
+
+test("parseRetryAfterMs: an HTTP-date header resolves to a future-relative delay", () => {
+  const future = new Date(Date.now() + 30_000).toUTCString();
+  const ms = parseRetryAfterMs(future);
+  // Allow slop for wall-clock time elapsed between Date.now() above and the
+  // parse itself -- assert it's in the right ballpark, not an exact ms match.
+  assert.ok(ms > 25_000 && ms <= 30_000, `expected ~30000, got ${ms}`);
+});
+
+test("parseRetryAfterMs: a past HTTP-date clamps to 0, never negative", () => {
+  const past = new Date(Date.now() - 30_000).toUTCString();
+  assert.equal(parseRetryAfterMs(past), 0);
+});
+
+test("parseRetryAfterMs: absent or unparseable input returns null", () => {
+  assert.equal(parseRetryAfterMs(undefined), null);
+  assert.equal(parseRetryAfterMs(""), null);
+  assert.equal(parseRetryAfterMs("not-a-header-value"), null);
+});
+
+// --- forwardChainFirehoseNotification: retry-after surfacing ----------------
+
+test("forwardChainFirehoseNotification: surfaces retryAfterMs when the response carries the header", async () => {
+  const result = await forwardChainFirehoseNotification(
+    "{}",
+    { ingestUrl: "https://hub.example.com/ingest", syncSecret: "shh" },
+    async () =>
+      new Response("{}", { status: 429, headers: { "retry-after": "60" } }),
+  );
+  assert.equal(result.status, 429);
+  assert.equal(result.retryAfterMs, 60_000);
+});
+
+test("forwardChainFirehoseNotification: no retryAfterMs key at all on a normal 2xx (unchanged return shape)", async () => {
+  const result = await forwardChainFirehoseNotification(
+    "{}",
+    { ingestUrl: "https://hub.example.com/ingest", syncSecret: "shh" },
+    async () => new Response("{}", { status: 202 }),
+  );
+  assert.deepEqual(result, { ok: true, status: 202 });
+  assert.equal("retryAfterMs" in result, false);
+});
+
+// --- forwardWithRetry: 429 handling (the real incident's actual fix) --------
+
+test("forwardWithRetry: a 429 uses retry-after for the pause, NOT the generic exponential backoff", async () => {
+  let calls = 0;
+  const sleeps = [];
+  const ok = await forwardWithRetry(
+    "{}",
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async () => {
+        calls += 1;
+        return new Response("{}", {
+          status: calls < 3 ? 429 : 202,
+          headers: { "retry-after": "5" },
+        });
+      },
+      sleepImpl: async (ms) => sleeps.push(ms),
+    },
+  );
+  assert.equal(ok, true);
+  assert.equal(calls, 3);
+  // Two 429s before the success on attempt 3 -- both pauses must be the
+  // retry-after value (5000ms), never CHAIN_FIREHOSE_BACKOFF_BASE_MS (500ms)
+  // or CHAIN_FIREHOSE_BACKOFF_BASE_MS*2 (1000ms), which is what the generic
+  // exponential schedule would have produced for attempts 0 and 1.
+  assert.deepEqual(sleeps, [5000, 5000]);
+});
+
+test("forwardWithRetry: a 429 with no retry-after header falls back to CHAIN_FIREHOSE_DEFAULT_RATE_LIMIT_PAUSE_MS", async () => {
+  const sleeps = [];
+  await forwardWithRetry(
+    "{}",
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async () => new Response("{}", { status: 429 }),
+      sleepImpl: async (ms) => sleeps.push(ms),
+    },
+  );
+  assert.deepEqual(sleeps, [
+    CHAIN_FIREHOSE_DEFAULT_RATE_LIMIT_PAUSE_MS,
+    CHAIN_FIREHOSE_DEFAULT_RATE_LIMIT_PAUSE_MS,
+  ]);
+});
+
+test("forwardWithRetry: an absurd retry-after value is clamped to CHAIN_FIREHOSE_MAX_RATE_LIMIT_PAUSE_MS", async () => {
+  const sleeps = [];
+  await forwardWithRetry(
+    "{}",
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async () =>
+        new Response("{}", {
+          status: 429,
+          headers: { "retry-after": "999999" },
+        }),
+      sleepImpl: async (ms) => sleeps.push(ms),
+    },
+  );
+  assert.ok(
+    sleeps.every((ms) => ms === CHAIN_FIREHOSE_MAX_RATE_LIMIT_PAUSE_MS),
+  );
+});
+
+test("forwardWithRetry: calls onRateLimited on EVERY 429 attempt, including the final one that then drops", async () => {
+  // All 3 attempts (CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS) 429 here, including
+  // the last -- onRateLimited must still fire on that final attempt (only
+  // the actual sleepImpl pause is skipped there, a separate concern) so
+  // forwardBatch's caller learns about the rate limit even when a payload
+  // gets dropped rather than successfully retried.
+  const pauses = [];
+  const ok = await forwardWithRetry(
+    "{}",
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async () =>
+        new Response("{}", { status: 429, headers: { "retry-after": "5" } }),
+      sleepImpl: async () => {},
+      onRateLimited: (pauseMs) => pauses.push(pauseMs),
+    },
+  );
+  assert.equal(ok, false);
+  assert.deepEqual(pauses, [5000, 5000, 5000]);
+});
+
+test("forwardWithRetry: onDrop receives the last-observed status code as its second argument", async () => {
+  let lastStatus;
+  await forwardWithRetry(
+    "{}",
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async () => new Response("{}", { status: 503 }),
+      sleepImpl: async () => {},
+      onDrop: (_payload, status) => {
+        lastStatus = status;
+      },
+    },
+  );
+  assert.equal(lastStatus, 503);
+});
+
+test("forwardWithRetry: onDrop's status is undefined when every attempt threw (not a stale status from an earlier attempt)", async () => {
+  let statusArgWasPassed = true;
+  let lastStatus = "unset";
+  await forwardWithRetry(
+    "{}",
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async () => {
+        throw new Error("network down");
+      },
+      sleepImpl: async () => {},
+      onDrop: (_payload, status) => {
+        lastStatus = status;
+      },
+    },
+  );
+  assert.equal(lastStatus, undefined);
+  assert.equal(statusArgWasPassed, true);
+});
+
+test("forwardWithRetry: a 429 followed by a thrown network error does not leak the 429's stale status into the drop", async () => {
+  // Regression test for the exact scoping bug caught while building this fix:
+  // `result` must reset each attempt, or a later thrown-error attempt would
+  // incorrectly report the PRIOR attempt's 429 status via onDrop.
+  let calls = 0;
+  let lastStatus = "unset";
+  await forwardWithRetry(
+    "{}",
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async () => {
+        calls += 1;
+        if (calls === 1) return new Response("{}", { status: 429 });
+        throw new Error("network down");
+      },
+      sleepImpl: async () => {},
+      onDrop: (_payload, status) => {
+        lastStatus = status;
+      },
+    },
+  );
+  assert.equal(
+    lastStatus,
+    undefined,
+    "must be undefined (the last attempt threw), not 429 (a stale earlier attempt)",
+  );
+});
+
+// --- forwardBatch: rate-limit aggregation ------------------------------------
+
+test("forwardBatch: surfaces rateLimitedForMs as the MAX pause seen across the batch's rows", async () => {
+  const rows = [
+    { id: 1, payload: { table: "blocks", block_number: 1 } },
+    { id: 2, payload: { table: "blocks", block_number: 2 } },
+  ];
+  const result = await forwardBatch(
+    rows,
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async (_url, init) =>
+        new Response("{}", {
+          status: 429,
+          headers: {
+            "retry-after": init.body.includes('"block_number":1') ? "5" : "20",
+          },
+        }),
+      sleepImpl: async () => {},
+    },
+  );
+  assert.equal(result.rateLimitedForMs, 20_000);
+});
+
+test("forwardBatch: no rateLimitedForMs key at all when nothing was rate limited (unchanged return shape)", async () => {
+  const result = await forwardBatch(
+    [{ id: 1, payload: {} }],
+    { ingestUrl: "u", syncSecret: "s" },
+    { fetchImpl: async () => new Response("{}", { status: 202 }) },
+  );
+  assert.deepEqual(result, { forwarded: 1, dropped: 0 });
+  assert.equal("rateLimitedForMs" in result, false);
+});
+
+// --- computeDropWindowUpdate / reportRateLimitPause: aggregate reporting ----
+// The real incident this whole fix addresses hit millions of drops in ~40h;
+// naive per-drop capture would have blown the free-tier event quota in
+// minutes and then been silently sampled away by Sentry itself. These tests
+// assert the aggregation actually withholds a report below threshold, and
+// actually fires at it -- computeDropWindowUpdate itself is pure (no Sentry
+// call, no module-level state -- see its own comment), so no mocking is
+// needed here at all; only reportRateLimitPause below still calls Sentry
+// directly.
+
+test("computeDropWindowUpdate: does not report before the count threshold is reached", () => {
+  const update = computeDropWindowUpdate(
+    null,
+    CHAIN_FIREHOSE_DROP_REPORT_THRESHOLD - 1,
+    429,
+    1_000_000,
+  );
+  assert.equal(update.report, false);
+  assert.deepEqual(update.nextWindow, {
+    startedAt: 1_000_000,
+    count: CHAIN_FIREHOSE_DROP_REPORT_THRESHOLD - 1,
+  });
+});
+
+test("computeDropWindowUpdate: reports exactly when the accumulated count crosses the threshold, carrying the right context", () => {
+  const start = 2_000_000;
+  const first = computeDropWindowUpdate(
+    null,
+    CHAIN_FIREHOSE_DROP_REPORT_THRESHOLD - 10,
+    429,
+    start,
+  );
+  assert.equal(first.report, false);
+  const second = computeDropWindowUpdate(
+    first.nextWindow,
+    10,
+    429,
+    start + 1000,
+  );
+  assert.equal(second.report, true);
+  assert.equal(second.count, CHAIN_FIREHOSE_DROP_REPORT_THRESHOLD);
+  assert.equal(second.elapsedMs, 1000);
+  assert.equal(second.lastStatus, 429);
+  // nextWindow is null once reported -- the caller's NEXT drop starts a
+  // fresh window rather than continuing to accumulate past the threshold
+  // just reported.
+  assert.equal(second.nextWindow, null);
+});
+
+test("computeDropWindowUpdate: reports on the time threshold even if the count threshold is never reached (a persistent low-volume problem isn't silent forever)", () => {
+  const start = 3_000_000;
+  const first = computeDropWindowUpdate(null, 1, 500, start);
+  assert.equal(first.report, false);
+  const second = computeDropWindowUpdate(
+    first.nextWindow,
+    1,
+    500,
+    start + CHAIN_FIREHOSE_DROP_REPORT_INTERVAL_MS,
+  );
+  assert.equal(second.report, true);
+  assert.equal(second.count, 2);
+});
+
+test("computeDropWindowUpdate: two independent windows (null starting state each time) never leak state into one another", () => {
+  // Regression test for the actual bug caught while building this: an
+  // earlier draft held count/startedAt as module-level variables, which
+  // leaked between unrelated calls (and unrelated unit tests) unless
+  // something explicitly reset them. Passing `null` here must always mean
+  // "a genuinely fresh window," never a stale value from a prior call.
+  const windowA = computeDropWindowUpdate(null, 200, 500, 1_000_000).nextWindow;
+  const windowB = computeDropWindowUpdate(null, 50, 429, 5_000_000);
+  assert.equal(windowB.count, 50, "windowB must not include windowA's 200");
+  assert.notEqual(windowA.startedAt, windowB.nextWindow.startedAt);
+});
+
+test("reportRateLimitPause: calls Sentry.captureMessage directly, once per call (naturally low-frequency, no aggregation needed)", () => {
+  captureMessage.mockClear();
+  reportRateLimitPause(65_000);
+  assert.equal(captureMessage.mock.calls.length, 1);
+  const [message, options] = captureMessage.mock.calls[0];
+  assert.match(message, /pausing 65000ms/);
+  assert.equal(options.extra.pauseMs, 65_000);
+});
+
+// --- initSentry ---------------------------------------------------------------
+
+test("initSentry: no-ops (never calls Sentry.init) when SENTRY_DSN is unset", () => {
+  sentryInit.mockClear();
+  setTag.mockClear();
+  vi.stubEnv("SENTRY_DSN", "");
+  initSentry();
+  assert.equal(sentryInit.mock.calls.length, 0);
+  assert.equal(setTag.mock.calls.length, 0);
+  vi.unstubAllEnvs();
+});
+
+test("initSentry: calls Sentry.init with dsn/environment/release and tags the component when SENTRY_DSN is set", () => {
+  sentryInit.mockClear();
+  setTag.mockClear();
+  vi.stubEnv("SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
+  vi.stubEnv("SENTRY_ENVIRONMENT", "staging");
+  vi.stubEnv("SENTRY_RELEASE", "deadbeef");
+  initSentry();
+  assert.equal(sentryInit.mock.calls.length, 1);
+  assert.deepEqual(sentryInit.mock.calls[0][0], {
+    dsn: "https://abc@o0.ingest.sentry.io/0",
+    environment: "staging",
+    release: "deadbeef",
+    tracesSampleRate: 0,
+  });
+  assert.deepEqual(setTag.mock.calls[0], ["component", "chain-firehose-relay"]);
+  vi.unstubAllEnvs();
+});
+
+test("initSentry: SENTRY_ENVIRONMENT defaults to 'production' when unset", () => {
+  sentryInit.mockClear();
+  vi.stubEnv("SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
+  vi.stubEnv("SENTRY_ENVIRONMENT", "");
+  initSentry();
+  assert.equal(sentryInit.mock.calls[0][0].environment, "production");
+  vi.unstubAllEnvs();
 });

--- a/tests/chain-firehose-routes.test.mjs
+++ b/tests/chain-firehose-routes.test.mjs
@@ -211,7 +211,7 @@ test("ingest: an over-limit request 429s with the rate-limit header family and n
   );
   assert.equal(res.status, 429);
   assert.equal(res.headers.get("retry-after"), "60");
-  assert.equal(res.headers.get("x-ratelimit-limit"), "120");
+  assert.equal(res.headers.get("x-ratelimit-limit"), "1200");
   assert.equal(res.headers.get("x-ratelimit-remaining"), "0");
   assert.ok(res.headers.get("x-ratelimit-policy"));
   assert.equal(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1054,11 +1054,29 @@ async function internalSyncRateLimited(request, env) {
 // SSE/WS/GraphQL-subscription subscriber -- so a leaked CHAIN_FIREHOSE_SYNC_SECRET
 // could flood every connected client with unbounded forged events, a distinct
 // amplification angle from the one-record-per-request internal-sync routes.
-// Generous cap: the #4981 box relay POSTs at most per-block (~5/min at ~12s
-// blocks); 120/60s leaves >20x headroom for multi-event NOTIFY bursts while
-// still firmly bounding abuse. Keyed per client IP; optional-chained so it's a
-// no-op when the binding is absent (local dev/CI).
-const CHAIN_FIREHOSE_INGEST_RATE_LIMIT = { limit: 120, windowSeconds: 60 };
+// Keyed per client IP; optional-chained so it's a no-op when the binding is
+// absent (local dev/CI).
+//
+// CORRECTED 2026-07 (real incident): the original 120/60s cap was sized for
+// the box relay's OLD LISTEN/NOTIFY design (one notification per BLOCK,
+// ~5/min at ~12s blocks). #5027 replaced that with an outbox-table poll,
+// forwarding one row per BLOCKS/EXTRINSICS/CHAIN_EVENTS/ACCOUNT_EVENTS row
+// (chain_events alone can be many per block) at up to
+// CHAIN_FIREHOSE_FORWARD_CONCURRENCY=16 concurrent requests -- a genuinely
+// different, much higher-volume traffic shape this limit was never
+// recalibrated for. The mismatch caused a real, confirmed incident: every
+// legitimate backlog-drain burst immediately 429'd, the relay's own retry
+// logic didn't back off on 429 any differently than any other failure, and
+// the resulting thundering-herd loop meant the backlog never actually
+// drained -- millions of rows accumulated over ~40h. Raised to a cap sized
+// for the CURRENT architecture's real legitimate throughput with meaningful
+// headroom, not "no real limit" -- still authenticated + per-IP, so this
+// isn't opening the endpoint to anonymous abuse, just no longer rate-limiting
+// the one legitimate caller into a permanent failure loop. The relay's own
+// forwardWithRetry now also properly respects retry-after and pauses its
+// whole poll loop on a 429 (scripts/chain-firehose-relay.mjs), so a real
+// spike still degrades gracefully instead of repeating this failure mode.
+const CHAIN_FIREHOSE_INGEST_RATE_LIMIT = { limit: 1200, windowSeconds: 60 };
 
 async function chainFirehoseIngestRateLimited(request, env) {
   if (!env.CHAIN_FIREHOSE_INGEST_RATE_LIMITER?.limit) return null;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -547,10 +547,14 @@
       },
     },
     {
+      // Raised from 120 -- see CHAIN_FIREHOSE_INGEST_RATE_LIMIT's own comment
+      // in workers/api.mjs for the full real-incident rationale (must match
+      // this binding exactly, or the header values workers/api.mjs reports
+      // lie about what's actually enforced).
       "name": "CHAIN_FIREHOSE_INGEST_RATE_LIMITER",
       "namespace_id": "1008",
       "simple": {
-        "limit": 120,
+        "limit": 1200,
         "period": 60,
       },
     },


### PR DESCRIPTION
## Summary

Root-causes and fixes a live incident (#6451): `chain-firehose-relay`'s outbox backlog grew to 9,942,268 undelivered rows over ~40 hours. Diagnosed live against the real deployed container and a real outbox payload — every forward attempt was getting HTTP 429 from the ingest endpoint's own rate limiter.

**Root cause:** `CHAIN_FIREHOSE_INGEST_RATE_LIMIT` (120 req/60s) was sized for the relay's OLD LISTEN/NOTIFY design (one notification per block, ~5/min). #5027 replaced that with an outbox-table poll forwarding one row per `blocks`/`extrinsics`/`chain_events`/`account_events` row at up to 16 concurrent requests — a fundamentally different traffic shape the rate limit was never recalibrated for. The relay's own retry logic applied the same short generic backoff to a 429 as to any other failure, so every backlog-drain burst re-triggered the same limit indefinitely — a self-sustaining failure loop, not a transient blip.

**Fix — both halves of the mismatch, either alone leaves the other in place:**
- `workers/api.mjs` + `wrangler.jsonc`: raised the rate limit to 1200/60s, sized for the current architecture. Still authenticated + per-IP, not opening the endpoint to anonymous abuse. (Only the `wrangler.jsonc` binding is actually enforced — the JS constant just generates response headers, so both needed updating in sync.)
- `scripts/chain-firehose-relay.mjs`: `forwardWithRetry` now honors the response's `retry-after` header on a 429 (capped against a pathological server value), and `forwardBatch`/`main()`'s poll loop pause the **whole batch/poll loop**, not just one row's own retries — the actual fix for the thundering-herd shape, since per-row backoff alone can't stop 16 concurrent requests from re-triggering the limit on the very next batch.

**Also adds Sentry error tracking** (the consolidated `metagraphed` project). Deliberately *not* one `captureMessage` per dropped payload — at this incident's actual scale (millions of drops), naive per-drop capture would have blown the free-tier event quota in minutes and then been silently sampled away by Sentry itself, hiding the incident rather than surfacing it. `computeDropWindowUpdate` aggregates instead: one event per 500 drops or 5 minutes of nonzero drop rate, whichever comes first — the same "escalate periodically, don't spam" shape as `roles/validator-ops/watchdog.py`'s own re-alert logic in `metagraphed-infra`. It's a pure function with no module-level state (`main()`'s poll loop owns the window + the actual `Sentry.captureMessage` call) — an earlier draft held the window as module-level mutable state and leaked between unrelated unit tests, exactly the bug this design avoids architecturally.

**Immediate mitigation, already applied directly to the live box** (separate from this code change): pruned 9,777,485 rows past the code's own 1-hour retention window via a batched DELETE (50k/batch, to avoid long lock contention with indexer-rs's own concurrent writes against a 10M-row table). Confirmed safe: `chain_firehose_outbox` is a transient delivery-queue mirror, not the source of truth — the pruned rows were 1-2 days stale, of zero value to a realtime firehose even if delivered.

## Test plan

- [x] 45 `chain-firehose-relay.test.mjs` tests pass (added ~24 new tests: `parseRetryAfterMs`, 429-specific backoff behavior, rate-limit propagation through `forwardBatch`, drop-window aggregation including an explicit state-leakage regression test, `initSentry`)
- [x] 14 `chain-firehose-routes.test.mjs` tests pass (updated the rate-limit-header assertion to the new value)
- [x] Diagnosed the actual 429 root cause live against the real production container and a real outbox payload before writing any fix
- [x] Confirmed `apps/ui`'s existing `@sentry/browser` test suite is unaffected by the shared `@sentry/core` dependency bump
- [x] `eslint` + `prettier --check` clean on all touched files
- [x] `node --check` on the edited script

Closes #6451.