### PR TITLE
feat(ui): add a reset affordance to /schemas and use the shared SearchInput

### DIFF
--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -27,6 +27,7 @@ import { schemasQuery, contractsQuery, metagraphedQueryKey } from "@/lib/metagra
 import { normalizeDriftStatus } from "@/lib/metagraphed/schema-drift";
 import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
 import { isStaleFreshness, classNames } from "@/lib/metagraphed/format";
+import { SearchInput, ResetFiltersButton } from "@/components/metagraphed/table-controls";
 import type { SchemaInfo } from "@/lib/metagraphed/types";
 
 const schemasSearchSchema = z.object({
@@ -354,11 +355,14 @@ function SchemaExplorer() {
         {/* Left rail */}
         <aside className="rounded-xl border border-border bg-card overflow-hidden flex flex-col max-h-[min(680px,70vh)]">
           <div className="border-b border-border p-3 space-y-2.5">
-            <input
+            {/* The shared SearchInput, which carries an aria-label (a
+                placeholder is not an accessible name), replacing the bespoke
+                unlabelled <input> (#6394). w-full keeps the left-rail width. */}
+            <SearchInput
               value={search.q}
-              onChange={(e) => setSearch({ q: e.target.value })}
+              onChange={(q) => setSearch({ q })}
               placeholder="Search schemas…"
-              className="w-full rounded-full border border-border bg-paper px-3 py-1.5 text-[12px] focus:outline-none focus:border-accent/50"
+              className="w-full"
             />
             <div className="flex items-center gap-1">
               {(["all", "drift", "stable"] as const).map((v) => (
@@ -377,8 +381,21 @@ function SchemaExplorer() {
                 </button>
               ))}
             </div>
-            <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
-              {filtered.length} of {all.length}
+            <div className="flex items-center justify-between gap-2">
+              <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                {filtered.length} of {all.length}
+              </div>
+              {/* One-click way back to the unfiltered view for a shared
+                  /schemas?q=X&drift=Y link -- clears BOTH the search text and
+                  the drift pill, matching the filtersActive/ResetFiltersButton
+                  convention every other list page uses (#6394). The `open` /
+                  `driftDetail` selection state is a viewer target, not a filter,
+                  so it is left untouched. */}
+              <ResetFiltersButton
+                active={!!search.q || search.drift !== "all"}
+                onReset={() => setSearch({ q: "", drift: "all" })}
+                bare
+              />
             </div>
           </div>
           <ul className="flex-1 overflow-y-auto divide-y divide-border/60">


### PR DESCRIPTION
Closes #6394

## The gap

`/schemas` persists `drift`/`q` in the URL, but there was no way to clear a shared `/schemas?q=X` link's search in one click — every other list page (`gaps`, `subnets`, `surfaces`, `providers`, `blocks`, `extrinsics`) has a reset affordance. Its search box was also a bespoke, **unlabelled** `<input>` rather than the shared `SearchInput`.

## Screenshots

The left rail now uses the shared `SearchInput` and shows a **Reset filters** control beside the result count. The capture **asserts** both deliverables rather than trusting the pixels:

```
before: Reset filters buttons = 0, aria-labelled search inputs = 0
after:  PASS: Reset filters present (1); search input has accessible name (1)
```

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6394/schemas-mobile-dark-after.png)<br><sub>after</sub> |

## The fix

- **Reset affordance** — a `ResetFiltersButton` beside the result count, visible only when a filter is active (`q` set **or** `drift !== "all"`), clearing **both** in one click via `setSearch({ q: "", drift: "all" })`. Same `filtersActive`/`ResetFiltersButton` convention every other list page uses. The `open`/`driftDetail` state is a *viewer* target, not a filter, so it's deliberately left untouched.
- **Shared `SearchInput`** — replaces the bespoke `<input>`. `SearchInput` carries an `aria-label` (a placeholder is **not** an accessible name for assistive tech) and the app's consistent styling; `w-full` preserves the left-rail width.

No behavioural change to filtering itself — the reset clears exactly `q` + `drift`.

## Verification

- The capture drives a filtered view (`?q=subnet`) so the reset control renders, and asserts the search input exposes `aria-label="Search schemas…"` (absent before).
- `ResetFiltersButton`/`SearchInput` are shared components with their own coverage, so this composes tested pieces.
- **No new type errors: 34 before, 34 after** — all pre-existing on clean `main` (a stale local ui-kit build), none in `schemas.tsx`, verified against a clean checkout.
- `eslint` on the committed blob: **0 errors**. `prettier --check`: clean. Pushed at `behind: 0`.
