### PR TITLE
fix(data-refresh): stop tracking a second copy of the fetch scripts in metagraphed-infra

### DIFF
--- a/deploy/metagraph-fetch.Dockerfile
+++ b/deploy/metagraph-fetch.Dockerfile
@@ -1,36 +1,46 @@
 # Box-side runner for metagraphed's first-party chain-direct fetch scripts
 # (fetch-metagraph-native.py, fetch-account-identity.py,
-# fetch-subnet-hyperparams.py) -- replaces the GitHub Actions `fetch` job
-# these three previously ran in (refresh-metagraph.yml / refresh-account-
-# identity.yml / refresh-subnet-hyperparams.yml, all retired). Deliberately
-# holds NO secrets and NO network egress beyond the chain RPC it's pointed
-# at: this is the untrusted half of the least-privilege split those
-# workflows' own comments documented ("the unpinned PyPI execution boundary
-# ... can only pass the JSON data artifact forward") -- the box's
-# roles/data-refresh-cron systemd units run this container with only
-# SUBTENSOR_RPC_URL (non-secret) in its env, then read the JSON it writes to
-# a bind-mounted /out and do the authenticated Postgres sync themselves, as a
-# separate step outside this container, exactly the same isolation the two
-# GitHub Actions jobs gave (fetch job has zero secrets; sign-and-stage job
-# starts from a fresh checkout and never runs this untrusted code).
+# fetch-subnet-hyperparams.py, fetch-validator-nominator-counts.py) --
+# replaces the GitHub Actions `fetch` job the first three previously ran in
+# (refresh-metagraph.yml / refresh-account-identity.yml / refresh-subnet-
+# hyperparams.yml, all retired); the fourth never had a GitHub Actions
+# equivalent. Deliberately holds NO secrets and NO network egress beyond the
+# chain RPC it's pointed at (plus GitHub, for the clone below): this is the
+# untrusted half of the least-privilege split those workflows' own comments
+# documented ("the unpinned PyPI execution boundary ... can only pass the
+# JSON data artifact forward") -- the box's roles/data-refresh-cron systemd
+# units run this container with only SUBTENSOR_RPC_URL (non-secret) in its
+# env, then read the JSON it writes to a bind-mounted /out and do the
+# authenticated Postgres sync themselves, as a separate step outside this
+# container, exactly the same isolation the two GitHub Actions jobs gave
+# (fetch job has zero secrets; sign-and-stage job starts from a fresh
+# checkout and never runs this untrusted code).
 #
-# One generic image for all three scripts -- which one to run is a runtime
-# argument (see entrypoint.sh). bittensor is pinned to a SINGLE version
-# (10.5.0) for all three: verified 2026-07-14 that fetch-metagraph-native.py
-# and fetch-account-identity.py's entire API surface (get_all_metagraphs_info/
-# MetagraphInfo) is byte-identical between bittensor 10.4.0 and 10.5.0 (the
-# versions the 3 source GitHub Actions workflows used to split across) --
-# fetch-subnet-hyperparams.py is the one that genuinely needs 10.5.0 (#4973,
-# certain SubnetHyperparameters fields are silently unreadable under 10.4.0),
-# so unifying costs nothing and simplifies this image to one locked venv.
+# One generic image for all four scripts -- which one to run is a runtime
+# argument (see scripts/metagraph-fetch-entrypoint.sh).
+#
+# Clones this repo at CONTAINER RUNTIME (entrypoint.sh) rather than baking
+# the fetch scripts into the image at build time -- see the entrypoint's own
+# header for why (a prior copy-based deployment in metagraphed-infra let
+# real fixes silently go stale). This does NOT reintroduce the exact risk a
+# 2026-07-14 security scan finding (P2) fixed: that finding was about
+# `uvx --from bittensor==X.Y` re-resolving bittensor and its ~46 transitive
+# dependencies FRESH from PyPI on every run with only a semver pin, NO hash
+# verification at all. This entrypoint still runs `uv sync --locked` --
+# hash-verified against uv.lock every single time, exactly like the old
+# build-time-only install did -- just reading a freshly-cloned copy of that
+# lock file instead of one baked into the image. The security property (no
+# unpinned/unverified PyPI resolution, ever) is unchanged; only WHEN the
+# verified install happens moved from image-build time to container-start
+# time, matching data-refresh-node.Dockerfile's own established pattern for
+# its own (npm-based) dependencies.
 #
 # Deployed the same way chain-firehose-relay/streamer are: the Ansible
 # `data-refresh-cron` role in JSONbored/metagraphed-infra copies this
