### PR TITLE
fix(ui): return focus to its trigger when TakeManagementModal closes

### DIFF
--- a/apps/ui/src/components/metagraphed/take-management-modal.test.ts
+++ b/apps/ui/src/components/metagraphed/take-management-modal.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #6419: TakeManagementModal's trigger (a caller-supplied render-prop) was a
+// plain sibling of <Sheet>, not its trigger — so Radix had no trigger node to
+// restore focus to on close, and closing the modal dropped focus to <body>.
+// Wrapping the render-prop in <SheetTrigger asChild> inside <Sheet> is the same
+// mechanism proven in-browser for SubnetCompareDrawer (#6420/#6527): before,
+// Escape leaves focus on <body>; after, it returns to the trigger.
+//
+// Owner-gated (only rendered for the connected owning coldkey), so a headless
+// keyboard demo of this instance isn't practical — hence source assertions on
+// the wiring, plus the linked in-browser proof of the identical mechanism.
+const source = readFileSync(
+  fileURLToPath(new URL("./take-management-modal.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("TakeManagementModal returns focus to its trigger (#6419)", () => {
+  it("wraps the render-prop trigger in a SheetTrigger", () => {
+    expect(source).toContain("<SheetTrigger asChild>{trigger(() => setOpen(true))}</SheetTrigger>");
+  });
+
+  it("imports SheetTrigger", () => {
+    const imports = source.slice(0, source.indexOf('} from "@jsonbored/ui-kit";'));
+    expect(imports).toContain("SheetTrigger");
+  });
+
+  // Just the component's own return block (up to its closing </Sheet>), so
+  // fragments in unrelated helper functions later in the file don't leak in.
+  const componentReturn = (() => {
+    const start = source.indexOf("return (");
+    const end = source.indexOf("</Sheet>\n  );", start) + "</Sheet>\n  );".length;
+    return source.slice(start, end);
+  })();
+
+  it("no longer renders the trigger as a fragment sibling outside <Sheet>", () => {
+    // The old shape: return (<>{trigger(...)}<Sheet>…). A SheetTrigger only
+    // wires focus-return when it sits inside <Sheet>, so the component now
+    // returns <Sheet> directly with the trigger within it.
+    expect(componentReturn.trimStart()).toMatch(/^return \(\s*<Sheet open=\{open\}/);
+    expect(componentReturn).not.toContain("<>");
+  });
+
+  it("keeps the trigger ahead of the content, both inside <Sheet>", () => {
+    const sheet = componentReturn.indexOf("<Sheet open");
+    const trigger = componentReturn.indexOf("<SheetTrigger");
+    const content = componentReturn.indexOf("<SheetContent");
+    expect(sheet).toBeGreaterThan(-1);
+    expect(trigger).toBeGreaterThan(sheet);
+    expect(content).toBeGreaterThan(trigger);
+  });
+
+  it("preserves the signature-in-flight close guard (handleOpenChange)", () => {
+    // The focus change must not weaken the guard that blocks closing mid-signature.
+    expect(source).toContain("if (!flow.canClose) return;");
+    expect(source).toContain("<Sheet open={open} onOpenChange={handleOpenChange}>");
+  });
+});

--- a/apps/ui/src/components/metagraphed/take-management-modal.tsx
+++ b/apps/ui/src/components/metagraphed/take-management-modal.tsx
@@ -15,6 +15,7 @@ import {
   SheetFooter,
   SheetHeader,
   SheetTitle,
+  SheetTrigger,
 } from "@jsonbored/ui-kit";
 import { WalletConnectPanel } from "@/components/metagraphed/wallet-connect";
 import { SearchInput } from "@/components/metagraphed/table-controls";
@@ -86,33 +87,36 @@ export function TakeManagementModal({
   };
 
   return (
-    <>
-      {trigger(() => setOpen(true))}
-      <Sheet open={open} onOpenChange={handleOpenChange}>
-        <SheetContent side="right" className="flex w-full flex-col overflow-y-auto sm:max-w-lg">
-          <SheetHeader>
-            <SheetTitle className="font-display text-lg">
-              Manage take · {validatorName ?? shortHash(hotkey, 6)}
-            </SheetTitle>
-            <SheetDescription>
-              {!flow.canClose
-                ? "This can't be closed while a signature is in flight."
-                : "Validator commission, network-wide"}
-            </SheetDescription>
-          </SheetHeader>
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      {/* #6419: the trigger was a plain sibling of <Sheet>, not its trigger, so
+          Radix had no trigger node to restore focus to on close -- closing the
+          modal dropped focus to <body>. Wrapping the caller's render-prop element
+          in <SheetTrigger asChild> inside <Sheet> is the same fix #6527 proved
+          in-browser for SubnetCompareDrawer: Radix tracks it and returns focus. */}
+      <SheetTrigger asChild>{trigger(() => setOpen(true))}</SheetTrigger>
+      <SheetContent side="right" className="flex w-full flex-col overflow-y-auto sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle className="font-display text-lg">
+            Manage take · {validatorName ?? shortHash(hotkey, 6)}
+          </SheetTitle>
+          <SheetDescription>
+            {!flow.canClose
+              ? "This can't be closed while a signature is in flight."
+              : "Validator commission, network-wide"}
+          </SheetDescription>
+        </SheetHeader>
 
-          <div className="mt-4 flex-1">
-            <TakeFlowBody
-              hotkey={hotkey}
-              flow={flow}
-              submitting={submitting}
-              onConfirm={handleConfirm}
-              onClose={() => handleOpenChange(false)}
-            />
-          </div>
-        </SheetContent>
-      </Sheet>
-    </>
+        <div className="mt-4 flex-1">
+          <TakeFlowBody
+            hotkey={hotkey}
+            flow={flow}
+            submitting={submitting}
+            onConfirm={handleConfirm}
+            onClose={() => handleOpenChange(false)}
+          />
+        </div>
+      </SheetContent>
+    </Sheet>
   );
 }
 


### PR DESCRIPTION
## What

`TakeManagementModal`'s trigger — a caller-supplied render-prop — was a plain sibling of `<Sheet>`, not its trigger. Radix returns focus to a dialog's trigger on close only when that trigger is a `<SheetTrigger>` inside `<Sheet>`; a bare sibling left Radix no trigger node, so **closing the modal dropped focus to `<body>`**.

The render-prop is now wrapped in `<SheetTrigger asChild>` inside `<Sheet>` — Radix tracks it and restores focus.

## Mechanism — proven, with an honest caveat

This is the **same fix, same mechanism** as #6527 (SubnetCompareDrawer), which I verified in a real browser: focus the trigger → `Enter` to open → `Escape` to close → focus returns to the trigger (before, it went to `<body>`).

I could not run that keyboard demo for *this* component: the "Manage take" button is **owner-gated** (`validators.$hotkey.tsx:317` — `isOwner`, only rendered for the connected wallet matching the validator's coldkey, and the wallet's live-extension check clears an injected one). So the evidence here is (1) the identical Radix mechanism proven in-browser in #6527, and (2) the source-assertion tests below confirming the wiring. Flagging that rather than implying a live demo I didn't run.

## Screenshots

`/validators/{hotkey}`, before/after — **identical by design** (a focus-return change renders nothing new; the Manage-take affordance is owner-gated and not shown to an unconnected visitor). Rows supplied per the contract.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

`take-management-modal.test.ts` (5 tests, source assertions — the component needs a router + wallet context and the suite is node-environment):

- the render-prop is wrapped in `<SheetTrigger asChild>`;
- `SheetTrigger` is imported;
- the trigger is no longer a fragment sibling outside `<Sheet>` (`<Sheet>` is now the single root);
- trigger precedes content, both inside `<Sheet>`;
- the signature-in-flight close guard (`if (!flow.canClose) return`) is preserved — the focus change must not weaken it.

**Verified meaningful: 4 of 5 fail against the upstream file** (the 5th, the close-guard invariant, passes both ways by design).

`apps/ui`: 144 files / 1080 tests pass, `tsc` clean, `eslint` 0 errors, `format:check` clean. Diff is 2 files under `apps/ui/src`.

Note: `StakeUnstakeModal` has the same bug (the header comment says this file mirrors it) — a separate follow-up, out of scope here.

Closes #6419
