### PR TITLE
fix(ui): add a mobile card fallback to the Runtime upgrade-history table

### DIFF
--- a/apps/ui/src/components/metagraphed/runtime-upgrade-card-list.test.ts
+++ b/apps/ui/src/components/metagraphed/runtime-upgrade-card-list.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { orderRuntimeUpgradesNewestFirst } from "./runtime-upgrade-card-list";
+import type { RuntimeTransition } from "@/lib/metagraphed/types";
+
+const tx = (spec_version: number, block_number: number): RuntimeTransition => ({
+  spec_version,
+  block_number,
+  observed_at: null,
+});
+
+describe("orderRuntimeUpgradesNewestFirst", () => {
+  it("reverses the backend's ascending order so the newest upgrade is first", () => {
+    // /api/v1/runtime returns transitions ascending by block_number.
+    const ascending = [tx(100, 1_000), tx(150, 5_000), tx(432, 8_636_190)];
+    const ordered = orderRuntimeUpgradesNewestFirst(ascending);
+    expect(ordered.map((r) => r.block_number)).toEqual([8_636_190, 5_000, 1_000]);
+  });
+
+  it("does not mutate the source array (it is a shared React Query cache value)", () => {
+    // The regression this guards: an in-place `.reverse()` would flip the cache
+    // array for the desktop table view and every other reader on re-render.
+    const source = [tx(100, 1_000), tx(150, 5_000)];
+    const snapshot = [...source];
+    orderRuntimeUpgradesNewestFirst(source);
+    expect(source).toEqual(snapshot);
+  });
+
+  it("returns an empty array unchanged", () => {
+    expect(orderRuntimeUpgradesNewestFirst([])).toEqual([]);
+  });
+});

