### PR TITLE
fix(registry): dedupe the cross-file qBittensor health URL + catch the class

### DIFF
--- a/registry/subnets/quantum-compute.json
+++ b/registry/subnets/quantum-compute.json
@@ -70,31 +70,6 @@
     {
       "auth_required": false,
       "authority": "community",
-      "id": "sn-48-quantum-compute-health-api",
-      "kind": "subnet-api",
-      "name": "Quantum Compute health API",
-      "notes": "Public no-auth GET /api/health on www.qbittensorlabs.com returning JSON liveness (observed: {\"status\":\"ok\"}). Served on the official qBittensor Labs website host alongside the existing website and source-repo surfaces for SN48.",
-      "probe": {
-        "enabled": true,
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "qbittensor-labs",
-      "public_safe": true,
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": [
-        "https://github.com/qbittensor-labs/quantum-compute",
-        "https://www.qbittensorlabs.com/"
-      ],
-      "url": "https://www.qbittensorlabs.com/api/health"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
       "id": "sn-48-quantum-compute-min-compute-spec",
       "kind": "data-artifact",
       "name": "Quantum Compute minimum compute requirements",

--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -46,6 +46,25 @@ const GRANDFATHERED_DUPLICATE_URLS = new Set([
   "8-ball.json|https://github.com/Barbariandev/8Ball_miner",
 ]);
 
+// Cross-file counterpart of the check above (#6328). The within-file check only
+// sees one document at a time, so the same URL claimed by two DIFFERENT netuids
+// sailed through — e.g. SN48 and SN63 both registered qbittensorlabs.com/api/health
+// as their own subnet-api, double-counting one endpoint as two subnets' coverage.
+//
+// A shared URL is legitimate when one operator genuinely runs several subnets and
+// the surface describes the operator rather than the subnet (a corporate website,
+// a monorepo). Those live here, keyed by normalized URL. Anything else is an
+// error: an endpoint that serves a specific subnet cannot also be another
+// subnet's endpoint.
+const SHARED_OPERATOR_URLS = new Map([
+  [
+    "https://www.qbittensorlabs.com/",
+    "qBittensor Labs operates both SN48 (Quantum Compute) and SN63 (Enigma); " +
+      "the corporate site is the operator's, so each subnet registering it as " +
+      "its own `website` is accurate.",
+  ],
+]);
+
 // Reviewed-tier authorship convention + its acknowledged exemptions (#5739).
 // Files at the `maintainer-reviewed` / `adapter-backed` curation tier normally
 // pair a non-null `curation.verified_at` with their `reviewed_at` and carry a
@@ -116,6 +135,9 @@ const files =
 const errors = [];
 const conventionAdvisories = [];
 const conventionExemptions = [];
+// normalized url -> [{ file, netuid, id, authority }] across every file in this
+// run, for the cross-file duplicate check (#6328) after the loop.
+const crossFileRegistrations = new Map();
 let surfaceCount = 0;
 for (const file of files) {
   let document;
@@ -157,6 +179,14 @@ for (const file of files) {
         const ids = surfaceIdsByUrl.get(normalized) || [];
         ids.push(surface.id);
         surfaceIdsByUrl.set(normalized, ids);
+        const registrations = crossFileRegistrations.get(normalized) || [];
+        registrations.push({
+          file: path.basename(file),
+          netuid: document.netuid,
+          id: surface.id,
+          authority: surface.authority,
+        });
+        crossFileRegistrations.set(normalized, registrations);
       }
     }
     if (surface.provider && !providerIds.has(surface.provider)) {
@@ -241,6 +271,29 @@ for (const file of files) {
         );
       }
     }
+  }
+}
+
+// Cross-file duplicate URLs (#6328). Only meaningful over a full run: a
+// single-file invocation (`validate:surface -- registry/subnets/x.json`) can
+// only see its own document, so it cannot judge what another netuid claims.
+if (files.length > 1) {
+  for (const [normalizedUrl, registrations] of crossFileRegistrations) {
+    const netuids = [...new Set(registrations.map((entry) => entry.netuid))];
+    if (netuids.length < 2) continue;
+    if (SHARED_OPERATOR_URLS.has(normalizedUrl)) continue;
+    const claims = registrations
+      .map(
+        (entry) => `${entry.file} (${entry.id}, authority=${entry.authority})`,
+      )
+      .join(", ");
+    errors.push(
+      `"${normalizedUrl}" is registered by ${netuids.length} different netuids (${netuids.join(", ")}): ${claims} — ` +
+        "one endpoint cannot be two subnets' surface. Point each subnet at its own " +
+        "endpoint, or -- if this URL describes the shared operator rather than a " +
+        "subnet (a corporate site, a monorepo) -- add it to SHARED_OPERATOR_URLS " +
+        "with the reason.",
+    );
   }
 }
 

