### PR TITLE
fix(api): read System::Account storage for account balance

### DIFF
--- a/src/account-balance.mjs
+++ b/src/account-balance.mjs
@@ -27,6 +27,24 @@ export const BALANCE_NEGATIVE_KV_TTL = 10; // seconds
 export const BALANCE_RPC_TIMEOUT_MS = 5000;
 const FINNEY_RPC_URL = "https://entrypoint-finney.opentensor.ai:443";
 
+// System::Account(AccountId) storage prefix = twox128("System") ++ twox128("Account").
+// Hard-coded: both halves are fixed runtime constants (the pallet/storage names
+// never change), and computing them would need an xxhash dependency this repo
+// doesn't carry — whereas blake2_128Concat below reuses the @noble/hashes blake2b
+// already imported for the SS58 checksum. Verified against a live finney
+// state_getStorage response.
+const SYSTEM_ACCOUNT_STORAGE_PREFIX =
+  "26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9";
+const ACCOUNT_ID_LENGTH = 32;
+// SCALE AccountInfo: nonce/consumers/providers/sufficients (u32 LE each = 16
+// bytes), then AccountData whose first two fields are free + reserved (u128 LE
+// each). Only free+reserved are read; the trailing frozen/flags (or legacy
+// misc_frozen/fee_frozen) fields are ignored, so both AccountData layouts decode.
+const ACCOUNT_DATA_FREE_OFFSET = 16;
+const ACCOUNT_DATA_RESERVED_OFFSET = 32;
+const U128_BYTES = 16;
+const RAO_PER_TAO = 1_000_000_000n;
+
 function decodeBase58(value) {
   const bytes = [0];
   for (const char of value) {
@@ -82,6 +100,67 @@ export function isFinneySs58Address(value) {
   );
 }
 
+function toHex(bytes) {
+  let out = "";
+  for (const byte of bytes) out += byte.toString(16).padStart(2, "0");
+  return out;
+}
+
+function hexToBytes(hex) {
+  const body = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (body.length === 0 || body.length % 2 !== 0) return null;
+  const bytes = new Uint8Array(body.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    const byte = Number.parseInt(body.slice(index * 2, index * 2 + 2), 16);
+    if (Number.isNaN(byte)) return null;
+    bytes[index] = byte;
+  }
+  return bytes;
+}
+
+function readU128Le(bytes, offset) {
+  let value = 0n;
+  for (let index = U128_BYTES - 1; index >= 0; index -= 1) {
+    value = (value << 8n) | BigInt(bytes[offset + index]);
+  }
+  return value;
+}
+
+// The 32-byte AccountId inside a finney SS58 (prefix byte, then AccountId32, then
+// the 2-byte checksum). Callers shape-check the address with isFinneySs58Address.
+function accountIdFromSs58(ss58) {
+  const decoded = decodeBase58(ss58);
+  if (decoded?.length !== FINNEY_SS58_DECODED_LENGTH) return null;
+  return decoded.subarray(1, 1 + ACCOUNT_ID_LENGTH);
+}
+
+// System::Account(accountId) = twox128("System") ++ twox128("Account")
+// ++ blake2_128Concat(accountId), where blake2_128Concat(x) = blake2b-128(x) ++ x.
+export function systemAccountStorageKey(accountId) {
+  return `0x${SYSTEM_ACCOUNT_STORAGE_PREFIX}${toHex(
+    blake2b(accountId, { dkLen: 16 }),
+  )}${toHex(accountId)}`;
+}
+
+// free + reserved (in rao) from a state_getStorage AccountInfo response, or null
+// when the node reported an error or returned an undecodable blob.
+export function accountInfoTotalRao(rpcBody) {
+  if (!rpcBody || rpcBody.error) return null;
+  const result = rpcBody.result;
+  // A never-seen account has no System::Account entry at all — that is a
+  // successful read of a zero balance, not an RPC failure.
+  if (result == null) return 0n;
+  if (typeof result !== "string") return null;
+  const bytes = hexToBytes(result);
+  if (!bytes || bytes.length < ACCOUNT_DATA_RESERVED_OFFSET + U128_BYTES) {
+    return null;
+  }
+  return (
+    readU128Le(bytes, ACCOUNT_DATA_FREE_OFFSET) +
+    readU128Le(bytes, ACCOUNT_DATA_RESERVED_OFFSET)
+  );
+}
+
 // Query live balance for one finney ss58. Uses METAGRAPH_CONTROL KV (60s TTL) when
 // present; balance_tao is null on RPC failure (schema-stable, never throws).
 export async function loadAccountBalance(env, ss58) {
@@ -102,6 +181,10 @@ export async function loadAccountBalance(env, ss58) {
   let rpcOk = false;
 
   try {
+    // `system_account` is NOT a real RPC method (finney answers -32601 "Method
+    // not found"), so this route returned null for every address (#6506). Read
+    // the System::Account storage entry directly instead — the same thing the
+    // absent method would have wrapped.
     const rpcResp = await fetch(FINNEY_RPC_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -109,24 +192,17 @@ export async function loadAccountBalance(env, ss58) {
       body: JSON.stringify({
         jsonrpc: "2.0",
         id: 1,
-        method: "system_account",
-        params: [ss58],
+        method: "state_getStorage",
+        params: [systemAccountStorageKey(accountIdFromSs58(ss58))],
       }),
     });
     if (rpcResp.ok) {
-      const rpcBody = await rpcResp.json();
-      const data = rpcBody?.result?.data;
-      if (data && typeof data.free !== "undefined") {
+      const totalRao = accountInfoTotalRao(await rpcResp.json());
+      if (totalRao != null) {
         // Sum in BigInt rao space, then divide once — avoids float precision loss
         // on large on-chain balances before converting the remainder to TAO.
-        const toRao = (v) =>
-          typeof v === "string"
-            ? BigInt(v)
-            : BigInt(Math.trunc(Number(v ?? 0)));
-        const totalRao = toRao(data.free) + toRao(data.reserved);
         balanceTao =
-          Number(totalRao / 1_000_000_000n) +
-          Number(totalRao % 1_000_000_000n) / 1e9;
+          Number(totalRao / RAO_PER_TAO) + Number(totalRao % RAO_PER_TAO) / 1e9;
         rpcOk = true;
       }
     }

--- a/tests/account-balance-loader.test.mjs
+++ b/tests/account-balance-loader.test.mjs
@@ -1,13 +1,32 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  accountInfoTotalRao,
   BALANCE_NEGATIVE_KV_TTL,
   BALANCE_RPC_TIMEOUT_MS,
   isFinneySs58Address,
   loadAccountBalance,
+  systemAccountStorageKey,
 } from "../src/account-balance.mjs";
 
 const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+// A SCALE-encoded AccountInfo blob: nonce/consumers/providers/sufficients
+// (u32 LE each) then AccountData's free + reserved (u128 LE each).
+function accountInfoHex(freeRao, reservedRao) {
+  const u128 = (value) => {
+    let hex = "";
+    let rest = BigInt(value);
+    for (let index = 0; index < 16; index += 1) {
+      hex += Number(rest & 0xffn)
+        .toString(16)
+        .padStart(2, "0");
+      rest >>= 8n;
+    }
+    return hex;
+  };
+  return `0x${"00000000".repeat(4)}${u128(freeRao)}${u128(reservedRao)}`;
+}
 
 describe("isFinneySs58Address", () => {
   test("accepts a valid finney address", () => {
@@ -30,39 +49,132 @@ describe("isFinneySs58Address", () => {
   });
 });
 
+describe("systemAccountStorageKey", () => {
+  test("derives twox128(System)++twox128(Account)++blake2_128Concat(accountId)", () => {
+    const accountId = Uint8Array.from({ length: 32 }, (_, i) => i);
+    const key = systemAccountStorageKey(accountId);
+    // 0x + 32-byte prefix + 16-byte blake2_128 + 32-byte accountId = 160 hex chars.
+    assert.equal(key.length, 2 + 64 + 32 + 64);
+    assert.match(
+      key,
+      /^0x26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9/,
+    );
+    // blake2_128Concat appends the raw key, so the accountId is the tail verbatim.
+    assert.ok(
+      key.endsWith(
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+      ),
+    );
+  });
+});
+
+describe("accountInfoTotalRao", () => {
+  test("sums free + reserved from a SCALE AccountInfo blob", () => {
+    assert.equal(accountInfoTotalRao({ result: accountInfoHex(7n, 3n) }), 10n);
+  });
+
+  test("treats an absent storage entry as a zero balance", () => {
+    assert.equal(accountInfoTotalRao({ result: null }), 0n);
+  });
+
+  test("returns null for an RPC error, a missing body, or a non-string result", () => {
+    assert.equal(accountInfoTotalRao({ error: { code: -32601 } }), null);
+    assert.equal(accountInfoTotalRao(null), null);
+    assert.equal(accountInfoTotalRao({ result: 42 }), null);
+  });
+
+  test("returns null for a truncated or non-hex blob", () => {
+    assert.equal(accountInfoTotalRao({ result: "0xdeadbeef" }), null);
+    assert.equal(accountInfoTotalRao({ result: "0xzz" }), null);
+    assert.equal(accountInfoTotalRao({ result: "0x123" }), null);
+    assert.equal(accountInfoTotalRao({ result: "0x" }), null);
+  });
+
+  test("tolerates a blob without the 0x prefix", () => {
+    assert.equal(
+      accountInfoTotalRao({ result: accountInfoHex(7n, 3n).slice(2) }),
+      10n,
+    );
+  });
+});
+
 describe("loadAccountBalance", () => {
-  test("decodes hex-encoded rao balances from finney RPC", async () => {
+  test("reads System::Account storage and sums free + reserved into TAO", async () => {
     const orig = globalThis.fetch;
-    globalThis.fetch = async () => ({
-      ok: true,
-      json: async () => ({
-        jsonrpc: "2.0",
-        id: 1,
-        result: { data: { free: "0x77359400", reserved: "0x1dcd6500" } },
-      }),
-    });
+    let sentBody;
+    globalThis.fetch = async (_url, init) => {
+      sentBody = JSON.parse(init.body);
+      return {
+        ok: true,
+        json: async () => ({
+          jsonrpc: "2.0",
+          id: 1,
+          result: accountInfoHex(2_000_000_000n, 500_000_000n),
+        }),
+      };
+    };
     try {
       const data = await loadAccountBalance({}, SS58);
       assert.equal(data.ss58, SS58);
       assert.equal(data.balance_tao, 2.5);
+      // #6506: system_account is not a real RPC method — the loader must do a
+      // raw System::Account storage read instead.
+      assert.equal(sentBody.method, "state_getStorage");
+      assert.match(sentBody.params[0], /^0x26aa394eea5630e07c48ae0c9558cef7/);
     } finally {
       globalThis.fetch = orig;
     }
   });
 
-  test("decodes numeric rao balances from finney RPC", async () => {
+  test("returns balance_tao:null for an address that isn't a decodable ss58", async () => {
+    // Routes shape-check with isFinneySs58Address first, but the loader itself
+    // must stay schema-stable rather than throw if handed a bad address.
+    const orig = globalThis.fetch;
+    let fetched = false;
+    globalThis.fetch = async () => {
+      fetched = true;
+      return { ok: true, json: async () => ({ result: null }) };
+    };
+    try {
+      const data = await loadAccountBalance({}, "notavalidss58address");
+      assert.equal(data.balance_tao, null);
+      assert.equal(
+        fetched,
+        false,
+        "must not query the node without an AccountId",
+      );
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  test("resolves a never-seen account (no storage entry) to 0, not null", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({ jsonrpc: "2.0", id: 1, result: null }),
+    });
+    try {
+      const data = await loadAccountBalance({}, SS58);
+      assert.equal(data.balance_tao, 0);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  test("returns balance_tao:null when the node reports an RPC error", async () => {
     const orig = globalThis.fetch;
     globalThis.fetch = async () => ({
       ok: true,
       json: async () => ({
         jsonrpc: "2.0",
         id: 1,
-        result: { data: { free: 2_000_000_000, reserved: 500_000_000 } },
+        error: { code: -32601, message: "Method not found" },
       }),
     });
     try {
       const data = await loadAccountBalance({}, SS58);
-      assert.equal(data.balance_tao, 2.5);
+      assert.equal(data.balance_tao, null);
     } finally {
       globalThis.fetch = orig;
     }

--- a/tests/account-balance.test.mjs
+++ b/tests/account-balance.test.mjs
@@ -17,6 +17,23 @@ function withFetchStub(stub, fn) {
   });
 }
 
+// A SCALE-encoded AccountInfo blob (#6506): nonce/consumers/providers/sufficients
+// (u32 LE each), then AccountData's free + reserved (u128 LE each).
+function accountInfoHex(freeRao, reservedRao = 0n) {
+  const u128 = (value) => {
+    let hex = "";
+    let rest = BigInt(value);
+    for (let index = 0; index < 16; index += 1) {
+      hex += Number(rest & 0xffn)
+        .toString(16)
+        .padStart(2, "0");
+      rest >>= 8n;
+    }
+    return hex;
+  };
+  return `0x${"00000000".repeat(4)}${u128(freeRao)}${u128(reservedRao)}`;
+}
+
 test("GET /accounts/{ss58}/balance returns balance_tao for a valid address", async () => {
   await withFetchStub(
     async (_url, _init) => ({
@@ -24,7 +41,13 @@ test("GET /accounts/{ss58}/balance returns balance_tao for a valid address", asy
       json: async () => ({
         jsonrpc: "2.0",
         id: 1,
-        result: { data: { free: 2_000_000_000, reserved: 500_000_000 } },
+        // SCALE AccountInfo (#6506): nonce/consumers/providers/sufficients
+        // (u32 LE each), then free = 2_000_000_000 and reserved = 500_000_000
+        // (u128 LE each) = 2_500_000_000 rao = 2.5 TAO.
+        result:
+          `0x${"00000000".repeat(4)}` +
+          "00943577000000000000000000000000" +
+          "0065cd1d000000000000000000000000",
       }),
     }),
     async () => {
@@ -105,17 +128,13 @@ test("GET /accounts/{ss58}/balance rejects overlong base58 before rate limiting 
 });
 
 test("GET /accounts/{ss58}/balance returns 200 with balance_tao:null on RPC failure", async () => {
-  // No fetch mock — the Worker's global fetch will fail or env has no fetch.
-  // Simulate by providing an env whose fetch throws.
-  const env = {
-    fetch: async () => {
+  // The loader calls globalThis.fetch, so stub that to throw (#6506: this used to
+  // pass only because the real RPC rejected the bogus system_account method).
+  const res = await withFetchStub(
+    async () => {
       throw new Error("network error");
     },
-  };
-  const res = await handleRequest(
-    req(`/api/v1/accounts/${SS58}/balance`),
-    env,
-    {},
+    () => handleRequest(req(`/api/v1/accounts/${SS58}/balance`), {}, {}),
   );
   assert.equal(res.status, 200);
   const body = await res.json();
@@ -208,12 +227,8 @@ test("GET /accounts/{ss58}/balance decodes hex-encoded rao balances", async () =
       json: async () => ({
         jsonrpc: "2.0",
         id: 1,
-        result: {
-          data: {
-            free: "0x77359400", // 2_000_000_000 rao in hex
-            reserved: "0x1DCD6500", // 500_000_000 rao in hex
-          },
-        },
+        // free 2_000_000_000 + reserved 500_000_000 rao = 2.5 TAO
+        result: accountInfoHex(2_000_000_000n, 500_000_000n),
       }),
     }),
     async () => {
@@ -248,7 +263,7 @@ test("GET /accounts/{ss58}/balance keeps u128 rao precision above 2^53 (#2070)",
       json: async () => ({
         jsonrpc: "2.0",
         id: 1,
-        result: { data: { free: `0x${freeRao.toString(16)}` } },
+        result: accountInfoHex(freeRao),
       }),
     }),
     async () => {
@@ -285,7 +300,7 @@ test("GET /accounts/{ss58}/balance returns null when RPC data.free is absent", a
   await withFetchStub(
     async () => ({
       ok: true,
-      json: async () => ({ jsonrpc: "2.0", id: 1, result: { data: {} } }),
+      json: async () => ({ jsonrpc: "2.0", id: 1, result: "0xdeadbeef" }),
     }),
     async () => {
       const res = await handleRequest(
@@ -317,7 +332,7 @@ test("GET /accounts/{ss58}/balance writes to KV on successful RPC fetch", async 
       json: async () => ({
         jsonrpc: "2.0",
         id: 1,
-        result: { data: { free: 1_000_000_000, reserved: 0 } },
+        result: accountInfoHex(1_000_000_000n),
       }),
     }),
     async () => {
@@ -348,7 +363,7 @@ test("GET /accounts/{ss58}/balance tolerates KV write failure", async () => {
       json: async () => ({
         jsonrpc: "2.0",
         id: 1,
-        result: { data: { free: 1_000_000_000, reserved: 0 } },
+        result: accountInfoHex(1_000_000_000n),
       }),
     }),
     async () => {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -12223,7 +12223,13 @@ describe("graphql — account_balance (#5700, live chain RPC via account-balance
         json: async () => ({
           jsonrpc: "2.0",
           id: 1,
-          result: { data: { free: 2_000_000_000, reserved: 500_000_000 } },
+          // SCALE AccountInfo (#6506): u32 nonce/consumers/providers/sufficients,
+          // then free 2_000_000_000 + reserved 500_000_000 rao (u128 LE) = 2.5 TAO.
+          result:
+            "0x" +
+            "00000000".repeat(4) +
+            "00943577000000000000000000000000" +
+            "0065cd1d000000000000000000000000",
         }),
       }),
       async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -11648,7 +11648,13 @@ describe("MCP account tools (get_account + events + subnets)", () => {
       json: async () => ({
         jsonrpc: "2.0",
         id: 1,
-        result: { data: { free: 2_000_000_000, reserved: 500_000_000 } },
+        // SCALE AccountInfo (#6506): u32 nonce/consumers/providers/sufficients,
+        // then free 2_000_000_000 + reserved 500_000_000 rao (u128 LE) = 2.5 TAO.
+        result:
+          "0x" +
+          "00000000".repeat(4) +
+          "00943577000000000000000000000000" +
+          "0065cd1d000000000000000000000000",
       }),
     });
     try {


### PR DESCRIPTION
## The bug

`GET /api/v1/accounts/{ss58}/balance` (plus the mirrored MCP `get_account_balance` and GraphQL `account_balance`) returned `balance_tao: null` for **every** address. `loadAccountBalance` called finney with `system_account` — **not a real RPC method**; the node answers `-32601 Method not found`, so `result.data.free` was never present and the balance silently fell through to null. It has never worked. No test caught it because every test mocked the response shape the absent method *would* have returned.

## The fix

Read the account's `System::Account` storage entry directly:

1. **Storage key** — `twox128("System") ++ twox128("Account") ++ blake2_128Concat(accountId)`. The two `twox128` halves are fixed runtime constants, so they're hard-coded (avoids adding an xxhash dependency); `blake2_128Concat` reuses the `@noble/hashes` blake2b already imported for the SS58 checksum.
2. **`state_getStorage`** with that key.
3. **SCALE-decode `AccountInfo`** — `nonce`/`consumers`/`providers`/`sufficients` (u32 LE each), then `AccountData`'s `free` + `reserved` (u128 LE each). Only `free`+`reserved` are read, so both the current `frozen`/`flags` and the legacy `misc_frozen`/`fee_frozen` `AccountData` layouts decode identically.

## Verified against live finney

Addresses that previously returned `null` now return real balances:

| address | before | after |
| --- | --- | --- |
| `5G9hfkx9wGB1…` | `null` | **0.137208108 TAO** |
| `5F4tQyWrhfGV…` | `null` | **5e-7 TAO** |

(Both small because staked TAO lives in SubtensorModule — `System::Account` holds `free`/`reserved`, which is exactly what this route reports.)

Contract is unchanged: an account with **no storage entry** resolves to `0` (a successful read of a zero balance), while RPC errors, undecodable blobs, and timeouts still resolve to `null`. KV positive/negative caching untouched.

## Tests

`systemAccountStorageKey` and `accountInfoTotalRao` are exported as pure functions and unit-tested per branch (blob decode, absent entry → `0`, RPC error / missing body / non-string result → `null`, truncated + non-hex blobs, missing `0x` prefix). Loader tests assert it now sends `state_getStorage` with a `System::Account`-prefixed key, and that a non-decodable address stays null without querying the node.

Tests mocking the old `system_account` shape are updated to the storage blob — in `account-balance*`, `graphql`, and `mcp-server`. That includes `tests/account-balance.test.mjs`'s RPC-failure case, which **only passed because the real RPC rejected the bogus method** and never stubbed `fetch`; it now stubs a throwing fetch properly.

100% line + branch coverage on every changed line locally; no new test failures across the affected suites.

Closes #6506