-# Dockerfile + scripts/pyproject.toml + scripts/uv.lock + the three scripts
-# into roles/data-refresh-cron/files/ and builds directly on the indexer box.
-# Re-run that role after updating any of these files to rebuild with the
-# latest fix. To bump the pinned bittensor version: edit scripts/pyproject.toml,
-# run `cd scripts && uv lock`, commit the updated scripts/uv.lock.
+# Dockerfile + scripts/metagraph-fetch-entrypoint.sh into
+# roles/data-refresh-cron/files/ and builds directly on the indexer box --
+# but no longer copies the fetch scripts themselves, pyproject.toml, or
+# uv.lock; those are cloned fresh at container start.
 #
 # Local:  docker build -f deploy/metagraph-fetch.Dockerfile -t metagraphed-data-refresh .
 #
@@ -45,36 +55,29 @@ FROM ghcr.io/astral-sh/uv:0.11.28@sha256:0f36cb9361a3346885ca3677e3767016687b5a1
 # python:3.12.11-slim-bookworm).
 FROM python:3.12.11-slim-bookworm@sha256:519591d6871b7bc437060736b9f7456b8731f1499a57e22e6c285135ae657bf7
 COPY --from=uv /uv /uvx /usr/local/bin/
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+# git: needed for the runtime clone. ca-certificates: needed for both the
+# HTTPS clone and the chain RPC / Postgres-sync HTTPS calls the fetch
+# scripts themselves make.
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -u 10001 -m fetcher
+RUN useradd -u 10001 -m fetcher \
+  && mkdir -p /repo \
+  && chown fetcher:fetcher /repo
 WORKDIR /app
 
-# Hash-locked dependency install at BUILD time, not runtime -- a security scan
-# correctly flagged the earlier `uvx --from bittensor==X.Y` pattern (2026-07-14,
-# P2): it re-resolved bittensor and its ~46 transitive dependencies from PyPI
-# fresh on EVERY container run with only a semver pin, no hash verification, so
-# a compromised release at that exact version (or any transitive dependency)
-# could execute inside this container on every fetch. `uv sync --locked`
-# verifies every artifact against uv.lock's embedded hashes and FAILS THE
-# BUILD on any mismatch -- verification happens once, at `docker build`, and
-# the resulting venv is baked into the image; no PyPI resolution happens at
-# container runtime anymore.
-COPY scripts/pyproject.toml scripts/uv.lock ./
-RUN uv sync --locked
-
-COPY scripts/fetch-metagraph-native.py ./scripts/fetch-metagraph-native.py
-COPY scripts/fetch-account-identity.py ./scripts/fetch-account-identity.py
-COPY scripts/fetch-subnet-hyperparams.py ./scripts/fetch-subnet-hyperparams.py
 COPY scripts/metagraph-fetch-entrypoint.sh ./entrypoint.sh
-RUN chmod +x ./entrypoint.sh && chown -R fetcher:fetcher /app
+RUN chmod +x ./entrypoint.sh
 
 USER fetcher
-ENV PATH="/app/.venv/bin:$PATH"
 # Provide at runtime: SCRIPT (one of fetch-metagraph-native.py /
