### PR TITLE
feat(workers): instrument data-api and registry-sync-api with Sentry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "dependencies": {
         "@duckdb/node-api": "^1.5.4-r.1",
         "@noble/hashes": "^2.2.0",
+        "@sentry/cloudflare": "^10.66.0",
         "@sentry/node": "^10.66.0",
         "graphql": "^17.0.2",
         "graphql-ws": "^6.1.0",
@@ -6234,6 +6235,41 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@sentry/cloudflare": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.66.0.tgz",
+      "integrity": "sha512-QYEZQsR09OO/0nfyZP4J56JG8zNO5PCPon7TM96fjjbKIbshpbUcr73XmUhHh3h1Kv0Ic/M5LWBm9eV6H5Cmmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@sentry/core": "10.66.0",
+        "@sentry/node": "10.66.0",
+        "@sentry/server-utils": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.x || ^5.x"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/cloudflare/node_modules/@sentry/core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.66.0.tgz",
+      "integrity": "sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/conventions": {

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
   "dependencies": {
     "@duckdb/node-api": "^1.5.4-r.1",
     "@noble/hashes": "^2.2.0",
+    "@sentry/cloudflare": "^10.66.0",
     "@sentry/node": "^10.66.0",
     "graphql": "^17.0.2",
     "graphql-ws": "^6.1.0",

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -92,6 +92,23 @@ export default defineConfig({
         "scripts/{artifact-budgets,lib,openapi-components,registry-identity}.mjs",
         "scripts/lib/{build-readiness,economics-artifacts,endpoint-artifacts,enrichment-queue-artifacts,formatting,readme-links}.mjs",
       ],
+      // The workers/*.sentry.mjs deploy-entry wrappers (metagraphed#6479;
+      // currently data-api.sentry.mjs + registry-sync-api.sentry.mjs --
+      // workers/api.mjs's own Sentry wrapper hit that Worker's 1024 KiB
+      // Cloudflare bundle ceiling, tracked separately, see #6479's own
+      // follow-up) are deliberately coverage-invisible for the same reason
+      // chain-firehose-relay.mjs is: @sentry/cloudflare's withSentry()
+      // requires real Cloudflare Workers runtime primitives
+      // (AsyncLocalStorage-based context propagation via workerd) that
+      // don't exist in this plain-Node vitest environment -- confirmed
+      // empirically, importing one crashes with "Cannot read properties of
+      // undefined (reading 'bind')" inside @sentry/cloudflare's own
+      // flush-lock registry. Each wrapper is a thin, mechanical ~15-line
+      // `Sentry.withSentry(fn, handler)` re-export; the REAL handler logic
+      // it wraps (workers/data-api.mjs, workers/registry-sync-api.mjs) is
+      // unaffected and stays fully covered as before -- these tests were
+      // never routed through the wrapper.
+      exclude: ["workers/*.sentry.mjs"],
       // BACKSTOP floors only — NOT the primary gate. The real PR coverage gate is
       // Codecov (delta-based project + patch coverage, see codecov.yml). That
       // avoids the fixed-pin churn where every PR must match a near-peak absolute

--- a/workers/data-api.sentry.mjs
+++ b/workers/data-api.sentry.mjs
@@ -1,0 +1,45 @@
+// Deploy entry point for workers/data-api.mjs -- wraps it with Sentry error
+// tracking (metagraphed#6479, part of #6485). Kept SEPARATE from the actual
+// handler (not wrapped inline in that file) because @sentry/cloudflare's
+// withSentry() requires real Cloudflare Workers runtime primitives
+// (AsyncLocalStorage-based context propagation via workerd) that don't
+// exist in the plain-Node vitest environment this repo's own tests already
+// run in -- confirmed empirically against workers/registry-sync-api.mjs
+// (the same pattern): wrapping a Worker's export inline crashed every one
+// of its existing tests with "Cannot read properties of undefined (reading
+// 'bind')" inside @sentry/cloudflare's flush-lock registry.
+// tests/data-api.test.mjs continues importing and exercising the real
+// handler directly (this file's own import below, unwrapped), completely
+// unaffected.
+//
+// wrangler.data.jsonc's "main" points HERE instead of at the raw handler
+// file, so only the actual deployed Worker -- running in the real workerd
+// runtime, never a test -- ever executes the wrapped path. This file
+// itself is excluded from coverage tracking (vitest.config.mjs) for the
+// same runtime-mismatch reason; it's a thin, mechanical re-export with no
+// logic of its own to test.
+//
+// withSentry() MUTATES `handler` in place and returns the same reference
+// (confirmed by reading @sentry/cloudflare's own source) -- this only
+// matters if something else also imports data-api.mjs's raw export in the
+// same module graph as this file, which nothing does today (tests import
+// the raw file only; only wrangler's build ever loads this wrapper).
+import * as Sentry from "@sentry/cloudflare";
+import handler from "./data-api.mjs";
+
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: env.SENTRY_DSN,
+    environment: env.SENTRY_ENVIRONMENT || "production",
+    // Cloudflare's own CF_VERSION_METADATA binding (added in
+    // wrangler.data.jsonc) when present, falling back to an explicit
+    // SENTRY_RELEASE var/secret -- matches @sentry/cloudflare's own
+    // documented auto-detection convention. Both undefined is a valid,
+    // accepted value (Sentry just omits release tagging), not an error.
+    release: env.SENTRY_RELEASE || env.CF_VERSION_METADATA?.id,
+    // Error tracking only, matching every other component in this rollout
+    // -- no performance tracing.
+    tracesSampleRate: 0,
+  }),
+  handler,
+);

--- a/workers/registry-sync-api.sentry.mjs
+++ b/workers/registry-sync-api.sentry.mjs
@@ -1,0 +1,45 @@
+// Deploy entry point for workers/registry-sync-api.mjs -- wraps it with
+// Sentry error tracking (metagraphed#6479, part of #6485). Kept SEPARATE
+// from the actual handler (not wrapped inline in that file) because
+// @sentry/cloudflare's withSentry() requires real Cloudflare Workers
+// runtime primitives (AsyncLocalStorage-based context propagation via
+// workerd) that don't exist in the plain-Node vitest environment this
+// repo's own tests already run in -- confirmed empirically: wrapping
+// registry-sync-api.mjs's export inline crashed all 27 of its existing
+// tests with "Cannot read properties of undefined (reading 'bind')" inside
+// @sentry/cloudflare's flush-lock registry. tests/registry-sync-api.test.mjs
+// continues importing and exercising the real handler directly (this file's
+// own import below, unwrapped), completely unaffected.
+//
+// wrangler.registry.jsonc's "main" points HERE instead of at the raw
+// handler file, so only the actual deployed Worker -- running in the real
+// workerd runtime, never a test -- ever executes the wrapped path. This
+// file itself is excluded from coverage tracking (vitest.config.mjs) for
+// the same runtime-mismatch reason; it's a thin, mechanical re-export with
+// no logic of its own to test.
+//
+// withSentry() MUTATES `handler` in place and returns the same reference
+// (confirmed by reading @sentry/cloudflare's own source) -- this only
+// matters if something else also imports registry-sync-api.mjs's raw
+// export in the same module graph as this file, which nothing does today
+// (tests import the raw file only; only wrangler's build ever loads this
+// wrapper).
+import * as Sentry from "@sentry/cloudflare";
+import handler from "./registry-sync-api.mjs";
+
+export default Sentry.withSentry(
+  (env) => ({
+    dsn: env.SENTRY_DSN,
+    environment: env.SENTRY_ENVIRONMENT || "production",
+    // Cloudflare's own CF_VERSION_METADATA binding (added in
+    // wrangler.registry.jsonc) when present, falling back to an explicit
+    // SENTRY_RELEASE var/secret -- matches @sentry/cloudflare's own
+    // documented auto-detection convention. Both undefined is a valid,
+    // accepted value (Sentry just omits release tagging), not an error.
+    release: env.SENTRY_RELEASE || env.CF_VERSION_METADATA?.id,
+    // Error tracking only, matching every other component in this rollout
+    // -- no performance tracing.
+    tracesSampleRate: 0,
+  }),
+  handler,
+);

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -29,7 +29,11 @@
   // is applied.
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "metagraphed-data-api",
-  "main": "workers/data-api.mjs",
+  // Sentry deploy-entry wrapper (metagraphed#6479/#6485), not the raw
+  // handler -- see workers/data-api.sentry.mjs's own header for why this
+  // can't be wrapped inline (breaks its existing tests, which import
+  // workers/data-api.mjs directly and are unaffected by this).
+  "main": "workers/data-api.sentry.mjs",
   // Reached only through the main Worker's DATA_API service binding. Wrangler
   // defaults workers.dev to enabled when a Worker has no public routes, so keep
   // both public and preview URLs disabled for this private data tier.
@@ -37,6 +41,15 @@
   "preview_urls": false,
   "compatibility_date": "2026-06-06",
   "compatibility_flags": ["nodejs_compat"],
+  // Auto-detected release for @sentry/cloudflare (workers/data-api.sentry.mjs's
+  // own CF_VERSION_METADATA?.id read) -- Cloudflare's own per-deploy
+  // version UUID, present on every deploy with no extra CI/build step
+  // needed. upload_source_maps makes Wrangler generate + upload sourcemaps
+  // for this Worker's own deploy.
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA",
+  },
+  "upload_source_maps": true,
   // Smart placement: run the Worker close to the Hyperdrive origin (self-hosted indexer
   // box Postgres, reached via Cloudflare Tunnel) to minimize the per-request DB round-trip,
   // not at the nearest edge to the client.

