### PR TITLE
chore(enrich): taostats identity gap-fills

### DIFF
--- a/registry/subnets/actual.json
+++ b/registry/subnets/actual.json
@@ -39,7 +39,7 @@
   "notes": "Reviewed overlay for SN95 Actual. The Actual Computer website metadata identifies the project with Bittensor, Subnet 95, decentralized AI, and inference software. The previous GitHub organization candidate currently returns 404 and is not promoted. Re-review pass (2026-07-15): fixed 1 missing probe block; still no GitHub source repository reference found anywhere on the site.",
   "schema_version": 1,
   "slug": "actual",
-  "source_repo": null,
+  "source_repo": "https://github.com/actual-computer/actual-subnet-95",
   "status": "active",
   "surfaces": [
     {


### PR DESCRIPTION
## Provenance

These are third-party **taostats** gap-fills — identity fields sourced from `https://api.taostats.io/api/subnet/identity/v1` that were missing in the metagraphed registry. Taostats is a third-party aggregator; these fills are included for human review and should be verified against the subnet's own primary sources before relying on them as authoritative.

## Fields touched

| Subnet | Netuid | Field | Value |
|--------|--------|-------|-------|
| Actual | 95 | `source_repo` | `https://github.com/actual-computer/actual-subnet-95` |

## Notes

- Ran against 129 taostats identity records; 9 initial schema-valid candidates after filtering to `source_repo`/`website_url`/`social.x` only (fields not in `subnet-manifest.schema.json` were skipped).
- After cross-checking subnet name alignment between taostats and registry, 7 candidates were dropped due to name mismatches (stale taostats netuid→name mappings) or clearly generic/placeholder URLs.
- SN119 Satori `source_repo` was explicitly excluded: the registry notes record that the `Satori119/Satori` repo previously returned 404 and was intentionally unset.
- Schema validation passes (`validate:schemas`).