### PR TITLE
fix(api): key analytics edge-cache entries on resolved param values

### DIFF
--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -25,7 +25,15 @@ import {
   analyticsQueryError,
   canonicalAnalyticsCacheRoute,
   canonicalHealthWindowCachePath,
+  handleChainStakeFlow,
+  handleChainWeights,
+  handleChainWeightSetters,
+  handleChainServing,
 } from "../workers/request-handlers/analytics.mjs";
+import { CHAIN_STAKE_FLOW_LIMIT_DEFAULT } from "../src/chain-stake-flow.mjs";
+import { CHAIN_WEIGHTS_LIMIT_DEFAULT } from "../src/chain-weights.mjs";
+import { CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT } from "../src/chain-weight-setters.mjs";
+import { CHAIN_SERVING_LIMIT_DEFAULT } from "../src/chain-serving.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
@@ -339,7 +347,115 @@ describe("validateQueryParams", () => {
   });
 });
 
+// #6356: end-to-end proof through the handlers themselves -- a bare request and
+// an explicit request for the handler's own documented default must land on ONE
+// edge-cache entry. Previously only `window` was resolved into the key, so these
+// two hashed apart while serving byte-identical bodies.
+describe("analytics edge-cache keys fold in resolved defaults (#6356)", () => {
+  let originalCaches;
+
+  afterEach(() => {
+    if (originalCaches === undefined) delete globalThis.caches;
+    else globalThis.caches = originalCaches;
+    originalCaches = undefined;
+  });
+
+  const ROUTES = [
+    {
+      name: "chain/stake-flow",
+      handler: handleChainStakeFlow,
+      path: "/api/v1/chain/stake-flow",
+      limit: CHAIN_STAKE_FLOW_LIMIT_DEFAULT,
+    },
+    {
+      name: "chain/weights",
+      handler: handleChainWeights,
+      path: "/api/v1/chain/weights",
+      limit: CHAIN_WEIGHTS_LIMIT_DEFAULT,
+    },
+    {
+      name: "chain/weights/setters",
+      handler: handleChainWeightSetters,
+      path: "/api/v1/chain/weights/setters",
+      limit: CHAIN_WEIGHT_SETTERS_LIMIT_DEFAULT,
+    },
+    {
+      name: "chain/serving",
+      handler: handleChainServing,
+      path: "/api/v1/chain/serving",
+      limit: CHAIN_SERVING_LIMIT_DEFAULT,
+    },
+  ];
+
+  async function cacheKeyFor(handler, path) {
+    const cache = mockCaches();
+    cache.install();
+    const { env } = dbWith({ rows: [] });
+    const res = await handler(req(path), env, url(path), ctx);
+    assert.equal(res.status, 200);
+    await Promise.resolve();
+    assert.equal(cache.putKeys.length, 1, `${path} must seed one cache entry`);
+    return cache.putKeys[0];
+  }
+
+  for (const route of ROUTES) {
+    test(`${route.name}: a bare request and ?limit=<default> share one entry`, async () => {
+      originalCaches = globalThis.caches;
+      const bare = await cacheKeyFor(route.handler, route.path);
+      const explicit = await cacheKeyFor(
+        route.handler,
+        `${route.path}?limit=${route.limit}`,
+      );
+      assert.equal(bare, explicit);
+      // The resolved default is actually in the key, not merely absent from both.
+      assert.match(bare, new RegExp(`limit=${route.limit}(&|$)`));
+      assert.match(bare, new RegExp(`window=${DEFAULT_ANALYTICS_WINDOW}(&|$)`));
+    });
+  }
+
+  // The CSV variant keys separately (same aggregation, different serialization),
+  // and must fold in the resolved default exactly the same way.
+  for (const route of ROUTES) {
+    test(`${route.name}: the CSV key also carries the resolved default`, async () => {
+      originalCaches = globalThis.caches;
+      const bare = await cacheKeyFor(route.handler, `${route.path}?format=csv`);
+      const explicit = await cacheKeyFor(
+        route.handler,
+        `${route.path}?limit=${route.limit}&format=csv`,
+      );
+      assert.equal(bare, explicit);
+      assert.match(bare, new RegExp(`limit=${route.limit}(&|$)`));
+      assert.match(bare, /format=csv$/);
+      // JSON and CSV must not collide on one entry.
+      const json = await cacheKeyFor(route.handler, route.path);
+      assert.notEqual(bare, json);
+    });
+  }
+
+  test("an explicit non-default limit still keys separately", async () => {
+    originalCaches = globalThis.caches;
+    const bare = await cacheKeyFor(handleChainServing, "/api/v1/chain/serving");
+    const wider = await cacheKeyFor(
+      handleChainServing,
+      "/api/v1/chain/serving?limit=5",
+    );
+    assert.notEqual(bare, wider);
+  });
+});
+
 describe("canonicalAnalyticsCacheRoute", () => {
+  // The helper now takes each param's already-resolved value (#6356) rather than
+  // re-deriving it from the raw URL, so the key reflects what the handler
+  // actually served. Call sites read via url.searchParams.get(), which decodes,
+  // so percent-encoding still normalizes -- exercised below.
+  const signersResolved = (requestUrl, overrides = {}) => ({
+    window: "30d",
+    limit: 10,
+    call_module: requestUrl.searchParams.get("call_module"),
+    sort: "total_fee_tao",
+    ...overrides,
+  });
+
   test("normalizes decoded query values for cache keys", () => {
     const plain = url(
       "/api/v1/chain/signers?call_module=Balances&limit=10&window=30d&sort=total_fee_tao",
@@ -349,12 +465,12 @@ describe("canonicalAnalyticsCacheRoute", () => {
     );
 
     assert.equal(
-      canonicalAnalyticsCacheRoute(plain, ["limit", "call_module", "sort"]),
+      canonicalAnalyticsCacheRoute(plain, signersResolved(plain)),
       "/api/v1/chain/signers?window=30d&limit=10&call_module=Balances&sort=total_fee_tao",
     );
     assert.equal(
-      canonicalAnalyticsCacheRoute(encoded, ["limit", "call_module", "sort"]),
-      canonicalAnalyticsCacheRoute(plain, ["limit", "call_module", "sort"]),
+      canonicalAnalyticsCacheRoute(encoded, signersResolved(encoded)),
+      canonicalAnalyticsCacheRoute(plain, signersResolved(plain)),
     );
   });
 
@@ -362,12 +478,15 @@ describe("canonicalAnalyticsCacheRoute", () => {
     const bare = url("/api/v1/chain/transfers?limit=25");
     const explicit = url(`/api/v1/chain/transfers?window=7d&limit=25`);
     assert.equal(
-      canonicalAnalyticsCacheRoute(bare, ["limit"]),
+      canonicalAnalyticsCacheRoute(bare, { limit: 25 }),
       `/api/v1/chain/transfers?window=${DEFAULT_ANALYTICS_WINDOW}&limit=25`,
     );
     assert.equal(
-      canonicalAnalyticsCacheRoute(explicit, ["limit"]),
-      canonicalAnalyticsCacheRoute(bare, ["limit"]),
+      canonicalAnalyticsCacheRoute(explicit, {
+        window: DEFAULT_ANALYTICS_WINDOW,
+        limit: 25,
+      }),
+      canonicalAnalyticsCacheRoute(bare, { limit: 25 }),
     );
   });
 
@@ -377,12 +496,77 @@ describe("canonicalAnalyticsCacheRoute", () => {
     );
 
     assert.equal(
-      canonicalAnalyticsCacheRoute(requestUrl, [
-        "group_by",
-        "limit",
-        "call_module",
-      ]),
+      canonicalAnalyticsCacheRoute(requestUrl, {
+        window: "30d",
+        group_by: "module_function",
+        limit: 10,
+        call_module: requestUrl.searchParams.get("call_module"),
+      }),
       "/api/v1/chain/calls?window=30d&group_by=module_function&limit=10&call_module=SubtensorModule",
+    );
+  });
+
+  // #6356: only `window` used to be defaulted into the key. Every other param
+  // entered it solely when the caller spelled it out, so a bare request and an
+  // explicit request for the handler's OWN documented default produced identical
+  // bodies under two different cache entries -- exactly the duplicate
+  // aggregation withEdgeCache exists to avoid.
+  test("a bare request and an explicit default limit share one cache entry", () => {
+    const bare = url("/api/v1/chain/signers");
+    const explicit = url("/api/v1/chain/signers?limit=50");
+    // 50 is handleChainSigners' documented default: both requests serve it.
+    const resolved = { window: DEFAULT_ANALYTICS_WINDOW, limit: 50 };
+    assert.equal(
+      canonicalAnalyticsCacheRoute(bare, resolved),
+      canonicalAnalyticsCacheRoute(explicit, resolved),
+    );
+    assert.equal(
+      canonicalAnalyticsCacheRoute(bare, resolved),
+      `/api/v1/chain/signers?window=${DEFAULT_ANALYTICS_WINDOW}&limit=50`,
+    );
+  });
+
+  test("a defaulted sort / group_by is keyed too, not just window", () => {
+    const bare = url("/api/v1/chain/calls");
+    assert.equal(
+      canonicalAnalyticsCacheRoute(bare, {
+        window: DEFAULT_ANALYTICS_WINDOW,
+        group_by: "module",
+        limit: 50,
+      }),
+      `/api/v1/chain/calls?window=${DEFAULT_ANALYTICS_WINDOW}&group_by=module&limit=50`,
+    );
+  });
+
+  test("a genuinely absent optional filter stays out of the key", () => {
+    // call_module has no default: unset must not become an empty-string param,
+    // or every bare request would key differently from itself.
+    const bare = url("/api/v1/chain/signers");
+    assert.equal(
+      canonicalAnalyticsCacheRoute(bare, {
+        window: DEFAULT_ANALYTICS_WINDOW,
+        limit: 50,
+        call_module: bare.searchParams.get("call_module"),
+        sort: "tx_count",
+      }),
+      `/api/v1/chain/signers?window=${DEFAULT_ANALYTICS_WINDOW}&limit=50&sort=tx_count`,
+    );
+  });
+
+  test("a real filter still separates entries (the fix is not over-broad)", () => {
+    const filtered = url("/api/v1/chain/signers?call_module=Balances");
+    const bare = url("/api/v1/chain/signers");
+    assert.notEqual(
+      canonicalAnalyticsCacheRoute(filtered, {
+        window: DEFAULT_ANALYTICS_WINDOW,
+        limit: 50,
+        call_module: filtered.searchParams.get("call_module"),
+      }),
+      canonicalAnalyticsCacheRoute(bare, {
+        window: DEFAULT_ANALYTICS_WINDOW,
+        limit: 50,
+        call_module: bare.searchParams.get("call_module"),
+      }),
     );
   });
 });
@@ -1650,8 +1834,11 @@ describe("chain analytics ?format=csv export", () => {
       "signer,tx_count,total_fee_tao,total_tip_tao,last_tx_block",
     );
     await Promise.resolve();
+    // #6356: the key now carries the handler's RESOLVED limit/sort, not just the
+    // params the caller happened to spell out -- so this bare request shares an
+    // entry with an explicit ?limit=50&sort=tx_count instead of fragmenting.
     assert.deepEqual(cache.putKeys, [
-      "https://edge-cache.metagraph.sh/analytics/2026-07-03.2/2026-06-18T00%3A00%3A00.000Z/chain-signers/api/v1/chain/signers?window=7d&format=csv",
+      "https://edge-cache.metagraph.sh/analytics/2026-07-03.2/2026-06-18T00%3A00%3A00.000Z/chain-signers/api/v1/chain/signers?window=7d&limit=50&sort=tx_count&format=csv",
     ]);
   });
 

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -158,19 +158,32 @@ function validateQueryParams(url, allowedParams) {
   return null;
 }
 
