### PR TITLE
fix(ui): use the shared EmptyState for subnet/provider not-found pages

### DIFF
--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -65,9 +65,11 @@ export const Route = createFileRoute("/providers/$slug")({
   notFoundComponent: () => (
     <AppShell>
       <PageHeading title="Provider not found" />
-      <Link to="/providers" className="text-sm underline">
-        Back to providers
-      </Link>
+      <EmptyState
+        title="Provider not found"
+        description="No provider matches this slug. Browse the provider directory to find the one you're looking for."
+        action={{ label: "Back to providers", href: "/providers" }}
+      />
     </AppShell>
   ),
 });

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -177,9 +177,11 @@ export const Route = createFileRoute("/subnets/$netuid")({
         title="Subnet not found"
         description="No active Finney netuid matches this URL."
       />
-      <Link to="/subnets" className="text-sm underline">
-        Back to registry
-      </Link>
+      <EmptyState
+        title="Subnet not found"
+        description="No active Finney netuid matches this URL. Browse the registry to find an active subnet."
+        action={{ label: "Back to registry", href: "/subnets" }}
+      />
     </AppShell>
   ),
 });


### PR DESCRIPTION
## What

Six entity-detail routes render a `notFoundComponent` when the URL param doesn't resolve. Four use the shared `EmptyState` component with a recovery `action` button (`accounts.$ss58.tsx`, `blocks.$ref.tsx`, `extrinsics.$hash.tsx`, `validators.$hotkey.tsx`); the other two fell back to a bare `PageHeading` + a plain underlined `<Link>`. This brings them into line:

- `subnets.$netuid.tsx` — `notFoundComponent` now renders `EmptyState` with a **Back to registry** action.
- `providers.$slug.tsx` — `notFoundComponent` now renders `EmptyState` with a **Back to providers** action.

The existing titles ("Subnet not found" / "Provider not found") are kept; only the recovery shell changes from a plain link to the shared `EmptyState` card. Happy-path (found) rendering is untouched. Both files already imported `EmptyState`.

## Screenshots (before / after)

3 viewports × 2 themes, on `/subnets/abc` (a non-numeric netuid → the not-found path). **Before** = a bare heading with a plain underlined link floating in empty space; **After** = the shared `EmptyState` card (icon, title, description, and a real "Back to registry" button), matching every sibling detail page. `providers.$slug.tsx` receives the byte-identical treatment.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jeffrey701/metagraphed/screenshots/6556-after-mobile-dark.png)<br><sub>after</sub> |


## Validation

- `eslint` — clean on both changed files (0 errors); `Link` remains used elsewhere in each file.
- `prettier --check` (apps/ui workspace config) — clean.
- Unit tests — full `apps/ui` suite unaffected (a not-found rendering-shell swap; no logic or happy-path change).

Closes #6556
