### PR TITLE
feat(ui): link the Validators and Chain-events empty states to their API

### DIFF
--- a/apps/ui/src/components/metagraphed/chain-events-feed.tsx
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { API_BASE } from "@/lib/metagraphed/config";
 import { SearchInput } from "@/components/metagraphed/table-controls";
 import { TimeAgo, ListShell, LoadMore } from "@jsonbored/ui-kit";
 import { chainEventsInfiniteQuery } from "@/lib/metagraphed/queries";
@@ -92,6 +93,18 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
         filtersActive
           ? "No chain events match these filters."
           : "No chain events indexed yet — the all-events backfill fills this feed."
+      }
+      // #6340: a genuinely-empty feed offers the same "open the API" action every
+      // other empty list page does; the filtered-empty case keeps no action,
+      // matching the filter-empty convention elsewhere.
+      action={
+        filtersActive
+          ? undefined
+          : {
+              label: "Open /api/v1/chain-events",
+              href: `${API_BASE}/api/v1/chain-events`,
+              external: true,
+            }
       }
     />
   );

--- a/apps/ui/src/routes/validators-index-empty-action.test.ts
+++ b/apps/ui/src/routes/validators-index-empty-action.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #6340: the Validators index and the Chain events feed's genuinely-empty
+// EmptyState had no `action` link to the underlying API, unlike every other
+// single-feed list page (blocks.index.tsx etc.). Both now offer "Open the API".
+// The chain-events filtered-empty case ("No chain events match these filters")
+// deliberately keeps no action, matching the filter-empty convention.
+//
+// Source assertions: the empty branch only renders when the live feed is empty
+// (it isn't), so a rendered test can't reach it; this suite is node-environment.
+const validators = readFileSync(
+  fileURLToPath(new URL("./validators.index.tsx", import.meta.url)),
+  "utf8",
+);
+const feed = readFileSync(
+  fileURLToPath(new URL("../components/metagraphed/chain-events-feed.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("empty-state 'Open the API' actions (#6340)", () => {
+  it("Validators index links its empty state to /api/v1/validators", () => {
+    const empty = validators.slice(
+      validators.indexOf("No validators indexed yet"),
+      validators.indexOf("No validators indexed yet") + 320,
+    );
+    expect(empty).toContain("action={{");
+    expect(empty).toContain('label: "Open /api/v1/validators"');
+    expect(empty).toContain("href: `${API_BASE}/api/v1/validators`");
+    expect(empty).toContain("external: true");
+  });
+
+  it("Chain events feed links its UNFILTERED empty state to /api/v1/chain-events", () => {
+    const empty = feed.slice(
+      feed.indexOf("const emptyNode"),
+      feed.indexOf("const emptyNode") + 700,
+    );
+    expect(empty).toContain("href: `${API_BASE}/api/v1/chain-events`");
+    expect(empty).toContain("external: true");
+  });
+
+  it("keeps the filtered-empty chain-events case action-less", () => {
+    // The action must be gated on filtersActive so a filter-empty view doesn't
+    // suggest "open the API" (it'd show unfiltered data, not the filtered subset).
+    const empty = feed.slice(
+      feed.indexOf("const emptyNode"),
+      feed.indexOf("const emptyNode") + 700,
+    );
+    expect(empty).toContain("filtersActive");
+    // The action expression branches on filtersActive → undefined.
+    expect(empty).toMatch(/action=\{\s*filtersActive\s*\?\s*undefined/);
+  });
+});

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -7,6 +7,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { PageHero, ShareButton, DownloadCsvButton, ActionBar } from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
+import { API_BASE } from "@/lib/metagraphed/config";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
@@ -207,6 +208,11 @@ function ValidatorsTable({
         <EmptyState
           title="No validators indexed yet"
           description="The global validator directory is empty for this window."
+          action={{
+            label: "Open /api/v1/validators",
+            href: `${API_BASE}/api/v1/validators`,
+            external: true,
+          }}
         />
       )}
 


### PR DESCRIPTION
## What

Every single-feed list page's zero-results `EmptyState` offers an `action` link to the underlying API (`blocks.index.tsx`, `extrinsics.index.tsx`, etc.) — but the **Validators index** and the **Chain events feed** (backing `/events` and the embedded explorer feed) didn't. A genuinely-empty view there was a dead end.

Both now offer the same "Open the API" action, matching the peer convention exactly (the pattern is lifted verbatim from `blocks.index.tsx:347-355`):

- `validators.index.tsx` → `Open /api/v1/validators`
- `chain-events-feed.tsx` (unfiltered empty) → `Open /api/v1/chain-events`

## Scope detail

The chain-events **filtered-empty** case ("No chain events match these filters") deliberately keeps **no** action — an "open the API" link there would show unfiltered data, not the filtered subset the user asked for. This matches the filter-empty convention elsewhere, so the action is gated on `filtersActive`. `leaderboards.tsx` is left alone (distinct `lastChecked` pattern, out of scope per the issue).

## Screenshots

`/validators`, before/after. The change is in the **empty branch**, which doesn't render on live (populated) data — so the captured pages are identical, and both linked endpoints return `200` (verified, not dead links). The action wiring is proven by the source tests below (they fail on the upstream file).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png)<br><sub>after</sub> |


## Testing

`validators-index-empty-action.test.ts` (3 tests, source assertions — the empty branch only renders when the live feed is empty, which it isn't, so a rendered test can't reach it; this suite is node-environment):

- the Validators empty state carries `action` → `Open /api/v1/validators` (`${API_BASE}`, `external: true`);
- the chain-events **unfiltered** empty state links `/api/v1/chain-events`;
- the **filtered**-empty case stays action-less (`action={filtersActive ? undefined : …}`).

**Verified meaningful: all 3 fail against the upstream files; all 3 pass restored.**

`apps/ui`: 150 files / 1101 tests pass, `tsc` clean, `eslint` 0 errors, `format:check` clean. `git diff -w` is +19 lines, 0 deletions. Diff is 3 files under `apps/ui/src`.

Closes #6340