### PR TITLE
feat(ui): surface the network-wide Total stake trend on /subnets

### DIFF
--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseInfiniteQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useEffect, useMemo } from "react";
 import { z } from "zod";
-import { Network, Radio, Layers, Activity } from "lucide-react";
+import { Network, Radio, Layers, Activity, Coins } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
@@ -49,6 +49,7 @@ import {
   subnetHealthMapQuery,
   agentCatalogMapQuery,
   economicsQuery,
+  economicsTrendsQuery,
 } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber, formatTao, isStaleFreshness } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
@@ -216,6 +217,11 @@ function SubnetsPage() {
 function SubnetsStatStrip() {
   const coverage = useSuspenseQuery(coverageQuery()).data.data ?? {};
   const health = useSuspenseQuery(healthQuery()).data.data ?? {};
+  // #6271: network-wide total stake, from the same subnet_snapshots rollup
+  // explorer.tsx's "Network economics trend" section charts — days[] is
+  // newest-first, so days[0] is the latest snapshot's value.
+  const trends = useSuspenseQuery(economicsTrendsQuery()).data.data;
+  const totalStake = trends.days[0]?.total_stake_tao ?? undefined;
   // Wired to the live /api/v1/coverage shape (same as CoverageFunnel): the older
   // netuids_active/netuids_total/adapter_backed fields are null on the live payload.
   const active =
@@ -239,7 +245,7 @@ function SubnetsStatStrip() {
   const totalH = health.total;
   const healthyOk = ok != null && totalH != null && totalH > 0 && ok / totalH > 0.9;
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
       <StatTile
         icon={Network}
         eyebrow="Active subnets"
@@ -259,6 +265,12 @@ function SubnetsStatStrip() {
         eyebrow="Healthy"
         value={ok != null && totalH ? `${formatNumber(ok)}/${formatNumber(totalH)}` : "—"}
         tone={healthyOk ? "ok" : "default"}
+      />
+      <StatTile
+        icon={Coins}
+        eyebrow="Total stake"
+        value={formatTao(totalStake)}
+        hint="network-wide"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- `/subnets`' stat strip (`SubnetsStatStrip`) rendered 4 tiles (Active subnets, Adapter-backed, Manifested surfaces, Healthy) with no network-wide stake figure at all, despite the exact same data already being charted on `/explorer`'s "Network economics trend" section via `economicsTrendsQuery()`.
- Added a 5th `StatTile` reading the latest snapshot's `total_stake_tao` from `economicsTrendsQuery()` (`days[0]`, newest-first — same field/query `explorer.tsx` already uses), formatted with the existing `formatTao` helper. Widened the grid from `md:grid-cols-4` to `md:grid-cols-5`. No backend/query changes — pure reuse of an already-live data source.

Closes #6271

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6271-mobile-dark-after.png)<br><sub>after</sub> |

## Test plan
- [x] `npx tsc --noEmit -p apps/ui` — clean
- [x] `npx vitest run` (apps/ui) — 150 files / 1101 tests pass
- [x] `npx eslint` / `npx prettier --check` on the changed file — clean (0 errors)
- [x] `npm run validate:artifact-budgets` — passed
- [x] Manual verification against a live dev server: the Total stake tile renders the correct live value (341.91M τ) alongside the existing 4 tiles