### PR TITLE
fix(chain-firehose-relay): port the heartbeat/--healthcheck mechanism

### DIFF
--- a/deploy/chain-firehose-relay.Dockerfile
+++ b/deploy/chain-firehose-relay.Dockerfile
@@ -35,3 +35,19 @@ USER relay
 # SENTRY_DSN, SENTRY_RELEASE (auto-derived from the freshly-cloned HEAD if
 # unset).
 ENTRYPOINT ["./entrypoint.sh"]
+
+# metagraphed-infra#63: this relay previously had zero monitoring coverage --
+# a dead poll loop could go unnoticed indefinitely since Docker's own
+# "Running" state only means the process hasn't exited, not that it's doing
+# anything useful. --healthcheck reads HEARTBEAT_FILE's mtime (see the
+# script's own comment on that constant) -- unhealthy once no poll iteration
+# has completed in HEARTBEAT_STALE_MS. start-period covers the real startup
+# path (the entrypoint's clone + npm ci, both quick, but generous margin
+# costs nothing here). /tmp/repo is a FIXED path the entrypoint always clones
+# into (see its own comment for why that's safe here) -- this HEALTHCHECK
+# CMD is baked into the image at build time and has no other way to find the
+# script. metagraphed-infra's docker-container-health-poll.sh (that role)
+# turns `docker inspect`'s resulting health status into a Prometheus-visible
+# metric -- Docker's HEALTHCHECK alone has no alerting of its own.
+HEALTHCHECK --interval=60s --timeout=5s --start-period=30s --retries=3 \
+  CMD ["node", "/tmp/repo/scripts/chain-firehose-relay.mjs", "--healthcheck"]

--- a/scripts/chain-firehose-relay-entrypoint.sh
+++ b/scripts/chain-firehose-relay-entrypoint.sh
@@ -6,9 +6,9 @@
 # so there's no persistent /repo volume or incremental-refresh branch here:
 # every container start (rare -- a crash-restart, or a deliberate `docker
 # compose up` after the Ansible role rebuilds the image) does one fresh,
-# shallow clone into a container-lifetime temp directory, then execs the
-# relay to run forever. This also means restarting the container (not just
-# rebuilding the image) is enough to pick up whatever is newest on main.
+# shallow clone, then execs the relay to run forever. This also means
+# restarting the container (not just rebuilding the image) is enough to pick
+# up whatever is newest on main.
 set -euo pipefail
 
 GIT_REPO_URL="https://github.com/JSONbored/metagraphed.git"
@@ -18,7 +18,17 @@ GIT_REPO_URL="https://github.com/JSONbored/metagraphed.git"
 # Loopover ORB before anything lands.
 GIT_REF="main"
 
-REPO_DIR="$(mktemp -d /tmp/metagraphed-clone.XXXXXX)"
+# A FIXED path, not mktemp's random suffix -- unlike the other clone-at-
+# runtime entrypoints, the Docker HEALTHCHECK directive (see the Dockerfile)
+# execs `node <path>/scripts/chain-firehose-relay.mjs --healthcheck`
+# directly, baked into the image at build time, so the clone location must
+# be a fixed, known path. Safe to hardcode here specifically because this
+# entrypoint never reuses an existing checkout across container restarts
+# (no persistent volume, see above) -- there is no "was this the leftover of
+# an interrupted clone" ambiguity the other entrypoints' mktemp-then-copy
+# pattern guards against, since the container filesystem itself is fresh
+# every single time this path is written to.
+REPO_DIR=/tmp/repo
 echo "entrypoint: cloning ${GIT_REPO_URL}@${GIT_REF} into ${REPO_DIR}"
 git clone --depth 1 --branch "$GIT_REF" "$GIT_REPO_URL" "$REPO_DIR"
 cd "$REPO_DIR"

--- a/scripts/chain-firehose-relay.mjs
+++ b/scripts/chain-firehose-relay.mjs
@@ -27,12 +27,15 @@
 //
 // Deployed the same way the retired streamer was: an Ansible role in
 // JSONbored/metagraphed-infra (roles/chain-firehose-relay/) builds
