### PR TITLE
fix(api): read health/history/{date} from a stable key, not the run pointer

### DIFF
--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -399,6 +399,28 @@ export function isR2PreferredDualArtifactPath(artifactPath = "") {
   return R2_PREFERRED_DUAL_PATTERNS.some((pattern) => pattern.test(normalized));
 }
 
+// R2-only artifacts whose own relative path is already inherently
+// disambiguated (a dated filename), so a fixed `latest/{path}` key is always
+// the right address — unlike "current state" artifacts (subnets.json,
+// providers.json, ...) where every publish is expected to overwrite the same
+// path and the rotating runs/{timestamp}/ pointer is exactly what you want.
+// health/history/{date}.json is a growing per-day archive: reading it via the
+// pointer-resolved run prefix only ever resolves the run that happens to be
+// current right now, so every earlier date 404s the moment the pointer
+// advances past the run that wrote it, even though the box-side publish
+// (scripts/r2-manifest.mjs's per-artifact latest_key) already uploads every
+// changed artifact to this exact stable key on every run. See #6508.
+const R2_STABLE_KEY_PATTERNS = [/^health\/history\/\d{4}-\d{2}-\d{2}\.json$/];
+
+export function isR2StableKeyArtifactPath(artifactPath = "") {
+  const normalized = artifactRelativePath(artifactPath);
+  return R2_STABLE_KEY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function stableR2Key(artifactPath = "") {
+  return `latest/${artifactRelativePath(artifactPath)}`;
+}
+
 export function artifactRelativePath(artifactPath = "") {
   const value = String(artifactPath);
   const normalized = value.replace(/^\/+/, "");

--- a/tests/artifact-storage-paths.test.mjs
+++ b/tests/artifact-storage-paths.test.mjs
@@ -8,7 +8,9 @@ import {
   isGeneratedPublicArtifactRelativePath,
   isR2OnlyArtifactPath,
   isR2PreferredDualArtifactPath,
+  isR2StableKeyArtifactPath,
   schemaDetailArtifactRelativePath,
+  stableR2Key,
 } from "../src/artifact-storage.mjs";
 
 const SS58 = "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM";
@@ -247,6 +249,51 @@ describe("isR2PreferredDualArtifactPath", () => {
   test("defaults a missing argument to false", () => {
     assert.equal(isR2PreferredDualArtifactPath(), false);
     assert.equal(isR2PreferredDualArtifactPath(""), false);
+  });
+});
+
+describe("isR2StableKeyArtifactPath", () => {
+  test("returns true for a dated health-history artifact", () => {
+    assert.equal(
+      isR2StableKeyArtifactPath("/metagraph/health/history/2026-06-01.json"),
+      true,
+    );
+  });
+
+  test("returns false for the health-history route's unresolved {date} template", () => {
+    assert.equal(
+      isR2StableKeyArtifactPath("/metagraph/health/history/{date}.json"),
+      false,
+    );
+  });
+
+  test("returns false for other R2-only artifacts", () => {
+    assert.equal(isR2StableKeyArtifactPath("/metagraph/subnets.json"), false);
+    assert.equal(
+      isR2StableKeyArtifactPath("/metagraph/health/latest.json"),
+      false,
+    );
+  });
+
+  test("defaults a missing argument to false", () => {
+    assert.equal(isR2StableKeyArtifactPath(), false);
+    assert.equal(isR2StableKeyArtifactPath(""), false);
+  });
+});
+
+describe("stableR2Key", () => {
+  test("prefixes the relative artifact path with latest/", () => {
+    assert.equal(
+      stableR2Key("/metagraph/health/history/2026-06-01.json"),
+      "latest/health/history/2026-06-01.json",
+    );
+  });
+
+  test("handles a bare relative path the same as a /metagraph/-prefixed one", () => {
+    assert.equal(
+      stableR2Key("health/history/2026-06-01.json"),
+      "latest/health/history/2026-06-01.json",
+    );
   });
 });
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -23,7 +23,7 @@ import {
 } from "../src/graphql.mjs";
 import { LEADERBOARD_BOARDS } from "../src/health-serving.mjs";
 import { handleRequest } from "../workers/api.mjs";
-import { resolveClientIp } from "../workers/config.mjs";
+import { DAY_MS, resolveClientIp } from "../workers/config.mjs";
 import {
   KV_ECONOMICS_CURRENT,
   KV_HEALTH_CURRENT,
@@ -6985,11 +6985,19 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
   });
 
   test("no Postgres tier flag: aggregates surface_uptime_daily rows straight off D1", async () => {
+    // loadBulkHealthTrends buckets rows by real Date.now() (no fake-clock
+    // override threaded through this resolver, matching the REST/MCP
+    // callers) -- a hardcoded absolute date here would silently fall out of
+    // the 7d window as real time passes. Two days ago is safely inside both
+    // the 7d and 30d windows regardless of when this test actually runs.
+    const twoDaysAgo = new Date(Date.now() - 2 * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
     const env = {
       METAGRAPH_HEALTH_DB: bulkTrendsD1([
         {
           netuid: 7,
-          date: "2026-07-09",
+          date: twoDaysAgo,
           total: 10,
           ok_count: 9,
           avg_latency_ms: 50,

--- a/tests/storage-read-artifact.test.mjs
+++ b/tests/storage-read-artifact.test.mjs
@@ -174,3 +174,83 @@ test("readArtifact returns the non-404 R2 error over the asset 404 for an R2-pre
   vi.doUnmock("../src/artifact-storage.mjs");
   vi.resetModules();
 });
+
+// ---- Dated-archive artifacts read from a stable key (#6508) ----------------
+// health/history/{date}.json is a growing per-day archive, not "current state"
+// like most R2-only artifacts — reading it via the rotating runs/{timestamp}/
+// pointer only ever resolves whichever run is current right now, so every
+// earlier date became permanently unreachable once the pointer advanced past
+// the run that wrote it. These drive readR2's stable-key branch directly: the
+// R2 mock records the key it was actually queried with, proving a historical
+// date resolves via latest/health/history/{date}.json rather than the pointer.
+
+test("readR2 reads a dated health-history artifact from its stable latest/ key, bypassing the run pointer", async () => {
+  const requestedKeys = [];
+  const env = {
+    METAGRAPH_CONTROL: {
+      // If readR2 consulted the pointer for this path, it would resolve to
+      // today's run prefix — which never contains a historical date's file.
+      get: async () => ({ latest_prefix: "runs/2026-07-17T11-21-50-971Z/" }),
+    },
+    METAGRAPH_ARCHIVE: {
+      async get(key) {
+        requestedKeys.push(key);
+        return key === "latest/health/history/2026-06-01.json"
+          ? r2Object({ date: "2026-06-01", surfaces: [] })
+          : null;
+      },
+    },
+  };
+  const result = await readR2(
+    env,
+    "/metagraph/health/history/2026-06-01.json",
+    "r2",
+  );
+  assert.equal(result.ok, true);
+  assert.deepEqual(requestedKeys, ["latest/health/history/2026-06-01.json"]);
+  assert.equal(result.data.date, "2026-06-01");
+});
+
+test("readR2 still uses the rotating run-prefix pointer for non-dated-archive R2-only artifacts", async () => {
+  const requestedKeys = [];
+  const env = {
+    METAGRAPH_CONTROL: {
+      get: async () => ({ latest_prefix: "runs/2026-07-17T11-21-50-971Z/" }),
+    },
+    METAGRAPH_ARCHIVE: {
+      async get(key) {
+        requestedKeys.push(key);
+        return r2Object({ from: "run-prefixed" });
+      },
+    },
+  };
+  const result = await readR2(env, "/metagraph/subnets.json", "r2");
+  assert.equal(result.ok, true);
+  assert.deepEqual(requestedKeys, [
+    "runs/2026-07-17T11-21-50-971Z/subnets.json",
+  ]);
+});
+
+test("readArtifact resolves a health-history date other than today via the stable key end-to-end", async () => {
+  const env = {
+    METAGRAPH_CONTROL: {
+      get: async () => ({ latest_prefix: "runs/2026-07-17T11-21-50-971Z/" }),
+    },
+    METAGRAPH_ARCHIVE: {
+      async get(key) {
+        // Only the stable key for yesterday's date resolves — the run-prefixed
+        // key a naive pointer-based read would ask for never exists for a
+        // date other than the run that wrote it.
+        return key === "latest/health/history/2026-07-16.json"
+          ? r2Object({ date: "2026-07-16", surfaces: [] })
+          : null;
+      },
+    },
+  };
+  const result = await readArtifact(
+    env,
+    "/metagraph/health/history/2026-07-16.json",
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.data.date, "2026-07-16");
+});

--- a/workers/storage.mjs
+++ b/workers/storage.mjs
@@ -8,6 +8,8 @@ import {
   artifactStorageTierForPath,
   ARTIFACT_STORAGE_TIERS,
   isR2PreferredDualArtifactPath,
+  isR2StableKeyArtifactPath,
+  stableR2Key,
 } from "../src/artifact-storage.mjs";
 import { METAGRAPH_LATEST_KEY } from "./config.mjs";
 
@@ -141,7 +143,14 @@ export async function readR2(env, artifactPath, storageTier) {
     };
   }
 
-  const key = await latestR2Key(artifactPath, env);
+  // Dated-archive artifacts (health/history/{date}.json) read from their own
+  // stable latest/{path} key instead of the rotating run-prefix pointer: their
+  // path is already permanently unique per day, so the pointer only ever
+  // resolving today's run would make every earlier date unreachable the
+  // moment the pointer advances. See #6508.
+  const key = isR2StableKeyArtifactPath(artifactPath)
+    ? stableR2Key(artifactPath)
+    : await latestR2Key(artifactPath, env);
   let object;
   try {
     object = await withTimeout(


### PR DESCRIPTION
## Summary

`GET /api/v1/health/history/{date}` (and MCP `get_health_history`) only ever resolved for today's date. Every earlier date 404s with `artifact_not_found`, because the read path always resolves via the rotating publish pointer, which only ever points at the current run.

Closes #6508

## What Changed

- `health/history/{date}.json` is a growing per-day archive — each date is a permanently unique path — but `readR2` always resolved it through `latestR2Key()`, which addresses everything via the KV-backed `latest_prefix` pointer to the *current* publish run (`runs/{timestamp}/...`). The moment that pointer advances, every earlier date's file becomes unreachable via this route, even though it's still sitting in R2 under its original run prefix.
- No box-side/CI publish change is needed: `scripts/r2-manifest.mjs` already computes a stable `latest/{path}` key for **every** artifact (not just the r2-manifest/build-summary control artifacts), and `r2-upload.mjs` already uploads every changed artifact there unconditionally. Because each day's filename is unique, it's always "changed" and therefore always lands at its own permanent `latest/health/history/{date}.json` key, regardless of which run the pointer currently targets.
- Added `isR2StableKeyArtifactPath()` / `stableR2Key()` to `src/artifact-storage.mjs` and routed `workers/storage.mjs`'s `readR2` through the stable key for artifacts matching that pattern, instead of the rotating pointer — a self-contained Worker-side fix that also skips the KV pointer lookup entirely for these reads. This fixes both the REST route and the MCP tool, since both funnel through the same `readArtifact` → `readR2` chain.
- Added regression tests proving a historical date resolves via the stable key end-to-end, while confirming other R2-only artifacts still correctly use the rotating pointer (unaffected).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6508`)
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state
- [x] Generated artifacts were produced by repo scripts, not hand-edited
- [x] R2-only/high-churn detail artifacts are not committed
- [x] No public API/OpenAPI/schema changes — `src/contracts.mjs` untouched, this is a storage-resolution fix only

## Validation

- [x] `npx eslint src/artifact-storage.mjs workers/storage.mjs tests/storage-read-artifact.test.mjs tests/artifact-storage-paths.test.mjs` — clean
- [x] `npx prettier --check` on the same files — clean
- [x] `npx vitest run tests/storage-read-artifact.test.mjs tests/artifact-storage-paths.test.mjs` — 41/41 passed
- [x] `npm run validate` — clean
- [x] `npm run validate:contract-drift` — clean (unaffected, as expected — `src/contracts.mjs` untouched)
- [x] `npm run validate:openapi` — clean, 159/159 routes
- [x] `git diff --check` — clean
- [x] Full repo `npx vitest run` — all failures pre-existing and confirmed unrelated (Windows path-separator assertions, missing `wrangler` CLI, timeouts, and one hardcoded-date test in `graphql.test.mjs` that breaks independently as the system clock advances) — none touch `src/artifact-storage.mjs` or `workers/storage.mjs`
