### PR TITLE
fix(ui): add the missing ShareButton to the Accounts index PageHero

### DIFF
--- a/apps/ui/src/routes/accounts.index.tsx
+++ b/apps/ui/src/routes/accounts.index.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { TopActiveAccounts } from "@/components/metagraphed/top-active-accounts";
 import { TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS } from "@/components/metagraphed/top-active-accounts-ranking";
-import { PageHero } from "@jsonbored/ui-kit";
+import { PageHero, ActionBar, ShareButton } from "@jsonbored/ui-kit";
 import { isValidSs58 } from "@/lib/metagraphed/accounts";
 
 export const Route = createFileRoute("/accounts/")({
@@ -50,6 +50,11 @@ function AccountsPage() {
         live
         title="Accounts"
         description="Look up a Bittensor account by ss58 address (hotkey or coldkey) — its cross-subnet activity, current registrations, and first-party chain-event history."
+        actions={
+          <ActionBar>
+            <ShareButton bare />
+          </ActionBar>
+        }
       />
       <form onSubmit={submit} className="mx-auto w-full max-w-2xl">
         <label


### PR DESCRIPTION
## What

`accounts.index.tsx`'s `PageHero` had no `actions` prop — the Accounts index was the **only** list/index route missing the share affordance every peer provides (`blocks.index.tsx`, `extrinsics.index.tsx`, `subnets.index.tsx`, `providers.index.tsx`, `validators.index.tsx`, `leaderboards.tsx`, `events.index.tsx`, `runtime.index.tsx`, …).

This adds the exact same pattern every peer uses:

```tsx
actions={
  <ActionBar>
    <ShareButton bare />
  </ActionBar>
}
```

`ActionBar` and `ShareButton` come from `@jsonbored/ui-kit` (already the import source in the file). No other change.

## Screenshots (before / after)

3 viewports × 2 themes. **Before** = hero with no share control; **After** = the "Share view" button now sits below the description, matching every peer list page.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6333-after-mobile-dark.png)<br><sub>after</sub> |


## Validation

- `eslint` — clean on the changed file (0 errors).
- `prettier --check` (apps/ui workspace config) — clean.
- Unit tests — full `apps/ui` suite green: **141 files / 1065 tests passed** (no route/component tests broken by the additive change).

Closes #6333
