### PR TITLE
fix(ui): use the shared TableState error component for blocks detail sections

### DIFF
--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -5,7 +5,7 @@ import { ChevronLeft, ChevronRight, Boxes, FileText, Zap } from "lucide-react";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { EmptyState, ErrorState, PageHeading, Skeleton } from "@/components/metagraphed/states";
+import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import {
   CopyableCode,
@@ -16,6 +16,7 @@ import {
   ActionBar,
   SectionAnchor,
   StatTile,
+  TableState,
 } from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import {
@@ -300,15 +301,15 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         {extrinsicsQuery.isPending ? (
           <Skeleton className="h-44" />
         ) : extrinsicsQuery.error ? (
-          <div className="p-4">
-            <ErrorState
-              error={extrinsicsQuery.error}
-              context="block extrinsics"
-              onRetry={() => {
-                void extrinsicsQuery.refetch();
-              }}
-            />
-          </div>
+          <TableState
+            variant="error"
+            title="Couldn't load block extrinsics"
+            description="This section is optional — the rest of the block detail is unaffected."
+            error={extrinsicsQuery.error}
+            onRetry={() => {
+              void extrinsicsQuery.refetch();
+            }}
+          />
         ) : extrinsics.length === 0 ? (
           <EmptyState
             title="No block extrinsics"
@@ -381,15 +382,15 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         {eventsQuery.isPending ? (
           <Skeleton className="h-44" />
         ) : eventsQuery.error ? (
-          <div className="p-4">
-            <ErrorState
-              error={eventsQuery.error}
-              context="block events"
-              onRetry={() => {
-                void eventsQuery.refetch();
-              }}
-            />
-          </div>
+          <TableState
+            variant="error"
+            title="Couldn't load block events"
+            description="This section is optional — the rest of the block detail is unaffected."
+            error={eventsQuery.error}
+            onRetry={() => {
+              void eventsQuery.refetch();
+            }}
+          />
         ) : events.length === 0 ? (
           <EmptyState
             title="No block events"
@@ -444,15 +445,15 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         {chainEventsQuery.isPending ? (
           <Skeleton className="h-44" />
         ) : chainEventsQuery.error ? (
-          <div className="p-4">
-            <ErrorState
-              error={chainEventsQuery.error}
-              context="block chain events"
-              onRetry={() => {
-                void chainEventsQuery.refetch();
-              }}
-            />
-          </div>
+          <TableState
+            variant="error"
+            title="Couldn't load block chain events"
+            description="This section is optional — the rest of the block detail is unaffected."
+            error={chainEventsQuery.error}
+            onRetry={() => {
+              void chainEventsQuery.refetch();
+            }}
+          />
         ) : chainEvents.length === 0 ? (
           <EmptyState
             title="No chain events"


### PR DESCRIPTION
### What

`blocks.$ref.tsx`'s **Extrinsics / Events / Chain-events** section errors rendered the local `ErrorState` (from `@/components/metagraphed/states`), while every other detail page (`accounts.$ss58.tsx` uses it 14×, `subnets.$netuid.tsx` too) uses the shared `TableState variant="error"` from `@jsonbored/ui-kit`. The two are visually distinct (padding, icon, button shape), so the Blocks page showed a different error treatment than its siblings for no functional reason — the same house-rule (`states.tsx` #3962) that warns against mismatched *empty* states applies to error states.

### Fix

Replaced the 3 `ErrorState` call sites (extrinsics/events/chain-events) with `TableState variant="error"`, matching the `title`/`description`/`error`/`onRetry` shape `accounts.$ss58.tsx` already uses. The HTTP-status/API-URL sub-line still renders via `TableState`'s `error` prop. The local `ErrorState` export is untouched — it's still used by other routes (`explorer.tsx`/`index.tsx`).

### Screenshots

Captured on `/blocks/8642571` with the section endpoints forced to **HTTP 500**. Before = the one-off `ErrorState` (full API URL, wider card); after = the shared `TableState` (consistent with every other detail page). All 3 sections receive the identical swap; the Extrinsics section is shown.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/ultrahighsuper/metagraphed/screenshots/blocks-error-mobile-dark-after.png)<br><sub>after</sub> |

### Local checks
`typecheck` clean on the changed file; `prettier`/`eslint` clean; single-file diff. UI-only change (no logic).

Closes #6425
