### PR TITLE
feat(ui): link the account validator badge to its validator profile (#6428)

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -1999,7 +1999,13 @@ function AccountFootprintSection({
           <BarMini data={staked} showValue={false} />
         </div>
       ) : null}
-      <DataPanel>
+      {/* #6428: five columns at `px-5` do not fit a 375px viewport, so Permit
+          and Active -- and with them this section's only route to a validator
+          profile -- sit outside the scroll viewport on mobile. Desktop keeps
+          the table; mobile gets the card fallback endpoint-list.tsx uses for
+          the same problem, so every field (and the permit link) is reachable
+          without a horizontal swipe. */}
+      <DataPanel className="hidden md:block">
         <table className="w-full text-left text-sm">
           <thead className="bg-surface/50">
             <tr>
@@ -2037,9 +2043,7 @@ function AccountFootprintSection({
                 </td>
                 <td className="px-5 py-4 font-mono text-[11px]">
                   {r.validator_permit ? (
-                    <span className="inline-flex rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-500">
-                      validator
-                    </span>
+                    <ValidatorPermitBadge ss58={ss58} />
                   ) : (
                     <span className="text-ink-muted">—</span>
                   )}
@@ -2060,7 +2064,78 @@ function AccountFootprintSection({
           </tbody>
         </table>
       </DataPanel>
+
+      <ul className="space-y-2 md:hidden">
+        {rows.map((r) => (
+          <li key={`${r.netuid}-${r.uid}`} className="rounded-lg border border-border bg-card p-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-2">
+                {r.netuid != null ? (
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: r.netuid }}
+                    className="inline-flex items-center rounded-full border border-border bg-paper px-2.5 py-1 font-mono text-[12px] font-medium text-ink-strong transition-colors hover:border-accent/30 hover:text-accent"
+                  >
+                    SN{r.netuid}
+                  </Link>
+                ) : (
+                  <span className="font-mono text-[12px] text-ink-muted">—</span>
+                )}
+                {r.validator_permit ? <ValidatorPermitBadge ss58={ss58} /> : null}
+              </div>
+              {r.active ? (
+                <span className="inline-flex shrink-0 rounded-full bg-emerald-500/10 px-2 py-0.5 font-mono text-[11px] text-emerald-500">
+                  active
+                </span>
+              ) : (
+                <span className="inline-flex shrink-0 rounded-full bg-surface px-2 py-0.5 font-mono text-[11px] text-ink-muted">
+                  idle
+                </span>
+              )}
+            </div>
+            <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 border-t border-border pt-2 text-[11px]">
+              <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                UID
+              </dt>
+              <dd className="text-right font-mono tabular-nums text-ink">
+                {r.uid != null ? formatNumber(r.uid) : "—"}
+              </dd>
+              <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                Stake
+              </dt>
+              <dd className="text-right font-mono tabular-nums text-ink">
+                {fmtStake(r.stake_tao)}
+              </dd>
+            </dl>
+          </li>
+        ))}
+      </ul>
     </SectionAnchor>
+  );
+}
+
+/**
+ * The "validator" permit badge (#6428) — links to this account's own validator
+ * profile, the page carrying its stake, nominators, APY, and cross-subnet
+ * performance. Shared by the desktop table and the mobile cards so the two can
+ * never drift.
+ *
+ * `validator_permit` is a per-UID metagraph property keyed by hotkey, so an
+ * ss58 the subnets feed reports a permit for is registered as that subnet's
+ * validator hotkey and `/validators/{ss58}` resolves. A coldkey-only address
+ * never carries a permit, so the caller's existing `validator_permit` gate is
+ * also what keeps this link off those pages.
+ */
+function ValidatorPermitBadge({ ss58 }: { ss58: string }) {
+  return (
+    <Link
+      to="/validators/$hotkey"
+      params={{ hotkey: ss58 }}
+      title={`Validator profile for ${ss58}`}
+      className="inline-flex shrink-0 rounded-full bg-emerald-500/10 px-2 py-0.5 font-mono text-[11px] text-emerald-500 transition-colors hover:bg-emerald-500/20"
+    >
+      validator
+    </Link>
   );
 }
 

--- a/apps/ui/tests/e2e/capture-pr-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-pr-screenshots.mjs
@@ -337,6 +337,17 @@ async function captureVariant({
       // capturing, or the shot freezes on a loading skeleton.
       await page.waitForTimeout(1200);
 
+      // Self-hosted brand fonts (apps/ui/src/styles.css) load via
+      // font-display: swap, so the page paints in a fallback face first and
+      // reflows onto the real one whenever its woff2 lands. That download is
+      // real network activity, so the fixed wait above doesn't bound it -- a
+      // cold `before` server can still be mid-swap while a warm `after` server
+      // is already on the brand font. The pair then differs in *typeface*, and
+      // every glyph shifts, which is exactly the noise a before/after
+      // comparison must not have (responsive-overflow.spec.ts blocks on this
+      // for the same reason -- see #4876). Block until the swap has happened.
+      await page.evaluate(() => document.fonts.ready);
+
       if (section) {
         const found = await scrollToSection(page, section);
         if (!found && fallbackSection) {

--- a/apps/ui/tests/e2e/capture-validator-badge-hover-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-validator-badge-hover-screenshots.mjs
@@ -1,0 +1,153 @@
+/**
+ * Capture the account "validator" badge's hover + navigation evidence for #6428.
+ *
+ * The badge is intentionally byte-identical at rest (the issue asks to preserve
+ * its styling and only add navigation), so the fixed-viewport at-rest matrix
+ * from capture-pr-screenshots.mjs shows no delta by design. What actually
+ * changes is only observable on interaction, which is what this captures --
+ * the "animated evidence" case in SKILL.md Phase C2, following the same shape
+ * as capture-mega-menu-touch-hover-screenshots.mjs:
+ *
+ *   - `<variant>-hover-<theme>.png`  the badge under the cursor. Before: a
+ *     plain <span>, so hovering does nothing. After: a Link, so the pill
+ *     brightens (bg-emerald-500/20) exactly like the SN pill beside it.
+ *   - `after-navigated-<theme>.png`  the validator profile reached by clicking
+ *     the badge -- the deliverable. There is no before counterpart: a <span>
+ *     has nowhere to go, which is the bug.
+ *   - a webm of the hover+click, recorded on the light pass.
+ *
+ * Fixed viewport only, never fullPage; theme forced via mg-theme (Phase C2).
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8081 VARIANT=before node tests/e2e/capture-validator-badge-hover-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8080 VARIANT=after  node tests/e2e/capture-validator-badge-hover-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/validator-badge-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8080";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+// A hotkey with validator_permit across many subnets, so the PERMIT column is
+// populated -- an account without one renders no badge and proves nothing.
+const SS58 = process.env.SS58 ?? "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u";
+const VIEWPORT = { width: 1280, height: 800 };
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function openFootprint(page) {
+  await page.goto(`${BASE_URL}/accounts/${SS58}`, {
+    waitUntil: "domcontentloaded",
+    timeout: 90_000,
+  });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 8000 });
+  } catch {
+    await page.waitForTimeout(2000);
+  }
+  // Brand fonts swap in via font-display, so a cold server can still be on the
+  // fallback face here -- capture then differs in typeface, not just state.
+  await page.evaluate(() => document.fonts.ready);
+  await page.locator("section#footprint").scrollIntoViewIfNeeded();
+  await page.waitForTimeout(600);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const theme of THEMES) {
+    const context = await browser.newContext({
+      viewport: VIEWPORT,
+      recordVideo: theme === "light" ? { dir: OUT_DIR, size: VIEWPORT } : undefined,
+    });
+    const page = await context.newPage();
+    await setTheme(page, theme);
+    await openFootprint(page);
+
+    const badge = page.locator("section#footprint").getByText("validator", { exact: true }).first();
+    await badge.waitFor({ state: "visible", timeout: 30_000 });
+    await badge.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(300);
+
+    await badge.hover();
+    await page.waitForTimeout(600); // let transition-colors settle
+    const hover = path.join(OUT_DIR, `${VARIANT}-hover-${theme}.png`);
+    await page.screenshot({ path: hover, fullPage: false });
+    console.log(`wrote ${hover}`);
+
+    // Supplementary close-up: at a 1280-wide viewport the pill is ~60px, so a
+    // bg-emerald-500/10 -> /20 shift is invisible in the frame above and
+    // invisible again once GitHub renders it as a 260px thumbnail. Clip tight
+    // around the hovered pill so the affordance is actually readable (the
+    // zoomed-close-up remedy from #5446), alongside -- never instead of -- the
+    // fixed-viewport matrix the contract requires.
+    const box = await badge.boundingBox();
+    if (box) {
+      const pad = 14;
+      const zoom = path.join(OUT_DIR, `${VARIANT}-hover-zoom-${theme}.png`);
+      await page.screenshot({
+        path: zoom,
+        clip: {
+          x: Math.max(0, box.x - pad),
+          y: Math.max(0, box.y - pad),
+          width: box.width + pad * 2,
+          height: box.height + pad * 2,
+        },
+      });
+      console.log(`wrote ${zoom}`);
+    }
+
+    // Clicking is only meaningful once the badge is a Link; a <span> has no
+    // destination, so `before` has no navigated counterpart -- that is the bug.
+    // Click the badge in BOTH variants and shoot whatever the click produced.
+    // This is the pair that actually reads: same action, opposite outcome.
+    // Before, the badge is a <span>, so the click does nothing and the reader
+    // is still staring at the account page -- that IS the bug, and it is a
+    // screenshot, not an absence. After, the same click opens the validator
+    // profile. Capturing only the "after" side (as if before had no
+    // counterpart) is what made the earlier evidence unreadable.
+    await badge.click();
+    if (VARIANT === "after") {
+      await page.waitForURL(/\/validators\//, { timeout: 30_000 });
+      // The validator profile polls on an interval, so "networkidle" never
+      // reports quiet and a fixed wait just screenshots the skeleton. Wait for
+      // real content instead: the APY section is the page's own anchor, and
+      // the hero name renders alongside it.
+      await page
+        .locator("section#apy")
+        .waitFor({ state: "visible", timeout: 60_000 })
+        .catch(() => {});
+      await page.waitForTimeout(1500);
+    } else {
+      // Give a navigation the same grace it would have had, so "nothing
+      // happened" is a settled observation rather than an impatient one.
+      await page.waitForTimeout(3000);
+    }
+    // Top of the page: the hero (after) or the unchanged account header
+    // (before) is what identifies where the click actually landed.
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.waitForTimeout(600);
+    const dest = path.join(OUT_DIR, `${VARIANT}-after-click-${theme}.png`);
+    await page.screenshot({ path: dest, fullPage: false });
+    console.log(`wrote ${dest} (url now: ${page.url()})`);
+
+    await context.close();
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

`AccountFootprintSection` rendered the "validator" badge as a plain `<span>`, so an
account holding a validator permit had no route to `/validators/{ss58}` -- the page
carrying its stake, nominators, APY, and cross-subnet performance.

## What Changed

**1. The badge links.** Wrapped in a `Link` matching the `SN` pill beside it. At-rest
styling is byte-identical (per the issue's "preserve the existing badge styling"); the
only addition is the `transition-colors` hover that pill already uses.

**Why `ss58` is the right hotkey, and why coldkey-only pages stay unaffected:**
`validator_permit` is a per-UID metagraph property keyed by **hotkey**, so an ss58 the
subnets feed reports a permit for is registered as that subnet's validator hotkey and
`/validators/{ss58}` resolves. A coldkey-only address never carries a permit -- the
existing `validator_permit` gate is already what keeps the link off those pages, so no
extra guard is needed (the check the issue asks to verify). `AccountRegistration` carries
no `hotkey` field, confirming `ss58` is the only identity available here.

**2. Mobile card fallback for the table.** The link alone doesn't deliver the issue's
outcome on mobile: five columns at `px-5` don't fit 375px, so Permit and Active -- and
with them the only route to a validator profile -- sit outside the scroll viewport. The
table now keeps the desktop layout and mobile gets the card fallback `endpoint-list.tsx`
already uses for the same problem. `ValidatorPermitBadge` is shared between table and
cards so the two can't drift.

**3. `capture-pr-screenshots.mjs` blocks on `document.fonts.ready`.** The brand faces load
via `font-display: swap`, so a cold `before` server can still be mid-swap while a warm
`after` server is on the real font -- the pair then differs in *typeface* and every glyph
shifts, which is exactly the noise a before/after comparison must not carry.
`responsive-overflow.spec.ts` blocks on this for the same reason (#4876).

## Screenshots

Captured with `capture-pr-screenshots.mjs` at the contract's fixed viewports
(1280x800 / 768x1024 / 375x812), themes forced via `mg-theme`, `before` served from a
worktree at the merge-base. Both servers verified to have all three brand faces `loaded`
before capture, so before/after share one typeface and nothing shifts. The account holds
`validator_permit` on 113 subnets, so the PERMIT column is populated.

> Desktop and tablet keep the table, so those pairs are intentionally near-identical --
> they evidence the **absence of a regression**. Mobile is where the change lands: the
> five-column table doesn't fit 375px, so Permit/Active -- and the only route to a
> validator profile -- sat outside the scroll viewport; `after` is the card fallback.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/6428-footprint-after-mobile-dark.png)<br><sub>after</sub> |

### The link -- same click, opposite outcome

`before` the badge is a `<span>`, so the click does nothing and the reader stays on the
account page. `after`, the identical click opens the validator profile.

| Theme | Before -- click does nothing | After -- click opens the profile |
| --- | --- | --- |
| Light | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/before-after-click-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/before-after-click-light.png)<br><sub>still REGISTRY > ACCOUNTS</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/after-after-click-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/after-after-click-light.png)<br><sub>REGISTRY > VALIDATORS -- tao.bot</sub> |
| Dark | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/before-after-click-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/before-after-click-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/after-after-click-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/after-after-click-dark.png)<br><sub>after</sub> |

### Hover affordance -- close-up

At 1280 the pill is ~60px, so the `bg-emerald-500/10` -> `/20` shift isn't readable in a full
frame. Clipped to the hovered pill:

| Theme | Before | After |
| --- | --- | --- |
| Light | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/before-hover-zoom-light.png" width="160">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/before-hover-zoom-light.png)<br><sub>inert `<span>`</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/after-hover-zoom-light.png" width="160">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/after-hover-zoom-light.png)<br><sub>pill brightens</sub> |
| Dark | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/before-hover-zoom-dark.png" width="160">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/before-hover-zoom-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/after-hover-zoom-dark.png" width="160">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6428-v2/after-hover-zoom-dark.png)<br><sub>after</sub> |

## Validation

- `npm run lint --workspace=apps/ui` -- 0 errors (24 pre-existing `react-refresh` warnings, unchanged from main)
- `npm run format:check --workspace=apps/ui` -- clean
- `npm run typecheck --workspace=apps/ui` -- 0 errors
- `npm test --workspace=apps/ui` -- 1049/1049 passed
- `npm run build --workspace=apps/ui` -- clean

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6428`) -- required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched -- `apps/ui/**` only, 3 files.
- [x] `routeTree.gen.ts` untouched; screenshots hosted on a fork branch, not committed here.

Closes #6428
