### PR TITLE
refactor(ui): migrate accounts/validators card shadows to a theme-adaptive token (#6398)

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -231,7 +231,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
               Cross-subnet registrations, first-party chain events, and daily activity rollups for
               one Bittensor account.
             </p>
-            <div className="max-w-full sm:max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
+            <div className="max-w-full sm:max-w-fit rounded-2xl border border-border/80 bg-card/80 px-3 py-2 mg-card-glow">
               <CopyableCode value={ss58} truncate={false} className="max-w-full" />
             </div>
           </div>
@@ -285,28 +285,28 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
                 : "live RPC"
           }
           tone={balanceResult.isError ? "down" : "accent"}
-          className="rounded-2xl bg-card/95 p-5 shadow-[0_24px_80px_-52px_rgba(45,212,191,0.45)]"
+          className="rounded-2xl bg-card/95 p-5 mg-card-glow-accent"
         />
         <StatTile
           icon={Activity}
           eyebrow="Events"
           value={formatNumber(account.event_count)}
           hint="indexed first-party"
-          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 mg-card-glow"
         />
         <StatTile
           icon={Boxes}
           eyebrow="Subnets"
           value={formatNumber(account.subnet_count)}
           hint="active footprint"
-          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 mg-card-glow"
         />
         <StatTile
           icon={Clock}
           eyebrow="Last seen"
           value={<TimeAgo at={account.last_seen_at ?? undefined} />}
           hint="near-realtime · chain-direct index"
-          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 mg-card-glow"
         />
       </div>
 
