### PR TITLE
fix(ui): validate account/validator identifiers at the router level

### DIFF
--- a/apps/ui/src/lib/metagraphed/entity-not-found-meta.test.ts
+++ b/apps/ui/src/lib/metagraphed/entity-not-found-meta.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { entityNotFoundMeta } from "@/lib/metagraphed/entity-not-found-meta";
+
+// #6429: accounts.$ss58.tsx and validators.$hotkey.tsx had no router-level
+// identifier validation, so a junk id rendered a fully-formed page. Adding
+// parseParams fixes the body — but NOT the metadata: head() still runs with the
+// raw param. Verified against the routes that already validate: /blocks/not-a-ref
+// titles "Block not-a-ref — Metagraphed" and /subnets/not-a-netuid titles
+// "Subnet not-a-netuid — Metagraphed" today. This helper is what actually keeps
+// the junk id out of the title, and both routes share it.
+const find = (meta: Array<Record<string, unknown>>, key: string, value: string) =>
+  meta.find((m) => m[key] === value);
+
+describe("entityNotFoundMeta (#6429)", () => {
+  it("titles the page not-found instead of echoing the bad identifier", () => {
+    const { meta } = entityNotFoundMeta("Account", "not a valid ss58");
+    expect(meta[0]).toEqual({ title: "Account not found — Metagraphed" });
+    // The regression: the title must never carry the raw param.
+    expect(JSON.stringify(meta)).not.toContain("not-an-ss58");
+  });
+
+  it("marks the page noindex — these URLs are unbounded", () => {
+    // Any string is a URL here, so a crawler could otherwise index one page per
+    // malformed id.
+    const { meta } = entityNotFoundMeta("Validator", "not a valid hotkey");
+    expect(find(meta, "name", "robots")).toEqual({
+      name: "robots",
+      content: "noindex",
+    });
+  });
+
+  it("carries the caller's description into both description tags", () => {
+    const detail = "This validator identifier is not a valid Bittensor ss58 hotkey.";
+    const { meta } = entityNotFoundMeta("Validator", detail);
+    expect(find(meta, "name", "description")).toEqual({
+      name: "description",
+      content: detail,
+    });
+    expect(find(meta, "property", "og:description")).toEqual({
+      property: "og:description",
+      content: detail,
+    });
+  });
+
+  it("keeps og:title in step with the title", () => {
+    const { meta } = entityNotFoundMeta("Account", "x");
+    expect(find(meta, "property", "og:title")).toEqual({
+      property: "og:title",
+      content: "Account not found — Metagraphed",
+    });
+  });
+
+  it("names the entity the route serves, so the two routes read differently", () => {
+    expect(entityNotFoundMeta("Account", "x").meta[0]).toEqual({
+      title: "Account not found — Metagraphed",
+    });
+    expect(entityNotFoundMeta("Validator", "x").meta[0]).toEqual({
+      title: "Validator not found — Metagraphed",
+    });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/entity-not-found-meta.ts
+++ b/apps/ui/src/lib/metagraphed/entity-not-found-meta.ts
@@ -1,0 +1,26 @@
+/**
+ * `head()` metadata for a detail route whose identifier is malformed (#6429).
+ *
+ * The router's `parseParams` rejects a bad identifier so the not-found boundary
+ * renders — but it does **not** stop `head()` running with the raw param. That's
+ * observable on the routes that already validate: `/blocks/not-a-ref` titles the
+ * page "Block not-a-ref — Metagraphed", and `/subnets/not-a-netuid` titles it
+ * "Subnet not-a-netuid — Metagraphed". Without this, the not-found boundary
+ * renders under a title asserting the junk id is a real entity, and crawlers are
+ * invited to index one page per malformed URL.
+ *
+ * `noindex` is the point of the robots tag: these URLs are unbounded (any string
+ * is one), so they must never enter an index.
+ */
+export function entityNotFoundMeta(entity: string, description: string) {
+  const title = `${entity} not found — Metagraphed`;
+  return {
+    meta: [
+      { title },
+      { name: "description", content: description },
+      { property: "og:title", content: title },
+      { property: "og:description", content: description },
+      { name: "robots", content: "noindex" },
+    ],
+  };
+}

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, notFound, useNavigate } from "@tanstack/react-router";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Fragment, Suspense, useState, type ReactNode } from "react";
 import {
@@ -74,6 +74,7 @@ import { isValidSs58, ss58PathSegment } from "@/lib/metagraphed/accounts";
 import { accountFeedSectionPhase } from "@/lib/metagraphed/account-feed-section";
 import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
 import { subnetPositionSearch } from "@/lib/metagraphed/subnet-position-link";
+import { entityNotFoundMeta } from "@/lib/metagraphed/entity-not-found-meta";
 import type {
   AccountCounterparty,
   AccountStakeFlowSubnet,
@@ -104,7 +105,27 @@ export const Route = createFileRoute("/accounts/$ss58")({
       ev_offset: Number.isInteger(offsetNum) && offsetNum > 0 ? offsetNum : undefined,
     };
   },
+  // #6429: validate the ss58 at the router level, matching blocks.$ref.tsx
+  // (#3422) and subnets.$netuid.tsx. parseParams runs before head()/the loader,
+  // so an invalid address renders the real not-found boundary instead of a
+  // fully-formed page whose metadata interpolates the bad param.
+  parseParams: ({ ss58 }) => {
+    if (!isValidSs58(ss58)) throw notFound();
+    return { ss58 };
+  },
   head: ({ params }) => {
+    // parseParams above rejects a malformed ss58, but head() still runs with the
+    // raw param -- verified against the routes that already validate: /blocks/
+    // not-a-ref titles "Block not-a-ref" and /subnets/not-a-netuid titles
+    // "Subnet not-a-netuid" today. So the not-found metadata is guarded here
+    // too, or the boundary would render under a title asserting the bad id is a
+    // real account (#6429).
+    if (!isValidSs58(params.ss58)) {
+      return entityNotFoundMeta(
+        "Account",
+        "This account identifier is not a valid Bittensor ss58 address.",
+      );
+    }
     const label = shortHash(params.ss58) ?? params.ss58;
     const title = `Account ${label} — Metagraphed`;
     const description = `Bittensor account ${label}: cross-subnet activity, registrations, and first-party chain-event history on Metagraphed.`;
@@ -117,6 +138,26 @@ export const Route = createFileRoute("/accounts/$ss58")({
       ],
     };
   },
+  notFoundComponent: () => (
+    <AppShell>
+      <PageHeading
+        eyebrow="Explorer"
+        title="Invalid account address"
+        description="Account addresses are ss58 (base58) strings, 46–49 characters long."
+      />
+      <EmptyState
+        title="Invalid account address"
+        description="Bittensor addresses use the base58 alphabet (no 0, O, I, or l), are 46–49 characters long, and typically start with 5. Check for a truncated or wrong-chain address, then try again."
+        action={{ label: "Back to accounts", href: "/accounts" }}
+      />
+      <p className="mt-3 text-center text-[11px] text-ink-muted">
+        Example:{" "}
+        <span className="font-mono break-all text-ink-strong">
+          5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        </span>
+      </p>
+    </AppShell>
+  ),
   component: AccountDetailPage,
 });
 
@@ -133,29 +174,9 @@ function AccountDetailPage() {
   );
 }
 
+// The router's parseParams guarantees a well-formed ss58 here (#6429), so this
+// no longer re-checks it -- same shape as blocks.$ref.tsx's BlockDetailPage.
 function AccountDetail({ ss58 }: { ss58: string }) {
-  if (!isValidSs58(ss58)) {
-    return (
-      <>
-        <PageHeading
-          eyebrow="Explorer"
-          title="Invalid account address"
-          description="Account addresses are ss58 (base58) strings, 46–49 characters long."
-        />
-        <EmptyState
-          title="Invalid account address"
-          description="Bittensor addresses use the base58 alphabet (no 0, O, I, or l), are 46–49 characters long, and typically start with 5. Check for a truncated or wrong-chain address, then try again."
-          action={{ label: "Back to accounts", href: "/accounts" }}
-        />
-        <p className="mt-3 text-center text-[11px] text-ink-muted">
-          Example:{" "}
-          <span className="font-mono break-all text-ink-strong">
-            5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-          </span>
-        </p>
-      </>
-    );
-  }
   return <ValidAccountDetail ss58={ss58} />;
 }
 

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, notFound, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense } from "react";
 import { z } from "zod";
