### PR TITLE
feat(ui): add a subnet-scoped Watch alert form, mirroring the validator one

### DIFF
--- a/apps/ui/src/components/metagraphed/watch-alert-form.tsx
+++ b/apps/ui/src/components/metagraphed/watch-alert-form.tsx
@@ -1,0 +1,136 @@
+import { type ReactNode } from "react";
+import { CopyableCode } from "@jsonbored/ui-kit";
+import { ApiError } from "@/lib/metagraphed/client";
+
+// Shared primitives for the "watch this X" alert-trigger forms (#6558). Both
+// WatchValidatorAlert (account-scoped) and WatchSubnetAlert (netuid-scoped) POST
+// to the same #4984 /api/v1/alerts/triggers endpoint with the same create-token
+// gate and owner-token-once-shown result, differing only in which match field
+// they send. These are the parts that are identical between them.
+
+// Must match src/alert-triggers.mjs — ALERT_TRIGGER_CREATE_TOKEN_HEADER.
+export const CREATE_TOKEN_HEADER = "x-alert-trigger-create-token";
+
+export const CHANNELS = ["webhook", "discord"] as const;
+export type Channel = (typeof CHANNELS)[number];
+
+export const inputCls =
+  "w-full rounded border border-border bg-card px-2.5 py-1.5 text-[13px] text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30";
+
+/** Distinguishes the create-token gate, validation, and rate-limit rejections. */
+export function describeApiError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 401) return "Unauthorized — check your creation token.";
+    if (error.status === 429) return "Too many requests — slow down and try again shortly.";
+    if (error.status === 503) return "Alert triggers aren't enabled on this deployment yet.";
+    if (error.status === 400) {
+      return "Invalid alert configuration — check the destination format for the selected channel.";
+    }
+    return error.message || "Request failed.";
+  }
+  return "Request failed.";
+}
+
+export function ErrorPanel({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      className="rounded border border-health-down/30 bg-health-down/5 p-3 text-[12px] text-health-down"
+    >
+      {message}
+    </div>
+  );
+}
+
+export function Field({
+  label,
+  hint,
+  required,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  required?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1 block font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+        {label}
+        {required ? <span className="text-health-down"> *</span> : null}
+      </span>
+      {children}
+      {hint ? <span className="mt-1 block text-[11px] text-ink-muted">{hint}</span> : null}
+    </label>
+  );
+}
+
+/** The delivery-channel radio group + the destination URL field, identical
+ *  between the two watch forms. */
+export function ChannelAndDestinationFields({
+  channel,
+  onChannelChange,
+  destination,
+  onDestinationChange,
+}: {
+  channel: Channel;
+  onChannelChange: (c: Channel) => void;
+  destination: string;
+  onDestinationChange: (d: string) => void;
+}) {
+  return (
+    <>
+      <Field label="Delivery channel">
+        <div className="flex gap-4">
+          {CHANNELS.map((c) => (
+            <label key={c} className="inline-flex items-center gap-1.5 text-[12px] text-ink">
+              <input
+                type="radio"
+                name="channel"
+                checked={channel === c}
+                onChange={() => onChannelChange(c)}
+              />
+              <span className="capitalize">{c}</span>
+            </label>
+          ))}
+        </div>
+      </Field>
+      <Field
+        label={channel === "discord" ? "Discord webhook URL" : "Webhook URL"}
+        required
+        hint={
+          channel === "discord"
+            ? "A Discord incoming-webhook URL (Server Settings → Integrations → Webhooks)."
+            : "A public HTTPS endpoint that will receive the alert POST."
+        }
+      >
+        <input
+          type="url"
+          required
+          placeholder={
+            channel === "discord"
+              ? "https://discord.com/api/webhooks/…"
+              : "https://hooks.example.com/alert"
+          }
+          value={destination}
+          onChange={(e) => onDestinationChange(e.target.value)}
+          className={inputCls}
+        />
+      </Field>
+    </>
+  );
+}
+
+/** The one-time result panel: the trigger id + the owner token shown once. */
+export function CreatedTokenPanel({ id, ownerToken }: { id: string; ownerToken: string }) {
+  return (
+    <div className="space-y-2 rounded border border-accent/40 bg-primary-soft/40 p-4">
+      <p className="text-[12px] font-medium text-health-warn">
+        The owner token below is shown once and is never echoed back by GET — store it now to manage
+        or delete this alert later via the API.
+      </p>
+      <CopyableCode label="id" value={id} truncate={false} className="w-full" />
+      <CopyableCode label="owner token" value={ownerToken} truncate={false} className="w-full" />
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/watch-subnet-alert.test.ts
+++ b/apps/ui/src/components/metagraphed/watch-subnet-alert.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { ApiError } from "@/lib/metagraphed/client";
+import { describeApiError } from "@/components/metagraphed/watch-alert-form";
+
+// #6558: the backend (src/alert-triggers.mjs) already validates netuid-scoped
+// alert triggers, but only the validator page had a Watch UI. WatchSubnetAlert
+// extends the same pattern to subnets — same #4984 endpoint, create-token gate,
+// and one-time owner-token result — sending `netuid` instead of `account`.
+const subnetForm = readFileSync(
+  fileURLToPath(new URL("./watch-subnet-alert.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("WatchSubnetAlert posts a netuid-scoped trigger (#6558)", () => {
+  it("sends netuid, not account, to the alert-triggers endpoint", () => {
+    const body = subnetForm.slice(
+      subnetForm.indexOf("body: JSON.stringify"),
+      subnetForm.indexOf("body: JSON.stringify") + 260,
+    );
+    expect(body).toContain("netuid,");
+    expect(body).not.toContain("account:");
+    // event_kind stays optional, matching the validator form's shape.
+    expect(body).toContain("...(vars.eventKind ? { event_kind: vars.eventKind } : {})");
+  });
+
+  it("POSTs to the shared alert-triggers endpoint with the create-token header", () => {
+    expect(subnetForm).toContain('"/api/v1/alerts/triggers"');
+    expect(subnetForm).toContain("[CREATE_TOKEN_HEADER]: vars.token");
+  });
+});
+
+// The error mapping is shared between both watch forms and drives the token-gate
+// / rate-limit / not-enabled messaging, so it's worth pinning directly.
+describe("describeApiError (shared alert-form helper)", () => {
+  const err = (status: number, message = "") =>
+    new ApiError(message, { status, url: "/api/v1/alerts/triggers" });
+
+  it("maps the create-token gate (401) to an actionable message", () => {
+    expect(describeApiError(err(401))).toMatch(/creation token/i);
+  });
+
+  it("maps rate-limit (429) and not-enabled (503) distinctly", () => {
+    expect(describeApiError(err(429))).toMatch(/too many requests/i);
+    expect(describeApiError(err(503))).toMatch(/aren't enabled/i);
+  });
+
+  it("maps a 400 to a config/destination hint", () => {
+    expect(describeApiError(err(400))).toMatch(/invalid alert configuration/i);
+  });
+
+  it("falls back for a non-ApiError", () => {
+    expect(describeApiError(new Error("boom"))).toBe("Request failed.");
+  });
+});

--- a/apps/ui/src/components/metagraphed/watch-subnet-alert.tsx
+++ b/apps/ui/src/components/metagraphed/watch-subnet-alert.tsx
@@ -14,14 +14,15 @@ import {
   type Channel,
 } from "@/components/metagraphed/watch-alert-form";
 
-// #4984's event_kind is a single value per trigger (not a filter list), so
-// this is a single-select rather than the webhook manager's checkbox-set
-// "kinds" pattern. Leaving it unset still matches every event for this
-// hotkey (validateAlertTriggerInput requires only one of
-// netuid/event_kind/account/min_amount_tao — `account` below always
-// satisfies that on its own).
+// The backend (src/alert-triggers.mjs) validates `netuid` (0-65535) as an
+// independently-sufficient match condition, so a netuid-only trigger fires on
+// every matching chain event for that subnet. This mirrors WatchValidatorAlert
+// (account-scoped) — same #4984 endpoint, create-token gate, and one-time
+// owner-token result — but sends `netuid` instead of `account` (#6558).
+// Mirror WatchValidatorAlert's proven kinds (the backend accepts any string but
+// only these are known to occur); the netuid scope is what makes it subnet-wide.
 const EVENT_KINDS = [
-  { value: "", label: "Any delegation or stake event" },
+  { value: "", label: "Any event on this subnet" },
   { value: "DelegateAdded", label: "New delegation" },
   { value: "StakeAdded", label: "Stake added" },
 ] as const;
@@ -33,8 +34,8 @@ interface CreateVariables {
   destination: string;
 }
 
-/** "Watch this validator": a scoped alert trigger (account=hotkey) over the existing #4984 alerts API. */
-export function WatchValidatorAlert({ hotkey }: { hotkey: string }) {
+/** "Watch this subnet": a netuid-scoped alert trigger over the existing #4984 alerts API. */
+export function WatchSubnetAlert({ netuid }: { netuid: number }) {
   const [token, setToken] = useState("");
   const [eventKind, setEventKind] = useState("");
   const [channel, setChannel] = useState<Channel>("webhook");
@@ -50,7 +51,7 @@ export function WatchValidatorAlert({ hotkey }: { hotkey: string }) {
             [CREATE_TOKEN_HEADER]: vars.token,
           },
           body: JSON.stringify({
-            account: hotkey,
+            netuid,
             ...(vars.eventKind ? { event_kind: vars.eventKind } : {}),
             channel: vars.channel,
             destination: vars.destination,
@@ -76,15 +77,11 @@ export function WatchValidatorAlert({ hotkey }: { hotkey: string }) {
   return (
     <div className="space-y-3">
       <p className="max-w-2xl text-[13px] text-ink-muted">
-        Get a webhook or Discord notification when this validator receives new delegations or stake.
-        Creation requires a trigger token issued by a metagraphed operator — this app never bundles
-        one.
+        Get a webhook or Discord notification for on-chain activity on SN{netuid}. Creation requires
+        a trigger token issued by a metagraphed operator — this app never bundles one.
       </p>
       <form onSubmit={onSubmit} className="space-y-3 rounded border border-border bg-card p-4">
-        <Field
-          label="Event"
-          hint="Leave as 'any' to watch every delegation/stake event for this hotkey."
-        >
+        <Field label="Event" hint="Leave as 'any' to watch every indexed event on this subnet.">
           <select
             value={eventKind}
             onChange={(e) => setEventKind(e.target.value)}
@@ -122,7 +119,7 @@ export function WatchValidatorAlert({ hotkey }: { hotkey: string }) {
           disabled={mutation.isPending}
           className="inline-flex items-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 text-[12px] font-medium text-ink-strong hover:bg-primary-soft/80 disabled:opacity-50"
         >
-          {mutation.isPending ? "Creating…" : "Watch this validator"}
+          {mutation.isPending ? "Creating…" : "Watch this subnet"}
         </button>
       </form>
 

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -115,6 +115,7 @@ import { SubnetValidatorsPreview } from "@/components/metagraphed/subnet-validat
 import { SubnetFilterProvider } from "@/components/metagraphed/subnet-filter-context";
 import { SubnetCompareDrawer } from "@/components/metagraphed/subnet-compare-drawer";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
+import { WatchSubnetAlert } from "@/components/metagraphed/watch-subnet-alert";
 
 type SearchParams = {
   tab?: string;
@@ -345,6 +346,21 @@ function ProfileShell({ netuid }: { netuid: number }) {
             </SectionAnchor>
           ) : null}
           {tab === "api" ? <ApiPanel netuid={netuid} /> : null}
+        </div>
+
+        {/* #6558: the backend accepts netuid-scoped alert triggers, but only the
+            validator page exposed a Watch UI. Extend the same pattern here.
+            Outside the tab switch, so it's reachable from any tab -- same as the
+            "Watch this validator" section on the validator page. */}
+        <div className="mt-8">
+          <SectionAnchor
+            id="watch"
+            title="Watch this subnet"
+            subtitle="Alert on on-chain activity for this subnet, via the existing chain alert-triggers API."
+            tone="accent"
+          >
+            <WatchSubnetAlert netuid={netuid} />
+          </SectionAnchor>
         </div>
 
         {/* #6432: outside the tab switch, so the way back is there whichever


### PR DESCRIPTION
## What

`src/alert-triggers.mjs` validates a trigger's `netuid` (0-65535) as an independently-sufficient match condition — the backend is explicitly built for **subnet-scoped** alert triggers. But the frontend only wired the alerts API into one place: `WatchValidatorAlert` (account-scoped), on the validator detail page. There was no way to subscribe to a whole subnet's on-chain activity.

This adds **`WatchSubnetAlert`** — the same form, create-token gate, and one-time owner-token result — sending `netuid` instead of `account`, rendered as a persistent "Watch this subnet" section on `subnets.$netuid.tsx` (same placement/style convention the validator page uses).

## Factoring

Rather than duplicate ~130 lines, I extracted the identical parts (`describeApiError`, `Field`, `ErrorPanel`, the channel+destination fields, the created-token panel, the create-token header, channel type) into a shared **`watch-alert-form.tsx`**, and refactored `WatchValidatorAlert` to use it too. So the diff is: new shared module + new subnet form + validator form slimmed to its account-specific parts + one section on the subnet page. `src/alert-triggers.mjs` is untouched — it already accepts netuid-only triggers.

## Screenshots

`/subnets/1` at the new `#watch` section — the "Watch this subnet" form (before: the section didn't exist). The form matches the validator page's Watch form exactly, differing only in copy ("this subnet" / "SN1") and the netuid it targets.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6558-watch-subnet-after-mobile-dark.png)<br><sub>after</sub> |


## Testing

`watch-subnet-alert.test.ts` (6 tests):
- **behavioural:** the form POSTs `netuid` (not `account`) to `/api/v1/alerts/triggers` with the create-token header; `event_kind` stays optional.
- **shared helper unit tests:** `describeApiError` maps the create-token gate (401), rate-limit (429), not-enabled (503), and 400 config errors distinctly, and falls back for a non-`ApiError` — this drives the token-gate/rate-limit messaging both watch forms share.

**Verified meaningful: the netuid-POST assertions fail when the new component is absent.** The form also renders in a browser (the "Watch this subnet" section, its dropdown, channel radios, and token field all present on `/subnets/1`).

`apps/ui`: 152 files / 1111 tests pass, `tsc` clean, `eslint` 0 errors, `format:check` clean. Diff is 5 files under `apps/ui/src` (+~300/-113 — the −113 is the validator form de-duplicated into the shared module).

Closes #6558