### PR TITLE
fix(registry): repoint SN48 health API at its own domain and catch cross-file duplicate endpoints

### DIFF
--- a/registry/subnets/quantum-compute.json
+++ b/registry/subnets/quantum-compute.json
@@ -73,7 +73,7 @@
       "id": "sn-48-quantum-compute-health-api",
       "kind": "subnet-api",
       "name": "Quantum Compute health API",
-      "notes": "Public no-auth GET /api/health on www.qbittensorlabs.com returning JSON liveness (observed: {\"status\":\"ok\"}). Served on the official qBittensor Labs website host alongside the existing website and source-repo surfaces for SN48.",
+      "notes": "Public no-auth GET /api/health on www.openquantum.com returning JSON liveness (observed: {\"status\":\"ok\"}). Open Quantum is SN48's own market-facing product per the subnet README's \"What is Open Quantum?\" section, and its documentation host (docs.openquantum.com) is already registered as this subnet's docs surface. Replaces the previous www.qbittensorlabs.com/api/health value: that is the shared qBittensor Labs corporate-site liveness route, registered identically by SN63 Enigma, whose repository -- not this one -- is what references the qbittensorlabs.com domain (#6328).",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -87,10 +87,10 @@
         "submitted_by": "kiannidev"
       },
       "source_urls": [
-        "https://github.com/qbittensor-labs/quantum-compute",
-        "https://www.qbittensorlabs.com/"
+        "https://github.com/qbittensor-labs/quantum-compute/blob/main/README.md",
+        "https://www.qbittensorlabs.com/quantum"
       ],
-      "url": "https://www.qbittensorlabs.com/api/health"
+      "url": "https://www.openquantum.com/api/health"
     },
     {
       "auth_required": false,

--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -46,6 +46,16 @@ const GRANDFATHERED_DUPLICATE_URLS = new Set([
   "8-ball.json|https://github.com/Barbariandev/8Ball_miner",
 ]);
 
+// Kinds whose URL answers "where does THIS subnet expose its own mechanism".
+// The identical endpoint under two different netuids is a contradiction rather
+// than a style choice — one file was copy-pasted from the other's template and
+// never repointed (#6328: SN48 Quantum Compute and SN63 Enigma both registered
+// their operator's corporate-site health route). Org-level identity kinds are
+// deliberately absent: one operator legitimately fronts several subnets from a
+// single website or doc host, which is why those two subnets correctly keep the
+// shared www.qbittensorlabs.com website surface on both files.
+const PER_SUBNET_ENDPOINT_KINDS = new Set(["subnet-api", "openapi", "sse"]);
+
 // Reviewed-tier authorship convention + its acknowledged exemptions (#5739).
 // Files at the `maintainer-reviewed` / `adapter-backed` curation tier normally
 // pair a non-null `curation.verified_at` with their `reviewed_at` and carry a
@@ -112,6 +122,43 @@ const files =
   fileArgs.length > 0
     ? fileArgs.map((arg) => path.resolve(arg))
     : await listJsonFiles(path.join(repoRoot, "registry/subnets"));
+
+// Cross-file endpoint registrations (#6328). The within-file duplicate check
+// below only ever sees one document at a time, so an endpoint copy-pasted from
+// another subnet's file slips past it. Index every registry file plus whatever
+// is under validation (deduped by resolved path) so the documented single-file
+// lane — `npm run validate:surface -- registry/subnets/<slug>.json` — still
+// catches a collision with a subnet the contributor never opened, rather than
+// deferring it to CI, where the gate closes the PR instead of coaching it.
+// Mirrors the native-chain index above: built once, up front, best-effort.
+const validatedPaths = new Set(files.map((file) => path.resolve(file)));
+const endpointRegistrationsByUrl = new Map();
+try {
+  const indexPaths = new Set(
+    (await listJsonFiles(path.join(repoRoot, "registry/subnets"))).map((file) =>
+      path.resolve(file),
+    ),
+  );
+  for (const file of validatedPaths) indexPaths.add(file);
+  for (const file of indexPaths) {
+    let document;
+    try {
+      document = await readJson(file);
+    } catch {
+      continue; // Unreadable files are reported by the per-file loop below.
+    }
+    for (const surface of document.surfaces || []) {
+      if (!PER_SUBNET_ENDPOINT_KINDS.has(surface.kind)) continue;
+      const normalized = normalizePublicUrl(surface.url);
+      if (!normalized) continue;
+      const registrations = endpointRegistrationsByUrl.get(normalized) || [];
+      registrations.push({ file, id: surface.id, netuid: document.netuid });
+      endpointRegistrationsByUrl.set(normalized, registrations);
+    }
+  }
+} catch {
+  // Registry unreadable — skip the cross-file endpoint dedup check.
+}
 
 const errors = [];
 const conventionAdvisories = [];
@@ -242,6 +289,28 @@ for (const file of files) {
       }
     }
   }
