### PR TITLE
fix(ui): link a block's Author and an extrinsic's Signer to their account page

### DIFF
--- a/apps/ui/src/components/metagraphed/account-address.test.ts
+++ b/apps/ui/src/components/metagraphed/account-address.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { AccountAddress } from "@/components/metagraphed/account-address";
+
+// #6424: blocks.$ref.tsx's "Author" and extrinsics.$hash.tsx's "Signer" rendered
+// their ss58 through a bare CopyableCode — copy-only, no navigation — while the
+// events table further down the SAME page linked its ss58 values via
+// AccountAddress. Both fields were dead ends.
+//
+// AccountAddress composes TanStack's <Link>, which needs a router context to
+// render; this suite is node-environment with no DOM. So these CREATE the
+// element and walk the returned tree — the wiring (does it produce a
+// /accounts/$ss58 link, with what text) is exactly what regressed.
+const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+type AnyProps = Record<string, unknown>;
+
+/** Depth-first search for the first element whose props satisfy `match`. */
+function findElement(
+  node: ReactNode,
+  match: (props: AnyProps) => boolean,
+): ReactElement<AnyProps> | undefined {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const hit = findElement(child, match);
+      if (hit) return hit;
+    }
+    return undefined;
+  }
+  if (!isValidElement(node)) return undefined;
+  const el = node as ReactElement<AnyProps>;
+  if (match(el.props)) return el;
+  return findElement(el.props.children as ReactNode, match);
+}
+
+const linkIn = (node: ReactNode) => findElement(node, (p) => p.to === "/accounts/$ss58");
+
+describe("AccountAddress links ss58 values to their account page (#6424)", () => {
+  it("renders a /accounts/$ss58 link for a valid ss58", () => {
+    const tree = AccountAddress({ ss58: SS58, fallback: "—" });
+    const link = linkIn(tree);
+    expect(link).toBeDefined();
+    expect(link?.props.params).toEqual({ ss58: SS58 });
+    // The full value stays reachable via title, however the text is shortened.
+    expect(link?.props.title).toBe(SS58);
+  });
+
+  it("truncate={false} shows the whole address — the Author/Signer field's existing treatment", () => {
+    const link = linkIn(AccountAddress({ ss58: SS58, fallback: "—", truncate: false }));
+    expect(link?.props.children).toBe(SS58);
+  });
+
+  it("still truncates by default, so table cells are unaffected", () => {
+    const link = linkIn(AccountAddress({ ss58: SS58, fallback: "—" }));
+    expect(link?.props.children).not.toBe(SS58);
+    expect(String(link?.props.children)).toMatch(/…/);
+  });
+
+  it("renders the fallback — not a link — when the value is missing or invalid", () => {
+    for (const bad of [null, undefined, "", "not-an-ss58"]) {
+      const tree = AccountAddress({ ss58: bad, fallback: "—" });
+      expect(linkIn(tree), `expected no link for ${JSON.stringify(bad)}`).toBeUndefined();
+      // The component returns <>{fallback}</>, so the fallback is the fragment's
+      // child -- this is what keeps the fields' existing "—" for an absent value.
+      expect((tree as ReactElement<AnyProps>).props.children).toBe("—");
+    }
+  });
+
+  it("keeps a copy affordance carrying the untruncated value", () => {
+    // The issue requires the untruncated copy affordance CopyableCode offered to
+    // survive the switch: the copy button must still copy the FULL ss58, even
+    // when the visible text is shortened.
+    const copy = findElement(
+      AccountAddress({ ss58: SS58, fallback: "—" }),
+      (p) => p.value === SS58 && p.label === "account",
+    );
+    expect(copy).toBeDefined();
+  });
+});

