### PR TITLE
fix(ui): give the command palette's Copy action a keyboard path (#6414)

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -43,6 +43,7 @@ import { searchQuery, semanticSearchQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
 import { isValidSs58 } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { isCopySelectedKey } from "@/lib/metagraphed/command-palette-keys";
 import { getDocsNav } from "@/lib/docs-nav.functions";
 import {
   CommandDialog,
@@ -585,6 +586,21 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
         value={q}
         onValueChange={setQ}
         placeholder="Search subnets, surfaces, endpoints, providers, docs…"
+        // #6414: the per-row Copy button was mouse-only -- cmdk keeps focus on
+        // this input, so a keyboard user could never reach it. ⌘/Ctrl+C now
+        // copies the highlighted row's link by triggering that row's own Copy
+        // button (Open-in-new-tab already has ⌘+Enter via onSelect's modifier).
+        onKeyDown={(e) => {
+          const input = e.currentTarget;
+          const hasTextSelection = input.selectionStart !== input.selectionEnd;
+          if (!isCopySelectedKey(e, hasTextSelection)) return;
+          const selected = document.querySelector("[cmdk-item][aria-selected='true']");
+          const copyBtn = selected?.querySelector<HTMLButtonElement>('[data-action="copy"]');
+          if (copyBtn) {
+            e.preventDefault();
+            copyBtn.click();
+          }
+        }}
       />
 
       {/* Scope filter row */}
@@ -907,7 +923,8 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
         <span className="inline-flex items-center gap-2 flex-wrap">
           <Kbd>↑</Kbd>
           <Kbd>↓</Kbd> move <Kbd>⏎</Kbd> open <Kbd>⌘</Kbd>
-          <Kbd>⏎</Kbd> new tab <Kbd>Esc</Kbd> close
+          <Kbd>⏎</Kbd> new tab <Kbd>⌘</Kbd>
+          <Kbd>C</Kbd> copy <Kbd>Esc</Kbd> close
         </span>
         <span className="inline-flex items-center gap-1">
           <Star className="size-2.5" />
@@ -931,6 +948,10 @@ function ItemActions({ onCopy, onNewTab }: { onCopy: () => void; onNewTab: () =>
     >
       <button
         type="button"
+        // #6414: the keyboard ⌘/Ctrl+C handler on CommandInput finds the
+        // selected row's button by this attribute and clicks it, so the copy
+        // path stays in one place (this onClick) for both mouse and keyboard.
+        data-action="copy"
         onClick={(e) => {
           stop(e);
           onCopy();

--- a/apps/ui/src/lib/metagraphed/command-palette-keys.test.ts
+++ b/apps/ui/src/lib/metagraphed/command-palette-keys.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { isCopySelectedKey, type CopyKeyEvent } from "@/lib/metagraphed/command-palette-keys";
+
+const key = (over: Partial<CopyKeyEvent>): CopyKeyEvent => ({
+  metaKey: false,
+  ctrlKey: false,
+  shiftKey: false,
+  key: "c",
+  ...over,
+});
+
+describe("isCopySelectedKey", () => {
+  it("fires on ⌘C and Ctrl+C when the input has no text selection", () => {
+    expect(isCopySelectedKey(key({ metaKey: true }), false)).toBe(true);
+    expect(isCopySelectedKey(key({ ctrlKey: true }), false)).toBe(true);
+    expect(isCopySelectedKey(key({ ctrlKey: true, key: "C" }), false)).toBe(true);
+  });
+
+  it("ignores Ctrl+Shift+C — that's the devtools inspect shortcut", () => {
+    expect(isCopySelectedKey(key({ ctrlKey: true, shiftKey: true }), false)).toBe(false);
+  });
+
+  it("ignores a plain 'c' (that's search input, not a command)", () => {
+    expect(isCopySelectedKey(key({}), false)).toBe(false);
+  });
+
+  it("ignores other modified keys", () => {
+    expect(isCopySelectedKey(key({ metaKey: true, key: "v" }), false)).toBe(false);
+    expect(isCopySelectedKey(key({ metaKey: true, key: "Enter" }), false)).toBe(false);
+  });
+
+  it("defers to native copy when the user has selected input text", () => {
+    expect(isCopySelectedKey(key({ metaKey: true }), true)).toBe(false);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/command-palette-keys.ts
+++ b/apps/ui/src/lib/metagraphed/command-palette-keys.ts
@@ -1,0 +1,28 @@
+/** The subset of a keyboard event `isCopySelectedKey` reads — structural so the
+ * predicate is unit-testable without a real event. */
+export interface CopyKeyEvent {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  key: string;
+}
+
+/**
+ * Whether a keydown in the command palette should copy the highlighted result's
+ * link (#6414). ⌘/Ctrl + C, with **no** Shift — Ctrl+Shift+C is the browser's
+ * "inspect element" devtools shortcut, so it's deliberately excluded despite the
+ * issue floating it. Suppressed when the user has actually selected text in the
+ * search input, so a plain ⌘C there still copies that text natively rather than
+ * being hijacked.
+ *
+ * Kept pure (no DOM, no event methods) so the modifier matrix is unit-tested in
+ * the plain-node suite; the caller does the DOM lookup + click.
+ */
+export function isCopySelectedKey(e: CopyKeyEvent, hasInputTextSelection: boolean): boolean {
+  return (
+    (e.metaKey || e.ctrlKey) &&
+    !e.shiftKey &&
+    (e.key === "c" || e.key === "C") &&
+    !hasInputTextSelection
+  );
+}

--- a/apps/ui/tests/e2e/capture-palette-copy-screenshots.mjs
+++ b/apps/ui/tests/e2e/capture-palette-copy-screenshots.mjs
@@ -1,0 +1,82 @@
+/**
+ * Capture the command palette for #6414 (the added ⌘C copy footer hint).
+ *
+ * The palette is a ⌘K modal, so this opens it (with a query so a row is
+ * selected and the footer renders) and shoots the FIXED VIEWPORT -- never a
+ * crop, per SKILL.md Phase C2. The visible delta is the footer's new "⌘C copy"
+ * hint. The local dev server hydrates flakily, so it retries whole loads until
+ * the palette renders, with a long settle for React's post-mismatch client
+ * regeneration.
+ *
+ * Usage:
+ *   UI_BASE_URL=http://127.0.0.1:8081 VARIANT=before node tests/e2e/capture-palette-copy-screenshots.mjs
+ *   UI_BASE_URL=http://127.0.0.1:8080 VARIANT=after  node tests/e2e/capture-palette-copy-screenshots.mjs
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/palette-copy-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://127.0.0.1:8080";
+const VARIANT = process.env.VARIANT === "before" ? "before" : "after";
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const THEMES = ["light", "dark"];
+
+async function openPalette(page) {
+  // Long settle: the dev server can hydrate-mismatch and regenerate client-side.
+  await page.waitForTimeout(6000);
+  await page.evaluate(() => document.fonts.ready);
+  await page.keyboard.press("Control+k");
+  await page.waitForFunction(() => document.activeElement?.getAttribute("cmdk-input") != null, {
+    timeout: 8000,
+  });
+  await page.keyboard.type("subnets");
+  await page.waitForFunction(() => !!document.querySelector("[cmdk-item][aria-selected='true']"), {
+    timeout: 8000,
+  });
+  await page.waitForTimeout(500);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    for (const theme of THEMES) {
+      let done = false;
+      for (let attempt = 1; attempt <= 12 && !done; attempt++) {
+        const context = await browser.newContext({
+          viewport: { width: viewport.width, height: viewport.height },
+        });
+        const page = await context.newPage();
+        try {
+          await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+          await page.evaluate((t) => localStorage.setItem("mg-theme", t), theme);
+          await page.reload({ waitUntil: "domcontentloaded", timeout: 90_000 });
+          await openPalette(page);
+          const file = path.join(OUT_DIR, `${VARIANT}-${viewport.name}-${theme}.png`);
+          await page.screenshot({ path: file, fullPage: false });
+          console.log(`wrote ${file} (attempt ${attempt})`);
+          done = true;
+        } catch {
+          console.log(`${viewport.name}/${theme} attempt ${attempt}: palette flake, retrying`);
+        }
+        await context.close();
+      }
+      if (!done) console.log(`${viewport.name}/${theme}: could not render palette in 12 attempts`);
+    }
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Each command-palette result row's "Copy link" / "Open in new tab" buttons live in a
`hidden group-hover/group-data-[selected]` wrapper. cmdk keeps DOM focus on the search input
(rows are only `aria-selected` via activedescendant), so the buttons were reachable **only by
mouse hover** — or by tabbing through the entire scope-filter row first. "Copy link" had no
practical keyboard path at all.

## What Changed

**Open-in-new-tab already had a keyboard path** and I confirmed it: `onSelect` passes the
⌘/Ctrl modifier to `openTarget`, so **⌘+Enter opens the highlighted row in a new tab** (the
footer already documented it). This PR wires the genuinely-missing half:

**⌘/Ctrl+C copies the highlighted row's link**, by triggering that row's own Copy button (via
a `data-action="copy"` hook) — so mouse and keyboard share the single existing copy handler,
with no duplicated logic. Two guards:
- **Shift excluded** — `Ctrl+Shift+C` is the browser's inspect-element shortcut.
- **Defers to native copy** when the user has actually selected text in the search input.

The modifier decision is a pure `isCopySelectedKey` predicate with a unit test covering the
combo matrix (⌘C / Ctrl+C fire; Ctrl+Shift+C, plain `c`, other modified keys, and
copy-with-text-selection don't). This suite runs in a plain-node environment, no DOM. The
shortcut is added to the palette's existing footer hint row.

## Screenshots

3 viewports × 2 themes × before/after, fixed-viewport captures of the open palette (queried so
a row is selected and the footer renders). The only change is the footer gaining a `⌘C copy`
hint — visible in the footer row of each `after` shot, absent in each `before`.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/after-desktop-light.png)<br><sub>after — ⌘C copy</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6414-palette-copy/after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npm run lint --workspace=apps/ui` — clean (0 errors on the changed files)
- `npm run typecheck --workspace=apps/ui` — clean
- `npm test --workspace=apps/ui` — passing, incl. 5 new `command-palette-keys.test.ts` cases
- `npm run build --workspace=apps/ui` — clean

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6414`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched — `apps/ui/**` only.
- [x] `routeTree.gen.ts` untouched; screenshots hosted on a fork branch, not committed here.

Closes #6414