+}
+
+// Only report a collision that actually involves a file under validation — the
+// index spans the whole registry, but a contributor validating their own file
+// must not be handed someone else's pre-existing debt as their failure.
+for (const [normalizedUrl, registrations] of endpointRegistrationsByUrl) {
+  const netuids = new Set(registrations.map((r) => r.netuid));
+  if (netuids.size < 2) continue;
+  if (!registrations.some((r) => validatedPaths.has(r.file))) continue;
+  const fileList = [
+    ...new Set(registrations.map((r) => path.basename(r.file))),
+  ].join(" + ");
+  const registrationList = registrations
+    .map((r) => `SN${r.netuid} ${r.id}`)
+    .join(", ");
+  errors.push(
+    `${fileList}: "${normalizedUrl}" is registered as a per-subnet endpoint by ` +
+      `${netuids.size} different subnets (${registrationList}) — one endpoint cannot ` +
+      "serve two subnets' mechanisms, so one of these was copied from the other's " +
+      "template and never repointed. Point each subnet at the endpoint it actually " +
+      "owns, or drop the surface from the subnet that does not own it.",
+  );
 }
 
 if (errors.length > 0) {

--- a/tests/validate-surface-cross-file-duplicate-url.test.mjs
+++ b/tests/validate-surface-cross-file-duplicate-url.test.mjs
@@ -1,0 +1,259 @@
+// Regression coverage for #6328: validate-surface.mjs now fails when two
+// different subnets register the identical per-subnet endpoint URL — the
+// cross-file counterpart of the within-file duplicate check (#5737). The live
+// instance: SN48 Quantum Compute and SN63 Enigma both pointed a subnet-api
+// "health" surface at their operator's shared corporate-site liveness route.
+// Mirrors validate-surface-duplicate-url.test.mjs's subprocess-fixture pattern.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, test } from "vitest";
+import { listJsonFiles, readJson, repoRoot } from "../scripts/lib.mjs";
+
+function runNode(args) {
+  try {
+    const stdout = execFileSync(process.execPath, args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return { status: 0, output: stdout };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      output: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+    };
+  }
+}
+
+function surface(id, kind, url) {
+  return {
+    id,
+    kind,
+    name: `Fixture ${id}`,
+    url,
+    provider: "academia",
+    authority: "community",
+    auth_required: false,
+    public_safe: true,
+    review: { state: "community-submitted" },
+  };
+}
+
+describe("validate-surface.mjs cross-file duplicate-endpoint check", () => {
+  let tempDir;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  function writeFixtures(...documents) {
+    tempDir = mkdtempSync(`${tmpdir()}/metagraphed-validate-surface-xfile-`);
+    return documents.map((doc) => {
+      const document = {
+        schema_version: 1,
+        slug: `fixture-${doc.netuid}`,
+        name: `Fixture Subnet ${doc.netuid}`,
+        status: "active",
+        categories: [],
+        links: [],
+        ...doc,
+      };
+      const fixturePath = path.join(tempDir, `fixture-${doc.netuid}.json`);
+      writeFileSync(fixturePath, JSON.stringify(document, null, 2));
+      return fixturePath;
+    });
+  }
+
+  test("fails when two subnets register the identical subnet-api endpoint", () => {
+    const fixturePaths = writeFixtures(
+      {
+        netuid: 998,
+        surfaces: [
+          surface(
+            "fixture-998-health",
+            "subnet-api",
+            "https://api.fixture.example/health",
+          ),
+        ],
+      },
+      {
+        netuid: 999,
+        surfaces: [
+          surface(
+            "fixture-999-health",
+            "subnet-api",
+            "https://api.fixture.example/health",
+          ),
+        ],
+      },
+    );
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...fixturePaths,
+    ]);
+
+    assert.equal(status, 1);
+    assert.match(
+      output,
+      /registered as a per-subnet endpoint by 2 different subnets/,
+    );
+    assert.match(output, /SN998 fixture-998-health/);
+    assert.match(output, /SN999 fixture-999-health/);
+  });
+
+  test("catches the duplicate even when only a trailing slash differs", () => {
+    const fixturePaths = writeFixtures(
+      {
+        netuid: 998,
+        surfaces: [
+          surface(
+            "fixture-998-openapi",
+            "openapi",
+            "https://api.fixture.example/openapi.json",
+          ),
+        ],
+      },
+      {
+        netuid: 999,
+        surfaces: [
+          surface(
+            "fixture-999-openapi",
+            "openapi",
+            "https://api.fixture.example/openapi.json/",
+          ),
+        ],
+      },
+    );
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...fixturePaths,
+    ]);
+
+    assert.equal(status, 1);
+    assert.match(
+      output,
+      /registered as a per-subnet endpoint by 2 different subnets/,
+    );
+  });
+
+  test("allows one operator's shared website across two of its subnets", () => {
+    // Deliberate: the #6328 data fix keeps www.qbittensorlabs.com registered as
+    // a website surface on BOTH SN48 and SN63, because one operator legitimately
+    // fronts several subnets from a single corporate site. Only the kinds that
+    // answer "where does THIS subnet expose its mechanism" are exclusive.
+    const fixturePaths = writeFixtures(
+      {
+        netuid: 998,
+        surfaces: [
+          surface(
+            "fixture-998-website",
+            "website",
+            "https://lab.fixture.example/",
+          ),
+        ],
+      },
+      {
+        netuid: 999,
+        surfaces: [
+          surface(
+            "fixture-999-website",
+            "website",
+            "https://lab.fixture.example/",
+          ),
+        ],
+      },
+    );
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...fixturePaths,
+    ]);
+
+    assert.equal(status, 0, output);
+  });
+
+  test("passes when each subnet registers its own distinct endpoint", () => {
+    const fixturePaths = writeFixtures(
+      {
+        netuid: 998,
+        surfaces: [
+          surface(
+            "fixture-998-health",
+            "subnet-api",
+            "https://api-998.fixture.example/health",
+          ),
+        ],
+      },
+      {
+        netuid: 999,
+        surfaces: [
+          surface(
+            "fixture-999-health",
+            "subnet-api",
+            "https://api-999.fixture.example/health",
+          ),
+        ],
+      },
+    );
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...fixturePaths,
+    ]);
+
+    assert.equal(status, 0, output);
+  });
+
+  test("catches a collision with the registry when only the new file is validated", async () => {
+    // The index spans the whole registry, not just the files under validation,
+    // so the documented single-file lane (`validate:surface -- <one file>`)
+    // still catches an endpoint copied from a subnet the contributor never
+    // opened — instead of deferring it to CI, where the gate closes the PR.
+    const files = await listJsonFiles(path.join(repoRoot, "registry/subnets"));
+    let borrowed;
+    for (const file of files) {
+      const document = await readJson(file);
+      const found = (document.surfaces || []).find(
+        (entry) => entry.kind === "subnet-api" && typeof entry.url === "string",
+      );
+      if (found) {
+        borrowed = { url: found.url, netuid: document.netuid };
+        break;
+      }
+    }
+    assert.ok(borrowed, "registry should contain at least one subnet-api URL");
+    assert.notEqual(borrowed.netuid, 999);
+
+    const [fixturePath] = writeFixtures({
+      netuid: 999,
+      surfaces: [surface("fixture-999-borrowed", "subnet-api", borrowed.url)],
+    });
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 1);
+    assert.match(
+      output,
+      /registered as a per-subnet endpoint by 2 different subnets/,
+    );
+    assert.match(output, /fixture-999-borrowed/);
+  });
+
+  test("the full registry has no cross-file endpoint collisions", () => {
+    // Sanity-check the check against real data: after the #6328 data fix,
+    // running with no file args (validates every subnet file) must be clean.
+    const { status, output } = runNode(["scripts/validate-surface.mjs"]);
+    assert.equal(status, 0, output);
+  });
+});


