### PR TITLE
feat(api): add list-query pagination to the /incidents route

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -18807,6 +18807,14 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d";
+                netuid?: number;
+                fields?: string;
+                limit?: number;
+                cursor?: number;
+                /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
+                sort?: "downtime_ms" | "incident_count" | "netuid" | "surface_id";
+                /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
+                order?: "asc" | "desc";
             };
             header?: never;
             path?: never;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -9511,8 +9511,10 @@
       "method": "GET",
       "path": "/api/v1/incidents",
       "public": true,
-      "query_collection": null,
-      "query_filter_names": [],
+      "query_collection": "incidents",
+      "query_filter_names": [
+        "netuid"
+      ],
       "query_parameters": [
         {
           "name": "window",
@@ -9522,6 +9524,58 @@
               "30d"
             ],
             "type": "string"
+          }
+        },
+        {
+          "name": "netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "cursor",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+          "name": "sort",
+          "schema": {
+            "enum": [
+              "downtime_ms",
+              "incident_count",
+              "netuid",
+              "surface_id"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+          "name": "order",
+          "schema": {
+            "enum": [
+              "asc",
+              "desc"
+            ]
           }
         }
       ]

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -37447,6 +37447,70 @@
               ],
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "downtime_ms",
+                "incident_count",
+                "netuid",
+                "surface_id"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
           }
         ],
         "responses": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -18807,6 +18807,14 @@ export interface operations {
         parameters: {
             query?: {
                 window?: "7d" | "30d";
+                netuid?: number;
+                fields?: string;
+                limit?: number;
+                cursor?: number;
+                /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
+                sort?: "downtime_ms" | "incident_count" | "netuid" | "surface_id";
+                /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
+                order?: "asc" | "desc";
             };
             header?: never;
             path?: never;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -294,6 +294,16 @@ export const API_QUERY_COLLECTIONS = {
       "status",
     ],
   }),
