### PR TITLE
feat(ui): surface the owning coldkey on the validator detail page (#6427)

### DIFF
--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -7,6 +7,7 @@ import { Boxes, Coins, Gauge, Percent, TriangleAlert, Users, Zap } from "lucide-
 import { useWallet } from "@/hooks/use-wallet";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
+import { AccountAddress } from "@/components/metagraphed/account-address";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
@@ -290,6 +291,27 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
             </span>
             <span className="inline-flex max-w-full min-w-0 rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
               <CopyableCode value={hotkey} truncate={false} className="max-w-full" />
+            </span>
+            {/* #6427: the payload already carries the owning coldkey -- it was
+                only ever read for the owner check that gates the take modal, so
+                a visitor had no way to see which account operates this hotkey.
+                Public and unconditional, beside the hotkey it belongs to.
+                AccountAddress is the app's shared ss58 treatment (accounts link
+                + hover preview + copy) and covers a coldkey as readily as a
+                hotkey; its `fallback` handles the null the API normalizes an
+                absent coldkey to. `break-all` so the full 48-char address wraps
+                on a 375px viewport instead of escaping it. */}
+            <span className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-[11px]">
+              <span className="shrink-0 font-mono uppercase tracking-widest text-ink-muted">
+                Coldkey
+              </span>
+              <span className="min-w-0 break-all font-mono text-ink-strong">
+                <AccountAddress
+                  ss58={detail.coldkey}
+                  truncate={false}
+                  fallback={<span className="text-ink-muted">Not reported</span>}
+                />
+              </span>
             </span>
           </span>
         }


### PR DESCRIPTION
## Summary

`validatorDetailQuery` already normalizes `coldkey` into `ValidatorDetail`, but the page
only ever read it to decide whether the connected wallet owns this validator (the gate on
the take modal). A visitor had no way to tell which account operates a hotkey: the identity
chip shows self-declared operator identity — which is *declared on* the coldkey but never
shows it — and the raw address appeared nowhere.

## What Changed

Rendered it beside the hotkey it belongs to, public and unconditional. No owner gating:
this is chain-public data every visitor can already read straight from the API, and the
issue explicitly asks not to restrict it.

```tsx
<AccountAddress
  ss58={detail.coldkey}
  truncate={false}
  fallback={<span className="text-ink-muted">Not reported</span>}
/>
```

**Why `AccountAddress` rather than a hand-rolled `Link`:** it's the app's shared ss58
treatment — `/accounts/$ss58` link + entity hover preview + copy button — and its own
contract already states that route *"is the app's one lookup route for any ss58 value
regardless of whether it's a hotkey or coldkey, so this covers both."* A coldkey needs no
special case.

**Null handling** is the component's own `fallback` path: the query normalizes an absent
coldkey to `null`, so that case renders "Not reported" rather than a dead link — no extra
guard.

**`break-all` on the value** so the full 48-char address wraps at 375px instead of escaping
the viewport (verified in the mobile shots below). The hotkey above it is shown in full
too, and a truncated *owner* address would defeat the point of surfacing it.

## Screenshots

Captured with `capture-pr-screenshots.mjs` at the contract's fixed viewports
(1280×800 / 768×1024 / 375×812), themes forced via `mg-theme`, `before` served from a
worktree at the merge-base with the brand faces verified loaded on both, so the pair shares
one typeface.

The `after` shots show `COLDKEY 5GsbTgfvgCH4xdqSkiPb7EaBBFLHjWH5vfEALhJaewSFpZX9` — a real
owner address, distinct from the hotkey above it, linked to `/accounts/$ss58`.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-after-mobile-light.png)<br><sub>after — wraps, no overflow</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6427-coldkey/6427-coldkey-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npm run lint --workspace=apps/ui` — clean
- `npm run format:check --workspace=apps/ui` — clean
- `npm run typecheck --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — 1062/1062 passed
- `npm run test:e2e --workspace=apps/ui` — 25/26; the one failure is
  `evidence-deep-link.spec.ts` on `/subnets/1`, which reproduces identically on **pristine
  `main` without this change** (verified as a control) and is green on CI — a
  slow-local-hydration artifact, unrelated to this PR's route.
- `npm run build --workspace=apps/ui` — clean

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6427`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state — the coldkey is chain-public data the API already serves.
- [x] No generated artifacts touched — `apps/ui/**` only, 1 file.
- [x] `routeTree.gen.ts` untouched; screenshots hosted on a fork branch, not committed here.

Closes #6427
