### PR TITLE
feat(ui): link a validator's owning coldkey on its detail page

### DIFF
--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -14,6 +14,7 @@ import { PageHero, ShareButton, SectionAnchor, CopyableCode, StatTile } from "@j
 import { ValidatorHistoryChart } from "@/components/metagraphed/validator-history-chart";
 import { ValidatorApyPanel } from "@/components/metagraphed/validator-apy-panel";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
+import { AccountAddress } from "@/components/metagraphed/account-address";
 import { WatchValidatorAlert } from "@/components/metagraphed/watch-validator-alert";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
 import { TakeManagementModal } from "@/components/metagraphed/take-management-modal";
@@ -309,6 +310,19 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
             </span>
             <span className="inline-flex max-w-full min-w-0 rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
               <CopyableCode value={hotkey} truncate={false} className="max-w-full" />
+            </span>
+            {/* The owning coldkey — the account that controls this hotkey.
+                Previously used only for the isOwner check + the owner-only
+                Manage-take modal, so a regular visitor had no way to reach it
+                (#6427). Linked for everyone via AccountAddress (hover-card +
+                copy), which renders the fallback when the tier has no coldkey. */}
+            <span className="flex flex-wrap items-center gap-2 text-[11px] text-ink-muted">
+              <span className="font-mono uppercase tracking-widest">Coldkey</span>
+              <AccountAddress
+                ss58={detail.coldkey}
+                truncate={false}
+                fallback={<span>Not recorded</span>}
+              />
             </span>
           </span>
         }


### PR DESCRIPTION
Closes #6427

## The gap

`validatorDetailQuery` already normalizes `coldkey` into `ValidatorDetail`, but the validator detail page used `detail.coldkey` only for the `isOwner` check and to feed the **owner-only** `TakeManagementModal`. `ValidatorIdentityChip` shows the self-declared identity name, never the raw coldkey. So a regular visitor had no way to discover which account controls a given validator hotkey.

## Screenshots

A new **Coldkey** field in the hero, right below the hotkey. The capture **asserts** the link resolves rather than trusting the pixels:

```
before: /accounts links in the hero region = 0
after:  Coldkey label present; owning-account link -> /accounts/5GsbTgfvgCH4xdqSkiPb7EaBBFLHjWH5vfEALhJaewSFpZX9
```

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6427/validator-mobile-dark-after.png)<br><sub>after</sub> |

## The fix

- Renders `detail.coldkey` via the shared `AccountAddress` component — a `Link to="/accounts/$ss58"` with the standard hover-card preview and copy button, so the owning account is reachable **for everyone**, not gated on `isOwner`.
- The `null`/invalid case needs no branch here: `AccountAddress` renders its `fallback` (`Not recorded`) when `ss58` is absent or fails `isValidSs58`.
- No behavioural change to the owner-only take flow — that path still reads `detail.coldkey` exactly as before.

## Verification

- The capture drives a **live** validator (`5E2LP6…`) whose API record carries a real owning coldkey (`5GsbTg…`), and asserts the rendered `href` matches it.
- `AccountAddress` already has its own component test (`account-address.test.ts`) covering the linked-vs-fallback rendering, so this reuses tested behaviour rather than adding untested logic.
- **No new type errors: 34 before, 34 after** — all pre-existing on clean `main` (a stale local ui-kit build), none in the file I touched, verified against a clean checkout.
- `eslint` on the committed blob: **0 errors**. `prettier --check`: clean. Rebased onto a main that moved 4 commits; pushed at `behind: 0`.
