### PR TITLE
docs(ui): add a Protocol section — general Bittensor stake/registration/proxy/delegation education

### DIFF
--- a/apps/ui/content/docs/protocol/meta.json
+++ b/apps/ui/content/docs/protocol/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Protocol",
+  "pages": [
+    "stake-weight",
+    "registration-and-permits",
+    "weight-setting-and-rewards",
+    "proxies",
+    "root-delegation"
+  ]
+}

--- a/apps/ui/content/docs/protocol/proxies.mdx
+++ b/apps/ui/content/docs/protocol/proxies.mdx
@@ -1,0 +1,76 @@
+---
+title: Proxy accounts
+description: How pallet_proxy lets an account delegate scoped, revocable authority to another key without a multisig ceremony per action — proxy types, transfer safety, and pure proxies.
+---
+
+Bittensor runs on Substrate, and inherits `pallet_proxy` from it — a general delegation mechanism
+that solves a problem multisig alone doesn't: letting an account authorize routine, narrowly-scoped
+actions on its behalf without requiring a fresh multi-party signing ceremony every single time.
+
+## The basic mechanism
+
+An account grants a proxy once: `add_proxy(delegate, proxy_type, delay)`. From that point on, the
+delegate submits `Proxy.proxy(real, inner_call)`, signed with **its own key**, and the chain checks
+`inner_call` against `proxy_type`'s allow-list before executing it as if `real` had submitted it
+directly. No further approval from `real` is needed per call — the authorization already happened
+once, at grant time.
+
+This is a different mechanism from multisig (`pallet_multisig`), not a variant of it. Multisig
+requires N-of-M live signatures for every single call; proxy requires one grant, then arbitrarily
+many delegate-signed calls against that grant's scope. The two compose naturally: a multisig can
+grant a proxy via one multisig-approved call, after which the proxy's day-to-day use needs no
+further multisig involvement at all.
+
+## Proxy types scope what the delegate can do
+
+`ProxyType` is an enum, and the delegate's calls are filtered against whichever variant was granted.
+Common variants relevant to running infrastructure on Bittensor:
+
+| `ProxyType`     | Scope                                                                                                                                                          |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Registration`  | Subnet/neuron registration calls only.                                                                                                                         |
+| `ChildKeys`     | `set_children` and related delegation calls only.                                                                                                              |
+| `Staking`       | Stake/unstake calls only — cannot register, cannot move funds via transfer.                                                                                    |
+| `Transfer`      | Unrestricted transfers — the highest-risk grant, since a compromised delegate key can move everything.                                                         |
+| `SmallTransfer` | Transfers capped at **0.5 TAO / 0.5 Alpha per transaction** — meaningfully safer than unrestricted `Transfer` while still allowing small operational payments. |
+| `NonTransfer`   | Everything except calls that move funds out — a broad "do anything operational" grant that structurally can't drain the account.                               |
+| `RootClaim`     | Root-network-specific claim calls.                                                                                                                             |
+
+Source: the `ProxyType` enum and its call-filtering logic, `common/src/proxy.rs` and
+`runtime/src/proxy_filters/`.
+
+Multiple narrow grants can be layered — e.g. `Registration` + `ChildKeys` + `Staking` together give
+a delegate everything needed to run day-to-day validator operations, while structurally being unable
+to ever move funds out, since none of those three variants' allow-lists include a transfer call.
+
+## The delay/announce safety net for transfer-capable proxies
+
+For proxy types that _can_ move funds (`Transfer`, `SmallTransfer`), `add_proxy`'s `delay` parameter
+matters. A non-zero delay requires the delegate to first `announce` an intended call, then wait
+`delay` blocks before it can actually execute — during which the real account owner can inspect the
+pending announcement and `reject_announcement` it if it's wrong or malicious. This turns a single
+compromised or buggy delegate key from an instant-loss scenario into a bounded, reviewable window.
+
+For non-transfer-capable proxy types (`Registration`, `ChildKeys`, `Staking`, `NonTransfer`), a
+zero delay is safe by construction — there's nothing in their allow-list that could unilaterally
+remove value from the account, so there's nothing an announce window would meaningfully protect
+against.
+
+## Standard proxies vs. pure proxies
+
+Everything above describes a **standard proxy**: `real` is an ordinary, already-existing account —
+a normal keypair or a multisig address — and the proxy grant is layered on top of it.
+
+A **pure proxy** is different: `create_pure` derives a brand-new account address deterministically
+from `(creator, proxy_type, index, creation_block, extrinsic_index)` — an address with **no private
+key at all**. It exists purely as a proxy-controlled account; the only way to act as it is through a
+proxy grant, from the start.
+
+This solves a specific, real operational problem: **a raw multisig's address is itself derived from
+its exact signatory set and threshold.** Add, remove, or replace even one signer, and you get a
+_different_ multisig address — meaning any membership change requires migrating every asset and
+position to the new address, with all the cost and disruption that implies. A pure proxy's address
+depends on none of that: the _set of accounts currently proxying for it_ can be swapped freely (grant
+a proxy to the new controller, revoke the old one) without the pure proxy's own address — and
+everything staked or registered under it — ever changing. Membership rotation becomes a proxy
+grant/revoke, not an asset migration.

--- a/apps/ui/content/docs/protocol/registration-and-permits.mdx
+++ b/apps/ui/content/docs/protocol/registration-and-permits.mdx
@@ -1,0 +1,87 @@
+---
+title: Registration and validator permits
+description: What it actually costs to get a UID on a Bittensor subnet, why that's a completely different thing from holding a validator permit, and why some subnets encrypt weight submissions.
+---
+
+Getting a slot on a subnet and being able to validate on it are two separate, independently-gated
+things. Conflating them is one of the most common sources of confusion for anyone new to running
+infrastructure on Bittensor.
+
+## Registering a UID: the recycle-burn auction
+
+Every subnet has a fixed capacity — `max_uids` (256 on most active subnets today) — and a
+registration cost paid in TAO, burned (not staked, not transferred to anyone) to claim one of those
+slots. This cost isn't fixed: it behaves like a continuous auction.
+
+- **Rises with demand.** Each successful registration nudges the cost up, governed by
+  `target_regs_per_interval` (how many registrations per block-window the subnet "expects") and
+  `burn_increase_mult`.
+- **Decays toward a floor over time.** Absent new registrations, cost drifts back down on a
+  `burn_half_life`, bounded between `min_burn_tao` and `max_burn_tao`.
+
+Practically: a subnet with heavy recent registration activity can cost orders of magnitude more to
+enter than one that's quiet, and the same subnet's cost can swing significantly week to week. There
+is no fixed "price list" — always query a subnet's _current_ registration cost before registering,
+never rely on a cached or previously-seen figure.
+
+Registering gets you a UID — a slot, nothing more. It doesn't grant weight-setting ability, doesn't
+guarantee emissions, and doesn't require any minimum stake by itself.
+
+## A full subnet prunes on every new registration
+
+Once a subnet is at `max_uids` capacity (very common on active subnets), every new registration
+immediately prunes an existing low-priority UID to make room — there's no "subnet full, try again
+later" state, registration always succeeds if paid for and a slot always opens up for it. Freshly
+registered UIDs are shielded for `immunity_period` blocks, but once that window closes, a UID with a
+weak pruning score (low incentive for miners, low stake for validators) is the most exposed to being
+replaced by the _next_ registration. This is a live, ongoing risk on any subnet sitting at capacity,
+not a one-time concern at registration time.
+
+## Validator permits: a completely separate, stake-based mechanism
+
+A **validator permit** is not purchased and not requested — it's computed automatically, every
+epoch, purely from [stake-weight](/docs/protocol/stake-weight):
+
+> Each epoch, the top `max_validators` registered UIDs on a subnet, ranked by `stake_weight`,
+> receive `validator_permit = true`. Everyone else does not.
+
+`max_validators` is itself a per-subnet hyperparameter (commonly, but not universally, 64 — always
+check the specific subnet, never assume) — a separate cap from `max_uids`, the total registration
+capacity. A subnet can easily have far more registered UIDs than it has validator seats; most of
+those UIDs are miners, competing on incentive rather than stake rank.
+
+Two consequences worth being explicit about, since they're easy to conflate:
+
+- **Losing a permit and losing a UID are different events.** Falling out of the top-`max_validators`
+  by stake costs you the permit at the next epoch — no fee, no re-registration, it comes back
+  automatically the moment your stake rank recovers. Losing the UID entirely (deregistration/pruning,
+  see above) is a separate, pruning-driven mechanism tied to subnet capacity, and does require
+  re-registering (re-paying the recycle cost) to get back in.
+- **Holding a permit isn't the same as earning anything from it.** A permitted validator that never
+  submits fresh weights contributes nothing to consensus and earns nothing from the seat — see
+  [weight-setting and rewards](/docs/protocol/weight-setting-and-rewards) for why.
+
+Source: hyperparameter fields (`max_uids`, `max_validators`, `immunity_period`,
+`min_burn_tao`/`max_burn_tao`/`burn_half_life`/`target_regs_per_interval`) queried live per subnet;
+permit computation in `pallets/subtensor/src/staking/stake_utils.rs`.
+
+## Commit-reveal weight submission
+
+Some subnets encrypt weight submissions for a window before they take effect, rather than accepting
+plaintext weights directly. This exists specifically to blunt **weight-copying**: if weights are
+visible the instant they're submitted, another validator can simply mirror the highest-stake
+validator's vector without doing any independent evaluation work, at zero cost to themselves.
+Commit-reveal breaks that by hiding the content of a submission until after the window it would have
+been copyable in has passed.
+
+Three distinct complexity tiers exist in practice, controlled by a subnet's `commit_reveal_enabled`
+flag and its reveal period:
+
+| Tier       | `commit_reveal_enabled` | Behavior                                                                                                                                      |
+| ---------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Off        | `false`                 | Weights submitted and take effect directly, no encryption.                                                                                    |
+| Period = 1 | `true`                  | Commit this epoch, reveal takes effect the same or next epoch — one round-trip.                                                               |
+| Period > 1 | `true`                  | Reveal is delayed across multiple epochs, requiring the submitter to track and persist reveal state across that whole window before it lands. |
+
+A subnet can flip `commit_reveal_enabled` at any time via governance — anything built against a
+subnet's weight-submission behavior needs to detect and handle that change, not assume it's static.

--- a/apps/ui/content/docs/protocol/root-delegation.mdx
+++ b/apps/ui/content/docs/protocol/root-delegation.mdx
@@ -1,0 +1,74 @@
+---
+title: Root stake and childkey delegation
+description: How set_children lets a parent hotkey's root-network stake back child hotkeys across many subnets at once — the mechanics, the thresholds, and what delegation does not replace.
+---
+
+Root network (netuid 0) stake is what makes a single position count on more than one subnet at
+once — see [stake-weight](/docs/protocol/stake-weight) for the underlying formula. Childkey
+delegation is the mechanism that actually routes a share of that root position outward to specific
+hotkeys on specific subnets.
+
+## What `set_children` does
+
+A parent hotkey calls `set_children(netuid, children)`, where `children` is a list of
+`(proportion, child_hotkey)` pairs — up to 5 children per call, scoped to that one subnet
+(`ensure_childkey_count` enforces the per-call limit). This creates a `ChildKeys` entry for
+`(parent, netuid)`, naming which child hotkeys get a cut of that parent's inherited weight on that
+specific subnet, and how large a cut each gets.
+
+Critically, what a child inherits is **the parent's root stake specifically** — the same
+`root_tao_stake` term from the [stake-weight formula](/docs/protocol/stake-weight), read fresh at
+computation time — not whatever the parent happens to hold directly on that subnet. A parent with
+zero Alpha stake on a given subnet can still back a child there, purely off its root position.
+
+Source: `pallets/subtensor/src/staking/set_children.rs`, `stake_utils.rs`.
+
+## The gate: `StakeThreshold`
+
+`set_children` isn't available to just any hotkey — the parent must clear
+`get_total_stake_for_hotkey(parent) >= StakeThreshold`. Two things worth being precise about here:
+
+- **`StakeThreshold` is live-queryable and currently 1000 TAO** — governance-adjustable, always
+  re-check rather than assuming this figure holds indefinitely.
+- **The threshold check sums the parent's stake across every subnet it holds any stake on at all**
+  (root included), each converted to a TAO-equivalent value at that subnet's current Alpha price —
+  not just root stake in isolation. A parent could in principle clear the threshold through Alpha
+  stake spread across several subnets, though only the root-stake component actually gets inherited
+  by children (per the formula above).
+
+There is no requirement that the parent be registered on the target subnet at all — `set_children`
+has no `is_hotkey_registered_on_network(parent, netuid)` check anywhere in the extrinsic. A parent
+can back children on subnets it has never registered a UID on itself.
+
+## The cooldown
+
+`set_children` doesn't take effect immediately. `PendingChildKeyCooldown` — currently **~7200
+blocks, roughly 24 hours** — delays when a new or changed `ChildKeys` entry actually starts
+affecting stake-weight calculations. Budget this into any rollout timeline: a child isn't earning
+from the inherited pool the moment the `set_children` transaction lands, only after the cooldown
+clears.
+
+## No cap on how many subnets one root position can back
+
+Each `(parent, netuid)` `ChildKeys` entry is independent, and every subnet's `stake_weight`
+calculation reads the _same_ root position fresh, on its own. There's no cross-subnet ledger that
+depletes the parent's root stake as it gets allocated to more children across more subnets — the
+same 1000 TAO root position (as a concrete example) can back a child on ten different subnets
+simultaneously, each computing its own inherited share independently, with no accounting mechanism
+that treats the pool as "spent" by being counted more than once. This is the core reason root
+delegation scales more efficiently than splitting a fixed pool of capital N ways across N subnets:
+each subnet's calculation gets the (discounted) full root value, not a shrinking 1/N fraction of it.
+
+## What delegation does not replace
+
+**A child hotkey still needs its own [UID registration](/docs/protocol/registration-and-permits) on
+the target subnet.** Delegation shares stake-weight; it does not substitute for having a
+registered neuron in the first place. The sequence is always: register the child hotkey on the
+subnet (paying that subnet's own recycle-burn cost), _then_ `set_children` on the parent to route it
+a share of root stake, _then_ wait out the cooldown before the inherited weight actually counts. Skip
+the registration step and there's no UID for the inherited stake-weight to attach to at all.
+
+The inherited stake-weight is also not merely a permit-eligibility bump — it flows into
+`active_stake` and from there directly into the Yuma Consensus dividends calculation covered on
+[weight-setting and rewards](/docs/protocol/weight-setting-and-rewards). A child earning inherited
+weight earns real, proportional emissions from it, the same as if it held that stake directly.

--- a/apps/ui/content/docs/protocol/stake-weight.mdx
+++ b/apps/ui/content/docs/protocol/stake-weight.mdx
@@ -1,0 +1,80 @@
+---
+title: Understanding stake-weight
+description: How Bittensor actually weighs stake per subnet — the two-component stake_weight formula, why root TAO counts differently than subnet Alpha, and what that means practically for anyone staking or validating.
+---
+
+Bittensor's dynamic-TAO upgrade (February 2025) split every subnet's economy into its own Alpha
+token with a constant-product AMM against TAO. A natural question follows: if each subnet's Alpha
+is its own siloed market, does staking TAO to one subnet do anything for your position on any
+other subnet? The answer is yes, but through a specific, discounted mechanism — not by staking the
+same TAO twice.
+
+## The two components
+
+For a given hotkey on a given subnet, the chain computes a single `stake_weight` value that drives
+everything else — validator permit eligibility, incentive/dividend distribution, all of it. It has
+two parts:
+
+```
+stake_weight = alpha_stake + tao_weight × root_tao_stake
+```
+
+- **`alpha_stake`** — Alpha tokens this hotkey holds staked directly on _this_ subnet, at full 1.0×
+  weight. Fully siloed: staking Alpha on subnet A contributes nothing to subnet B's calculation.
+- **`root_tao_stake`** — this hotkey's stake on the **root network** (netuid 0), read fresh
+  regardless of which subnet's `stake_weight` is being computed. Root stake isn't subnet-specific,
+  so the same root position feeds into every subnet's calculation independently.
+- **`tao_weight`** — a network-wide discount multiplier applied to the root-stake contribution.
+  Currently **0.18** (governance-adjustable — see below).
+
+Source: `pallets/subtensor/src/staking/stake_utils.rs`,
+`get_stake_weights_for_hotkey_on_subnet`.
+
+## Why the discount exists
+
+Public documentation describes `tao_weight` as intended to decay from parity toward a lower
+steady-state over roughly 100 days following the Feb 2025 dTAO launch, gradually shifting
+influence toward directly-staked Alpha as each subnet's own market matures. In practice, live
+on-chain state shows the value still sitting at 0.18 well over a year past that original schedule —
+some sources point to a further reversion planned for a different emissions model. Treat 0.18 as
+**current reality, not a fixed constant**: it's a live storage value (`SubtensorModule::TaoWeight`),
+set by governance, and worth re-querying before relying on it for anything beyond rough intuition.
+
+<Callout title="Query it live, don't hardcode it">
+  `tao_weight` can change via governance at any time. Query `SubtensorModule::TaoWeight` directly
+  (via `btcli` or a raw storage query against a subtensor RPC endpoint) immediately before using it
+  in any calculation — this page's value is a point-in-time snapshot, not a protocol guarantee.
+</Callout>
+
+## What this means practically
+
+The two components trade off differently:
+
+|                 | Alpha stake (direct)      | Root TAO stake              |
+| --------------- | ------------------------- | --------------------------- |
+| Weight          | 1.0×                      | 0.18×                       |
+| Scope           | One subnet only           | Every subnet simultaneously |
+| Market exposure | That subnet's Alpha price | TAO                         |
+
+Directly staking Alpha on a subnet is the stronger per-subnet lever — full weight, no discount —
+but the position only counts there. Root TAO stake is weaker per-subnet (0.18× that of an
+equivalent direct stake) but counts on **every** subnet at once, since each subnet's `stake_weight`
+formula reads the same root position independently, with no cross-subnet accounting that "spends
+down" a fixed pool as it's counted on more subnets.
+
+This is also the mechanism that makes [childkey delegation](/docs/protocol/root-delegation) work:
+a child hotkey on a given subnet inherits a proportional share of its _parent's root stake_
+specifically — not the parent's stake on that subnet — which is exactly the `root_tao_stake` term
+in the formula above, evaluated for the parent instead of the child directly.
+
+## Where stake-weight actually gets used
+
+`stake_weight` isn't just an internal number — it's the input to two separate, consequential
+mechanisms covered on other pages here:
+
+- **[Validator permits](/docs/protocol/registration-and-permits)** are assigned each epoch to
+  whichever registered UIDs on a subnet rank highest by `stake_weight`, up to that subnet's
+  `max_validators` cap.
+- **[Weight-setting and rewards](/docs/protocol/weight-setting-and-rewards)** feed `stake_weight`
+  (as `active_stake`) directly into the Yuma Consensus dividends calculation — it's not just
+  permit-eligibility, it determines how much of a validator's emission is actually earned.

--- a/apps/ui/content/docs/protocol/weight-setting-and-rewards.mdx
+++ b/apps/ui/content/docs/protocol/weight-setting-and-rewards.mdx
@@ -1,0 +1,67 @@
+---
+title: Weight-setting, tempos, and rewards
+description: What validators actually submit, when a subnet's consensus run happens relative to chain blocks, and how incentive and dividends get computed from it.
+---
+
+Weight-setting is the core act a validator performs on Bittensor: periodically scoring every miner
+on a subnet and submitting that scoring as an on-chain vector. Everything downstream — who earns
+what, whose stake actually matters — runs off the aggregate of those submissions.
+
+## Block production vs. subnet epochs
+
+These are two different clocks, easy to conflate:
+
+- **Chain block production** — the whole Bittensor chain produces a new block on a fixed, short
+  cadence (seconds). This is global, shared by every subnet.
+- **Subnet epoch** — each subnet has its own `tempo` hyperparameter, measured in blocks (360 is a
+  common default, but it's per-subnet and governance-adjustable). When a subnet's block count since
+  its last epoch reaches `tempo`, that subnet runs its own **Yuma Consensus epoch** — the point
+  where accumulated weight submissions actually get turned into emissions.
+
+Weights can be submitted at any point between epochs, but they don't do anything on their own until
+the epoch boundary triggers the consensus run that consumes them. A validator that only submits
+right before the boundary and one that submits steadily throughout the tempo window can end up
+contributing identically, as long as both submissions are fresh enough — see `weights_rate_limit`
+below for the constraint on how often submission is even allowed.
+
+## What happens at an epoch boundary
+
+Source: `pallets/subtensor/src/epoch/run_epoch.rs`.
+
+1. **Bonds update.** Each validator holds a "bond" toward each miner, which moves toward alignment
+   with the _consensus-weighted_ view across all validators — not toward any single validator's own
+   opinion. A validator whose weights consistently agree with where other high-stake validators land
+   builds bonds that track consensus; one that diverges builds weaker bonds. This is the mechanism
+   that rewards genuine independent evaluation converging with the group, rather than either pure
+   copying or pure divergence.
+2. **Incentive is computed per miner** from the consensus-weighted score across all validators'
+   submitted weights — a rank/softmax-style computation, not a simple average, tuned by the `kappa`
+   hyperparameter.
+3. **Dividends are computed per validator** from that validator's bonds combined with its
+   [stake-weight](/docs/protocol/stake-weight) (used here as `active_stake`) — not from weights
+   submitted alone. A validator with strong bonds but negligible stake-weight, or strong stake-weight
+   but no meaningful bonds (never submitted fresh weights), earns correspondingly little.
+4. **`combined_emission = incentive + dividends`, computed per neuron, not as a fixed split of one
+   pool.** These aren't two halves of a subnet's emission divided by role — a UID's incentive and
+   dividend components are each independently derived from that UID's own miner-side and
+   validator-side activity respectively. A UID that's both a miner and a validator on subnets that
+   allow it earns from both terms; a pure-miner UID's dividend term is simply zero, and vice versa.
+
+## Why staleness matters
+
+A validator's `last_update` — the block of its most recent successful weight submission — factoring
+against the subnet's `weights_rate_limit` determines whether that validator's submission is
+considered current for a given epoch run. Weights that have gone stale (not resubmitted within the
+subnet's rate-limit window) don't meaningfully contribute at the next epoch boundary — a permitted
+validator sitting on old weights is, from the reward mechanism's perspective, functionally similar
+to one that never submits at all. Holding a [validator permit](/docs/protocol/registration-and-permits)
+is necessary but not sufficient — the dividend term only materializes from genuinely current,
+regularly-refreshed weight submissions.
+
+<Callout title="Permit ≠ earning">
+  A validator can hold a permit indefinitely without submitting weights — nothing revokes the permit
+  for inactivity by itself, since permit assignment is purely stake-rank based (see [registration
+  and permits](/docs/protocol/registration-and-permits)). But an inactive permit holder's dividend
+  term stays at or near zero the entire time, since dividends are earned from bonds built by
+  actually submitting current weights, not from holding the seat.
+</Callout>


### PR DESCRIPTION
## Summary

Adds `apps/ui/content/docs/protocol/` — 5 new fumadocs pages covering general Bittensor protocol mechanics, sourced from the primary `opentensor/subtensor` pallet source per each sub-issue's own brief. No metagraphed-specific strategy content, per #6346's explicit scope note.

- Closes #6347
- Closes #6350
- Closes #6351
- Closes #6349
- Closes #6348
- Closes #6346

## Screenshots

New pages, so there's no "before" state — after only, desktop, both themes.

| Page | Light | Dark |
|---|---|---|
| Understanding stake-weight | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/after-stake-weight-light.png) | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/after-stake-weight-dark.png) |
| Registration and validator permits | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/after-registration-and-permits-light.png) | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/after-registration-and-permits-dark.png) |
| Weight-setting, tempos, and rewards | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/after-weight-setting-and-rewards-light.png) | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/after-weight-setting-and-rewards-dark.png) |
| Proxy accounts | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/after-proxies-light.png) | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/after-proxies-dark.png) |
| Root stake and childkey delegation | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/after-root-delegation-light.png) | ![](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/after-root-delegation-dark.png) |

Confirmed: sidebar correctly groups all 5 under a new "Protocol" section (separate from the existing API-reference pages) in reading order; prev/next pagination between pages works; cross-links between pages resolve; formula/table/callout/code-block rendering all correct.

## Test plan

- [x] `npx fumadocs-mdx` — regenerated the content collection cleanly
- [x] `npx prettier --check content/docs/protocol/` — clean
- [x] Captured real screenshots via a Playwright script (`tests/e2e/capture-protocol-docs-screenshots.mjs`, not committed — one-off, matching the existing `capture-*-screenshots.mjs` convention) against a real dev server, both themes, all 5 pages