### PR TITLE
refactor(ui): unify the /gaps reset-filter affordances (#6390)

### DIFF
--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -19,6 +19,7 @@ import {
   MiniRadial,
 } from "@jsonbored/ui-kit";
 import { Skeleton } from "@/components/metagraphed/states";
+import { ResetFiltersButton } from "@/components/metagraphed/table-controls";
 import { X, Search } from "lucide-react";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { IntegrabilityBoard } from "@/components/metagraphed/integrability-board";
@@ -586,15 +587,10 @@ function OpenGapsSection() {
         onChange={(v) => setSearch({ sort: v as typeof search.sort })}
         options={SORT_OPTIONS as readonly string[]}
       />
-      {hasFilters ? (
-        <button
-          type="button"
-          onClick={() => navigate({ search: {} as never, replace: true })}
-          className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] text-ink-muted hover:text-ink-strong"
-        >
-          <X className="size-3" /> Clear
-        </button>
-      ) : null}
+      <ResetFiltersButton
+        active={hasFilters}
+        onReset={() => navigate({ search: {} as never, replace: true })}
+      />
       <span className="ml-auto font-mono text-[10px] text-ink-muted">
         {sorted.length} of {rows.length}
       </span>
@@ -657,7 +653,7 @@ function OpenGapsSection() {
             onClick={() => setSearch({ missing: "" })}
             className="ml-auto inline-flex items-center gap-1 rounded-full border border-border bg-paper px-2 py-0.5 text-[10px] uppercase tracking-widest text-ink-muted hover:text-ink-strong"
           >
-            <X className="size-3" /> clear filter
+            <X className="size-3" /> clear
           </button>
         </div>
       ) : null}


### PR DESCRIPTION
## Summary

`apps/ui/src/routes/gaps.tsx` had four hand-rolled reset controls with four
different labels -- `clear`, `Clear`, `clear filter`, `Reset filters` -- and none
reused `table-controls.tsx`'s `ResetFiltersButton`, the component every other
multi-filter list page (`surfaces.tsx`, `subnets.index.tsx`, `blocks.index.tsx`,
`extrinsics.index.tsx`, `providers.index.tsx`) uses verbatim.

## What Changed

**Toolbar reset -> shared component.** The toolbar's `Clear` button cleared the whole
filter set, which is exactly `ResetFiltersButton`'s job, so it now renders the shared
`ResetFiltersButton` with `active={hasFilters}` -- identical usage to the sibling
pages, and the bespoke button markup is gone.

**The two scoped chip-clears are standardized.** The coverage-matrix chip read `clear`
and the open-gaps missing-kind chip read `clear filter`; both clear only the `missing`
selection, so they now share one `clear` label, casing, and icon.

**The empty-state action keeps `Reset filters`** as the canonical full-reset wording
(the issue asks for this).

**Why the chips stay scoped affordances rather than becoming `ResetFiltersButton`:**
that component announces `Clear search, filters, and pagination` and clears *everything*.
A chip that only drops the missing-kind filter shouldn't claim to reset the whole page --
that would contradict the issue's own "each control still clears only its own scoped
filter state." So the full-reset controls converge on `Reset filters` and the scoped
clears converge on `clear`: two honest labels by scope instead of four arbitrary ones.

No behavioral change -- every control clears exactly what it did before.

## Screenshots

`/gaps?missing=docs` -- a missing-kind filter that currently matches no open gaps, so
all four affordances are on screen at once: the toolbar reset, the open-gaps chip, and
the empty-state action (the coverage-matrix chip sits higher up the page). `before` is
the merge-base. Captured at the contract's fixed viewports, themes forced via
`mg-theme`, fonts settled before capture.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-before-desktop-light.png)<br><sub>four different labels</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-after-desktop-light.png)<br><sub>consistent</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-before-desktop-dark.png)<br><sub>four different labels</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-after-desktop-dark.png)<br><sub>consistent</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-before-tablet-light.png)<br><sub>four different labels</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-after-tablet-light.png)<br><sub>consistent</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-before-tablet-dark.png)<br><sub>four different labels</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-after-tablet-dark.png)<br><sub>consistent</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-before-mobile-light.png)<br><sub>four different labels</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-after-mobile-light.png)<br><sub>consistent</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-before-mobile-dark.png)<br><sub>four different labels</sub> | [<img src="https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/rust-toml/metagraphed/screenshots/6390-gaps-reset/6390-gaps-reset-after-mobile-dark.png)<br><sub>consistent</sub> |

Before, the toolbar says `Clear` and the open-gaps chip says `CLEAR FILTER`; after, the
toolbar says `Reset filters` (shared component) and the chip says `CLEAR`, matching the
coverage-matrix chip. On mobile the toolbar reset wraps onto its own row -- no overflow.

## Validation

- `npm run lint --workspace=apps/ui` -- 0 errors
- `npm run format:check --workspace=apps/ui` -- clean
- `npm run typecheck --workspace=apps/ui` -- 0 errors
- `npm test --workspace=apps/ui` -- 1072/1072 passed
- `npm run build --workspace=apps/ui` -- clean

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6390`) -- required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched -- one file under `apps/ui/**`.
- [x] `routeTree.gen.ts` untouched; screenshots hosted on the `screenshots` branch, not committed here.

Closes #6390
