### PR TITLE
fix(ui): add a mobile card fallback to the subnet-detail NeuronTable

### DIFF
--- a/apps/ui/src/components/metagraphed/neuron-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-card-list.tsx
@@ -1,0 +1,149 @@
+import { Link } from "@tanstack/react-router";
+import { Coins } from "lucide-react";
+import { CopyButton } from "@jsonbored/ui-kit";
+import { classNames } from "@/lib/metagraphed/format";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
+import {
+  taoCompact,
+  scoreStr,
+  SponsoredBadge,
+  validatorTrustValue,
+} from "@/components/metagraphed/neuron-format";
+import {
+  annualizedDelegatorApyPct,
+  formatApyPct,
+  formatTakePct,
+} from "@/lib/metagraphed/validator-apy";
+import type { MetagraphNeuron } from "@/lib/metagraphed/types";
+
+type NeuronCardListProps = {
+  netuid: number;
+  rows: MetagraphNeuron[];
+  isValidator: boolean;
+  onSelect?: (uid: number) => void;
+  selectedUid?: number | null;
+};
+
+/**
+ * Mobile card fallback for {@link NeuronTable} (#6335): the 8–10 column
+ * neuron/validator table is undiscoverably clipped behind horizontal scroll on
+ * a narrow viewport, so below `md` each neuron renders as a stacked card
+ * instead — mirroring the `md:hidden` card path every other tabular list page
+ * provides. Renders the same `rows` (already sorted by the parent) and the same
+ * per-variant field set the table shows, so the mobile view never hides a
+ * column the desktop table surfaces.
+ */
+export function NeuronCardList({
+  netuid,
+  rows,
+  isValidator,
+  onSelect,
+  selectedUid,
+}: NeuronCardListProps) {
+  return (
+    <div className="md:hidden divide-y divide-border/60">
+      {rows.map((n) => {
+        const active = selectedUid === n.uid;
+        return (
+          <div
+            key={n.uid}
+            className={classNames("space-y-2 px-3 py-3", active && "bg-accent-surface")}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-mono text-[12px] tabular-nums text-ink-strong">
+                {onSelect ? (
+                  <button
+                    type="button"
+                    className="underline underline-offset-2 hover:text-accent"
+                    onClick={() => onSelect(n.uid)}
+                  >
+                    UID {n.uid}
+                  </button>
+                ) : (
+                  <>UID {n.uid}</>
+                )}
+              </span>
+              {n.validator_permit ? (
+                <span className="inline-flex items-center rounded border border-accent/40 bg-accent-surface px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider text-accent-text">
+                  Validator
+                </span>
+              ) : null}
+            </div>
+
+            <div className="flex min-w-0 items-center gap-1.5 font-mono text-[11px]">
+              {n.featured ? <SponsoredBadge /> : null}
+              {n.hotkey ? (
+                <>
+                  <Link
+                    to={isValidator ? "/validators/$hotkey" : "/accounts/$ss58"}
+                    params={isValidator ? { hotkey: n.hotkey } : { ss58: n.hotkey }}
+                    className="truncate text-ink-muted hover:text-ink hover:underline"
+                    title={n.hotkey}
+                  >
+                    {shortHash(n.hotkey) ?? n.hotkey}
+                  </Link>
+                  <CopyButton value={n.hotkey} label="hotkey" compact />
+                </>
+              ) : (
+                <span className="text-ink-muted">—</span>
+              )}
+            </div>
+
+            <dl className="grid grid-cols-2 gap-x-3 gap-y-1.5 font-mono text-[11px]">
+              <Stat label="Stake τ" value={taoCompact(n.stake_tao)} strong />
+              <Stat label="Emission τ" value={taoCompact(n.emission_tao)} />
+              {isValidator ? (
+                <>
+                  <Stat label="Dividends" value={scoreStr(n.dividends)} />
+                  <Stat label="Val Trust" value={scoreStr(validatorTrustValue(n))} />
+                  <Stat label="Take" value={formatTakePct(n.take)} />
+                  <Stat
+                    label="Est. APY"
+                    value={formatApyPct(
+                      annualizedDelegatorApyPct(n.emission_tao ?? 0, n.stake_tao ?? 0, n.take),
+                    )}
+                  />
+                </>
+              ) : (
+                <>
+                  <Stat label="Rank" value={n.rank == null ? "—" : String(n.rank)} />
+                  <Stat label="Trust" value={scoreStr(n.trust)} />
+                  <Stat label="Consensus" value={scoreStr(n.consensus)} />
+                </>
+              )}
+            </dl>
+
+            {isValidator && n.hotkey ? (
+              <StakeUnstakeModal
+                hotkey={n.hotkey}
+                netuid={netuid}
+                trigger={(open) => (
+                  <button
+                    type="button"
+                    onClick={open}
+                    className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong transition-colors hover:border-accent/50 hover:text-accent"
+                  >
+                    <Coins className="size-3 text-ink-muted" aria-hidden />
+                    Delegate
+                  </button>
+                )}
+              />
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function Stat({ label, value, strong }: { label: string; value: string; strong?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <dt className="text-[10px] uppercase tracking-widest text-ink-muted">{label}</dt>
+      <dd className={classNames("tabular-nums", strong ? "text-ink-strong" : "text-ink-muted")}>
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/neuron-format.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-format.tsx
@@ -7,6 +7,7 @@
  * gzip budget. Anything that only needs a formatter should import from
  * here, not from `neuron-table.tsx`.
  */
+import type { MetagraphNeuron } from "@/lib/metagraphed/types";
 
 /** Format a TAO value compactly. Stake can run into the millions; emission and
  * incentive are sub-unit. Null/non-finite collapses to an em-dash. */
@@ -23,6 +24,16 @@ export function taoCompact(v?: number | null): string {
 export function scoreStr(v?: number | null): string {
   if (v == null || !Number.isFinite(v)) return "—";
   return v.toFixed(3);
+}
+
+/**
+ * Validator scoring lives in `validator_trust`, but the chain only populates it
+ * for permitted neurons — fall back to plain `trust` when the payload omits it.
+ * Lives here (not `neuron-table.tsx`) so both the table and its mobile card
+ * fallback can share it without a circular import.
+ */
+export function validatorTrustValue(n: MetagraphNeuron): number | null | undefined {
+  return n.validator_trust ?? n.trust;
 }
 
 /**

--- a/apps/ui/src/components/metagraphed/neuron-table.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-table.tsx
@@ -7,7 +7,13 @@ import { classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
-import { taoCompact, scoreStr, SponsoredBadge } from "@/components/metagraphed/neuron-format";
+import { NeuronCardList } from "@/components/metagraphed/neuron-card-list";
+import {
+  taoCompact,
+  scoreStr,
+  SponsoredBadge,
+  validatorTrustValue,
+} from "@/components/metagraphed/neuron-format";
 import {
   annualizedDelegatorApyPct,
   formatApyPct,
@@ -46,14 +52,6 @@ export const NUMERIC_FIELDS = new Set<SortField>([
   "validator_trust",
   "take",
 ]);
-
-/**
- * Validator scoring lives in validator_trust, but the chain only populates it
- * for permitted neurons — fall back to plain `trust` when the payload omits it.
- */
-function validatorTrustValue(n: MetagraphNeuron): number | null | undefined {
-  return n.validator_trust ?? n.trust;
-}
 
 function sortValue(n: MetagraphNeuron, field: SortField): number {
   const v = field === "validator_trust" ? validatorTrustValue(n) : n[field];
@@ -136,7 +134,7 @@ export function NeuronTable({
 
   return (
     <div className="rounded-xl border border-border bg-card overflow-hidden">
-      <div className="overflow-x-auto">
+      <div className="hidden md:block overflow-x-auto">
         <table className="w-full text-sm">
           <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
             <tr>
@@ -298,6 +296,13 @@ export function NeuronTable({
           </tbody>
         </table>
       </div>
+      <NeuronCardList
+        netuid={netuid}
+        rows={sorted}
+        isValidator={isValidator}
+        onSelect={onSelect}
+        selectedUid={selectedUid}
+      />
       <div className="border-t border-border/60 bg-surface/30 px-3 py-1.5 flex flex-wrap items-center justify-between gap-2 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
         <span>
           {sorted.length} {sorted.length === 1 ? "neuron" : "neurons"} · subnet {netuid}


### PR DESCRIPTION
## What

`NeuronTable` (the 8–10 column neuron/validator table backing the subnet detail page's **Metagraph** and **Validators** tabs) was wrapped only in `overflow-x-auto`, with no `md:hidden` card view — so on a narrow viewport its trailing columns (rank/trust/consensus, or dividends/val-trust/take/APY/permit) sit behind an undiscoverable horizontal scroll. It was the last neuron/validator table without the `md:hidden` card fallback every other tabular list page provides.

- **`NeuronCardList`** (new, `apps/ui/src/components/metagraphed/neuron-card-list.tsx`) — a `md:hidden` stacked-card view rendered below the `md` breakpoint. Each card shows the UID (drill-in `onSelect`), the permit badge, the hotkey (variant-correct link + `CopyButton` + sponsored pin), and the **same per-variant field set the table shows** (miner: Stake/Emission/Rank/Trust/Consensus; validator: Stake/Emission/Dividends/Val Trust/Take/Est. APY), plus the validator `Delegate` trigger. It renders the same already-sorted `rows` the table receives, so the mobile view never hides a column the desktop table surfaces.
- The existing `<table>` is now `hidden md:block` (unchanged at `md` and up); the shared `neurons · subnet` + Download-CSV footer is untouched below both.
- `validatorTrustValue` moved from `neuron-table.tsx` to the shared `neuron-format.tsx` (its documented home for "anything that only needs a formatter") so the table and the card list share it without a circular import. No behaviour change.

## Screenshots (before / after)

3 viewports × 2 themes, on `/subnets/1` → **Metagraph** tab (the miner variant; the Validators tab uses the same `NeuronTable`). **Before** = table with trailing columns clipped off-screen behind horizontal scroll; **After** = stacked cards with every field visible, no horizontal scroll below `md`. Desktop/Tablet (≥`md`) keep the table unchanged.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6335-after-mobile-dark.png)<br><sub>after</sub> |


## Validation

- `eslint` — clean on the changed/new files (0 errors).
- `prettier --check` (apps/ui workspace config) — clean.
- Unit tests — full `apps/ui` suite green: **141 files / 1065 tests passed**, including `neuron-table.test.ts` (the sponsored-placement sort invariant is unaffected).

Closes #6335
