### PR TITLE
feat(ui): add the bottom-of-page back-to-index link to validators and subnets (#6432)

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -378,6 +378,11 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       {/* #3340: the aggregated fund-flow view over the same transfer data. */}
       <AccountCounterpartiesSection ss58={ss58} />
 
+      {/* #6432: deliberately NOT "← All accounts" like the other detail pages'
+          back-links. /accounts is a lookup form, not an index -- there is no
+          list of every chain account to go back to -- so the label names what
+          the destination actually is. Sibling pages (blocks, extrinsics,
+          validators, subnets) do point at real directories and use "← All X". */}
       <div className="mt-6">
         <Link
           to="/accounts"

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -345,6 +345,19 @@ function ProfileShell({ netuid }: { netuid: number }) {
           ) : null}
           {tab === "api" ? <ApiPanel netuid={netuid} /> : null}
         </div>
+
+        {/* #6432: outside the tab switch, so the way back is there whichever
+            tab a reader ends on -- this profile is the longest page in the app
+            and the masthead breadcrumb is far behind by the time they finish.
+            Same placement/styling as blocks.$ref.tsx and extrinsics.$hash.tsx. */}
+        <div className="mt-6">
+          <Link
+            to="/subnets"
+            className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
+          >
+            ← All subnets
+          </Link>
+        </div>
       </SubnetFilterProvider>
     </TimeRangeProvider>
   );

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -463,6 +463,19 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         <WatchValidatorAlert hotkey={hotkey} />
       </SectionAnchor>
 
+      {/* #6432: same placement blocks.$ref.tsx and extrinsics.$hash.tsx use --
+          after the content sections, ahead of the endpoint snippet -- so the
+          way back sits where a reader who has scrolled the whole profile is
+          already looking, rather than only in the masthead breadcrumb. */}
+      <div className="mt-6">
+        <Link
+          to="/validators"
+          className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2.5 py-1 text-[11px] font-medium hover:border-ink/30"
+        >
+          ← All validators
+        </Link>
+      </div>
+
       <SectionAnchor
         id="call"
         title="Call this endpoint"

