### PR TITLE
fix(api): resolve schemas + fixtures through the stable latest/ key

### DIFF
--- a/tests/storage-read-artifact.test.mjs
+++ b/tests/storage-read-artifact.test.mjs
@@ -228,6 +228,103 @@ test("readR2 for a health/history date reads the literal latest/ key even when t
   assert.equal(requestedKey, "latest/health/history/2026-07-01.json");
 });
 
+// ---- schemas/fixtures stable-latest key (#6509) ----------------------------
+// Same shape as health/history above, different cause: these are mutable,
+// best-effort per-item captures. A single transient failure on the most
+// recent publish makes that one item vanish from the run-prefix tree
+// entirely, while a perfectly good prior capture sits untouched at the
+// literal latest/ key.
+
+test("latestR2Key resolves an individual schema document through the literal latest/ prefix", async () => {
+  const env = {
+    METAGRAPH_CONTROL: {
+      async get() {
+        return { latest_prefix: "runs/2026-07-17T11-21-50-971Z/" };
+      },
+    },
+  };
+  const key = await latestR2Key(
+    "/metagraph/schemas/sn-6-numinous-openapi-schema.json",
+    env,
+  );
+  assert.equal(key, "latest/schemas/sn-6-numinous-openapi-schema.json");
+});
+
+test("latestR2Key still resolves schemas/index.json through the pointer's run prefix, not the stable key", async () => {
+  const env = {
+    METAGRAPH_CONTROL: {
+      async get() {
+        return { latest_prefix: "runs/2026-07-17T11-21-50-971Z/" };
+      },
+    },
+  };
+  const key = await latestR2Key("/metagraph/schemas/index.json", env);
+  assert.equal(key, "runs/2026-07-17T11-21-50-971Z/schemas/index.json");
+});
+
+test("latestR2Key resolves an individual fixture document through the literal latest/ prefix", async () => {
+  const env = {
+    METAGRAPH_CONTROL: {
+      async get() {
+        return { latest_prefix: "runs/2026-07-17T11-21-50-971Z/" };
+      },
+    },
+  };
+  const key = await latestR2Key(
+    "/metagraph/fixtures/sn-1-apex-healthcheck-ready.json",
+    env,
+  );
+  assert.equal(key, "latest/fixtures/sn-1-apex-healthcheck-ready.json");
+});
+
+test("latestR2Key still resolves fixtures/_capture-report.json through the pointer's run prefix, not the stable key", async () => {
+  const env = {
+    METAGRAPH_CONTROL: {
+      async get() {
+        return { latest_prefix: "runs/2026-07-17T11-21-50-971Z/" };
+      },
+    },
+  };
+  const key = await latestR2Key(
+    "/metagraph/fixtures/_capture-report.json",
+    env,
+  );
+  assert.equal(
+    key,
+    "runs/2026-07-17T11-21-50-971Z/fixtures/_capture-report.json",
+  );
+});
+
+test("readR2 for a schema document reads the literal latest/ key even when the pointer names a different run prefix", async () => {
+  let requestedKey;
+  const env = {
+    METAGRAPH_CONTROL: {
+      async get() {
+        return { latest_prefix: "runs/2026-07-17T11-21-50-971Z/" };
+      },
+    },
+    METAGRAPH_ARCHIVE: {
+      async get(key) {
+        requestedKey = key;
+        return r2Object({ surface_id: "sn-6-numinous-openapi-schema" });
+      },
+    },
+  };
+  const result = await readR2(
+    env,
+    "/metagraph/schemas/sn-6-numinous-openapi-schema.json",
+    "r2",
+  );
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.data, {
+    surface_id: "sn-6-numinous-openapi-schema",
+  });
+  assert.equal(
+    requestedKey,
+    "latest/schemas/sn-6-numinous-openapi-schema.json",
+  );
+});
+
 // ---- R2-preferred dual artifacts (lines 78-87) -----------------------------
 // R2_PREFERRED_DUAL_PATTERNS is currently empty (subnets/coverage moved to plain
 // R2-only), so isR2PreferredDualArtifactPath() never matches a real path. The

--- a/workers/storage.mjs
+++ b/workers/storage.mjs
@@ -194,24 +194,46 @@ export async function readR2Object(env, artifactPath, storageTier) {
   };
 }
 