-function canonicalAnalyticsCacheRoute(url, params = []) {
+// Build the canonical edge-cache key for an analytics route from the handler's
+// ALREADY-RESOLVED param values, so a bare request and an explicit request for
+// the handler's own documented default share one cache entry (#6356).
+//
+// `resolved` is an ordered map of param -> resolved value; its key order is the
+// key's param order (window is always emitted first). Pass the value the handler
+// actually used, not the raw query string: previously only `window` was
+// defaulted here and every other param entered the key only when the caller
+// spelled it out, so `?limit=50` and a bare request (which also means 50) hashed
+// to two entries with identical bodies -- undercutting the "don't re-execute the
+// same aggregation for a cross-colo / agent-polling burst" purpose withEdgeCache
+// documents. Mirrors canonicalLeaderboardsCachePath / canonicalGlobalValidators-
+// CachePath, which already resolve their defaults before keying.
+//
+// A null/undefined value means the param is genuinely absent with no default
+// (e.g. an unset `call_module` filter), so it stays out of the key.
+function canonicalAnalyticsCacheRoute(url, resolved = {}) {
   const search = new URL("https://cache-key.invalid/").searchParams;
-  for (const param of [ANALYTICS_WINDOW_PARAM, ...params]) {
-    const value = url.searchParams.get(param);
-    if (value !== null) {
-      search.set(param, value);
-      continue;
-    }
-    // Normalize the default window into the cache key so a bare request and an
-    // explicit ?window=<default> request share one edge-cache entry.
-    if (param === ANALYTICS_WINDOW_PARAM) {
-      search.set(param, DEFAULT_ANALYTICS_WINDOW);
-    }
+  search.set(
+    ANALYTICS_WINDOW_PARAM,
+    resolved[ANALYTICS_WINDOW_PARAM] ?? DEFAULT_ANALYTICS_WINDOW,
+  );
+  for (const [param, value] of Object.entries(resolved)) {
+    if (param === ANALYTICS_WINDOW_PARAM) continue;
+    if (value === null || value === undefined) continue;
+    search.set(param, String(value));
   }
   const query = search.toString();
   return `${url.pathname}${query ? `?${query}` : ""}`;
@@ -937,7 +950,7 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
     "module_function",
   ]);
   if (groupByError) return analyticsQueryError(groupByError);
-  const { error: limitError } = parseLimitParam(url, {
+  const { limit, error: limitError } = parseLimitParam(url, {
     defaultLimit: 50,
     maxLimit: 100,
   });
@@ -999,7 +1012,12 @@ export async function handleChainCalls(request, env, url, ctx = {}) {
       );
       return usedFallback ? markD1FallbackResponse(response) : response;
     },
-    `${canonicalAnalyticsCacheRoute(url, ["group_by", "limit", "call_module"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, {
+      window: label,
+      group_by: groupBy,
+      limit,
+      call_module: url.searchParams.get("call_module"),
+    })}${csv ? "&format=csv" : ""}`,
   );
 }
 
