### PR TITLE
feat(workers): upload Sentry source maps + git-based release for the 3 core Workers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@sentry/cli": "^3.6.0",
         "@vitest/coverage-v8": "^4.1.10",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -6220,20 +6221,7 @@
         }
       }
     },
-    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/core": {
-      "version": "10.66.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.66.0.tgz",
-      "integrity": "sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/conventions": "^0.16.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/cli": {
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli": {
       "version": "2.58.6",
       "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.6.tgz",
       "integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
@@ -6264,7 +6252,7 @@
         "@sentry/cli-win32-x64": "2.58.6"
       }
     },
-    "node_modules/@sentry/cli-darwin": {
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-darwin": {
       "version": "2.58.6",
       "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
       "integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
@@ -6278,7 +6266,7 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/cli-linux-arm": {
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-linux-arm": {
       "version": "2.58.6",
       "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
       "integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
@@ -6297,7 +6285,7 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/cli-linux-arm64": {
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-linux-arm64": {
       "version": "2.58.6",
       "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
       "integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
@@ -6316,7 +6304,7 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/cli-linux-i686": {
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-linux-i686": {
       "version": "2.58.6",
       "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
       "integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
@@ -6336,7 +6324,7 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/cli-linux-x64": {
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-linux-x64": {
       "version": "2.58.6",
       "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
       "integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
@@ -6355,7 +6343,7 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/cli-win32-arm64": {
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-win32-arm64": {
       "version": "2.58.6",
       "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
       "integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
@@ -6372,7 +6360,7 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/cli-win32-i686": {
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-win32-i686": {
       "version": "2.58.6",
       "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
       "integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
@@ -6390,7 +6378,7 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/cli-win32-x64": {
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/cli-win32-x64": {
       "version": "2.58.6",
       "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
       "integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
@@ -6407,7 +6395,20 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/cli/node_modules/agent-base": {
+    "node_modules/@sentry/bundler-plugins/node_modules/@sentry/core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.66.0.tgz",
+      "integrity": "sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
@@ -6420,7 +6421,7 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+    "node_modules/@sentry/bundler-plugins/node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
@@ -6434,7 +6435,7 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@sentry/cli/node_modules/node-fetch": {
+    "node_modules/@sentry/bundler-plugins/node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
@@ -6453,6 +6454,189 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.6.0.tgz",
+      "integrity": "sha512-79XC8o59G/i3VqmnoQD74a/QD/422eQQlUqiPd3sEvcYCxnaZialRVAsxuNEFd6sx4aVGpqt775MMDT9cV/lMg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "undici": "^6.22.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "3.6.0",
+        "@sentry/cli-linux-arm": "3.6.0",
+        "@sentry/cli-linux-arm64": "3.6.0",
+        "@sentry/cli-linux-i686": "3.6.0",
+        "@sentry/cli-linux-x64": "3.6.0",
+        "@sentry/cli-win32-arm64": "3.6.0",
+        "@sentry/cli-win32-i686": "3.6.0",
+        "@sentry/cli-win32-x64": "3.6.0"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.6.0.tgz",
+      "integrity": "sha512-C2SWHKaEP8NoYkLDr5jwrzklTwlJkzPIx7lu2LZrwBuHG/sNhWdili0ED2mD86b6Q90hlcMtuBm5IHUwcZ6FTQ==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.6.0.tgz",
+      "integrity": "sha512-S9xsDZTvybOGbrqqZ7DvF7JCNKp4cakDWJ4LdvQX+z82cHQSoLkYOXkA3EafDfWV9BGIRMIXitMMiSsV2PMU4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.6.0.tgz",
+      "integrity": "sha512-Rc+DB8vuTDpwqY2BxIPnooYk2ZDYQytF+n4nfi6pZZsJtr3SFFe+3wIWVmCVqxiHkaISb33+iJIDxOOqhkSNbQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.6.0.tgz",
+      "integrity": "sha512-PQ7+ctNmWtHgmbKa+rJheHU7D9GHJXafgWYfVW6gt7R0Ag9LxiDVYLGjrL4G/i7AGFNgudXFaLkGKNX7HUjc+g==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.6.0.tgz",
+      "integrity": "sha512-c+7xNg5BAaPE8N2Q6pg3Q/kt97JSaskuQIjRxHaFuDbCkJvww4VozY6mW5NUMJaW48rEs3mahWKamTLqJsO3wQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.6.0.tgz",
+      "integrity": "sha512-zhZ7YyGreHSKZ92Mwb9h4cEyL0I/eND7W6XIUXUW0BCCmxFOMc71vlQpUw8gijHIsFDbv8c8a6VOSkeRuwbSwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.6.0.tgz",
+      "integrity": "sha512-JaxzVDdyetrPBp8NHh2yNAYdDk79ROXqfAfjQwG5z6V764MMMrf2WrhQ7EwoKXOPtBLm/drbOcYgaxHuDZKGRw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.6.0.tgz",
+      "integrity": "sha512-LW0078VlxaUeVMMLA15A1zhkvZ5vby/lwthtBXPoBSDdTcgbTE4D4gQXM9vEapV28SvCO3fVIek3pbtrkaeDMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@sentry/cloudflare": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,9 @@
     "worker:deploy:dry-run": "node scripts/worker-deploy-dry-run.mjs",
     "worker:bundle:budget": "node scripts/worker-bundle-budget.mjs",
     "worker:check-deploy-drift": "node scripts/check-worker-deploy-drift.mjs",
+    "deploy:api": "scripts/deploy-worker-with-sourcemaps.sh wrangler.jsonc",
+    "deploy:data-api": "scripts/deploy-worker-with-sourcemaps.sh wrangler.data.jsonc",
+    "deploy:registry-sync-api": "scripts/deploy-worker-with-sourcemaps.sh wrangler.registry.jsonc",
     "smoke:live": "node scripts/smoke-live-api.mjs",
     "lint": "eslint .",
     "format:check": "prettier --check .",
@@ -134,6 +137,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@sentry/cli": "^3.6.0",
     "@vitest/coverage-v8": "^4.1.10",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/scripts/deploy-worker-with-sourcemaps.sh
+++ b/scripts/deploy-worker-with-sourcemaps.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Deploys one of the 3 core Cloudflare Workers and uploads its source maps to
+# the consolidated `metagraphed` Sentry project, so a captured error's
+# minified stack trace (workers/*.sentry.mjs bundle, e.g. "api.sentry.js:
+# 18:8835") resolves to real source. wrangler.*.jsonc's own upload_source_maps
+# only makes wrangler PRODUCE source maps as build output -- it does not push
+# them into Sentry; that needs this explicit sentry-cli step reading the same
+# output directory.
+#
+# The release value is generated once here (sentry-cli releases propose-
+# version, git-derived) and passed to the deploy itself via --var, so the
+# Worker's OWN release tag at runtime (env.SENTRY_RELEASE, read by workers/
+# *.sentry.mjs's withSentry() options callback -- see that file's own header)
+# is the exact same value the source maps get uploaded under. Previously the
+# runtime release fell back to CF_VERSION_METADATA's UUID, which has no
+# relationship to a git commit -- this also makes Sentry's suspect-commit
+# detection actually work against the linked JSONbored/metagraphed repo.
+#
+# Run via Cloudflare Workers Builds' own "Deploy command" setting (Settings ->
+# Build) for each Worker project -- not invoked by any GitHub Actions
+# workflow, these 3 Workers deploy through Cloudflare's own git-triggered
+# build system. Needs SENTRY_AUTH_TOKEN set as a Workers BUILD secret (not a
+# runtime Variable/Secret -- sentry-cli only runs during the build, never
+# reaches the deployed Worker) on each of the 3 Worker projects.
+#
+# Usage: scripts/deploy-worker-with-sourcemaps.sh <wrangler-config.jsonc>
+set -euo pipefail
+
+CONFIG="$1"
+OUTDIR="dist/worker-$(basename "$CONFIG" .jsonc)"
+
+export SENTRY_ORG="jsonbored"
+export SENTRY_PROJECT="metagraphed"
+
+RELEASE=$(npx sentry-cli releases propose-version)
+
+npx wrangler deploy \
+  --config "$CONFIG" \
+  --outdir "$OUTDIR" \
+  --upload-source-maps \
+  --var "SENTRY_RELEASE:$RELEASE"
+
+npx sentry-cli releases new "$RELEASE"
+# --auto reads the linked GitHub repo's commit range since the last release
+# (Sentry's GitHub integration, connected separately in the dashboard) --
+# powers suspect-commit detection on issues from this release.
+npx sentry-cli releases set-commits "$RELEASE" --auto
+npx sentry-cli sourcemaps upload \
+  --release="$RELEASE" \
+  --strip-prefix "$OUTDIR/.." \
+  "$OUTDIR"
+npx sentry-cli releases finalize "$RELEASE"


### PR DESCRIPTION
## Summary

`wrangler.*.jsonc`'s `upload_source_maps: true` only makes Wrangler produce source maps as build output — it doesn't push them into Sentry, so every captured error's stack trace stayed minified (confirmed on a real production error: `api.sentry.js:18:8835`, not a real source line).

Adds `scripts/deploy-worker-with-sourcemaps.sh`, wired as each Worker's new `deploy:api`/`deploy:data-api`/`deploy:registry-sync-api` npm script:
- Generates a git-derived release (`sentry-cli releases propose-version`)
- Passes it to the deploy itself via `--var` so the Worker's own runtime release tag (`env.SENTRY_RELEASE`, already the first-priority fallback in `workers/*.sentry.mjs`'s `withSentry()` options) matches what the source maps get uploaded under
- Uploads the source maps via `sentry-cli`
- Links commits via `--auto` against the now-connected `JSONbored/metagraphed` GitHub integration, so suspect-commit detection has something to work with — the previous release value (`CF_VERSION_METADATA`'s UUID) had no relationship to a git commit at all

## Deploy config needed (Cloudflare dashboard, done separately)

Set as each of the 3 Workers' "Deploy command" in Workers Builds settings (replacing whatever ran before): `npm run deploy:api` / `npm run deploy:data-api` / `npm run deploy:registry-sync-api`. Needs `SENTRY_AUTH_TOKEN` set as a Workers **Build secret** (build-time only, never reaches the deployed Worker's runtime) on each.

## Test plan

- [x] `bash -n scripts/deploy-worker-with-sourcemaps.sh` — syntax check
- [x] `npx sentry-cli --version` — confirms the new devDependency resolves
- [x] `npm run worker:deploy:dry-run` / `npm run cloudflare:verify:dry-run` — unaffected, still pass
- [x] `npx prettier --check package.json` — clean