### PR TITLE
feat(wss-lb): instrument with Sentry error tracking

### DIFF
--- a/deploy/wss-lb/package-lock.json
+++ b/deploy/wss-lb/package-lock.json
@@ -8,10 +8,424 @@
       "name": "metagraphed-wss-lb",
       "version": "0.0.0",
       "dependencies": {
+        "@sentry/node": "^10.66.0",
         "ws": "^8.21.0"
       },
       "engines": {
         "node": ">=20.20.2"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.0.tgz",
+      "integrity": "sha512-aN3Oq8r1J3gPJtCwErP664gM0+HhM1I1lujPr9TMTCcEl/joQQbpGpeMdts9B1+W2wHMsvioDMv5F4PvMWE6gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.6.2.tgz",
+      "integrity": "sha512-5vBrtIEL+UVbO0YWWoyYG4QMgR+ZfnIL3xlteIkAmU7YaAPhc28k3md/NM14tnkfXKjKOn9yUzEA9AYUmNpvJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.66.0.tgz",
+      "integrity": "sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.66.0.tgz",
+      "integrity": "sha512-5Ow7iQiRjaSaEOmqEIkYV368hFFzShIZCXPoj+wX3JtOmKFrsNu6lr8/VJlQs7cyjFS6tzE50PrLrD8iAPS/8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0",
+        "@sentry/node-core": "10.66.0",
+        "@sentry/opentelemetry": "10.66.0",
+        "@sentry/server-utils": "10.66.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.66.0.tgz",
+      "integrity": "sha512-SUnXHROqSdSetKgZC1goDEKCuMz3OmQ1h4rxzWeexLyqan+pensZXfLouP6jzZXlA8e/HP7uQg78LnfqYDcZlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0",
+        "@sentry/opentelemetry": "10.66.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.66.0.tgz",
+      "integrity": "sha512-K5Y9IettN9yIOnpqCs40HRLGqaGUoaQ50+ZsLqX2kPCk3TzJVpKZ9icKwaJ4Nxm72QgGVT5Ovfr/9FXbgd3b/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.66.0.tgz",
+      "integrity": "sha512-h9EM9Wz9Mc6w2Vn7Fyh6ozjy4JC2UbUvWf9Ra1HYA4KMeYqjFA5/o0oB4pg4w/TF+rb+9OF/HNqxjuczxpudpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.6.1",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.1.tgz",
+      "integrity": "sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ws": {

--- a/deploy/wss-lb/package.json
+++ b/deploy/wss-lb/package.json
@@ -9,6 +9,7 @@
     "test": "node --test --test-force-exit test/*.test.mjs"
   },
   "dependencies": {
+    "@sentry/node": "^10.66.0",
     "ws": "^8.21.0"
   },
   "engines": {

--- a/deploy/wss-lb/src/observability.mjs
+++ b/deploy/wss-lb/src/observability.mjs
@@ -1,0 +1,83 @@
+// Sentry error tracking for wss-lb (ADR 0013). Reports to the consolidated
+// `metagraphed` Sentry project. Silently no-ops if SENTRY_DSN is unset,
+// matching this service's own best-effort design elsewhere.
+//
+// A separate module from server.mjs (not inlined) so the pure aggregate-
+// reporting logic below can be unit-tested with `node --test` the same way
+// select.mjs/proxy.mjs already are, without importing server.mjs itself --
+// that file runs its HTTP server + refresh loop as an unconditional
+// top-level side effect on import, so it can't be required by a test file
+// directly (see server.mjs's own header).
+import * as Sentry from "@sentry/node";
+
+export function initSentry() {
+  const dsn = process.env.SENTRY_DSN;
+  if (!dsn) return;
+  Sentry.init({
+    dsn,
+    environment: process.env.SENTRY_ENVIRONMENT || "production",
+    // Railway's own commit-SHA env var, injected automatically for a
+    // git-based deploy -- no wss-lb-specific entrypoint wiring needed the
+    // way the box-side clone-at-runtime scripts require (this service still
+    // deploys via Railway, see the Dockerfile's own header). An explicit
+    // SENTRY_RELEASE still wins if one is somehow already set.
+    release: process.env.SENTRY_RELEASE || process.env.RAILWAY_GIT_COMMIT_SHA,
+    tracesSampleRate: 0,
+  });
+  Sentry.setTag("component", "wss-lb");
+}
+
+export const NO_UPSTREAM_REPORT_THRESHOLD = 50;
+export const NO_UPSTREAM_REPORT_INTERVAL_MS = 5 * 60 * 1000;
+
+// Pure state-transition function -- same design as chain-firehose-relay.mjs's
+// computeDropWindowUpdate, for the same reason: a client-connect storm during
+// a real upstream-pool outage could reject many clients per second (every
+// concurrent reconnect attempt), and naive per-rejection capture would blow
+// through the free-tier Sentry event quota and then be silently sampled away
+// by Sentry itself -- the opposite of the point. Holds no module-level
+// mutable state itself; the caller (server.mjs) owns the actual window
+// variable, the same split chain-firehose-relay.mjs's own comment explains.
+export function computeNoUpstreamWindowUpdate(
+  window,
+  network,
+  now = Date.now(),
+) {
+  const startedAt = window?.startedAt ?? now;
+  const totalCount = (window?.count ?? 0) + 1;
+  const elapsedMs = now - startedAt;
+  const report =
+    totalCount >= NO_UPSTREAM_REPORT_THRESHOLD ||
+    elapsedMs >= NO_UPSTREAM_REPORT_INTERVAL_MS;
+  return {
+    report,
+    count: totalCount,
+    elapsedMs,
+    lastNetwork: network,
+    nextWindow: report ? null : { startedAt, count: totalCount },
+  };
+}
+
+export function reportNoUpstreamWindow(update) {
+  Sentry.captureMessage(
+    `wss-lb: ${update.count} client(s) rejected for no available upstream (last network: ${update.lastNetwork}) in the last ${Math.round(update.elapsedMs / 1000)}s`,
+    {
+      level: "warning",
+      extra: {
+        count: update.count,
+        lastNetwork: update.lastNetwork,
+        windowMs: update.elapsedMs,
+      },
+    },
+  );
+}
+
+// Pool freshness is a LEVEL, not a per-check event -- report only on the
+// fresh→stale EDGE (server.mjs tracks the previous state and calls this once
+// per transition), not on every refresh tick while already stale, which
+// would spam once per REFRESH_MS for the entire duration of an outage.
+export function reportPoolStale(reason) {
+  Sentry.captureMessage(`wss-lb: RPC pool refresh is stale -- ${reason}`, {
+    level: "warning",
+  });
+}

--- a/deploy/wss-lb/src/proxy.mjs
+++ b/deploy/wss-lb/src/proxy.mjs
@@ -139,6 +139,11 @@ export function proxy(client, upstreams, opts = {}) {
     if (clientClosed) return;
     if (attempt >= upstreams.length) {
       try {
+        opts.onNoUpstream?.();
+      } catch {
+        /* a reporting-callback failure must never prevent closing the client */
+      }
+      try {
         client.close(1013, "no upstream available");
       } catch {
         /* already closed */

--- a/deploy/wss-lb/src/server.mjs
+++ b/deploy/wss-lb/src/server.mjs
@@ -12,7 +12,9 @@
 // INTEGRATION-PENDING: the live ws-piping is verified on deploy; the pure
 // upstream selection is unit-tested (test/select.test.mjs). Public behind
 // Cloudflare DNS for TLS/DDoS. Env: METAGRAPHED_API, PORT, REFRESH_MS,
-// MAX_BLOCK_LAG, NETWORKS, HANDSHAKE_TIMEOUT_MS.
+// MAX_BLOCK_LAG, NETWORKS, HANDSHAKE_TIMEOUT_MS. Optionally SENTRY_DSN/
+// SENTRY_ENVIRONMENT/SENTRY_RELEASE (silently no-ops if SENTRY_DSN is unset
+// -- see src/observability.mjs).
 import http from "node:http";
 
 import { WebSocketServer } from "ws";
@@ -20,6 +22,14 @@ import { WebSocketServer } from "ws";
 import { MAX_RPC_BODY_BYTES } from "./rpc-policy.mjs";
 import { proxy } from "./proxy.mjs";
 import { selectWssUpstreams } from "./select.mjs";
+import {
+  initSentry,
+  computeNoUpstreamWindowUpdate,
+  reportNoUpstreamWindow,
+  reportPoolStale,
+} from "./observability.mjs";
+
+initSentry();
 
 // Numeric env with a NaN/positivity guard: Number(process.env.X || d) returns NaN
 // for a non-numeric string (the `|| d` only catches empty/unset), which would
@@ -43,6 +53,14 @@ const log = (...a) => console.log(new Date().toISOString(), ...a);
 
 let poolsArtifact = null;
 let lastRefresh = 0;
+let wasStale = false; // edge-detection state -- see reportPoolStale's own comment
+let noUpstreamWindow = null; // owned here, not module-level in observability.mjs -- see computeNoUpstreamWindowUpdate's own comment
+
+function noteNoUpstream(network) {
+  const update = computeNoUpstreamWindowUpdate(noUpstreamWindow, network);
+  noUpstreamWindow = update.nextWindow;
+  if (update.report) reportNoUpstreamWindow(update);
+}
 
 async function refresh() {
   try {
@@ -64,6 +82,11 @@ async function refresh() {
   } catch (e) {
     log("refresh failed:", String(e?.message || e).slice(0, 160));
   }
+  const stale = !lastRefresh || Date.now() - lastRefresh > REFRESH_MS * 3;
+  if (stale && !wasStale) {
+    reportPoolStale(`no successful refresh in over ${REFRESH_MS * 3}ms`);
+  }
+  wasStale = stale;
 }
 
 function poolFor(network) {
@@ -138,6 +161,7 @@ server.on("upgrade", (req, socket, head) => {
   if (!upstreams.length) {
     socket.write("HTTP/1.1 503 Service Unavailable\r\n\r\n");
     socket.destroy();
+    noteNoUpstream(network);
     return;
   }
   wss.handleUpgrade(req, socket, head, (client) => {
@@ -145,7 +169,10 @@ server.on("upgrade", (req, socket, head) => {
     client.on("pong", () => {
       client.isAlive = true;
     });
-    proxy(client, upstreams, { handshakeTimeout: HANDSHAKE_TIMEOUT_MS });
+    proxy(client, upstreams, {
+      handshakeTimeout: HANDSHAKE_TIMEOUT_MS,
+      onNoUpstream: () => noteNoUpstream(network),
+    });
   });
 });
 

--- a/deploy/wss-lb/test/observability.test.mjs
+++ b/deploy/wss-lb/test/observability.test.mjs
@@ -1,0 +1,78 @@
+// Pure-logic tests for wss-lb's Sentry aggregate-reporting window. Zero deps
+// (no real Sentry.init call is ever needed to exercise this logic) — run
+// with: node --test deploy/wss-lb/test/
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  NO_UPSTREAM_REPORT_THRESHOLD,
+  NO_UPSTREAM_REPORT_INTERVAL_MS,
+  computeNoUpstreamWindowUpdate,
+  initSentry,
+} from "../src/observability.mjs";
+
+test("computeNoUpstreamWindowUpdate: does not report before the count threshold or interval is reached", () => {
+  const update = computeNoUpstreamWindowUpdate(null, "finney", 1_000_000);
+  assert.equal(update.report, false);
+  assert.equal(update.count, 1);
+  assert.equal(update.lastNetwork, "finney");
+  assert.deepEqual(update.nextWindow, { startedAt: 1_000_000, count: 1 });
+});
+
+test("computeNoUpstreamWindowUpdate: reports once the count threshold is crossed", () => {
+  let window = null;
+  let update;
+  for (let i = 0; i < NO_UPSTREAM_REPORT_THRESHOLD; i += 1) {
+    update = computeNoUpstreamWindowUpdate(window, "finney", 1_000_000);
+    window = update.nextWindow;
+  }
+  assert.equal(update.report, true);
+  assert.equal(update.count, NO_UPSTREAM_REPORT_THRESHOLD);
+  assert.equal(update.nextWindow, null); // resets after reporting
+});
+
+test("computeNoUpstreamWindowUpdate: reports once the interval elapses, even below the count threshold", () => {
+  const first = computeNoUpstreamWindowUpdate(null, "finney", 1_000_000);
+  const later = computeNoUpstreamWindowUpdate(
+    first.nextWindow,
+    "finney",
+    1_000_000 + NO_UPSTREAM_REPORT_INTERVAL_MS,
+  );
+  assert.equal(later.report, true);
+  assert.equal(later.count, 2);
+});
+
+test("computeNoUpstreamWindowUpdate: tracks the most recently affected network", () => {
+  const first = computeNoUpstreamWindowUpdate(null, "finney", 1_000_000);
+  const second = computeNoUpstreamWindowUpdate(
+    first.nextWindow,
+    "test",
+    1_000_100,
+  );
+  assert.equal(second.lastNetwork, "test");
+});
+
+test("computeNoUpstreamWindowUpdate: two independent windows never leak state into one another", () => {
+  // Regression test for the same class of bug chain-firehose-relay.mjs's own
+  // computeDropWindowUpdate test suite guards against: passing `null` must
+  // always mean "a genuinely fresh window," never a stale value from a prior
+  // call, since this function deliberately holds no module-level state itself.
+  const windowA = computeNoUpstreamWindowUpdate(
+    null,
+    "finney",
+    1_000_000,
+  ).nextWindow;
+  const windowB = computeNoUpstreamWindowUpdate(null, "test", 5_000_000);
+  assert.equal(windowB.count, 1, "windowB must not include windowA's count");
+  assert.notEqual(windowA.startedAt, windowB.startedAt);
+});
+
+test("initSentry: no-op (does not throw) when SENTRY_DSN is unset", () => {
+  const prior = process.env.SENTRY_DSN;
+  delete process.env.SENTRY_DSN;
+  try {
+    assert.doesNotThrow(() => initSentry());
+  } finally {
+    if (prior !== undefined) process.env.SENTRY_DSN = prior;
+  }
+});

--- a/deploy/wss-lb/test/proxy.test.mjs
+++ b/deploy/wss-lb/test/proxy.test.mjs
@@ -36,12 +36,12 @@ function echoServer() {
   });
 }
 
-function lbServer(upstreams) {
+function lbServer(upstreams, proxyOpts = {}) {
   return new Promise((resolve) => {
     const http = createServer();
     const wss = new WebSocketServer({ server: http });
     wss.on("connection", (client) =>
-      proxy(client, upstreams, { handshakeTimeout: 2000 }),
+      proxy(client, upstreams, { handshakeTimeout: 2000, ...proxyOpts }),
     );
     http.listen(0, "127.0.0.1", () => {
       const { port } = http.address();
@@ -97,6 +97,42 @@ test("all upstreams dead → client closed with 1013", async () => {
   });
   assert.equal(code, 1013);
   await lb.close();
+});
+
+test("all upstreams dead → onNoUpstream fires exactly once (for Sentry aggregate reporting)", async () => {
+  let calls = 0;
+  const lb = await lbServer([await deadUrl(), await deadUrl()], {
+    onNoUpstream: () => {
+      calls += 1;
+    },
+  });
+  await new Promise((resolve) => {
+    const c = new WebSocket(lb.url);
+    c.on("close", () => resolve());
+    setTimeout(resolve, 8000);
+  });
+  assert.equal(calls, 1);
+  await lb.close();
+});
+
+test("onNoUpstream is never called on a successful failover (only on total exhaustion)", async () => {
+  let calls = 0;
+  const good = await echoServer();
+  const lb = await lbServer([await deadUrl(), good.url], {
+    onNoUpstream: () => {
+      calls += 1;
+    },
+  });
+  await new Promise((resolve, reject) => {
+    const c = new WebSocket(lb.url);
+    c.on("open", () => c.close());
+    c.on("close", resolve);
+    c.on("error", reject);
+    setTimeout(() => reject(new Error("timeout")), 8000);
+  });
+  assert.equal(calls, 0);
+  await lb.close();
+  await good.close();
 });
 
 test("security: unsafe and oversized client RPC frames do not reach upstream", async () => {


### PR DESCRIPTION
## Summary

Closes #6475. Part of the metagraphed/Ventura Labs Sentry rollout (#6485).

`deploy/wss-lb` had zero error tracking. Adds a new `src/observability.mjs` module (kept separate from `server.mjs`, which runs its HTTP server + refresh loop as an unconditional side effect on import, so it can't be required from a test file directly) with:

- `initSentry()`, gated on `SENTRY_DSN`, matching every other instrumented process from this rollout. Release defaults to Railway's own `RAILWAY_GIT_COMMIT_SHA` -- this service still deploys via Railway, not the box-side clone-at-runtime pattern the rest of this rollout used.
- `computeNoUpstreamWindowUpdate()` -- an aggregate/threshold reporter for clients rejected due to no available upstream. Same design as `chain-firehose-relay.mjs`'s `computeDropWindowUpdate`, for the same reason: a real upstream-pool outage could reject many clients per second (every concurrent reconnect attempt), and naive per-rejection capture would blow through the free-tier event quota and then be silently sampled away by Sentry itself.
- `reportPoolStale()` -- fired on the fresh→stale **edge** of the RPC-pools refresh cycle, not on every refresh tick while already stale (which would spam once per `REFRESH_MS` for an entire outage's duration).

`proxy.mjs` gained an `opts.onNoUpstream` callback (fired once all upstreams are exhausted at connect time), matching its existing `opts.handshakeTimeout` convention -- no Sentry import in `proxy.mjs` itself, keeping it exactly as pure/independently-testable as before.

## Test plan

- [x] Real `docker build` + `docker run`: container starts cleanly with `SENTRY_DSN` unset (no-op path), `/healthz` reports real live pool data (5 finney + 2 test endpoints) fetched from production
- [x] `npm test` (in `deploy/wss-lb/`): 22/22 passing -- 14 existing + 6 new `observability.test.mjs` (pure aggregate-window logic) + 2 new `proxy.test.mjs` (`onNoUpstream` fires exactly once on total exhaustion, never fires on a successful failover)
- [x] `npm run lint` / `npx prettier --check` clean
- [x] `npm run scan:public-safety` passes