### PR TITLE
fix(api): resolve health/history dates through the stable latest/ key

### DIFF
--- a/tests/storage-read-artifact.test.mjs
+++ b/tests/storage-read-artifact.test.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { test, vi } from "vitest";
-import { readArtifact, readAsset, readR2 } from "../workers/storage.mjs";
+import {
+  readArtifact,
+  readAsset,
+  readR2,
+  latestR2Key,
+} from "../workers/storage.mjs";
 
 // A git/dual-tier artifact (not in any R2-only pattern) serves ASSETS-first,
 // then falls back to R2. These tests drive that fallback chain and the
@@ -92,6 +97,65 @@ test("readR2 returns r2_binding_missing when no archive binding is configured", 
   assert.equal(result.ok, false);
   assert.equal(result.status, 404);
   assert.equal(result.code, "r2_binding_missing");
+});
+
+// ---- health/history stable-latest key (#6508) ------------------------------
+// Every artifact but health/history/{date}.json resolves through the
+// versioned run-prefix the KV pointer names (atomic reads across a whole
+// publish). health/history is write-once per date, so it bypasses that
+// pointer and always reads the literal "latest/" prefix -- the one key
+// space r2-upload.mjs actually accumulates one file per date into.
+
+test("latestR2Key resolves a health/history date through the literal latest/ prefix, ignoring the run-prefix pointer", async () => {
+  const env = {
+    METAGRAPH_CONTROL: {
+      async get() {
+        return { latest_prefix: "runs/2026-07-17T11-21-50-971Z/" };
+      },
+    },
+  };
+  const key = await latestR2Key(
+    "/metagraph/health/history/2026-07-01.json",
+    env,
+  );
+  assert.equal(key, "latest/health/history/2026-07-01.json");
+});
+
+test("latestR2Key still resolves an ordinary artifact through the pointer's run prefix", async () => {
+  const env = {
+    METAGRAPH_CONTROL: {
+      async get() {
+        return { latest_prefix: "runs/2026-07-17T11-21-50-971Z/" };
+      },
+    },
+  };
+  const key = await latestR2Key("/metagraph/subnets.json", env);
+  assert.equal(key, "runs/2026-07-17T11-21-50-971Z/subnets.json");
+});
+
+test("readR2 for a health/history date reads the literal latest/ key even when the pointer names a different run prefix", async () => {
+  let requestedKey;
+  const env = {
+    METAGRAPH_CONTROL: {
+      async get() {
+        return { latest_prefix: "runs/2026-07-17T11-21-50-971Z/" };
+      },
+    },
+    METAGRAPH_ARCHIVE: {
+      async get(key) {
+        requestedKey = key;
+        return r2Object({ date: "2026-07-01" });
+      },
+    },
+  };
+  const result = await readR2(
+    env,
+    "/metagraph/health/history/2026-07-01.json",
+    "r2",
+  );
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.data, { date: "2026-07-01" });
+  assert.equal(requestedKey, "latest/health/history/2026-07-01.json");
 });
 
 // ---- R2-preferred dual artifacts (lines 78-87) -----------------------------

--- a/workers/storage.mjs
+++ b/workers/storage.mjs
@@ -177,11 +177,39 @@ export async function readR2(env, artifactPath, storageTier) {
   };
 }
 
+// health/history/{date}.json is the one artifact every publish writes a
+// NEW, distinct, write-once key for (today's date), never overwriting a
+// prior date's key -- unlike every other artifact, which the versioned
+// run-prefix pointer exists specifically to read atomically (see
+// kv-publish-pointer.mjs's own comment: pointing latest_prefix at the
+// immutable run prefix, not the mutable literal "latest/" prefix, avoids
+// ever serving a mix of stale + fresh artifacts from a partially-uploaded
+// publish). That atomicity concern doesn't apply here because a past
+// date's file is never touched by a later publish, so reading it via the
+// literal "latest/" prefix instead of the current run's prefix is safe --
+// and necessary, since r2-upload.mjs uploads every artifact to BOTH keys
+// (METAGRAPH_R2_UPLOAD_HISTORY=1 in production), but only the literal
+// "latest/" prefix accumulates one file per date across every past
+// publish; the run-prefix tree only ever contains THAT run's single date
+// (#6508 -- every date but today was unreachable through the normal
+// pointer-resolved prefix).
+const STABLE_LATEST_ARTIFACT_PATTERNS = [
+  /^\/metagraph\/health\/history\/\d{4}-\d{2}-\d{2}\.json$/,
+];
+
 export async function latestR2Key(artifactPath, env) {
+  const relativePath = artifactPath.replace(/^\/metagraph\//, "");
+  if (
+    STABLE_LATEST_ARTIFACT_PATTERNS.some((pattern) =>
+      pattern.test(artifactPath),
+    )
+  ) {
+    return `latest/${relativePath}`;
+  }
   const pointer = await latestPointer(env);
   const prefix =
     pointer?.latest_prefix || env.METAGRAPH_R2_LATEST_PREFIX || "latest/";
-  return `${prefix}${artifactPath.replace(/^\/metagraph\//, "")}`;
+  return `${prefix}${relativePath}`;
 }
 
 // In-isolate memo for the publish pointer (#367). Cloudflare reuses Worker


### PR DESCRIPTION
## Summary
- `GET /api/v1/health/history/{date}` only ever resolved today's date -- every earlier date 404'd, even though `scripts/build-artifacts.mjs` faithfully writes one dated snapshot every day.
- Root cause: reads resolve through `latestR2Key`'s pointer-named prefix (`runs/{timestamp}/`), which `kv-publish-pointer.mjs` deliberately points at the current run's own immutable prefix -- correct for atomicity on artifacts a publish overwrites wholesale, but that run-prefix tree only ever contains THAT run's single date for `health/history/{date}.json`.
- `r2-upload.mjs` already uploads every artifact to a second, stable `latest/{path}` key on every run (`METAGRAPH_R2_UPLOAD_HISTORY=1` in production). For date-keyed files like `health/history/{date}.json`, each day's upload targets a *different* literal key, so this stable prefix naturally accumulates one file per date, forever -- confirmed live: reading `latest/health/history/{date}.json` for the last 30 days in production R2 succeeded for all 30.
- Fix: `health/history/{date}.json` now resolves through the literal `latest/` prefix directly, bypassing the run-prefix pointer -- no storage-path redesign, no new publish step, just reading the archive that was already there.

Closes #6508. Found during a full data-source audit following D1 retirement (unrelated to D1).

## Test plan
- [x] `npx vitest run tests/storage-read-artifact.test.mjs tests/storage-pointer-memo.test.mjs` -- 14/14 passing, including 3 new regression tests
- [x] `npx eslint` / `npx prettier --check` clean
- [x] `npm run test:ci` -- full suite (298 files / 8935 tests) green
- [x] Verified live pre-fix (production 404 on `/api/v1/health/history/{yesterday}`) and confirmed the literal `latest/health/history/{date}.json` key is readable in production R2 for the last 30 days