### PR TITLE
fix(api): expose the full rate-limit header set on AI-endpoint 429s

### DIFF
--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -976,7 +976,7 @@ describe("AI routes through the Worker dispatch", () => {
     assert.equal(res.status, 405);
   });
 
-  test("rate-limited request returns 429", async () => {
+  test("rate-limited request returns 429 with the full rate-limit header set (#6572)", async () => {
     const env = aiWorkerEnv({
       AI_RATE_LIMITER: { limit: () => Promise.resolve({ success: false }) },
     });
@@ -986,7 +986,31 @@ describe("AI routes through the Worker dispatch", () => {
       {},
     );
     assert.equal(res.status, 429);
+    assert.equal((await res.json()).error.code, "rate_limited");
+    // The AI 429 now advertises quota like the webhook/alert-trigger limiters do,
+    // sourced from the AI_RATE_LIMITER binding (limit 20 / period 60).
     assert.equal(res.headers.get("retry-after"), "60");
+    assert.equal(res.headers.get("x-ratelimit-limit"), "20");
+    assert.equal(res.headers.get("x-ratelimit-policy"), "20;w=60");
+    assert.equal(res.headers.get("x-ratelimit-remaining"), "0");
+  });
+
+  test("the /ask 429 carries the same rate-limit header set (#6572)", async () => {
+    const env = aiWorkerEnv({
+      AI_RATE_LIMITER: { limit: () => Promise.resolve({ success: false }) },
+    });
+    const res = await handleRequest(
+      new Request(ASK_URL, {
+        method: "POST",
+        body: JSON.stringify({ question: "x" }),
+      }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 429);
+    assert.equal(res.headers.get("x-ratelimit-limit"), "20");
+    assert.equal(res.headers.get("x-ratelimit-policy"), "20;w=60");
+    assert.equal(res.headers.get("x-ratelimit-remaining"), "0");
   });
 
   test("an AI backend failure degrades to 502", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -4328,13 +4328,24 @@ function aiUnavailableResponse() {
   );
 }
 
+// Mirrors the AI_RATE_LIMITER binding's `simple` config (limit 20 / period 60s)
+// so the 429's advertised quota matches what the limiter actually enforces.
+const AI_RATE_LIMIT = { limit: 20, windowSeconds: 60 };
+
 function aiRateLimitedResponse() {
+  // Same standard rate-limit header set the webhook / alert-trigger 429s expose
+  // (#6572), so an AI client can discover its quota, not just the retry delay.
   return errorResponse(
     "rate_limited",
     "Too many AI requests. Please retry shortly.",
     429,
     {},
-    { "retry-after": "60" },
+    {
+      "retry-after": String(AI_RATE_LIMIT.windowSeconds),
+      "x-ratelimit-limit": String(AI_RATE_LIMIT.limit),
+      "x-ratelimit-policy": `${AI_RATE_LIMIT.limit};w=${AI_RATE_LIMIT.windowSeconds}`,
+      "x-ratelimit-remaining": "0",
+    },
   );
 }
 


### PR DESCRIPTION
## Summary

`aiRateLimitedResponse()` in `workers/api.mjs` — the 429 for `POST /api/v1/ask` (`handleAskRequest`) and `GET /api/v1/search/semantic` (`handleSemanticSearchRequest`) — returned only a `retry-after` header. Its siblings `webhookSubscriptionRateLimited()` and the alert-trigger proxy expose the full `x-ratelimit-*` set, so an AI-endpoint client could learn only the retry delay, not its quota or remaining budget (#6572).

## Change

- Add a named `AI_RATE_LIMIT = { limit: 20, windowSeconds: 60 }` constant, mirroring the `AI_RATE_LIMITER` binding's `simple` config (`limit: 20, period: 60`) — the config object the issue notes was missing.
- Give `aiRateLimitedResponse()` the same header shape as `webhookSubscriptionRateLimited()`: `retry-after`, `x-ratelimit-limit`, `x-ratelimit-policy` (`20;w=60`), `x-ratelimit-remaining` (`0`).
- The 429 status and `rate_limited` / "Too many AI requests…" error body are **unchanged**. Both shared call sites (ask + semantic-search) inherit the headers.

## Tests

`tests/ai-search.test.mjs`: the existing semantic-search 429 test now asserts the full header set, and a new test covers the `/ask` 429 carrying the same headers. All pass; the changed function is fully covered.

Closes #6572