### PR TITLE
fix(ui): surface a fetch error in the Related Multisig calls section

### DIFF
--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -15,6 +15,7 @@ import {
   ActionBar,
   SectionAnchor,
   StatTile,
+  TableState,
 } from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { extrinsicQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
@@ -313,6 +314,18 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
         >
           {relatedQuery.isLoading ? (
             <Skeleton className="h-16 w-full" />
+          ) : relatedQuery.isError ? (
+            // Without this branch a failed lookup left `data` undefined, so
+            // `relatedCalls` fell through to [] and rendered the same "no other
+            // extrinsics" copy as a genuinely empty result -- the one case where
+            // this page asserted something it hadn't actually learned (#6426).
+            <TableState
+              variant="error"
+              title="Couldn't load related Multisig calls"
+              description="The related-calls lookup is optional enrichment — the rest of this extrinsic's detail is unaffected."
+              error={relatedQuery.error}
+              onRetry={() => relatedQuery.refetch()}
+            />
           ) : relatedCalls.length > 0 ? (
             <ul className="flex flex-col gap-2">
               {relatedCalls.map((e) => (

--- a/apps/ui/tests/e2e/fixtures/extrinsic-multisig-6426.json
+++ b/apps/ui/tests/e2e/fixtures/extrinsic-multisig-6426.json
@@ -1,0 +1,104 @@
+{
+  "ok": true,
+  "schema_version": 1,
+  "data": {
+    "schema_version": 1,
+    "ref": "0x25a23bcd160f1403ed130b1cd594302b8fc949f99802e7aee15e8a5670238564",
+    "extrinsic": {
+      "block_number": 8636169,
+      "extrinsic_index": 9,
+      "extrinsic_hash": "0x25a23bcd160f1403ed130b1cd594302b8fc949f99802e7aee15e8a5670238564",
+      "signer": "5E7RCRrPVS8TckCDjr92B5ciGziwz2kfvxe4URy3L7AgirGJ",
+      "call_module": "Multisig",
+      "call_function": "approve_as_multi",
+      "call_args": [
+        { "name": "threshold", "type": "u16", "value": 2 },
+        {
+          "name": "other_signatories",
+          "type": "Vec<AccountId32>",
+          "value": [
+            "5FevFjov8435t5XC2MUSRpFYxtthE8pZy1toHpgAAia3ZphG",
+            "5GRCukV2rZmSVfJhAXoLjcrU1pMVCf2Ra1ydbiCFZdaQXDXo"
+          ]
+        },
+        { "name": "maybe_timepoint", "type": "Option<Timepoint<u32>>", "value": null },
+        {
+          "name": "call_hash",
+          "type": "[u8; 32]",
+          "value": "0xa13d2fea4527d2f98e486b1bb7ad669dd9b5fab52dfd03b832ceb115c5423cbf"
+        },
+        {
+          "name": "max_weight",
+          "type": "Weight",
+          "value": { "ref_time": 225661257015, "proof_size": 1112109 }
+        }
+      ],
+      "success": true,
+      "fee_tao": 0.000131929,
+      "tip_tao": 0,
+      "observed_at": "2026-07-16T19:26:00.000Z"
+    },
+    "events": [
+      {
+        "block_number": 8636169,
+        "event_index": 153,
+        "event_kind": "Withdraw",
+        "hotkey": null,
+        "coldkey": "5E7RCRrPVS8TckCDjr92B5ciGziwz2kfvxe4URy3L7AgirGJ",
+        "netuid": null,
+        "uid": null,
+        "amount_tao": 0.112995087,
+        "alpha_amount": null,
+        "observed_at": "2026-07-16T19:26:00.000Z",
+        "extrinsic_index": 9
+      },
+      {
+        "block_number": 8636169,
+        "event_index": 154,
+        "event_kind": "Reserved",
+        "hotkey": null,
+        "coldkey": "5E7RCRrPVS8TckCDjr92B5ciGziwz2kfvxe4URy3L7AgirGJ",
+        "netuid": null,
+        "uid": null,
+        "amount_tao": 0.196,
+        "alpha_amount": null,
+        "observed_at": "2026-07-16T19:26:00.000Z",
+        "extrinsic_index": 9
+      },
+      {
+        "block_number": 8636169,
+        "event_index": 156,
+        "event_kind": "Deposit",
+        "hotkey": null,
+        "coldkey": "5E7RCRrPVS8TckCDjr92B5ciGziwz2kfvxe4URy3L7AgirGJ",
+        "netuid": null,
+        "uid": null,
+        "amount_tao": 0.112863158,
+        "alpha_amount": null,
+        "observed_at": "2026-07-16T19:26:00.000Z",
+        "extrinsic_index": 9
+      },
+      {
+        "block_number": 8636169,
+        "event_index": 157,
+        "event_kind": "Deposit",
+        "hotkey": null,
+        "coldkey": "5HjhkCMa89QJbFULs8WPZBgVg8kMq5qdX1nx7CnQpZgoyKAN",
+        "netuid": null,
+        "uid": null,
+        "amount_tao": 0.000131929,
+        "alpha_amount": null,
+        "observed_at": "2026-07-16T19:26:00.000Z",
+        "extrinsic_index": 9
+      }
+    ]
+  },
+  "meta": {
+    "artifact_path": "/metagraph/extrinsics/0x25a23bcd160f1403ed130b1cd594302b8fc949f99802e7aee15e8a5670238564.json",
+    "cache": "short",
+    "contract_version": "2026-06-06.1",
+    "generated_at": "2026-07-16T19:26:00.000Z",
+    "published_at": "2026-07-17T11:21:50.971Z",
+    "source": "chain-events"
+  }
+}

--- a/apps/ui/tests/e2e/multisig-related-error.spec.ts
+++ b/apps/ui/tests/e2e/multisig-related-error.spec.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test, expect } from "@playwright/test";
+
+// #6426: extrinsics.$hash.tsx's "Related Multisig calls" section had no isError
+// branch. A failed relatedQuery fetch left `data` undefined, so relatedCalls
+// became [] and the section rendered the SAME "No other extrinsics reference
+// this call_hash yet." copy as a genuine zero-row result -- a reader could not
+// tell "no siblings" from "we couldn't find out". The fix adds an isError
+// branch rendering TableState variant="error"; these tests pin both directions
+// and the first fails on the pre-fix code, which is the point.
+//
+// Deterministic by design, mirroring evidence-deep-link.spec.ts: every
+// api.metagraph.sh request is fulfilled locally (no live chain data), so a
+// real multisig call gaining or losing siblings can never make this flap. The
+// only moving part is the related-calls request's status -- 500 for the error
+// case, an empty 200 for the empty case.
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// An approve_as_multi, so its call_args carry a direct call_hash and
+// multisigCallHash() returns non-null -- the precondition for the section to
+// render at all (an as_multi nests its call and would not).
+const DETAIL = readFileSync(path.join(HERE, "fixtures", "extrinsic-multisig-6426.json"), "utf8");
+const HASH = "0x25a23bcd160f1403ed130b1cd594302b8fc949f99802e7aee15e8a5670238564";
+const ROUTE = `/extrinsics/${HASH}`;
+
+const isRelatedCalls = (url: string) =>
+  url.includes("/api/v1/extrinsics?") && url.includes("call_hash=");
+
+/**
+ * Stubs every api.metagraph.sh request so nothing hits live data, then lets the
+ * caller decide how the related-calls lookup resolves. Routes are matched
+ * last-registered-first, so the specific handlers below win over the catch-all.
+ */
+async function openExtrinsic(
+  page: import("@playwright/test").Page,
+  relatedResponder: (route: import("@playwright/test").Route) => Promise<void> | void,
+) {
+  // Catch-all first (lowest priority): anything we don't care about resolves to
+  // an empty-but-valid payload rather than reaching the network.
+  await page.route("**/api.metagraph.sh/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, data: {} }),
+    }),
+  );
+  // The extrinsic detail itself must succeed or the page never renders.
+  await page.route(`**/api/v1/extrinsics/${HASH}**`, (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: DETAIL }),
+  );
+  // The related-calls lookup -- the request under test.
+  await page.route((url) => isRelatedCalls(url.toString()), relatedResponder);
+
+  await page.goto(ROUTE);
+  // The client retries a failed query 3x with backoff (router.tsx), so give the
+  // error state time to settle rather than asserting on a mid-retry skeleton.
+  const section = page.locator("section#multisig-chain");
+  await expect(section).toBeVisible();
+}
+
+test.describe("#6426 Related Multisig calls error state", () => {
+  test("a failed lookup shows an error state, not the empty-result copy", async ({ page }) => {
+    await openExtrinsic(page, (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: false, error: { code: "internal", message: "boom" } }),
+      }),
+    );
+
+    const section = page.locator("section#multisig-chain");
+    // The client retries a failed query 3x with backoff before isError flips
+    // (router.tsx), so allow well past that window rather than the 5s default.
+    await expect(section.getByText("Couldn't load related Multisig calls")).toBeVisible({
+      timeout: 20_000,
+    });
+    // The whole point: a fetch failure must NOT read as "no related calls".
+    await expect(
+      section.getByText("No other extrinsics reference this call_hash yet."),
+    ).toHaveCount(0);
+  });
+
+  test("a successful empty lookup still shows the empty-result copy", async ({ page }) => {
+    await openExtrinsic(page, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { extrinsics: [] } }),
+      }),
+    );
+
+    const section = page.locator("section#multisig-chain");
+    await expect(
+      section.getByText("No other extrinsics reference this call_hash yet."),
+    ).toBeVisible();
+    await expect(section.getByText("Couldn't load related Multisig calls")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## What & why

`relatedQuery` (the "Related Multisig calls" lookup) had **no `isError` branch anywhere**. A genuine fetch failure leaves `data` undefined, so `relatedCalls` falls through to `[]` and the section renders the exact same copy as a real empty result:

> No other extrinsics reference this call_hash yet.

That was the one place on this page asserting something it hadn't actually learned — a reader couldn't tell *"this call has no siblings"* from *"we couldn't find out"*.

## Approach

Adds the missing `relatedQuery.isError` branch rendering `TableState variant="error"` with retry — the same treatment every optional/secondary query on the sibling `accounts.$ss58.tsx` page already gives its own failures (`Couldn't load signed extrinsics` / `Couldn't load transfers`), and the component the issue points at. The empty-result copy now only shows when the fetch actually succeeded with zero rows. Branch order is `isLoading → isError → rows → empty`, so a failure can no longer reach the empty copy.

No logic changes beyond the added branch; nothing else in the section moved.

## Verification

Full Phase C3 preflight (the same steps, in the same order, as the `ui` CI job):

| Step | Command | Result |
| --- | --- | --- |
| lint | `npm run lint --workspace=apps/ui` | 0 errors |
| format | `npm run format:check --workspace=apps/ui` | clean |
| typecheck | `npm run typecheck --workspace=apps/ui` | clean |
| unit | `npm test --workspace=apps/ui` | 140 files, 1062 tests passed |
| build | `npm run build --workspace=apps/ui` | green |

## Screenshots

Same Phase C2 contract (fixed viewports only, never full-page, themes forced via `mg-theme`, `before` served from a separate worktree at the merge base) — but this defect is only observable while the request is failing, so the matrix was captured with **the related-calls request (`/api/v1/extrinsics?…call_hash=…`) forced to HTTP 500**, and nothing else. The API base is the real one in both columns (visible in the "Call this endpoint" snippet); only that single request is intercepted. The `HTTP 500 · injected failure` line visible in the `after` column is that injected error surfacing through `TableState` — which is the point.

`before` is the bug: a failed lookup silently claims there are no related calls. `after` says the lookup failed and offers retry.

Route: `/extrinsics/0x25a23bcd…238564` (an `approve_as_multi`, so it carries a direct `call_hash` and the section actually renders), anchored on `#multisig-chain`.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6426-multisig-error-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6426
