### PR TITLE
fix(ui): share one theme-adaptive SuccessBadge across the extrinsic feeds

### DIFF
--- a/apps/ui/src/components/metagraphed/call-module-extrinsics-table.tsx
+++ b/apps/ui/src/components/metagraphed/call-module-extrinsics-table.tsx
@@ -3,6 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { TimeAgo, ListShell, CopyableCode, CopyButton } from "@jsonbored/ui-kit";
 import { EmptyState } from "@/components/metagraphed/states";
+import { SuccessBadge } from "@/components/metagraphed/success-badge";
 import {
   PageSizeSelect,
   ResetFiltersButton,
@@ -31,15 +32,6 @@ interface Props {
   emptyTitle: string;
   emptyDescription: string;
   emptyApiPath: string;
-}
-
-function SuccessBadge({ success }: { success?: boolean | null }) {
-  if (success == null) return <span className="text-ink-muted">—</span>;
-  return success ? (
-    <span className="text-emerald-500">ok</span>
-  ) : (
-    <span className="text-rose-500">fail</span>
-  );
 }
 
 /** Shared paginated/filtered extrinsics table for a fixed call_module feed

--- a/apps/ui/src/components/metagraphed/success-badge.tsx
+++ b/apps/ui/src/components/metagraphed/success-badge.tsx
@@ -1,0 +1,24 @@
+/**
+ * The extrinsic-success indicator, shared by every feed that renders one
+ * (#6403).
+ *
+ * It previously existed as two byte-identical private copies (extrinsics.index
+ * and call-module-extrinsics-table) plus a third inline ternary in
+ * blocks.$ref, which disagreed with itself: its fail branch already used the
+ * `--health-down` token while its success branch stayed on raw
+ * `text-emerald-500`. The raw Tailwind palette is not theme-adaptive here --
+ * `text-health-ok` / `text-health-down` are the tokens the rest of the app
+ * uses for exactly this ok/down semantic (52 and 70 call sites), so a success
+ * indicator rendered in emerald was the odd one out in both themes.
+ *
+ * `success == null` means the tier has no reading for that extrinsic (not a
+ * failure), so it renders the muted em-dash placeholder rather than "fail".
+ */
+export function SuccessBadge({ success }: { success?: boolean | null }) {
+  if (success == null) return <span className="text-ink-muted">—</span>;
+  return success ? (
+    <span className="text-health-ok">ok</span>
+  ) : (
+    <span className="text-health-down">fail</span>
+  );
+}

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -329,11 +329,18 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
                 {extrinsics.map((extrinsic) => {
                   const result =
                     extrinsic.success == null ? "—" : extrinsic.success ? "Success" : "Failed";
+                  // This table spells the result out ("Success"/"Failed")
+                  // rather than the feeds' "ok"/"fail", so it keeps its own
+                  // rendering instead of the shared SuccessBadge -- swapping it
+                  // in would silently reword the page. What it borrows is the
+                  // token pair: the fail branch already used --health-down
+                  // while success stayed on raw emerald, so the two halves of
+                  // one ternary disagreed (#6403).
                   const resultClass =
                     extrinsic.success == null
                       ? "text-ink-muted"
                       : extrinsic.success
-                        ? "text-emerald-500"
+                        ? "text-health-ok"
                         : "text-health-down";
 
                   return (

--- a/apps/ui/src/routes/extrinsics.index.tsx
+++ b/apps/ui/src/routes/extrinsics.index.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { ChevronLeft, ChevronRight, SlidersHorizontal } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { SuccessBadge } from "@/components/metagraphed/success-badge";
 import { useRefetchInterval } from "@/hooks/use-refetch-interval";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
@@ -152,15 +153,6 @@ function FeesTrendCard() {
         formatValue={formatTao}
       />
     </section>
-  );
-}
-
-function SuccessBadge({ success }: { success?: boolean | null }) {
-  if (success == null) return <span className="text-ink-muted">—</span>;
-  return success ? (
-    <span className="text-emerald-500">ok</span>
-  ) : (
-    <span className="text-rose-500">fail</span>
   );
 }
 


### PR DESCRIPTION
Closes #6403

## The bug

`extrinsics.index.tsx` and `call-module-extrinsics-table.tsx` each defined a **byte-identical** private `SuccessBadge` on raw `text-emerald-500`/`text-rose-500`. `blocks.$ref.tsx` implemented the same semantic inline while **disagreeing with itself** — its fail branch already used `text-health-down` while its success branch stayed on emerald.

The raw Tailwind palette isn't theme-adaptive for this semantic: `text-health-ok` / `text-health-down` are the tokens the rest of the app uses for exactly ok/down (**52** and **70** call sites), so an emerald success indicator was the odd one out in both themes.

## Screenshots

The `/extrinsics` feed's Result column. The change is a colour token, so the capture scrolls the table into frame and **reports the computed colour** rather than asking you to trust the pixels:

```
before: computed colour of the "ok" badge = lab(66.9756 -58.27 19.5419)   (emerald-500)
after:  computed colour of the "ok" badge = oklch(0.55 0.18 150)          (--health-ok)
"ok" badges on screen: 88
```

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6403/extrinsics-mobile-dark-after.png)<br><sub>after</sub> |

## The fix

- One shared `components/metagraphed/success-badge.tsx` on the health tokens. **Both** duplicate definitions are deleted and their call sites import it.
- `success == null` still renders the muted em-dash — the tier has no reading for that extrinsic, which is not a failure.
- **`blocks.$ref.tsx` deliberately keeps its own rendering** and takes the issue's second option ("or align its success branch to the same token"). That table spells the result out — **"Success"/"Failed"** — rather than the feeds' "ok"/"fail", so swapping in the shared badge would have silently reworded the page, a change the issue didn't ask for. What it borrows is the token pair, which is the actual defect.

## Verification

- No raw `text-emerald-500`/`text-rose-500` remains in any of the three files; exactly **one** `SuccessBadge` definition now exists in the app.
- **No new type errors: 34 before, 34 after** — every one pre-existing on clean `main` (a stale local ui-kit build reporting a `compact` prop mismatch, including in a file I touched; I verified the count against a clean checkout rather than assume).
- `eslint` on the committed blobs: **0 errors**. `prettier --check`: clean.
- Rebased onto a main that moved 3 commits mid-work; pushed at `behind: 0`.