@@ -1020,7 +1038,7 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
   if (sortError) return analyticsQueryError(sortError);
   // limit/call_module no longer feed a live D1 read (see the retirement note
   // below) but are still shape-validated so the REST contract stays stable.
-  const { error: limitError } = parseLimitParam(url, {
+  const { limit, error: limitError } = parseLimitParam(url, {
     defaultLimit: 50,
     maxLimit: 100,
   });
@@ -1073,7 +1091,12 @@ export async function handleChainSigners(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit", "call_module", "sort"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, {
+      window: label,
+      limit,
+      call_module: url.searchParams.get("call_module"),
+      sort,
+    })}${csv ? "&format=csv" : ""}`,
   );
 }
 
@@ -1088,7 +1111,7 @@ export async function handleChainTransfers(request, env, url, ctx = {}) {
   if (formatError) return analyticsQueryError(formatError);
   // limit no longer feeds a live D1 read (see the retirement note below) but
   // is still shape-validated so the REST contract stays stable.
-  const { error: limitError } = parseLimitParam(url, {
+  const { limit, error: limitError } = parseLimitParam(url, {
     defaultLimit: 25,
     maxLimit: 100,
   });
@@ -1155,7 +1178,7 @@ export async function handleChainTransfers(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, { window: label, limit })}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })
@@ -1175,7 +1198,7 @@ export async function handleChainTransferPairs(request, env, url, ctx = {}) {
   if (formatError) return analyticsQueryError(formatError);
   // limit no longer feeds a live D1 read (see the retirement note below) but
   // is still shape-validated so the REST contract stays stable.
-  const { error: limitError } = parseLimitParam(url, {
+  const { limit, error: limitError } = parseLimitParam(url, {
     defaultLimit: 25,
     maxLimit: 100,
   });
@@ -1233,7 +1256,11 @@ export async function handleChainTransferPairs(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit", "sort"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, {
+      window: label,
+      limit,
+      sort,
+    })}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })
@@ -1302,7 +1329,7 @@ export async function handleChainStakeFlow(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, { window: label, limit })}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })
@@ -1456,7 +1483,7 @@ export async function handleChainWeights(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, { window: label, limit })}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })
@@ -1523,7 +1550,7 @@ export async function handleChainWeightSetters(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, { window: label, limit })}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })
@@ -1591,7 +1618,7 @@ export async function handleChainServing(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, { window: label, limit })}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })
@@ -1659,7 +1686,7 @@ export async function handleChainPrometheus(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, { window: label, limit })}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })
@@ -1728,7 +1755,7 @@ export async function handleChainAxonRemovals(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, { window: label, limit })}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })
@@ -1796,7 +1823,7 @@ export async function handleChainRegistrations(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, { window: label, limit })}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })
@@ -1865,7 +1892,7 @@ export async function handleChainDeregistrations(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, { window: label, limit })}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })
@@ -1933,7 +1960,7 @@ export async function handleChainStakeMoves(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, { window: label, limit })}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })
@@ -2001,7 +2028,7 @@ export async function handleChainStakeTransfers(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, { window: label, limit })}${csv ? "&format=csv" : ""}`,
   );
   return request.method === "HEAD"
     ? new Response(null, { status: response.status, headers: response.headers })
