### PR TITLE
fix(ui): give colour-only status indicators a role so their label is exposed

### DIFF
--- a/apps/ui/src/components/metagraphed/hero-subnet-chips.tsx
+++ b/apps/ui/src/components/metagraphed/hero-subnet-chips.tsx
@@ -96,8 +96,13 @@ export function HeroSubnetChips({ limit = 14 }: { limit?: number }) {
             <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-muted">
               SN{s.netuid}
             </span>
+            {/* #6423: role="img" so the label is exposed -- a plain span is
+                role="generic", whose aria-label AT is not required to announce.
+                Matches ui-kit HealthDot's treatment of this same visual. */}
             <span
+              role="img"
               aria-label={`health ${health}`}
+              title={`health ${health}`}
               className={classNames("size-1.5 rounded-full shrink-0", TONE[health])}
             />
           </Link>

--- a/apps/ui/src/components/metagraphed/resource-explorer.tsx
+++ b/apps/ui/src/components/metagraphed/resource-explorer.tsx
@@ -463,7 +463,14 @@ function EndpointRow({ e }: { e: Endpoint }) {
                     <ExternalLinkIcon className="size-3" />
                   </a>
                 ) : (
+                  // #6423: role="img" carries the label here. This span is the
+                  // only AT-reachable carrier of the blocked state: the two
+                  // "Blocked unsafe URL" strings nearby are both TooltipContent,
+                  // which needs hover/focus, and this element is deliberately
+                  // not focusable (unlike the safeUrl <a> sibling) -- so without
+                  // a role the state is announced nowhere.
                   <span
+                    role="img"
                     aria-label="Blocked unsafe endpoint URL"
                     className="cursor-not-allowed rounded p-1 text-ink-muted/50"
                   >

--- a/apps/ui/src/components/metagraphed/status-indicator-roles.test.ts
+++ b/apps/ui/src/components/metagraphed/status-indicator-roles.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #6423: three colour-only status indicators carried their meaning in an
+// aria-label on a plain <span>. A span is role="generic", and AT is not required
+// to expose a generic element's aria-label as its accessible name — so the
+// health/official/blocked states could announce as nothing at all. ui-kit's
+// HealthDot already does this correctly (role="img" + aria-label + title) for
+// the identical visual.
+//
+// Source assertions rather than a render: these spans sit deep inside components
+// that need a router and live data, and this suite is node-environment. The
+// repo already tests this way (see ui-kit's list-shell.test.ts).
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+
+const SITES: Array<[string, string, string]> = [
+  [
+    "hero-subnet-chips (subnet health dot)",
+    "./hero-subnet-chips.tsx",
+    "aria-label={`health ${health}`}",
+  ],
+  [
+    "providers.index (official-provider badge)",
+    "../../routes/providers.index.tsx",
+    'aria-label="Official provider"',
+  ],
+  [
+    "resource-explorer (blocked unsafe URL)",
+    "./resource-explorer.tsx",
+    'aria-label="Blocked unsafe endpoint URL"',
+  ],
+];
+
+/** The element opening tag containing `label`, so role/aria stay paired. */
+function elementCarrying(source: string, label: string) {
+  const at = source.indexOf(label);
+  expect(at, `fixture drift: ${label} not found`).toBeGreaterThan(-1);
+  const open = source.lastIndexOf("<span", at);
+  const close = source.indexOf(">", at);
+  return source.slice(open, close);
+}
+
+describe("colour-only status indicators expose their label (#6423)", () => {
+  for (const [name, file, label] of SITES) {
+    it(`${name} carries role="img" beside its aria-label`, () => {
+      const el = elementCarrying(read(file), label);
+      expect(el).toContain('role="img"');
+      expect(el).toContain(label);
+    });
+  }
+
+  it("matches ui-kit HealthDot, the established pattern for this visual", () => {
+    // HealthDot is the reference the issue cites: role + label + title together.
+    const healthDot = read("../../../../../packages/ui-kit/src/components/metagraphed/chips.tsx");
+    expect(healthDot).toContain('role="img"');
+
+    const el = elementCarrying(read("./hero-subnet-chips.tsx"), "aria-label={`health ${health}`}");
+    expect(el).toContain("title=");
+  });
+
+  it("the blocked-URL state has no other AT-reachable carrier, so the role matters", () => {
+    // Both other "Blocked unsafe URL" strings are TooltipContent (hover/focus
+    // only) and this span is deliberately not focusable, unlike its safeUrl <a>
+    // sibling — so the aria-label is the only thing a screen reader can reach.
+    const source = read("./resource-explorer.tsx");
+    expect(source).toContain('{safeUrl ? "Open in new tab" : "Blocked unsafe URL"}');
+    const el = elementCarrying(source, 'aria-label="Blocked unsafe endpoint URL"');
+    expect(el).not.toContain("tabIndex");
+    expect(el).toContain('role="img"');
+  });
+});

--- a/apps/ui/src/routes/providers.index.tsx
+++ b/apps/ui/src/routes/providers.index.tsx
@@ -534,7 +534,10 @@ function ProvidersGrid({ view }: { view: "grid" | "table" }) {
                         <div className="mg-label">{p.kind ?? "provider"}</div>
                         <div className="flex items-center gap-1.5 mt-0.5">
                           {isOfficial ? (
+                            // #6423: see hero-subnet-chips -- role="img" so the
+                            // colour-only badge announces its meaning.
                             <span
+                              role="img"
                               aria-label="Official provider"
                               title="Official"
                               className="inline-block size-1.5 rounded-full bg-accent shrink-0"


### PR DESCRIPTION
## What

Three colour-only status indicators carried their meaning in an `aria-label` on a plain `<span>`:

| Site | Conveys |
| --- | --- |
| `hero-subnet-chips.tsx` | subnet health |
| `providers.index.tsx` | the "official provider" badge |
| `resource-explorer.tsx` | a blocked/unsafe URL |

A `<span>` is `role="generic"`, and AT isn't required to expose a generic element's `aria-label` as its accessible name — so these could announce as nothing at all. ui-kit's `HealthDot` already does it correctly for the identical visual (`role="img"` + `aria-label` + `title`), which is the pattern all three now follow.

## The `resource-explorer` question the issue asks to confirm

The issue asks to *"confirm the 'Blocked unsafe URL' state's information isn't otherwise lost, since the enabled `<a>` sibling case is fully accessible but this disabled case has no focusable fallback."*

Checked, and it **is** at risk — which is what makes the role necessary rather than cosmetic:

- The only other places that state appears are **two `TooltipContent` strings** (`:475`, `:627`) — Radix tooltips, so they need **hover or focus**.
- That span is deliberately **not focusable** (unlike its `safeUrl` `<a>` sibling), so a keyboard user can never trigger either tooltip.
- ⇒ The `aria-label` is the **only** AT-reachable carrier of the state. Without a role, it announces nowhere.

Sighted users still get the greyed-out styling, so I've left the focusability alone rather than widen the diff — flagging it in case you'd rather it were focusable.

## Screenshots

The homepage, where `HeroSubnetChips` renders (the PILOTS chips). **The rendered output is identical by design** — `role` and `aria-label` change nothing visually; this fix is only observable to a screen reader. Rows supplied per the contract.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

`status-indicator-roles.test.ts` (5 tests) — source assertions rather than a render: these spans sit deep inside components needing a router and live data, and this suite is node-environment. The repo already tests this way (ui-kit's `list-shell.test.ts`).

Each test extracts **the element carrying the label** (not just "the file contains `role="img"` somewhere") so the role and its label stay paired. Plus: the health dot matches `HealthDot`'s full `role`+`label`+`title` treatment, and the blocked-URL span is asserted non-focusable with the role present — pinning the reasoning above.

**Verified meaningful: all 5 fail against the three upstream files; all 5 pass restored.**

`apps/ui`: 141 files / 1065 tests pass, `tsc` clean, `eslint` 0 errors, repo `format:check` clean. Diff is 4 files, all under `apps/ui/src` — no strays.

Closes #6423
