### PR TITLE
fix(chain-firehose-relay): convert Dockerfile to clone-at-runtime

### DIFF
--- a/deploy/chain-firehose-relay.Dockerfile
+++ b/deploy/chain-firehose-relay.Dockerfile
@@ -6,31 +6,32 @@
 # scripts/chain-firehose-relay.mjs's own header comment for why this is safe
 # by construction, unlike the retired streamer (docs/adr/0014).
 #
-# Deployed the same way the (also retired) metagraphed-streamer was: the
-# Ansible `chain-firehose-relay` role in JSONbored/metagraphed-infra copies
-# this Dockerfile + scripts/chain-firehose-relay.mjs into
-# roles/chain-firehose-relay/files/ and builds directly on the indexer box
-# (no cross-compilation concern -- this is a single small ESM file + one npm
-# dependency). Re-run that role after updating either file to rebuild with
-# the latest fix.
+# Clone-at-runtime, like metagraph-fetch.Dockerfile/data-refresh-node.Dockerfile
+# /economics-refresh.Dockerfile: this image holds no copy of
+# chain-firehose-relay.mjs itself (see scripts/chain-firehose-relay-entrypoint.sh).
+# metagraphed-infra used to track a second, independently-drifting copy of
+# this file (metagraphed#6451); the entrypoint now clones the real one from
+# GitHub at container start instead. The Ansible `chain-firehose-relay` role
+# in JSONbored/metagraphed-infra now copies only this Dockerfile + the
+# entrypoint script into roles/chain-firehose-relay/files/ and builds
+# directly on the indexer box. Restarting the container (not rebuilding the
+# image) is enough to pick up the latest main.
 #
 # Local:  docker build -f deploy/chain-firehose-relay.Dockerfile -t metagraphed-chain-firehose-relay .
 FROM node:22.23.1-alpine
+RUN apk add --no-cache bash git ca-certificates
 # BusyBox adduser (Alpine's) -- -D skips setting a password, -u pins the uid.
 RUN adduser -D -u 10001 relay
 WORKDIR /app
 
-# Pinned dependencies (postgres.js matches the root package.json's own pin,
-# the same driver workers/data-api.mjs uses) -- never auto-pull a future
-# release independently of the rest of the repo. @sentry/node also matches
-# the root package.json pin.
-RUN npm install --no-audit --no-fund postgres@3.4.9 @sentry/node@10.66.0
-
-COPY scripts/chain-firehose-relay.mjs ./scripts/chain-firehose-relay.mjs
+COPY --chown=relay:relay scripts/chain-firehose-relay-entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
 
 ENV NODE_ENV=production
 
 USER relay
 # Provide at runtime (NOT baked in): DATABASE_URL, CHAIN_FIREHOSE_SYNC_SECRET,
-# and optionally CHAIN_FIREHOSE_INGEST_URL (defaults to the production hub).
-CMD ["node", "scripts/chain-firehose-relay.mjs"]
+# and optionally CHAIN_FIREHOSE_INGEST_URL (defaults to the production hub),
+# SENTRY_DSN, SENTRY_RELEASE (auto-derived from the freshly-cloned HEAD if
+# unset).
+ENTRYPOINT ["./entrypoint.sh"]

