### PR TITLE
fix(ui): disclose the agents page's API source and add a ShareButton

### DIFF
--- a/apps/ui/src/routes/agents.tsx
+++ b/apps/ui/src/routes/agents.tsx
@@ -13,8 +13,11 @@ import {
   ArrowUpRight,
 } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import {
   PageHero,
+  ActionBar,
+  ShareButton,
   CopyButton,
   ExternalLink,
   McpToolsList,
@@ -100,12 +103,18 @@ function AgentsPage() {
         live
         title="Use AI to explore Bittensor"
         description="Point any agent at metagraphed — over MCP, a typed SDK, or plain HTTP — and it can find, explain, and call the right Bittensor subnet for a task. No key, no account."
+        actions={
+          <ActionBar>
+            <ShareButton bare />
+          </ActionBar>
+        }
       />
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-[40rem] w-full" />}>
           <AgentsBody />
         </Suspense>
       </QueryErrorBoundary>
+      <ApiSourceFooter paths={["/api/v1/agent-resources"]} />
     </AppShell>
   );
 }


### PR DESCRIPTION
## What

`agents.tsx` ("For AI agents") renders live query data (`agentResourcesQuery()`, sourced from `/api/v1/agent-resources`) but — unlike every other live-data route — carried **no `ApiSourceFooter`** to disclose that source, and its `PageHero` had **no `ShareButton`**. Two small additions bring it to parity:

```tsx
// PageHero
actions={
  <ActionBar>
    <ShareButton bare />
  </ActionBar>
}
// …and before </AppShell>:
<ApiSourceFooter paths={["/api/v1/agent-resources"]} />
```

`ActionBar`/`ShareButton` come from `@jsonbored/ui-kit`; `ApiSourceFooter` is the same shared component every other live-data route already uses. No other change.

## Screenshots (before / after)

3 viewports × 2 themes, framed on the hero — **Before** = no share control; **After** = the "Share view" button below the description. (The `ApiSourceFooter` is added at the page bottom, citing `/api/v1/agent-resources`, matching the placement on every peer route — below the fold of these hero-framed shots.)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6336-after-mobile-dark.png)<br><sub>after</sub> |


## Validation

- `eslint` — clean on the changed file (0 errors).
- `prettier --check` (apps/ui workspace config) — clean.
- Unit tests — full `apps/ui` suite green: **141 files / 1065 tests passed**.

Closes #6336
