### PR TITLE
fix(ui): use health-* tokens for accounts page status and role badges

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -591,9 +591,9 @@ function AccountExtrinsicsSection({
                   {x.success == null ? (
                     <span className="text-ink-muted">—</span>
                   ) : x.success ? (
-                    <span className="text-emerald-500">ok</span>
+                    <span className="text-health-ok">ok</span>
                   ) : (
-                    <span className="text-rose-500">fail</span>
+                    <span className="text-health-down">fail</span>
                   )}
                 </td>
                 <td className="px-5 py-4 text-right font-mono text-[11px] text-ink-muted">
@@ -700,9 +700,9 @@ function AccountTransfersSection({
                   </td>
                   <td className="px-5 py-4 font-mono text-[11px]">
                     {t.direction === "received" ? (
-                      <span className="text-emerald-500">received</span>
+                      <span className="text-health-ok">received</span>
                     ) : t.direction === "sent" ? (
-                      <span className="text-amber-500">sent</span>
+                      <span className="text-health-warn-text">sent</span>
                     ) : (
                       <span className="text-ink-muted">—</span>
                     )}
@@ -1005,7 +1005,7 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
                   {p.net_tao == null ? (
                     <span className="text-ink-muted">—</span>
                   ) : (
-                    <span className={p.net_tao >= 0 ? "text-emerald-500" : "text-amber-500"}>
+                    <span className={p.net_tao >= 0 ? "text-health-ok" : "text-health-warn-text"}>
                       {p.net_tao >= 0 ? "+" : ""}
                       {formatNumber(p.net_tao)} τ
                     </span>
@@ -1043,12 +1043,15 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
 
 const STAKE_FLOW_WINDOWS = ["7d", "30d", "90d"] as const;
 
-// Direction label → tone, reusing the emerald/amber/muted convention the
-// transfers section uses for sent/received direction.
+// Direction label → tone, reusing the health-ok/warn/muted convention the
+// transfers section uses for sent/received direction. `exiting` and `churning`
+// were amber-500 vs amber-400 -- a shade split the health-* scale doesn't carry,
+// so both land on the single warn tone; the branches stay as they are because the
+// tone is the only thing this maps.
 function stakeFlowDirClass(dir: string | null | undefined): string {
-  if (dir === "accumulating") return "text-emerald-500";
-  if (dir === "exiting") return "text-amber-500";
-  if (dir === "churning") return "text-amber-400";
+  if (dir === "accumulating") return "text-health-ok";
+  if (dir === "exiting") return "text-health-warn-text";
+  if (dir === "churning") return "text-health-warn-text";
   return "text-ink-muted"; // idle / unknown
 }
 
@@ -1124,7 +1127,9 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
           tone="accent"
           value={
             <span
-              className={netFlow != null && netFlow < 0 ? "text-amber-500" : "text-emerald-500"}
+              className={
+                netFlow != null && netFlow < 0 ? "text-health-warn-text" : "text-health-ok"
+              }
             >
               {netStr}
             </span>
@@ -1215,7 +1220,9 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
                         <span className="text-ink-muted">—</span>
                       ) : (
                         <span
-                          className={s.net_flow_tao >= 0 ? "text-emerald-500" : "text-amber-500"}
+                          className={
+                            s.net_flow_tao >= 0 ? "text-health-ok" : "text-health-warn-text"
+                          }
                         >
                           {s.net_flow_tao >= 0 ? "+" : "−"}
                           {fmtStake(Math.abs(s.net_flow_tao))}
@@ -1365,9 +1372,9 @@ function AccountPortfolioSection({ ss58 }: { ss58: string }) {
                     </td>
                     <td className="px-5 py-4 font-mono text-[11px]">
                       {pos.role === "validator" ? (
-                        <span className="text-emerald-500">validator</span>
+                        <span className="text-health-ok">validator</span>
                       ) : pos.role === "miner" ? (
-                        <span className="text-sky-500">miner</span>
+                        <span className="text-chart-1">miner</span>
                       ) : (
                         <span className="text-ink-muted">{"—"}</span>
                       )}
@@ -2037,7 +2044,7 @@ function AccountFootprintSection({
                 </td>
                 <td className="px-5 py-4 font-mono text-[11px]">
                   {r.validator_permit ? (
-                    <span className="inline-flex rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-500">
+                    <span className="inline-flex rounded-full bg-health-ok/10 px-2 py-0.5 text-health-ok">
                       validator
                     </span>
                   ) : (
@@ -2046,7 +2053,7 @@ function AccountFootprintSection({
                 </td>
                 <td className="px-5 py-4 font-mono text-[11px]">
                   {r.active ? (
-                    <span className="inline-flex rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-500">
+                    <span className="inline-flex rounded-full bg-health-ok/10 px-2 py-0.5 text-health-ok">
                       active
                     </span>
                   ) : (


### PR DESCRIPTION
## What & why

`accounts.$ss58.tsx` styled its ok/fail, sent/received, stake-flow direction, role and permit badges with raw Tailwind palette colors (`emerald-500`, `rose-500`, `amber-500`/`amber-400`, `sky-500`).

This app themes entirely by swapping CSS variables on `.dark` — there is not a single `dark:` variant anywhere under `routes/` or `components/metagraphed/` — so those raw palette colors were the only text colors in the file that stayed put when the theme changed. The same file already reaches for the token at line 179-180 (`text-health-down` for "Unavailable").

## The mapping (14 sites)

| From | To |
| --- | --- |
| `text-emerald-500` | `text-health-ok` |
| `text-rose-500` | `text-health-down` |
| `text-amber-500` / `text-amber-400` | `text-health-warn-text` |
| `text-sky-500` (miner) | `text-chart-1` |
| `bg-emerald-500/10` | `bg-health-ok/10` |

Two calls worth flagging:

- **amber → `health-warn-text`, not `health-warn`.** Every one of these sites styles small text (`text-[11px]`/`[12px]` table cells), and that token exists for exactly this case — its own doc says it is *"only for small warn text on paper/card, which needs 4.5:1"*. Using the plain warn tone here would reintroduce the contrast gap that #6405/#6408 are open about. This is safe in dark mode too: `.dark` already aliases `--health-warn-text: var(--health-warn)` precisely because the dark amber clears AA on its own.
- **miner → `chart-1`.** There is no `role-*` scale, and no other file colors a miner/validator role pair, so there was no existing role token to reuse. `chart-1` (`oklch(0.64 0.13 250)`) is the app's only blue and the nearest theme-swapped equivalent to `sky-500` — this adds no new token rather than inventing one. Happy to switch to a dedicated `--role-*` token if you'd prefer that.

`exiting`/`churning` were `amber-500` vs `amber-400`; the `health-*` scale carries no such shade split, so both land on the one warn tone. `stakeFlowDirClass` keeps its branching exactly as it was, per the issue.

## Verification

Full Phase C3 preflight (the same steps, in the same order, as the `ui` CI job):

| Step | Command | Result |
| --- | --- | --- |
| lint | `npm run lint --workspace=apps/ui` | 0 errors |
| format | `npm run format:check --workspace=apps/ui` | clean |
| typecheck | `npm run typecheck --workspace=apps/ui` | clean |
| unit | `npm test --workspace=apps/ui` | 140 files, 1062 tests passed |
| e2e | `npm run test:e2e --workspace=apps/ui` | responsive-overflow green |
| build | `npm run build --workspace=apps/ui` | green |

Prettier is pinned to the lockfile's 3.9.5 and eslint run from `apps/ui`, so both the `checks` and `ui` jobs' formatters agree.

On the "no test evidence" nit: this is a class-name-only swap with no logic change — `stakeFlowDirClass`'s branching is byte-for-byte unchanged and every other site is a literal string in JSX. There is no behaviour to assert that a test could observe; the theme-adaptivity this fixes is a CSS-variable concern, evidenced by the light/dark matrix below rather than by a unit test. Happy to add coverage if you'd like it anyway.

## Screenshots

Captured with `npm run screenshots --workspace=apps/ui` (Phase C2): fixed viewports only, themes forced via `mg-theme`, `before` served from a separate worktree at the merge base. Anchored on the **Transfers** section, where `received` (`health-ok`) and `sent` (`health-warn-text`) sit side by side — the clearest view of the change. The same swap applies to the extrinsics ok/fail, counterparties, stake-flow, portfolio and footprint badges further down the page.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6402