--- a/apps/ui/tests/e2e/capture-back-link-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-back-link-screenshots.mjs
@@ -1,0 +1,134 @@
+/**
+ * Capture the bottom-of-page "back to index" link for #6432.
+ *
+ * capture-pr-screenshots.mjs can't drive this one: `--section` pins a section's
+ * top just under the sticky header, but the back-link sits *above* the section
+ * it precedes, so it lands off-frame -- and in the `before` variant the link
+ * doesn't exist at all, so there is no id to anchor on either. Same contract as
+ * Phase C2 (fixed viewports only, never fullPage; theme forced via mg-theme;
+ * 3 viewports x 2 themes x {before, after}), just a different scroll strategy:
+ * anchor on a landmark that exists in BOTH variants and align its BOTTOM with
+ * the viewport bottom, so the space the link occupies is what fills the frame.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8081 VARIANT=before node tests/e2e/capture-back-link-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8080 VARIANT=after  node tests/e2e/capture-back-link-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/back-link-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8080";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const HOTKEY = process.env.HOTKEY ?? "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u";
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const THEMES = ["light", "dark"];
+
+/**
+ * `anchor` exists in both variants; the link renders directly above it (or, on
+ * /subnets/:netuid, at the very page bottom -- `anchor: null` scrolls there).
+ */
+const PAGES = [
+  { key: "validators", route: `/validators/${HOTKEY}`, anchor: "call" },
+  { key: "subnets", route: "/subnets/1", anchor: null },
+];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function open(page, route) {
+  await page.goto(`${BASE_URL}${route}`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  try {
+    await page.waitForLoadState("networkidle", { timeout: 8000 });
+  } catch {
+    await page.waitForTimeout(2500);
+  }
+  // Brand faces swap in via font-display; a mid-swap capture differs in
+  // typeface from a warm one and every glyph shifts (#4876).
+  await page.evaluate(() => document.fonts.ready);
+}
+
+/** Bring the region the link occupies into frame, clear of the sticky masthead.
+ *
+ * With an `anchor`, align that section's BOTTOM with the viewport bottom -- the
+ * link renders directly above it, so it lands mid-frame.
+ *
+ * Without one (/subnets/:netuid, where the link is the page's last body
+ * element), anchor off the AppShell footer instead: park its top at 75% of the
+ * viewport so the ~180px above it -- which is exactly where the link sits -- is
+ * in the lower-middle of the frame. Scrolling to `document.body.scrollHeight`
+ * looks right but isn't: the footer is ~590px tall, so the link lands ~34px
+ * from the viewport top, underneath the ~130px sticky header, and the shot
+ * comes back showing only the footer.
+ *
+ * Re-scrolls after a settle so late-resolving queries can't push it away.
+ */
+async function scrollToBackLink(page, anchor) {
+  const doScroll = () =>
+    page.evaluate((id) => {
+      if (id) {
+        const el = document.getElementById(id);
+        if (el) {
+          el.scrollIntoView({ block: "end", behavior: "instant" });
+          return;
+        }
+      }
+      const footer = document.querySelector("footer");
+      if (footer) {
+        const footerTop = footer.getBoundingClientRect().top + window.scrollY;
+        window.scrollTo({
+          top: Math.max(0, footerTop - window.innerHeight * 0.75),
+          behavior: "instant",
+        });
+        return;
+      }
+      window.scrollTo({ top: document.body.scrollHeight, behavior: "instant" });
+    }, anchor);
+  await doScroll();
+  await page.waitForTimeout(600);
+  await doScroll();
+  await page.waitForTimeout(300);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await setTheme(page, theme);
+
+      for (const p of PAGES) {
+        await open(page, p.route);
+        await scrollToBackLink(page, p.anchor);
+        const file = path.join(OUT_DIR, `${p.key}-${VARIANT}-${viewport.name}-${theme}.png`);
+        await page.screenshot({ path: file, fullPage: false });
+        console.log(`wrote ${file}`);
+      }
+
+      await context.close();
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

`blocks.$ref.tsx` and `extrinsics.$hash.tsx` both close their loaded body with a
`← All blocks` / `← All extrinsics` link, and `accounts.$ss58.tsx` has one too.
`validators.$hotkey.tsx` had none, and `subnets.$netuid.tsx` only had one inside its
`notFoundComponent` — never in the successful render. Those are the two longest detail
pages in the app, so a reader who scrolls to the end is furthest from the masthead
breadcrumb exactly where the convenience link is missing.

## What Changed

Added one to each, at the same spot and with the same styling the two reference pages use:
after the content sections, ahead of the endpoint snippet. On `subnets.$netuid.tsx` the
link sits **outside the tab switch**, so it's there whichever tab the reader ends on.

## The wording question

The issue asks to *confirm intent before standardizing* `accounts.$ss58.tsx`'s
`← Account lookup`. Confirmed — and it should stay as-is:

**`/accounts` is a lookup form, not an index.** Its own copy reads *"Look up a Bittensor
account by ss58 address (hotkey or coldkey)"* and it renders a search input, because there
is no list of every chain account to go back to. `← All accounts` would name a page that
doesn't exist.

The pages that *do* point at real directories use the `← All X` form, and their labels are
truthful:

| Page | Destination | Label |
| --- | --- | --- |
| `validators.$hotkey` | `/validators` — "Network-wide validator **directory**" | `← All validators` (new) |
| `subnets.$netuid` | `/subnets` — "**Every** active Finney netuid" | `← All subnets` (new) |
| `accounts.$ss58` | `/accounts` — a **lookup form** | `← Account lookup` (unchanged) |

So the label tracks what the destination actually is, rather than being uniform for its own
sake. That reasoning is recorded as a comment at the link itself, so the next person to
notice the inconsistency finds the answer in the code rather than in this PR.

`providers.$slug.tsx` is out of scope — the issue's Requirements and Deliverables name only
`validators.$hotkey.tsx` and `subnets.$netuid.tsx`.

## Screenshots

Captured at the contract's fixed viewports (1280×800 / 768×1024 / 375×812), themes forced
via `mg-theme`, `before` served from a worktree at the merge-base, both servers verified to
have the brand faces loaded so the pair shares one typeface.

`capture-pr-screenshots.mjs` can't drive this one — `--section` pins a section's *top* under
the sticky header, but the link sits *above* the section it precedes, and in `before` there
is no link to anchor on at all. The included `capture-back-link-screenshots.mjs` follows the
same contract with a scroll strategy that anchors on a landmark present in both variants.

### validators.$hotkey — `← All validators`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/validators-after-mobile-dark.png)<br><sub>after</sub> |

### subnets.$netuid — `← All subnets`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6432-back-link/subnets-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npm run lint --workspace=apps/ui` — clean
- `npm run format:check --workspace=apps/ui` — clean
- `npm run typecheck --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 1060/1060 passed
- `npm run test:e2e --workspace=apps/ui` — 26/26 passed
- `npm run build --workspace=apps/ui` — clean

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6432`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched — `apps/ui/**` only, 4 files.
- [x] `routeTree.gen.ts` untouched; screenshots hosted on a fork branch, not committed here.

Closes #6432
