### PR TITLE
fix(chain-firehose-relay): proactively pace batch forwarding to stay under the ingest rate limit

### DIFF
--- a/scripts/chain-firehose-relay.mjs
+++ b/scripts/chain-firehose-relay.mjs
@@ -187,10 +187,41 @@ export function isHeartbeatFresh(
 export const CHAIN_FIREHOSE_POLL_BATCH_SIZE = 200;
 
 // Idle poll interval -- how long to wait before re-polling after a batch came
-// back empty. When a poll DOES claim rows, the loop re-polls immediately
-// (no sleep) to drain a backlog quickly rather than waiting out this
-// interval between every batch.
+// back empty. When a poll DOES claim rows, the loop paces itself (see
+// computeBatchPaceDelayMs below) instead of either waiting out this idle
+// interval or re-polling with no delay at all.
 export const CHAIN_FIREHOSE_POLL_INTERVAL_MS = 250;
+
+// Server-side cap this relay must stay under (CHAIN_FIREHOSE_INGEST_RATE_LIMIT
+// in workers/api.mjs: 1200 req/60s, per-IP). Targets 80% of it, not the full
+// 1200, so ordinary jitter (network latency variance, GC pauses, the
+// window's own boundary behavior) doesn't tip a batch over the edge even
+// when this pacing is working correctly.
+export const CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S = 960;
+
+// Pure: how long to additionally sleep after a non-rate-limited batch of
+// `claimed` rows took `elapsedMs` wall-clock time to forward, so the
+// SUSTAINED rate across batches never organically bursts past the ingest
+// endpoint's own rate limit. This is the fix for a real 2026-07-17 incident,
+// distinct from the retry-after fix above (that one handles a single 429
+// correctly; this one prevents the NEXT batch from re-triggering one at all).
+// The prior design re-polled immediately whenever a batch wasn't rate
+// limited, so any real backlog fired CHAIN_FIREHOSE_POLL_BATCH_SIZE (200)
+// requests in a couple of seconds -- roughly 8x the sustained rate the limit
+// allows -- guaranteeing the VERY NEXT batch re-triggered the same 429. The
+// relay then correctly paused for retry-after, resumed, immediately
+// re-burst, and repeated forever: a livelock reactive backoff alone can
+// never recover from, because every retry attempt is already over the limit
+// before the first response even comes back. Confirmed live: a real backlog
+// sat at ~230k pending with a 100% 429 rate for over an hour until this fix.
+// Proactive pacing keeps the relay's own request rate under the cap in the
+// first place, so backlog draining converges instead of oscillating forever.
+export function computeBatchPaceDelayMs(claimed, elapsedMs) {
+  if (claimed <= 0) return 0;
+  const targetMs =
+    (claimed / CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S) * 60_000;
+  return Math.max(0, targetMs - elapsedMs);
+}
 
 // How long a row stays in the outbox before cleanup deletes it. Delivered
 // rows are only retained for observability, while pending rows older than
@@ -550,6 +581,7 @@ async function main() {
     `[chain-firehose-relay] polling chain_firehose_outbox every ${CHAIN_FIREHOSE_POLL_INTERVAL_MS}ms, forwarding to ${config.ingestUrl}`,
   );
   while (!shuttingDown) {
+    const pollStartedAt = Date.now();
     const { claimed, rateLimitedForMs } = await pollOnce();
     touchHeartbeat(); // tracks poll-loop liveness, independent of claim/forward outcome -- see HEARTBEAT_FILE's own comment
     if (Date.now() - lastCleanupAt >= CHAIN_FIREHOSE_CLEANUP_INTERVAL_MS) {
@@ -557,12 +589,12 @@ async function main() {
       lastCleanupAt = Date.now();
     }
     if (rateLimitedForMs > 0) {
-      // The actual fix for the real 2026-07 incident: pause the WHOLE poll
-      // loop for the ingest endpoint's own stated recovery window instead of
-      // immediately claiming and firing another CHAIN_FIREHOSE_FORWARD_CONCURRENCY
-      // batch straight into the same rate limit. Reported once per pause
-      // (not per dropped row -- see reportRateLimitPause's own comment) so
-      // this is visible without becoming its own flood.
+      // Pause the WHOLE poll loop for the ingest endpoint's own stated
+      // recovery window instead of immediately claiming and firing another
+      // CHAIN_FIREHOSE_FORWARD_CONCURRENCY batch straight into the same rate
+      // limit. Reported once per pause (not per dropped row -- see
+      // reportRateLimitPause's own comment) so this is visible without
+      // becoming its own flood.
       console.error(
         `[chain-firehose-relay] rate limited by the ingest endpoint -- pausing ${rateLimitedForMs}ms before the next poll`,
       );
@@ -572,9 +604,19 @@ async function main() {
       await new Promise((resolve) =>
         setTimeout(resolve, CHAIN_FIREHOSE_POLL_INTERVAL_MS),
       );
+    } else {
+      // claimed > 0 and not rate limited: pace the next poll instead of
+      // looping immediately -- see computeBatchPaceDelayMs's own comment for
+      // why an unpaced immediate reloop reliably re-triggers the same 429
+      // this batch just avoided.
+      const paceDelayMs = computeBatchPaceDelayMs(
+        claimed,
+        Date.now() - pollStartedAt,
+      );
+      if (paceDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, paceDelayMs));
+      }
     }
-    // claimed > 0 and not rate limited: loop again immediately to drain a
-    // backlog faster than one CHAIN_FIREHOSE_POLL_INTERVAL_MS per batch would.
   }
   await sql.end({ timeout: 5 });
   process.exit(0);

--- a/tests/chain-firehose-relay.test.mjs
+++ b/tests/chain-firehose-relay.test.mjs
@@ -41,7 +41,10 @@ import {
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
   CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS,
   CHAIN_FIREHOSE_MAX_RATE_LIMIT_PAUSE_MS,
+  CHAIN_FIREHOSE_POLL_BATCH_SIZE,
+  CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S,
   computeBackoffDelayMs,
+  computeBatchPaceDelayMs,
   computeDropWindowUpdate,
   forwardBatch,
   forwardChainFirehoseNotification,
@@ -137,6 +140,68 @@ test("computeBackoffDelayMs: doubles per attempt, capped at maxMs", () => {
 test("computeBackoffDelayMs: honors custom baseMs/maxMs", () => {
   assert.equal(computeBackoffDelayMs(1, { baseMs: 100, maxMs: 1000 }), 200);
   assert.equal(computeBackoffDelayMs(10, { baseMs: 100, maxMs: 1000 }), 1000);
+});
+
+// --- computeBatchPaceDelayMs -------------------------------------------------
+
+test("computeBatchPaceDelayMs: a full batch that forwarded instantly gets the full target delay", () => {
+  // 200 rows at the safe rate takes (200/960)*60_000 = 12_500ms; if forwarding
+  // itself took ~0ms, the full 12_500ms must still be slept.
+  const delay = computeBatchPaceDelayMs(CHAIN_FIREHOSE_POLL_BATCH_SIZE, 0);
+  assert.equal(delay, 12_500);
+});
+
+test("computeBatchPaceDelayMs: subtracts wall-clock time the batch already spent forwarding", () => {
+  const delay = computeBatchPaceDelayMs(CHAIN_FIREHOSE_POLL_BATCH_SIZE, 5_000);
+  assert.equal(delay, 12_500 - 5_000);
+});
+
+test("computeBatchPaceDelayMs: never negative -- a batch that took longer than its target needs no extra pause", () => {
+  assert.equal(
+    computeBatchPaceDelayMs(CHAIN_FIREHOSE_POLL_BATCH_SIZE, 99_999),
+    0,
+  );
+});
+
+test("computeBatchPaceDelayMs: zero or negative claimed count needs no pause", () => {
+  assert.equal(computeBatchPaceDelayMs(0, 0), 0);
+  assert.equal(computeBatchPaceDelayMs(-1, 0), 0);
+});
+
+test("computeBatchPaceDelayMs: scales proportionally with a partial batch, not just full ones", () => {
+  // A partial batch of 50 rows only needs to pace to (50/960)*60_000 ≈ 3_125ms,
+  // not the full-batch target -- pacing scales with actual claimed rows so a
+  // relay that's nearly caught up isn't throttled as hard as one draining a
+  // real backlog.
+  const delay = computeBatchPaceDelayMs(50, 0);
+  assert.equal(delay, (50 / CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S) * 60_000);
+  assert.ok(delay < 12_500);
+});
+
+test("computeBatchPaceDelayMs: sustained full-batch pacing stays at/under the safe rate, not the raw 1200 limit", () => {
+  // Simulate draining a large backlog: every batch forwards CHAIN_FIREHOSE_POLL_BATCH_SIZE
+  // rows in negligible wall-clock time, so the loop is paced entirely by this
+  // function. Over N batches the total elapsed time must be at least
+  // N * batchSize / CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S seconds --
+  // i.e. the achieved rate never exceeds the safe target, which itself sits
+  // comfortably under the server's real 1200/60s cap (see this function's
+  // own header comment for why 100% of the raw limit is deliberately not
+  // the target).
+  const batches = 12;
+  let totalDelayMs = 0;
+  for (let i = 0; i < batches; i += 1) {
+    totalDelayMs += computeBatchPaceDelayMs(CHAIN_FIREHOSE_POLL_BATCH_SIZE, 0);
+  }
+  const achievedRatePer60s =
+    (batches * CHAIN_FIREHOSE_POLL_BATCH_SIZE * 60_000) / totalDelayMs;
+  assert.ok(
+    achievedRatePer60s <= CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S + 0.01,
+    `achieved rate ${achievedRatePer60s}/60s exceeded the safe target ${CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S}/60s`,
+  );
+  assert.ok(
+    achievedRatePer60s < 1200,
+    "achieved rate must stay under the raw server limit too",
+  );
 });
 
 // --- forwardChainFirehoseNotification ----------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #6451, which closed ~2 hours before this recurrence. Confirmed live on the indexer box: `chain_firehose_outbox` had 230k+ pending rows, and 100% of `chain-firehose-relay` log lines over a 20-minute window were `rate limited by the ingest endpoint` — zero successful deliveries.

## Root cause

#6451's fix (raise the server-side limit to 1200/60s, respect `retry-after`, pause the whole poll loop on a 429) fixed the *reactive* half of the problem but left the *proactive* half unaddressed. The poll loop's `claimed > 0 and not rate limited: loop again immediately` path has no pacing: a full `CHAIN_FIREHOSE_POLL_BATCH_SIZE` (200) batch at `CHAIN_FIREHOSE_FORWARD_CONCURRENCY` (16) forwards in roughly a couple of seconds — on the order of 8x the sustained rate 1200/60s allows.

So the moment there's a real backlog (more than one batch's worth), the very next batch after any non-rate-limited one re-triggers the same 429. The relay correctly pauses for `retry-after`, resumes, immediately re-bursts past the limit again, and repeats forever. This is a livelock reactive backoff alone can never recover from — every retry attempt is already over the limit before the first response even comes back.

## Fix

`computeBatchPaceDelayMs` (pure, unit-tested) paces batch *starts* to stay at/under 80% of the server's 1200/60s limit, scaling proportionally with however many rows were actually claimed — not a fixed per-poll sleep, and not reactive to a 429 that's already happened. A relay nearly caught up (a small partial batch) paces lightly; one draining a real backlog paces to the full target. Draining now converges instead of oscillating.

## What Changed

- `scripts/chain-firehose-relay.mjs`: added `CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S` (960, 80% of the server's 1200 cap for jitter headroom) and `computeBatchPaceDelayMs`; wired into `main()`'s poll loop in place of the unconditional immediate-reloop.
- `tests/chain-firehose-relay.test.mjs`: 6 new tests covering the full-batch target delay, subtracting already-elapsed forward time, the non-negative floor, zero/negative claimed counts, proportional partial-batch scaling, and a sustained-pacing simulation asserting the achieved rate never exceeds the safe target (or the raw server limit).

## Deploy note

This script is deployed by cloning the repo fresh at container start (`deploy/chain-firehose-relay.Dockerfile`, see its own header comment) rather than being baked into an image at build time, so a restart of the `chain-firehose-relay` container on the indexer box picks this fix up directly — no separate deploy step needed once this merges. I'll restart it after merge and confirm the backlog actually starts draining.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (None — this file has no API/schema surface.)

## Validation

- [x] `npm run lint` / `npm run format:check`
- [x] `npx vitest run tests/chain-firehose-relay.test.mjs` (56 tests, 6 new)
- [x] `npm run test:ci` (full suite, green)
- [x] `npm run build` (clean, deploy-owned artifacts correctly auto-reverted)
- [x] `npm run pipeline:check` (running the full local-CI-equivalent, not a hand-picked subset)
- [x] `git diff --check`

Closes #6451