### PR TITLE
fix(ui): add a reset-filters control to ChainEventsFeed

### DIFF
--- a/apps/ui/src/components/metagraphed/chain-events-feed.tsx
+++ b/apps/ui/src/components/metagraphed/chain-events-feed.tsx
@@ -2,7 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
 import { API_BASE } from "@/lib/metagraphed/config";
-import { SearchInput } from "@/components/metagraphed/table-controls";
+import { ResetFiltersButton, SearchInput } from "@/components/metagraphed/table-controls";
 import { TimeAgo, ListShell, LoadMore } from "@jsonbored/ui-kit";
 import { chainEventsInfiniteQuery } from "@/lib/metagraphed/queries";
 import { formatNumber } from "@/lib/metagraphed/format";
@@ -83,6 +83,15 @@ export function ChainEventsFeed({ pallet, method, cursor, onFilter }: Props) {
         onChange={(v) => onFilter({ method: v })}
         placeholder={pallet.trim() ? "Filter by method" : "Method (requires pallet)"}
         className="min-w-[140px] flex-none font-mono text-[11px]"
+      />
+      {/* #6387: a filtered /events?pallet=X or /explorer?pallet=X link is
+          URL-persisted and otherwise stuck until manually cleared, unlike every
+          other filterable feed (blocks/extrinsics/providers/surfaces/subnets),
+          which all render a ResetFiltersButton. Clearing pallet+method via the
+          existing onFilter also resets the cursor at both call sites. */}
+      <ResetFiltersButton
+        active={filtersActive}
+        onReset={() => onFilter({ pallet: "", method: "" })}
       />
     </>
   );


### PR DESCRIPTION
## What & why

`ChainEventsFeed` renders two free-text pallet/method `SearchInput`s but no clear affordance anywhere. Both call sites — `events.index.tsx` and `explorer.tsx` — persist `pallet`/`method` in the URL, so a filtered `/events?pallet=X` or `/explorer?pallet=X` link is stuck until manually cleared. Every other filterable feed on a comparable route (`blocks`, `extrinsics`, `providers`, `surfaces`, `subnets`, `call-module-extrinsics-table`) already renders a `ResetFiltersButton`; this feed was the lone exception.

## Approach

Add `ResetFiltersButton` to the feed's filter block, gated on the already-computed `filtersActive`. It clears `pallet` + `method` through the existing `onFilter` callback.

The fix stays contained to the shared component — no call-site change is needed — because both call sites already pair every `onFilter` patch with a cursor reset (`events.index.tsx` sets `cursor: ""`, `explorer.tsx` sets `events_cursor: ""`), so clearing the filters also restarts the feed from the newest page, exactly as the issue asks.

## Verification

Full Phase C3 preflight (same steps/order as the `ui` CI job):

| Step | Command | Result |
| --- | --- | --- |
| lint | `npm run lint --workspace=apps/ui` | 0 errors |
| format | `npm run format:check --workspace=apps/ui` | clean |
| typecheck | `npm run typecheck --workspace=apps/ui` | clean |
| unit | `npm test --workspace=apps/ui` | 151 files, 1105 tests passed |
| build | `npm run build --workspace=apps/ui` | green |

Drove it end to end on `/events?pallet=System`: the "Reset filters" button appears beside the filter inputs, and clicking it returns to the unfiltered feed.

## Screenshots

Phase C2 contract (fixed viewports, never full-page, themes forced via `mg-theme`). Captured on `/events?pallet=System` so a filter is active — `before` has no way back to the unfiltered feed; `after` shows the one-click **Reset filters** control.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6387-reset-filters-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6387
