### PR TITLE
fix(ui): return focus to its trigger when StakeUnstakeModal closes

### DIFF
--- a/apps/ui/src/components/metagraphed/stake-unstake-modal.test.ts
+++ b/apps/ui/src/components/metagraphed/stake-unstake-modal.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #6415: StakeUnstakeModal's trigger (a caller-supplied render-prop) was a plain
+// sibling of <Sheet>, not its trigger, so Radix had no trigger node to restore
+// focus to on close and dropped focus to <body>. Wrapping the render-prop in
+// <SheetTrigger asChild> inside <Sheet> is the same fix landed for
+// SubnetCompareDrawer (#6527) and TakeManagementModal (#6531). Unlike those, the
+// "Delegate" trigger here is not wallet-gated, so it's verified in a browser:
+// before, Escape leaves focus on <body>; after, it returns to the trigger.
+const source = readFileSync(
+  fileURLToPath(new URL("./stake-unstake-modal.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("StakeUnstakeModal returns focus to its trigger (#6415)", () => {
+  it("wraps the render-prop trigger in a SheetTrigger", () => {
+    expect(source).toContain("<SheetTrigger asChild>{trigger(() => setOpen(true))}</SheetTrigger>");
+  });
+
+  it("imports SheetTrigger", () => {
+    const imports = source.slice(0, source.indexOf('} from "@jsonbored/ui-kit";'));
+    expect(imports).toContain("SheetTrigger");
+  });
+
+  // Just the component's own return block, so fragments in later helpers don't leak in.
+  const componentReturn = (() => {
+    const start = source.indexOf("return (");
+    const end = source.indexOf("</Sheet>\n  );", start) + "</Sheet>\n  );".length;
+    return source.slice(start, end);
+  })();
+
+  it("no longer renders the trigger as a fragment sibling outside <Sheet>", () => {
+    expect(componentReturn.trimStart()).toMatch(/^return \(\s*<Sheet open=\{open\}/);
+    expect(componentReturn).not.toContain("<>");
+  });
+
+  it("keeps the trigger ahead of the content, both inside <Sheet>", () => {
+    const sheet = componentReturn.indexOf("<Sheet open");
+    const trigger = componentReturn.indexOf("<SheetTrigger");
+    const content = componentReturn.indexOf("<SheetContent");
+    expect(sheet).toBeGreaterThan(-1);
+    expect(trigger).toBeGreaterThan(sheet);
+    expect(content).toBeGreaterThan(trigger);
+  });
+
+  it("preserves the signature-in-flight close guard (handleOpenChange)", () => {
+    expect(source).toContain("if (!flow.canClose) return;");
+    expect(source).toContain("<Sheet open={open} onOpenChange={handleOpenChange}>");
+  });
+});

--- a/apps/ui/src/components/metagraphed/stake-unstake-modal.tsx
+++ b/apps/ui/src/components/metagraphed/stake-unstake-modal.tsx
@@ -8,6 +8,7 @@ import {
   SheetFooter,
   SheetHeader,
   SheetTitle,
+  SheetTrigger,
 } from "@jsonbored/ui-kit";
 import { WalletConnectPanel } from "@/components/metagraphed/wallet-connect";
 import { StakeAmountInput } from "@/components/metagraphed/stake-amount-input";
@@ -116,35 +117,39 @@ export function StakeUnstakeModal({
   };
 
   return (
-    <>
-      {trigger(() => setOpen(true))}
-      <Sheet open={open} onOpenChange={handleOpenChange}>
-        <SheetContent side="right" className="flex w-full flex-col overflow-y-auto sm:max-w-lg">
-          <SheetHeader>
-            <SheetTitle className="font-display text-lg">
-              {ACTION_VERB[flow.action]} · {validatorName ?? shortHash(hotkey, 6)}
-            </SheetTitle>
-            <SheetDescription>
-              {subnetName ? `${subnetName} (SN${netuid})` : `Subnet ${netuid}`}
-              {!flow.canClose ? " — this can't be closed while a signature is in flight." : ""}
-            </SheetDescription>
-          </SheetHeader>
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      {/* #6415: the trigger was a plain sibling of <Sheet>, not its trigger, so
+          Radix had no trigger node to restore focus to on close -- closing the
+          modal dropped focus to <body>. Wrapping the caller's render-prop element
+          in <SheetTrigger asChild> inside <Sheet> is the same fix landed for
+          SubnetCompareDrawer (#6527) and TakeManagementModal (#6531): Radix
+          tracks it and returns focus. */}
+      <SheetTrigger asChild>{trigger(() => setOpen(true))}</SheetTrigger>
+      <SheetContent side="right" className="flex w-full flex-col overflow-y-auto sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle className="font-display text-lg">
+            {ACTION_VERB[flow.action]} · {validatorName ?? shortHash(hotkey, 6)}
+          </SheetTitle>
+          <SheetDescription>
+            {subnetName ? `${subnetName} (SN${netuid})` : `Subnet ${netuid}`}
+            {!flow.canClose ? " — this can't be closed while a signature is in flight." : ""}
+          </SheetDescription>
+        </SheetHeader>
 
-          <div className="mt-4 flex-1">
-            <StakeFlowBody
-              hotkey={hotkey}
-              netuid={netuid}
-              subnetName={subnetName}
-              validatorName={validatorName}
-              flow={flow}
-              submitting={submitting}
-              onConfirm={handleConfirm}
-              onClose={() => handleOpenChange(false)}
-            />
-          </div>
-        </SheetContent>
-      </Sheet>
-    </>
+        <div className="mt-4 flex-1">
+          <StakeFlowBody
+            hotkey={hotkey}
+            netuid={netuid}
+            subnetName={subnetName}
+            validatorName={validatorName}
+            flow={flow}
+            submitting={submitting}
+            onConfirm={handleConfirm}
+            onClose={() => handleOpenChange(false)}
+          />
+        </div>
+      </SheetContent>
+    </Sheet>
   );
 }
 


### PR DESCRIPTION
## What

`StakeUnstakeModal`'s trigger — a caller-supplied render-prop — was a plain sibling of `<Sheet>`, not its trigger (its call sites: `neuron-table.tsx`, `subnet-validators-preview.tsx`, `sponsored-validator-callout.tsx`, `validators.$hotkey.tsx`, each a bare `<button onClick={open}>`). Radix restores focus to a dialog's trigger on close only when it's a `<SheetTrigger>` inside `<Sheet>`, so closing the modal **dropped focus to `<body>`**.

The render-prop is now wrapped in `<SheetTrigger asChild>` inside `<Sheet>` — the same fix already merged for `SubnetCompareDrawer` (#6527) and `TakeManagementModal` (#6531). (This file was called out as the remaining sibling in #6531.)

## Proof — keyboard focus return, in a real browser

The "Delegate" trigger (in the subnet metagraph/validators `NeuronTable`) is **not** wallet-gated, so a live demo is possible: focus it, `Enter` to open, `Escape` to close, read `document.activeElement`:

| | after Escape |
| --- | --- |
| **before** | ❌ focus on `<body>` — lost |
| **after** | ✅ focus back on the **Delegate** button |

## Screenshots

`/subnets/1?tab=validators`, before/after — **identical by design** (a focus-return change renders nothing new). Rows supplied per the contract.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png)<br><sub>after</sub> |


## Testing

`stake-unstake-modal.test.ts` (5 tests, source assertions): the render-prop is wrapped in `<SheetTrigger asChild>`; `SheetTrigger` is imported; the component returns `<Sheet>` directly (no fragment sibling); trigger precedes content, both inside `<Sheet>`; and the signature-in-flight close guard (`if (!flow.canClose) return`) is preserved.

**Verified meaningful: 4 of 5 fail against the upstream file** (the 5th, the close guard, passes both ways). Plus the in-browser proof above.

`apps/ui`: 147 files / 1093 tests pass, `tsc` clean, `eslint` 0 errors, `format:check` clean. Diff is 2 files under `apps/ui/src`.

Closes #6415