@@ -2020,7 +2047,7 @@ export async function handleChainFees(request, env, url, ctx = {}) {
   if (error) return analyticsQueryError(error);
   const formatError = validateFormatParam(url);
   if (formatError) return analyticsQueryError(formatError);
-  const { error: limitError } = parseLimitParam(url, {
+  const { limit, error: limitError } = parseLimitParam(url, {
     defaultLimit: 25,
     maxLimit: 100,
   });
@@ -2076,7 +2103,11 @@ export async function handleChainFees(request, env, url, ctx = {}) {
         "short",
       );
     },
-    `${canonicalAnalyticsCacheRoute(url, ["limit", "call_module"])}${csv ? "&format=csv" : ""}`,
+    `${canonicalAnalyticsCacheRoute(url, {
+      window: label,
+      limit,
+      call_module: url.searchParams.get("call_module"),
+    })}${csv ? "&format=csv" : ""}`,
   );
 }
 


### PR DESCRIPTION
Closes #6356

## The bug

`canonicalAnalyticsCacheRoute` defaulted **only** the `window` param. Every other extra param (`limit`, `sort`, `call_module`, `group_by`) entered the cache key solely when the caller spelled it out — so a bare request and an explicit request for the handler's **own documented default** produced byte-identical bodies under two different cache entries, across ~14 `/api/v1/chain/*` routes.

