### PR TITLE
fix(ui): return focus to the Compare button when SubnetCompareDrawer closes

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-compare-drawer.test.ts
+++ b/apps/ui/src/components/metagraphed/subnet-compare-drawer.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #6420: the "Compare" button was a plain sibling of <Sheet>, not its trigger,
+// so Radix had no trigger node to restore focus to on close — closing the drawer
+// dropped focus to <body>. Making the button a <SheetTrigger> inside <Sheet>
+// lets Radix track it and return focus. Verified in a real browser: before,
+// Escape leaves focus on <body>; after, it returns to the Compare button.
+//
+// Source assertion (this component needs a router + live queries to render, and
+// the suite is node-environment; the repo tests this way — ui-kit list-shell.test.ts).
+const source = readFileSync(
+  fileURLToPath(new URL("./subnet-compare-drawer.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("SubnetCompareDrawer returns focus to its trigger (#6420)", () => {
+  it("wraps the Compare button in a SheetTrigger", () => {
+    // The trigger must be a SheetTrigger with the button as its asChild child —
+    // that is the only thing that makes Radix restore focus on close.
+    const trigger = source.slice(
+      source.indexOf("<SheetTrigger"),
+      source.indexOf("</SheetTrigger>"),
+    );
+    expect(trigger).toContain("asChild");
+    expect(trigger).toContain("Compare");
+  });
+
+  it("imports SheetTrigger", () => {
+    expect(source).toContain("SheetTrigger");
+  });
+
+  it("no longer opens via a bare onClick sibling button", () => {
+    // The old bug: <button onClick={() => setOpen(true)}> as a fragment sibling
+    // of <Sheet>. SheetTrigger drives the open state through Sheet's context now,
+    // so that manual onClick is gone.
+    expect(source).not.toContain("onClick={() => setOpen(true)}");
+  });
+
+  it("keeps <Sheet> as the single root so the trigger lives inside it", () => {
+    // A SheetTrigger only wires focus-return when it is within the <Sheet> tree;
+    // the component now returns <Sheet>…</Sheet> directly rather than a fragment
+    // with the button outside it.
+    const ret = source.slice(source.indexOf("return ("));
+    expect(ret).toContain("<Sheet open={open}");
+    // The trigger precedes the content, both inside the Sheet.
+    expect(ret.indexOf("<SheetTrigger")).toBeGreaterThan(ret.indexOf("<Sheet open"));
+    expect(ret.indexOf("<SheetContent")).toBeGreaterThan(ret.indexOf("<SheetTrigger"));
+  });
+});

--- a/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-compare-drawer.tsx
@@ -1,7 +1,14 @@
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, GitCompare, X } from "lucide-react";
-import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@jsonbored/ui-kit";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@jsonbored/ui-kit";
 import {
   economicsQuery,
   subnetEndpointsQuery,
@@ -22,78 +29,79 @@ export function SubnetCompareDrawer({ netuid }: { netuid: number }) {
   const [peer, setPeer] = useState<number | null>(null);
 
   return (
-    <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong hover:border-accent/50 hover:text-accent transition-colors"
-        aria-haspopup="dialog"
-      >
-        <GitCompare className="size-3 text-ink-muted" />
-        Compare
-      </button>
+    <Sheet open={open} onOpenChange={setOpen}>
+      {/* #6420: the Compare button is now a SheetTrigger inside <Sheet>, so Radix
+          tracks it and restores focus to it on close. As a plain sibling it was
+          never the dialog's trigger, so closing dropped focus to <body>. */}
+      <SheetTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong hover:border-accent/50 hover:text-accent transition-colors"
+        >
+          <GitCompare className="size-3 text-ink-muted" />
+          Compare
+        </button>
+      </SheetTrigger>
 
-      <Sheet open={open} onOpenChange={setOpen}>
-        <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto">
-          <SheetHeader>
-            <SheetTitle className="font-display text-lg">Compare with another subnet</SheetTitle>
-            <SheetDescription>
-              Pick any active netuid (0–1024). Differences in pool ratio, top providers, and
-              endpoint health are highlighted.
-            </SheetDescription>
-          </SheetHeader>
+      <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle className="font-display text-lg">Compare with another subnet</SheetTitle>
+          <SheetDescription>
+            Pick any active netuid (0–1024). Differences in pool ratio, top providers, and endpoint
+            health are highlighted.
+          </SheetDescription>
+        </SheetHeader>
 
-          <form
-            className="mt-4 flex items-center gap-2"
-            onSubmit={(e) => {
-              e.preventDefault();
-              const n = Number(draft.replace(/\D/g, ""));
-              if (Number.isFinite(n)) setPeer(n);
-            }}
+        <form
+          className="mt-4 flex items-center gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            const n = Number(draft.replace(/\D/g, ""));
+            if (Number.isFinite(n)) setPeer(n);
+          }}
+        >
+          <label htmlFor="cmp-netuid" className="sr-only">
+            Compare against netuid
+          </label>
+          <input
+            id="cmp-netuid"
+            inputMode="numeric"
+            placeholder="e.g. 1"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            className="w-32 rounded border border-border bg-card px-2 py-1.5 font-mono text-sm tabular-nums text-ink-strong focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          />
+          <button
+            type="submit"
+            className="inline-flex items-center gap-1 rounded border border-border bg-card px-2.5 py-1.5 text-[11px] font-medium text-ink-strong hover:border-accent/50 hover:text-accent"
           >
-            <label htmlFor="cmp-netuid" className="sr-only">
-              Compare against netuid
-            </label>
-            <input
-              id="cmp-netuid"
-              inputMode="numeric"
-              placeholder="e.g. 1"
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              className="w-32 rounded border border-border bg-card px-2 py-1.5 font-mono text-sm tabular-nums text-ink-strong focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            />
+            Compare <ArrowRight className="size-3" />
+          </button>
+          {peer != null ? (
             <button
-              type="submit"
-              className="inline-flex items-center gap-1 rounded border border-border bg-card px-2.5 py-1.5 text-[11px] font-medium text-ink-strong hover:border-accent/50 hover:text-accent"
+              type="button"
+              onClick={() => {
+                setPeer(null);
+                setDraft("");
+              }}
+              className="ml-auto inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
             >
-              Compare <ArrowRight className="size-3" />
+              <X className="size-3" /> clear
             </button>
-            {peer != null ? (
-              <button
-                type="button"
-                onClick={() => {
-                  setPeer(null);
-                  setDraft("");
-                }}
-                className="ml-auto inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
-              >
-                <X className="size-3" /> clear
-              </button>
-            ) : null}
-          </form>
+          ) : null}
+        </form>
 
-          <div className="mt-5">
-            {peer == null ? (
-              <p className="rounded border border-dashed border-border bg-paper/40 px-3 py-6 text-center text-[12px] text-ink-muted">
-                Enter a netuid above to load a side-by-side comparison.
-              </p>
-            ) : (
-              <CompareBody base={netuid} peer={peer} />
-            )}
-          </div>
-        </SheetContent>
-      </Sheet>
-    </>
+        <div className="mt-5">
+          {peer == null ? (
+            <p className="rounded border border-dashed border-border bg-paper/40 px-3 py-6 text-center text-[12px] text-ink-muted">
+              Enter a netuid above to load a side-by-side comparison.
+            </p>
+          ) : (
+            <CompareBody base={netuid} peer={peer} />
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
   );
 }
 


### PR DESCRIPTION
## What

`SubnetCompareDrawer`'s "Compare" button was a plain sibling of `<Sheet>`, not its trigger. Radix returns focus to a dialog's trigger on close — but only when the trigger is a `<SheetTrigger>` inside the `<Sheet>` tree. With a bare `<button onClick={() => setOpen(true)}>` outside it, Radix had no trigger node, so **closing the drawer dropped focus to `<body>`** — a keyboard user lost their place.

The button is now a `<SheetTrigger asChild>` inside `<Sheet>`. Radix tracks it and restores focus on close.

## Proof — keyboard focus return (the fix is invisible, so this is the real evidence)

On `/subnets/1`: focus the Compare button, `Enter` to open, `Escape` to close, then read `document.activeElement`:

| | after Escape |
| --- | --- |
| **before** | ❌ focus on `<body>` — lost |
| **after** | ✅ focus back on the **Compare** button |

Both open the dialog identically; only the close-focus behaviour differs.

## Note on the cited precedent

The related issues (#6418/#6419) point at `StakeUnstakeModal` as the fix pattern. Worth flagging: that file has the **same** bug — a render-prop trigger outside `<Sheet>`, no `SheetTrigger` — so it's a sibling finding, not a fixed reference. This PR fixes only `SubnetCompareDrawer`; the others need their own (structurally different) fixes.

## Screenshots

`/subnets/1`, before/after. **Identical by design** — a focus-return change alters nothing rendered; it's observable only to keyboard/AT users (the table above). Rows supplied per the contract.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

`subnet-compare-drawer.test.ts` (4 tests, source assertions — the component needs a router + live queries and this suite is node-environment; the repo tests this way, e.g. ui-kit `list-shell.test.ts`):

- the Compare button is wrapped in a `SheetTrigger` (`asChild`, carrying "Compare");
- `SheetTrigger` is imported;
- the old bare `onClick={() => setOpen(true)}` sibling is gone;
- `<Sheet>` is the single root and the trigger precedes the content inside it — the arrangement Radix needs to wire focus-return.

**Verified meaningful: all 4 fail against the upstream file; all 4 pass restored.** And the browser focus test above is the behavioural proof.

`apps/ui`: 143 files / 1076 tests pass, `tsc` clean, `eslint` 0 errors, `format:check` clean. Diff is 2 files under `apps/ui/src`.

Closes #6420