+  // Global cross-subnet downtime ledger served by GET /api/v1/incidents (#6571):
+  // the per-surface `surfaces` rollup formatGlobalIncidents produces, paginated
+  // on top of the route's own `window` scope so callers can page/sort/filter a
+  // 30-day list the same way the sibling endpoint-incidents route already does.
+  incidents: queryCollection("surfaces", {
+    filters: {
+      netuid: integerSchema,
+    },
+    sort: ["downtime_ms", "incident_count", "netuid", "surface_id"],
+  }),
   gaps: queryCollection("gaps", {
     filters: {
       netuid: integerSchema,
@@ -3904,7 +3914,9 @@ export const API_ROUTES = [
     "Fetch recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window (computed live from D1). Pair with /api/v1/health for the overall status summary.",
     "short",
     ["health", "analytics"],
-    [{ name: "window", schema: { type: "string", enum: ["7d", "30d"] } }],
+    listQueryWith("incidents", [
+      { name: "window", schema: { type: "string", enum: ["7d", "30d"] } },
+    ]),
   ),
   route(
     "schemas",
@@ -4436,6 +4448,15 @@ function listQuery(collection, options = {}) {
       },
     ],
   };
+}
+
+// A list-query spec (pagination/sort/filter) fronted by a set of route-specific
+// query parameters the collection itself doesn't own — e.g. the incidents route's
+// `window` scope (#6571). The extra parameters lead, then the standard list-query
+// params, so `window` still reads first in the OpenAPI parameter list.
+function listQueryWith(collection, extraParameters) {
+  const spec = listQuery(collection);
+  return { ...spec, parameters: [...extraParameters, ...spec.parameters] };
 }
 
 function csvListQuery(collection, options = {}) {

--- a/tests/request-handlers-analytics.test.mjs
+++ b/tests/request-handlers-analytics.test.mjs
@@ -1439,9 +1439,9 @@ describe("handleGlobalIncidents", () => {
 
   test("rejects unsupported extra params", async () => {
     const res = await handleGlobalIncidents(
-      req(`${base}?window=7d&netuid=7`),
+      req(`${base}?window=7d&bogus=1`),
       emptyEnv(),
-      url(`${base}?window=7d&netuid=7`),
+      url(`${base}?window=7d&bogus=1`),
     );
     await errorJson(res);
   });
@@ -1520,6 +1520,100 @@ describe("handleGlobalIncidents", () => {
       url(`${base}?window=7d`),
     );
     assert.equal(res.status, 200);
+  });
+
+  // #6571: the window-scoped ledger now pages/sorts/filters like the sibling
+  // endpoint-incidents route. Non-empty surfaces come from the Postgres tier (the
+  // D1 fallback ledger is always empty now), so these stub DATA_API with a payload
+  // in the exact shape formatGlobalIncidents emits.
+  function withSurfaces(surfaces) {
+    const { env } = dbWith({ rows: [] });
+    env.METAGRAPH_HEALTH_SOURCE = "postgres";
+    env.DATA_API = {
+      fetch: async () =>
+        Response.json({
+          schema_version: 1,
+          window: "7d",
+          observed_at: LAST_RUN_AT,
+          source: "live-cron-prober",
+          summary: {
+            incident_count: surfaces.length,
+            affected_surface_count: surfaces.length,
+          },
+          surfaces,
+        }),
+    };
+    return env;
+  }
+
+  const SURFACE_ROWS = [
+    { netuid: 7, surface_id: "a", incident_count: 1, downtime_ms: 300 },
+    { netuid: 7, surface_id: "b", incident_count: 3, downtime_ms: 100 },
+    { netuid: 12, surface_id: "c", incident_count: 2, downtime_ms: 900 },
+  ];
+
+  test("paginates the surfaces ledger and advertises a Link header", async () => {
+    const p = `${base}?window=7d&limit=1`;
+    const res = await handleGlobalIncidents(
+      req(p),
+      withSurfaces(SURFACE_ROWS),
+      url(p),
+    );
+    const body = await json(res);
+    assert.equal(body.data.surfaces.length, 1);
+    assert.equal(body.meta.pagination.collection, "surfaces");
+    assert.equal(body.meta.pagination.total, 3);
+    assert.equal(body.meta.pagination.limit, 1);
+    assert.equal(body.meta.pagination.next_cursor, 1);
+    const link = res.headers.get("link");
+    assert.ok(link.includes('rel="next"'));
+    // window is pinned onto every page link, never dropped back to the 7d default.
+    assert.ok(link.includes("window=7d"));
+  });
+
+  test("sort + order reorder the surfaces list", async () => {
+    const p = `${base}?window=7d&sort=downtime_ms&order=desc`;
+    const body = await json(
+      await handleGlobalIncidents(req(p), withSurfaces(SURFACE_ROWS), url(p)),
+    );
+    assert.deepEqual(
+      body.data.surfaces.map((s) => s.surface_id),
+      ["c", "a", "b"],
+    );
+    assert.equal(body.meta.pagination.sort, "downtime_ms");
+    assert.equal(body.meta.pagination.order, "desc");
+  });
+
+  test("netuid filter narrows the surfaces list", async () => {
+    const p = `${base}?window=7d&netuid=12`;
+    const body = await json(
+      await handleGlobalIncidents(req(p), withSurfaces(SURFACE_ROWS), url(p)),
+    );
+    assert.deepEqual(
+      body.data.surfaces.map((s) => s.netuid),
+      [12],
+    );
+    assert.equal(body.meta.pagination.total, 1);
+  });
+
+  test("rejects an out-of-range limit like the sibling list routes", async () => {
+    const p = `${base}?window=7d&limit=abc`;
+    const body = await errorJson(
+      await handleGlobalIncidents(req(p), withSurfaces(SURFACE_ROWS), url(p)),
+    );
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "limit");
+  });
+
+  test("unpaged request omits the Link header", async () => {
+    const p = `${base}?window=7d`;
+    const res = await handleGlobalIncidents(
+      req(p),
+      withSurfaces(SURFACE_ROWS),
+      url(p),
+    );
+    await json(res);
+    assert.equal(res.headers.get("link"), null);
   });
 });
 

