### PR TITLE
fix(scripts): point validate advisory at the real review:promote script

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1606,7 +1606,7 @@ for (const subnet of subnets) {
 // curation.level, which is a maintainer-only action (a contributor PR touching
 // registry curation is gate-blocked), so this can't be a hard assert without
 // coupling the check to a maintainer registry edit. A maintainer resolves it with
-// `npm run promote-reviewed -- --write`.
+// `npm run review:promote`.
 const subnetsByNetuidForReview = new Map(subnets.map((s) => [s.netuid, s]));
 const unmaterializedReviews = findUnmaterializedMaintainerReviews(
   reviewDecisionsDocument.decisions || [],
@@ -1614,7 +1614,7 @@ const unmaterializedReviews = findUnmaterializedMaintainerReviews(
 );
 if (unmaterializedReviews.length > 0) {
   console.warn(
-    `advisory: maintainer-reviewed decision(s) recorded in registry/reviews/maintainer-reviewed.json but not yet materialized on the subnet overlay — run 'npm run promote-reviewed -- --write' (maintainer-only): ${unmaterializedReviews
+    `advisory: maintainer-reviewed decision(s) recorded in registry/reviews/maintainer-reviewed.json but not yet materialized on the subnet overlay — run 'npm run review:promote' (maintainer-only): ${unmaterializedReviews
       .map((v) => `${v.slug} (netuid ${v.netuid}, level "${v.level}")`)
       .join(", ")}`,
   );


### PR DESCRIPTION
## Summary

Fixes #6360. `scripts/validate.mjs` told maintainers to run `npm run promote-reviewed -- --write`, but `package.json` has no `promote-reviewed` script — the real one is `review:promote` (`package.json:38` → `node scripts/promote-reviewed.mjs --write`). Running the printed command failed with `npm error Missing script: "promote-reviewed"`.

Both locations named in the issue now reference the real script:
- `scripts/validate.mjs:1609` (comment)
- `scripts/validate.mjs:1617` (the `console.warn` remediation string shown when `npm run validate` finds an unmaterialized maintainer-reviewed decision)

`npm run review:promote` already implies `--write`, so the `-- --write` suffix is dropped (matching `docs/backend-artifact-contracts.md:358`).

### Note on scope
The two remaining `promote-reviewed` mentions in this file (`:1486`, `:1602`) refer to the **script file** `scripts/promote-reviewed.mjs`, which is correctly named — those are intentionally left unchanged. Only the two npm-command strings were wrong.

## Validation
- `npx eslint scripts/validate.mjs` → clean (no errors)
- `npx prettier --check scripts/validate.mjs` → clean
- Diff is 2 lines in 1 file; no behavior change beyond the printed remediation text.

Closes #6360