### PR TITLE
fix(ui): use the AA-safe text-accent-text token on 5 static accent CTA pills

### DIFF
--- a/apps/ui/src/components/metagraphed/resource-explorer.tsx
+++ b/apps/ui/src/components/metagraphed/resource-explorer.tsx
@@ -137,7 +137,7 @@ function FiltersTrigger({ filter }: { filter: ReturnType<typeof useSubnetFilter>
           <Filter className="size-3" />
           <span className="hidden sm:inline">Filters</span>
           {activeCount > 0 ? (
-            <span className="rounded-full bg-accent/15 px-1.5 font-mono text-[10px] text-accent">
+            <span className="rounded-full bg-accent/15 px-1.5 font-mono text-[10px] text-accent-text">
               {activeCount}
             </span>
           ) : null}

--- a/apps/ui/src/components/metagraphed/rpc-proxy.tsx
+++ b/apps/ui/src/components/metagraphed/rpc-proxy.tsx
@@ -70,7 +70,7 @@ export function ProxyHero() {
           Live
         </span>
         <span className="mg-label">Load-balanced reverse proxy</span>
-        <span className="rounded border border-accent/30 bg-accent/10 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-accent">
+        <span className="rounded border border-accent/30 bg-accent/10 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-accent-text">
           {label}
         </span>
       </div>

--- a/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
+++ b/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
@@ -103,7 +103,7 @@ function DriftBody({
               onOpenInExplorer(schema.id);
               onClose();
             }}
-            className="inline-flex items-center gap-1.5 rounded-full border border-accent/40 bg-primary-soft px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest text-accent hover:bg-primary-soft/80"
+            className="inline-flex items-center gap-1.5 rounded-full border border-accent/40 bg-primary-soft px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest text-accent-text hover:bg-primary-soft/80"
           >
             open in explorer
           </button>

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -243,7 +243,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
             </ActionBar>
             <a
               href="#history"
-              className="inline-flex items-center rounded-full border border-accent/30 bg-accent/10 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/15"
+              className="inline-flex items-center rounded-full border border-accent/30 bg-accent/10 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-accent-text transition-colors hover:bg-accent/15"
             >
               View activity
             </a>

--- a/apps/ui/src/routes/schemas.tsx
+++ b/apps/ui/src/routes/schemas.tsx
@@ -207,7 +207,7 @@ function SchemasHero() {
           <Link
             to="/docs/$"
             params={{ _splat: "api-reference" }}
-            className="inline-flex items-center rounded-full border border-accent/30 bg-accent/10 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent/15"
+            className="inline-flex items-center rounded-full border border-accent/30 bg-accent/10 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-accent-text transition-colors hover:bg-accent/15"
           >
             Browse reference
           </Link>


### PR DESCRIPTION
## What

Five static (non-conditional) accent CTA pills/badges used `text-accent`, which in **light** theme is the lighter mint (`--accent`, oklch L≈0.74) sitting on a soft `bg-accent/10` fill — a low-contrast pairing that fails AA. The AA-safe token for accent-on-surface text is `text-accent-text` (`--accent-text`, oklch L≈0.515 in light theme), already used by the directly-analogous badge in `subnets.$netuid.tsx`. This swaps the five outliers to match:

- `apps/ui/src/routes/schemas.tsx` — the "Browse reference" hero pill
- `apps/ui/src/routes/accounts.$ss58.tsx` — the jump-to-section pill (byte-identical to the schemas one)
- `apps/ui/src/components/metagraphed/resource-explorer.tsx`, `rpc-proxy.tsx`, `schema-drift-detail.tsx` — the same static-badge shape

Only the `text-accent` → `text-accent-text` foreground swap; `border-accent`/`bg-accent` fills are left untouched, and no conditional/hover/icon `text-accent` usages were changed.

## Screenshots (before / after)

3 viewports × 2 themes, framed on the `/schemas` "Browse reference" pill. **Before** = light-mint pill text; **After** = the AA-safe darker accent text.

> **Note on the Dark rows:** the fix is a **light-theme** contrast correction. In dark theme `--accent-text` is aliased to `--accent` (dark mode already meets contrast on these fills), so the Dark before/after are identical **by design** — included for completeness.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6405-after-mobile-dark.png)<br><sub>after</sub> |


## Validation

- `eslint` — clean on all 5 changed files (0 errors).
- `prettier --check` (apps/ui workspace config) — clean.
- Unit tests — full `apps/ui` suite green: **141 files / 1065 tests passed** (a pure class-token swap; no logic touched).

Closes #6405
