### PR TITLE
fix(ui): use health-* tokens for accounts page status and role badges

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -617,9 +617,9 @@ function AccountExtrinsicsSection({
                   {x.success == null ? (
                     <span className="text-ink-muted">—</span>
                   ) : x.success ? (
-                    <span className="text-emerald-500">ok</span>
+                    <span className="text-health-ok">ok</span>
                   ) : (
-                    <span className="text-rose-500">fail</span>
+                    <span className="text-health-down">fail</span>
                   )}
                 </td>
                 <td className="px-5 py-4 text-right font-mono text-[11px] text-ink-muted">
@@ -726,9 +726,9 @@ function AccountTransfersSection({
                   </td>
                   <td className="px-5 py-4 font-mono text-[11px]">
                     {t.direction === "received" ? (
-                      <span className="text-emerald-500">received</span>
+                      <span className="text-health-ok">received</span>
                     ) : t.direction === "sent" ? (
-                      <span className="text-amber-500">sent</span>
+                      <span className="text-health-warn-text">sent</span>
                     ) : (
                       <span className="text-ink-muted">—</span>
                     )}
@@ -1031,7 +1031,7 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
                   {p.net_tao == null ? (
                     <span className="text-ink-muted">—</span>
                   ) : (
-                    <span className={p.net_tao >= 0 ? "text-emerald-500" : "text-amber-500"}>
+                    <span className={p.net_tao >= 0 ? "text-health-ok" : "text-health-warn-text"}>
                       {p.net_tao >= 0 ? "+" : ""}
                       {formatNumber(p.net_tao)} τ
                     </span>
@@ -1069,12 +1069,15 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
 
 const STAKE_FLOW_WINDOWS = ["7d", "30d", "90d"] as const;
 
-// Direction label → tone, reusing the emerald/amber/muted convention the
-// transfers section uses for sent/received direction.
+// Direction label → tone, reusing the health-ok/warn/muted convention the
+// transfers section uses for sent/received direction. `exiting` and `churning`
+// were amber-500 vs amber-400 -- a shade split the health-* scale doesn't carry,
+// so both land on the single warn tone; the branches stay as they are because the
+// tone is the only thing this maps.
 function stakeFlowDirClass(dir: string | null | undefined): string {
-  if (dir === "accumulating") return "text-emerald-500";
-  if (dir === "exiting") return "text-amber-500";
-  if (dir === "churning") return "text-amber-400";
+  if (dir === "accumulating") return "text-health-ok";
+  if (dir === "exiting") return "text-health-warn-text";
+  if (dir === "churning") return "text-health-warn-text";
   return "text-ink-muted"; // idle / unknown
 }
 
@@ -1150,7 +1153,9 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
           tone="accent"
           value={
             <span
-              className={netFlow != null && netFlow < 0 ? "text-amber-500" : "text-emerald-500"}
+              className={
+                netFlow != null && netFlow < 0 ? "text-health-warn-text" : "text-health-ok"
+              }
             >
               {netStr}
             </span>
@@ -1241,7 +1246,9 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
                         <span className="text-ink-muted">—</span>
                       ) : (
                         <span
-                          className={s.net_flow_tao >= 0 ? "text-emerald-500" : "text-amber-500"}
+                          className={
+                            s.net_flow_tao >= 0 ? "text-health-ok" : "text-health-warn-text"
+                          }
                         >
                           {s.net_flow_tao >= 0 ? "+" : "−"}
                           {fmtStake(Math.abs(s.net_flow_tao))}
@@ -1391,9 +1398,9 @@ function AccountPortfolioSection({ ss58 }: { ss58: string }) {
                     </td>
                     <td className="px-5 py-4 font-mono text-[11px]">
                       {pos.role === "validator" ? (
-                        <span className="text-emerald-500">validator</span>
+                        <span className="text-health-ok">validator</span>
                       ) : pos.role === "miner" ? (
-                        <span className="text-sky-500">miner</span>
+                        <span className="text-chart-1">miner</span>
                       ) : (
                         <span className="text-ink-muted">{"—"}</span>
                       )}
@@ -2076,7 +2083,7 @@ function AccountFootprintSection({
                 </td>
                 <td className="px-5 py-4 font-mono text-[11px]">
                   {r.active ? (
-                    <span className="inline-flex rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-500">
+                    <span className="inline-flex rounded-full bg-health-ok/10 px-2 py-0.5 text-health-ok">
                       active
                     </span>
                   ) : (
@@ -2110,7 +2117,7 @@ function AccountFootprintSection({
                 {r.validator_permit ? <ValidatorPermitBadge ss58={ss58} /> : null}
               </div>
               {r.active ? (
-                <span className="inline-flex shrink-0 rounded-full bg-emerald-500/10 px-2 py-0.5 font-mono text-[11px] text-emerald-500">
+                <span className="inline-flex shrink-0 rounded-full bg-health-ok/10 px-2 py-0.5 font-mono text-[11px] text-health-ok">
                   active
                 </span>
               ) : (
@@ -2158,7 +2165,7 @@ function ValidatorPermitBadge({ ss58 }: { ss58: string }) {
       to="/validators/$hotkey"
       params={{ hotkey: ss58 }}
       title={`Validator profile for ${ss58}`}
-      className="inline-flex shrink-0 rounded-full bg-emerald-500/10 px-2 py-0.5 font-mono text-[11px] text-emerald-500 transition-colors hover:bg-emerald-500/20"
+      className="inline-flex shrink-0 rounded-full bg-health-ok/10 px-2 py-0.5 font-mono text-[11px] text-health-ok transition-colors hover:bg-health-ok/20"
     >
       validator
     </Link>


### PR DESCRIPTION
## What & why

`accounts.$ss58.tsx` styled its ok/fail, sent/received, stake-flow direction, role and permit badges with raw Tailwind palette colors (`emerald-500`, `rose-500`, `amber-500`/`amber-400`, `sky-500`). This app themes entirely by swapping CSS variables on `.dark` — there is not a single `dark:` variant anywhere under `routes/` or `components/metagraphed/` — so those raw palette colors were the only text colors in the file that stayed put when the theme changed. The same file already reaches for the token at line 179-180 (`text-health-down` for "Unavailable").

## The mapping

| From | To |
| --- | --- |
| `text-emerald-500` | `text-health-ok` |
| `text-rose-500` | `text-health-down` |
| `text-amber-500` / `text-amber-400` | `text-health-warn-text` |
| `text-sky-500` (miner) | `text-chart-1` |
| `bg-emerald-500/10` (+ `hover:bg-*/20`) | `bg-health-ok/10` |

This also covers the `ValidatorPermitBadge` component and the `active` badge in the footprint section (both still on raw `emerald-500` after a recent refactor consolidated the inline badges).

Two calls worth flagging:

- **amber → `health-warn-text`, not `health-warn`.** Every one of these sites styles small text (`text-[11px]`/`[12px]` table cells), and that token exists for exactly this case — its own doc says it is *"only for small warn text on paper/card, which needs 4.5:1"*. This is safe in dark mode too: `.dark` already aliases `--health-warn-text: var(--health-warn)` because the dark amber clears AA on its own. Using the plain warn tone would reintroduce the contrast gap #6405/#6408 are open about.
- **miner → `chart-1`.** There is no `role-*` scale and no other file colors a miner/validator role pair, so `chart-1` (`oklch(0.64 0.13 250)`, the app's only blue) is the nearest theme-swapped equivalent to `sky-500` — adding no new token rather than inventing one. Happy to switch to a dedicated `--role-*` token if you'd prefer.

`exiting`/`churning` were `amber-500` vs `amber-400`; the `health-*` scale carries no such shade split, so both land on the one warn tone. `stakeFlowDirClass` keeps its branching exactly as it was.

## Verification

Full Phase C3 preflight (same steps/order as the `ui` CI job):

| Step | Command | Result |
| --- | --- | --- |
| lint | `npm run lint --workspace=apps/ui` | 0 errors |
| format | `npm run format:check --workspace=apps/ui` | clean |
| typecheck | `npm run typecheck --workspace=apps/ui` | clean |
| unit | `npm test --workspace=apps/ui` | 143 files, 1075 tests passed |
| build | `npm run build --workspace=apps/ui` | green |

## Screenshots

Phase C2 contract (fixed viewports, never full-page, themes forced via `mg-theme`, `before` from a separate worktree at the merge base). Anchored on the **Transfers** section, where `received` (`health-ok`) and `sent` (`health-warn-text`) sit side by side. The same swap applies to the extrinsics ok/fail, counterparties, stake-flow, portfolio and footprint badges further down the page.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6402-health-tokens-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6402
