### PR TITLE
fix(api): compensate for the missing self-stake row in account positions

### DIFF
--- a/src/account-nominator-positions.mjs
+++ b/src/account-nominator-positions.mjs
@@ -142,6 +142,64 @@ export function distinctHotkeys(positionRows) {
   return [...seen];
 }
 
+// #6507: nominator_positions (the box-side Alpha-scan sync, outside this
+// repo) systematically misses a coldkey's own self-stake on a hotkey it
+// owns -- confirmed against real SN1 validator coldkeys showing
+// position_count: 0 despite 100K+ TAO of self-stake, while correctly
+// capturing THIRD-PARTY delegations on other hotkeys. The actual scan/sync
+// script can't be fixed from this repo, so this compensates at the read
+// layer instead: for every (hotkey, netuid) the queried coldkey is the
+// REGISTERING owner of (neurons.coldkey) but has no captured position row
+// for, synthesize one holding the residual share -- 1 minus every OTHER
+// coldkey's already-captured share_fraction for that same hotkey+netuid
+// (the correctly-synced third-party rows).
+//
+// Approximation, not a real ledger row: if some OTHER coldkey's delegation
+// on that hotkey is ALSO missing from the sync (not just self-stake), this
+// overcounts by that amount. But self-stake is virtually always a hotkey's
+// largest position, so this closes the dominant, confirmed gap without
+// waiting on an out-of-repo fix. `captured_at` is left null (there is no
+// real capture timestamp for a synthesized row); buildAccountPositions
+// already treats a null captured_at as "excluded from latestCapturedAt",
+// same as any other row with a blank/absent timestamp.
+export function ownedHotkeySelfStakeRows(
+  ownedRows,
+  positionRows,
+  otherCapturedFractionByKey,
+  ss58,
+) {
+  const covered = new Set(
+    (Array.isArray(positionRows) ? positionRows : []).map(
+      (row) => `${row?.hotkey}|${row?.netuid}`,
+    ),
+  );
+  const fractionByKey =
+    otherCapturedFractionByKey instanceof Map
+      ? otherCapturedFractionByKey
+      : new Map();
+  const seenOwned = new Set();
+  const out = [];
+  for (const row of Array.isArray(ownedRows) ? ownedRows : []) {
+    const hotkey = typeof row?.hotkey === "string" ? row.hotkey : null;
+    const netuid = nonNegativeInt(row?.netuid);
+    if (!hotkey || netuid == null) continue;
+    const key = `${hotkey}|${netuid}`;
+    if (covered.has(key) || seenOwned.has(key)) continue;
+    seenOwned.add(key);
+    const otherFraction = fractionByKey.get(key) ?? 0;
+    const residual = 1 - otherFraction;
+    if (!(residual > 0)) continue;
+    out.push({
+      coldkey: ss58,
+      hotkey,
+      netuid,
+      share_fraction: residual,
+      captured_at: null,
+    });
+  }
+  return out;
+}
+
 // Postgres neurons rows (hotkey, netuid, stake_tao) -> a "hotkey|netuid" ->
 // stake_tao Map, for buildAccountPositions' join above.
 export function stakeByHotkeyNetuid(neuronRows) {

--- a/tests/account-nominator-positions.test.mjs
+++ b/tests/account-nominator-positions.test.mjs
@@ -5,6 +5,7 @@ import {
   NOMINATOR_POSITION_INSERT_COLUMNS,
   buildAccountPositions,
   distinctHotkeys,
+  ownedHotkeySelfStakeRows,
   stakeByHotkeyNetuid,
 } from "../src/account-nominator-positions.mjs";
 import { handleRequest } from "../workers/api.mjs";
@@ -131,6 +132,131 @@ describe("distinctHotkeys", () => {
   test("is cold-safe and skips blank hotkeys", () => {
     assert.deepEqual(distinctHotkeys(null), []);
     assert.deepEqual(distinctHotkeys([{ hotkey: "" }, { hotkey: null }]), []);
+  });
+});
+
+describe("ownedHotkeySelfStakeRows (#6507)", () => {
+  test("synthesizes the residual share for an owned hotkey with no captured position row", () => {
+    const rows = ownedHotkeySelfStakeRows(
+      [{ hotkey: "5Validator", netuid: 1 }],
+      [], // no existing nominator_positions rows for this coldkey at all
+      new Map([["5Validator|1", 0.15]]), // other coldkeys already hold 15%
+      "5Owner",
+    );
+    assert.deepEqual(rows, [
+      {
+        coldkey: "5Owner",
+        hotkey: "5Validator",
+        netuid: 1,
+        share_fraction: 0.85,
+        captured_at: null,
+      },
+    ]);
+  });
+
+  test("assumes 100% self-stake when no other coldkey has captured anything", () => {
+    const rows = ownedHotkeySelfStakeRows(
+      [{ hotkey: "5Validator", netuid: 1 }],
+      [],
+      new Map(), // empty -- no other coldkey has any captured share
+      "5Owner",
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].share_fraction, 1);
+  });
+
+  test("does not synthesize a row for an owned (hotkey, netuid) already covered by a real position row", () => {
+    const rows = ownedHotkeySelfStakeRows(
+      [{ hotkey: "5Validator", netuid: 1 }],
+      [
+        {
+          coldkey: "5Owner",
+          hotkey: "5Validator",
+          netuid: 1,
+          share_fraction: 0.9,
+          captured_at: 123,
+        },
+      ],
+      new Map([["5Validator|1", 0.1]]),
+      "5Owner",
+    );
+    assert.deepEqual(rows, []);
+  });
+
+  test("only fills the specific missing (hotkey, netuid) pair -- a covered netuid on the same owned hotkey is left alone", () => {
+    const rows = ownedHotkeySelfStakeRows(
+      [
+        { hotkey: "5Validator", netuid: 1 },
+        { hotkey: "5Validator", netuid: 2 },
+      ],
+      [
+        {
+          coldkey: "5Owner",
+          hotkey: "5Validator",
+          netuid: 1,
+          share_fraction: 0.9,
+          captured_at: 123,
+        },
+      ],
+      new Map([["5Validator|2", 0.2]]),
+      "5Owner",
+    );
+    assert.deepEqual(rows, [
+      {
+        coldkey: "5Owner",
+        hotkey: "5Validator",
+        netuid: 2,
+        share_fraction: 0.8,
+        captured_at: null,
+      },
+    ]);
+  });
+
+  test("skips a would-be-zero-or-negative residual (every other coldkey already accounts for the full share)", () => {
+    const rows = ownedHotkeySelfStakeRows(
+      [{ hotkey: "5Validator", netuid: 1 }],
+      [],
+      new Map([["5Validator|1", 1]]),
+      "5Owner",
+    );
+    assert.deepEqual(rows, []);
+  });
+
+  test("dedupes a duplicated owned-row entry for the same (hotkey, netuid)", () => {
+    const rows = ownedHotkeySelfStakeRows(
+      [
+        { hotkey: "5Validator", netuid: 1 },
+        { hotkey: "5Validator", netuid: 1 },
+      ],
+      [],
+      new Map(),
+      "5Owner",
+    );
+    assert.equal(rows.length, 1);
+  });
+
+  test("is cold-safe: null/blank owned rows, a null positionRows, and a non-Map fraction lookup never throw", () => {
+    assert.deepEqual(ownedHotkeySelfStakeRows(null, [], null, "5Owner"), []);
+    assert.deepEqual(
+      ownedHotkeySelfStakeRows(
+        [{ hotkey: "", netuid: 1 }, { hotkey: "5Validator", netuid: -1 }, {}],
+        [],
+        new Map(),
+        "5Owner",
+      ),
+      [],
+    );
+    // positionRows itself (not just ownedRows) is null-safe -- the "covered"
+    // set falls back to empty rather than throwing on Array.isArray(null).
+    assert.equal(
+      ownedHotkeySelfStakeRows(
+        [{ hotkey: "5Validator", netuid: 1 }],
+        null,
+        new Map(),
+        "5Owner",
+      ).length,
+      1,
+    );
   });
 });
 

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -116,6 +116,17 @@ const nominatorPositionsSyncFailure = vi.hoisted(() => ({ error: null }));
 // isolation purpose as subnetTemposQueryFailure above, but for
 // loadNominatorPositions' own SELECT.
 const nominatorPositionsQueryFailure = vi.hoisted(() => ({ error: null }));