-// deploy/chain-firehose-relay.Dockerfile directly on the indexer box,
-// COPYing this script in. See that Dockerfile's own header comment.
+// deploy/chain-firehose-relay.Dockerfile directly on the indexer box. That
+// image clones this repo fresh at container start (metagraphed#6451) rather
+// than baking this script in at build time -- see that Dockerfile's own
+// header comment.
 //
 // Run: DATABASE_URL=... CHAIN_FIREHOSE_INGEST_URL=... \
 //      CHAIN_FIREHOSE_SYNC_SECRET=... node scripts/chain-firehose-relay.mjs
 
+import { writeFileSync, statSync } from "node:fs";
 import postgres from "postgres";
 import * as Sentry from "@sentry/node";
 
@@ -118,6 +121,62 @@ export function reportRateLimitPause(pauseMs) {
 export const CHAIN_FIREHOSE_INGEST_TOKEN_HEADER = "x-chain-firehose-sync-token";
 export const DEFAULT_CHAIN_FIREHOSE_INGEST_URL =
   "https://api.metagraph.sh/api/v1/internal/chain-firehose-ingest";
+
+// This relay previously had zero monitoring coverage -- no metrics
+// endpoint, nothing in Prometheus/Alertmanager references it, so a
+// silently-dead poll loop (a crash-loop, an unnoticed DATABASE_URL change,
+// etc.) could go unnoticed indefinitely. HEARTBEAT_FILE is touched on every
+// poll loop iteration (regardless of whether it claimed any rows, and
+// regardless of forward success/failure -- this tracks "is the poll loop
+// still alive," a separate question from "are forwards succeeding," which
+// the drop-window Sentry reporting above already covers). The Docker
+// HEALTHCHECK in deploy/chain-firehose-relay.Dockerfile reads this file's
+// mtime via the --healthcheck CLI flag below; metagraphed-infra's
+// docker-container-health-poll.sh then turns the container's own Docker
+// health status into a node_exporter textfile metric a real Prometheus
+// alert rule can fire on. Deliberately inside the CONTAINER's own
+// filesystem (not a bind-mounted host path): avoids any cross-boundary
+// write-permission plumbing between this container's non-root uid and
+// node_exporter's host-side textfile collector directory.
+//
+// Ported from metagraphed-infra's own copy of this script
+// (metagraphed-infra#63), which had drifted this feature in independently
+// -- landed there directly instead of here first -- and would otherwise
+// have been silently lost once metagraphed-infra stopped tracking its own
+// copy of this file (metagraphed#6451). Adapted for the outbox-poll loop
+// this script now runs (touched once per poll iteration) instead of the
+// retired LISTEN subscription (originally touched once per NOTIFY).
+export const HEARTBEAT_FILE = "/tmp/chain-firehose-relay-heartbeat";
+// Generous over CHAIN_FIREHOSE_POLL_INTERVAL_MS (250ms) and even a full
+// rate-limit pause (capped at CHAIN_FIREHOSE_MAX_RATE_LIMIT_PAUSE_MS, 5min)
+// -- tolerates a complete rate-limit recovery cycle plus margin before
+// flagging unhealthy, so this never false-alarms on the exact recovery
+// behavior the poll loop is supposed to do.
+export const HEARTBEAT_STALE_MS = 10 * 60 * 1000;
+
+export function touchHeartbeat(path = HEARTBEAT_FILE) {
+  // Best-effort -- a heartbeat-write failure must never crash the relay's
+  // actual job (forwarding payloads). Falls back to letting the
+  // HEALTHCHECK go unhealthy (visible) rather than silently swallowing a
+  // real filesystem problem some other way.
+  try {
+    writeFileSync(path, String(Date.now()));
+  } catch (error) {
+    console.error("[chain-firehose-relay] failed to write heartbeat:", error);
+  }
+}
+
+export function isHeartbeatFresh(
+  path = HEARTBEAT_FILE,
+  now = Date.now(),
+  maxAgeMs = HEARTBEAT_STALE_MS,
+) {
+  try {
+    return now - statSync(path).mtimeMs < maxAgeMs;
+  } catch {
+    return false; // no heartbeat file yet (e.g. still starting up) -- not fresh
+  }
+}
 
 // How many outbox rows to claim per poll -- bounds one iteration's worth of
 // sequential forwarding work, the same role CHAIN_FIREHOSE_QUEUE_MAX_SIZE
@@ -486,11 +545,13 @@ async function main() {
   }
 
   let lastCleanupAt = Date.now();
+  touchHeartbeat(); // write once at startup so HEALTHCHECK's --start-period grace doesn't immediately expire on a quiet first poll
   console.log(
     `[chain-firehose-relay] polling chain_firehose_outbox every ${CHAIN_FIREHOSE_POLL_INTERVAL_MS}ms, forwarding to ${config.ingestUrl}`,
   );
   while (!shuttingDown) {
     const { claimed, rateLimitedForMs } = await pollOnce();
+    touchHeartbeat(); // tracks poll-loop liveness, independent of claim/forward outcome -- see HEARTBEAT_FILE's own comment
     if (Date.now() - lastCleanupAt >= CHAIN_FIREHOSE_CLEANUP_INTERVAL_MS) {
       await cleanupOnce();
       lastCleanupAt = Date.now();
@@ -520,16 +581,25 @@ async function main() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch(async (error) => {
-    console.error("[chain-firehose-relay] fatal:", error);
-    // Explicitly caught here, so @sentry/node's default
-    // OnUnhandledRejection integration never sees this -- Node does not
-    // consider a promise "unhandled" once something calls .catch() on it.
-    // flush() before process.exit(1) is required: process.exit() is
-    // synchronous and does not wait for Sentry's background network send.
-    Sentry.captureException(error);
-    await Sentry.flush(2000);
-    process.exit(1);
-  });
+  if (process.argv.includes("--healthcheck")) {
+    // Docker HEALTHCHECK entry point (see
+    // deploy/chain-firehose-relay.Dockerfile) -- reuses this same
+    // image/script rather than a separate file. isHeartbeatFresh's pure
+    // logic is unit-tested directly; this just wires it to a process exit
+    // code, which is all HEALTHCHECK actually reads.
+    process.exit(isHeartbeatFresh() ? 0 : 1);
+  } else {
+    main().catch(async (error) => {
+      console.error("[chain-firehose-relay] fatal:", error);
+      // Explicitly caught here, so @sentry/node's default
+      // OnUnhandledRejection integration never sees this -- Node does not
+      // consider a promise "unhandled" once something calls .catch() on it.
+      // flush() before process.exit(1) is required: process.exit() is
+      // synchronous and does not wait for Sentry's background network send.
+      Sentry.captureException(error);
+      await Sentry.flush(2000);
+      process.exit(1);
+    });
+  }
 }
 /* v8 ignore stop */

--- a/tests/chain-firehose-relay.test.mjs
+++ b/tests/chain-firehose-relay.test.mjs
@@ -6,6 +6,9 @@
 // function's own /* v8 ignore */ comment. Every decision it makes is tested
 // directly here instead.
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { test, vi } from "vitest";
 
 // Hoisted spies -- mocked the same way apps/ui/src/lib/error-reporting.test.ts
@@ -44,10 +47,12 @@ import {
   forwardChainFirehoseNotification,
   forwardWithRetry,
   initSentry,
+  isHeartbeatFresh,
   mapBounded,
   parseRelayConfig,
   parseRetryAfterMs,
   reportRateLimitPause,
+  touchHeartbeat,
 } from "../scripts/chain-firehose-relay.mjs";
 
 // --- mapBounded ---------------------------------------------------------------
@@ -717,4 +722,59 @@ test("initSentry: SENTRY_ENVIRONMENT defaults to 'production' when unset", () =>
   initSentry();
   assert.equal(sentryInit.mock.calls[0][0].environment, "production");
   vi.unstubAllEnvs();
+});
+
+// --- touchHeartbeat / isHeartbeatFresh -----------------------------------------
+// Real filesystem, not mocked -- matches tests/backup-postgres.test.mjs's own
+// mkdtempSync convention. Both functions default to the real HEARTBEAT_FILE
+// path, but take an explicit `path` override precisely so tests never touch
+// /tmp/chain-firehose-relay-heartbeat itself.
+
+function withHeartbeatDir(fn) {
+  const dir = mkdtempSync(path.join(tmpdir(), "metagraphed-heartbeat-test-"));
+  try {
+    return fn(path.join(dir, "heartbeat"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("touchHeartbeat: writes the file; isHeartbeatFresh then reports fresh", () => {
+  withHeartbeatDir((heartbeatPath) => {
+    touchHeartbeat(heartbeatPath);
+    assert.equal(isHeartbeatFresh(heartbeatPath), true);
+  });
+});
+
+test("isHeartbeatFresh: false when the file doesn't exist yet (e.g. still starting up)", () => {
+  withHeartbeatDir((heartbeatPath) => {
+    assert.equal(isHeartbeatFresh(heartbeatPath), false);
+  });
+});
+
+test("isHeartbeatFresh: false once now - mtime exceeds maxAgeMs", () => {
+  withHeartbeatDir((heartbeatPath) => {
+    touchHeartbeat(heartbeatPath);
+    const farFuture = Date.now() + 1_000_000;
+    assert.equal(isHeartbeatFresh(heartbeatPath, farFuture, 10_000), false);
+  });
+});
+
+test("isHeartbeatFresh: true when now - mtime is under maxAgeMs", () => {
+  withHeartbeatDir((heartbeatPath) => {
+    touchHeartbeat(heartbeatPath);
+    const soonAfter = Date.now() + 5_000;
+    assert.equal(isHeartbeatFresh(heartbeatPath, soonAfter, 10_000), true);
+  });
+});
+
+test("touchHeartbeat: a write failure (unwritable path) is swallowed, never throws", () => {
+  // Passing a DIRECTORY (not a file path) makes writeFileSync throw EISDIR --
+  // touchHeartbeat must catch it, not crash the relay's actual job.
+  const dir = mkdtempSync(path.join(tmpdir(), "metagraphed-heartbeat-test-"));
+  try {
+    assert.doesNotThrow(() => touchHeartbeat(dir));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

Follow-up to #6459 (which auto-merged before this commit could be added -- see below). `metagraphed-infra`'s own copy of `scripts/chain-firehose-relay.mjs` had a heartbeat file + `--healthcheck` CLI entry point (metagraphed-infra#63) that was never ported here when #5027/#6452 rewrote the relay from LISTEN/NOTIFY to outbox-polling -- it had drifted in directly on the infra side instead of landing here first. `metagraphed-infra`#74 stops tracking that copy and would have silently regressed that monitoring coverage in production without this port, since the Docker `HEALTHCHECK` directive backing it has no canonical script to call.

Ported and adapted for the poll loop: `HEARTBEAT_FILE` is touched once per poll iteration (not once per NOTIFY). Also fixes `scripts/chain-firehose-relay-entrypoint.sh` to clone into a **fixed** path (`/tmp/repo`) instead of `mktemp`'s random suffix, and adds the `HEALTHCHECK` directive to `deploy/chain-firehose-relay.Dockerfile` -- the `HEALTHCHECK` CMD execs `node <path>/scripts/chain-firehose-relay.mjs --healthcheck` directly, baked into the image at build time, so it needs a known, stable location.

**Why a separate PR from #6459**: I pushed this commit to #6459's branch expecting it to land in the same PR, but #6459 had already auto-merged at the prior commit (Dockerfile-only) by the time this one landed -- the second push went to an orphaned branch never attached to any open PR, so it was never actually reviewed or CI-tested. Caught it while verifying end-to-end with a real container before wiring `metagraphed-infra`#74 to depend on it. This PR is that same commit, cherry-picked onto current `main`.

## Test plan

- [x] `npm test -- tests/chain-firehose-relay.test.mjs`: 50/50 passing, including new `touchHeartbeat`/`isHeartbeatFresh` tests (real tmpfile I/O, matching `tests/backup-postgres.test.mjs`'s own convention)
- [x] Real `docker build` + `docker run`: entrypoint clones, runs `npm ci --ignore-scripts`, execs, reaches `DATABASE_URL` validation as expected
- [x] `docker exec ... --healthcheck` against a live poll loop with this exact code: heartbeat file is written, exits 0; against a process with no heartbeat yet, exits 1 (never hangs/times out) -- verified directly against a running container
- [x] `shellcheck scripts/chain-firehose-relay-entrypoint.sh` clean
- [x] `npm run lint` / `npx prettier --check` clean
- [x] `npm run scan:public-safety` passes