@@ -35,6 +35,7 @@ import {
 } from "@/lib/metagraphed/validator-apy";
 import type { ValidatorDetailSubnet } from "@/lib/metagraphed/types";
 import { subnetPositionSearch } from "@/lib/metagraphed/subnet-position-link";
+import { entityNotFoundMeta } from "@/lib/metagraphed/entity-not-found-meta";
 
 const validatorDetailSearchSchema = z.object({
   window: fallback(z.enum(["7d", "30d", "90d"]), "30d").default("30d"),
@@ -48,7 +49,25 @@ const validatorDetailSearchSchema = z.object({
 
 export const Route = createFileRoute("/validators/$hotkey")({
   validateSearch: zodValidator(validatorDetailSearchSchema),
+  // #6429: validate the hotkey at the router level, matching blocks.$ref.tsx
+  // (#3422) and subnets.$netuid.tsx. parseParams runs before head()/the loader,
+  // so an invalid hotkey renders the real not-found boundary instead of a
+  // fully-formed page whose metadata interpolates the bad param.
+  parseParams: ({ hotkey }) => {
+    if (!isValidSs58(hotkey)) throw notFound();
+    return { hotkey };
+  },
   head: ({ params }) => {
+    // See accounts.$ss58.tsx: parseParams rejects a malformed hotkey, but head()
+    // still runs with the raw param (the already-validating /blocks and /subnets
+    // routes title invalid ids the same way today), so the not-found metadata is
+    // guarded here too (#6429).
+    if (!isValidSs58(params.hotkey)) {
+      return entityNotFoundMeta(
+        "Validator",
+        "This validator identifier is not a valid Bittensor ss58 hotkey.",
+      );
+    }
     const label = shortHash(params.hotkey) ?? params.hotkey;
     return {
       meta: [
@@ -65,6 +84,20 @@ export const Route = createFileRoute("/validators/$hotkey")({
       ],
     };
   },
+  notFoundComponent: () => (
+    <AppShell>
+      <PageHeading
+        eyebrow="Explorer"
+        title="Invalid hotkey"
+        description="Validator hotkeys must be a valid ss58 (base58) string."
+      />
+      <EmptyState
+        title="Invalid hotkey"
+        description="Use a valid validator hotkey ss58 address."
+        action={{ label: "Back to validators", href: "/validators" }}
+      />
+    </AppShell>
+  ),
   component: ValidatorDetailPage,
 });
 
@@ -81,23 +114,9 @@ function ValidatorDetailPage() {
   );
 }
 
+// The router's parseParams guarantees a well-formed hotkey here (#6429), so this
+// no longer re-checks it -- same shape as blocks.$ref.tsx's BlockDetailPage.
 function ValidatorDetailGate({ hotkey }: { hotkey: string }) {
-  if (!isValidSs58(hotkey)) {
-    return (
-      <>
-        <PageHeading
-          eyebrow="Explorer"
-          title="Invalid hotkey"
-          description="Validator hotkeys must be a valid ss58 (base58) string."
-        />
-        <EmptyState
-          title="Invalid hotkey"
-          description="Use a valid validator hotkey ss58 address."
-          action={{ label: "Back to validators", href: "/validators" }}
-        />
-      </>
-    );
-  }
   return <ValidatorDetail hotkey={hotkey} />;
 }
 


### PR DESCRIPTION
## What

`blocks.$ref.tsx` and `subnets.$netuid.tsx` validate their identifier at the router level via `parseParams`, throwing `notFound()` so an invalid one renders the real not-found boundary. `accounts.$ss58.tsx` and `validators.$hotkey.tsx` had no `parseParams` — validation happened post-mount, inside the component.

Both routes now get `parseParams` + a route-level `notFoundComponent`, and their in-component `isValidSs58` branches are gone, per `blocks.$ref.tsx`'s precedent.

## ⚠️ The issue's premise doesn't hold — `parseParams` does **not** gate `head()`

The issue states that `blocks.$ref.tsx` throws "so `head()` is never invoked with a known-bad param". I checked the two routes it cites as the precedent, and that isn't what happens:

| Route | Already has `parseParams`? | `<title>` for a junk id |
| --- | --- | --- |
| `/blocks/not-a-ref` | ✅ yes | `Block not-a-ref — Metagraphed` |
| `/subnets/not-a-netuid` | ✅ yes | `Subnet not-a-netuid — Metagraphed` |

`head()` runs with the raw param regardless. So `parseParams` alone fixes the **body** but not the **metadata**, and this PR's stated Expected Outcome — *"instead of a fully-formed page with bad metadata"* — would not have been met by doing only what the issue asks.

So `head()` is guarded too, via a shared `entityNotFoundMeta()` helper both routes call:

| | before | after |
| --- | --- | --- |
| `/accounts/not-an-ss58` | `Account not-an-ss58 — Metagraphed` | **`Account not found — Metagraphed`** |
| `/validators/not-an-ss58` | `Validator not-an-ss58 — Metagraphed` | **`Validator not found — Metagraphed`** |
| `/accounts/5G9hfk…` (valid) | `Account 5G9hfk…hjwrc5` | unchanged |

It also sets `robots: noindex` — these URLs are unbounded (any string is one), so they should never be indexed.

I've left `/blocks` and `/subnets` alone: same gap, but out of this issue's scope. Happy to follow up if you want `entityNotFoundMeta` applied there too.

## Screenshots

`/accounts/not-an-ss58` — the surface that changed. Before: the in-component branch. After: the route-level not-found boundary.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

`entity-not-found-meta.test.ts` (5 tests): the title never echoes the raw param; `noindex` is set; the description reaches both the `description` and `og:description` tags; `og:title` stays in step with `title`; and each route names its own entity.

The helper exists partly for this reason — the guard's logic is unit-testable without importing a route's full component tree (this suite is node-environment, and the routes pull in `AppShell`).

`apps/ui`: **140 files / 1059 tests** pass, `tsc` clean, `eslint` 0 errors, repo `format:check` clean.

Verified in a browser on both servers: invalid ids render the not-found boundary under a clean title, and valid `/accounts/5G9hfk…` / `/validators/5G9hfk…` pages are unchanged.

Closes #6429

<sub>Supersedes #6488, which the gate closed on a failing `ui` lint job — I'd committed a throwaway probe script (`apps/ui/v2.mjs`) by accident. Same code, stray removed; `eslint .` and `format:check` are clean and the diff is 4 files, all under `apps/ui/src`.</sub>
