### PR TITLE
feat(ui): add CSV export to the block-detail Extrinsics and Events tables

### DIFF
--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -17,6 +17,7 @@ import {
   SectionAnchor,
   StatTile,
   TableState,
+  DownloadCsvButton,
 } from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import {
@@ -26,6 +27,7 @@ import {
   blockQuery,
 } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
+import { buildUrl } from "@/lib/metagraphed/client";
 import { blockRefPathSegment, isValidBlockRef, shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
 import { formatChainEventArgs } from "@/lib/metagraphed/chain-event-args";
@@ -297,7 +299,12 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         </dl>
       </SectionAnchor>
 
-      <SectionAnchor id="extrinsics" title="Extrinsics" tone="accent">
+      <SectionAnchor
+        id="extrinsics"
+        title="Extrinsics"
+        tone="accent"
+        right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/extrinsics`)} />}
+      >
         {extrinsicsQuery.isPending ? (
           <Skeleton className="h-44" />
         ) : extrinsicsQuery.error ? (
@@ -385,7 +392,12 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
         )}
       </SectionAnchor>
 
-      <SectionAnchor id="events" title="Events" tone="accent">
+      <SectionAnchor
+        id="events"
+        title="Events"
+        tone="accent"
+        right={<DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/events`)} />}
+      >
         {eventsQuery.isPending ? (
           <Skeleton className="h-44" />
         ) : eventsQuery.error ? (


### PR DESCRIPTION
## What

`blocks.$ref.tsx`'s **Extrinsics** and **Events** tables had no CSV export, unlike the structurally identical account-detail tables (`accounts.$ss58.tsx`), which pair each table with a `DownloadCsvButton`. This adds the same affordance to both block-detail tables, following that precedent (button in each `SectionAnchor`'s `right` slot):

- Extrinsics → `DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/extrinsics`)}`
- Events → `DownloadCsvButton url={buildUrl(`/api/v1/blocks/${sourceRef}/events`)}`

Both endpoints already exist (they back this same file's own `EndpointSnippet`); no REST change. `DownloadCsvButton`/`buildUrl` are the same imports the account page uses.

## Screenshots (before / after)

3 viewports × 2 themes, framed on the block-detail Events section header. **Before** = section header with no export control; **After** = the "Download CSV" button now sits in the section header (the Extrinsics section gets the byte-identical button; the tables themselves are unchanged — shown mid-load here).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6559-after-mobile-dark.png)<br><sub>after</sub> |


## Validation

- `eslint` — clean on the changed file (0 errors).
- `prettier --check` (apps/ui workspace config) — clean.
- Unit tests — full `apps/ui` suite unaffected (additive: two shared `DownloadCsvButton`s pointed at existing endpoints, no logic touched).

Closes #6559
