### PR TITLE
fix(ui): give the neuron drill-down card's hotkey/coldkey a copy affordance

### DIFF
--- a/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-detail-card.tsx
@@ -5,7 +5,7 @@ import { subnetNeuronQuery } from "@/lib/metagraphed/queries";
 import { RealtimeFreshness, StatTile } from "@jsonbored/ui-kit";
 import { EmptyState } from "@/components/metagraphed/states";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
-import { shortHash } from "@/lib/metagraphed/blocks";
+import { AccountAddress } from "@/components/metagraphed/account-address";
 import { formatNumber } from "@/lib/metagraphed/format";
 
 function scoreStr(v?: number | null): string {
@@ -145,14 +145,13 @@ function KeyRow({ label, value }: { label: string; value?: string }) {
         {label}
       </span>
       {value ? (
-        <Link
-          to="/accounts/$ss58"
-          params={{ ss58: value }}
-          className="font-mono text-[12px] text-ink hover:text-accent hover:underline"
-          title={value}
-        >
-          {shortHash(value) ?? value}
-        </Link>
+        <span className="font-mono text-[12px] text-ink">
+          <AccountAddress
+            ss58={value}
+            compact
+            fallback={<span className="text-ink-muted">{value}</span>}
+          />
+        </span>
       ) : (
         <span className="font-mono text-[12px] text-ink-muted">—</span>
       )}


### PR DESCRIPTION
Closes #6339

`neuron-detail-card.tsx`'s `KeyRow` rendered the hotkey and coldkey as a plain `/accounts/$ss58` Link with no copy affordance — the only identifier display on the subnet detail drill-down without one.

`KeyRow` now uses the shared `AccountAddress` component (the same treatment ss58 values get in `blocks.$ref`/`blocks.index`), which pairs the link with an account hover-card and a `CopyButton`. It's passed `compact` — the prop that formalizes the `-my-3.5` offset — so the 44px touch target folds into the row's own height. Measured on `/subnets/64?tab=metagraph&uid=27`: row height unchanged at **18px → 18px**, button hit-area 44px.

Captured at the Phase C2 matrix — fixed viewports (375×812 / 768×1024 / 1280×800), each theme forced via `mg-theme`, with the drill-down card open (`?uid=27`).

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6339/6339-after-mobile-dark.png)<br><sub>after</sub> |

### Verification

`prettier` clean · `eslint` 0 errors · `tsc --noEmit` 0 · `vitest` 1075/1075 passing (143 files). `AccountAddress` handles the invalid/missing-ss58 case via its `fallback`; the zero row-height delta was measured in the browser with the button toggled on/off.
