### PR TITLE
fix(scripts): drop the dead health/latest.json artifact budget

### DIFF
--- a/scripts/artifact-budgets.mjs
+++ b/scripts/artifact-budgets.mjs
@@ -6,7 +6,6 @@ export const ARTIFACT_SIZE_BUDGETS = [
   budget("endpoints.json", 2_500_000, 5_000_000),
   budget("providers/*/endpoints.json", 1_000_000, 3_000_000),
   budget("evidence-ledger.json", 1_000_000, 3_000_000),
-  budget("health/latest.json", 1_000_000, 3_000_000),
   budget("health/history/*.json", 650_000, 1_250_000),
   budget("search.json", 750_000, 2_000_000),
   budget("openapi.json", 1_400_000, 1_750_000),

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, test } from "vitest";
 import {
+  ARTIFACT_SIZE_BUDGETS,
   evaluateArtifactBudgets,
   summarizeArtifactBudgets,
 } from "../scripts/artifact-budgets.mjs";
@@ -2356,6 +2357,47 @@ describe("script utility contracts", () => {
     assert.deepEqual(
       results.map((result) => result.status),
       ["ok", "ok", "warn", "warn"],
+    );
+  });
+
+  test("every artifact size budget maps to a real build-artifacts write", async () => {
+    // Guard against dead budget rules (issue #6364): a `budget(path, ...)` entry
+    // is only ever evaluated against artifacts build-artifacts.mjs actually
+    // emits, so an entry with no corresponding `artifactFile(...)` write is inert
+    // and silently rots. Statically collect every literal/template path passed to
+    // `artifactFile(...)` and assert each budget pattern matches at least one.
+    const source = await readFile(
+      path.join(repoRoot, "scripts/build-artifacts.mjs"),
+      "utf8",
+    );
+    const writtenPatterns = new Set();
+    const callRe = /artifactFile\(\s*(?:"([^"]+)"|`([^`]+)`)/g;
+    for (let match = callRe.exec(source); match; match = callRe.exec(source)) {
+      // Collapse each `${…}` interpolation to a single path-segment glob, then to
+      // a representative concrete segment, mirroring how the runtime resolves a
+      // templated write to a real relative path.
+      const concrete = (match[1] ?? match[2])
+        .replace(/\$\{[^}]*\}/g, "*")
+        .replace(/\*/g, "seg");
+      writtenPatterns.add(concrete);
+    }
+
+    const budgetToRegExp = (pattern) =>
+      new RegExp(
+        `^${pattern
+          .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+          .replace(/\*/g, "[^/]*")}$`,
+      );
+
+    const orphaned = ARTIFACT_SIZE_BUDGETS.filter((entry) => {
+      const regex = budgetToRegExp(entry.path);
+      return ![...writtenPatterns].some((written) => regex.test(written));
+    }).map((entry) => entry.path);
+
+    assert.deepEqual(
+      orphaned,
+      [],
+      `budget entries with no matching build-artifacts write: ${orphaned.join(", ")}`,
     );
   });
 


### PR DESCRIPTION
## What

`ARTIFACT_SIZE_BUDGETS` in `scripts/artifact-budgets.mjs` carried
`budget("health/latest.json", ...)`, but `scripts/build-artifacts.mjs` no longer
writes `health/latest.json` — current-state health is live-only (served from
KV/D1), as the comment at `build-artifacts.mjs:1238-1245` documents. Because
`evaluateArtifactBudgets` only ever scores a rule against artifacts that are
actually produced, this entry can never match and is permanently inert.

## Changes

- Remove the dead `budget("health/latest.json", ...)` rule.
- Add a regression test (`tests/script-utils.test.mjs`) that statically collects
  every literal/template path passed to `artifactFile(...)` in
  `build-artifacts.mjs` and asserts each remaining `ARTIFACT_SIZE_BUDGETS` entry
  matches at least one real write — so a future dead entry fails CI instead of
  rotting silently.

## Verification

- `npx vitest run tests/script-utils.test.mjs tests/contracts.test.mjs` — green
  (the new test passes; re-adding the removed line makes it fail with
  `budget entries with no matching build-artifacts write: health/latest.json`).
- `npm run lint` / `npm run format:check` — clean.

Closes #6364