--- a/workers/list-query.mjs
+++ b/workers/list-query.mjs
@@ -78,7 +78,7 @@ function effectiveFilterNames(config, queryFilterNames = []) {
 // query and pins the resolved cursor + limit, so a client can walk pages without
 // rebuilding the request. Null when no relation applies (unpaged, single page,
 // or empty) so the caller omits the header.
-function listQueryParamNames(queryCollection, queryFilterNames = []) {
+export function listQueryParamNames(queryCollection, queryFilterNames = []) {
   const config = API_QUERY_COLLECTIONS[queryCollection];
   if (!config) return [];
   return listQueryParamNamesForConfig(config, queryFilterNames);

--- a/workers/request-handlers/analytics.mjs
+++ b/workers/request-handlers/analytics.mjs
@@ -43,6 +43,11 @@ import {
 import { loadBulkHealthTrends } from "../../src/bulk-health-trends.mjs";
 import { formatGlobalIncidents } from "../../src/health-serving.mjs";
 import {
+  applyQueryFilters,
+  listQueryParamNames,
+  paginationLinkHeader,
+} from "../list-query.mjs";
+import {
   loadSubnetHealthTrends,
   loadSubnetIncidents,
   loadSubnetPercentiles,
@@ -622,8 +627,13 @@ export async function loadGlobalIncidentsLedger(env, { label = "7d" } = {}) {
   return { data, incidentRows: [] };
 }
 
+// The list-query params GET /api/v1/incidents accepts on top of its own `window`
+// scope (#6571): limit/cursor/sort/order + the netuid filter, so a caller can page
+// a 30-day incident list the way the sibling endpoint-incidents route already can.
+const GLOBAL_INCIDENTS_LIST_PARAMS = listQueryParamNames("incidents");
+
 export async function handleGlobalIncidents(request, env, url) {
-  const { label, error } = analyticsWindow(url);
+  const { label, error } = analyticsWindow(url, GLOBAL_INCIDENTS_LIST_PARAMS);
   if (error) {
     return analyticsQueryError(error);
   }
@@ -635,17 +645,37 @@ export async function handleGlobalIncidents(request, env, url) {
     const result = await loadGlobalIncidentsLedger(env, { label });
     data = result.data;
   }
+  // Page/sort/filter the window-scoped `surfaces` ledger through the shared
+  // list-query engine (#6571). `window` is this route's own scope param, already
+  // validated above, so it is stripped before the engine — which only knows the
+  // collection's own vocabulary and would otherwise reject it as an unknown param.
+  const listUrl = new URL(url.href);
+  listUrl.searchParams.delete("window");
+  const transformed = applyQueryFilters(data, listUrl, "incidents");
+  if (transformed.error) {
+    return analyticsQueryError(transformed.error);
+  }
+  // Pin the resolved window onto every page link so paging a non-default window
+  // doesn't silently fall back to 7d (canonicalListSearch keeps only list params).
+  const link = paginationLinkHeader(url, transformed.meta.pagination, {
+    queryCollection: "incidents",
+    searchParams: { window: label },
+  });
   const response = await envelopeResponse(
     request,
     {
-      data,
-      meta: await analyticsMeta(
-        env,
-        "/metagraph/incidents.json",
-        data.observed_at,
-      ),
+      data: transformed.data,
+      meta: {
+        ...(await analyticsMeta(
+          env,
+          "/metagraph/incidents.json",
+          data.observed_at,
+        )),
+        ...transformed.meta,
+      },
     },
     "short",
+    link ? { link } : {},
   );
   return isFallback ? markD1FallbackResponse(response) : response;
 }


### PR DESCRIPTION
feat(api): add list-query pagination to the /incidents route

The global GET /api/v1/incidents route only accepted a `window` enum,
while its sibling /api/v1/endpoint-incidents is fully listQuery-registered
(limit/cursor/sort/filters). A caller couldn't page, sort, or filter a
30-day incident list even though it's a clearly growable collection.

Register a new `incidents` list-query collection over the per-surface
`surfaces` rollup formatGlobalIncidents emits (netuid filter; sort by
downtime_ms/incident_count/netuid/surface_id) and expose it on the route
alongside the existing `window` param via a small listQueryWith helper.
handleGlobalIncidents now runs the shared list-query engine on top of its
window-scoped ledger: `window` stays this route's own scope (validated up
front, then stripped before the engine, which only knows the collection
vocabulary), and an RFC 8288 Link header pins the resolved window onto
every page link so paging never silently falls back to 7d.

Closes #6571