-# fetch-account-identity.py / fetch-subnet-hyperparams.py), SUBTENSOR_RPC_URL
-# (non-secret -- our own fullnode's tailnet address), and whichever *_JSON
-# output-path env var the target script reads (see each script's own
-# OUT/module-level constant). Mount /out for the result.
+# fetch-account-identity.py / fetch-subnet-hyperparams.py /
+# fetch-validator-nominator-counts.py), SUBTENSOR_RPC_URL (non-secret -- our
+# own fullnode's tailnet address), optionally SENTRY_DSN/SENTRY_ENVIRONMENT
+# (silently no-op if unset -- see scripts/observability.py), and whichever
+# *_JSON output-path env var(s) the target script reads (see each script's
+# own OUT/module-level constant(s)). Mount /out for the result(s) and /repo
+# as a persistent volume (so the entrypoint's git clone + uv sync are only
+# paid in full on the FIRST run against a given volume, not every
+# daily/weekly cron tick).
 ENTRYPOINT ["./entrypoint.sh"]

--- a/scripts/fetch-metagraph-native.py
+++ b/scripts/fetch-metagraph-native.py
@@ -109,24 +109,39 @@ def main():
         if mechid == 0 or nu not in by_netuid:
             by_netuid[nu] = info
 
+    errors = []
+
     def storage_vec(netuid, name):
         try:
             r = s.substrate.query("SubtensorModule", name, [netuid])
             return list(getattr(r, "value", r) or [])
