### PR TITLE
fix(ui): surface the validator's controlling coldkey for all visitors

### DIFF
--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -8,6 +8,7 @@ import { useWallet } from "@/hooks/use-wallet";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { AccountAddress } from "@/components/metagraphed/account-address";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { PageHero, ShareButton, SectionAnchor, CopyableCode, StatTile } from "@jsonbored/ui-kit";
@@ -309,6 +310,16 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
             </span>
             <span className="inline-flex max-w-full min-w-0 rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
               <CopyableCode value={hotkey} truncate={false} className="max-w-full" />
+            </span>
+            {/* Surface the controlling coldkey for every visitor (#6427) — it was
+                previously read only for the owner check, never shown or linked. */}
+            <span className="inline-flex items-center gap-2 font-mono text-[11px] text-ink-muted">
+              <span className="uppercase tracking-widest text-[10px]">Coldkey</span>
+              <AccountAddress
+                ss58={detail.coldkey}
+                compact
+                fallback={<span className="text-ink-subtle">—</span>}
+              />
             </span>
           </span>
         }


### PR DESCRIPTION
Closes #6427

`validators.$hotkey.tsx` read `detail.coldkey` only for the `isOwner` check (and passed it to the owner-only `TakeManagementModal`) — it was never rendered as visible text or a link, so a regular visitor had no way to see which account controls a given validator hotkey. `ValidatorIdentityChip` shows only the declared identity name, not the raw coldkey.

This renders a **"Coldkey"** field in the hero, directly below the hotkey, via the shared `AccountAddress` component (account hover-card + `CopyButton`, `compact` spacing) — the same treatment ss58 values get elsewhere. Not gated on `isOwner`; the `coldkey == null` case degrades to a dash via `AccountAddress`'s `fallback`.

Captured at the Phase C2 matrix — fixed viewports (375×812 / 768×1024 / 1280×800), each theme forced via `mg-theme`, on a validator detail page.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/dhgoal/metagraphed/screenshots/6427/after-mobile-dark.png)<br><sub>after</sub> |

### Verification

`prettier` clean · `eslint` 0 errors · `tsc --noEmit` 0 · `vitest` 1088/1088 passing (146 files). The new field renders the coldkey as a `/accounts/$ss58` link with a copy button for all visitors, confirmed in the live browser.