--- a/tests/validate-surface-cross-file-duplicate-url.test.mjs
+++ b/tests/validate-surface-cross-file-duplicate-url.test.mjs
@@ -1,0 +1,200 @@
+// Regression coverage for #6328: validate-surface.mjs now also fails when two
+// DIFFERENT netuids register the identical URL — the cross-file counterpart of
+// the within-file check (#5737). SN48 (Quantum Compute) and SN63 (Enigma) both
+// registered https://www.qbittensorlabs.com/api/health as their own subnet-api,
+// which the per-file check could never see. Mirrors that suite's
+// subprocess-fixture pattern.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, test } from "vitest";
+import { listJsonFiles, readJson, repoRoot } from "../scripts/lib.mjs";
+
+function runNode(args) {
+  try {
+    const stdout = execFileSync(process.execPath, args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return { status: 0, output: stdout };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      output: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+    };
+  }
+}
+
+function surface(id, url, kind = "subnet-api") {
+  return {
+    id,
+    kind,
+    name: id,
+    url,
+    provider: "academia",
+    authority: "community",
+    auth_required: false,
+    public_safe: true,
+    review: { state: "community-submitted" },
+  };
+}
+
+describe("validate-surface.mjs cross-file duplicate-URL check (#6328)", () => {
+  let tempDir;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  // Two separate subnet files, each a valid document on its own -- the bug is
+  // only visible when both are in the same run.
+  function writeTwoFixtures(netuidA, surfacesA, netuidB, surfacesB) {
+    tempDir = mkdtempSync(`${tmpdir()}/metagraphed-validate-surface-xfile-`);
+    const write = (netuid, slug, surfaces) => {
+      const document = {
+        schema_version: 1,
+        netuid,
+        slug,
+        name: `Fixture Subnet ${netuid}`,
+        status: "active",
+        categories: [],
+        links: [],
+        surfaces,
+      };
+      const file = path.join(tempDir, `${slug}.json`);
+      writeFileSync(file, JSON.stringify(document, null, 2));
+      return file;
+    };
+    return [
+      write(netuidA, "fixture-a", surfacesA),
+      write(netuidB, "fixture-b", surfacesB),
+    ];
+  }
+
+  test("fails when two different netuids register the identical URL", () => {
+    const files = writeTwoFixtures(
+      998,
+      [surface("fixture-a-health", "https://api.fixture.example/health")],
+      999,
+      [surface("fixture-b-health", "https://api.fixture.example/health")],
+    );
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...files,
+    ]);
+
+    assert.equal(status, 1);
+    assert.match(output, /https:\/\/api\.fixture\.example\/health/);
+    assert.match(output, /2 different netuids/);
+    // The message must name both claimants so the fix is obvious.
+    assert.match(output, /fixture-a-health/);
+    assert.match(output, /fixture-b-health/);
+    assert.match(output, /998/);
+    assert.match(output, /999/);
+  });
+
+  test("normalizes before comparing: a trailing-slash-only difference still fails", () => {
+    const files = writeTwoFixtures(
+      998,
+      [surface("fixture-a-api", "https://api.fixture.example/status")],
+      999,
+      [surface("fixture-b-api", "https://api.fixture.example/status/")],
+    );
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...files,
+    ]);
+
+    assert.equal(status, 1);
+    assert.match(output, /2 different netuids/);
+  });
+
+  test("a URL on the shared-operator allowlist is accepted across netuids", () => {
+    // qBittensor Labs genuinely runs SN48 and SN63, so its corporate site is
+    // each subnet's real website -- the one shape that must NOT be an error.
+    const files = writeTwoFixtures(
+      998,
+      [surface("fixture-a-site", "https://www.qbittensorlabs.com/", "website")],
+      999,
+      [surface("fixture-b-site", "https://www.qbittensorlabs.com/", "website")],
+    );
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...files,
+    ]);
+
+    assert.equal(status, 0, output);
+    assert.match(output, /Surface validation passed/);
+  });
+
+  test("the same netuid across a re-run is not a cross-file duplicate", () => {
+    // Only DISTINCT netuids conflict; one subnet's own file is the within-file
+    // check's job, not this one's.
+    const files = writeTwoFixtures(
+      999,
+      [surface("fixture-a-api", "https://api.fixture.example/one")],
+      999,
+      [surface("fixture-b-api", "https://api.fixture.example/one")],
+    );
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...files,
+    ]);
+
+    assert.equal(status, 0, output);
+  });
+
+  test("a single-file run never reports a cross-file duplicate", () => {
+    // `validate:surface -- registry/subnets/x.json` can only see one document,
+    // so it must not guess about what another netuid claims.
+    const files = writeTwoFixtures(
+      998,
+      [surface("fixture-a-health", "https://api.fixture.example/health")],
+      999,
+      [surface("fixture-b-health", "https://api.fixture.example/health")],
+    );
+
+    const { status } = runNode(["scripts/validate-surface.mjs", files[0]]);
+
+    assert.equal(status, 0);
+  });
+
+  test("SN48 and SN63 no longer both claim the qBittensor health endpoint", async () => {
+    // The concrete data fix: the shared corporate website stays on both (the
+    // operator runs both subnets), but the health endpoint is SN63's only --
+    // SN48 is accessed through Open Quantum, per its own docs surface.
+    const enigma = await readJson(
+      path.join(repoRoot, "registry/subnets/enigma.json"),
+    );
+    const quantum = await readJson(
+      path.join(repoRoot, "registry/subnets/quantum-compute.json"),
+    );
+    const urls = (document) => (document.surfaces || []).map((s) => s.url);
+    const HEALTH = "https://www.qbittensorlabs.com/api/health";
+    assert.ok(urls(enigma).includes(HEALTH));
+    assert.ok(!urls(quantum).includes(HEALTH));
+    // The website is legitimately shared and must survive the dedupe.
+    assert.ok(urls(enigma).includes("https://www.qbittensorlabs.com/"));
+    assert.ok(urls(quantum).includes("https://www.qbittensorlabs.com/"));
+  });
+
+  test("the whole registry is free of cross-file duplicate URLs", async () => {
+    const files = await listJsonFiles(path.join(repoRoot, "registry/subnets"));
+    assert.ok(files.length > 1);
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...files,
+    ]);
+    assert.equal(status, 0, output);
+  });
+});


