### PR TITLE
fix(registry): set schema_url on machine-readable openapi surfaces and enforce it

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -222,7 +222,8 @@
         "https://api.chutes.ai/openapi.json",
         "https://github.com/chutesai/chutes"
       ],
-      "url": "https://api.chutes.ai/openapi.json"
+      "url": "https://api.chutes.ai/openapi.json",
+      "schema_url": "https://api.chutes.ai/openapi.json"
     },
     {
       "auth_required": false,

--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -137,7 +137,8 @@
         "https://www.desearch.ai/openapi.json",
         "https://api.desearch.ai"
       ],
-      "url": "https://www.desearch.ai/openapi.json"
+      "url": "https://www.desearch.ai/openapi.json",
+      "schema_url": "https://www.desearch.ai/openapi.json"
     },
     {
       "auth_required": true,

--- a/registry/subnets/green-compute.json
+++ b/registry/subnets/green-compute.json
@@ -101,7 +101,8 @@
         "https://api.green-compute.com/openapi.json",
         "https://www.green-compute.com/"
       ],
-      "url": "https://api.green-compute.com/openapi.json"
+      "url": "https://api.green-compute.com/openapi.json",
+      "schema_url": "https://api.green-compute.com/openapi.json"
     },
     {
       "auth_required": false,

--- a/registry/subnets/handshake58.json
+++ b/registry/subnets/handshake58.json
@@ -143,7 +143,8 @@
         "https://handshake58.com/.well-known/ai-plugin.json",
         "https://handshake58.com/openapi.json"
       ],
-      "url": "https://handshake58.com/openapi.json"
+      "url": "https://handshake58.com/openapi.json",
+      "schema_url": "https://handshake58.com/openapi.json"
     },
     {
       "auth_required": false,

--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -142,7 +142,8 @@
         "https://tournament-api.nepher.ai/docs",
         "https://tournament-api.nepher.ai/openapi.json"
       ],
-      "url": "https://tournament-api.nepher.ai/openapi.json"
+      "url": "https://tournament-api.nepher.ai/openapi.json",
+      "schema_url": "https://tournament-api.nepher.ai/openapi.json"
     },
     {
       "auth_required": true,

--- a/registry/subnets/verathos.json
+++ b/registry/subnets/verathos.json
@@ -116,7 +116,8 @@
         "https://verathos.ai/docs",
         "https://verathos.ai/openapi.json"
       ],
-      "url": "https://verathos.ai/openapi.json"
+      "url": "https://verathos.ai/openapi.json",
+      "schema_url": "https://verathos.ai/openapi.json"
     },
     {
       "auth_required": false,

--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -201,6 +201,18 @@ for (const file of files) {
           "(the /rpc endpoint lane), not per-subnet contributor surfaces.",
       );
     }
+    // A surface that advertises a machine-readable schema must say where to fetch
+    // it: schema_status is the claim, schema_url is the address. 56/62 openapi
+    // surfaces already pair them (schema_url is usually the surface's own url, but
+    // not always — numinous.json serves docs at url and the spec at schema_url), so
+    // the claim without the address leaves callers with nothing to fetch (#6331).
+    if (surface.schema_status === "machine-readable" && !surface.schema_url) {
+      errors.push(
+        `${label}: schema_status "machine-readable" requires a schema_url pointing at ` +
+          "the fetchable spec (commonly the surface's own url) — a machine-readable " +
+          "claim with no address gives callers nothing to fetch.",
+      );
+    }
   }
   for (const [normalizedUrl, ids] of surfaceIdsByUrl) {
     if (


### PR DESCRIPTION
## Summary

Fixes #6331. Six `kind: "openapi"` surfaces claimed `schema_status: "machine-readable"` without a `schema_url`, so they advertised a fetchable spec while telling callers nothing about where to fetch it. Both deliverables are covered.

### 1. `schema_url` set on all 6 surfaces
Per the issue, I **verified each spec is actually served at the URL before copying it** (rather than assuming the 56-file `schema_url === url` precedent holds):

| file | surface | live probe of its `url` |
|---|---|---|
| `chutes.json` | `sn-64-chutes-openapi` | 200 · OpenAPI **3.1.0** · 165 paths |
| `desearch.json` | `sn-22-desearch-openapi` | 200 · OpenAPI **3.1.0** · 35 paths |
| `green-compute.json` | `sn-110-green-compute-openapi` | 200 · OpenAPI **3.1.0** · 99 paths |
| `handshake58.json` | `sn-58-handshake58-openapi` | 200 · OpenAPI **3.0.3** · 4 paths |
| `nepher-robotics.json` | `sn-49-nepher-tournament-openapi` | 200 · OpenAPI **3.1.0** · 138 paths |
| `verathos.json` | `sn-96-verathos-openapi` | 200 · OpenAPI **3.1.0** · 24 paths |

All six serve a real spec at their own `url`, so `schema_url = url` is factually correct in every case (the `numinous.json` split — docs at `url`, spec at `schema_url` — does not apply to any of them). One field added per file; nothing else touched.

### 2. Validation check added
`scripts/validate-surface.mjs` now errors when the claim has no address:

```
<file> (<surface-id>): schema_status "machine-readable" requires a schema_url pointing at
the fetchable spec (commonly the surface's own url) — a machine-readable claim with no
address gives callers nothing to fetch.
```

It sits with the other per-surface checks and is deliberately keyed on `schema_status` rather than `kind === "openapi"`, so any future kind making the same claim is covered too. A comment records the 56/62 precedent and the `numinous.json` counter-example (why `schema_url` is a separate field and not just `url`).

### Verification (both directions)
- **Passes on the fixed registry:** `npm run validate:surface` → **1122 surfaces across 129 subnet files**, no errors.
- **Catches a regression:** temporarily deleting `verathos.json`'s new `schema_url` reproduces the error, then passes again once restored — so the check is genuinely load-bearing, not inert.
- Re-scan for the original defect: **0** surfaces now claim `machine-readable` without `schema_url` (was 6).

## Validation
- `npm run validate:surface` (full registry) → passed (1122 surfaces / 129 files)
- `npx eslint scripts/validate-surface.mjs` → clean
- `npx prettier --check` → clean on all 7 files

Closes #6331