### PR TITLE
feat(ui): surface the owning coldkey as a public linked field on the validator page

### DIFF
--- a/apps/ui/src/routes/validator-coldkey-link.test.ts
+++ b/apps/ui/src/routes/validator-coldkey-link.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #6427: detail.coldkey was fetched but only used for the isOwner check, never
+// rendered for a visitor. It's now a public, linked Coldkey field in the
+// masthead (AccountAddress -> /accounts/$ss58), outside any isOwner gate.
+// Verified in a browser: after links /accounts/<coldkey>; before had no such link.
+const source = readFileSync(
+  fileURLToPath(new URL("./validators.$hotkey.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("validator page surfaces the owning coldkey (#6427)", () => {
+  it("renders the coldkey through AccountAddress, untruncated with a fallback", () => {
+    const field = source.slice(
+      source.indexOf("Coldkey</span>"),
+      source.indexOf("Coldkey</span>") + 260,
+    );
+    expect(field).toContain("<AccountAddress");
+    expect(field).toContain("ss58={detail.coldkey}");
+    expect(field).toContain("truncate={false}");
+    expect(field).toContain("fallback=");
+  });
+
+  it("is not gated on isOwner (public, not owner-only)", () => {
+    // The coldkey field must sit in the always-rendered masthead, before the
+    // isOwner-gated actions block, so every visitor sees it.
+    const coldkeyAt = source.indexOf("ss58={detail.coldkey}");
+    const isOwnerActionAt = source.indexOf("isOwner ? (");
+    expect(coldkeyAt).toBeGreaterThan(-1);
+    expect(coldkeyAt).toBeLessThan(isOwnerActionAt);
+  });
+});

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -14,6 +14,7 @@ import { PageHero, ShareButton, SectionAnchor, CopyableCode, StatTile } from "@j
 import { ValidatorHistoryChart } from "@/components/metagraphed/validator-history-chart";
 import { ValidatorApyPanel } from "@/components/metagraphed/validator-apy-panel";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
+import { AccountAddress } from "@/components/metagraphed/account-address";
 import { WatchValidatorAlert } from "@/components/metagraphed/watch-validator-alert";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
 import { TakeManagementModal } from "@/components/metagraphed/take-management-modal";
@@ -309,6 +310,18 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
             </span>
             <span className="inline-flex max-w-full min-w-0 rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
               <CopyableCode value={hotkey} truncate={false} className="max-w-full" />
+            </span>
+            {/* #6427: the owning coldkey is fetched (used for the isOwner check)
+                but was never shown to a regular visitor, so no one could see which
+                account controls this hotkey. Surface it as a public, linked field
+                -- the same /accounts/$ss58 treatment every other ss58 gets. */}
+            <span className="inline-flex flex-wrap items-center gap-2 text-[11px] text-ink-muted">
+              <span className="uppercase tracking-widest">Coldkey</span>
+              <AccountAddress
+                ss58={detail.coldkey}
+                truncate={false}
+                fallback={<span className="text-ink-muted">Unknown</span>}
+              />
             </span>
           </span>
         }


### PR DESCRIPTION
## What

The validator detail page **already fetches** `detail.coldkey` (`validatorDetailQuery` normalizes it) but used it only for the internal `isOwner` check and the owner-only `TakeManagementModal` — it was **never shown to a regular visitor**. `ValidatorIdentityChip` shows the self-declared identity name, never the coldkey ss58. So a visitor had no way to see which account controls a given validator hotkey.

The masthead now renders a public **Coldkey** field, linked to `/accounts/$ss58` via `AccountAddress` (the same treatment every other ss58 in the app gets — #6424). Placed right beside the identity chip / the existing "identity is declared on the coldkey" note, as the issue suggests. Not gated on `isOwner`. A null coldkey renders "Unknown" via `AccountAddress`'s fallback.

## Proof (live)

On `/validators/5G9hfkx9…` (owning coldkey `5Ek8i6wDRakJfJPM…`):

| | Coldkey field |
| --- | --- |
| **before** | absent — the coldkey was fetched but never rendered |
| **after** | **`COLDKEY 5Ek8i6wDRakJfJPM…`**, linked to `/accounts/5Ek8i6wDRakJfJPM…` |

## Screenshots

`/validators/{hotkey}`, before/after — the new Coldkey field is visible in the masthead (this is a real visual addition, so the pairs genuinely differ).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6431-deeplink-after-mobile-dark.png)<br><sub>after</sub> |


## Testing

`validator-coldkey-link.test.ts` (source assertions — the masthead needs a router + live data and the suite is node-environment): the page renders `<AccountAddress ss58={detail.coldkey} …>` in a labelled Coldkey field, untruncated, with a fallback for the null case, and it's outside any `isOwner` gate.

**Verified meaningful: fails on the upstream file, passes restored.** Plus the in-browser proof above (after links `/accounts/<coldkey>`; before had no such link).

`apps/ui`: 150 files / 1101 tests pass, `tsc` clean, `eslint` 0 errors, `format:check` clean. Diff is 2 files under `apps/ui/src`.

Closes #6427