### PR TITLE
fix(registry): dedupe SN7 allways URL and drop stale grandfathered duplicates

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -194,7 +194,8 @@
       },
       "provider": "allways",
       "public_safe": true,
-      "url": "https://api.all-ways.io/miners/leaderboard"
+      "url": "https://api.all-ways.io/miners/leaderboard",
+      "source_urls": ["https://api.all-ways.io/swagger-json"]
     },
     {
       "auth_required": false,
@@ -272,28 +273,6 @@
       "provider": "allways",
       "public_safe": true,
       "url": "https://api.all-ways.io/sse"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "id": "sn-7-allways-data-artifact",
-      "kind": "data-artifact",
-      "name": "Allways community data-artifact",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "allways",
-      "public_safe": true,
-      "review": {
-        "confidence": "medium",
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": ["https://api.all-ways.io/swagger-json"],
-      "url": "https://api.all-ways.io/miners/leaderboard"
     },
     {
       "auth_required": false,

--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -44,9 +44,6 @@ const BASE_LAYER_KINDS = new Set(["subtensor-rpc", "subtensor-wss", "archive"]);
 // its underlying duplicate is actually resolved in the registry file.
 const GRANDFATHERED_DUPLICATE_URLS = new Set([
   "8-ball.json|https://github.com/Barbariandev/8Ball_miner",
-  "allways.json|https://api.all-ways.io/miners/leaderboard",
-  "bitmind.json|https://api.bitmind.ai/health",
-  "gradients.json|https://api.gradients.io/v1/network/status",
 ]);
 
 // Reviewed-tier authorship convention + its acknowledged exemptions (#5739).


### PR DESCRIPTION
## Summary

Fixes #5736 — and closes the loop the issue implies but doesn't spell out: the **grandfather allowlist that was masking these duplicates**.

### 1. The duplicate itself
`registry/subnets/allways.json` registered `https://api.all-ways.io/miners/leaderboard` twice:
- `allways-miners-leaderboard` — `subnet-api`, `provider-claimed`, probe `GET`/`json` ✅ **kept**
- `sn-7-allways-data-artifact` — `data-artifact`, `community`, probe `HEAD`/`any` ❌ **removed**

Verified the live response to pick the accurate kind (per the issue's guidance):
```
GET https://api.all-ways.io/miners/leaderboard → 200 application/json
[{"uid":189,"crownShare":1,"successRate":0.974,"completedSwaps":38, ...}]
```
It's a **live callable JSON endpoint**, so `subnet-api` is correct; `data-artifact` implies a static file. The survivor also carries the stronger `provider-claimed` authority and the probe matching the real response.

Per the issue's "fold the removed entry's data into the survivor" clause, the removed surface's `source_urls: ["https://api.all-ways.io/swagger-json"]` is carried onto the survivor (verified live: 200, an OpenAPI 3.0 document) — strengthening its provenance.

### 2. The stale grandfather entries (the part that actually matters)
`scripts/validate-surface.mjs` has a `GRANDFATHERED_DUPLICATE_URLS` allowlist that suppresses the duplicate-URL error. It listed **all three** files from this issue — but `bitmind.json` and `gradients.json` **were already deduped on `main`**, so those two entries were *already* dead code silently masking any future regression on those exact URLs. This PR removes all three now-resolved entries:

```diff
 const GRANDFATHERED_DUPLICATE_URLS = new Set([
   "8-ball.json|https://github.com/Barbariandev/8Ball_miner",
-  "allways.json|https://api.all-ways.io/miners/leaderboard",
-  "bitmind.json|https://api.bitmind.ai/health",
-  "gradients.json|https://api.gradients.io/v1/network/status",
 ]);
```

**`8-ball.json` is deliberately kept** — it is still a live duplicate (`sn-125-eightball-source-repo` and `sn-125-eightball-docs` both normalize to `https://github.com/Barbariandev/8Ball_miner`; they differ only by a `#readme` fragment). Removing it is out of scope for this issue.

### Verification (both directions)
- With the 3 entries removed, `allways.json`, `bitmind.json`, `gradients.json` all validate clean → the entries were genuinely stale.
- Temporarily dropping the **8-ball** entry reproduces the error, proving it is still load-bearing and correctly retained:
  ```
  8-ball.json: "https://github.com/Barbariandev/8Ball_miner" is registered by 2 surfaces
  (sn-125-eightball-source-repo, sn-125-eightball-docs) — dedupe to the one surface kind…
  ```
- A repo-wide scan confirms `allways.json` was the **last** duplicate-URL group; after this there are **0 registry-wide**, and the allowlist now contains only the one genuinely-grandfathered case.

## Validation
- `npm run validate:surface` (full registry) → **passed: 1121 surfaces across 129 subnet files**
- `npm run validate:surface -- registry/subnets/{allways,bitmind,gradients,8-ball}.json` → all passed
- `npx eslint scripts/validate-surface.mjs` → clean
- `npx prettier --check` → clean on both files

Closes #5736