### PR TITLE
fix(registry): normalize prediction-market to prediction-markets category (#6332)

### DIFF
--- a/registry/subnets/8-ball.json
+++ b/registry/subnets/8-ball.json
@@ -4,7 +4,7 @@
     "identity-reviewed",
     "official-source-repo",
     "official-website",
-    "prediction-market"
+    "prediction-markets"
   ],
   "curation": {
     "gap_notes": [

--- a/registry/subnets/sparket.json
+++ b/registry/subnets/sparket.json
@@ -4,7 +4,7 @@
     "identity-reviewed",
     "official-source-repo",
     "official-website",
-    "prediction-market",
+    "prediction-markets",
     "sports"
   ],
   "curation": {


### PR DESCRIPTION
Closes #6332.

A registry-wide inventory found the same concept spelled two ways in `categories[]`: `8-ball.json` and `sparket.json` used the singular `prediction-market`, while `almanac.json` and `degenbrain.json` used the plural `prediction-markets`. A category-based filter/facet for one spelling therefore silently excluded the files using the other.

This adopts the canonical plural (`prediction-markets`, matching the more common corpus convention, e.g. `language-models`) on the two singular files. Pure data fix — no `categories` enum is introduced (out of scope per the issue).

- `registry/subnets/8-ball.json`: `prediction-market` → `prediction-markets`
- `registry/subnets/sparket.json`: `prediction-market` → `prediction-markets`

A full grep confirms zero remaining singular occurrences, and all four relevant subnets now share the plural spelling.
