### PR TITLE
fix(ci): keep an empty migrations/ dir so validate-migrations doesn't ENOENT

### DIFF
--- a/migrations/.gitkeep
+++ b/migrations/.gitkeep
@@ -1,0 +1,3 @@
+# D1 fully eliminated (2026-07-17, #6477). This directory is intentionally empty --
+# kept only so scripts/validate-migrations.mjs's fs.readdir() call doesn't ENOENT.
+# See issue #6474 for the tracked follow-up to remove this validator entirely.


### PR DESCRIPTION
## Summary

#6477 deleted the entire `migrations/` directory (the D1 schema-migration ledger, now orphaned per the D1 retirement in #6455/#6477). `scripts/validate-migrations.mjs` calls `fs.readdir()` on `migrations/` unconditionally, which throws `ENOENT` when the directory doesn't exist at all, rather than validating cleanly against zero files. This landed on `main` because the PR's required checks (test/ui/python/Superagent/contributor-trust) were already green when auto-merge fired; the `checks` job (which runs `validate:migrations`) was still in flight and failed shortly after the merge decision was made — a genuine gap in my own verification before pushing the PR's later commits, since I only ran `npm run validate` (the registry validator) locally, not every individual `validate:*` script.

## What Changed

- Restored `migrations/` as an empty directory (via a `.gitkeep` placeholder documenting why) so `fs.readdir()` succeeds with `[]` and the validator prints "Validated 0 migration file(s)" instead of crashing.

## Out of scope

Whether to remove `validate:migrations`/`scripts/validate-migrations.mjs` entirely now that D1 (and its migration ledger) is permanently retired is a separate, non-urgent cleanup — noted in [issue #6474](https://github.com/JSONbored/metagraphed/issues/6474) as a candidate for the same follow-up pass that will eventually delete the actual D1 database resource.

## Validation

- [x] `npm run validate:migrations` (was ENOENT, now "Validated 0 migration file(s)")
- [x] `npm run lint` / `npm run format:check`
- [x] `git diff --check`

Refs #6474