### PR DESCRIPTION
## Summary

`registry/subnets/quantum-compute.json` (SN48) and `registry/subnets/enigma.json` (SN63) both registered `https://www.qbittensorlabs.com/api/health` as a `subnet-api` health surface. I reproduced the issue's cross-file scan against current `main` and confirm its finding exactly: **2 URLs are shared across two different netuids in the whole registry**, both on `www.qbittensorlabs.com` (the website root and the `/api/health` route) — nothing else.

### Which subnet owns the domain

The issue asks this to be settled from the site's own content/structure rather than a live probe:

- **The corporate site fronts both subnets.** `www.qbittensorlabs.com` is qBitTensor Labs' company site; its own body copy renders `$ ls ~/subnets/` followed by "Subnet 63 ENIGMA" and "Subnet 48 QUANTUM COMPUTE", with `/enigma` and `/quantum` sub-pages. So one operator legitimately runs both — the issue's first hypothesis.
- **But the `/api/health` route is SN63's, not SN48's.** The `qbittensor-labs/enigma` repository references `qbittensorlabs.com` in **7 files** (`README.md`, `qbittensor/utils/env.py`, `setup.py`, `treasury/scripts/vote_payout.py`, `workbench/README.md`); the `qbittensor-labs/quantum-compute` repository references it in **0**. SN48's entry was copy-pasted from SN63's template — the issue's second hypothesis, for the health surface specifically.
- **SN48's own domain is `openquantum.com`.** Its README has a "What is Open Quantum?" section describing Open Quantum as the market-facing product for SN48, and this file **already** registers `docs.openquantum.com` as its `docs` surface.

