### PR TITLE
fix(data-api): scope account stake-flow/stake-moves to hotkey or coldkey

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -3370,6 +3370,17 @@ test("GET /api/v1/accounts/:ss58/stake-flow defaults to summing both directions"
   expect(queryText()).toContain("event_kind IN (?, ?)");
 });
 
+test("GET /api/v1/accounts/:ss58/stake-flow matches the address as either hotkey or coldkey", async () => {
+  // Regression test: this query used to filter on coldkey only, so an
+  // address that only ever appears as a hotkey (e.g. a validator receiving
+  // delegations) silently reported an all-zero flow card despite having
+  // real account_events rows -- see the base /accounts/:ss58 route just
+  // above, which has always matched (hotkey = $1 OR coldkey = $1).
+  mockRows.current = [];
+  await req(`/api/v1/accounts/${SS58}/stake-flow`);
+  expect(queryText()).toContain("(hotkey = ? OR coldkey = ?)");
+});
+
 test("GET /api/v1/accounts/:ss58/stake-flow narrows to one side via ?direction=in", async () => {
   mockRows.current = [];
   await req(`/api/v1/accounts/${SS58}/stake-flow?direction=in`);
@@ -3412,6 +3423,14 @@ test("GET /api/v1/subnets/:netuid/stake-flow defaults to summing both directions
   mockRows.current = [];
   await req("/api/v1/subnets/4/stake-flow");
   expect(queryText()).toContain("event_kind IN (?, ?)");
+});
+
+test("GET /api/v1/accounts/:ss58/stake-moves matches the address as either hotkey or coldkey", async () => {
+  // Regression test: same coldkey-only bug as stake-flow above -- a hotkey-only
+  // address must still surface its StakeMoved re-delegation activity.
+  mockRows.current = [];
+  await req(`/api/v1/accounts/${SS58}/stake-moves`);
+  expect(queryText()).toContain("(hotkey = ? OR coldkey = ?)");
 });
 
 test("GET /api/v1/accounts/:ss58/stake-moves groups movements per subnet", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -5837,7 +5837,7 @@ export default {
           SELECT netuid, event_kind, COALESCE(SUM(amount_tao), 0) AS total_tao,
             COUNT(*) AS event_count, MAX(observed_at) AS last_observed
           FROM account_events
-          WHERE coldkey = ${address}
+          WHERE (hotkey = ${address} OR coldkey = ${address})
             ${directionParam === "in" ? sql`AND event_kind = ${STAKE_ADDED_KIND}` : directionParam === "out" ? sql`AND event_kind = ${STAKE_REMOVED_KIND}` : sql`AND event_kind IN (${STAKE_ADDED_KIND}, ${STAKE_REMOVED_KIND})`}
             AND observed_at >= ${cutoff}
           GROUP BY netuid, event_kind`;
@@ -5902,7 +5902,7 @@ export default {
           SELECT netuid, COUNT(*) AS movements, MIN(observed_at) AS first_observed,
                  MAX(observed_at) AS last_observed
           FROM account_events
-          WHERE coldkey = ${address} AND event_kind = ${STAKE_MOVED_EVENT_KIND} AND observed_at >= ${cutoff}
+          WHERE (hotkey = ${address} OR coldkey = ${address}) AND event_kind = ${STAKE_MOVED_EVENT_KIND} AND observed_at >= ${cutoff}
           GROUP BY netuid`;
           return json({
             data: buildAccountStakeMoves(rows, address, {


### PR DESCRIPTION
## Summary
- `GET /api/v1/accounts/{ss58}/stake-flow` and `GET /api/v1/accounts/{ss58}/stake-moves` filtered `account_events` on `coldkey = $1` only.
- Any address that only ever appears as a **hotkey** (e.g. a validator receiving third-party delegations) got an all-zero flow/moves card even with real, current activity.
- Confirmed live: a validator hotkey with 1083 StakeAdded / 1106 StakeRemoved / 141 StakeMoved events (per the base `/accounts/{ss58}` route, which has always matched `hotkey = $1 OR coldkey = $1`) returned all zeros from both `/stake-flow` and `/stake-moves`.
- Fix: match both routes' `WHERE` clauses to the same `(hotkey = $1 OR coldkey = $1)` convention the base account route already uses.

Found during a full data-source audit following D1 retirement (unrelated to D1 -- this bug predates it and is purely a query-scoping issue in the Postgres tier).

## Test plan
- [x] `npx vitest run tests/data-api.test.mjs` -- 474/474 passing, including 2 new regression tests asserting the `(hotkey = ? OR coldkey = ?)` clause for both routes
- [x] `npx eslint` / `npx prettier --check` clean
- [x] Reproduced live pre-fix (curl against production showed the discrepancy), verified the query change against the exact failing address