That undercuts the reason `withEdgeCache` exists. Its own header comment: a *"cross-colo / agent-polling burst"* must not *"re-execute the same aggregation needlessly"* — which is exactly what an agent polling `?limit=50` (the default) alongside a UI hitting the bare route caused.

Verified against the real helper, before → after:

```
chain/signers   bare  vs  ?limit=50        two keys  ->  ONE key
chain/calls     bare  vs  ?limit=50&group_by=module   two keys  ->  ONE key
chain/signers   ?call_module=Balances vs bare         two keys  ->  two keys  (unchanged: a real filter must still separate)
```

## The fix

The helper now takes each param's **already-resolved value** instead of re-deriving it from the raw URL — mirroring `canonicalLeaderboardsCachePath` and `canonicalGlobalValidatorsCachePath`, which already resolve their defaults before keying (the issue's requirement).

- **15 call sites** pass their resolved values; `window` reuses the `label` `analyticsWindow` already resolved. Key order is the object's insertion order, so the canonical key shape (window first, then the route's own order) is **unchanged** — the existing order tests still pass untouched.
- **5 handlers** (`chain calls`/`signers`/`transfers`/`transfer-pairs`/`fees`) validated the limit but **discarded the value** (`const { error: limitError }`) since #4772 retired their live D1 read. The key needs it, so the resolved limit is now captured.
- A `null` value (an unset `call_module`) stays out of the key, so a bare request cannot key differently from itself.

## Two tests asserted the old behaviour

- The edge-cache test pinned the old bare-request key `?window=7d&format=csv` — **no `limit`/`sort`**. That key *was* the bug, so it is updated to the corrected contract rather than worked around.
- The three helper tests used the array signature; updated to the resolved-value form, preserving their intent (including the percent-decoding case — call sites read via `url.searchParams.get()`, which decodes).

## New coverage the fix required

`handleChainStakeFlow`, `handleChainWeights`, `handleChainWeightSetters` and `handleChainServing` had **no handler-level tests at all** — their `withEdgeCache` line never executed. Rather than shrink the diff, I covered them: each now drives the real handler and asserts a bare request and `?limit=<default>` land on **one** entry, in both JSON and CSV form (JSON/CSV still key apart), plus that an explicit non-default limit still separates.

```
13 suites pass, including data-api, analytics, analytics-live, analytics-edge-cache,
chain-analytics and every per-route chain suite.
```

Patch coverage measured locally the way codecov measures it — every added line mapped against `coverage-final.json`'s `statementMap`/`branchMap`: **51/51 covered statements and branch arms = 100%** (target 99%), no partials. It read 84.31% before the new handler tests, which is what caught the gap. `eslint` clean, `prettier --check` clean; re-verified after rebasing onto a main that moved 8 commits, pushed at `behind: 0`.