--- a/wrangler.registry.jsonc
+++ b/wrangler.registry.jsonc
@@ -9,9 +9,23 @@
   // Deploy: wrangler deploy -c wrangler.registry.jsonc
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "metagraphed-registry-sync-api",
-  "main": "workers/registry-sync-api.mjs",
+  // Sentry deploy-entry wrapper (metagraphed#6479/#6485), not the raw
+  // handler -- see workers/registry-sync-api.sentry.mjs's own header for
+  // why this can't be wrapped inline (breaks its 27 existing tests, which
+  // import workers/registry-sync-api.mjs directly and are unaffected by
+  // this).
+  "main": "workers/registry-sync-api.sentry.mjs",
   "compatibility_date": "2026-06-06",
   "compatibility_flags": ["nodejs_compat"],
+  // Auto-detected release for @sentry/cloudflare
+  // (workers/registry-sync-api.sentry.mjs's own CF_VERSION_METADATA?.id
+  // read) -- Cloudflare's own per-deploy version UUID, present on every
+  // deploy with no extra CI/build step needed. upload_source_maps makes
+  // Wrangler generate + upload sourcemaps for this Worker's own deploy.
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA",
+  },
+  "upload_source_maps": true,
   // Deliberately NOT smart-placed, unlike wrangler.data.jsonc's read-only
   // sibling. #4767 added `placement: {mode: "smart"}` here on a latency
   // rationale and was reverted the same day every registry-sync write was


