### PR TITLE
feat(api,ui): wire Download CSV into the Runtime page

### DIFF
--- a/apps/ui/src/routes/runtime.index.tsx
+++ b/apps/ui/src/routes/runtime.index.tsx
@@ -4,9 +4,17 @@ import { Suspense, type ReactNode } from "react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
-import { PageHero, ShareButton, ActionBar, TableState, TimeAgo } from "@jsonbored/ui-kit";
+import {
+  PageHero,
+  ShareButton,
+  DownloadCsvButton,
+  ActionBar,
+  TableState,
+  TimeAgo,
+} from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { runtimeVersionHistoryQuery } from "@/lib/metagraphed/queries";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { formatNumber } from "@/lib/metagraphed/format";
 import type { RuntimeVersionHistory } from "@/lib/metagraphed/types";
 
@@ -31,6 +39,7 @@ export const Route = createFileRoute("/runtime/")({
 });
 
 function RuntimePage() {
+  const runtimeCsvUrl = buildUrl("/api/v1/runtime", { format: "csv" });
   return (
     <AppShell>
       <PageHero
@@ -40,6 +49,10 @@ function RuntimePage() {
         description="Spec-version upgrade history for the Bittensor chain, tracked from the first-party blocks tier — every observed runtime upgrade, newest first."
         actions={
           <ActionBar>
+            {/* /api/v1/runtime is a single whole-window aggregate with no
+                filters to carry, so the export needs no query params beyond
+                format -- unlike the filtered feeds' <page>QueryParams(search). */}
+            <DownloadCsvButton url={runtimeCsvUrl} bare />
             <ShareButton bare />
           </ActionBar>
         }

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -1711,7 +1711,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the spec-version transition timeline — the earliest known block at each distinct runtime spec_version, ascending by block_number. No query params: a single aggregate over the whole retained blocks window. spec_version is best-effort/nullable and wasn't tracked before 2026-06-25, so coverage_from_block/coverage_from_at bound what this endpoint can see. Computed live from the first-party blocks D1 tier (#4316/3.1). */
+        /** Fetch the spec-version transition timeline — the earliest known block at each distinct runtime spec_version, ascending by block_number. A single aggregate over the whole retained blocks window, nothing to filter or paginate. spec_version is best-effort/nullable and wasn't tracked before 2026-06-25, so coverage_from_block/coverage_from_at bound what this endpoint can see. Computed live from the first-party blocks D1 tier (#4316/3.1). Pass ?format=csv to download the transition timeline as CSV (the current_spec_version + coverage_from_* rollup stays JSON-only). */
         get: operations["runtimeVersions"];
         put?: never;
         post?: never;
@@ -21629,14 +21629,17 @@ export interface operations {
     };
     runtimeVersions: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Response format override. Use `csv` to download the transition timeline as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -21689,6 +21692,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RuntimeVersionsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -7823,14 +7823,26 @@
     {
       "artifact_path": "/metagraph/runtime.json",
       "cache": "short",
-      "description": "Fetch the spec-version transition timeline — the earliest known block at each distinct runtime spec_version, ascending by block_number. No query params: a single aggregate over the whole retained blocks window. spec_version is best-effort/nullable and wasn't tracked before 2026-06-25, so coverage_from_block/coverage_from_at bound what this endpoint can see. Computed live from the first-party blocks D1 tier (#4316/3.1).",
+      "description": "Fetch the spec-version transition timeline — the earliest known block at each distinct runtime spec_version, ascending by block_number. A single aggregate over the whole retained blocks window, nothing to filter or paginate. spec_version is best-effort/nullable and wasn't tracked before 2026-06-25, so coverage_from_block/coverage_from_at bound what this endpoint can see. Computed live from the first-party blocks D1 tier (#4316/3.1). Pass ?format=csv to download the transition timeline as CSV (the current_spec_version + coverage_from_* rollup stays JSON-only).",
       "id": "runtime-versions",
       "method": "GET",
       "path": "/api/v1/runtime",
       "public": true,
       "query_collection": null,
       "query_filter_names": [],
-      "query_parameters": []
+      "query_parameters": [
+        {
+          "description": "Response format override. Use `csv` to download the transition timeline as text/csv; `json` (default) keeps the response envelope.",
+          "name": "format",
+          "schema": {
+            "enum": [
+              "json",
+              "csv"
+            ],
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/chain/activity.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -42299,7 +42299,21 @@
     "/api/v1/runtime": {
       "get": {
         "operationId": "runtimeVersions",
-        "parameters": [],
+        "parameters": [
+          {
+            "description": "Response format override. Use `csv` to download the transition timeline as text/csv; `json` (default) keeps the response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -42358,9 +42372,15 @@
                     }
                   ]
                 }
+              },
+              "text/csv": {
+                "example": "netuid,name\r\n7,Allways",
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"
@@ -42417,7 +42437,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch the spec-version transition timeline — the earliest known block at each distinct runtime spec_version, ascending by block_number. No query params: a single aggregate over the whole retained blocks window. spec_version is best-effort/nullable and wasn't tracked before 2026-06-25, so coverage_from_block/coverage_from_at bound what this endpoint can see. Computed live from the first-party blocks D1 tier (#4316/3.1).",
+        "summary": "Fetch the spec-version transition timeline — the earliest known block at each distinct runtime spec_version, ascending by block_number. A single aggregate over the whole retained blocks window, nothing to filter or paginate. spec_version is best-effort/nullable and wasn't tracked before 2026-06-25, so coverage_from_block/coverage_from_at bound what this endpoint can see. Computed live from the first-party blocks D1 tier (#4316/3.1). Pass ?format=csv to download the transition timeline as CSV (the current_spec_version + coverage_from_* rollup stays JSON-only).",
         "tags": [
           "blocks",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1711,7 +1711,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch the spec-version transition timeline — the earliest known block at each distinct runtime spec_version, ascending by block_number. No query params: a single aggregate over the whole retained blocks window. spec_version is best-effort/nullable and wasn't tracked before 2026-06-25, so coverage_from_block/coverage_from_at bound what this endpoint can see. Computed live from the first-party blocks D1 tier (#4316/3.1). */
+        /** Fetch the spec-version transition timeline — the earliest known block at each distinct runtime spec_version, ascending by block_number. A single aggregate over the whole retained blocks window, nothing to filter or paginate. spec_version is best-effort/nullable and wasn't tracked before 2026-06-25, so coverage_from_block/coverage_from_at bound what this endpoint can see. Computed live from the first-party blocks D1 tier (#4316/3.1). Pass ?format=csv to download the transition timeline as CSV (the current_spec_version + coverage_from_* rollup stays JSON-only). */
         get: operations["runtimeVersions"];
         put?: never;
         post?: never;
@@ -21629,14 +21629,17 @@ export interface operations {
     };
     runtimeVersions: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Response format override. Use `csv` to download the transition timeline as text/csv; `json` (default) keeps the response envelope. */
+                format?: "json" | "csv";
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];
@@ -21689,6 +21692,11 @@ export interface operations {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RuntimeVersionsArtifact"];
                     };
+                    /**
+                     * @example netuid,name
+                     *     7,Allways
+                     */
+                    "text/csv": string;
                 };
             };
             /** @description ETag matched and the cached response is still valid. */

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -3312,10 +3312,20 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/runtime",
     "/metagraph/runtime.json",
-    "Fetch the spec-version transition timeline — the earliest known block at each distinct runtime spec_version, ascending by block_number. No query params: a single aggregate over the whole retained blocks window. spec_version is best-effort/nullable and wasn't tracked before 2026-06-25, so coverage_from_block/coverage_from_at bound what this endpoint can see. Computed live from the first-party blocks D1 tier (#4316/3.1).",
+    "Fetch the spec-version transition timeline — the earliest known block at each distinct runtime spec_version, ascending by block_number. A single aggregate over the whole retained blocks window, nothing to filter or paginate. spec_version is best-effort/nullable and wasn't tracked before 2026-06-25, so coverage_from_block/coverage_from_at bound what this endpoint can see. Computed live from the first-party blocks D1 tier (#4316/3.1). Pass ?format=csv to download the transition timeline as CSV (the current_spec_version + coverage_from_* rollup stays JSON-only).",
     "short",
     ["blocks", "analytics"],
-    [],
+    {
+      csvResponse: true,
+      parameters: [
+        {
+          name: "format",
+          description:
+            "Response format override. Use `csv` to download the transition timeline as text/csv; `json` (default) keeps the response envelope.",
+          schema: { type: "string", enum: ["json", "csv"] },
+        },
+      ],
+    },
     [],
   ),
   route(

--- a/tests/request-handlers-entities.test.mjs
+++ b/tests/request-handlers-entities.test.mjs
@@ -5201,6 +5201,114 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
+  // #6392: /runtime was the one Explorer list page with no CSV export, because
+  // the route rejected every query param -- ?format=csv 400'd before it could
+  // reach the handler.
+  describe("handleRuntime CSV export (#6392)", () => {
+    function pgEnv(transitions) {
+      const { env } = dbWith({ blocksFeed: [blockRow()] });
+      env.METAGRAPH_BLOCKS_SOURCE = "postgres";
+      env.DATA_API = {
+        fetch: async () =>
+          Response.json({
+            schema_version: 1,
+            transitions,
+            transition_count: transitions.length,
+            current_spec_version: transitions.at(-1)?.spec_version ?? null,
+            coverage_from_block: transitions[0]?.block_number ?? null,
+            coverage_from_at: transitions[0]?.observed_at ?? null,
+          }),
+      };
+      return env;
+    }
+
+    const ROWS = [
+      {
+        spec_version: 423,
+        block_number: 8000000,
+        observed_at: "2026-06-25T00:00:00.000Z",
+      },
+      {
+        spec_version: 424,
+        block_number: 8100000,
+        observed_at: "2026-07-01T00:00:00.000Z",
+      },
+    ];
+
+    test("?format=csv exports the transition timeline with the on-screen columns", async () => {
+      const res = await handleRuntime(
+        req("/api/v1/runtime?format=csv"),
+        pgEnv(ROWS),
+        url("/api/v1/runtime?format=csv"),
+      );
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get("content-type") || "", /text\/csv/);
+      assert.equal(
+        res.headers.get("content-disposition"),
+        'attachment; filename="runtime-versions.csv"',
+      );
+      const lines = (await res.text()).trim().split("\r\n");
+      // The three columns the /runtime table renders: Spec Version | Block | Observed.
+      assert.equal(lines[0], "spec_version,block_number,observed_at");
+      assert.equal(lines[1], "423,8000000,2026-06-25T00:00:00.000Z");
+      assert.equal(lines.length, ROWS.length + 1);
+    });
+
+    test("the default response is still the JSON envelope", async () => {
+      const res = await handleRuntime(
+        req("/api/v1/runtime"),
+        pgEnv(ROWS),
+        url("/api/v1/runtime"),
+      );
+      assert.match(res.headers.get("content-type") || "", /application\/json/);
+      const body = await res.json();
+      // The rollup fields stay JSON-only -- they describe the series, not a row.
+      assert.equal(body.data.current_spec_version, 424);
+      assert.equal(body.data.coverage_from_block, 8000000);
+    });
+
+    test("?format=json is accepted and keeps the envelope", async () => {
+      const res = await handleRuntime(
+        req("/api/v1/runtime?format=json"),
+        pgEnv(ROWS),
+        url("/api/v1/runtime?format=json"),
+      );
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get("content-type") || "", /application\/json/);
+    });
+
+    test("a cold store yields a header-only CSV, never an error", async () => {
+      const res = await handleRuntime(
+        req("/api/v1/runtime?format=csv"),
+        pgEnv([]),
+        url("/api/v1/runtime?format=csv"),
+      );
+      assert.equal(res.status, 200);
+      assert.equal(
+        (await res.text()).trim(),
+        "spec_version,block_number,observed_at",
+      );
+    });
+
+    test("an unsupported format is still rejected", async () => {
+      const res = await handleRuntime(
+        req("/api/v1/runtime?format=bogus"),
+        pgEnv(ROWS),
+        url("/api/v1/runtime?format=bogus"),
+      );
+      assert.equal(res.status, 400);
+    });
+
+    test("an unknown query param is still rejected (format is the only one)", async () => {
+      const res = await handleRuntime(
+        req("/api/v1/runtime?limit=5"),
+        pgEnv(ROWS),
+        url("/api/v1/runtime?limit=5"),
+      );
+      assert.equal(res.status, 400);
+    });
+  });
+
   // #4832 Tier 1b: the remaining account_events-derived handlers with no
   // Postgres tier at all -- same pattern as Tier 1a above.
 

--- a/workers/request-handlers/entities.mjs
+++ b/workers/request-handlers/entities.mjs
@@ -4101,20 +4101,44 @@ export async function handleGovernanceConfigChanges(request, env, url) {
   );
 }
 
+// The three columns the /runtime page's table renders (Spec Version | Block |
+// Observed), in that order, so the download matches what the reader sees.
+const RUNTIME_VERSIONS_CSV_COLUMNS = [
+  "spec_version",
+  "block_number",
+  "observed_at",
+];
+
 // GET /api/v1/runtime (#4316/3.1): the spec-version transition timeline — the
 // earliest known block at each distinct spec_version the blocks D1 tier has
 // observed, ascending by block_number. A single-row aggregate over the whole
-// retained window, nothing to filter or paginate. See src/runtime-versions.mjs
-// for the coverage caveat (spec_version wasn't tracked before 2026-06-25 and
-// can't be back-filled for rows written before then).
+// retained window, nothing to filter or paginate (?format=csv is the one
+// accepted param, #6392). See src/runtime-versions.mjs for the coverage caveat
+// (spec_version wasn't tracked before 2026-06-25 and can't be back-filled for
+// rows written before then).
 export async function handleRuntime(request, env, url) {
-  const validationError = validateQueryParams(url, []);
+  const validationError = validateEntityQuery(url, ["format"]);
   if (validationError) return analyticsQueryError(validationError);
   // #4909 D1 retirement: blocks' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
   const data =
     (await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE")) ??
     buildRuntimeVersionHistory([]);
+  // CSV exports the row-shaped transition timeline -- the same three columns
+  // the /runtime page's table renders (#6392). The rollup fields
+  // (current_spec_version, coverage_from_block/at) describe the series rather
+  // than belonging to any row, so they stay JSON-only, mirroring how
+  // chain-signers/chain-fees export their leaderboard and keep their totals out
+  // of the CSV. A cold store yields transitions: [] -> a header-only CSV.
+  if (csvRequested(url, request)) {
+    return csvResponse(
+      data.transitions,
+      "runtime-versions",
+      "short",
+      request,
+      RUNTIME_VERSIONS_CSV_COLUMNS,
+    );
+  }
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
Closes #6392

`/runtime` was the one Explorer list page with no CSV export — the last unshipped installment of the "wire Download CSV into <page>" series (#3403/#3404/#3408/#5562/#5665).

## Screenshots

**Download CSV** now sits beside **Share view**, the same slot and order every sibling page's `ActionBar` uses. Fixed-viewport captures (never fullPage), theme forced via `mg-theme` + reload; before = `main`, after = this branch.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6392/runtime-mobile-dark-after.png)<br><sub>after</sub> |

## This was not a frontend-only job

The issue asks to "confirm (and add if missing) `format=csv` support". It was missing — `/api/v1/runtime` rejected **every** query param (`validateQueryParams(url, [])`), so `?format=csv` 400'd before it could reach the handler. Verified against the live route before changing anything:

```
before:  /api/v1/runtime?format=csv  ->  400
after:   /api/v1/runtime?format=csv  ->  200  text/csv  attachment; filename="runtime-versions.csv"
         header row: spec_version,block_number,observed_at
```

**Backend**
- `handleRuntime` accepts the one param via the same `validateEntityQuery(url, ["format"])` idiom its neighbours in this file already use — so `?format=bogus` **and** any unknown param are still rejected (`?limit=5` → 400).
- The CSV exports `data.transitions` with the three columns the page's table actually renders (**Spec Version | Block | Observed** → `spec_version`, `block_number`, `observed_at`), satisfying the issue's "CSV must match the on-screen table's columns". The rollup fields (`current_spec_version`, `coverage_from_block/at`) describe the series rather than any row, so they stay JSON-only — mirroring how `chain-signers`/`chain-fees` export their leaderboard and keep totals out of the CSV.
- A cold store yields `transitions: []` → a header-only CSV, never an error.
- The route contract gains `csvResponse` + the `format` parameter, so the generated OpenAPI documents both (`200` now advertises `application/json` **and** `text/csv`).

**Frontend**
- `DownloadCsvButton` in `runtime.index.tsx`'s `PageHero.actions`. `/api/v1/runtime` is a single whole-window aggregate with no filters to carry, so the export URL needs no params beyond `format` — unlike the filtered feeds, which spread their `<page>QueryParams(search)`.

## Tests

6 new cases in `tests/request-handlers-entities.test.mjs`. They are real regression tests — **I reverted the handler and confirmed they fail without it**: the CSV body/headers/filename, the JSON default (asserting the rollup stays JSON-only), `?format=json`, the cold header-only CSV, `?format=bogus` → 400, and that unknown params are still refused.

The Playwright capture **asserts** the control exists rather than just photographing it:

```
PASS: Download CSV control present (1 match(es))
Share view control present: true
before: Download CSV controls on /runtime = 0
```

```
tests/request-handlers-entities.test.mjs  passed
tests/contracts.test.mjs                  passed
tests/api-coverage.test.mjs               passed
validate:contract-drift / validate:types / validate:openapi  -> pass
```

Derived artifacts (`openapi.json`, `types.d.ts`, `api-index.json`, `packages/contract/index.d.ts`) regenerated and verified **byte-identical to a fresh build after rebasing** onto a main that moved 3 commits mid-work. `eslint` clean, `prettier --check` clean, pushed at `behind: 0`.