+// State for loadOtherCapturedFractionByHotkeys' own SELECT (#6507's
+// self-stake fallback) -- dispatched by its own distinctive text match (the
+// SUM(share_fraction) aggregate, unique to this query) rather than the
+// shared mockRows.current, since loadNeuronStakeByHotkeys is ALSO an
+// sql.unsafe call in the same route and would otherwise collide on it.
+const otherCapturedFractionRows = vi.hoisted(() => ({ current: [] }));
+const otherCapturedFractionQueryFailure = vi.hoisted(() => ({ error: null }));
+// State for loadOwnedHotkeyPositions' own SELECT (#6507) -- same isolation
+// purpose as nominatorPositionsQueryFailure above, but for the
+// `FROM neurons WHERE coldkey` query specifically.
+const ownedHotkeyPositionsQueryFailure = vi.hoisted(() => ({ error: null }));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -201,6 +212,12 @@ vi.mock("postgres", () => ({
         /FROM nominator_positions\b/.test(text)
       ) {
         return Promise.reject(nominatorPositionsQueryFailure.error);
+      }
+      if (
+        ownedHotkeyPositionsQueryFailure.error &&
+        /FROM neurons WHERE coldkey\b/.test(text)
+      ) {
+        return Promise.reject(ownedHotkeyPositionsQueryFailure.error);
       }
       if (
         subnetSnapshotSyncFailure.error &&
@@ -296,6 +313,12 @@ vi.mock("postgres", () => ({
           return Promise.reject(accountIdentityJoinQueryFailure.error);
         }
         return Promise.resolve(accountIdentityJoinRows.current);
+      }
+      if (/SUM\(share_fraction\) AS other_fraction/.test(text)) {
+        if (otherCapturedFractionQueryFailure.error) {
+          return Promise.reject(otherCapturedFractionQueryFailure.error);
+        }
+        return Promise.resolve(otherCapturedFractionRows.current);
       }
       return Promise.resolve(mockRows.current);
     };
@@ -397,6 +420,9 @@ beforeEach(() => {
   featuredValidatorsQueryFailure.error = null;
   accountIdentityJoinRows.current = [];
   accountIdentityJoinQueryFailure.error = null;
+  otherCapturedFractionRows.current = [];
+  otherCapturedFractionQueryFailure.error = null;
+  ownedHotkeyPositionsQueryFailure.error = null;
   mockRows.current = [
     {
       block_number: "123",
@@ -4837,11 +4863,13 @@ test("nominator-positions-sync issues a single INSERT for a payload at or under 
 });
 
 test("GET /api/v1/accounts/:ss58/positions joins share_fraction against live neurons stake_tao (#5233)", async () => {
-  // loadNominatorPositions is a plain tagged-template call -- consumes
-  // mockQueue. loadNeuronStakeByHotkeys goes through sql.unsafe (an IN-list
-  // query), which this mock always answers from mockRows.current regardless
-  // of mockQueue (see the sql.unsafe branch's own fallback), so the two rows
-  // are primed separately rather than both queued.
+  // loadNominatorPositions and loadOwnedHotkeyPositions (#6507) are both
+  // plain tagged-template calls -- consume mockQueue in order.
+  // loadOtherCapturedFractionByHotkeys short-circuits without a query since
+  // loadOwnedHotkeyPositions returns no rows (distinctHotkeys is empty).
+  // loadNeuronStakeByHotkeys goes through sql.unsafe (an IN-list query),
+  // which this mock always answers from mockRows.current regardless of
+  // mockQueue, so that one row is primed separately rather than queued.
   mockQueue.current = [
     [], // sql.begin's leading `SET statement_timeout`
     [
@@ -4853,12 +4881,14 @@ test("GET /api/v1/accounts/:ss58/positions joins share_fraction against live neu
         captured_at: "1780000000000",
       },
     ], // loadNominatorPositions
+    [], // loadOwnedHotkeyPositions -- this coldkey owns no hotkeys
   ];
   mockRows.current = [{ hotkey: "5Hk1", netuid: 3, stake_tao: "1000" }]; // loadNeuronStakeByHotkeys
   const res = await req("/api/v1/accounts/5Cold1/positions");
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(queryText()).toMatch(/FROM nominator_positions WHERE coldkey/);
+  expect(queryText()).toMatch(/FROM neurons WHERE coldkey/);
   expect(queryText()).toMatch(/FROM neurons WHERE hotkey IN/);
   expect(body.ss58).toBe("5Cold1");
   expect(body.position_count).toBe(1);
@@ -4869,7 +4899,8 @@ test("GET /api/v1/accounts/:ss58/positions joins share_fraction against live neu
 test("GET /api/v1/accounts/:ss58/positions returns an empty card for a coldkey with no positions", async () => {
   mockQueue.current = [
     [], // sql.begin's leading `SET statement_timeout`
-    [], // loadNominatorPositions -- no rows, so distinctHotkeys is empty and loadNeuronStakeByHotkeys short-circuits without a query
+    [], // loadNominatorPositions -- no rows
+    [], // loadOwnedHotkeyPositions -- owns no hotkeys either, so distinctHotkeys is empty and both loadOtherCapturedFractionByHotkeys and loadNeuronStakeByHotkeys short-circuit without a query
   ];
   const res = await req("/api/v1/accounts/5NoPositions/positions");
   expect(res.status).toBe(200);
@@ -4877,6 +4908,128 @@ test("GET /api/v1/accounts/:ss58/positions returns an empty card for a coldkey w
   expect(body.position_count).toBe(0);
   expect(body.total_stake_tao).toBe(0);
   expect(body.positions).toEqual([]);
+});
+
+test("GET /api/v1/accounts/:ss58/positions fills in the owning coldkey's missing self-stake (#6507)", async () => {
+  // This coldkey has no captured nominator_positions row at all, but owns
+  // (registered) hotkey 5Validator in netuid 1 -- the exact real-world shape
+  // the issue reports (e.g. position_count: 0 despite 100K+ TAO self-stake).
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [], // loadNominatorPositions -- no captured rows for this coldkey
+    [{ hotkey: "5Validator", netuid: 1 }], // loadOwnedHotkeyPositions
+  ];
+  // Two other coldkeys already correctly hold 15% combined -- matches the
+  // issue's own repro where third-party delegations DO show up correctly.
+  otherCapturedFractionRows.current = [
+    { hotkey: "5Validator", netuid: 1, other_fraction: "0.15" },
+  ];
+  mockRows.current = [{ hotkey: "5Validator", netuid: 1, stake_tao: "166000" }]; // loadNeuronStakeByHotkeys
+  const res = await req("/api/v1/accounts/5Owner/positions");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(queryText()).toMatch(/SUM\(share_fraction\) AS other_fraction/);
+  expect(body.position_count).toBe(1);
+  expect(body.positions[0].hotkey).toBe("5Validator");
+  expect(body.positions[0].share_fraction).toBeCloseTo(0.85);
+  expect(body.positions[0].stake_tao).toBeCloseTo(141100);
+  expect(body.total_stake_tao).toBeCloseTo(141100);
+});
+
+test("GET /api/v1/accounts/:ss58/positions does not duplicate an owned hotkey's already-captured position row", async () => {
+  // This coldkey already HAS a real nominator_positions row for the hotkey
+  // it owns -- the sync isn't broken for this specific (hotkey, netuid), so
+  // no synthesized row should be added on top of it.
+  mockQueue.current = [
+    [],
+    [
+      {
+        coldkey: "5Owner",
+        hotkey: "5Validator",
+        netuid: 1,
+        share_fraction: 0.9,
+        captured_at: "1780000000000",
+      },
+    ], // loadNominatorPositions
+    [{ hotkey: "5Validator", netuid: 1 }], // loadOwnedHotkeyPositions
+  ];
+  mockRows.current = [{ hotkey: "5Validator", netuid: 1, stake_tao: "1000" }];
+  const res = await req("/api/v1/accounts/5Owner/positions");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.position_count).toBe(1);
+  expect(body.positions[0].share_fraction).toBeCloseTo(0.9);
+});
+
+test("GET /api/v1/accounts/:ss58/positions treats a missing other_fraction cell as zero already-captured (full self-stake residual)", async () => {
+  mockQueue.current = [
+    [],
+    [], // loadNominatorPositions -- no captured rows
+    [{ hotkey: "5Validator", netuid: 1 }], // loadOwnedHotkeyPositions
+  ];
+  // A row with no other_fraction cell at all (not even null) -- Number(undefined)
+  // is NaN, exercising the `|| 0` fallback rather than a real captured amount.
+  otherCapturedFractionRows.current = [{ hotkey: "5Validator", netuid: 1 }];
+  mockRows.current = [{ hotkey: "5Validator", netuid: 1, stake_tao: "1000" }];
+  const res = await req("/api/v1/accounts/5Owner/positions");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.position_count).toBe(1);
+  expect(body.positions[0].share_fraction).toBeCloseTo(1);
+  expect(body.positions[0].stake_tao).toBeCloseTo(1000);
+});
+
+test("GET /api/v1/accounts/:ss58/positions still serves the real positions when the owned-hotkey lookup fails", async () => {
+  // #6507's fallback is a compensating read, not a hard dependency -- a
+  // failure in the new owned-hotkey lookup must not break the route's
+  // existing, already-captured positions.
+  ownedHotkeyPositionsQueryFailure.error = new Error(
+    'relation "neurons" does not exist',
+  );
+  mockQueue.current = [
+    [],
+    [
+      {
+        coldkey: "5Cold1",
+        hotkey: "5Hk1",
+        netuid: 3,
+        share_fraction: 0.25,
+        captured_at: "1780000000000",
+      },
+    ], // loadNominatorPositions
+  ];
+  mockRows.current = [{ hotkey: "5Hk1", netuid: 3, stake_tao: "1000" }];
+  const res = await req("/api/v1/accounts/5Cold1/positions");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.position_count).toBe(1);
+  expect(body.positions[0].stake_tao).toBe(250);
+});
+
+test("GET /api/v1/accounts/:ss58/positions still serves the real positions when the other-captured-fraction lookup fails", async () => {
+  otherCapturedFractionQueryFailure.error = new Error("connection reset");
+  mockQueue.current = [
+    [],
+    [
+      {
+        coldkey: "5Cold1",
+        hotkey: "5Hk1",
+        netuid: 3,
+        share_fraction: 0.25,
+        captured_at: "1780000000000",
+      },
+    ], // loadNominatorPositions
+    [{ hotkey: "5Owned", netuid: 9 }], // loadOwnedHotkeyPositions -- a different owned hotkey, so the failing lookup actually gets exercised
+  ];
+  mockRows.current = [{ hotkey: "5Hk1", netuid: 3, stake_tao: "1000" }];
+  const res = await req("/api/v1/accounts/5Cold1/positions");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  // The owned-but-unresolvable hotkey contributes nothing (the fallback
+  // degrades to skipping it), but the real captured position is unaffected.
+  expect(body.position_count).toBe(1);
+  expect(body.positions[0].hotkey).toBe("5Hk1");
+  expect(body.positions[0].stake_tao).toBe(250);
 });
 
 test("GET /api/v1/accounts/:ss58/positions still serves an empty card when the nominator_positions read fails", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -322,6 +322,7 @@ import {
   NOMINATOR_POSITION_INSERT_COLUMNS,
   buildAccountPositions,
   distinctHotkeys,
+  ownedHotkeySelfStakeRows,
   stakeByHotkeyNetuid,
 } from "../src/account-nominator-positions.mjs";
 import {
@@ -2820,6 +2821,52 @@ async function loadNominatorPositions(sql, ss58) {
   } catch (err) {
     console.error("nominator_positions query failed:", err);
     return [];
+  }
+}
+
+// hotkeys this coldkey is the REGISTERING owner of (neurons.coldkey), across
+// every subnet it's registered in -- the candidate set for #6507's
+// self-stake fallback (see ownedHotkeySelfStakeRows). Savepoint-isolated
+// like the sibling loaders above.
+async function loadOwnedHotkeyPositions(sql, ss58) {
+  try {
+    return await sql.savepoint(
+      (sql) => sql`
+        SELECT hotkey, netuid FROM neurons WHERE coldkey = ${ss58}`,
+    );
+  } catch (err) {
+    console.error("owned-hotkey neurons query failed:", err);
+    return [];
+  }
+}
+
+// SUM of every OTHER coldkey's captured share_fraction, grouped by
+// (hotkey, netuid), for the hotkeys this coldkey appears to own (#6507) --
+// the residual (1 minus this sum) is that hotkey's still-uncaptured share,
+// which ownedHotkeySelfStakeRows attributes back to the owning coldkey.
+// Same scalar-placeholder IN-list shape as loadNeuronStakeByHotkeys above.
+async function loadOtherCapturedFractionByHotkeys(sql, hotkeys, ss58) {
+  if (hotkeys.length === 0) return new Map();
+  try {
+    const placeholders = hotkeys.map((_, i) => `$${i + 1}::text`).join(", ");
+    const rows = await sql.savepoint((sql) =>
+      sql.unsafe(
+        `SELECT hotkey, netuid, SUM(share_fraction) AS other_fraction
+         FROM nominator_positions
+         WHERE hotkey IN (${placeholders}) AND coldkey != $${hotkeys.length + 1}::text
+         GROUP BY hotkey, netuid`,
+        [...hotkeys, ss58],
+      ),
+    );
+    return new Map(
+      rows.map((row) => [
+        `${row.hotkey}|${row.netuid}`,
+        Number(row.other_fraction) || 0,
+      ]),
+    );
+  } catch (err) {
+    console.error("other-coldkey captured-fraction query failed:", err);
+    return new Map();
   }
 }
 
@@ -6705,12 +6752,30 @@ export default {
         if (acctPositions) {
           const ss58 = decodeURIComponent(acctPositions[1]);
           const positionRows = await loadNominatorPositions(sql, ss58);
+          // #6507: fill in this coldkey's own missing self-stake on any
+          // hotkey it owns but has no captured position row for -- see
+          // ownedHotkeySelfStakeRows's header comment for the full rationale.
+          const ownedRows = await loadOwnedHotkeyPositions(sql, ss58);
+          const otherFractionByKey = await loadOtherCapturedFractionByHotkeys(
+            sql,
+            distinctHotkeys(ownedRows),
+            ss58,
+          );
+          const allPositionRows = [
+            ...positionRows,
+            ...ownedHotkeySelfStakeRows(
+              ownedRows,
+              positionRows,
+              otherFractionByKey,
+              ss58,
+            ),
+          ];
           const hotkeyNetuidStake = await loadNeuronStakeByHotkeys(
             sql,
-            distinctHotkeys(positionRows),
+            distinctHotkeys(allPositionRows),
           );
           return json(
-            buildAccountPositions(positionRows, hotkeyNetuidStake, ss58),
+            buildAccountPositions(allPositionRows, hotkeyNetuidStake, ss58),
           );
         }
 


### PR DESCRIPTION
`GET /api/v1/accounts/{ss58}/positions` (and the mirrored MCP tool `get_account_positions`, same backend) undercounts stake for validator coldkeys: `nominator_positions` correctly captures third-party delegations but systematically misses a coldkey's own self-stake on a hotkey it owns. Confirmed against 3 real SN1 validator coldkeys showing `position_count: 0` despite 100K+ TAO of self-stake, while correctly showing small third-party-delegated positions on other subnets.

## Root cause

The root cause is the external Alpha-scan sync job that populates `nominator_positions` — **outside this repo**, in a box-side script. I confirmed neither of this repo's own code paths is at fault:
- The write-path handler (`handleNominatorPositionsSync` in `workers/data-api.mjs`) just validates row shape and upserts whatever it's POSTed — no filtering logic that would explain excluding self-stake.
- The read-path reconstruction (`buildAccountPositions`) just joins whatever rows exist against live neuron stake — no special-casing either.

Since the actual sync script can't be fixed from this repo, this PR compensates at the read layer instead.

## Fix

For every `(hotkey, netuid)` the queried coldkey is the **registering owner** of (`neurons.coldkey`) but has no captured `nominator_positions` row for, synthesize one holding the residual share — `1` minus every *other* coldkey's already-correct captured `share_fraction` for that same hotkey+netuid (the correctly-synced third-party rows).

This is an approximation, not a real ledger row: if some *other* coldkey's delegation on that hotkey is *also* missing from the sync (not just self-stake), this overcounts by that amount. But self-stake is virtually always a hotkey's largest position, so this closes the dominant, confirmed gap without waiting on an out-of-repo fix.

- **`src/account-nominator-positions.mjs`**: new `ownedHotkeySelfStakeRows(ownedRows, positionRows, otherCapturedFractionByKey, ss58)` — pure, unit-tested, cold-safe.
- **`workers/data-api.mjs`**: two new Postgres loaders (`loadOwnedHotkeyPositions`, `loadOtherCapturedFractionByHotkeys`), wired into the existing `/positions` route right before the existing `loadNeuronStakeByHotkeys` join. Both are savepoint-isolated like their siblings, so a failure in either degrades gracefully to the route's pre-existing behavior rather than breaking the request.
- **No MCP-side change needed** — `get_account_positions` proxies to this same REST endpoint via `tryPostgresTier`, so the fix applies identically to both surfaces.

## Tests

- `tests/account-nominator-positions.test.mjs`: 7 new cases for `ownedHotkeySelfStakeRows` — residual-share synthesis, 100%-self-stake when no other coldkey has captured anything, skipping an already-covered `(hotkey, netuid)`, only filling the specific missing pair on a multi-subnet hotkey, skipping a zero/negative residual, deduping a duplicated owned-row entry, and cold-safety (null owned rows / null positionRows / non-Map fraction lookup).
- `tests/data-api.test.mjs`: 5 new route-level cases — the full self-stake fallback end-to-end (matching the issue's own real-account numbers), not duplicating an already-captured position, treating a missing `other_fraction` cell as zero-captured, and graceful degradation when either new loader's query fails.
- Extended the existing "joins share_fraction against live neurons stake_tao" and "empty card" tests for the new query in the call sequence.

Full relevant suites green (1594 tests: `account-nominator-positions.test.mjs`, `data-api.test.mjs`, `mcp-server.test.mjs`), and my diff is 100% branch-covered (verified against the exact diff line ranges in both changed source files, not the whole-file/global coverage number, which is dominated by unrelated pre-existing gaps in these two large files).

```
npx vitest run tests/account-nominator-positions.test.mjs tests/data-api.test.mjs tests/mcp-server.test.mjs
npx eslint src/account-nominator-positions.mjs workers/data-api.mjs tests/account-nominator-positions.test.mjs tests/data-api.test.mjs
npx prettier --check src/account-nominator-positions.mjs workers/data-api.mjs tests/account-nominator-positions.test.mjs tests/data-api.test.mjs
npm run validate
git diff --check
```

Closes #6507