### PR TITLE
fix(ui): move focus to the hash-nav target so deep links reach assistive tech (#6421)

### DIFF
--- a/apps/ui/src/components/metagraphed/use-hash-scroll.test.ts
+++ b/apps/ui/src/components/metagraphed/use-hash-scroll.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+import { focusHashTarget, type FocusableEl } from "./use-hash-scroll";
+
+/** A fake element recording its tabindex attribute + focus calls, so the
+ * focus-follows-hash logic (#6421) is exercised without a DOM — the suite runs
+ * in a plain node environment. */
+function fakeEl(initialTabIndex?: string) {
+  const attrs = new Map<string, string>();
+  if (initialTabIndex !== undefined) attrs.set("tabindex", initialTabIndex);
+  const classes = new Set<string>();
+  const focus = vi.fn<(options?: { preventScroll?: boolean }) => void>();
+  const el: FocusableEl = {
+    hasAttribute: (n) => attrs.has(n),
+    setAttribute: (n, v) => void attrs.set(n, v),
+    classList: { add: (t) => void classes.add(t) },
+    focus,
+  };
+  return { el, attrs, classes, focus };
+}
+
+describe("focusHashTarget", () => {
+  it("moves focus with preventScroll so it doesn't fight the smooth scroll", () => {
+    const { el, focus } = fakeEl();
+    focusHashTarget(el);
+    expect(focus).toHaveBeenCalledTimes(1);
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it("makes an unfocusable section focusable and LEAVES the tabindex in place", () => {
+    // Persisting tabindex="-1" is deliberate: removing it (as back-to-top does
+    // for <main>) blurs the section back to <body>, reverting a keyboard user's
+    // focus. tabindex="-1" is not a tab stop, so leaving it costs nothing.
+    const { el, attrs } = fakeEl(); // a <section>/<h2> has no tabindex
+    focusHashTarget(el);
+    expect(attrs.get("tabindex")).toBe("-1");
+  });
+
+  it("marks the target so it gets the app's focus ring instead of the UA outline", () => {
+    const { el, classes } = fakeEl();
+    focusHashTarget(el);
+    expect(classes.has("mg-hash-focus")).toBe(true);
+  });
+
+  it("leaves an element's own tabindex untouched", () => {
+    const { el, attrs, focus } = fakeEl("0"); // already focusable, e.g. tabindex="0"
+    focusHashTarget(el);
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+    // Its real tabindex must survive — we neither overwrite nor strip it.
+    expect(attrs.get("tabindex")).toBe("0");
+  });
+});

--- a/apps/ui/src/components/metagraphed/use-hash-scroll.ts
+++ b/apps/ui/src/components/metagraphed/use-hash-scroll.ts
@@ -1,11 +1,51 @@
 import { useEffect } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 
+/** The slice of an element `focusHashTarget` needs — kept structural so the
+ * branch is unit-testable with a fake handle (the suite has no DOM), and so a
+ * real `HTMLElement` satisfies it without a cast. */
+export interface FocusableEl {
+  hasAttribute(name: string): boolean;
+  setAttribute(name: string, value: string): void;
+  classList: { add(token: string): void };
+  focus(options?: { preventScroll?: boolean }): void;
+}
+
+/**
+ * Move DOM focus — and with it the screen-reader cursor — to a hash-nav target
+ * after it has scrolled into view (#6421). `scrollIntoView` moves only the
+ * viewport, so without this a deep link is silent to screen-reader users and a
+ * no-op for keyboard users (whose next Tab still starts from the top).
+ *
+ * A `<section>`/`<h2>` isn't focusable by default, so give it `tabindex="-1"`
+ * when it lacks one, and focus with `preventScroll: true` so it doesn't fight
+ * the smooth scroll — the technique `back-to-top.tsx` uses. The one departure:
+ * `back-to-top.tsx` strips the tabindex from `<main>` on a 0ms timer, but doing
+ * that here blurs the freshly focused section straight back to `<body>`
+ * (verified) — which reverts a keyboard user's focus to the top and defeats the
+ * "focus follows the scroll" outcome. `tabindex="-1"` is not a keyboard tab
+ * stop, so leaving it in place keeps focus on the section without polluting the
+ * tab order (the only thing the removal guarded against). An element that
+ * already carries a tabindex keeps its own value, untouched.
+ *
+ * The `mg-hash-focus` class swaps the browser's default focus outline — a boxy,
+ * off-brand rectangle — for the app's soft accent ring (styles.css). It's
+ * scoped to `:focus`, so the class can persist harmlessly and only paints while
+ * the element is actually focused. Programmatic focus fires `:focus` but not
+ * `:focus-visible`, which is why the rule targets `:focus` directly.
+ */
+export function focusHashTarget(el: FocusableEl): void {
+  el.classList.add("mg-hash-focus");
+  if (!el.hasAttribute("tabindex")) el.setAttribute("tabindex", "-1");
+  el.focus({ preventScroll: true });
+}
+
 /**
  * Watches `location.hash` and:
  *  - if the hash is in `sectionToTab` and the current tab differs, switches
  *    the `tab` search param to the matching tab,
- *  - then smooth-scrolls the element with that id into view.
+ *  - then smooth-scrolls the element with that id into view and moves focus to
+ *    it so the deep link is announced to assistive tech (#6421).
  *
  * This wires up cross-tab deep links like
  *   /subnets/7?tab=overview#endpoints
@@ -31,10 +71,19 @@ export function useHashScroll(activeTab: string, sectionToTab: Record<string, st
       return;
     }
 
-    // After tab switch / on initial mount, scroll the section into view.
+    // After tab switch / on initial mount, scroll the section into view and
+    // move focus to it, so keyboard/screen-reader users following the link
+    // land on the section rather than having only the viewport shift (#6421).
     const scroll = () => {
       const el = document.getElementById(id);
-      if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+      if (!el) return;
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+      // Focus the section's heading when it has one, else the section itself
+      // (#6421 permits either). The heading is the better target: its focus
+      // ring is a tight, legible indicator rather than an outline around the
+      // whole section box, and a screen reader announces the heading text.
+      const focusTarget = el.querySelector<HTMLElement>("h1, h2, h3, h4, [role='heading']") ?? el;
+      focusHashTarget(focusTarget);
     };
     // Defer so the panel for the new tab has time to mount.
     const t = window.setTimeout(scroll, 80);

--- a/apps/ui/src/styles.css
+++ b/apps/ui/src/styles.css
@@ -15,3 +15,18 @@
 
 @import "@jsonbored/ui-kit/styles.css";
 @import "./styles/fumadocs-theme.css";
+
+/* #6421: on-brand focus ring for a hash-nav target (the heading/section
+   useHashScroll focuses). Replaces the browser's boxy default outline with the
+   app's soft accent ring + offset, matching the `focus-visible:ring-2 ring-ring`
+   treatment interactive elements use. Programmatic focus fires `:focus` but not
+   `:focus-visible`, so this targets `:focus`; the `mg-hash-focus` class persists
+   harmlessly and only paints while the element is actually focused. */
+.mg-hash-focus:focus-visible,
+.mg-hash-focus:focus {
+  outline: none;
+  border-radius: 0.5rem;
+  box-shadow:
+    0 0 0 2px var(--background, var(--paper, #fff)),
+    0 0 0 4px var(--ring);
+}

--- a/apps/ui/tests/e2e/capture-hashscroll-focus-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-hashscroll-focus-screenshots.mjs
@@ -1,0 +1,93 @@
+/**
+ * Capture the hash-nav focus indicator for #6421.
+ *
+ * capture-pr-screenshots.mjs can't drive this: the change is what happens when
+ * useHashScroll resolves a deep link, so the shot has to land on the hash URL
+ * and let the hook scroll + focus. Same Phase C2 contract otherwise -- fixed
+ * viewports only, never fullPage, theme forced via mg-theme.
+ *
+ * The evidence is the focus ring: `after` focuses the target section's heading
+ * (a visible outline on "ECONOMICS"), `before` only scrolls it into view with
+ * no focus indicator. The section's own scroll-mt-32 clears the sticky header,
+ * so the heading lands in-frame.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8081 VARIANT=before node tests/e2e/capture-hashscroll-focus-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8080 VARIANT=after  node tests/e2e/capture-hashscroll-focus-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/hashscroll-focus-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8080";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+// A subnet section that renders on the default overview tab.
+const ROUTE = "/subnets/1#economics";
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const THEMES = ["light", "dark"];
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await setTheme(page, theme);
+
+      // Land on the hash URL so useHashScroll fires on mount.
+      await page.goto(`${BASE_URL}${ROUTE}`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+      try {
+        await page.waitForLoadState("networkidle", { timeout: 8000 });
+      } catch {
+        await page.waitForTimeout(2500);
+      }
+      // Brand faces swap in via font-display; wait so before/after share one.
+      await page.evaluate(() => document.fonts.ready);
+      // The hook defers its scroll+focus (80ms); give it and the smooth scroll room.
+      await page.waitForTimeout(1200);
+
+      // The hook's smooth scroll lands at a slightly different offset run to
+      // run, which would drift the heading in/out of frame. Park the target
+      // heading at a fixed spot in BOTH variants so the pair is directly
+      // comparable -- scrolling doesn't blur, so the `after` focus ring stays.
+      await page.evaluate(() => {
+        const h = document.querySelector("#economics h2");
+        if (h) {
+          const y = h.getBoundingClientRect().top + window.scrollY - 180;
+          window.scrollTo({ top: Math.max(0, y), behavior: "instant" });
+        }
+      });
+      await page.waitForTimeout(300);
+
+      const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      console.log(`wrote ${file}`);
+      await context.close();
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

`useHashScroll` only called `scrollIntoView`, which shifts the viewport but never moves DOM
focus or the screen-reader cursor. A screen-reader or keyboard user following an in-page
deep link — `/subnets/7?tab=overview#endpoints`, or a `SectionAnchor` "copy link" — heard
and landed on nothing; the page silently scrolled underneath them.

## What Changed

After the scroll, focus the target's **heading** (falling back to the element itself), using
the `tabindex` + `preventScroll` technique `back-to-top.tsx` uses: a heading isn't focusable
by default, so give it `tabindex="-1"` when it lacks one and focus with `preventScroll: true`
so it doesn't fight the smooth scroll. The heading is the better target than the section box
— a screen reader announces its text, and its focus ring is a tight indicator rather than an
outline around a whole panel.

**One deliberate departure from `back-to-top.tsx`, verified in a browser:** it strips the
`tabindex` from `<main>` on a 0ms timer, but doing that here **blurs the freshly focused
heading straight back to `<body>`** — which reverts a keyboard user's focus to the top and
defeats "focus follows the scroll". `tabindex="-1"` is not a keyboard tab stop, so leaving it
in place keeps focus on the heading without polluting the tab order, which is the only thing
the removal guarded against.

**On-brand focus indicator.** Programmatic focus renders the browser's default boxy outline,
which is off the app's design language. The `mg-hash-focus` class (added to the target)
swaps it for the app's soft, rounded accent ring with an offset (`styles.css`), matching the
`focus-visible:ring-2 ring-ring` treatment interactive elements already use. Programmatic
focus fires `:focus` but not `:focus-visible`, so the rule targets `:focus`; the class only
paints while the element is actually focused.

The focus logic is factored into a pure `focusHashTarget(el)` so the branches are unit-tested
with a fake element (this suite runs in a plain node environment with no DOM).

## Screenshots

`after` focuses the deep-linked section's heading, which shows the app's soft accent focus
ring; `before` only scrolls it into view (no focus indicator). Captured at the contract's
fixed viewports (1280×800 / 768×1024 / 375×812), themes forced via `mg-theme`, `before`
served from a worktree at the merge-base, both landing on `/subnets/1#economics` with the
heading parked at a fixed offset so the pair is directly comparable. The only delta is the
ring on "ECONOMICS".

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/after-desktop-light.png)<br><sub>after — soft accent ring</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6421-hashscroll-focus/after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npm run lint --workspace=apps/ui` — clean (0 errors, 0 warnings on the changed files)
- `npm run typecheck --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — passing, incl. 4 `use-hash-scroll.test.ts` cases (adds a
  tabindex to an unfocusable heading and leaves it; leaves an existing one untouched; marks
  the target with `mg-hash-focus`; focuses with `preventScroll`)
- `npm run build --workspace=apps/ui` — clean
- `npm run test:e2e --workspace=apps/ui` — the 3 failures (`evidence-deep-link`, ×2
  `multisig-related-error`) reproduce identically on pristine `main` without this change
  (verified as a control) and are green on CI — a slow-local-hydration artifact, unrelated to
  this PR, which touches none of those routes.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6421`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched — `apps/ui/**` only.
- [x] `routeTree.gen.ts` untouched; screenshots hosted on a fork branch, not committed here.

Closes #6421
