### PR TITLE
fix(ui): use shared AccountAddress for the validators-table coldkey cell

### DIFF
--- a/apps/ui/src/components/metagraphed/account-address.tsx
+++ b/apps/ui/src/components/metagraphed/account-address.tsx
@@ -22,6 +22,7 @@ export function AccountAddress({
   copyButtonClassName,
   compact,
   truncate = true,
+  label,
 }: {
   ss58?: string | null;
   fallback: ReactNode;
@@ -37,6 +38,13 @@ export function AccountAddress({
   copyButtonClassName?: string;
   /** Forwarded to the inner CopyButton — pass true inside a dense table/list row. See CopyButton's `compact` doc. */
   compact?: boolean;
+  /**
+   * Accessible label for the copy button, e.g. "coldkey" for a coldkey column
+   * (#6338). Defaults to "account" — the generic case for a bare ss58 — so
+   * existing call sites are unchanged; pass it where the column names a more
+   * specific role.
+   */
+  label?: string;
 }) {
   if (ss58 && isValidSs58(ss58)) {
     return (
@@ -48,7 +56,7 @@ export function AccountAddress({
         </EntityHoverCard>
         <CopyButton
           value={ss58}
-          label="account"
+          label={label ?? "account"}
           className={copyButtonClassName}
           compact={compact}
         />

--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -3,6 +3,7 @@ import { CopyButton } from "@jsonbored/ui-kit";
 
 import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
+import { AccountAddress } from "@/components/metagraphed/account-address";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
 
 export interface ValidatorCardListProps {
@@ -45,21 +46,11 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
                 back into the row so it does not add vertical spacing. */}
             <div className="flex min-w-0 items-center gap-1.5 font-mono text-[11px] text-ink-muted">
               <span className="uppercase tracking-widest text-[10px]">coldkey</span>
-              {v.coldkey ? (
-                <>
-                  <Link
-                    to="/accounts/$ss58"
-                    params={{ ss58: v.coldkey }}
-                    title={v.coldkey}
-                    className="truncate hover:text-accent hover:underline"
-                  >
-                    {f.coldkeyShort}
-                  </Link>
-                  <CopyButton value={v.coldkey} label="coldkey" compact />
-                </>
-              ) : (
-                "—"
-              )}
+              {/* Coldkey links to /accounts/$ss58, so it uses the shared
+                  AccountAddress for the hover-card preview + copy (#6338). The
+                  hotkey row above stays hand-rolled -- it links to
+                  /validators/$hotkey, which EntityHoverCard does not support. */}
+              <AccountAddress ss58={v.coldkey} label="coldkey" compact fallback="—" />
             </div>
             <dl className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-[11px]">
               <Stat label="Active subnets" value={f.subnetsLabel} />

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -5,6 +5,7 @@ import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
+import { AccountAddress } from "@/components/metagraphed/account-address";
 import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
 
@@ -68,22 +69,11 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     header: "Coldkey",
     thClassName: TH_BASE,
     tdClassName: `${TD_BASE} text-ink-muted`,
-    cell: (v) =>
-      v.coldkey ? (
-        <div className="flex items-center gap-1.5">
-          <Link
-            to="/accounts/$ss58"
-            params={{ ss58: v.coldkey }}
-            className="hover:text-accent hover:underline"
-            title={v.coldkey}
-          >
-            {shortHash(v.coldkey) ?? v.coldkey}
-          </Link>
-          <CopyButton value={v.coldkey} label="coldkey" compact />
-        </div>
-      ) : (
-        "—"
-      ),
+    // The coldkey links to /accounts/$ss58, so it uses the shared AccountAddress
+    // (hover-card preview + copy), like every other ss58 cell -- #6338. The
+    // Hotkey column above stays hand-rolled: it links to /validators/$hotkey, a
+    // kind EntityHoverCard doesn't support.
+    cell: (v) => <AccountAddress ss58={v.coldkey} label="coldkey" compact fallback="—" />,
   },
   {
     ...numeric("Take"),


### PR DESCRIPTION
Closes #6338

## The bug

The desktop **Coldkey** column (`validator-columns.tsx`) and the mobile card's coldkey row (`validator-card-list.tsx`) each hand-rolled a `Link` + `shortHash` + `CopyButton`. So a coldkey in the validators table was the **only** ss58 link in the app *without* the account hover-card preview — every other ss58 cell (block author, extrinsic signer, …) goes through `AccountAddress`, which wraps the link in `EntityHoverCard kind="account"`.

## Screenshots

The change is a **hover** affordance, so the static table is unchanged — the capture hovers a coldkey cell and reports whether the preview popover appears:

```
before: hover popover on the coldkey cell = 0
after:  hover popover on the coldkey cell = 1
```

| Viewport · Theme | Before (hovering coldkey) | After (hovering coldkey) |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-desktop-light-before.png" width="300">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-desktop-light-before.png)<br><sub>before — no preview</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-desktop-light-after.png" width="300">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-desktop-light-after.png)<br><sub>after — account preview</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-desktop-dark-before.png" width="300">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-desktop-dark-before.png)<br><sub>before — no preview</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-desktop-dark-after.png" width="300">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-desktop-dark-after.png)<br><sub>after — account preview</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-tablet-light-before.png" width="300">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-tablet-light-before.png)<br><sub>before — no preview</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-tablet-light-after.png" width="300">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-tablet-light-after.png)<br><sub>after — account preview</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-tablet-dark-before.png" width="300">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-tablet-dark-before.png)<br><sub>before — no preview</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-tablet-dark-after.png" width="300">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6338/coldkey-tablet-dark-after.png)<br><sub>after — account preview</sub> |

## The fix

- Both coldkey cells now use the shared `AccountAddress`. The adjacent **Hotkey** cells stay hand-rolled *by design* — they link to `/validators/$hotkey`, a kind `EntityHoverCard` doesn't support (the issue calls this out explicitly).
- **The `label` gotcha the issue flags:** `AccountAddress` hardcoded `label="account"` on its copy button, so a naive swap would have silently relabelled the coldkey copy button from "coldkey" to "account". I added an **optional `label` prop** (default `"account"`, so *every existing call site is unchanged*), and both coldkey sites pass `label="coldkey"` — preserving the prior accessible label the issue asks to keep. `compact` is forwarded as before to keep the dense row height.

No behavioural change beyond adding the hover preview and routing the copy button's label through the shared component.

## Verification

- The capture asserts the popover count goes 0 → 1 on hover of a real `/accounts/$ss58` link in the table.
- Screenshots are **desktop + tablet only**: the hover-card is a pointer affordance, and the Coldkey *column* is the desktop table — the mobile card list (the other edited file) renders its coldkey through the same `AccountAddress` now, but a touch device has no hover state to capture. Both files' cells are the identical one-component swap.
- **No new type errors** — the only 2 `tsc` errors are pre-existing in `vite.config.ts` (a missing `@sentry/vite-plugin` dep just added to main), none in my 3 files; verified against a clean checkout.
- `eslint` on the committed blobs: **0 errors**. `prettier --check` in place: clean — re-verified *after* rebasing onto a main that moved 6 commits. Pushed at `behind: 0`.
