### PR TITLE
fix(ui): default the Sentry DSN on production builds

### DIFF
--- a/apps/ui/.env.example
+++ b/apps/ui/.env.example
@@ -18,3 +18,19 @@ VITE_METAGRAPH_API_BASE=https://api.metagraph.sh
 #
 # Leave blank to fall back to GitHub org avatars + the monogram tile.
 VITE_ICON_PROXY_URL=
+
+# Sentry DSN for browser-side error reporting (src/lib/error-reporting.ts).
+# A DSN is designed to be public/embeddable, so the code already falls back
+# to the real "metagraphed" project DSN on production builds when this is
+# unset -- only set this to override with a different project/DSN, or to
+# opt a local `vite dev` build into Sentry too (normally silent in dev).
+VITE_SENTRY_DSN=
+
+# Sentry auth token for uploading source maps at build time (@sentry/vite-
+# plugin, wired in vite.config.ts). Unlike the DSN above this IS a real
+# secret (a Sentry API token) -- currently only settable via the Cloudflare
+# dashboard's Workers Builds "build variables" for this project (not
+# exposed through wrangler/the Cloudflare API as of this writing). Sourcemap
+# upload is optional (readable stack traces in Sentry vs. raw minified
+# column:line refs) -- Sentry itself works without it.
+SENTRY_AUTH_TOKEN=

--- a/apps/ui/src/lib/error-reporting.test.ts
+++ b/apps/ui/src/lib/error-reporting.test.ts
@@ -28,14 +28,25 @@ describe("reportError", () => {
     expect(reportLovableError).toHaveBeenCalledWith(err, { boundary: "panel_shell" });
   });
 
