### PR TITLE
feat(ui): add a reset control to the probe-history filters (#6393)

### DIFF
--- a/apps/ui/src/components/metagraphed/status-diagnostics.tsx
+++ b/apps/ui/src/components/metagraphed/status-diagnostics.tsx
@@ -8,7 +8,12 @@ import {
 } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
 import { HealthPill, TimeAgo, TableState, BarMini, type BarMiniDatum } from "@jsonbored/ui-kit";
-import { SortHeader, ariaSort, SelectFilter } from "@/components/metagraphed/table-controls";
+import {
+  SortHeader,
+  ariaSort,
+  SelectFilter,
+  ResetFiltersButton,
+} from "@/components/metagraphed/table-controls";
 import { Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import type { HealthHistorySurface, SourceHealthProvider } from "@/lib/metagraphed/types";
@@ -186,6 +191,14 @@ function HealthHistoryBody({ date }: { date: string }) {
             { value: "down", label: "failed" },
             { value: "unknown", label: "unknown" },
           ]}
+        />
+        {/* Scoped to the two keys this row owns. `date` has its own control in
+            the header above, and sort/order/window are set from other parts of
+            /status -- clearing them from here would drop state the reader never
+            touched from this row. */}
+        <ResetFiltersButton
+          active={Boolean(kind || status)}
+          onReset={() => navigate({ search: (prev) => ({ ...prev, kind: "", status: "" }) })}
         />
         <span className="ml-auto font-mono text-[10px] text-ink-muted">
           {rows.length} of {res.data.surfaces.length} surfaces


### PR DESCRIPTION
## Summary

`/status` persists the probe-history drilldown's `kind`/`status` filters in the URL
(#3977), so a shared `/status?kind=X&status=Y` link lands the reader on a filtered
table with no one-click way back to the unfiltered view. Every comparable multi-filter
table in the app already ships a `ResetFiltersButton` -- `HealthHistoryDrilldown` was
the one that didn't.

## What Changed

`ResetFiltersButton` is added to the filter row, `active` whenever `kind` or `status` is
set, resetting both through the same `navigate({ search })` pattern the row's own
`onSort` already uses -- no new state, no new plumbing.

**Scoped to only `kind`/`status`** (the issue's deliverable): the drilldown's `date` has
its own control in the section header, and `sort`/`order`/`window` are driven from other
parts of `/status`. Clearing them from this row would drop state the reader never
touched here, so the reset spreads `prev` and overwrites just those two keys.

**The unfiltered view is unchanged.** `ResetFiltersButton` returns `null` when
`!active`, so with no filters set the row renders exactly as before -- the control only
appears once there is something to reset.

## Screenshots

Captured at the contract's fixed viewports (1280x800 / 768x1024 / 375x812), themes
forced via `mg-theme`, both variants served from one dev server against live probe data
with fonts settled before capture, so the pairs differ in exactly one thing. Route:
`/status?kind=subnet-api&status=ok` -- a real filtered view (273 of 1780 surfaces), which
is the state the issue is about. `before` is the merge-base.

| Viewport · Theme | Before -- filters set, no reset | After -- one click back to unfiltered |
| --- | --- | --- |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-before-mobile-light.png)<br><sub>no way back</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-after-mobile-light.png)<br><sub>Reset filters</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-before-mobile-dark.png)<br><sub>no way back</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-after-mobile-dark.png)<br><sub>Reset filters</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-before-tablet-light.png)<br><sub>no way back</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-after-tablet-light.png)<br><sub>Reset filters</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-before-tablet-dark.png)<br><sub>no way back</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-after-tablet-dark.png)<br><sub>Reset filters</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-before-desktop-light.png)<br><sub>no way back</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-after-desktop-light.png)<br><sub>Reset filters</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-before-desktop-dark.png)<br><sub>no way back</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6393-reset/6393-reset-after-desktop-dark.png)<br><sub>Reset filters</sub> |

At 375px the row wraps and the control drops beside the surface count -- the existing
`flex-wrap` handles it, no overflow.

## Validation

- `npm run lint --workspace=apps/ui` -- 0 errors
- `npm run format:check --workspace=apps/ui` -- clean
- `npm run typecheck --workspace=apps/ui` -- 0 errors
- `npm test --workspace=apps/ui` -- 1049/1049 passed
- `npm run build --workspace=apps/ui` -- clean
- Reset button asserted present in all 6 after-shots and absent in all 6 before-shots during capture

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6393`) -- required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched -- one file under `apps/ui/**`.
- [x] `routeTree.gen.ts` untouched; screenshots hosted on the `screenshots` branch, not committed here.

Closes #6393
