### PR TITLE
fix(registry): canonicalize prediction-market category to prediction-markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Refreshed weekly by [`.github/workflows/gittensor-impact.yml`](.github/workflows
 
 **129 curated subnets** — 118 with a site, 47 with docs, 118 with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](https://metagraph.sh)**; per-subnet JSON at `https://api.metagraph.sh/api/v1/subnets/{netuid}`.
 
-**Focus areas:** `compute` 9 · `data` 7 · `defi` 7 · `inference` 5 · `language-models` 4 · `computer-vision` 3 · `finance` 3 · `dashboard` 2 · `data-artifact` 2 · `decentralized-training` 2 · `depin` 2 · `distributed-training` 2
+**Focus areas:** `compute` 9 · `data` 7 · `defi` 7 · `inference` 5 · `language-models` 4 · `prediction-markets` 4 · `computer-vision` 3 · `finance` 3 · `dashboard` 2 · `data-artifact` 2 · `decentralized-training` 2 · `depin` 2
 
 - **[root](https://metagraph.sh/subnets/0)** `SN0` — `chain-rpc` · [site](https://bittensor.com) · [docs](https://docs.learnbittensor.org/concepts/bittensor-networks) · [repo](https://github.com/opentensor/subtensor)
 - **[Apex](https://metagraph.sh/subnets/1)** `SN1` · [site](https://apex.macrocosmos.ai/) · [docs](https://docs.macrocosmos.ai/subnets/subnet-1-apex) · [repo](https://github.com/macrocosm-os/apex)
@@ -186,7 +186,7 @@ Refreshed weekly by [`.github/workflows/gittensor-impact.yml`](.github/workflows
 - **[Yanez MIID](https://metagraph.sh/subnets/54)** `SN54` — `compliance` `synthetic-data` · [site](https://www.yanez.ai/) · [repo](https://github.com/yanez-compliance/MIID-subnet)
 - **[NIOME](https://metagraph.sh/subnets/55)** `SN55` — `genomics` `synthetic-data` · [site](https://niome.genomes.io/) · [repo](https://github.com/genomesio/subnet-niome)
 - **[Gradients](https://metagraph.sh/subnets/56)** `SN56` — `ai-training` `operational-interface` · [site](https://www.gradients.io/) · [docs](https://api.gradients.io/docs) · [repo](https://github.com/gradients-ai/G.O.D)
-- **[Sparket](https://metagraph.sh/subnets/57)** `SN57` — `prediction-market` `sports` · [site](https://sparket.ai/) · [repo](https://github.com/sparket-ai/sparket-ai)
+- **[Sparket](https://metagraph.sh/subnets/57)** `SN57` — `prediction-markets` `sports` · [site](https://sparket.ai/) · [repo](https://github.com/sparket-ai/sparket-ai)
 - **[Handshake58](https://metagraph.sh/subnets/58)** `SN58` — `ai-marketplace` `payments` · [site](https://handshake58.com) · [docs](https://handshake58.com/skill.md) · [repo](https://github.com/Handshake58/HS58-subnet)
 - **[Babelbit](https://metagraph.sh/subnets/59)** `SN59` — `language` · [site](https://babelbit.ai/) · [repo](https://github.com/babelbit/babelbit_subnet)
 - **[Bitsec](https://metagraph.sh/subnets/60)** `SN60` — `security` · [site](https://bitsec.ai/) · [repo](https://github.com/Bitsec-AI/sandbox)
@@ -254,7 +254,7 @@ Refreshed weekly by [`.github/workflows/gittensor-impact.yml`](.github/workflows
 - **[Bitrecs](https://metagraph.sh/subnets/122)** `SN122` — `recommendations` · [site](https://www.bitrecs.ai/) · [docs](https://bitrecs.gitbook.io/bitrecs-docs/) · [repo](https://github.com/bitrecs/bitrecs-subnet)
 - **[MANTIS](https://metagraph.sh/subnets/123)** `SN123` — `sdk` · [site](https://mantis123.com/) · [repo](https://github.com/Barbariandev/MANTIS)
 - **[Swarm](https://metagraph.sh/subnets/124)** `SN124` — `robotics` · [site](https://swarm124.com/) · [repo](https://github.com/swarm-subnet/swarm)
-- **[8 Ball](https://metagraph.sh/subnets/125)** `SN125` — `prediction-market` · [site](https://8ball125.com/) · [docs](https://github.com/Barbariandev/8Ball_miner#readme) · [repo](https://github.com/Barbariandev/8Ball_miner)
+- **[8 Ball](https://metagraph.sh/subnets/125)** `SN125` — `prediction-markets` · [site](https://8ball125.com/) · [docs](https://github.com/Barbariandev/8Ball_miner#readme) · [repo](https://github.com/Barbariandev/8Ball_miner)
 - **[Poker44](https://metagraph.sh/subnets/126)** `SN126` — `security` · [site](https://poker44.net/) · [repo](https://github.com/Poker44/Poker44-subnet)
 - **[Astrid](https://metagraph.sh/subnets/127)** `SN127` — `trading-strategies` · [site](https://astrid.global/) · [repo](https://github.com/astridintelligence/sn-127)
 - **[ByteLeap](https://metagraph.sh/subnets/128)** `SN128` — `compute` · [site](https://byteleap.ai/) · [repo](https://github.com/byteleapai/byteleap-Validator)

--- a/registry/subnets/8-ball.json
+++ b/registry/subnets/8-ball.json
@@ -4,7 +4,7 @@
     "identity-reviewed",
     "official-source-repo",
     "official-website",
-    "prediction-market"
+    "prediction-markets"
   ],
   "curation": {
     "gap_notes": [

--- a/registry/subnets/sparket.json
+++ b/registry/subnets/sparket.json
@@ -4,7 +4,7 @@
     "identity-reviewed",
     "official-source-repo",
     "official-website",
-    "prediction-market",
+    "prediction-markets",
     "sports"
   ],
   "curation": {


### PR DESCRIPTION
## Summary

Fixes #6332. The registry used two spellings for one concept — `prediction-market` (`8-ball.json` SN125, `sparket.json` SN57) and `prediction-markets` (`almanac.json` SN41, `degenbrain.json` SN90) — so a category filter/facet for one spelling silently excluded the other two subnets.

Adopts the plural `prediction-markets` as canonical (per the issue's recommendation; matches the corpus convention — `language-models`, `capital-markets`, `trading-strategies`).

### Changes
- `registry/subnets/8-ball.json` — `categories[]`: `prediction-market` → `prediction-markets`
- `registry/subnets/sparket.json` — `categories[]`: `prediction-market` → `prediction-markets`
- `README.md` — regenerated via `npm run readme:catalog` (the catalog section is generated and CI-checked by `npm run validate:readme-catalog`, so it would otherwise go stale)

### Downstream consumers checked
Searched the whole repo for the singular spelling, not just `registry/subnets/`:
- **README.md** was the one real consumer — it is generated, so it is regenerated here rather than hand-edited.
- The remaining `prediction-market` hits are **English prose inside `notes` fields** (e.g. "prediction-market statements", "prediction-market contract addresses") — correct usage, intentionally untouched.
- No docs page or filter config hardcodes the category value.
- `apps/ui/tests/e2e/har/*.har` are frozen recorded HTTP fixtures, not category config — out of scope.

### Effect (matches the issue's Expected Outcome)
The regenerated README's **Focus areas** line now reads `prediction-markets 4` — previously the singular/plural split kept the count at 2 and the category off the list entirely. All 4 subnets (SN41, SN57, SN90, SN125) now group together.

Per the issue this stays a **pure data fix** — no `categories` enum is added (explicitly out of scope).

## Validation
- `npm run validate:readme-catalog` → "README catalog up to date (129 curated subnets)"
- `npm run validate:surface -- registry/subnets/8-ball.json` → passed (5 surfaces)
- `npm run validate:surface -- registry/subnets/sparket.json` → passed (5 surfaces)
- `npx prettier --check` → clean on all 3 committed files

Closes #6332