### PR TITLE
fix(webhooks): strip trailing FQDN dot so localhost. cannot bypass the SSRF blocklist

### DIFF
--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -74,9 +74,18 @@ const PRIVATE_IPV4_PATTERNS = [
 ];
 
 function normalizedHostname(value) {
-  return String(value || "")
-    .toLowerCase()
-    .replace(/^\[|\]$/g, "");
+  return (
+    String(value || "")
+      .toLowerCase()
+      .replace(/^\[|\]$/g, "")
+      // Strip trailing FQDN dot(s). The URL parser keeps them (localhost. →
+      // "localhost.", localhost.. → "localhost.."), so without this the name
+      // blocklist below (=== "localhost", .endsWith(".internal"/".local")) misses
+      // "localhost.", "x.internal.", "y.local." and they pass as public. The prober
+      // + probe-core guards already normalize this; strip every trailing dot so the
+      // multi-dot form can't slip through either.
+      .replace(/\.+$/, "")
+  );
 }
 
 function isIpv4Literal(host) {

--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -128,6 +128,18 @@ describe("isPublicWebhookUrl", () => {
     assert.equal(isPublicWebhookUrl("https://router/x"), false);
   });
 
+  test("rejects a trailing-dot FQDN that would bypass the name blocklist", () => {
+    // The URL parser keeps the trailing dot (localhost. → "localhost."), so an
+    // un-normalized host slips past the "=== localhost" / ".internal" / ".local"
+    // checks. Every trailing dot must be stripped, including the multi-dot form.
+    assert.equal(isPublicWebhookUrl("https://localhost./x"), false);
+    assert.equal(isPublicWebhookUrl("https://localhost../x"), false);
+    assert.equal(isPublicWebhookUrl("https://svc.internal./x"), false);
+    assert.equal(isPublicWebhookUrl("https://printer.local./x"), false);
+    // A public FQDN with a trailing dot normalizes to its dotless form (still ok).
+    assert.equal(isPublicWebhookUrl("https://hooks.example.com./mg"), true);
+  });
+
   test("rejects a private IPv4 literal host", () => {
     assert.equal(isPublicWebhookUrl("https://169.254.169.254/x"), false);
   });


### PR DESCRIPTION
## Summary

`isPublicWebhookUrl` (the subscription-time SSRF guard in `src/webhooks.mjs`) normalizes a hostname by stripping IPv6 brackets but **not a trailing FQDN dot**. The WHATWG URL parser preserves that dot, so the name blocklist is bypassed.

```js
function normalizedHostname(value) {
  return String(value || "").toLowerCase().replace(/^\[|\]$/g, "");
  // no trailing-dot strip
}
```

## Root cause

`new URL("https://localhost./")` has `hostname === "localhost."` (and `"localhost../"` → `"localhost.."`). The blocklist checks are exact/suffix:

```js
if (host === "localhost" || host.endsWith(".localhost")) return false;
if (host.endsWith(".internal") || host.endsWith(".local")) return false;
```

`"localhost."` is not `=== "localhost"`, and `"svc.internal."` does not `.endsWith(".internal")`, so these fall through to the final `return host.includes(".")` → **accepted as public**.

Demonstrated before the fix: `isPublicWebhookUrl("https://localhost./")`, `".../svc.internal./"`, `".../printer.local./"` all return `true`.

The two sibling guards already normalize this — `src/health-prober.mjs` and `src/health-probe-core.mjs` both `.replace(/\.$/, "")`. The webhook guard was the outlier.

## Fix

Strip **every** trailing dot in `normalizedHostname` (`/\.+$/`), which closes both the single-dot and the multi-dot (`localhost..`) forms — the latter of which the siblings' single-dot `.replace(/\.$/, "")` would still miss.

## Impact / severity

Defense-in-depth. This is the subscription-time validation gate; a stored `localhost.`-style subscription is still re-resolved and rejected by the Node dispatcher at delivery (`safeWebhookFetch` DNS-pins and re-validates), so this is not a demonstrated live SSRF — it stops a non-public target being accepted as a valid subscription in the first place, and restores parity with the other two guards.

## Tests

- `tests/webhooks-core.test.mjs`: new case asserting `localhost.`, `localhost..`, `svc.internal.`, `printer.local.` → not public, and that a public FQDN with a trailing dot (`hooks.example.com.`) stays allowed.
- All 165 webhook tests pass; `eslint` + `prettier --check` clean; the changed line is covered.

## Risk / tradeoffs

- Backward compatible: a trailing-dot FQDN is semantically equal to its dotless form, so stripping is correct normalization — no legitimate public target changes classification.

_Unsolicited bug fix — external contributors cannot open issues on this repo, so no `Closes #` is linked._