### The fix (one file)

`https://www.openquantum.com/api/health` is live and serves the same no-auth JSON liveness route (`{"status":"ok"}`, HTTP 200) on the domain SN48 actually owns. This PR repoints SN48's health surface there, reusing the exact `source_urls` pair this file already uses to prove the `openquantum.com` docs surface. Only `quantum-compute.json` changes — matching the deliverable's "in one of the two files".

Per the issue's requirement, **the shared `website` surface stays on both files**: one operator legitimately fronts several subnets from a single corporate site.

### The check

`validate-surface.mjs`'s existing duplicate-URL check (#5737) only ever sees one document at a time, so a copy-pasted endpoint slips past it. The new check indexes surfaces across files and fails when one URL is registered by two different netuids.

It is scoped to `subnet-api` / `openapi` / `sse` — the kinds whose URL answers *"where does THIS subnet expose its own mechanism"*, where a shared URL is a contradiction rather than a style choice. Org-level identity kinds are deliberately excluded, which is exactly what keeps the legitimate shared `qbittensorlabs.com` website surface passing on both files.

The index spans the whole registry rather than only the files under validation, so the documented single-file lane (`npm run validate:surface -- registry/subnets/<slug>.json`) catches a collision with a subnet the contributor never opened — instead of deferring it to CI, where the PR is closed rather than coached.

## Validation

Proved in both directions:

```
# with this fix
$ npm run validate:surface
Surface validation passed: 1121 surface(s) across 129 subnet file(s).

# re-broken to the original state (SN48 health -> qbittensorlabs.com/api/health)
$ npm run validate:surface
Surface validation failed (1 issue(s)):
- enigma.json + quantum-compute.json: "https://www.qbittensorlabs.com/api/health" is
  registered as a per-subnet endpoint by 2 different subnets (SN63 sn-63-enigma-health,
  SN48 sn-48-quantum-compute-health-api) — one endpoint cannot serve two subnets'
  mechanisms, so one of these was copied from the other's template and never repointed.

# and the single-file lane catches it too, not just the full-registry run
$ npm run validate:surface -- registry/subnets/quantum-compute.json
Surface validation failed (1 issue(s)): ...
```

- `tests/validate-surface-cross-file-duplicate-url.test.mjs` — 6 regression tests: fires on a duplicate endpoint across two netuids; fires when only a trailing slash differs; **passes** for one operator's shared website across two subnets (guards the #6328 data decision above); passes on distinct endpoints; catches a fixture colliding with the real registry when only that one file is validated; and asserts the full registry is clean.
- `npx vitest run tests/validate-surface-cross-file-duplicate-url.test.mjs tests/validate-surface-duplicate-url.test.mjs` → 11 passed (the existing #5737 check is unaffected).
- `npx eslint` + `prettier --check` clean on all three files.
- Live: `https://www.openquantum.com/api/health` → 200 `{"status":"ok"}`; both `source_urls` → 200.

Closes #6328
