### PR TITLE
feat(scripts): instrument the 7 data-refresh-economics/node scripts with Sentry

### DIFF
--- a/scripts/backfill-registry-postgres.mjs
+++ b/scripts/backfill-registry-postgres.mjs
@@ -41,6 +41,9 @@ import {
 } from "./lib.mjs";
 import { generateBaselineOverlaySet } from "./generated-overlays.mjs";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.mjs";
+import { initSentry } from "./observability.mjs";
+
+initSentry("backfill-registry-postgres");
 
 const args = new Set(process.argv.slice(2));
 const dryRun = args.has("--dry-run");

--- a/scripts/data-refresh-node-entrypoint.sh
+++ b/scripts/data-refresh-node-entrypoint.sh
@@ -43,6 +43,13 @@ install_deps() {
     git diff --stat -- . ':(exclude)node_modules' >&2
     exit 1
   fi
+  # Reports the ACTUAL commit whichever script runs next came from --
+  # computed here (install_deps is called from every path that goes on to
+  # run a script) rather than injected by metagraphed-infra's Ansible, since
+  # that repo holds no copy of this code to derive a meaningful SHA from at
+  # all. An explicit override still wins if one is somehow already set.
+  : "${SENTRY_RELEASE:=$(git -C "$REPO_DIR" rev-parse HEAD)}"
+  export SENTRY_RELEASE
 }
 
 if [ "$STEP" = "registry-sync-fast" ]; then

--- a/scripts/discover-testnet-surfaces.mjs
+++ b/scripts/discover-testnet-surfaces.mjs
@@ -23,6 +23,7 @@ import {
   repoRoot,
   buildTimestamp,
 } from "./lib.mjs";
+import { initSentry, captureFatalAndExit } from "./observability.mjs";
 
 const SNAPSHOT = path.join(repoRoot, "registry/native/test-subnets.json");
 const PROBE_TIMEOUT_MS = 8000;
