### PR TITLE
fix(scripts): stop probes-smoke writing the retired static health/* paths

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -361,7 +361,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `npm run schemas:snapshot`: fetch machine-readable OpenAPI/Swagger JSON snapshots and update schema drift.
 - `npm run schemas:bundle`: bundle canonical modular JSON Schema components into `schemas/api-components.schema.json`.
 - `npm run adapters:snapshot`: capture safe Allways/Gittensor public adapter summaries.
-- `METAGRAPH_WRITE_PROBE_RESULTS=1 npm run probes:smoke`: run live read-only probes and persist health/RPC history.
+- `METAGRAPH_WRITE_PROBE_RESULTS=1 npm run probes:smoke`: run live read-only probes and persist the RPC/endpoint artifacts, per-subnet badge data, and the daily `health/history` snapshot. Current-state health now persists to the local fallback cache only (`.cache/metagraphed/health/latest.json`, which `build-artifacts.mjs` reads) — it no longer writes the retired static `health/latest.json`, `health/summary.json`, or `health/subnets/*.json` paths the live API serves from KV/D1 and unconditionally 410s.
 - `npm run r2:manifest`: regenerate the Cloudflare R2 manifest from current public artifacts.
 - `npm run r2:download:dry-run`: summarize an R2 restore/download without writing local files.
 - `npm run kv:publish:dry-run`: summarize KV latest pointer, feature flags, endpoint pool, and freshness control records.

--- a/scripts/probes-smoke.mjs
+++ b/scripts/probes-smoke.mjs
@@ -105,12 +105,16 @@ if (process.env.METAGRAPH_WRITE_PROBE_RESULTS === "1") {
     contractVersion,
     source: "live-smoke-probe",
   });
+  // Current-state health is local-cache-only now. build-artifacts.mjs
+  // intentionally stopped publishing health/latest.json, health/summary.json,
+  // and health/subnets/*.json (the live /api/v1/health routes serve from KV/D1),
+  // and the Worker unconditionally 410s those static paths. We only seed the
+  // local fallback cache that build-artifacts.mjs still reads — the retired
+  // static writes below are gone.
   await writeJson(
     path.join(repoRoot, ".cache/metagraphed/health/latest.json"),
     artifact.latest,
   );
-  await writeJson(artifactOutputPath("health/latest.json"), artifact.latest);
-  await writeJson(artifactOutputPath("health/summary.json"), artifact.summary);
   await writeJson(
     artifactOutputPath("rpc-endpoints.json"),
     rpcEndpointArtifact,
@@ -192,25 +196,12 @@ if (process.env.METAGRAPH_WRITE_PROBE_RESULTS === "1") {
     buildHealthHistoryArtifact(artifact.latest, day),
   );
   await fs.rm(
-    artifactOutputPath("health/subnets/0.json").replace(/\/0\.json$/, ""),
-    {
-      recursive: true,
-      force: true,
-    },
-  );
-  await fs.rm(
     artifactOutputPath("health/badges/0.json").replace(/\/0\.json$/, ""),
     {
       recursive: true,
       force: true,
     },
   );
-  for (const [netuid, subnetHealth] of artifact.subnets) {
-    await writeJson(
-      artifactOutputPath(`health/subnets/${netuid}.json`),
-      subnetHealth,
-    );
-  }
   for (const [netuid, badge] of artifact.badges) {
     await writeJson(artifactOutputPath(`health/badges/${netuid}.json`), badge);
   }


### PR DESCRIPTION
## Summary

`scripts/probes-smoke.mjs` (under `METAGRAPH_WRITE_PROBE_RESULTS=1`) still wrote
the exact current-state health artifacts `build-artifacts.mjs` deliberately
stopped publishing — `health/latest.json`, `health/summary.json`, and
`health/subnets/{netuid}.json`. Those three paths are marked
`RETIRED_CURRENT_HEALTH` in the contract catalog and the Worker unconditionally
returns 410 for them (`RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN`), so the writes
were provably dead weight. This drops them and updates the docs.

Closes #6363

## What Changed

- Removed the three retired static-path writes from `probes-smoke.mjs`:
  `health/latest.json`, `health/summary.json`, and the
  `health/subnets/{netuid}.json` loop (plus its now-orphaned `health/subnets/0`
  cleanup `fs.rm`). Added a short comment explaining the current-state health is
  local-cache-only and why the static writes are gone.
- Kept everything that is still live: the `.cache/metagraphed/health/latest.json`
  local fallback cache (`build-artifacts.mjs` reads it), the daily
  `health/history/{date}.json` snapshot, the RPC/endpoint artifacts, and the
  per-subnet `health/badges/{netuid}.json` writes (that badge artifact is not
  retired — `discovery.mjs` still reads it as a fallback behind the live cron
  snapshot).
- Updated `docs/backend-artifact-contracts.md` so the `probes:smoke` command
  description reflects that current-state health now persists to the local
  fallback cache only, not the retired static paths.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6363`).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] No generated artifacts hand-edited (only a script and a doc changed).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] No public API/OpenAPI/schema changes — the retired paths already 410.

## Validation

- `npm run lint` — clean
- `npm run format:check` — clean
- `npm run validate:docs` — passed
- `npx vitest run tests/api-coverage.test.mjs tests/artifacts.test.mjs` — green
  (the changed script is not on any API/read path)
- `git diff --check` — clean
