### PR TITLE
feat(ui): flag an unrecognized hotkey on the validator detail page (#6430)

### DIFF
--- a/apps/ui/src/lib/metagraphed/validator-recognition.test.ts
+++ b/apps/ui/src/lib/metagraphed/validator-recognition.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  isUnrecognizedValidator,
+  type ValidatorRecognitionSignals,
+} from "@/lib/metagraphed/validator-recognition";
+
+/** A hotkey that was never seen validating: the zeroed aggregate the
+ * schema-stable endpoint returns for any well-formed ss58 (#6430). */
+const UNRECOGNIZED: ValidatorRecognitionSignals = {
+  subnet_count: 0,
+  total_stake_tao: 0,
+  nominator_count: null,
+};
+
+describe("isUnrecognizedValidator", () => {
+  it("flags the all-zero aggregate a never-registered hotkey resolves to", () => {
+    expect(isUnrecognizedValidator(UNRECOGNIZED)).toBe(true);
+  });
+
+  it("treats an absent nominator_count the same as an explicit null", () => {
+    // The low-frequency nominator source may omit the field entirely rather
+    // than send null, which is why the check is `== null`.
+    expect(
+      isUnrecognizedValidator({
+        ...UNRECOGNIZED,
+        nominator_count: undefined as unknown as null,
+      }),
+    ).toBe(true);
+  });
+
+  // Each signal alone is a real state a genuine validator can be in, so none of
+  // them may flag on its own -- that would slander a live validator.
+  it("does not flag a registered validator that is fully unstaked", () => {
+    expect(isUnrecognizedValidator({ ...UNRECOGNIZED, subnet_count: 3 })).toBe(false);
+  });
+
+  it("does not flag a deregistered validator that still holds stake", () => {
+    expect(isUnrecognizedValidator({ ...UNRECOGNIZED, total_stake_tao: 1200.5 })).toBe(false);
+  });
+
+  it("does not flag a validator whose nominator count is a genuine zero", () => {
+    expect(isUnrecognizedValidator({ ...UNRECOGNIZED, nominator_count: 0 })).toBe(false);
+  });
+
+  it("does not flag a fully populated validator", () => {
+    expect(
+      isUnrecognizedValidator({
+        subnet_count: 12,
+        total_stake_tao: 56_280_000,
+        nominator_count: 41,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/validator-recognition.ts
+++ b/apps/ui/src/lib/metagraphed/validator-recognition.ts
@@ -1,0 +1,34 @@
+import type { ValidatorDetail } from "@/lib/metagraphed/types";
+
+/** The core signals a validator-detail payload carries for a real validator. */
+export type ValidatorRecognitionSignals = Pick<
+  ValidatorDetail,
+  "subnet_count" | "total_stake_tao" | "nominator_count"
+>;
+
+/**
+ * True when a `ValidatorDetail` carries no signal that the hotkey was ever seen
+ * validating. Kept pure (no JSX, no component imports) so the branches are
+ * unit-tested apart from the DOM, mirroring `validator-card-fields.ts`.
+ *
+ * `GET /api/v1/validators/{hotkey}` is schema-stable: any well-formed ss58
+ * resolves to a zeroed aggregate rather than an error (see
+ * `validatorDetailQuery`'s contract). That is deliberate on the API side, but
+ * it means a mistyped or never-registered hotkey renders a page of unexplained
+ * zeros that looks identical to a real validator with nothing staked. This is
+ * the frontend-only heuristic that tells the two apart (#6430) — it changes no
+ * contract and gates only a notice, never the data.
+ *
+ * All three signals must be empty together. Any one of them alone is a real
+ * state a genuine validator can be in:
+ *   - `subnet_count === 0` — deregistered everywhere but still holding stake.
+ *   - `total_stake_tao === 0` — fully unstaked but still registered.
+ *   - `nominator_count == null` — the low-frequency nominator source simply has
+ *     no row yet, which is why this reads `== null` (null *or* absent) rather
+ *     than treating a genuine zero-nominator validator as unrecognized.
+ */
+export function isUnrecognizedValidator(detail: ValidatorRecognitionSignals): boolean {
+  return (
+    detail.subnet_count === 0 && detail.total_stake_tao === 0 && detail.nominator_count == null
+  );
+}

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -3,7 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { Boxes, Coins, Gauge, Percent, Users, Zap } from "lucide-react";
+import { Boxes, Coins, Gauge, Percent, TriangleAlert, Users, Zap } from "lucide-react";
 import { useWallet } from "@/hooks/use-wallet";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
@@ -27,6 +27,7 @@ import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { hasValidatorIdentity } from "@/lib/metagraphed/validator-identity";
+import { isUnrecognizedValidator } from "@/lib/metagraphed/validator-recognition";
 import {
   annualizedDelegatorApyPct,
   formatApyPct,
@@ -323,6 +324,32 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         }
         caption="explorer / v1"
       />
+
+      {/* #6430: the endpoint is schema-stable, so a mistyped or never-registered
+          hotkey resolves to a zeroed aggregate and renders a page of zeros that
+          looks exactly like a real validator holding nothing. Say so up front,
+          above the tiles it explains. Deliberately a notice and not an
+          EmptyState swap (the blocks/extrinsics treatment): the payload really
+          is valid and the rest of the page stays useful for confirming the
+          address you looked up. */}
+      {isUnrecognizedValidator(detail) ? (
+        <div
+          role="status"
+          className="mb-8 flex items-start gap-3 rounded-2xl border border-health-warn/40 bg-health-warn/5 px-4 py-3"
+        >
+          <TriangleAlert className="mt-0.5 size-4 shrink-0 text-health-warn" aria-hidden />
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-ink-strong">
+              This hotkey isn&apos;t a registered validator
+            </p>
+            <p className="mt-1 max-w-2xl text-[13px] text-ink-muted">
+              The address is a valid ss58, but it has never been seen validating on any subnet —
+              every figure below reads zero for that reason, not because the validator is idle. It
+              may be mistyped, or a coldkey rather than a hotkey.
+            </p>
+          </div>
+        </div>
+      ) : null}
 
       <div className="mb-12 grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6">
         <StatTile


### PR DESCRIPTION
## Summary

`GET /api/v1/validators/{hotkey}` is schema-stable: any well-formed ss58 resolves to a
zeroed aggregate rather than an error. That's deliberate on the API side, but
`validators.$hotkey.tsx` rendered the result unconditionally, so a mistyped or
never-registered hotkey produced a full `PageHero` and eight tiles of zeros that read
exactly like a real validator holding nothing — the only hint was "No active subnet
memberships" buried below the grid.

## What Changed

A prominent inline notice above the tiles it explains. `isUnrecognizedValidator` lives in
`lib/metagraphed/validator-recognition.ts` as a pure predicate with its own test, mirroring
`validator-card-fields.ts` ("kept pure … so the null-handling branches are unit-tested apart
from the DOM").

**All three signals must be empty together**, because each one alone is a state a genuine
validator can be in — flagging on any single signal would slander a live validator:

| Signal | Alone, it means |
| --- | --- |
| `subnet_count === 0` | deregistered everywhere but still holding stake |
| `total_stake_tao === 0` | fully unstaked but still registered |
| `nominator_count == null` | the low-frequency nominator source has no row yet |

The `== null` is deliberate (null *or* absent), which also keeps a real zero-nominator
validator from being flagged.

**Deliberately a notice, not an `EmptyState` swap.** `blocks.$ref.tsx` and
`extrinsics.$hash.tsx` replace the page for their analogous not-found case, but those
payloads are genuinely absent. This one is valid, and the issue asks for the signal
"without hard-blocking the rest of the still-valid, schema-stable page" — so the page stays
useful for confirming the address that was looked up. The API contract is untouched; this is
a frontend-only heuristic.

## Verification

The predicate was checked against live data, not just assumed:
`GET /api/v1/validators/5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY` (a well-formed
ss58 that has never validated on Bittensor) really does return
`subnet_count: 0, total_stake_tao: 0, nominator_count: null` — the exact shape the notice
fires on. That address is what the screenshots below use.

- `npm run lint --workspace=apps/ui` — clean
- `npm run format:check --workspace=apps/ui` — clean
- `npm run typecheck --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 1055/1055 passed (6 new, covering the all-zero path and
  each signal *not* flagging on its own)
- `npm run build --workspace=apps/ui` — clean

## Screenshots

Captured with `capture-pr-screenshots.mjs` at the contract's fixed viewports
(1280×800 / 768×1024 / 375×812), themes forced via `mg-theme`, `before` served from a
worktree at the merge-base.

| Viewport · Theme | Before — unexplained zeros | After — the notice |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6430-unrecognized/6430-unrecognized-after-mobile-dark.png)<br><sub>after</sub> |

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6430`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched — `apps/ui/**` only, 3 files.
- [x] API contract unchanged — frontend-only heuristic, as the issue requires.

Closes #6430
