### PR TITLE
fix(registry): normalize prediction-market category to the canonical plural

### DIFF
--- a/registry/subnets/8-ball.json
+++ b/registry/subnets/8-ball.json
@@ -4,7 +4,7 @@
     "identity-reviewed",
     "official-source-repo",
     "official-website",
-    "prediction-market"
+    "prediction-markets"
   ],
   "curation": {
     "gap_notes": [

--- a/registry/subnets/sparket.json
+++ b/registry/subnets/sparket.json
@@ -4,7 +4,7 @@
     "identity-reviewed",
     "official-source-repo",
     "official-website",
-    "prediction-market",
+    "prediction-markets",
     "sports"
   ],
   "curation": {


### PR DESCRIPTION
Closes #6332

`8-ball.json` and `sparket.json` used the singular `prediction-market` category, while `almanac.json` and `degenbrain.json` used the plural `prediction-markets` for the identical concept — so a category facet for one spelling silently excludes the other two subnets.

Per the issue's requirements, both files are updated to the canonical plural **`prediction-markets`**, matching the corpus convention (`language-models`, `capital-markets`, `model-artifacts`). Pure data fix — no `categories` enum added (out of scope per the issue).

### Change

```diff
 registry/subnets/8-ball.json  | "prediction-market"  → "prediction-markets"
 registry/subnets/sparket.json | "prediction-market", → "prediction-markets",
```

Only the two `categories[]` values change — the `notes` prose that mentions "prediction-market" in passing is untouched, and no array is reordered.

### Verification

`npm run validate:surface -- registry/subnets/8-ball.json registry/subnets/sparket.json` passes (10 surfaces across 2 files); both files remain valid JSON. Diff is exactly the two category strings (`git diff` = 2 insertions / 2 deletions).
