### PR TITLE
fix(ui): implement the ARIA tabs keyboard contract on role=tablist widgets (#6391)

### DIFF
--- a/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-kind-tabs.tsx
@@ -1,5 +1,6 @@
 import { classNames } from "@/lib/metagraphed/format";
 import { CATEGORY_LABEL, type EndpointCategory } from "@/lib/metagraphed/endpoint-pool";
+import { rovingTabIndex, useRovingTablist } from "@/hooks/use-roving-tablist";
 
 interface Props {
   value: EndpointCategory | "all";
@@ -10,24 +11,32 @@ interface Props {
 const ORDER: Array<EndpointCategory | "all"> = ["all", "rpc", "wss", "api", "sse", "data", "other"];
 
 export function EndpointKindTabs({ value, counts, onChange }: Props) {
+  // #6391: only "all" plus non-empty categories render, so roving-tabindex nav
+  // walks the actually-visible tabs (not the full ORDER).
+  const visible = ORDER.filter((k) => k === "all" || (counts[k] ?? 0) > 0);
+  const activeIndex = Math.max(0, visible.indexOf(value));
+  const { tabRef, onKeyDown } = useRovingTablist(visible.length, (i) => onChange(visible[i]));
+
   return (
     <div
       role="tablist"
       aria-label="Filter endpoints by kind"
       className="flex flex-wrap items-center gap-1.5"
     >
-      {ORDER.map((k) => {
+      {visible.map((k, i) => {
         const active = value === k;
         const label = k === "all" ? "All" : CATEGORY_LABEL[k];
         const count = counts[k];
-        if (k !== "all" && (count ?? 0) === 0) return null;
         return (
           <button
             key={k}
+            ref={tabRef(i)}
             type="button"
             role="tab"
             aria-selected={active}
+            tabIndex={rovingTabIndex(i, activeIndex)}
             onClick={() => onChange(k)}
+            onKeyDown={onKeyDown(i)}
             className={classNames(
               // !rounded-full overrides mg-focus-ring's hardcoded 6px ring radius.
               "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors mg-focus-ring !rounded-full",

--- a/apps/ui/src/hooks/use-roving-tablist.test.ts
+++ b/apps/ui/src/hooks/use-roving-tablist.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { isTablistNavKey, nextTabIndex, rovingTabIndex } from "./use-roving-tablist";
+
+describe("nextTabIndex", () => {
+  it("ArrowRight/ArrowDown advance and wrap at the end", () => {
+    expect(nextTabIndex(0, "ArrowRight", 3)).toBe(1);
+    expect(nextTabIndex(1, "ArrowDown", 3)).toBe(2);
+    expect(nextTabIndex(2, "ArrowRight", 3)).toBe(0); // wraps
+  });
+
+  it("ArrowLeft/ArrowUp retreat and wrap at the start", () => {
+    expect(nextTabIndex(2, "ArrowLeft", 3)).toBe(1);
+    expect(nextTabIndex(1, "ArrowUp", 3)).toBe(0);
+    expect(nextTabIndex(0, "ArrowLeft", 3)).toBe(2); // wraps
+  });
+
+  it("Home/End jump to the first/last item", () => {
+    expect(nextTabIndex(2, "Home", 4)).toBe(0);
+    expect(nextTabIndex(0, "End", 4)).toBe(3);
+  });
+
+  it("returns null for keys it doesn't handle", () => {
+    expect(nextTabIndex(0, "Enter", 3)).toBeNull();
+    expect(nextTabIndex(0, " ", 3)).toBeNull();
+    expect(nextTabIndex(0, "Tab", 3)).toBeNull();
+    expect(nextTabIndex(0, "a", 3)).toBeNull();
+  });
+
+  it("returns null for an empty list", () => {
+    expect(nextTabIndex(0, "ArrowRight", 0)).toBeNull();
+    expect(nextTabIndex(0, "Home", 0)).toBeNull();
+  });
+});
+
+describe("isTablistNavKey", () => {
+  it("recognizes the six navigation keys", () => {
+    for (const k of ["ArrowRight", "ArrowLeft", "ArrowDown", "ArrowUp", "Home", "End"]) {
+      expect(isTablistNavKey(k)).toBe(true);
+    }
+  });
+
+  it("rejects non-navigation keys", () => {
+    for (const k of ["Enter", " ", "Tab", "Escape", "a"]) {
+      expect(isTablistNavKey(k)).toBe(false);
+    }
+  });
+});
+
+describe("rovingTabIndex", () => {
+  it("is 0 for the active tab and -1 otherwise", () => {
+    expect(rovingTabIndex(1, 1)).toBe(0);
+    expect(rovingTabIndex(0, 1)).toBe(-1);
+    expect(rovingTabIndex(2, 1)).toBe(-1);
+  });
+});
+
+// #6391: the three `role="tablist"` widgets must actually consume the hook — a
+// roving tabIndex, an onKeyDown wired to the hook, and a ref for focus movement.
+// These components need the full app shell + a router to render, so (matching the
+// api-source-context.test.tsx precedent) this suite asserts on their source rather
+// than rendering them.
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+
+describe("tablist consumers wire the roving-tablist contract", () => {
+  const consumers = [
+    ["EndpointKindTabs", "../components/metagraphed/endpoint-kind-tabs.tsx"],
+    ["explorer section tabs", "../routes/explorer.tsx"],
+    ["stake/unstake direction toggle", "../routes/subnets.$netuid.tsx"],
+  ] as const;
+
+  for (const [name, rel] of consumers) {
+    it(`${name} imports and applies the hook`, () => {
+      const src = read(rel);
+      expect(src).toMatch(/use-roving-tablist/);
+      expect(src).toMatch(/useRovingTablist\(/);
+      expect(src).toMatch(/rovingTabIndex\(/);
+      // the hook's onKeyDown is threaded onto the tab button
+      expect(src).toMatch(/onKeyDown=\{/);
+    });
+  }
+});

--- a/apps/ui/src/hooks/use-roving-tablist.ts
+++ b/apps/ui/src/hooks/use-roving-tablist.ts
@@ -1,0 +1,93 @@
+import { useCallback, useRef, type KeyboardEvent as ReactKeyboardEvent } from "react";
+
+// #6391: several `role="tablist"` widgets (endpoints' EndpointKindTabs, explorer's
+// section tabs, the subnet stake/unstake toggle) render `role="tab"`/`aria-selected`
+// on plain `<button onClick>` elements with no keyboard handler — so they advertise
+// the WAI-ARIA APG tabs pattern via `role` but never implement its arrow-key contract.
+// This hook factors that contract (roving tabIndex + ArrowLeft/Right + Home/End) into
+// one shared primitive those tablists consume, matching the manual ArrowLeft/Right
+// idiom already used in nav-mega-menu.tsx.
+
+/**
+ * Pure next-index computation for a horizontal tablist. Given the current index,
+ * the key pressed, and the item count, returns the index that should receive
+ * focus, or `null` when the key isn't a navigation key this list handles.
+ *
+ * ArrowRight/ArrowLeft wrap around the ends (APG "automatic activation" tablists
+ * conventionally wrap); Home/End jump to the first/last item.
+ */
+export function nextTabIndex(current: number, key: string, count: number): number | null {
+  if (count <= 0) return null;
+  switch (key) {
+    case "ArrowRight":
+    case "ArrowDown":
+      return (current + 1) % count;
+    case "ArrowLeft":
+    case "ArrowUp":
+      return (current - 1 + count) % count;
+    case "Home":
+      return 0;
+    case "End":
+      return count - 1;
+    default:
+      return null;
+  }
+}
+
+/** The keys `nextTabIndex` treats as navigation (and the tablist should preventDefault on). */
+export function isTablistNavKey(key: string): boolean {
+  return (
+    key === "ArrowRight" ||
+    key === "ArrowLeft" ||
+    key === "ArrowDown" ||
+    key === "ArrowUp" ||
+    key === "Home" ||
+    key === "End"
+  );
+}
+
+interface RovingTablist {
+  /** Ref callback to attach to each tab button, in list order (call with the item's index). */
+  tabRef: (index: number) => (el: HTMLElement | null) => void;
+  /** `onKeyDown` for a tab button at `index`: moves DOM focus (and selection) per the APG contract. */
+  onKeyDown: (index: number) => (e: ReactKeyboardEvent<HTMLElement>) => void;
+}
+
+/** Roving `tabIndex` for a tab: 0 for the active tab, -1 for the rest, so only the
+ *  active tab is in the Tab order and arrow keys move within the list. */
+export function rovingTabIndex(index: number, activeIndex: number): 0 | -1 {
+  return index === activeIndex ? 0 : -1;
+}
+
+/**
+ * Wire the WAI-ARIA tabs keyboard contract onto a horizontal `role="tablist"`.
+ *
+ * `count` is the number of rendered tabs; `onSelect(index)` selects the tab (the
+ * same effect as the button's existing onClick) — arrow navigation moves focus AND
+ * selects, matching the "automatic activation" tablists these components already are.
+ * Pair with `rovingTabIndex(i, activeIndex)` on each button so only the active tab
+ * is in the Tab order and arrow keys move within.
+ */
+export function useRovingTablist(count: number, onSelect: (index: number) => void): RovingTablist {
+  const refs = useRef<(HTMLElement | null)[]>([]);
+
+  const tabRef = useCallback(
+    (index: number) => (el: HTMLElement | null) => {
+      refs.current[index] = el;
+    },
+    [],
+  );
+
+  const onKeyDown = useCallback(
+    (index: number) => (e: ReactKeyboardEvent<HTMLElement>) => {
+      const next = nextTabIndex(index, e.key, count);
+      if (next == null) return;
+      e.preventDefault();
+      refs.current[next]?.focus();
+      onSelect(next);
+    },
+    [count, onSelect],
+  );
+
+  return { tabRef, onKeyDown };
+}

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -44,6 +44,7 @@ import {
   economicsTrendsQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+import { rovingTabIndex, useRovingTablist } from "@/hooks/use-roving-tablist";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import type {
   ChainCalls,
@@ -1293,6 +1294,15 @@ function ExplorerDashboard() {
   // longer one ~24,000px vertical feed. Only the active tab's panels mount; the
   // queries above are batched once, so switching tabs never re-suspends.
   const [tab, setTab] = useState<ExplorerTab>("activity");
+  // #6391: arrow-key navigation for the role="tablist" section switcher.
+  const tabActiveIndex = Math.max(
+    0,
+    EXPLORER_TABS.findIndex((t) => t.id === tab),
+  );
+  const { tabRef: explorerTabRef, onKeyDown: explorerTabKeyDown } = useRovingTablist(
+    EXPLORER_TABS.length,
+    (i) => setTab(EXPLORER_TABS[i].id),
+  );
   return (
     <div className="space-y-10">
       {/* window toggle */}
@@ -1355,13 +1365,16 @@ function ExplorerDashboard() {
         role="tablist"
         aria-label="Explorer sections"
       >
-        {EXPLORER_TABS.map((t) => (
+        {EXPLORER_TABS.map((t, i) => (
           <button
             key={t.id}
+            ref={explorerTabRef(i)}
             type="button"
             role="tab"
             aria-selected={tab === t.id}
+            tabIndex={rovingTabIndex(i, tabActiveIndex)}
             onClick={() => setTab(t.id)}
+            onKeyDown={explorerTabKeyDown(i)}
             className={
               tab === t.id
                 ? "rounded-full border border-accent/40 bg-accent/10 px-3.5 py-1.5 font-mono text-[11px] uppercase tracking-widest text-accent-text"

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -83,6 +83,7 @@ import {
   subnetStakeQuoteQuery,
 } from "@/lib/metagraphed/queries";
 import { isStaleFreshness, formatNumber, classNames } from "@/lib/metagraphed/format";
+import { rovingTabIndex, useRovingTablist } from "@/hooks/use-roving-tablist";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import {
   eventKindCategory,
@@ -801,6 +802,12 @@ function fmtQuotePrice(v: number): string {
 function StakeQuoteCalculator({ netuid }: { netuid: number }) {
   const [amountInput, setAmountInput] = useState("");
   const [direction, setDirection] = useState<(typeof STAKE_QUOTE_DIRECTIONS)[number]>("stake");
+  // #6391: arrow-key navigation for the role="tablist" direction toggle.
+  const directionIndex = Math.max(0, STAKE_QUOTE_DIRECTIONS.indexOf(direction));
+  const { tabRef: directionTabRef, onKeyDown: directionKeyDown } = useRovingTablist(
+    STAKE_QUOTE_DIRECTIONS.length,
+    (i) => setDirection(STAKE_QUOTE_DIRECTIONS[i]),
+  );
   const amount = Number(amountInput);
   const hasValidAmount = amountInput.trim() !== "" && Number.isFinite(amount) && amount > 0;
   const result = useQuery(subnetStakeQuoteQuery(netuid, hasValidAmount ? amount : 0, direction));
@@ -837,15 +844,18 @@ function StakeQuoteCalculator({ netuid }: { netuid: number }) {
             aria-label="Stake or unstake"
             className="inline-flex items-center rounded-md border border-border bg-card p-0.5"
           >
-            {STAKE_QUOTE_DIRECTIONS.map((d) => {
+            {STAKE_QUOTE_DIRECTIONS.map((d, i) => {
               const active = d === direction;
               return (
                 <button
                   key={d}
+                  ref={directionTabRef(i)}
                   type="button"
                   role="tab"
                   aria-selected={active}
+                  tabIndex={rovingTabIndex(i, directionIndex)}
                   onClick={() => setDirection(d)}
+                  onKeyDown={directionKeyDown(i)}
                   className={classNames(
                     "min-h-8 rounded px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest transition-colors",
                     active ? "bg-surface text-ink-strong" : "text-ink-muted hover:text-ink-strong",


### PR DESCRIPTION
## Summary

Three `role="tablist"` widgets — `EndpointKindTabs` (`/endpoints`), the explorer section tabs (`/explorer`), and the subnet stake/unstake direction toggle (`/subnets/{netuid}`) — render `role="tab"` / `aria-selected` on plain `<button onClick>` elements with **no keyboard handling**. They advertise the WAI-ARIA APG tabs pattern via `role` but implement none of its arrow-key contract: no Left/Right movement, no Home/End, no roving `tabIndex`. A keyboard-only user reaches the list and can't navigate it the way the `role` promises.

## Fix

Add a shared **`useRovingTablist`** hook (`apps/ui/src/hooks/use-roving-tablist.ts`) that factors the contract into one primitive the three tablists consume:

- **`nextTabIndex(current, key, count)`** — pure index math: ArrowRight/ArrowDown advance, ArrowLeft/ArrowUp retreat (both wrap around the ends, matching these automatic-activation tablists), Home/End jump to first/last; returns `null` for any other key.
- **`rovingTabIndex(index, activeIndex)`** — `0` for the active tab, `-1` for the rest, so only the active tab is in the Tab order and arrow keys move within the list.
- **`useRovingTablist(count, onSelect)`** — wires `ref` + `onKeyDown` onto each tab; arrow navigation moves DOM focus **and** selects (these lists already activate on click).

This mirrors the manual ArrowLeft/Right idiom already in `nav-mega-menu.tsx`, and the command palette (`cmdk`) referenced by the issue as the app's working keyboard example.

**No visual change:** `role`, `aria-selected`, and every className are unchanged on all three widgets — the diff only adds `tabIndex`, `ref`, and `onKeyDown`. The before/after screenshots below are identical by design (they confirm no visual regression); the behavior change is keyboard-only.

## Tests

`apps/ui/src/hooks/use-roving-tablist.test.ts`:
- Exhaustive unit tests for the pure functions (`nextTabIndex` wrap/Home/End/null cases, empty-list guard; `isTablistNavKey`; `rovingTabIndex`).
- Source assertions that each of the three consumers imports and applies the hook (`useRovingTablist(` / `rovingTabIndex(` / `onKeyDown={`) — matching the `api-source-context.test.tsx` precedent, since these components need the full app shell + router to render.

## Validation

- `npm test --workspace=apps/ui` → 1109 passed (11 new)
- `npm run typecheck --workspace=apps/ui` → clean · `npm run lint --workspace=apps/ui` → clean
- `npm run test:e2e --workspace=apps/ui` — the responsive-overflow specs for `/endpoints`, `/subnets/1`, `/explorer` pass (the unrelated `#6426 multisig` / `#6434 evidence` / `/status` specs fail identically on the base commit — pre-existing, not from this diff)
- `npm run build --workspace=apps/ui` → clean

## Screenshots (`/endpoints`, tablist page — visually unchanged)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6391-tablist-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6391