@@ -265,8 +266,14 @@ if (
   process.argv[1] &&
   path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
 ) {
-  main().catch((error) => {
+  initSentry("discover-testnet-surfaces");
+  main().catch(async (error) => {
     console.error(`testnet discovery failed: ${error?.message || error}`);
-    process.exit(1);
+    // Explicit capture required here (not left to @sentry/node's default
+    // OnUnhandledRejection integration, see observability.mjs's own
+    // comment): Node stops considering a promise "unhandled" once
+    // something calls .catch() on it, which this script already did
+    // before Sentry instrumentation existed.
+    await captureFatalAndExit(error);
   });
 }

--- a/scripts/economics-refresh-entrypoint.sh
+++ b/scripts/economics-refresh-entrypoint.sh
@@ -84,6 +84,16 @@ else
   cd "$REPO_DIR"
 fi
 
+# Reports the ACTUAL commit whichever step runs next came from. Placed here
+# (after all three branches above, not inside install_deps) because the
+# economics step's own branch deliberately skips install_deps -- it reuses
+# the SAME volume the snapshot container's install_deps just populated, a
+# separate `docker run` invocation with its own fresh environment, so
+# SENTRY_RELEASE would otherwise be unset for that step specifically. An
+# explicit override still wins if one is somehow already set.
+: "${SENTRY_RELEASE:=$(git -C "$REPO_DIR" rev-parse HEAD)}"
+export SENTRY_RELEASE
+
 case "$STEP" in
   snapshot)
     : "${SUBTENSOR_RPC_URL:?SUBTENSOR_RPC_URL env var required for the snapshot step}"

--- a/scripts/export-parquet.mjs
+++ b/scripts/export-parquet.mjs
@@ -34,6 +34,9 @@ import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { sha256Hex, stableStringify } from "./lib.mjs";
+import { initSentry } from "./observability.mjs";
+
+initSentry("export-parquet");
 
 const args = new Set(process.argv.slice(2));
 const dryRun = args.has("--dry-run");

--- a/scripts/observability.mjs
+++ b/scripts/observability.mjs
@@ -1,0 +1,51 @@
+// Shared Sentry init for the box-side Node data-refresh scripts run via
+// metagraphed-infra's data-refresh-economics/data-refresh-node Ansible
+// roles (scripts/economics-refresh-entrypoint.sh /
+// data-refresh-node-entrypoint.sh, both of which clone this repo at
+// container runtime -- see those entrypoints' own headers). Used by
+// refresh-economics.mjs, refresh-native-snapshot.mjs,
+// backfill-registry-postgres.mjs, discover-testnet-surfaces.mjs,
+// export-parquet.mjs, reconcile-neurons.mjs, and
+// sync-registry-to-postgres.mjs so all seven report to the same
+// consolidated `metagraphed` Sentry project with a consistent `component`
+// tag -- matching scripts/observability.py's own Python-side convention
+// for the chain-fetch scripts.
+import * as Sentry from "@sentry/node";
+
+// No-ops silently if SENTRY_DSN is unset, matching every other
+// instrumented process in this rollout (SENTRY_DSN is not a secret in the
+// same sense a sync token is -- Sentry DSNs are designed to be safe in
+// client-side/public code, write-only -- so passing it into these scripts'
+// existing "gets zero secrets" trust boundaries where applicable doesn't
+// weaken them).
+export function initSentry(component) {
+  const dsn = process.env.SENTRY_DSN;
+  if (!dsn) return;
+  Sentry.init({
+    dsn,
+    environment: process.env.SENTRY_ENVIRONMENT || "production",
+    release: process.env.SENTRY_RELEASE, // set by the entrypoint's own git rev-parse
+    // Error tracking only -- these are short-lived batch scripts run on a
+    // 3min/daily/weekly cron, not request-serving services.
+    tracesSampleRate: 0,
+  });
+  Sentry.setTag("component", component);
+  // Every script this module is used by is a ONE-SHOT process, not a
+  // long-running poll loop like chain-firehose-relay.mjs -- an error that
+  // propagates uncaught (the common case: most of these scripts have no
+  // top-level try/catch at all, relying on Node's own default "print and
+  // exit 1" behavior) is automatically captured, flushed, and reported by
+  // @sentry/node's own default OnUncaughtException/OnUnhandledRejection
+  // integrations, installed as a side effect of Sentry.init() above -- no
+  // manual process.on() wiring needed here. The one exception is a script
+  // with its OWN explicit top-level `.catch()` (discover-testnet-
+  // surfaces.mjs): Node stops considering a promise "unhandled" once
+  // something calls .catch() on it, so that one script calls
+  // captureFatalAndExit() below directly instead of relying on the default.
+}
+
+export async function captureFatalAndExit(error, exitCode = 1) {
+  Sentry.captureException(error);
+  await Sentry.flush(2000);
+  process.exit(exitCode);
+}

--- a/scripts/reconcile-neurons.mjs
+++ b/scripts/reconcile-neurons.mjs
@@ -29,6 +29,9 @@
 import postgres from "postgres";
 import { readFile } from "node:fs/promises";
 import { stableStringify } from "./lib.mjs";
+import { initSentry } from "./observability.mjs";
+
+initSentry("reconcile-neurons");
 
 // Below this absolute TAO delta, a mismatch is never flagged regardless of
 // relative size -- avoids false positives on near-zero stakes where a tiny

--- a/scripts/refresh-economics.mjs
+++ b/scripts/refresh-economics.mjs
@@ -26,6 +26,9 @@ import {
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.mjs";
 import { shouldPublishEconomics } from "./economics-floor.mjs";
+import { initSentry } from "./observability.mjs";
+
+initSentry("refresh-economics");
 
 const args = new Set(process.argv.slice(2));
 const write = args.has("--write");

--- a/scripts/refresh-native-snapshot.mjs
+++ b/scripts/refresh-native-snapshot.mjs
@@ -14,6 +14,9 @@
 // using the committed snapshot (this step is production-only).
 import { spawnSync } from "node:child_process";
 import { stableStringify } from "./lib.mjs";
+import { initSentry } from "./observability.mjs";
+
+initSentry("refresh-native-snapshot");
 
 const startedAt = process.env.METAGRAPH_BUILD_TIMESTAMP || null;
 

--- a/scripts/sync-registry-to-postgres.mjs
+++ b/scripts/sync-registry-to-postgres.mjs
@@ -49,6 +49,9 @@ import {
   subnetSurfaceKey,
 } from "./lib.mjs";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.mjs";
+import { initSentry } from "./observability.mjs";
+
+initSentry("sync-registry-to-postgres");
 
 const args = parseArgs(process.argv.slice(2));
 const operationalKindSet = new Set(OPERATIONAL_SURFACE_KINDS);

--- a/tests/observability.test.mjs
+++ b/tests/observability.test.mjs
@@ -1,0 +1,84 @@
+// Unit tests for scripts/observability.mjs -- the shared Sentry init for
+// the box-side data-refresh-economics/data-refresh-node scripts. Mocked the
+// same way tests/chain-firehose-relay.test.mjs mocks @sentry/node.
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+
+const captureException = vi.hoisted(() => vi.fn());
+const sentryInit = vi.hoisted(() => vi.fn());
+const setTag = vi.hoisted(() => vi.fn());
+const flush = vi.hoisted(() => vi.fn(async () => true));
+vi.mock("@sentry/node", () => ({
+  init: sentryInit,
+  setTag,
+  captureException,
+  flush,
+}));
+
+import { initSentry, captureFatalAndExit } from "../scripts/observability.mjs";
+
+test("initSentry: no-ops (never calls Sentry.init) when SENTRY_DSN is unset", () => {
+  sentryInit.mockClear();
+  setTag.mockClear();
+  vi.stubEnv("SENTRY_DSN", "");
+  initSentry("some-script");
+  assert.equal(sentryInit.mock.calls.length, 0);
+  assert.equal(setTag.mock.calls.length, 0);
+  vi.unstubAllEnvs();
+});
+
+test("initSentry: calls Sentry.init with dsn/environment/release and tags the component when SENTRY_DSN is set", () => {
+  sentryInit.mockClear();
+  setTag.mockClear();
+  vi.stubEnv("SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
+  vi.stubEnv("SENTRY_ENVIRONMENT", "staging");
+  vi.stubEnv("SENTRY_RELEASE", "deadbeef");
+  initSentry("sync-registry-to-postgres");
+  assert.equal(sentryInit.mock.calls.length, 1);
+  assert.deepEqual(sentryInit.mock.calls[0][0], {
+    dsn: "https://abc@o0.ingest.sentry.io/0",
+    environment: "staging",
+    release: "deadbeef",
+    tracesSampleRate: 0,
+  });
+  assert.deepEqual(setTag.mock.calls[0], [
+    "component",
+    "sync-registry-to-postgres",
+  ]);
+  vi.unstubAllEnvs();
+});
+
+test("initSentry: SENTRY_ENVIRONMENT defaults to 'production' when unset", () => {
+  sentryInit.mockClear();
+  vi.stubEnv("SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
+  vi.stubEnv("SENTRY_ENVIRONMENT", "");
+  initSentry("some-script");
+  assert.equal(sentryInit.mock.calls[0][0].environment, "production");
+  vi.unstubAllEnvs();
+});
+
+test("captureFatalAndExit: captures the exception, flushes, then exits with the given code", async () => {
+  captureException.mockClear();
+  flush.mockClear();
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
+  const error = new Error("boom");
+
+  await captureFatalAndExit(error, 2);
+
+  assert.equal(captureException.mock.calls.length, 1);
+  assert.equal(captureException.mock.calls[0][0], error);
+  assert.equal(flush.mock.calls.length, 1);
+  assert.equal(exitSpy.mock.calls.length, 1);
+  assert.equal(exitSpy.mock.calls[0][0], 2);
+  exitSpy.mockRestore();
+});
+
+test("captureFatalAndExit: defaults to exit code 1", async () => {
+  captureException.mockClear();
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
+
+  await captureFatalAndExit(new Error("boom"));
+
+  assert.equal(exitSpy.mock.calls[0][0], 1);
+  exitSpy.mockRestore();
+});


### PR DESCRIPTION
## Summary

Closes #6476. Part of the metagraphed/Ventura Labs Sentry rollout (#6485).

Adds a new `scripts/observability.mjs` shared module (`initSentry(component)` + `captureFatalAndExit(error, exitCode)`), matching `scripts/observability.py`'s own Python-side convention for the chain-fetch scripts, and wires it into all 7 target scripts:

- `refresh-economics.mjs`, `refresh-native-snapshot.mjs`, `backfill-registry-postgres.mjs`, `export-parquet.mjs`, `reconcile-neurons.mjs`, `sync-registry-to-postgres.mjs` -- just `initSentry()` near the top. All six are one-shot processes with no top-level `try/catch` of their own, so an error that propagates uncaught is automatically captured, flushed, and reported by `@sentry/node`'s own default `OnUncaughtException`/`OnUnhandledRejection` integrations -- no manual `process.on()` wiring needed.
- `discover-testnet-surfaces.mjs` is the one exception: it already had its own explicit `main().catch(...)`, so Node no longer considers that rejection "unhandled" once something calls `.catch()` on it -- wired `initSentry()` + an explicit `captureFatalAndExit()` call inside that existing catch block instead. `initSentry()` is called only inside the "am I the entrypoint" guard (this file also exports `classify` for reuse elsewhere), not at module top-level, so importing it for that export alone never has an init side effect.

Also adds `SENTRY_RELEASE` self-computation (`git rev-parse HEAD` of the freshly-cloned checkout) to both entrypoints that run these scripts:

- `economics-refresh-entrypoint.sh`: placed after the snapshot/economics/first-run branches converge (not inside `install_deps`), since the economics step deliberately skips `install_deps` to reuse the snapshot container's already-populated volume -- a separate `docker run` invocation with its own fresh environment, so `SENTRY_RELEASE` would otherwise be unset for that step specifically.
- `data-refresh-node-entrypoint.sh`: placed inside the shared `install_deps()` function instead, since (unlike economics-refresh) every path here that goes on to run a script calls `install_deps()` first.

## Test plan

- [x] Full `npx vitest run` (303 files / 8991 tests) passes with no regressions
- [x] Each of the 7 scripts smoke-tested individually (`node scripts/<name>.mjs` / `--dry-run`) -- all still import and run cleanly, failing only on their own expected domain errors (missing env vars) where applicable, never an import-time crash
- [x] New `tests/observability.test.mjs` -- 5 tests covering `initSentry`'s DSN-gated no-op/init paths and `captureFatalAndExit`'s capture+flush+exit sequence
- [x] `shellcheck` clean on both entrypoints
- [x] `npm run lint` / `npx prettier --check` clean
- [x] `npm run scan:public-safety` passes