--- a/apps/ui/src/components/metagraphed/runtime-upgrade-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/runtime-upgrade-card-list.tsx
@@ -1,0 +1,77 @@
+import { Link } from "@tanstack/react-router";
+import { TimeAgo } from "@jsonbored/ui-kit";
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { RuntimeTransition } from "@/lib/metagraphed/types";
+
+/**
+ * Backend `/api/v1/runtime` orders transitions ascending by block_number
+ * (earliest first); every timeline view on this site displays newest first.
+ * Returns a NEW array — the source array (a React Query cache value) must never
+ * be reversed in place, or an in-place `.reverse()` would flip the shared cache
+ * for the table view and any other reader on re-render.
+ */
+export function orderRuntimeUpgradesNewestFirst(
+  transitions: readonly RuntimeTransition[],
+): RuntimeTransition[] {
+  return [...transitions].reverse();
+}
+
+type RuntimeUpgradeCardListProps = {
+  rows: readonly RuntimeTransition[];
+  className?: string;
+};
+
+/**
+ * Mobile card fallback for the runtime spec-version upgrade table (#6334): the
+ * 3-column table is undiscoverably clipped behind horizontal scroll on a narrow
+ * viewport, so below `md` each upgrade renders as a stacked card instead —
+ * mirroring the `md:hidden` card path every other tabular list page provides
+ * (validators, leaderboards, providers, ListShell tables).
+ */
+export function RuntimeUpgradeCardList({ rows, className }: RuntimeUpgradeCardListProps) {
+  return (
+    <div className={className}>
+      {rows.map((row) => (
+        <div
+          key={`${row.spec_version}-${row.block_number}`}
+          className="min-w-0 space-y-2 rounded-lg border border-border bg-card p-3"
+        >
+          <div className="flex items-baseline justify-between gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              Spec Version
+            </span>
+            <span className="font-mono text-[13px] tabular-nums text-ink-strong">
+              {formatNumber(row.spec_version)}
+            </span>
+          </div>
+          <div className="flex items-baseline justify-between gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              Block
+            </span>
+            <span className="font-mono text-[12px] tabular-nums">
+              {row.block_number != null ? (
+                <Link
+                  to="/blocks/$ref"
+                  params={{ ref: String(row.block_number) }}
+                  className="text-ink hover:text-accent hover:underline"
+                >
+                  #{formatNumber(row.block_number)}
+                </Link>
+              ) : (
+                "—"
+              )}
+            </span>
+          </div>
+          <div className="flex items-baseline justify-between gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+              Observed
+            </span>
+            <span className="font-mono text-[12px] text-ink-muted">
+              {row.observed_at ? <TimeAgo at={row.observed_at} /> : "—"}
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/routes/runtime.index.tsx
+++ b/apps/ui/src/routes/runtime.index.tsx
@@ -6,6 +6,10 @@ import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { Skeleton } from "@/components/metagraphed/states";
 import { PageHero, ShareButton, ActionBar, TableState, TimeAgo } from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import {
+  RuntimeUpgradeCardList,
+  orderRuntimeUpgradesNewestFirst,
+} from "@/components/metagraphed/runtime-upgrade-card-list";
 import { runtimeVersionHistoryQuery } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
 import type { RuntimeVersionHistory } from "@/lib/metagraphed/types";
@@ -57,9 +61,7 @@ function RuntimePage() {
 function RuntimeContent() {
   const { data: res } = useSuspenseQuery(runtimeVersionHistoryQuery());
   const history = res.data;
-  // Backend orders transitions ascending by block_number (earliest first);
-  // display newest first, matching every other timeline view on this site.
-  const rows = [...history.transitions].reverse();
+  const rows = orderRuntimeUpgradesNewestFirst(history.transitions);
 
   return (
     <>
@@ -72,9 +74,10 @@ function RuntimeContent() {
           generatedAt={history.coverage_from_at ?? undefined}
         />
       ) : (
-        <div className="rounded-xl border border-border bg-card overflow-hidden">
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+        <>
+          <div className="hidden md:block rounded-xl border border-border bg-card overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
               <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
                 <tr>
                   <th className="px-3 py-2.5 text-left font-mono text-[10px] uppercase tracking-widest">
@@ -117,8 +120,13 @@ function RuntimeContent() {
                 ))}
               </tbody>
             </table>
+            </div>
           </div>
-        </div>
+          <RuntimeUpgradeCardList
+            rows={rows}
+            className="grid gap-3 sm:grid-cols-2 md:hidden"
+          />
+        </>
       )}
     </>
   );


### PR DESCRIPTION
## What

`runtime.index.tsx`'s spec-version upgrade table was wrapped only in `<div className="overflow-x-auto">`, with no `md:hidden` card view — the one tabular list page that lacked the mobile fallback every sibling provides (`validators.index.tsx`, `leaderboards.tsx`, `providers.index.tsx`, and every `ListShell` table). On a narrow viewport its columns sit behind an undiscoverable horizontal scroll.

This adds a `md:hidden` stacked-card list below the `md` breakpoint, mirroring the established `hidden md:block` table + `md:hidden` card pattern (`validators.index.tsx:182-218`):

- **`RuntimeUpgradeCardList`** (new, `apps/ui/src/components/metagraphed/runtime-upgrade-card-list.tsx`) — one card per upgrade showing spec version, the block `#`-link, and the observed time, using the same `min-w-0 rounded-lg border border-border bg-card` card styling as `ValidatorCardList`.
- The existing `<table>` is now `hidden md:block` (unchanged at `md` and up).
- The card list reuses the `rows` already computed in `RuntimeContent`; no new query or data path.

I extracted the row ordering into `orderRuntimeUpgradesNewestFirst()` (exported from the same file, consumed by both the table and the cards) so the "newest first" reversal is a single tested unit rather than an inline `.reverse()` duplicated per view.

## Screenshots (before / after)

3 viewports × 2 themes. **The change is scoped below the `md` breakpoint**, so **Tablet (768px) and Desktop (1280px) are intentionally identical before/after** — at `md` and up the table is unchanged; only **Mobile (375px)** switches from the horizontally-scrolling table to the stacked cards. All six combinations are shown so the no-regression at `≥md` is visible too.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6334-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

Run against `apps/ui` (Node 22):

- `eslint` — clean on the changed files (0 errors).
- `prettier --check` — clean.
- Unit tests — full `apps/ui` suite green: **141 files / 1065 tests passed**, including the new `runtime-upgrade-card-list.test.ts` (3 cases: newest-first ordering, no in-place mutation of the shared query-cache array, empty input).
- Screenshots above were captured from the dev server at the three fixed viewports × both themes.
- `/runtime` is not in the responsive-overflow e2e route set (`overflow-check.config.js`), and the cards fit each viewport with no horizontal scroll (see mobile shots).

## Notes

- The card list is a small presentational component; the only logic (`orderRuntimeUpgradesNewestFirst`) is unit-tested. Nothing beyond the issue's stated scope was added.

Closes #6334
