### PR TITLE
fix(ui): use AA-safe text token for accent pills

### DIFF
--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -179,7 +179,7 @@ function EndpointsPage() {
               onClick={() => setTab(t.id)}
               className={
                 tab === t.id
-                  ? "rounded-full border border-accent/40 bg-accent/10 px-3.5 py-1.5 font-mono text-[11px] uppercase tracking-widest text-accent"
+                  ? "rounded-full border border-accent/40 bg-accent/10 px-3.5 py-1.5 font-mono text-[11px] uppercase tracking-widest text-accent-text"
                   : "rounded-full border border-border bg-card px-3.5 py-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30 hover:text-ink-strong"
               }
             >

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -1304,7 +1304,7 @@ function ExplorerDashboard() {
             onClick={() => navigate({ search: { window: w } })}
             className={
               w === win
-                ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent"
+                ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent-text"
                 : "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30"
             }
           >
@@ -1364,7 +1364,7 @@ function ExplorerDashboard() {
             onClick={() => setTab(t.id)}
             className={
               tab === t.id
-                ? "rounded-full border border-accent/40 bg-accent/10 px-3.5 py-1.5 font-mono text-[11px] uppercase tracking-widest text-accent"
+                ? "rounded-full border border-accent/40 bg-accent/10 px-3.5 py-1.5 font-mono text-[11px] uppercase tracking-widest text-accent-text"
                 : "rounded-full border border-border bg-card px-3.5 py-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30 hover:text-ink-strong"
             }
           >
@@ -1809,7 +1809,7 @@ function TransferPairsSection({ win }: { win: "7d" | "30d" }) {
               onClick={() => setSort(s)}
               className={
                 s === sort
-                  ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent"
+                  ? "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent-text"
                   : "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30"
               }
             >

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -56,7 +56,7 @@ export const Route = createFileRoute("/leaderboards")({
 
 const TH = "px-4 py-2.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted";
 const WINDOW_BTN_ACTIVE =
-  "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent";
+  "rounded-full border border-accent/40 bg-accent/10 px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-accent-text";
 const WINDOW_BTN =
   "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30";
 


### PR DESCRIPTION
## Summary

- replaces `text-accent` with the AA-safe `text-accent-text` token on all five active filter/tab pill sites
- leaves the existing accent border and background treatments unchanged
- verifies computed label contrast across all five sites in both themes (minimum 4.51:1 light, 10.40:1 dark)

Closes #6404

## Template Used

- Frontend (Path C)

## Screenshots

Representative `/endpoints` tab pills; the same shared token-only change applies to the Explorer and Leaderboards pills.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6404-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npx eslint apps/ui/src/routes/explorer.tsx apps/ui/src/routes/endpoints.tsx apps/ui/src/routes/leaderboards.tsx`
- `npx prettier --check apps/ui/src/routes/explorer.tsx apps/ui/src/routes/endpoints.tsx apps/ui/src/routes/leaderboards.tsx`
- `npm run typecheck --workspace=apps/ui` (after the same UI-kit build step CI runs)
- `npm test --workspace=apps/ui` — 140 files / 1,060 tests passed
- `npx playwright test tests/e2e/responsive-overflow.spec.ts --grep "/endpoints" --workers=1` — 4 passed
- production Vite build
- computed WCAG contrast check at all five sites in light and dark themes