@@ -359,7 +359,7 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
             {account.event_kinds.map((entry) => (
               <div
                 key={entry.kind}
-                className="rounded-2xl border border-border/80 bg-card/95 px-4 py-3 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.55)]"
+                className="rounded-2xl border border-border/80 bg-card/95 px-4 py-3 mg-card-glow"
               >
                 <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
                   event kind
@@ -779,8 +779,7 @@ function fmtAlphaPrice(v: number | null | undefined): string {
   return `${v < 1 ? v.toFixed(4) : v.toFixed(3)} τ`;
 }
 
-const KPI_TILE =
-  "rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.55)]";
+const KPI_TILE = "rounded-2xl border-border/80 bg-card/95 p-5 mg-card-glow";
 
 // Compact TAO formatter for the portfolio KPI tiles — a long raw value like
 // "338,030.153 τ" wraps + overflows a narrow StatTile, so summarise it (338.0k τ).
@@ -1203,7 +1202,7 @@ function AccountStakeFlowSection({ ss58 }: { ss58: string }) {
       </div>
 
       {bars.length > 0 ? (
-        <div className="mb-5 rounded-2xl border border-border/80 bg-card/95 px-5 py-4 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.55)]">
+        <div className="mb-5 rounded-2xl border border-border/80 bg-card/95 px-5 py-4 mg-card-glow">
           <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
             gross flow by subnet (τ)
           </div>
@@ -1469,7 +1468,7 @@ function AccountIdentitySection({ ss58 }: { ss58: string }) {
       tone="accent"
       info="GET /api/v1/accounts/{ss58}/identity — the coldkey's own on-chain identity, distinct from subnet identity and the validator directory's coldkey-identity join."
     >
-      <div className="rounded-2xl border border-border/80 bg-card/95 p-5 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.55)]">
+      <div className="rounded-2xl border border-border/80 bg-card/95 p-5 mg-card-glow">
         <div className="flex flex-wrap items-baseline justify-between gap-2">
           <span className="font-display text-lg font-semibold text-ink-strong">
             {identity.name ?? "Unnamed identity"}
@@ -2025,7 +2024,7 @@ function AccountFootprintSection({
       right={<SectionBadge>{formatNumber(rows.length)} subnets</SectionBadge>}
     >
       {staked.length > 0 ? (
-        <div className="mb-5 rounded-2xl border border-border/80 bg-card/95 px-5 py-4 shadow-[0_18px_50px_-44px_rgba(15,23,42,0.55)]">
+        <div className="mb-5 rounded-2xl border border-border/80 bg-card/95 px-5 py-4 mg-card-glow">
           <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
             stake by subnet (τ)
           </div>
@@ -2382,7 +2381,7 @@ function DataPanel({ children, className }: { children: ReactNode; className?: s
   return (
     <div
       className={classNames(
-        "overflow-x-auto rounded-[1.5rem] border border-border/80 bg-card/95 shadow-[0_28px_90px_-60px_rgba(15,23,42,0.45)]",
+        "overflow-x-auto rounded-[1.5rem] border border-border/80 bg-card/95 mg-card-glow",
         className,
       )}
     >
@@ -2401,7 +2400,7 @@ function AccountHeroAside({
   firstSeenAt: string | null;
 }) {
   return (
-    <div className="w-[20rem] rounded-[1.75rem] border border-border/80 bg-card/95 p-5 shadow-[0_32px_100px_-72px_rgba(15,23,42,0.65)]">
+    <div className="w-[20rem] rounded-[1.75rem] border border-border/80 bg-card/95 p-5 mg-card-glow">
       <div className="flex items-center justify-between gap-3">
         <div>
           <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted">

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -307,7 +307,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
               Cross-subnet performance, nominators, and staking history for one Bittensor validator
               hotkey.
             </span>
-            <span className="inline-flex max-w-full min-w-0 rounded-2xl border border-border/80 bg-card/80 px-3 py-2 shadow-[0_16px_40px_-32px_rgba(15,23,42,0.55)]">
+            <span className="inline-flex max-w-full min-w-0 rounded-2xl border border-border/80 bg-card/80 px-3 py-2 mg-card-glow">
               <CopyableCode value={hotkey} truncate={false} className="max-w-full" />
             </span>
           </span>
@@ -380,49 +380,49 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           hint={`Root ${taoCompact(detail.root_stake_tao)} · Alpha ${taoCompact(detail.alpha_stake_tao)}`}
           truncate={false}
           tone="accent"
-          className="rounded-2xl border-accent/25 bg-card/95 p-5 shadow-[0_24px_80px_-52px_rgba(45,212,191,0.45)]"
+          className="rounded-2xl border-accent/25 bg-card/95 p-5 mg-card-glow-accent"
         />
         <StatTile
           icon={Zap}
           eyebrow="Total emission"
           value={taoCompact(detail.total_emission_tao)}
           hint="across all subnets"
-          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 mg-card-glow"
         />
         <StatTile
           icon={Boxes}
           eyebrow="Active subnets"
           value={formatNumber(detail.subnet_count)}
           hint="validator memberships"
-          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 mg-card-glow"
         />
         <StatTile
           icon={Gauge}
           eyebrow="Avg validator trust"
           value={scoreStr(detail.avg_validator_trust)}
           hint="mean across subnets"
-          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 mg-card-glow"
         />
         <StatTile
           icon={Gauge}
           eyebrow="Max validator trust"
           value={scoreStr(detail.max_validator_trust)}
           hint="best subnet"
-          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 mg-card-glow"
         />
         <StatTile
           icon={Percent}
           eyebrow="Take rate"
           value={formatTakePct(detail.take)}
           hint="commission kept from delegators"
-          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 mg-card-glow"
         />
         <StatTile
           icon={Users}
           eyebrow="Nominators"
           value={detail.nominator_count != null ? formatNumber(detail.nominator_count) : "—"}
           hint="distinct coldkeys delegated"
-          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 mg-card-glow"
         />
         <StatTile
           icon={Zap}
@@ -430,7 +430,7 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
           value={formatApyPct(snapshotApy)}
           hint="latest snapshot · net of take"
           truncate={false}
-          className="rounded-2xl border-border/80 bg-card/95 p-5 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.45)]"
+          className="rounded-2xl border-border/80 bg-card/95 p-5 mg-card-glow"
         />
       </div>
 

--- a/packages/ui-kit/dist/index.css
+++ b/packages/ui-kit/dist/index.css
@@ -656,6 +656,12 @@ html[data-density=compact] .bg-card > table td {
   box-shadow: inset 3px 0 0 0 var(--accent);
   background-color: color-mix(in oklab, var(--accent) 8%, var(--surface));
 }
+.mg-card-glow {
+  box-shadow: 0 24px 80px -58px color-mix(in oklab, var(--ink-strong) 45%, transparent);
+}
+.mg-card-glow-accent {
+  box-shadow: 0 24px 80px -52px color-mix(in oklab, var(--accent) 45%, transparent);
+}
 .mg-skel-crossfade > * {
   transition: opacity 200ms cubic-bezier(0.22, 1, 0.36, 1);
 }

--- a/packages/ui-kit/src/styles.css
+++ b/packages/ui-kit/src/styles.css
@@ -902,6 +902,21 @@ html[data-density="compact"] .bg-card > table td {
   background-color: color-mix(in oklab, var(--accent) 8%, var(--surface));
 }
 
+/* Soft card elevation for detail-page panels. Derives the tint from
+   --ink-strong (near-white in .dark) via the same color-mix idiom as
+   .mg-metric-tile, so the glow adapts across themes instead of a fixed
+   slate-900 rgba that vanishes on a dark background (#6398). */
+.mg-card-glow {
+  box-shadow: 0 24px 80px -58px
+    color-mix(in oklab, var(--ink-strong) 45%, transparent);
+}
+
+/* Accent-tinted variant for the primary/summary card on the same pages. */
+.mg-card-glow-accent {
+  box-shadow: 0 24px 80px -52px
+    color-mix(in oklab, var(--accent) 45%, transparent);
+}
+
 .mg-skel-crossfade > * {
   transition: opacity 200ms cubic-bezier(0.22, 1, 0.36, 1);
 }


### PR DESCRIPTION
## Summary

`accounts.$ss58.tsx` and `validators.$hotkey.tsx` hardcoded ~21 card shadows as raw
`rgba(15,23,42,*)` (Tailwind slate-900) or `rgba(45,212,191,*)` (accent). `rgba(15,23,42)`
doesn't derive from `--ink-strong` -- which flips to near-white in `.dark` -- so those
shadows can't adapt across themes and go effectively invisible on a dark background,
unlike the design system's own `color-mix(in oklab, var(--ink-strong) N%, transparent)`
idiom (`styles.css:920`).

## What Changed

- Added two shared utilities to `packages/ui-kit/src/styles.css`, next to the existing
  `color-mix` shadow idiom: `.mg-card-glow` (ink) and `.mg-card-glow-accent` (accent).
- Swapped all **19 ink + 2 accent** raw-rgba shadow occurrences across both route files
  to the utilities. Rebuilt `packages/ui-kit/dist` so `dist/index.css` carries the classes.
- Geometry is unified to the dominant `0 24px 80px -58px` elevation these cards already
  shared (10 of them were already exactly that); the tint now comes from the theme's own
  `--ink-strong` / `--accent`.

## Screenshots

Captured on `/accounts/$ss58` (both routes use the same shared utility, so they adapt
identically). Matrix at the contract's fixed viewports, themes forced via `mg-theme`.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-desktop-light.png)<br><sub>raw rgba</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-desktop-light.png)<br><sub>token</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-desktop-dark.png)<br><sub>raw rgba</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-desktop-dark.png)<br><sub>token</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-tablet-light.png)<br><sub>raw rgba</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-tablet-light.png)<br><sub>token</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-tablet-dark.png)<br><sub>raw rgba</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-tablet-dark.png)<br><sub>token</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-mobile-light.png)<br><sub>raw rgba</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-mobile-light.png)<br><sub>token</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-mobile-dark.png)<br><sub>raw rgba</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-mobile-dark.png)<br><sub>token</sub> |

**The change is subtle by design** -- these shadows use a large blur with negative spread,
so they read as a faint glow, not a drop shadow. In **light** mode `--ink-strong` is dark,
so before/after are near-identical (no regression). In **dark** mode is where it matters:
the fixed slate-900 tint was invisible, the token renders a faint adaptive glow. Close-up
of the accent card in dark mode:

| Dark · close-up | Before | After |
| --- | --- | --- |
| Account-signal card | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-zoom-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-before-zoom-dark.png)<br><sub>flat -- slate tint invisible on dark</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-zoom-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6398-shadow-tokens/6398-after-zoom-dark.png)<br><sub>faint adaptive glow</sub> |

Concrete proof of the change (computed `box-shadow` on a `.mg-card-glow` card, from the
running page):

- **before:** `0 24px 80px -58px rgba(15,23,42,0.45)` -- fixed, does not vary by theme
- **after:** `0 24px 80px -58px oklab(... / 0.45)` from `color-mix(in oklab, var(--ink-strong) 45%, transparent)` -- resolves dark in light mode, light in dark mode

`validators.$hotkey.tsx`'s 9 cards use the identical `.mg-card-glow`/`.mg-card-glow-accent`
utilities, so their shadows adapt the same way.

## Validation

- `npm run typecheck --workspace=apps/ui` -- 0 errors
- `npm run typecheck --workspace=packages/ui-kit` -- 0 errors
- `npm test --workspace=packages/ui-kit` -- 75/75 passed
- `npm test --workspace=apps/ui` -- passed (pre-existing Windows-only CRLF failures in unrelated #6415/#6419 source-read tests aside; they fail on base too and pass on Linux CI)
- `npm run lint --workspace=apps/ui` / `format:check` -- clean
- `npm run build --workspace=packages/ui-kit` -- rebuilt; `git diff -- packages/ui-kit/dist` is empty on a fresh rebuild (drift check passes)

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6398`) -- required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Only generated artifact touched is `packages/ui-kit/dist` (rebuilt from source).
- [x] `routeTree.gen.ts` untouched; screenshots hosted on the `screenshots` branch, not committed here.

Closes #6398
