### PR TITLE
fix(registry): dedupe SN7 allways leaderboard URL registered under two kinds

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -276,28 +276,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-7-allways-data-artifact",
-      "kind": "data-artifact",
-      "name": "Allways community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "allways",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.all-ways.io/swagger-json"],
-      "url": "https://api.all-ways.io/miners/leaderboard"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-7-allways-subnet-api",
       "kind": "subnet-api",
       "name": "Allways swaps API",


### PR DESCRIPTION
## Summary

Addresses #5736. `registry/subnets/allways.json` registered `https://api.all-ways.io/miners/leaderboard` **twice** under two different kinds, double-counting one endpoint in surface-count/coverage aggregates:

- `allways-miners-leaderboard` — `kind: subnet-api`, `authority: provider-claimed`, probe `GET`/`expect: json`
- `sn-7-allways-data-artifact` — `kind: data-artifact`, `authority: community`, probe `HEAD`/`expect: any`

### Which entry survives, and why
Kept the **`subnet-api`** entry and removed the `data-artifact` duplicate. Verified the live response shape (per the issue's guidance):

```
GET https://api.all-ways.io/miners/leaderboard → 200, application/json
[{"uid":189,"crownShare":1,"successRate":0.974,"completedSwaps":38, ...}]
```

It's a **live, callable JSON API endpoint**, not a static file — so `subnet-api` is the accurate kind. The surviving entry also carries the stronger `provider-claimed` authority and the probe that actually matches the response (`GET`/`json` vs the duplicate's `HEAD`/`any`). The removed entry had no `notes` and no unique data to fold into the survivor.

Only the duplicate surface object was deleted (22 lines) — no other surface, and no `schema_version`/`curation`/top-level field, was touched.

### Scope note on the other two files
The issue also lists `bitmind.json` (SN34) and `gradients.json` (SN56). **Both are already resolved on current `main`** — I re-checked by URL rather than by surface id:

| file | duplicate-URL groups |
|---|---|
| `allways.json` | 1 → **fixed here** |
| `bitmind.json` | 0 (already deduped) |
| `gradients.json` | 0 (already deduped) |

A repo-wide sweep of all subnet files confirms `allways.json` was the **last remaining** duplicate-URL group; after this change there are **0 registry-wide**.

## Validation
- `npm run validate:surface -- registry/subnets/allways.json` → passed
- `npx prettier --check registry/subnets/allways.json` → clean
- Post-change duplicate-URL scan: 0 groups in this file, 0 registry-wide

Closes #5736