### PR TITLE
fix(ui): enable Reset filters when only the Callable-only toggle is active (#6386)

### DIFF
--- a/apps/ui/src/lib/metagraphed/endpoints-filters.test.ts
+++ b/apps/ui/src/lib/metagraphed/endpoints-filters.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { endpointsFiltersActive, type EndpointsFilterState } from "./endpoints-filters";
+
+/** The schema defaults: nothing narrowing the table, callable-only left on. */
+const DEFAULTS: EndpointsFilterState = {
+  q: "",
+  category: "all",
+  provider: "",
+  health: "",
+  netuid: "",
+  region: "",
+  eligibility: "",
+  callable: true,
+};
+
+describe("endpointsFiltersActive (#6386)", () => {
+  it("is inactive when every filter is at its default", () => {
+    expect(endpointsFiltersActive(DEFAULTS)).toBe(false);
+  });
+
+  it("treats turning the Callable-only toggle off as an active filter", () => {
+    // The regression: this state used to leave "Reset filters" disabled even
+    // though callable !== its default, so the toggle could not be reset.
+    expect(endpointsFiltersActive({ ...DEFAULTS, callable: false })).toBe(true);
+  });
+
+  it("stays inactive while Callable-only is at its true default", () => {
+    expect(endpointsFiltersActive({ ...DEFAULTS, callable: true })).toBe(false);
+  });
+
+  it.each([
+    ["q", { q: "rpc" }],
+    ["category", { category: "wss" }],
+    ["provider", { provider: "latent" }],
+    ["health", { health: "down" }],
+    ["netuid", { netuid: "42" }],
+    ["region", { region: "us-east" }],
+    ["eligibility", { eligibility: "pool-member" }],
+  ] satisfies [string, Partial<EndpointsFilterState>][])(
+    "is active when %s alone is set",
+    (_name, override) => {
+      expect(endpointsFiltersActive({ ...DEFAULTS, ...override })).toBe(true);
+    },
+  );
+
+  it("is active when a text filter and the toggle are both non-default", () => {
+    expect(endpointsFiltersActive({ ...DEFAULTS, q: "rpc", callable: false })).toBe(true);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/endpoints-filters.ts
+++ b/apps/ui/src/lib/metagraphed/endpoints-filters.ts
@@ -1,0 +1,38 @@
+/**
+ * Whether any non-default filter is currently narrowing the /endpoints table --
+ * the enabled state of that page's "Reset filters" button (#6386).
+ *
+ * The subtlety is `callable` ("Callable only"), which defaults to `true`: like
+ * subnets.index.tsx's `includeRoot` (#6270), it is toggling it OFF that makes it
+ * an active filter, so the predicate checks `callable !== true`, not truthiness.
+ * The prior inline check omitted `callable` entirely, so with the toggle as the
+ * only active filter the Reset button stayed disabled -- even though resetAll
+ * would have restored `callable: true` if it could have been clicked.
+ *
+ * Kept pure (a plain predicate over the URL search state) so it is unit-tested
+ * apart from the route/DOM, mirroring filter-disclosure.ts.
+ */
+export interface EndpointsFilterState {
+  q: string;
+  category: string;
+  provider: string;
+  health: string;
+  netuid: string;
+  region: string;
+  eligibility: string;
+  callable: boolean;
+}
+
+export function endpointsFiltersActive(search: EndpointsFilterState): boolean {
+  return (
+    search.q !== "" ||
+    search.category !== "all" ||
+    search.provider !== "" ||
+    search.health !== "" ||
+    search.netuid !== "" ||
+    search.region !== "" ||
+    search.eligibility !== "" ||
+    // Defaults to true; hiding directory links is what makes it "active" (#6386).
+    search.callable !== true
+  );
+}

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -62,6 +62,7 @@ import {
 } from "@/lib/metagraphed/endpoint-pool";
 
 import type { Endpoint, RpcPool, RpcEndpoint, Provider, Subnet } from "@/lib/metagraphed/types";
+import { endpointsFiltersActive } from "@/lib/metagraphed/endpoints-filters";
 
 const endpointsSearchSchema = z.object({
   q: fallback(z.string(), "").default(""),
@@ -760,14 +761,16 @@ function EndpointsTable() {
   const safePage = Math.min(search.page, totalPages);
   const pageRows = sorted.slice((safePage - 1) * search.pageSize, safePage * search.pageSize);
 
-  const hasFilters =
-    search.q ||
-    search.category !== "all" ||
-    search.provider ||
-    search.health ||
-    search.netuid ||
-    search.region ||
-    search.eligibility;
+  const hasFilters = endpointsFiltersActive({
+    q: search.q,
+    category: search.category,
+    provider: search.provider,
+    health: search.health,
+    netuid: search.netuid,
+    region: search.region,
+    eligibility: search.eligibility,
+    callable: search.callable,
+  });
 
   // The table filters client-side over the full fetched list; the CSV export
   // hits the backend route directly (full endpoint snapshot, no client filters).


### PR DESCRIPTION
Closes #6386

## Summary

On `/endpoints`, the "Reset filters" button's `hasFilters` gate omitted `search.callable`, so with the **"Callable only"** toggle flipped off as the *only* non-default filter the button stayed disabled — even though its own `resetAll` would have restored `callable: true` if it could have been clicked. Turning the toggle off is a real, non-default filter, so Reset should be enabled.

## What Changed

- Extracted the filter-active predicate into a pure, unit-tested `endpointsFiltersActive` helper in `apps/ui/src/lib/metagraphed/endpoints-filters.ts` (mirroring `filter-disclosure.ts`), and folded in `callable !== true`.
- `callable` defaults to `true`, so — exactly like `subnets.index.tsx`'s `includeRoot` (#6270) — it is toggling it **off** that counts as active. The predicate checks `!== true`, not truthiness.
- Wired `endpoints.tsx` to the helper; added `endpoints-filters.test.ts` covering the regression (callable-off alone → active), each text filter alone, and the all-default (inactive) case.

Behaviour after: toggling "Callable only" off with no other filter set enables "Reset filters", and clicking it restores `callable: true`. No other page behaviour changes.

## Screenshots — /endpoints (Endpoints tab), "Callable only" toggled off, no other filter

Before, "Reset filters" is disabled (greyed); after, it is enabled.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| **Desktop · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-after-desktop-light.png)<br><sub>after</sub> |
| **Desktop · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-after-desktop-dark.png)<br><sub>after</sub> |
| **Tablet · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-after-tablet-light.png)<br><sub>after</sub> |
| **Tablet · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-after-tablet-dark.png)<br><sub>after</sub> |
| **Mobile · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-after-mobile-light.png)<br><sub>after</sub> |
| **Mobile · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6386/6386-reset-after-mobile-dark.png)<br><sub>after</sub> |

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6386`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none — UI-only)*

## Validation

- [x] `npx vitest run src/lib/metagraphed/endpoints-filters.test.ts` — 11 passing
- [x] `npm run typecheck` — clean for changed files
- [x] `npx prettier --check` / `npx eslint` — clean (apps/ui config)
- [x] `git diff --check`
- [x] 12-image before/after screenshot matrix (3 viewports x 2 themes)