-// health/history/{date}.json is the one artifact every publish writes a
-// NEW, distinct, write-once key for (today's date), never overwriting a
-// prior date's key -- unlike every other artifact, which the versioned
-// run-prefix pointer exists specifically to read atomically (see
-// kv-publish-pointer.mjs's own comment: pointing latest_prefix at the
-// immutable run prefix, not the mutable literal "latest/" prefix, avoids
-// ever serving a mix of stale + fresh artifacts from a partially-uploaded
-// publish). That atomicity concern doesn't apply here because a past
-// date's file is never touched by a later publish, so reading it via the
-// literal "latest/" prefix instead of the current run's prefix is safe --
-// and necessary, since r2-upload.mjs uploads every artifact to BOTH keys
-// (METAGRAPH_R2_UPLOAD_HISTORY=1 in production), but only the literal
-// "latest/" prefix accumulates one file per date across every past
-// publish; the run-prefix tree only ever contains THAT run's single date
-// (#6508 -- every date but today was unreachable through the normal
-// pointer-resolved prefix).
+// Artifacts that read through the literal "latest/" prefix instead of the
+// versioned run-prefix the KV pointer names. Every OTHER artifact resolves
+// through that run-prefix pointer deliberately (see kv-publish-pointer.mjs's
+// own comment: pointing latest_prefix at the immutable run prefix, not the
+// mutable literal "latest/" prefix, avoids ever serving a mix of stale +
+// fresh artifacts from a partially-uploaded publish). That atomicity
+// guarantee only matters for artifacts a publish is expected to refresh
+// WHOLESALE every run; it actively hurts two different classes of artifact
+// that don't fit that shape, both fixed here (#6508, #6509):
+//
+//   - health/history/{date}.json: a write-once key per date, never
+//     overwritten by a later publish. The run-prefix tree only ever
+//     contains THAT run's single date, so every prior date became
+//     unreachable the moment a new run's publish flipped the pointer, even
+//     though the write side faithfully writes one dated snapshot every day.
+//   - schemas/{surface_id}.json and fixtures/{surface_id}.json: mutable,
+//     but populated by a BEST-EFFORT per-item live capture (a third-party
+//     host being briefly unreachable skips writing that one item for this
+//     run, without failing the whole publish). The run-prefix tree only
+//     ever contains what THIS run's capture actually produced, so a single
+//     transient per-item failure makes that item vanish from the current
+//     run-prefix entirely -- even though a perfectly good prior capture is
+//     still sitting untouched under the literal "latest/" key.
+//
+// r2-upload.mjs already uploads every artifact to BOTH keys
+// (METAGRAPH_R2_UPLOAD_HISTORY=1 in production); the literal "latest/"
+// prefix is only ever updated on a SUCCESSFUL capture for these artifacts
+// (never deleted on failure), so reading it directly is strictly safer than
+// the run-prefix for this shape -- confirmed live for both classes: 30/30
+// recent health/history dates and a known schemas/{surface_id}.json (whose
+// pointer-resolved path 404'd) were both readable at their literal
+// "latest/" key.
 const STABLE_LATEST_ARTIFACT_PATTERNS = [
   /^\/metagraph\/health\/history\/\d{4}-\d{2}-\d{2}\.json$/,
+  /^\/metagraph\/schemas\/(?!index\.json$)[A-Za-z0-9._:-]+\.json$/,
+  // Excludes _capture-report.json (a whole-run summary, not a per-item
+  // capture) -- the surface_id charset (see get_api_schema's own validation
+  // in src/mcp-server.mjs) includes "_", so this needs the same explicit
+  // exclusion as schemas/index.json above, not just relying on the charset.
+  /^\/metagraph\/fixtures\/(?!_capture-report\.json$)[A-Za-z0-9._:-]+\.json$/,
 ];
 
 export async function latestR2Key(artifactPath, env) {


### PR DESCRIPTION
## Summary
- `GET /metagraph/schemas/{surface_id}.json` and `.../fixtures/{surface_id}.json` could 404 for a surface with a perfectly good prior capture sitting in R2, whenever that surface's live capture failed on just the most recent publish.
- Same underlying mechanism as #6508 (merged), different trigger: `schemas/{surface_id}.json`/`fixtures/{surface_id}.json` are mutable, best-effort per-item captures -- a third-party host being briefly unreachable skips writing that one item for the current run without failing the whole publish. Reads resolve through the run-prefix pointer, which only ever contains what THAT run's capture actually produced, so a single transient per-item failure makes the item vanish from the current run-prefix entirely, even though the literal `latest/` key (only ever updated on success, never deleted on failure) still holds the last known-good copy.
- Confirmed live: `sn-6-numinous-openapi-schema`'s pointer-resolved path 404'd while its literal `latest/schemas/sn-6-numinous-openapi-schema.json` key returned a full, valid document (captured weeks earlier, matching `index.json`'s own `observed_at`) -- `index.json` was telling the truth the whole time; the individual-file read path just never looked where `r2-upload.mjs` was already keeping it.
- `schemas/index.json` and `fixtures/_capture-report.json` are deliberately excluded -- both are whole-run summaries, not per-item captures, so they keep the normal run-prefix (atomic-read) behavior.

Closes #6509. Found during a full data-source audit following D1 retirement (unrelated to D1).

## Test plan
- [x] `npx vitest run tests/storage-read-artifact.test.mjs tests/storage-pointer-memo.test.mjs` -- 24/24 passing, including 5 new regression tests (schema stable-key, schema index.json exclusion, fixture stable-key, fixture report exclusion, end-to-end readR2)
- [x] `npx eslint` / `npx prettier --check` clean
- [x] `npm run test:ci` -- full suite (298 files / 8951 tests) green
- [x] Verified live pre-fix (production 404 on a known-captured schema surface) and confirmed the literal `latest/schemas/{surface_id}.json` key is readable in production R2