-  it("does NOT touch Sentry when no DSN is configured", async () => {
+  it("does NOT touch Sentry when no DSN is configured and it's not a production build", async () => {
     vi.stubEnv("VITE_SENTRY_DSN", "");
+    vi.stubEnv("PROD", false);
     const { reportError } = await import("./error-reporting");
     reportError(new Error("boom"), {});
     // allow any (non-existent) microtasks to flush
     await Promise.resolve();
     expect(captureException).not.toHaveBeenCalled();
     expect(init).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the real project DSN on a production build with no explicit override", async () => {
+    vi.stubEnv("VITE_SENTRY_DSN", "");
+    vi.stubEnv("PROD", true);
+    const { reportError } = await import("./error-reporting");
+    reportError(new Error("boom"), {});
+    await vi.waitFor(() => expect(init).toHaveBeenCalled());
+    expect(init.mock.calls[0][0].dsn).toMatch(/^https:\/\/.+@.+\.ingest\..+\.sentry\.io\/\d+$/);
+    expect(captureException).toHaveBeenCalled();
   });
 
   it("captures the exception via Sentry when a DSN is configured", async () => {

--- a/apps/ui/src/lib/error-reporting.ts
+++ b/apps/ui/src/lib/error-reporting.ts
@@ -8,8 +8,8 @@ import { reportLovableError } from "./lovable-error-reporting";
  * directly.
  *
  * Sinks, in order, all best-effort:
- *  1. Sentry — only when a build-time `VITE_SENTRY_DSN` is set. `@sentry/browser`
- *     is loaded via a DYNAMIC import so it costs zero bundle bytes when the DSN
+ *  1. Sentry — enabled whenever a DSN is available. `@sentry/browser` is
+ *     loaded via a DYNAMIC import so it costs zero bundle bytes when the DSN
  *     is unset (the import is tree-shaken / never reached). Tagged with a
  *     `release` (Cloudflare Workers Builds' own commit SHA, bridged in at
  *     build time via vite.config.ts's `define` -- see vite.config.ts's own
@@ -17,17 +17,32 @@ import { reportLovableError } from "./lovable-error-reporting";
  *     `import.meta.env.PROD`), so a regression can be traced to the deploy
  *     that introduced it. Source maps for this release are uploaded by
  *     `@sentry/vite-plugin` (also wired in vite.config.ts), gated on
- *     `SENTRY_AUTH_TOKEN` being set -- absent everywhere except the
- *     production Cloudflare Workers Build once configured.
+ *     `SENTRY_AUTH_TOKEN` being set -- absent everywhere except a production
+ *     Cloudflare Workers Build that has it configured (a real Sentry API
+ *     token, unlike the DSN below, so it can't have a code-level default
+ *     the same way -- sourcemap upload stays opt-in until a maintainer sets
+ *     it as a Workers Builds dashboard build variable).
  *  2. Lovable capture channel — best-effort, no-op outside the Lovable editor.
  *  3. `console.error` in dev so the boundary + context are always greppable
  *     locally.
  *
- * No backend change is required: when `VITE_SENTRY_DSN` is unset this degrades
- * to the existing best-effort behaviour with no eager Sentry load.
+ * DSN resolution mirrors DEFAULT_API_BASE's own convention
+ * (src/lib/metagraphed/config.ts): `VITE_SENTRY_DSN` overrides when a build
+ * sets it (e.g. a future Workers Builds dashboard config), otherwise falls
+ * back to the real "metagraphed" project DSN -- safe to hardcode since a
+ * Sentry DSN is designed to be public/embeddable in client JS (see
+ * scripts/observability.mjs's own comment on the same point). The fallback
+ * only applies to production builds (`import.meta.env.PROD`); `vite dev`
+ * stays silent by default so local debugging doesn't mix into production
+ * error tracking, matching this module's pre-existing "no eager Sentry load
+ * unless configured" intent.
  */
 
-const SENTRY_DSN = import.meta.env?.VITE_SENTRY_DSN as string | undefined;
+const SENTRY_PROJECT_DSN =
+  "https://998bd096e2c9f1d81781ed3a88fed0b9@o4511631313666048.ingest.us.sentry.io/4511749777588224";
+const SENTRY_DSN =
+  (import.meta.env?.VITE_SENTRY_DSN as string | undefined) ||
+  (import.meta.env?.PROD ? SENTRY_PROJECT_DSN : undefined);
 // Bridged in at build time from Cloudflare Workers Builds' own
 // WORKERS_CI_COMMIT_SHA (see vite.config.ts's `define` block) -- "" (not
 // undefined) whenever that var wasn't set, since Vite's `define` replaces


### PR DESCRIPTION
## Summary

`apps/ui`'s Sentry init has been dead code since it shipped (#6497). `VITE_SENTRY_DSN` is a Cloudflare Workers Builds build-time variable, and those are dashboard-only -- not exposed via wrangler or the Cloudflare API -- so nothing ever set it, and `Sentry.init()` has never once run in production. Confirmed live: the deployed bundle's own error-boundary chunk evaluates the DSN constant to `undefined` (`l={}, n=l?.VITE_SENTRY_DSN`).

Rather than depend on a dashboard-only mechanism, this mirrors the codebase's own existing convention for exactly this shape of value: `DEFAULT_API_BASE` (`src/lib/metagraphed/config.ts`) already falls back to a hardcoded production default when its `VITE_*` var is unset. A Sentry DSN is designed to be public/embeddable in client-side JS (same reasoning `scripts/observability.mjs` already documents for the box-side scripts), so it's safe to hardcode the same way.

The fallback only applies on production builds (`import.meta.env.PROD`) -- local `vite dev` stays silent by default, matching this module's pre-existing "no eager Sentry load unless configured" intent, so debugging locally never mixes into production error tracking.

`SENTRY_AUTH_TOKEN` (source-map upload) is a real secret and can't get the same treatment -- documented in `.env.example` as still needing a maintainer to set it as a Workers Builds dashboard build variable. Sentry works without it; sourcemap upload just improves stack-trace readability.

Found + last piece fixed during a full data-source + observability audit following D1 retirement (unrelated to D1). Closes the loop on that audit's Sentry findings -- all other targets (3 Cloudflare Workers, wss-lb on Railway, chain-firehose-relay + 4 data-refresh roles on the indexer box) already fixed and verified live.

## Test plan
- [x] `npx vitest run src/lib/error-reporting.test.ts` -- 6/6 passing, including 1 new test covering the production-default fallback
- [x] `npx vitest run` (full apps/ui suite) -- 149 files / 1099 tests passing
- [x] `npx tsc --noEmit` clean for the changed files (pre-existing unrelated errors in `packages/ui-kit`-dependent routes and `types.ts`, confirmed via a clean `ui-kit` build)
- [x] `npx eslint` / `npx prettier --check` clean
- [x] No visual change -- confined to `apps/ui/src/lib/**` + tests, so this follows the normal gate per the UI PR convention