### PR DESCRIPTION
## Summary

Part of #6479, part of the metagraphed/Ventura Labs Sentry rollout (#6485). Scoped to 2 of the 3 core Workers -- `workers/api.mjs`'s own wrapper is tracked separately as #6502: its bundle has no headroom left for `@sentry/cloudflare`'s ~56 KiB gzipped footprint.

Adds `workers/data-api.sentry.mjs` and `workers/registry-sync-api.sentry.mjs` as new Sentry deploy-entry wrappers, importing/re-exporting from their real handler files (`workers/data-api.mjs`, `workers/registry-sync-api.mjs`) unchanged. `wrangler.data.jsonc`/`wrangler.registry.jsonc`'s `"main"` now point at these wrappers instead of the raw handler files, plus a new `version_metadata` binding (`CF_VERSION_METADATA`, Cloudflare's own per-deploy version UUID) and `upload_source_maps` for Wrangler's own sourcemap upload.

**Why a separate wrapper file, not an inline wrap**: discovered empirically that `@sentry/cloudflare`'s `withSentry()` requires real Cloudflare Workers runtime primitives (AsyncLocalStorage-based context propagation via workerd) that don't exist in the plain-Node vitest environment this repo's own tests run in -- wrapping a handler's export inline crashed every one of its existing tests with `Cannot read properties of undefined (reading 'bind')` inside `@sentry/cloudflare`'s flush-lock registry. `tests/data-api.test.mjs` and `tests/registry-sync-api.test.mjs` continue importing and exercising the real handlers directly, completely unaffected. The new wrapper files are excluded from coverage tracking (`vitest.config.mjs`) for the same runtime-mismatch reason `chain-firehose-relay.mjs` already is.

**`workers/api.mjs`'s bundle-budget blocker** (see #6502 for the full writeup): confirmed via `npm run worker:bundle:budget` that this Worker was already at 999.2 KiB gzipped (warn 1000 KiB, fail 1020 KiB, Cloudflare's actual hard ceiling 1024 KiB) before this change -- adding `@sentry/cloudflare` pushed it to 1054.9 KiB, 30.9 KiB **over Cloudflare's real deploy limit**. A narrower `import { withSentry }` made no measurable difference.

## Test plan

- [x] Full `npx vitest run` (303 files / 8997 tests) passes with zero regressions
- [x] Real `wrangler deploy --dry-run` against both configs: all bindings resolve cleanly (`HYPERDRIVE`, rate limiters, the new `CF_VERSION_METADATA`)
- [x] `npm run worker:bundle:budget` passes for the main Worker (unaffected, since it isn't touched by this PR)
- [x] `npm run lint` / `npx prettier --check` clean
- [x] `npm run scan:public-safety` passes
- [x] `npm run validate` passes