--- a/scripts/chain-firehose-relay-entrypoint.sh
+++ b/scripts/chain-firehose-relay-entrypoint.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Runs the box-side realtime chain-event firehose relay (#4981, #5027, ADR
+# 0015) -- see deploy/chain-firehose-relay.Dockerfile's header. Unlike the
+# metagraph-fetch/data-refresh-node/economics-refresh entrypoints, this
+# process is a single always-on daemon, not a periodically re-invoked job,
+# so there's no persistent /repo volume or incremental-refresh branch here:
+# every container start (rare -- a crash-restart, or a deliberate `docker
+# compose up` after the Ansible role rebuilds the image) does one fresh,
+# shallow clone into a container-lifetime temp directory, then execs the
+# relay to run forever. This also means restarting the container (not just
+# rebuilding the image) is enough to pick up whatever is newest on main.
+set -euo pipefail
+
+GIT_REPO_URL="https://github.com/JSONbored/metagraphed.git"
+# Floating branch, not a pinned commit SHA -- same rationale as the other
+# clone-at-runtime entrypoints (data-refresh-node-entrypoint.sh,
+# economics-refresh-entrypoint.sh): main already requires review + CI +
+# Loopover ORB before anything lands.
+GIT_REF="main"
+
+REPO_DIR="$(mktemp -d /tmp/metagraphed-clone.XXXXXX)"
+echo "entrypoint: cloning ${GIT_REPO_URL}@${GIT_REF} into ${REPO_DIR}"
+git clone --depth 1 --branch "$GIT_REF" "$GIT_REPO_URL" "$REPO_DIR"
+cd "$REPO_DIR"
+
+echo "entrypoint: npm ci --ignore-scripts"
+npm ci --ignore-scripts --no-audit --no-fund
+# --ignore-scripts closes the install-time-arbitrary-code vector (lifecycle
+# scripts from any of this repo's npm dependencies); this check catches
+# anything that still wrote to the tracked source tree some other way. Same
+# defense as economics-refresh-entrypoint.sh / data-refresh-node-entrypoint.sh.
+if ! git diff --quiet -- . ':(exclude)node_modules'; then
+  echo "entrypoint: npm ci modified tracked source files -- aborting" >&2
+  git diff --stat -- . ':(exclude)node_modules' >&2
+  exit 1
+fi
+
+# Sentry release -- the freshly-cloned HEAD, since this script now lives
+# only in metagraphed (metagraphed#6451): metagraphed-infra's own commit SHA
+# would no longer identify what code is actually running here.
+: "${SENTRY_RELEASE:=$(git rev-parse HEAD)}"
+export SENTRY_RELEASE
+
+echo "entrypoint: node scripts/chain-firehose-relay.mjs (release ${SENTRY_RELEASE})"
+exec node scripts/chain-firehose-relay.mjs


### PR DESCRIPTION
## Summary

Part of the drift reconciliation started in #6456 (context: #6451). `metagraphed-infra`'s `chain-firehose-relay` Ansible role tracked its own copy of `scripts/chain-firehose-relay.mjs`, independently of this repo's canonical one -- the same duplication #6456 already fixed for the four fetch scripts. That copy had drifted badly: it was still the retired LISTEN/NOTIFY-based script from before #5027/#6452 rewrote this relay to outbox-polling.

This PR converts `deploy/chain-firehose-relay.Dockerfile` to the same clone-at-runtime pattern: the image now holds no copy of `chain-firehose-relay.mjs` at all. A new `scripts/chain-firehose-relay-entrypoint.sh` clones `metagraphed` fresh at container start and execs the relay from the clone.

Unlike the fetch scripts / `data-refresh-node`, this process is a single always-on daemon rather than a periodically re-invoked job, so the entrypoint deliberately skips the persistent-volume + incremental-refresh machinery those use: every container start (rare -- a crash-restart or a deliberate rebuild) does one fresh shallow clone + `npm ci --ignore-scripts` into a **fixed** path (`/tmp/repo`, not a random `mktemp` suffix), then execs. This also means restarting the container (not rebuilding the image) is enough to pick up the latest `main`.

`SENTRY_RELEASE` is now computed from the freshly-cloned HEAD when unset, matching the fetch-scripts entrypoint's convention -- the release that matters is this repo's commit, not `metagraphed-infra`'s.

**Also**: while verifying this, found that `metagraphed-infra`'s stale copy had a heartbeat file + `--healthcheck` CLI entry point (metagraphed-infra#63) that was never ported here when #5027/#6452 rewrote the relay -- it had drifted in directly on the infra side. Deleting that copy without porting the mechanism first would have silently regressed production monitoring coverage (the Docker `HEALTHCHECK` directive would have nothing to call). Ported `HEARTBEAT_FILE`/`touchHeartbeat`/`isHeartbeatFresh`/the `--healthcheck` branch into the canonical script, adapted for the poll loop (touched once per iteration instead of once per NOTIFY), and added the `HEALTHCHECK` directive back to the Dockerfile against the now-fixed `/tmp/repo` path.

Follow-up (not in this PR): `metagraphed-infra`'s `chain-firehose-relay` role still needs to stop copying `scripts/chain-firehose-relay.mjs` as a local file and redeploy to the box (separate PR, in progress).

## Test plan

- [x] `docker build -f deploy/chain-firehose-relay.Dockerfile` succeeds
- [x] `docker run` (no `DATABASE_URL`): entrypoint clones, runs `npm ci --ignore-scripts` (569 packages), passes the tracked-file diff check, computes `SENTRY_RELEASE` from the cloned HEAD, execs the relay, which fails at its own `DATABASE_URL` validation as expected
- [x] `docker run` against a disposable local Postgres with a real `chain_firehose_outbox` table: entrypoint completes clone/install/exec, `postgres` driver connects cleanly under Alpine/musl, relay polls successfully
- [x] `docker exec ... --healthcheck` against a live poll loop: heartbeat file is written, exits 0; against a process with no heartbeat yet, exits 1 (never hangs/times out) -- verified end-to-end with a real running container, not just unit tests
- [x] `npm test -- tests/chain-firehose-relay.test.mjs`: 50/50 passing, including new `touchHeartbeat`/`isHeartbeatFresh` tests (real tmpfile I/O, matching `tests/backup-postgres.test.mjs`'s own convention)
- [x] `shellcheck scripts/chain-firehose-relay-entrypoint.sh` clean
- [x] `npm run lint` / `npx prettier --check` clean
- [x] `npm run scan:public-safety` passes