### PR TITLE
fix(registry): canonicalize prediction-market category to prediction-markets

### DIFF
--- a/registry/subnets/8-ball.json
+++ b/registry/subnets/8-ball.json
@@ -4,7 +4,7 @@
     "identity-reviewed",
     "official-source-repo",
     "official-website",
-    "prediction-market"
+    "prediction-markets"
   ],
   "curation": {
     "gap_notes": [

--- a/registry/subnets/sparket.json
+++ b/registry/subnets/sparket.json
@@ -4,7 +4,7 @@
     "identity-reviewed",
     "official-source-repo",
     "official-website",
-    "prediction-market",
+    "prediction-markets",
     "sports"
   ],
   "curation": {


### PR DESCRIPTION
## Summary

Fixes #6332. The registry used two spellings for the same concept — `prediction-market` (`8-ball.json` SN125, `sparket.json` SN57) and `prediction-markets` (`almanac.json` SN41, `degenbrain.json` SN90) — so a category filter/facet for one spelling silently excluded the other two subnets.

This adopts the plural `prediction-markets` as canonical (per the issue's recommendation) and updates the two singular files.

- `registry/subnets/8-ball.json`: `prediction-market` → `prediction-markets`
- `registry/subnets/sparket.json`: `prediction-market` → `prediction-markets`

Plural matches the dominant convention elsewhere in the corpus (`language-models`, `capital-markets`, `trading-strategies`, `developer-tools`). Verified registry-wide that these were the only two files using the singular form; existing alphabetical ordering of `categories[]` is preserved in both files.

Per the issue this is a **pure data fix** — no `categories` enum is added (explicitly out of scope).

## Expected outcome
A category filter for "prediction markets" now surfaces all 4 relevant subnets (SN41, SN57, SN90, SN125) instead of 2.

## Validation
- `npm run validate:surface -- registry/subnets/8-ball.json` → passed (5 surfaces)
- `npm run validate:surface -- registry/subnets/sparket.json` → passed (5 surfaces)
- `npx prettier --check` → clean
- Diff is exactly 1 line per file, 2 files.

Closes #6332