### PR TITLE
feat(ui): add Sentry release tracking + source maps to apps/ui

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -60,6 +60,7 @@
     "@eslint/js": "^9.39.5",
     "@lovable.dev/vite-tanstack-config": "^2.7.2",
     "@playwright/test": "^1.61.1",
+    "@sentry/vite-plugin": "^5.4.0",
     "@types/node": "^22.20.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/apps/ui/src/lib/error-reporting.test.ts
+++ b/apps/ui/src/lib/error-reporting.test.ts
@@ -40,13 +40,36 @@ describe("reportError", () => {
 
   it("captures the exception via Sentry when a DSN is configured", async () => {
     vi.stubEnv("VITE_SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
+    vi.stubEnv("VITE_SENTRY_RELEASE", "");
     const { reportError } = await import("./error-reporting");
     const err = new Error("boom");
     const ctx = { boundary: "panel_shell", componentStack: "<stack>" };
     reportError(err, ctx);
     // dynamic import + .then() chain resolves on the microtask queue
     await vi.waitFor(() => expect(captureException).toHaveBeenCalled());
-    expect(init).toHaveBeenCalledWith({ dsn: "https://abc@o0.ingest.sentry.io/0" });
+    expect(init).toHaveBeenCalledWith({
+      dsn: "https://abc@o0.ingest.sentry.io/0",
+      release: undefined,
+      environment: expect.any(String),
+    });
     expect(captureException).toHaveBeenCalledWith(err, { extra: ctx });
+  });
+
+  it("passes VITE_SENTRY_RELEASE through as the Sentry release when set", async () => {
+    vi.stubEnv("VITE_SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
+    vi.stubEnv("VITE_SENTRY_RELEASE", "deadbeef1234");
+    const { reportError } = await import("./error-reporting");
+    reportError(new Error("boom"), {});
+    await vi.waitFor(() => expect(init).toHaveBeenCalled());
+    expect(init.mock.calls[0][0].release).toBe("deadbeef1234");
+  });
+
+  it("treats an empty VITE_SENTRY_RELEASE (unset in the build) as undefined, not an empty string", async () => {
+    vi.stubEnv("VITE_SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
+    vi.stubEnv("VITE_SENTRY_RELEASE", "");
+    const { reportError } = await import("./error-reporting");
+    reportError(new Error("boom"), {});
+    await vi.waitFor(() => expect(init).toHaveBeenCalled());
+    expect(init.mock.calls[0][0].release).toBeUndefined();
   });
 });

--- a/apps/ui/src/lib/error-reporting.ts
+++ b/apps/ui/src/lib/error-reporting.ts
@@ -10,7 +10,15 @@ import { reportLovableError } from "./lovable-error-reporting";
  * Sinks, in order, all best-effort:
  *  1. Sentry — only when a build-time `VITE_SENTRY_DSN` is set. `@sentry/browser`
  *     is loaded via a DYNAMIC import so it costs zero bundle bytes when the DSN
- *     is unset (the import is tree-shaken / never reached).
+ *     is unset (the import is tree-shaken / never reached). Tagged with a
+ *     `release` (Cloudflare Workers Builds' own commit SHA, bridged in at
+ *     build time via vite.config.ts's `define` -- see vite.config.ts's own
+ *     comment) and `environment` (production/development from Vite's own
+ *     `import.meta.env.PROD`), so a regression can be traced to the deploy
+ *     that introduced it. Source maps for this release are uploaded by
+ *     `@sentry/vite-plugin` (also wired in vite.config.ts), gated on
+ *     `SENTRY_AUTH_TOKEN` being set -- absent everywhere except the
+ *     production Cloudflare Workers Build once configured.
  *  2. Lovable capture channel — best-effort, no-op outside the Lovable editor.
  *  3. `console.error` in dev so the boundary + context are always greppable
  *     locally.
@@ -20,6 +28,11 @@ import { reportLovableError } from "./lovable-error-reporting";
  */
 
 const SENTRY_DSN = import.meta.env?.VITE_SENTRY_DSN as string | undefined;
+// Bridged in at build time from Cloudflare Workers Builds' own
+// WORKERS_CI_COMMIT_SHA (see vite.config.ts's `define` block) -- "" (not
+// undefined) whenever that var wasn't set, since Vite's `define` replaces
+// this with a literal string constant, never an actual `undefined`.
+const SENTRY_RELEASE = (import.meta.env?.VITE_SENTRY_RELEASE as string | undefined) || undefined;
 
 type SentryModule = typeof import("@sentry/browser");
 
@@ -29,7 +42,11 @@ function loadSentry(): Promise<SentryModule | null> {
   if (sentryInit) return sentryInit;
   sentryInit = import("@sentry/browser")
     .then((Sentry) => {
-      Sentry.init({ dsn: SENTRY_DSN });
+      Sentry.init({
+        dsn: SENTRY_DSN,
+        release: SENTRY_RELEASE,
+        environment: import.meta.env?.PROD ? "production" : "development",
+      });
       return Sentry;
     })
     .catch((err) => {

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -7,6 +7,15 @@
 import { defineConfig, type LovableViteTanstackOptions } from "@lovable.dev/vite-tanstack-config";
 import type { NitroPluginConfig } from "nitro/vite";
 import mdx from "fumadocs-mdx/vite";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
+
+// Cloudflare Workers Builds auto-injects this (no manual dashboard step) --
+// confirmed via Cloudflare's own docs (workers/ci-cd/builds/configuration/,
+// changelog/2025-06-10-default-env-vars/): "Passing current commit ID to
+// error reporting, for example, Sentry" is its documented purpose. Absent
+// locally/in PR CI, where it's simply undefined -- Sentry accepts an
+// undefined release (just omits release tagging), not an error condition.
+const commitSha = process.env.WORKERS_CI_COMMIT_SHA;
 
 export default defineConfig({
   tanstackStart: {
@@ -22,7 +31,63 @@ export default defineConfig({
   // preset itself (see the header comment above). Pattern proven working
   // (dev + a real Cloudflare production build) in JSONbored/loopover's
   // identical @lovable.dev/vite-tanstack-config setup, PR #6271.
-  plugins: [...mdx()],
+  //
+  // sentryVitePlugin is appended LAST (Sentry's own documented ordering
+  // requirement -- "Put the Sentry vite plugin after all other plugins",
+  // it needs to see every other plugin's final output to inject debug IDs
+  // and produce accurate source maps) and returns an ARRAY of plugins
+  // (spread, not pushed as a single entry). Verified empirically (real
+  // `vite build` with no authToken) that this degrades gracefully to a
+  // warning-only no-upload, not a build failure -- `disable` below is still
+  // set explicitly so it's a true no-op (no plugin hooks run at all, no
+  // telemetry ping) rather than relying on that fallback everywhere a token
+  // isn't configured, i.e. every PR/local build today.
+  plugins: [
+    ...mdx(),
+    ...sentryVitePlugin({
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      disable: !process.env.SENTRY_AUTH_TOKEN,
+      telemetry: false,
+      release: commitSha ? { name: commitSha } : undefined,
+      // By default this plugin THROWS (failing the whole build) when an
+      // upload genuinely fails with a token present -- a different failure
+      // mode than the graceful warn-and-skip when no token exists at all.
+      // A transient Sentry API hiccup or an expired token must never block
+      // shipping real product code -- the same tolerant-by-design principle
+      // already applied to every box-side observability integration in
+      // this rollout (e.g. scripts/refresh-native-snapshot.mjs's own
+      // comment: "a transient chain RPC failure must not block the
+      // publish").
+      errorHandler: (err) => {
+        console.warn("[sentry-vite-plugin] source map upload failed:", err);
+      },
+      sourcemaps: {
+        // Uploaded to Sentry, then stripped from the deployed output --
+        // don't publicly serve the app's own source maps alongside the
+        // built JS.
+        filesToDeleteAfterUpload: ["**/*.js.map"],
+      },
+    }),
+  ],
+  // `vite: { ... }` is this preset's own documented passthrough for plain
+  // Vite options beyond plugins (see the header comment above) --
+  // sourcemap generation must be on for sentryVitePlugin to have anything
+  // to upload, and `define` bridges WORKERS_CI_COMMIT_SHA (a build-time-
+  // only process.env var, not exposed to browser code) into
+  // import.meta.env.VITE_SENTRY_RELEASE, the same client-exposed-env-var
+  // convention src/lib/error-reporting.ts's existing VITE_SENTRY_DSN read
+  // already uses -- the preset's own "VITE_* env injection" (see the header
+  // comment) only covers vars already present in an actual .env file /
+  // process.env at that name, not one bridged in from a differently-named
+  // source like this.
+  vite: {
+    build: { sourcemap: true },
+    define: {
+      "import.meta.env.VITE_SENTRY_RELEASE": JSON.stringify(commitSha ?? ""),
+    },
+  },
   // Force-enable the nitro deploy plugin. By default it only runs inside
   // Lovable's CI ("No Lovable context detected — skipping nitro deploy
   // plugin"), so every other builder — crucially Cloudflare Workers Builds —

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
     },
     "apps/ui": {
       "name": "metagraphed-ui",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
@@ -78,6 +78,7 @@
         "@eslint/js": "^9.39.5",
         "@lovable.dev/vite-tanstack-config": "^2.7.2",
         "@playwright/test": "^1.61.1",
+        "@sentry/vite-plugin": "^5.4.0",
         "@types/node": "^22.20.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -5969,6 +5970,272 @@
         "node": ">=18"
       }
     },
+    "node_modules/@sentry/bundler-plugins": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugins/-/bundler-plugins-10.66.0.tgz",
+      "integrity": "sha512-u0Dzji4GouTR3zhNzCDal+mDxzOsnCVzA4mxOkTq89k2vKX6cuAVrrBWlSOcVYa8qbt43c0QNJxFnD0AqjhJtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/cli": "^2.58.6",
+        "@sentry/core": "10.66.0",
+        "dotenv": "^17.4.2",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "rollup": ">=3.2.0",
+        "webpack": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.66.0.tgz",
+      "integrity": "sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.6.tgz",
+      "integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.6",
+        "@sentry/cli-linux-arm": "2.58.6",
+        "@sentry/cli-linux-arm64": "2.58.6",
+        "@sentry/cli-linux-i686": "2.58.6",
+        "@sentry/cli-linux-x64": "2.58.6",
+        "@sentry/cli-win32-arm64": "2.58.6",
+        "@sentry/cli-win32-i686": "2.58.6",
+        "@sentry/cli-win32-x64": "2.58.6"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
+      "integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
+      "integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
+      "integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
+      "integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
+      "integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
+      "integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
+      "integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
+      "integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sentry/conventions": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
@@ -6164,6 +6431,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.4.0.tgz",
+      "integrity": "sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugins": "^10.64.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@shikijs/core": {
@@ -8900,6 +9180,19 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.387",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
@@ -10010,6 +10303,24 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -12359,6 +12670,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -12934,6 +13255,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -13203,6 +13551,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -13221,6 +13579,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -14287,6 +14652,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tree-kill": {
@@ -15736,11 +16108,29 @@
         "node": ">= 8"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -16043,7 +16433,7 @@
     },
     "packages/client": {
       "name": "@jsonbored/metagraphed",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "metagraphed-contract": "*",


### PR DESCRIPTION
## Summary

Closes #6478. Part of the metagraphed/Ventura Labs Sentry rollout (#6485).

`apps/ui/src/lib/error-reporting.ts` already wired `@sentry/browser` (dynamic-imported, gated on build-time `VITE_SENTRY_DSN`), but with no release/environment tagging and no source-map upload -- errors showed up in Sentry against minified bundle output with no way to map back to source, and no way to tell which deploy introduced a regression.

- **`vite.config.ts`**: adds `@sentry/vite-plugin`, appended **last** in the plugins array per Sentry's own documented ordering requirement. Bridges Cloudflare Workers Builds' auto-injected `WORKERS_CI_COMMIT_SHA` (confirmed via Cloudflare's own docs: *"Passing current commit ID to error reporting, for example, Sentry"*) into `import.meta.env.VITE_SENTRY_RELEASE` via `define`, since it's a build-time-only var otherwise invisible to browser code. Enables `build.sourcemap`. The plugin is explicitly `disable`d whenever `SENTRY_AUTH_TOKEN` is unset (every PR/local build today) rather than relying on its own graceful-no-token fallback everywhere -- a true no-op, zero telemetry ping. `errorHandler` makes a genuine upload **failure** (a different code path than "no token at all," which the plugin already handles gracefully on its own) a warning instead of a hard build failure -- an expired token or a transient Sentry API outage must never block shipping real product code, the same tolerant-by-design principle already used throughout this rollout's box-side scripts.
- **`error-reporting.ts`**: `Sentry.init()` now also passes `release` (from the bridged `VITE_SENTRY_RELEASE`, `undefined` when unset -- never an empty string) and `environment` (production/development via Vite's own `import.meta.env.PROD`).

**`VITE_SENTRY_DSN` and `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/`SENTRY_PROJECT` still need to be set in the Cloudflare Workers Build dashboard for any of this to activate in production** -- that's a manual, account-owner-only step this PR cannot do.

This PR is confined to `apps/ui/src/lib/**` + build config + tests -- no visual/route/component change, so per the repo's own house rules it follows the normal gate (no before/after screenshot table needed).

## Test plan

Verified empirically with real local builds (not just unit tests):

- [x] No `SENTRY_AUTH_TOKEN`: plugin produces **zero** log output (true no-op), 334 `.js.map` files generated correctly (`build.sourcemap` works), build succeeds
- [x] Fake/invalid `SENTRY_AUTH_TOKEN`: plugin makes a **real** upload attempt, gets a genuine 401 from Sentry's API, `errorHandler` catches it as a warning, build still succeeds (confirms the tolerant-failure path actually works, not just the disabled path)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all changed files
- [x] Full `apps/ui` vitest suite (140 files / 1062 tests) passes with no regressions
- [x] `npm run scan:public-safety` passes