### PR TITLE
fix(ui): move focus to the target section on in-page hash navigation

### DIFF
--- a/apps/ui/src/components/metagraphed/use-hash-scroll.ts
+++ b/apps/ui/src/components/metagraphed/use-hash-scroll.ts
@@ -31,10 +31,23 @@ export function useHashScroll(activeTab: string, sectionToTab: Record<string, st
       return;
     }
 
-    // After tab switch / on initial mount, scroll the section into view.
+    // After tab switch / on initial mount, scroll the section into view AND
+    // move focus (the screen-reader cursor) to it — scrollIntoView alone moves
+    // the viewport but strands assistive tech, so a deep link / SectionAnchor
+    // "copy link" announced nothing. Mirrors BackToTop's technique: a temporary
+    // tabindex="-1" lets a non-focusable section receive focus, and
+    // preventScroll keeps .focus() from fighting the smooth scroll above.
     const scroll = () => {
       const el = document.getElementById(id);
-      if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+      if (!el) return;
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+      const hadTabIndex = el.hasAttribute("tabindex");
+      if (!hadTabIndex) el.setAttribute("tabindex", "-1");
+      el.focus({ preventScroll: true });
+      if (!hadTabIndex) {
+        // Clean up so we don't pollute the tab order.
+        window.setTimeout(() => el.removeAttribute("tabindex"), 0);
+      }
     };
     // Defer so the panel for the new tab has time to mount.
     const t = window.setTimeout(scroll, 80);


### PR DESCRIPTION
### What

`useHashScroll` (`apps/ui/src/components/metagraphed/use-hash-scroll.ts`) called only `el.scrollIntoView({ behavior: "smooth", block: "start" })` — that moves the visual viewport but never moves DOM focus / the screen-reader cursor. A keyboard or screen-reader user following an in-page deep link (e.g. `/subnets/7?tab=overview#endpoints`, or a `SectionAnchor` "copy link") heard nothing change.

### Fix

After the `scrollIntoView`, move focus to the resolved `#id` section using the exact technique `packages/ui-kit/.../back-to-top.tsx` already uses:
- a temporary `tabindex="-1"` so a non-focusable section container can receive focus,
- `.focus({ preventScroll: true })` so focusing doesn't fight the smooth scroll,
- cleanup of the temporary attribute (via `setTimeout(…, 0)`) so the tab order isn't polluted.

### Note on screenshots

This is a **non-visual** change to a hook (`useHashScroll`): the scroll behavior is unchanged and there is no rendered/layout difference — the only change is that DOM focus now follows the scroll (assistive-tech behavior). There is nothing visual to capture in a before/after, so no screenshot table is included (per the `apps/ui/src/hooks`-style no-visual-change exemption). Verified by keyboard: following a deep link now lands focus on the target section.

### Local checks
`typecheck` clean on the changed file; `prettier`/`eslint` clean; single-file diff.

Closes #6421