-        except Exception:
+        except Exception as exc:
+            # A per-netuid storage read failing must not silently null out
+            # that subnet's data with no signal (metagraphed-infra#62) --
+            # record it and keep going (matching fetch-subnet-hyperparams.py's
+            # accumulate-and-fail-at-the-end pattern) rather than either
+            # crashing the whole run on one flaky call while every other
+            # subnet is fine, or silently emitting validator_trust=None for
+            # this subnet as if that were valid data.
+            errors.append(f"netuid={netuid}: {name} storage read failed: {exc}")
             return []
 
     def delegate_takes():
         """SubtensorModule::Delegates: hotkey (SS58) -> take (u16 raw), a flat
-        StorageMap with no netuid key — fetched once for the whole network."""
-        try:
-            takes = {}
-            for key, value in s.substrate.query_map("SubtensorModule", "Delegates"):
-                hotkey = getattr(key, "value", key)
-                takes[hotkey] = u16_ratio(getattr(value, "value", value))
-            return takes
-        except Exception:
-            return {}
+        StorageMap with no netuid key — fetched once for the whole network.
+        Deliberately NOT wrapped in try/except (metagraphed-infra#62): this is
+        a single global read, not a per-netuid one, so there's no "keep going
+        for the other subnets" case to preserve here -- a failure means every
+        row's `take` would be wrong, so the run must fail outright (an
+        uncaught exception here crashes the script with a non-zero exit,
+        which is what should happen) rather than silently emit take=None for
+        every neuron network-wide.
+        """
+        takes = {}
+        for key, value in s.substrate.query_map("SubtensorModule", "Delegates"):
+            hotkey = getattr(key, "value", key)
+            takes[hotkey] = u16_ratio(getattr(value, "value", value))
+        return takes
 
     takes = delegate_takes()
     captured_at = int(time.time() * 1000)
@@ -198,8 +213,17 @@ def main():
     with open(OUT, "w") as fh:
         json.dump(valid, fh)
     sys.stderr.write(
-        f"wrote {len(valid)} neurons across {len(by_netuid)} subnets -> {OUT}\n"
+        f"wrote {len(valid)} neurons across {len(by_netuid)} subnets "
+        f"({len(errors)} error(s)) -> {OUT}\n"
     )
+    for err in errors:
+        sys.stderr.write(f"  {err}\n")
+    # This feeds a full-snapshot loader -- a partial ValidatorTrust read for
+    # even one subnet must fail the run instead of authenticating a
+    # degraded snapshot as complete (metagraphed-infra#62), matching
+    # fetch-subnet-hyperparams.py's own exit-on-any-error convention.
+    if errors:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/metagraph-fetch-entrypoint.sh
+++ b/scripts/metagraph-fetch-entrypoint.sh
@@ -1,13 +1,72 @@
 #!/usr/bin/env bash
-# Runs exactly one of the three fetch scripts, matching each script's own
-# original GitHub-Actions invocation behavior -- see
+# Runs one of the four box-side chain-direct fetch scripts, matching each
+# script's own original GitHub-Actions invocation behavior -- see
 # deploy/metagraph-fetch.Dockerfile's header for why this container holds no
-# secrets, and for why bittensor is now baked into the image at build time
-# (hash-locked via scripts/uv.lock) rather than resolved fresh from PyPI on
-# every run (fixed 2026-07-14 in response to a security scan finding, P2).
+# secrets.
+#
+# Clones this repo at CONTAINER RUNTIME rather than baking the scripts into
+# the image at build time. A prior copy-based deployment (metagraphed-infra
+# tracking its own local copy of these exact files, rebuilt on its own
+# schedule) let real fixes silently go stale between the two repos: a
+# fail-loud correctness fix and Sentry instrumentation both landed only in
+# that copy and never made it back to this canonical source, until that
+# drift was found and fixed directly. Matching
+# scripts/data-refresh-node-entrypoint.sh's own established pattern instead
+# closes that gap architecturally -- there is only ever one copy of these
+# scripts anywhere, so there is nothing left to go stale.
 set -euo pipefail
 
-: "${SCRIPT:?SCRIPT env var required (fetch-metagraph-native.py / fetch-account-identity.py / fetch-subnet-hyperparams.py)}"
+: "${SCRIPT:?SCRIPT env var required (fetch-metagraph-native.py / fetch-account-identity.py / fetch-subnet-hyperparams.py / fetch-validator-nominator-counts.py)}"
 
-echo "entrypoint: python scripts/${SCRIPT} (bittensor pinned + hash-locked at image build time, see scripts/uv.lock)"
-exec python "scripts/${SCRIPT}"
+REPO_DIR=/repo
+GIT_REPO_URL="https://github.com/JSONbored/metagraphed.git"
+# Floating branch, not a pinned commit SHA -- same rationale as
+# economics-refresh-entrypoint.sh/data-refresh-node-entrypoint.sh: this job
+# needs to stay current with code fixes, and main already requires review +
+# CI before anything lands.
+GIT_REF="main"
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+  # Clone into a temp dir, THEN copy its contents into $REPO_DIR -- an
+  # interrupted clone straight into $REPO_DIR would leave a partial .git
+  # directory that this same "already cloned?" check would treat as success
+  # on the NEXT run, silently proceeding against a broken checkout (the same
+  # fix economics-refresh-entrypoint.sh's own header documents finding via a
+  # security review). Copy, not `mv`, for the same reason: $REPO_DIR is the
+  # volume's own mount point, not a plain directory that can be
+  # removed/replaced wholesale.
+  CLONE_TMP="$(mktemp -d /tmp/metagraphed-clone.XXXXXX)"
+  echo "entrypoint: cloning ${GIT_REPO_URL}@${GIT_REF} (first run on this volume)"
+  git clone --depth 1 --branch "$GIT_REF" "$GIT_REPO_URL" "$CLONE_TMP"
+  find "$REPO_DIR" -mindepth 1 -delete
+  cp -a "$CLONE_TMP"/. "$REPO_DIR"/
+  rm -rf "$CLONE_TMP"
+else
+  echo "entrypoint: refreshing existing checkout"
+  git -C "$REPO_DIR" fetch --depth 1 origin "$GIT_REF"
+  git -C "$REPO_DIR" reset --hard "origin/${GIT_REF}"
+  # Deliberately NO `git clean -fdx` here, unlike the sibling JS entrypoints
+  # -- scripts/.venv (uv's own dependency cache, persisted across runs on
+  # this same volume so a daily/weekly cron tick doesn't pay a full
+  # bittensor + sentry-sdk install every single time) is untracked and would
+  # otherwise be wiped on every refresh, defeating the point of the
+  # persistent volume. Nothing else in this checkout is ever written to
+  # locally (these scripts write their OUTPUT to the separately-mounted
+  # /out, never anywhere inside $REPO_DIR), so there's no equivalent risk of
+  # stale local state the other entrypoints' git clean actually guards
+  # against.
+fi
+
+cd "$REPO_DIR/scripts"
+echo "entrypoint: uv sync --locked"
+uv sync --locked
+
+# Reports the ACTUAL commit this run's code came from -- computed here, not
+# injected by metagraphed-infra's Ansible, since that repo no longer holds
+# any copy of this code to derive a meaningful SHA from at all. An explicit
+# override still wins if one is somehow already set.
+: "${SENTRY_RELEASE:=$(git -C "$REPO_DIR" rev-parse HEAD)}"
+export SENTRY_RELEASE
+
+echo "entrypoint: uv run python ${SCRIPT} (release=${SENTRY_RELEASE})"
+exec uv run python "${SCRIPT}"

--- a/scripts/observability.py
+++ b/scripts/observability.py
@@ -1,0 +1,67 @@
+"""Shared Sentry init for the box-side chain-direct fetch scripts -- used by
+fetch-metagraph-native.py, fetch-account-identity.py,
+fetch-subnet-hyperparams.py, and fetch-validator-nominator-counts.py so all
+four report to the same consolidated `metagraphed` Sentry project with a
+consistent `component` tag. Deployed via metagraphed-infra's data-refresh-cron
+Ansible role, which clones this repo at container runtime rather than
+tracking its own copy of these scripts -- see metagraph-fetch-entrypoint.sh's
+own header for why (a prior copy-based deployment let this exact class of
+file go stale between the two repos).
+"""
+
+import os
+
+
+def init_sentry(component):
+    """No-ops silently if SENTRY_DSN is unset, matching this fetch
+    container's own "gets zero secrets" design (see
+    deploy/metagraph-fetch.Dockerfile's header) -- SENTRY_DSN is NOT a
+    secret in the same sense (Sentry DSNs are designed to be safe to embed
+    in client-side/public code, write-only), so passing it into this
+    untrusted container is consistent with that design, not a violation of
+    it. Safe to call even if sentry_sdk somehow isn't installed (falls back
+    to a no-op with a stderr warning instead of crashing the caller).
+    """
+    dsn = os.environ.get("SENTRY_DSN")
+    if not dsn:
+        return
+    try:
+        import sentry_sdk
+    except ImportError:
+        import sys
+
+        print(
+            f"[{component}] SENTRY_DSN is set but sentry_sdk is not installed -- skipping init",
+            file=sys.stderr,
+        )
+        return
+
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=os.environ.get("SENTRY_ENVIRONMENT", "production"),
+        # Set by metagraphed-infra to the deployed metagraphed git SHA (the
+        # commit this container's entrypoint cloned at startup). None is a
+        # valid, accepted value (Sentry just omits release tagging), not an
+        # error condition.
+        release=os.environ.get("SENTRY_RELEASE"),
+        # Error tracking only -- these are short-lived batch scripts run on
+        # a daily/weekly cron, not request-serving services.
+        traces_sample_rate=0.0,
+    )
+    sentry_sdk.set_tag("component", component)
+
+
+def capture_exception(exc=None, **tags):
+    """Thin wrapper so callers never need `import sentry_sdk` directly --
+    keeps every fetch script importable/unit-testable without sentry_sdk
+    installed at all, matching this codebase's existing lazy-bittensor-
+    import convention. Safe to call unconditionally.
+    """
+    try:
+        import sentry_sdk
+    except ImportError:
+        return
+    with sentry_sdk.new_scope() as scope:
+        for key, value in tags.items():
+            scope.set_tag(key, value)
+        sentry_sdk.capture_exception(exc)

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -2,7 +2,7 @@
 name = "metagraphed-data-refresh"
 version = "0.0.0"
 requires-python = ">=3.12"
-dependencies = ["bittensor==10.5.0"]
+dependencies = ["bittensor==10.5.0", "sentry-sdk==2.66.0"]
 
 [tool.uv]
 package = false

--- a/scripts/uv.lock
+++ b/scripts/uv.lock
@@ -535,10 +535,14 @@ version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "bittensor" },
+    { name = "sentry-sdk" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "bittensor", specifier = "==10.5.0" }]
+requires-dist = [
+    { name = "bittensor", specifier = "==10.5.0" },
+    { name = "sentry-sdk", specifier = "==2.66.0" },
+]
 
 [[package]]
 name = "msgpack"
@@ -1077,6 +1081,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9d/72/75d0b85443fbc8d9f38d08d2b1b67cc184ce35280e4a3813cda2f445f3a4/retry-0.9.2.tar.gz", hash = "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4", size = 6448, upload-time = "2016-05-11T13:58:51.541Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/0d/53aea75710af4528a25ed6837d71d117602b01946b307a3912cb3cfcbcba/retry-0.9.2-py2.py3-none-any.whl", hash = "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606", size = 7986, upload-time = "2016-05-11T13:58:39.925Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.66.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/ff/670abe04c5072719b5060ed93851d0d69525d60f8f2c5810f8becd58f9c1/sentry_sdk-2.66.0.tar.gz", hash = "sha256:9727d35aa83c56cd53294676fe65b96296a334c9ce107fa2142bd70f47acb265", size = 935745, upload-time = "2026-07-16T12:42:04.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/bb/49b10783f29067da2eec179320617e94faf63196609de47aeab3c26c3325/sentry_sdk-2.66.0-py3-none-any.whl", hash = "sha256:096136c214c602be2b323524d30755dc5b30ec5a218a206207f33b12c05c6f11", size = 504769, upload-time = "2026-07-16T12:42:02.919Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Root cause of a systemic drift problem, found while investigating the 2026-07 `chain-firehose-relay` incident (#6451): `metagraphed-infra`'s Ansible role deployed these 4 fetch scripts by baking a **local copy** of each file into its own repo. Keeping that copy in sync with this canonical source was a fully manual, unenforced process, and it had already silently drifted — a real fail-loud correctness fix and Sentry instrumentation both landed only in the `metagraphed-infra` copy and never made it back here.

**Fix:** converts to the same clone-at-runtime pattern `data-refresh-node.Dockerfile` already uses. `metagraph-fetch-entrypoint.sh` now clones this repo fresh into a persistent volume on first run (matching `economics-refresh-entrypoint.sh`'s atomic-clone-then-copy hardening), refreshes it on subsequent runs, then `uv sync --locked` + runs the target script. `metagraphed-infra` will no longer hold any copy of these files — there's nothing left to go stale.

**Does this reintroduce the 2026-07-14 P2 security finding?** No — see `deploy/metagraph-fetch.Dockerfile`'s own comment. That finding was about `uvx --from bittensor==X.Y` re-resolving dependencies fresh with only a semver pin and *no hash verification*. This still runs `uv sync --locked`, hash-verified against `uv.lock`, every single time — only *when* that verified install happens moved from image-build time to container-start time.

Also adds `scripts/observability.py` (shared Sentry init) wired into all four fetch scripts, and ports the fail-loud fix that had only existed in the `metagraphed-infra` copy until now.

## Test plan

- [x] Real `docker build` + two real `docker run` invocations against the actual production chain endpoint (not mocked)
- [x] First run: confirmed the full clone → `uv sync --locked` → fetch cycle (129 real subnet-hyperparameter rows), correctly auto-derived `SENTRY_RELEASE` from the freshly-cloned HEAD
- [x] Second run against the SAME persistent volume: confirmed the refresh path (not re-clone) and `uv sync` resolving from cache in <1ms instead of reinstalling bittensor's full dependency tree
- [x] `py_compile` clean on all touched Python files
- [x] `shellcheck` clean on the entrypoint
- [x] `uv.lock` diff confirmed minimal (only `sentry-sdk` added)

Part of #6451.