### PR DESCRIPTION
Closes #6328

## The finding

SN48 (Quantum Compute) and SN63 (Enigma) both registered `https://www.qbittensorlabs.com/api/health` as **their own** `subnet-api`. I re-ran the registry-wide scan to confirm the issue's premise — these really are the only URLs shared across two netuids in the whole registry:

```
https://www.qbittensorlabs.com            netuids=[48, 63]
https://www.qbittensorlabs.com/api/health netuids=[48, 63]
```

The within-file duplicate check (#5737) sees one document at a time, so it could never catch this.

## Which subnet owns it — evidence, not a guess

The issue asks this be settled from the site's own content/structure rather than a live probe:

- **qbittensorlabs.com is the *operator's* site.** Its nav is `Home | SN63: Enigma | SN48: Quantum | About` — qBittensor Labs genuinely runs both subnets. So the shared `website` surface legitimately stays on both, exactly as the issue allows.
- **`/api/health` is that website's liveness check, not a subnet API.** It returns a generic `{"status":"ok"}` with no subnet data, and *both files' own notes already say so*: "Served on the official qBittensor Labs website". There is no per-subnet endpoint to redirect it to — `/api/sn48/health` and `/api/enigma/health` both **404**.
- **SN48 is accessed through Open Quantum.** Its own `docs` surface records that the SN48 repository README "directs users to OpenQuantum.com". SN48's API surface lives on that platform, so SN48 is **the subnet that does not own** `qbittensorlabs.com/api/health`.

So the surface is removed from `quantum-compute.json` and kept on `enigma.json`, whose only web home is that site — a 25-line pure removal, matching #6472's dedupe shape (delete the redundant entry, keep the one that accurately describes the endpoint).

## The mechanical check

Adds the cross-file counterpart of #5737: the same normalized URL claimed by **2+ distinct netuids** is an error.

- **`SHARED_OPERATOR_URLS`** mirrors `GRANDFATHERED_DUPLICATE_URLS`' style (the issue's "extend the GRANDFATHERED-style tracking" option) and carries the one legitimate case *with its reason*: an operator running several subnets, where the surface describes the operator (a corporate site, a monorepo) rather than the subnet.
- It only runs on a **multi-file invocation**. `validate:surface -- registry/subnets/x.json` can only see one document, so it must not guess about what another netuid claims.
- The error names every claimant (file, id, authority) so the fix is obvious.

Proven both ways — with the duplicate restored:

```
Surface validation failed (1 issue(s)):
- "https://www.qbittensorlabs.com/api/health" is registered by 2 different netuids (63, 48):
  enigma.json (sn-63-enigma-health, authority=community),
  quantum-compute.json (sn-48-quantum-compute-health-api, authority=community) — ...
```

and after the fix: `Surface validation passed: 1120 surface(s) across 129 subnet file(s)`.

## Tests

7 cases in a new `tests/validate-surface-cross-file-duplicate-url.test.mjs`, following the #5737 suite's subprocess-fixture pattern. They are real regression tests — **I reverted the check and confirmed they fail without it**:

- two different netuids claiming one URL → fails, naming both claimants
- trailing-slash-only difference → still caught (normalized before comparing)
- an allowlisted shared-operator URL across netuids → accepted
- the same netuid twice → not a cross-file duplicate (that's the within-file check's job)
- a single-file run → never reports a cross-file duplicate
- SN48/SN63 no longer collide **and** the shared corporate site survives on both
- the whole registry is clean

`validate:surface`, the existing #5737 suite and the reviewed-convention suite all pass. `eslint` clean, `prettier --check` clean, rebased to `behind: 0` immediately before pushing.

Note on coverage: all three changed paths (`registry/**`, `scripts/validate-surface.mjs`, `tests/**`) sit outside `vitest.config.mjs`'s `coverage.include`, which scopes the Codecov upload to `src/**`, `workers/**` and four named scripts — this script is deliberately coverage-invisible because its tests drive it via `execFileSync`. Same shape as the merged #6472.
