### PR TITLE
feat(python): add typed convenience methods to match TypeScript SDK (…

### DIFF
--- a/python/src/metagraphed/__init__.py
+++ b/python/src/metagraphed/__init__.py
@@ -13,9 +13,13 @@ from .client import (
 )
 from .models import (
     AgentCatalogSubnet,
+    CandidateSurface,
     Endpoint,
+    HealthSummary,
     Provider,
     Subnet,
+    SubnetDetail,
+    SubnetProfile,
     Surface,
 )
 
@@ -27,13 +31,17 @@ from .aio import AsyncMetagraphedClient
 __all__ = [
     "AgentCatalogSubnet",
     "AsyncMetagraphedClient",
+    "CandidateSurface",
     "DEFAULT_BASE_URL",
     "DEFAULT_USER_AGENT",
     "Endpoint",
+    "HealthSummary",
     "MetagraphedClient",
     "MetagraphedError",
     "Provider",
     "Subnet",
+    "SubnetDetail",
+    "SubnetProfile",
     "Surface",
     "metagraphed_fetch",
     "metagraphed_fetch_all",

--- a/python/src/metagraphed/aio.py
+++ b/python/src/metagraphed/aio.py
@@ -30,7 +30,17 @@ from .client import (
     _query_pairs,
     _url_origin,
 )
-from .models import AgentCatalogSubnet, Endpoint, Provider, Subnet, Surface
+from .models import (
+    AgentCatalogSubnet,
+    CandidateSurface,
+    Endpoint,
+    HealthSummary,
+    Provider,
+    Subnet,
+    SubnetDetail,
+    SubnetProfile,
+    Surface,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - type-checking only
     import httpx
@@ -298,22 +308,67 @@ class AsyncMetagraphedClient:
             await self.fetch_all("/api/v1/subnets", query=query or None)
         )
 
+    async def get_subnet(self, netuid: Any) -> SubnetDetail:
+        """One subnet detail artifact as a typed
+        :class:`~metagraphed.models.SubnetDetail`."""
+        envelope = await self.fetch(
+            "/api/v1/subnets/{netuid}", path_params={"netuid": netuid}
+        )
+        data = envelope.get("data") if isinstance(envelope, dict) else None
+        subnet = data.get("subnet") if isinstance(data, dict) else None
+        return SubnetDetail.from_dict(subnet)
+
     async def surfaces(self, **query: Any) -> List[Surface]:
+        """Every surface as a typed :class:`~metagraphed.models.Surface`."""
         return Surface.list_from(
             await self.fetch_all("/api/v1/surfaces", query=query or None)
         )
 
     async def endpoints(self, **query: Any) -> List[Endpoint]:
+        """Every endpoint as a typed :class:`~metagraphed.models.Endpoint`."""
         return Endpoint.list_from(
             await self.fetch_all("/api/v1/endpoints", query=query or None)
         )
 
     async def providers(self, **query: Any) -> List[Provider]:
+        """Every provider as a typed :class:`~metagraphed.models.Provider`."""
         return Provider.list_from(
             await self.fetch_all("/api/v1/providers", query=query or None)
         )
 
+    async def get_provider(self, slug: Any) -> Provider:
+        """One provider as a typed :class:`~metagraphed.models.Provider`."""
+        envelope = await self.fetch(
+            "/api/v1/providers/{slug}", path_params={"slug": slug}
+        )
+        data = envelope.get("data") if isinstance(envelope, dict) else None
+        provider = data.get("provider") if isinstance(data, dict) else None
+        return Provider.from_dict(provider)
+
+    async def candidates(self, **query: Any) -> List[CandidateSurface]:
+        """Every candidate as a typed
+        :class:`~metagraphed.models.CandidateSurface`."""
+        return CandidateSurface.list_from(
+            await self.fetch_all("/api/v1/candidates", query=query or None)
+        )
+
+    async def profiles(self, **query: Any) -> List[SubnetProfile]:
+        """Every subnet profile as a typed
+        :class:`~metagraphed.models.SubnetProfile`."""
+        return SubnetProfile.list_from(
+            await self.fetch_all("/api/v1/profiles", query=query or None)
+        )
+
+    async def health(self) -> HealthSummary:
+        """Global operational health as a typed
+        :class:`~metagraphed.models.HealthSummary`."""
+        envelope = await self.fetch("/api/v1/health")
+        data = envelope.get("data") if isinstance(envelope, dict) else None
+        return HealthSummary.from_dict(data)
+
     async def agent_catalog(self, netuid: Any) -> AgentCatalogSubnet:
+        """One subnet's agent catalog as a typed
+        :class:`~metagraphed.models.AgentCatalogSubnet`."""
         envelope = await self.fetch(
             "/api/v1/agent-catalog/{netuid}", path_params={"netuid": netuid}
         )

--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -16,7 +16,17 @@ import urllib.request
 from importlib.metadata import PackageNotFoundError, version as _package_version
 from typing import Any, Iterator, List, Mapping, Optional, Sequence, Tuple
 
-from .models import AgentCatalogSubnet, Endpoint, Provider, Subnet, Surface
+from .models import (
+    AgentCatalogSubnet,
+    CandidateSurface,
+    Endpoint,
+    HealthSummary,
+    Provider,
+    Subnet,
+    SubnetDetail,
+    SubnetProfile,
+    Surface,
+)
 
 # Single source of truth = the package metadata (pyproject.toml `version`, which
 # release-please bumps); read it at runtime so the User-Agent can never disagree
@@ -548,6 +558,16 @@ class MetagraphedClient:
             self.fetch_all("/api/v1/subnets", query=query or None)
         )
 
+    def get_subnet(self, netuid: Any) -> SubnetDetail:
+        """One subnet detail artifact as a typed
+        :class:`~metagraphed.models.SubnetDetail`."""
+        envelope = self.fetch(
+            "/api/v1/subnets/{netuid}", path_params={"netuid": netuid}
+        )
+        data = envelope.get("data") if isinstance(envelope, dict) else None
+        subnet = data.get("subnet") if isinstance(data, dict) else None
+        return SubnetDetail.from_dict(subnet)
+
     def surfaces(self, **query: Any) -> List[Surface]:
         """Every surface as a typed :class:`~metagraphed.models.Surface`."""
         return Surface.list_from(
@@ -565,6 +585,36 @@ class MetagraphedClient:
         return Provider.list_from(
             self.fetch_all("/api/v1/providers", query=query or None)
         )
+
+    def get_provider(self, slug: Any) -> Provider:
+        """One provider as a typed :class:`~metagraphed.models.Provider`."""
+        envelope = self.fetch(
+            "/api/v1/providers/{slug}", path_params={"slug": slug}
+        )
+        data = envelope.get("data") if isinstance(envelope, dict) else None
+        provider = data.get("provider") if isinstance(data, dict) else None
+        return Provider.from_dict(provider)
+
+    def candidates(self, **query: Any) -> List[CandidateSurface]:
+        """Every candidate as a typed
+        :class:`~metagraphed.models.CandidateSurface`."""
+        return CandidateSurface.list_from(
+            self.fetch_all("/api/v1/candidates", query=query or None)
+        )
+
+    def profiles(self, **query: Any) -> List[SubnetProfile]:
+        """Every subnet profile as a typed
+        :class:`~metagraphed.models.SubnetProfile`."""
+        return SubnetProfile.list_from(
+            self.fetch_all("/api/v1/profiles", query=query or None)
+        )
+
+    def health(self) -> HealthSummary:
+        """Global operational health as a typed
+        :class:`~metagraphed.models.HealthSummary`."""
+        envelope = self.fetch("/api/v1/health")
+        data = envelope.get("data") if isinstance(envelope, dict) else None
+        return HealthSummary.from_dict(data)
 
     def agent_catalog(self, netuid: Any) -> AgentCatalogSubnet:
         """One subnet's agent catalog as a typed

--- a/python/src/metagraphed/models.py
+++ b/python/src/metagraphed/models.py
@@ -87,6 +87,37 @@ class Subnet(_Model):
 
 
 @dataclass
+class SubnetDetail(_Model):
+    """The ``data.subnet`` entity from ``GET /api/v1/subnets/{netuid}``.
+
+    The route's compound artifact also includes related surfaces, candidates,
+    and gaps; callers that need those can use the raw :meth:`client.fetch`
+    method. This model follows the OpenAPI ``SubnetDetail`` entity itself.
+    """
+
+    netuid: Optional[int] = None
+    slug: Optional[str] = None
+    name: Optional[str] = None
+    status: Optional[str] = None
+    subnet_type: Optional[str] = None
+    categories: Optional[List[str]] = None
+    derived_categories: Optional[List[str]] = None
+    coverage_level: Optional[str] = None
+    curation_level: Optional[str] = None
+    description: Optional[str] = None
+    symbol: Optional[str] = None
+    website_url: Optional[str] = None
+    docs_url: Optional[str] = None
+    source_repo: Optional[str] = None
+    logo_url: Optional[str] = None
+    tempo: Optional[int] = None
+    surface_count: Optional[int] = None
+    candidate_count: Optional[int] = None
+    gap_count: Optional[int] = None
+    raw: Mapping[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
 class Surface(_Model):
     id: Optional[str] = None
     netuid: Optional[int] = None
@@ -122,6 +153,65 @@ class Provider(_Model):
     authority: Optional[str] = None
     surface_count: Optional[int] = None
     raw: Mapping[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class CandidateSurface(_Model):
+    """One row from ``GET /api/v1/candidates``."""
+
+    id: Optional[str] = None
+    netuid: Optional[int] = None
+    state: Optional[str] = None
+    kind: Optional[str] = None
+    name: Optional[str] = None
+    url: Optional[str] = None
+    provider: Optional[str] = None
+    confidence: Optional[str] = None
+    auth_required: Optional[bool] = None
+    public_safe: Optional[bool] = None
+    source_urls: Optional[List[str]] = None
+    raw: Mapping[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class SubnetProfile(_Model):
+    """One row from ``GET /api/v1/profiles``."""
+
+    netuid: Optional[int] = None
+    slug: Optional[str] = None
+    name: Optional[str] = None
+    project_name: Optional[str] = None
+    subnet_type: Optional[str] = None
+    status: Optional[str] = None
+    categories: Optional[List[str]] = None
+    derived_categories: Optional[List[str]] = None
+    curation_level: Optional[str] = None
+    review_state: Optional[str] = None
+    confidence: Optional[str] = None
+    profile_level: Optional[str] = None
+    completeness_score: Optional[int] = None
+    integration_readiness: Optional[int] = None
+    surface_count: Optional[int] = None
+    endpoint_count: Optional[int] = None
+    raw: Mapping[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class HealthSummary(_Model):
+    """Global operational summary from ``GET /api/v1/health``."""
+
+    schema_version: Optional[int] = None
+    contract_version: Optional[str] = None
+    generated_at: Optional[str] = None
+    operational_observed_at: Optional[str] = None
+    scope: Optional[str] = None
+    source: Optional[str] = None
+    health_source: Optional[str] = None
+    global_: Optional[Mapping[str, Any]] = None
+    subnets: Optional[List[Mapping[str, Any]]] = None
+    raw: Mapping[str, Any] = field(default_factory=dict, repr=False)
+
+    _aliases: ClassVar[Mapping[str, str]] = {"global": "global_"}
 
 
 @dataclass

--- a/python/tests/test_aio.py
+++ b/python/tests/test_aio.py
@@ -12,9 +12,14 @@ except ImportError:  # pragma: no cover - exercised only without the extra
 from metagraphed import (
     AgentCatalogSubnet,
     AsyncMetagraphedClient,
+    CandidateSurface,
     Endpoint,
+    HealthSummary,
     MetagraphedError,
+    Provider,
     Subnet,
+    SubnetDetail,
+    SubnetProfile,
     Surface,
 )
 
@@ -149,6 +154,33 @@ class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(subnets[0].integration_readiness, 72)
         self.assertIsNone(subnets[0].completeness_score)
         self.assertNotIn("completeness_score", subnets[0].raw)
+
+    async def test_get_subnet_returns_typed_detail(self):
+        client = self._client(
+            httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "data": {
+                        "subnet": {
+                            "netuid": 7,
+                            "name": "Allways",
+                            "slug": "allways",
+                            "coverage_level": "verified",
+                        },
+                        "surfaces": [{"id": "sn-7-openapi"}],
+                        "candidate_surfaces": [],
+                        "gaps": {"missing_kinds": ["docs"]},
+                    },
+                },
+            )
+        )
+        detail = await client.get_subnet(7)
+        self.assertIsInstance(detail, SubnetDetail)
+        self.assertEqual(detail.netuid, 7)
+        self.assertEqual(detail.slug, "allways")
+        self.assertEqual(detail.coverage_level, "verified")
+        self.assertTrue(client._client.calls[0][1].endswith("/api/v1/subnets/7"))
 
     async def test_paginate_follows_next_cursor_with_nested_collection(self):
         # Mirrors README async usage of paginate via fetch_all / typed helpers:
@@ -305,6 +337,114 @@ class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(endpoint.monitoring_status, "monitored")
         self.assertEqual(endpoint.raw["id"], "ep-sn-7-subnet-api")
         self.assertFalse(hasattr(endpoint, "base_url"))
+
+    async def test_get_provider_returns_typed_provider(self):
+        client = self._client(
+            httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "data": {
+                        "provider": {
+                            "id": "macrocosmos",
+                            "name": "Macrocosmos",
+                            "authority": "official",
+                            "surface_count": 12,
+                        }
+                    },
+                },
+            )
+        )
+        provider = await client.get_provider("macrocosmos")
+        self.assertIsInstance(provider, Provider)
+        self.assertEqual(provider.slug, "macrocosmos")
+        self.assertEqual(provider.surface_count, 12)
+        self.assertTrue(
+            client._client.calls[0][1].endswith("/api/v1/providers/macrocosmos")
+        )
+
+    async def test_candidates_returns_typed_models(self):
+        client = self._client(
+            httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "candidates": [
+                            {
+                                "id": "candidate-7-openapi",
+                                "netuid": 7,
+                                "kind": "openapi",
+                                "state": "schema-valid",
+                                "confidence": "high",
+                            }
+                        ]
+                    },
+                    "meta": {
+                        "pagination": {
+                            "collection": "candidates",
+                            "next_cursor": None,
+                        }
+                    },
+                },
+            )
+        )
+        candidates = await client.candidates(confidence="high")
+        self.assertIsInstance(candidates[0], CandidateSurface)
+        self.assertEqual(candidates[0].id, "candidate-7-openapi")
+        self.assertEqual(client._client.calls[0][2], {"confidence": "high"})
+
+    async def test_profiles_returns_typed_models(self):
+        client = self._client(
+            httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "profiles": [
+                            {
+                                "netuid": 7,
+                                "slug": "allways",
+                                "name": "Allways",
+                                "profile_level": "operational",
+                                "completeness_score": 82,
+                            }
+                        ]
+                    },
+                    "meta": {
+                        "pagination": {
+                            "collection": "profiles",
+                            "next_cursor": None,
+                        }
+                    },
+                },
+            )
+        )
+        profiles = await client.profiles(profile_level="operational")
+        self.assertIsInstance(profiles[0], SubnetProfile)
+        self.assertEqual(profiles[0].completeness_score, 82)
+        self.assertEqual(
+            client._client.calls[0][2], {"profile_level": "operational"}
+        )
+
+    async def test_health_returns_typed_summary(self):
+        client = self._client(
+            httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "data": {
+                        "schema_version": 1,
+                        "global": {"status": "ok", "surface_count": 4},
+                        "subnets": [{"netuid": 7, "status": "ok"}],
+                        "health_source": "probe-derived",
+                    },
+                },
+            )
+        )
+        health = await client.health()
+        self.assertIsInstance(health, HealthSummary)
+        self.assertEqual(health.global_["status"], "ok")
+        self.assertEqual(health.subnets[0]["netuid"], 7)
+        self.assertTrue(client._client.calls[0][1].endswith("/api/v1/health"))
 
     async def test_agent_catalog_returns_typed_model(self):
         client = self._client(

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -10,11 +10,15 @@ import metagraphed.client as client
 
 from metagraphed import (
     AgentCatalogSubnet,
+    CandidateSurface,
     Endpoint,
+    HealthSummary,
     MetagraphedClient,
     MetagraphedError,
     Provider,
     Subnet,
+    SubnetDetail,
+    SubnetProfile,
     Surface,
     metagraphed_fetch,
     metagraphed_fetch_all,
@@ -579,6 +583,35 @@ class FetchAllAndModelsTest(unittest.TestCase):
         self.assertIsNone(subnets[0].completeness_score)
         self.assertNotIn("completeness_score", subnets[0].raw)
 
+    def test_get_subnet_returns_typed_detail(self):
+        def fake_urlopen(request, timeout=None):
+            self.assertIn("/api/v1/subnets/7", request.full_url)
+            return _FakeResponse(
+                {
+                    "ok": True,
+                    "data": {
+                        "subnet": {
+                            "netuid": 7,
+                            "name": "Allways",
+                            "slug": "allways",
+                            "coverage_level": "verified",
+                        },
+                        "surfaces": [{"id": "sn-7-openapi"}],
+                        "candidate_surfaces": [],
+                        "gaps": {"missing_kinds": ["docs"]},
+                    },
+                }
+            )
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            detail = MetagraphedClient().get_subnet(7)
+
+        self.assertIsInstance(detail, SubnetDetail)
+        self.assertEqual(detail.netuid, 7)
+        self.assertEqual(detail.slug, "allways")
+        self.assertEqual(detail.coverage_level, "verified")
+        self.assertEqual(detail.raw["name"], "Allways")
+
     def test_model_from_dict_ignores_unknown_and_keeps_raw(self):
         surface = Surface.from_dict(
             {"id": "x", "kind": "openapi", "unknown_field": 1}
@@ -800,6 +833,112 @@ class FetchAllAndModelsTest(unittest.TestCase):
             "https://should-not-become-a-typed-field.example",
         )
         self.assertIs(endpoint.raw["unknown_extra"], True)
+
+    def test_get_provider_returns_typed_provider(self):
+        def fake_urlopen(request, timeout=None):
+            self.assertIn("/api/v1/providers/macrocosmos", request.full_url)
+            return _FakeResponse(
+                {
+                    "ok": True,
+                    "data": {
+                        "provider": {
+                            "id": "macrocosmos",
+                            "name": "Macrocosmos",
+                            "authority": "official",
+                            "surface_count": 12,
+                        }
+                    },
+                }
+            )
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            provider = MetagraphedClient().get_provider("macrocosmos")
+
+        self.assertIsInstance(provider, Provider)
+        self.assertEqual(provider.slug, "macrocosmos")
+        self.assertEqual(provider.surface_count, 12)
+
+    def test_candidates_convenience_returns_typed_models(self):
+        pages = [
+            {
+                "data": {
+                    "candidates": [
+                        {
+                            "id": "candidate-7-openapi",
+                            "netuid": 7,
+                            "kind": "openapi",
+                            "state": "schema-valid",
+                            "confidence": "high",
+                            "url": "https://api.example.com/openapi.json",
+                        }
+                    ]
+                },
+                "meta": {
+                    "pagination": {
+                        "collection": "candidates",
+                        "next_cursor": None,
+                    }
+                },
+            }
+        ]
+        with self._patch_pages(pages):
+            candidates = MetagraphedClient().candidates(confidence="high")
+
+        self.assertIsInstance(candidates[0], CandidateSurface)
+        self.assertEqual(candidates[0].id, "candidate-7-openapi")
+        self.assertEqual(candidates[0].confidence, "high")
+
+    def test_profiles_convenience_returns_typed_models(self):
+        pages = [
+            {
+                "data": {
+                    "profiles": [
+                        {
+                            "netuid": 7,
+                            "slug": "allways",
+                            "name": "Allways",
+                            "profile_level": "operational",
+                            "completeness_score": 82,
+                        }
+                    ]
+                },
+                "meta": {
+                    "pagination": {
+                        "collection": "profiles",
+                        "next_cursor": None,
+                    }
+                },
+            }
+        ]
+        with self._patch_pages(pages):
+            profiles = MetagraphedClient().profiles(profile_level="operational")
+
+        self.assertIsInstance(profiles[0], SubnetProfile)
+        self.assertEqual(profiles[0].netuid, 7)
+        self.assertEqual(profiles[0].completeness_score, 82)
+
+    def test_health_returns_typed_summary(self):
+        def fake_urlopen(request, timeout=None):
+            self.assertIn("/api/v1/health", request.full_url)
+            return _FakeResponse(
+                {
+                    "ok": True,
+                    "data": {
+                        "schema_version": 1,
+                        "global": {"status": "ok", "surface_count": 4},
+                        "subnets": [{"netuid": 7, "status": "ok"}],
+                        "health_source": "probe-derived",
+                    },
+                }
+            )
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            health = MetagraphedClient().health()
+
+        self.assertIsInstance(health, HealthSummary)
+        self.assertEqual(health.global_["status"], "ok")
+        self.assertEqual(health.subnets[0]["netuid"], 7)
+        self.assertEqual(health.raw["health_source"], "probe-derived")
 
     def test_agent_catalog_returns_typed_model(self):
         # Realistic AgentCatalogSubnetArtifact data envelope


### PR DESCRIPTION
## Summary

- Bring the Python SDK's typed convenience layer to parity with the TypeScript SDK by adding sync and async `get_subnet`, `get_provider`, `candidates`, `profiles`, and `health` methods.
- Add lightweight typed models (`SubnetDetail`, `CandidateSurface`, `SubnetProfile`, `HealthSummary`) while preserving every response field on `.raw`.
- Cover each new method in both sync and async client tests.

Closes #6587

## What Changed

- **Models** (`python/src/metagraphed/models.py`): add `SubnetDetail` (from `data.subnet`), `CandidateSurface`, `SubnetProfile`, and `HealthSummary` (`global` → `global_` alias).
- **Sync client** (`python/src/metagraphed/client.py`): add `get_subnet`, `get_provider`, `candidates`, `profiles`, `health`.
- **Async client** (`python/src/metagraphed/aio.py`): matching methods + docstrings.
- **Exports** (`python/src/metagraphed/__init__.py`): export the new public model classes.
- **Tests**: `python/tests/test_client.py` and `python/tests/test_aio.py`.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6587`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. (N/A — Python SDK only.)
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (No API contract change.)

## Validation

- [x] `cd python && uv run --extra test python -m unittest discover -s tests` (70 passed, 1 skipped)
- [x] `python3 -m compileall -q python/src python/tests`
- [x] `npm run lint`
- [x] `git diff --check`
- [x] `npm run check`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:upvote`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage`
- [x] `npm run scan:public-safety`

## Template Used

backend-code
