### PR TITLE
fix(api): standardize handleAccountHistory validation errors to invalid_query

### DIFF
--- a/tests/account-history.test.mjs
+++ b/tests/account-history.test.mjs
@@ -100,7 +100,8 @@ test("GET /accounts/{ss58}/history rejects malformed ?from / ?to", async () => {
   assert.equal(bad.status, 400);
   const body = await bad.json();
   assert.equal(body.ok, false);
-  assert.equal(body.error.code, "invalid_param");
+  assert.equal(body.error.code, "invalid_query");
+  assert.equal(body.meta.parameter, "from");
 });
 
 test("GET /accounts/{ss58}/history rejects an unsupported query param", async () => {

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -2750,7 +2750,8 @@ describe("handleAccountHistory", () => {
       url(`/api/v1/accounts/${SS58}/history?from=June`),
     );
     const body = await errorJson(res);
-    assert.equal(body.error.code, "invalid_param");
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "from");
   });
 
   test("rejects malformed netuid filters with 400", async () => {
@@ -2764,7 +2765,8 @@ describe("handleAccountHistory", () => {
         url(`/api/v1/accounts/${SS58}/history?netuid=${netuid}`),
       );
       const body = await errorJson(res);
-      assert.equal(body.error.code, "invalid_param");
+      assert.equal(body.error.code, "invalid_query");
+      assert.equal(body.meta.parameter, "netuid");
     }
   });
 

--- a/tests/request-params.test.mjs
+++ b/tests/request-params.test.mjs
@@ -212,13 +212,19 @@ describe("parseDateRange", () => {
 
   test("errors on a malformed from bound", () => {
     const result = parseDateRange(url("from=June"));
-    assert.equal(result.error, "from/to must be YYYY-MM-DD dates.");
+    assert.deepEqual(result.error, {
+      parameter: "from",
+      message: "from must be a YYYY-MM-DD date.",
+    });
     assert.equal(result.from, undefined);
   });
 
   test("errors on a malformed to bound even when from is valid", () => {
     const result = parseDateRange(url("from=2026-06-01&to=nope"));
-    assert.equal(result.error, "from/to must be YYYY-MM-DD dates.");
+    assert.deepEqual(result.error, {
+      parameter: "to",
+      message: "to must be a YYYY-MM-DD date.",
+    });
   });
 
   test("is format-only — accepts a present but out-of-range date", () => {

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -2931,7 +2931,7 @@ export async function handleAccountHistory(request, env, ss58, url) {
   ]);
   if (validationError) return analyticsQueryError(validationError);
   const range = parseDateRange(url);
-  if (range.error) return errorResponse("invalid_param", range.error, 400);
+  if (range.error) return analyticsQueryError(range.error);
   const { from, to } = range;
   const { limit, offset } = parsePagination(url, FEED_PAGINATION);
   const netuid = url.searchParams.get("netuid");
@@ -2939,11 +2939,10 @@ export async function handleAccountHistory(request, env, ss58, url) {
     netuid != null &&
     (!/^\d+$/.test(netuid) || !Number.isSafeInteger(Number(netuid)))
   ) {
-    return errorResponse(
-      "invalid_param",
-      "netuid must be a non-negative integer.",
-      400,
-    );
+    return analyticsQueryError({
+      parameter: "netuid",
+      message: "netuid must be a non-negative integer.",
+    });
   }
   // Inverted YYYY-MM-DD bounds are a deterministic no-match. Short-circuit before
   // D1 so callers cannot force a scan to prove an impossible empty page.

--- a/workers/request-params.mjs
+++ b/workers/request-params.mjs
@@ -116,8 +116,15 @@ export function parseNonNegativeIntParam(raw, parameter) {
 export function parseDateRange(url) {
   const from = url.searchParams.get("from");
   const to = url.searchParams.get("to");
-  if ((from && !DAY_PATTERN.test(from)) || (to && !DAY_PATTERN.test(to))) {
-    return { error: "from/to must be YYYY-MM-DD dates." };
+  if (from && !DAY_PATTERN.test(from)) {
+    return {
+      error: { parameter: "from", message: "from must be a YYYY-MM-DD date." },
+    };
+  }
+  if (to && !DAY_PATTERN.test(to)) {
+    return {
+      error: { parameter: "to", message: "to must be a YYYY-MM-DD date." },
+    };
   }
   return { from: from || null, to: to || null };
 }


### PR DESCRIPTION
### The bug

`handleAccountHistory` (`workers/request-handlers/entities.mjs`) returned its date-range and netuid validation failures via `errorResponse("invalid_param", message, 400)` **with no `meta`** — while every sibling query-validation failure in this file routes through `analyticsQueryError` → `errorResponse("invalid_query", message, 400, { parameter })`.

Root cause: `parseDateRange` (`workers/request-params.mjs`) returned `{ error: "string" }` — the only parser in that file not returning the `{ error: { parameter, message } }` shape its siblings (`parseNonNegativeIntParam` / `parseLimitParam`) use — which forced the handler to hand-roll a divergent response. Per `workers/http.mjs`, that also meant these responses lacked the top-level `meta.parameter` field callers rely on elsewhere and set a different `x-metagraph-error-code` header.

### Fix

- `parseDateRange` now returns `{ error: { parameter: "from" | "to", message } }`, matching its sibling parsers (per-param message, mirroring `parseNonNegativeIntParam`'s `${parameter} must be …` style).
- `handleAccountHistory` routes both the date-range and netuid failures through `analyticsQueryError`, so they carry `invalid_query` + `meta.parameter` like every other endpoint's validation errors.
- Updated the affected assertions in the three listed test files (now asserting `invalid_query` + `meta.parameter`).

### Tests

`tests/request-params.test.mjs` (the two `parseDateRange` malformed-bound cases now assert the `{ parameter, message }` shape for both `from` and `to`), plus `tests/account-history.test.mjs` and `tests/request-handlers-entities.test.mjs` (the handler-level `from` and `netuid` cases now assert `invalid_query` + `meta.parameter`). Verified locally: the affected suites pass (398 tests), the two `parseDateRange` branches are both exercised, `eslint`/`prettier` clean on the changed files. Worker + test change only — no schema/contract regeneration.

Closes #6354
