### PR TITLE
fix(scripts): opt fixture capture out of Node's Happy-Eyeballs connect

### DIFF
--- a/scripts/capture-fixtures.mjs
+++ b/scripts/capture-fixtures.mjs
@@ -138,6 +138,15 @@ function pinnedFetch(url, resolvedAddresses, signal) {
           nextAddress += 1;
           callback(null, record.address, record.family);
         },
+        // Node's Happy-Eyeballs dual-stack connect path (default on since
+        // Node 20+) calls the custom `lookup` with `{ all: true }` and
+        // expects an array back; this callback only ever returns a single
+        // scalar address, which the multi-connect path then rejects as
+        // "Invalid IP address: undefined" -- a 100% failure regardless of
+        // target (confirmed live: every one of 598 fixtures failed
+        // identically). Opting out restores the single pinned-address
+        // connect this DNS-pinning lookup was actually written for.
+        autoSelectFamily: false,
         signal,
       },
       resolve,


### PR DESCRIPTION
## Summary
- `scripts/capture-fixtures.mjs`'s DNS-pinning `lookup` callback (SSRF/rebinding guard) only supports the old single-address `dns.lookup` callback signature.
- Node's Happy-Eyeballs dual-stack connect path (`autoSelectFamily`, default-on since Node 20+) calls custom `lookup` callbacks with `{ all: true }` and expects an array back -- this callback returns a scalar, so every request threw `TypeError [ERR_INVALID_IP_ADDRESS]: Invalid IP address: undefined`.
- Result in production: **0/598 fixtures captured**, `capture-failed` on 100% of candidates, which also broke `get_fixture`/`get_api_schema` downstream (both REST and MCP).
- The sibling `safeFetch` helper in `scripts/lib.mjs` (used by `snapshot-openapi.mjs` and others) was unaffected -- it goes through undici's `Agent`/dispatcher, not node:http's raw `lookup` option, and its `createPinnedLookup` already handles both callback shapes.
- Fix: `autoSelectFamily: false` on the request options -- this pinned single-address lookup never needed the multi-attempt path.

Found during a full data-source audit following D1 retirement (unrelated to D1 -- pure Node runtime-behavior regression).

## Test plan
- [x] Reproduced the exact `TypeError` locally against a known-healthy target (`apex.api.macrocosmos.ai`)
- [x] Confirmed `autoSelectFamily: false` resolves it against the same target
- [x] `node scripts/capture-fixtures.mjs --dry-run`: went from 0/590 (0%) to ~420/590 (~72%) captured; all remaining failures are legitimate (429 rate limits, non-JSON content-type, real 404/422/502/503, oversized bodies, genuine timeouts) -- zero `TypeError`s remain
- [x] `npx eslint` / `npx prettier --check` clean