--- a/apps/ui/src/components/metagraphed/account-address.tsx
+++ b/apps/ui/src/components/metagraphed/account-address.tsx
@@ -21,11 +21,19 @@ export function AccountAddress({
   keep,
   copyButtonClassName,
   compact,
+  truncate = true,
 }: {
   ss58?: string | null;
   fallback: ReactNode;
   /** Chars kept at each end before the ellipsis (passed to shortHash). Defaults to 6. */
   keep?: number;
+  /**
+   * Render the whole ss58 instead of shortHash's ellipsis form (#6424). Mirrors
+   * CopyableCode's own `truncate` prop, for the detail-page FieldRows that show
+   * the full value today -- a table cell wants the short form, a wide field row
+   * does not.
+   */
+  truncate?: boolean;
   copyButtonClassName?: string;
   /** Forwarded to the inner CopyButton — pass true inside a dense table/list row. See CopyButton's `compact` doc. */
   compact?: boolean;
@@ -35,7 +43,7 @@ export function AccountAddress({
       <span className="inline-flex items-center gap-1 min-w-0">
         <EntityHoverCard kind="account" ss58={ss58}>
           <Link to="/accounts/$ss58" params={{ ss58 }} className="hover:underline" title={ss58}>
-            {shortHash(ss58, keep)}
+            {truncate ? shortHash(ss58, keep) : ss58}
           </Link>
         </EntityHoverCard>
         <CopyButton

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -266,11 +266,14 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
             )}
           </FieldRow>
           <FieldRow label="Author">
-            {block.author ? (
-              <CopyableCode value={block.author} truncate={false} className="max-w-full" />
-            ) : (
-              <span className="text-ink-muted">—</span>
-            )}
+            {/* #6424: linked like every other ss58 on this page (see the events
+                table below) -- untruncated, so the full value stays readable and
+                copyable exactly as it was. */}
+            <AccountAddress
+              ss58={block.author}
+              truncate={false}
+              fallback={<span className="text-ink-muted">—</span>}
+            />
           </FieldRow>
           <FieldRow label="Extrinsics">
             <span className="font-mono text-sm text-ink tabular-nums">

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -257,11 +257,14 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
             </span>
           </FieldRow>
           <FieldRow label="Signer">
-            {extrinsic.signer ? (
-              <CopyableCode value={extrinsic.signer} truncate={false} className="max-w-full" />
-            ) : (
-              <span className="text-ink-muted">—</span>
-            )}
+            {/* #6424: linked like every other ss58 on this page (see the events
+                table below) -- untruncated, so the full value stays readable and
+                copyable exactly as it was. */}
+            <AccountAddress
+              ss58={extrinsic.signer}
+              truncate={false}
+              fallback={<span className="text-ink-muted">—</span>}
+            />
           </FieldRow>
           <FieldRow label="Result">
             <span className="font-mono text-sm text-ink">{result}</span>


### PR DESCRIPTION
## What

`blocks.$ref.tsx`'s **Author** and `extrinsics.$hash.tsx`'s **Signer** rendered their ss58 through a bare `CopyableCode` — copy-only, no navigation — while **the same files, a few hundred lines further down**, render ss58 values as clickable `/accounts/$ss58` links via `AccountAddress` (`blocks.$ref.tsx:421`, `extrinsics.$hash.tsx:382`). `AccountAddress`'s own doc comment calls `/accounts/$ss58` "the app's one lookup route for any ss58 value regardless of whether it's a hotkey or coldkey". Author/Signer were the dead ends.

Both now render through `AccountAddress`, matching the treatment already used on their own pages.

## Proof (live, real block)

`/blocks/8640823`, whose author is `5CPhKdvHmMqRmMUrpFnvLc6GUc…`:

| | `/accounts/…` links on the page |
| --- | --- |
| **before** | `5Dqju4…`, `5EEaaN…` — the events table only; **Author unlinked** |
| **after** | **`5CPhKdvHmMqRmMUrpFnvLc6GUc…`** (the Author), then the events links |

## Preserving the untruncated value — the part a naive swap breaks

The issue requires *"preserve the untruncated copy affordance both fields currently offer via `CopyableCode`"*. That matters: these fields pass `truncate={false}`, so they show the **whole 48-char address**, whereas `AccountAddress` shortens via `shortHash(ss58, keep=6)`. Swapping them straight over would have silently truncated a value that is fully visible today.

So `AccountAddress` gains a **`truncate` prop mirroring `CopyableCode`'s own** — the API these fields already used. Table cells keep the short form (default unchanged); the wide detail-page field rows pass `truncate={false}` and look exactly as they do now, only linked. The copy button already carried the full `ss58`, and still does.

## Screenshots

Captured at the `#details` section — the field rows this change touches — with real API data on both sides.


**One honest note on the visuals:** `CopyableCode` wrapped the value in a bordered chip; `AccountAddress` renders plain linked text plus the copy button. So the Author/Signer row loses that chip — which is inherent to rendering through `AccountAddress` as the issue asks, and it makes the row consistent with the sibling `BLOCK HASH` / `PARENT HASH` rows, which are already plain text. The address itself stays full-length and copyable. Flagging it so it isn't a surprise.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

`account-address.test.ts` (5 tests). `AccountAddress` composes TanStack's `<Link>`, which needs a router to render and this suite is node-environment — so the tests **create** the element and walk the tree, which is where the wiring regressed:

- a `/accounts/$ss58` link is produced for a valid ss58, with the right `params` and the full value on `title`;
- **`truncate={false}` renders the whole address** — the Author/Signer treatment;
- the default still truncates, so **table cells are unaffected**;
- missing/invalid values (`null`, `undefined`, `""`, `"not-an-ss58"`) render the fallback and **no link**;
- the copy affordance still carries the **untruncated** ss58.

**Verified meaningful:** reverting the two routes + `account-address.tsx` to upstream fails the `truncate={false}` assertion; restored, 5/5 pass.

`apps/ui`: 139 files / 1054 tests pass, `tsc` clean, `format:check` clean.

Closes #6424
