### PR TITLE
fix(ui): distinguish a failed related-Multisig-calls fetch from an empty result

### DIFF
--- a/apps/ui/src/routes/extrinsics-multisig-error.test.ts
+++ b/apps/ui/src/routes/extrinsics-multisig-error.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #6426: the "Related Multisig calls" section had no isError branch. A failed
+// fetch leaves data undefined, so relatedCalls becomes [] and the section
+// rendered "No other extrinsics reference this call_hash yet." — a failure and a
+// genuine empty result were indistinguishable, and the copy asserts something
+// the app doesn't actually know.
+//
+// Source assertions rather than a render: this section lives inside a route that
+// needs a router and live data, and this suite is node-environment. The repo
+// already tests this way (ui-kit's list-shell.test.ts).
+const source = readFileSync(
+  fileURLToPath(new URL("./extrinsics.$hash.tsx", import.meta.url)),
+  "utf8",
+);
+
+const EMPTY_COPY = "No other extrinsics reference this call_hash yet.";
+
+describe("Related Multisig calls distinguishes a fetch error from empty (#6426)", () => {
+  it("has an isError branch for the related-calls query", () => {
+    expect(source).toContain("relatedQuery.isError");
+  });
+
+  it("renders TableState variant=error with a retry, per the accounts.$ss58 pattern", () => {
+    const at = source.indexOf("relatedQuery.isError");
+    const branch = source.slice(at, source.indexOf(EMPTY_COPY));
+    expect(branch).toContain('variant="error"');
+    expect(branch).toContain("error={relatedQuery.error}");
+    expect(branch).toContain("relatedQuery.refetch()");
+  });
+
+  it("checks isError BEFORE the empty copy, so a failure can't fall through to it", () => {
+    // Order is the whole fix: if the empty branch were reachable first, a failed
+    // fetch would still claim there are no related calls.
+    const isError = source.indexOf("relatedQuery.isError");
+    const rows = source.indexOf("relatedCalls.length > 0");
+    const empty = source.indexOf(EMPTY_COPY);
+    expect(isError).toBeGreaterThan(-1);
+    expect(isError).toBeLessThan(rows);
+    expect(rows).toBeLessThan(empty);
+  });
+
+  it("keeps the loading branch ahead of both, so a pending fetch isn't an error", () => {
+    expect(source.indexOf("relatedQuery.isLoading")).toBeLessThan(
+      source.indexOf("relatedQuery.isError"),
+    );
+  });
+
+  it("still shows the empty copy — it is not replaced, only made unreachable on failure", () => {
+    expect(source).toContain(EMPTY_COPY);
+  });
+});

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -15,6 +15,7 @@ import {
   ActionBar,
   SectionAnchor,
   StatTile,
+  TableState,
 } from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { extrinsicQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
@@ -313,6 +314,18 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
         >
           {relatedQuery.isLoading ? (
             <Skeleton className="h-16 w-full" />
+          ) : relatedQuery.isError ? (
+            // #6426: a failed fetch left data undefined, so relatedCalls became
+            // [] and rendered as "no related calls" -- indistinguishable from a
+            // real empty result. Mirrors the isError + TableState treatment every
+            // secondary query on accounts.$ss58.tsx already uses.
+            <TableState
+              variant="error"
+              title="Couldn't load related Multisig calls"
+              description="Other extrinsics may reference this call_hash — this list failed to load, so it isn't necessarily empty."
+              error={relatedQuery.error}
+              onRetry={() => void relatedQuery.refetch()}
+            />
           ) : relatedCalls.length > 0 ? (
             <ul className="flex flex-col gap-2">
               {relatedCalls.map((e) => (


### PR DESCRIPTION
## What

The "Related Multisig calls" section computed `relatedCalls` from a `useQuery` with **no `isError` branch**. A genuine fetch failure leaves `data` undefined, so `relatedCalls` becomes `[]` and the section rendered:

> No other extrinsics reference this call_hash yet.

— asserting a fact the app doesn't actually know. Every other secondary query on the sibling `accounts.$ss58.tsx` page checks `isError` and renders `TableState variant="error"` with retry; this one now does too.

**The branch order is the fix**: `isLoading → isError → rows → empty`, so the empty copy is only reachable when the fetch genuinely succeeded with zero rows (the issue's second requirement).

## Proof — the error state, forced

Screenshots can't show this fix: on a healthy page the fetch succeeds, so before and after are identical. So I forced it, aborting **only** the related-calls lookup (it's the only request carrying `call_hash=`; the extrinsic detail itself stays healthy — exactly the scenario the issue describes):

| | behaviour when the related-calls fetch fails |
| --- | --- |
| **before** | ❌ *"No other extrinsics reference this call_hash yet."* — indistinguishable from a real empty result |
| **after** | ✅ **"Couldn't load related Multisig calls"** + retry |

Both still render the section, and both aborted the same 4 requests.

## Screenshots

`/extrinsics/0x25a23bcd…` at `#multisig-chain`, showing the section in its **successful** empty state — identical before/after, since the new branch only renders on failure.

One note on picking that extrinsic: the section only renders when `multisigCallHash()` resolves, and `as_multi` calls here carry a nested decoded `call` with **no `call_hash`** — so they render no section at all. `approve_as_multi` carries `call_hash` directly, which is why this hash was used.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

`extrinsics-multisig-error.test.ts` (5 tests) — source assertions (this section lives in a route needing a router and live data; the suite is node-environment, and the repo tests this way in ui-kit's `list-shell.test.ts`):

- an `isError` branch exists for the related-calls query;
- it renders `variant="error"` with `error={relatedQuery.error}` and a `refetch` retry, per the `accounts.$ss58.tsx` pattern;
- **`isError` is checked before the empty copy** — asserted by index, since a branch that exists but sits after the empty case would still let a failure fall through;
- `isLoading` stays ahead of both, so a pending fetch isn't reported as an error;
- the empty copy still exists — it's made unreachable on failure, not removed.

**Verified meaningful: 4 of the 5 fail against the upstream file** (the 5th passes both ways by design — it asserts the empty copy survives).

`apps/ui`: 141 files / 1065 tests pass, `tsc` clean, `eslint` 0 errors, `format:check` clean. Diff is 2 files, both under `apps/ui/src`.

Closes #6426
