### PR TITLE
fix(ui): reconcile two analytics panel headers to the shared text-sm size

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx
@@ -96,7 +96,7 @@ export function CoverageMatrix({ topN = 24 }: { topN?: number }) {
           <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
             Coverage matrix
           </div>
-          <h3 className="mt-0.5 font-display text-base font-semibold text-ink-strong">
+          <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
             What each subnet is missing
           </h3>
         </div>

--- a/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx
@@ -149,7 +149,7 @@ export function SchemaDriftMatrix({ setOpenSchema }: Props) {
           <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
             Drift matrix
           </div>
-          <h3 className="mt-0.5 font-display text-base font-semibold text-ink-strong">
+          <h3 className="mt-0.5 font-display text-sm font-semibold text-ink-strong">
             Every tracked schema, classified by change type
           </h3>
         </div>


### PR DESCRIPTION
## What

The shared "analytics panel header" shape (`<h3 class="font-display font-semibold …">`) renders at `text-sm` in seven places (`coverage-funnel.tsx`, `status-mosaic.tsx`, `what-changed-feed.tsx`, `network-pulse-band.tsx`, `registry-depth.tsx`, `coverage-matrix.tsx:310`, …) but two outliers used `text-base` — and `coverage-matrix.tsx` was self-inconsistent (`text-base` at :99, `text-sm` at :310). This reconciles the two outliers to `text-sm`:

- `apps/ui/src/components/metagraphed/analytics/schema-drift-matrix.tsx:152` (renders on `/schemas`)
- `apps/ui/src/components/metagraphed/analytics/coverage-matrix.tsx:99` (renders on `/gaps`)

Class-token only; no structural or logic change.

## Screenshots (before / after)

3 viewports × 2 themes, framed on the `/schemas` Drift-matrix panel header. **Before** = the larger `text-base` heading; **After** = `text-sm`, matching every sibling panel header (and the same file's own `:310` header). The `/gaps` CoverageMatrix header receives the byte-identical change on the identical header structure.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6406-after-mobile-dark.png)<br><sub>after</sub> |


## Validation

- `eslint` — clean on both changed files (0 errors).
- `prettier --check` (apps/ui workspace config) — clean.
- Unit tests — full `apps/ui` suite green (a pure class-token swap; no logic touched).

Closes #6406
