### PR TITLE
fix(mcp): reject an invalid limit instead of silently clamping it (#6569)

### DIFF
--- a/src/curation-mcp.mjs
+++ b/src/curation-mcp.mjs
@@ -41,12 +41,6 @@ function optionalEnum(args, key, allowed) {
   return value;
 }
 
-function clampLimit(value, fallback, max) {
-  if (typeof value !== "number") return fallback;
-  if (!Number.isFinite(value) || value < 1) return fallback;
-  return Math.min(max, Math.floor(value));
-}
-
 export function curationQueryUrl(args) {
   const url = new URL("https://mcp.internal/curation");
   if (args?.netuid !== undefined) {
@@ -69,7 +63,13 @@ export function curationQueryUrl(args) {
   const fields = optionalString(args, "fields");
   if (fields) url.searchParams.set("fields", fields);
   if (args?.limit !== undefined) {
-    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+    if (!Number.isInteger(args.limit) || args.limit < 1 || args.limit > 100) {
+      throw curationMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(args.limit));
   }
   if (args?.cursor !== undefined) {
     if (!Number.isInteger(args.cursor) || args.cursor < 0) {

--- a/src/endpoint-incidents-mcp.mjs
+++ b/src/endpoint-incidents-mcp.mjs
@@ -45,12 +45,6 @@ function optionalEnum(args, key, allowed) {
   return value;
 }
 
-function clampLimit(value, fallback, max) {
-  if (typeof value !== "number") return fallback;
-  if (!Number.isFinite(value) || value < 1) return fallback;
-  return Math.min(max, Math.floor(value));
-}
-
 export function endpointIncidentsQueryUrl(args) {
   const url = new URL("https://mcp.internal/endpoint-incidents");
   if (args?.netuid !== undefined) {
@@ -79,7 +73,13 @@ export function endpointIncidentsQueryUrl(args) {
   const fields = optionalString(args, "fields");
   if (fields) url.searchParams.set("fields", fields);
   if (args?.limit !== undefined) {
-    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+    if (!Number.isInteger(args.limit) || args.limit < 1 || args.limit > 100) {
+      throw endpointIncidentsMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(args.limit));
   }
   if (args?.cursor !== undefined) {
     if (!Number.isInteger(args.cursor) || args.cursor < 0) {

--- a/src/endpoint-pools-mcp.mjs
+++ b/src/endpoint-pools-mcp.mjs
@@ -53,12 +53,6 @@ function optionalRangeBound(args, key) {
   return value;
 }
 
-function clampLimit(value, fallback, max) {
-  if (typeof value !== "number") return fallback;
-  if (!Number.isFinite(value) || value < 1) return fallback;
-  return Math.min(max, Math.floor(value));
-}
-
 export function endpointPoolsQueryUrl(args) {
   const url = new URL("https://mcp.internal/endpoint-pools");
   const id = optionalString(args, "id");
@@ -88,7 +82,13 @@ export function endpointPoolsQueryUrl(args) {
     url.searchParams.set("max_endpoint_count", String(maxEndpoint));
   }
   if (args?.limit !== undefined) {
-    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+    if (!Number.isInteger(args.limit) || args.limit < 1 || args.limit > 100) {
+      throw endpointPoolsMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(args.limit));
   }
   if (args?.cursor !== undefined) {
     if (!Number.isInteger(args.cursor) || args.cursor < 0) {

--- a/src/evidence-mcp.mjs
+++ b/src/evidence-mcp.mjs
@@ -40,12 +40,6 @@ function optionalEnum(args, key, allowed) {
   return value;
 }
 
-function clampLimit(value, fallback, max) {
-  if (typeof value !== "number") return fallback;
-  if (!Number.isFinite(value) || value < 1) return fallback;
-  return Math.min(max, Math.floor(value));
-}
-
 export function evidenceQueryUrl(args) {
   const url = new URL("https://mcp.internal/evidence");
   const q = optionalString(args, "q");
@@ -57,7 +51,13 @@ export function evidenceQueryUrl(args) {
   const fields = optionalString(args, "fields");
   if (fields) url.searchParams.set("fields", fields);
   if (args?.limit !== undefined) {
-    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+    if (!Number.isInteger(args.limit) || args.limit < 1 || args.limit > 100) {
+      throw evidenceMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(args.limit));
   }
   if (args?.cursor !== undefined) {
     if (!Number.isInteger(args.cursor) || args.cursor < 0) {

--- a/src/gaps-mcp.mjs
+++ b/src/gaps-mcp.mjs
@@ -42,12 +42,6 @@ function optionalEnum(args, key, allowed) {
   return value;
 }
 
-function clampLimit(value, fallback, max) {
-  if (typeof value !== "number") return fallback;
-  if (!Number.isFinite(value) || value < 1) return fallback;
-  return Math.min(max, Math.floor(value));
-}
-
 export function gapsQueryUrl(args) {
   const url = new URL("https://mcp.internal/gaps");
   if (args?.netuid !== undefined) {
@@ -74,7 +68,13 @@ export function gapsQueryUrl(args) {
   const fields = optionalString(args, "fields");
   if (fields) url.searchParams.set("fields", fields);
   if (args?.limit !== undefined) {
-    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+    if (!Number.isInteger(args.limit) || args.limit < 1 || args.limit > 100) {
+      throw gapsMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(args.limit));
   }
   if (args?.cursor !== undefined) {
     if (!Number.isInteger(args.cursor) || args.cursor < 0) {

--- a/src/providers-mcp.mjs
+++ b/src/providers-mcp.mjs
@@ -42,12 +42,6 @@ function optionalEnum(args, key, allowed) {
   return value;
 }
 
-function clampLimit(value, fallback, max) {
-  if (typeof value !== "number") return fallback;
-  if (!Number.isFinite(value) || value < 1) return fallback;
-  return Math.min(max, Math.floor(value));
-}
-
 export function providersQueryUrl(args) {
   const url = new URL("https://mcp.internal/providers");
   const id = optionalString(args, "id");
@@ -63,7 +57,13 @@ export function providersQueryUrl(args) {
   const fields = optionalString(args, "fields");
   if (fields) url.searchParams.set("fields", fields);
   if (args?.limit !== undefined) {
-    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+    if (!Number.isInteger(args.limit) || args.limit < 1 || args.limit > 100) {
+      throw providersMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(args.limit));
   }
   if (args?.cursor !== undefined) {
     if (!Number.isInteger(args.cursor) || args.cursor < 0) {

--- a/src/search-index-mcp.mjs
+++ b/src/search-index-mcp.mjs
@@ -40,12 +40,6 @@ function optionalEnum(args, key, allowed) {
   return value;
 }
 
-function clampLimit(value, fallback, max) {
-  if (typeof value !== "number") return fallback;
-  if (!Number.isFinite(value) || value < 1) return fallback;
-  return Math.min(max, Math.floor(value));
-}
-
 export function searchIndexQueryUrl(args) {
   const url = new URL("https://mcp.internal/search-index");
   const q = optionalString(args, "q");
@@ -57,7 +51,13 @@ export function searchIndexQueryUrl(args) {
   const fields = optionalString(args, "fields");
   if (fields) url.searchParams.set("fields", fields);
   if (args?.limit !== undefined) {
-    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+    if (!Number.isInteger(args.limit) || args.limit < 1 || args.limit > 100) {
+      throw searchIndexMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(args.limit));
   }
   if (args?.cursor !== undefined) {
     if (!Number.isInteger(args.cursor) || args.cursor < 0) {

--- a/src/source-snapshots-mcp.mjs
+++ b/src/source-snapshots-mcp.mjs
@@ -40,12 +40,6 @@ function optionalEnum(args, key, allowed) {
   return value;
 }
 
-function clampLimit(value, fallback, max) {
-  if (typeof value !== "number") return fallback;
-  if (!Number.isFinite(value) || value < 1) return fallback;
-  return Math.min(max, Math.floor(value));
-}
-
 export function sourceSnapshotsQueryUrl(args) {
   const url = new URL("https://mcp.internal/source-snapshots");
   const q = optionalString(args, "q");
@@ -57,7 +51,13 @@ export function sourceSnapshotsQueryUrl(args) {
   const fields = optionalString(args, "fields");
   if (fields) url.searchParams.set("fields", fields);
   if (args?.limit !== undefined) {
-    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+    if (!Number.isInteger(args.limit) || args.limit < 1 || args.limit > 100) {
+      throw sourceSnapshotsMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(args.limit));
   }
   if (args?.cursor !== undefined) {
     if (!Number.isInteger(args.cursor) || args.cursor < 0) {

--- a/src/surfaces-mcp.mjs
+++ b/src/surfaces-mcp.mjs
@@ -42,12 +42,6 @@ function optionalEnum(args, key, allowed) {
   return value;
 }
 
-function clampLimit(value, fallback, max) {
-  if (typeof value !== "number") return fallback;
-  if (!Number.isFinite(value) || value < 1) return fallback;
-  return Math.min(max, Math.floor(value));
-}
-
 export function surfacesQueryUrl(args) {
   const url = new URL("https://mcp.internal/surfaces");
   if (args?.netuid !== undefined) {
@@ -70,7 +64,13 @@ export function surfacesQueryUrl(args) {
   const fields = optionalString(args, "fields");
   if (fields) url.searchParams.set("fields", fields);
   if (args?.limit !== undefined) {
-    url.searchParams.set("limit", String(clampLimit(args.limit, 50, 100)));
+    if (!Number.isInteger(args.limit) || args.limit < 1 || args.limit > 100) {
+      throw surfacesMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(args.limit));
   }
   if (args?.cursor !== undefined) {
     if (!Number.isInteger(args.cursor) || args.cursor < 0) {

--- a/tests/curation-mcp.test.mjs
+++ b/tests/curation-mcp.test.mjs
@@ -102,19 +102,25 @@ describe("curation-mcp", () => {
     assert.equal(url.searchParams.get("fields"), "netuid,name");
   });
 
-  test("curationQueryUrl clamps a non-numeric limit to the default", () => {
-    const url = curationQueryUrl({ limit: "lots" });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("curationQueryUrl rejects a non-numeric limit", () => {
+    assert.throws(
+      () => curationQueryUrl({ limit: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("curationQueryUrl clamps a sub-minimum numeric limit to the default", () => {
-    const url = curationQueryUrl({ limit: 0 });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("curationQueryUrl rejects a sub-minimum limit", () => {
+    assert.throws(
+      () => curationQueryUrl({ limit: 0 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("curationQueryUrl clamps limit above the MCP maximum", () => {
-    const url = curationQueryUrl({ limit: 500 });
-    assert.equal(url.searchParams.get("limit"), "100");
+  test("curationQueryUrl rejects a limit above the MCP maximum", () => {
+    assert.throws(
+      () => curationQueryUrl({ limit: 500 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
   test("curationQueryUrl rejects a fractional netuid", () => {

--- a/tests/endpoint-incidents-mcp.test.mjs
+++ b/tests/endpoint-incidents-mcp.test.mjs
@@ -161,19 +161,25 @@ describe("endpoint-incidents-mcp", () => {
     assert.equal(url.searchParams.get("fields"), "netuid,severity");
   });
 
-  test("endpointIncidentsQueryUrl clamps a non-numeric limit to the default", () => {
-    const url = endpointIncidentsQueryUrl({ limit: "lots" });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("endpointIncidentsQueryUrl rejects a non-numeric limit", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ limit: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("endpointIncidentsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
-    const url = endpointIncidentsQueryUrl({ limit: 0 });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("endpointIncidentsQueryUrl rejects a sub-minimum limit", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ limit: 0 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("endpointIncidentsQueryUrl clamps limit above the MCP maximum", () => {
-    const url = endpointIncidentsQueryUrl({ limit: 500 });
-    assert.equal(url.searchParams.get("limit"), "100");
+  test("endpointIncidentsQueryUrl rejects a limit above the MCP maximum", () => {
+    assert.throws(
+      () => endpointIncidentsQueryUrl({ limit: 500 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
   test("loadEndpointIncidentsList returns filtered rows with pagination meta", async () => {

--- a/tests/endpoint-pools-mcp.test.mjs
+++ b/tests/endpoint-pools-mcp.test.mjs
@@ -123,14 +123,18 @@ describe("endpoint-pools-mcp", () => {
     assert.equal(url.searchParams.get("fields"), "id,kind");
   });
 
-  test("endpointPoolsQueryUrl clamps a non-numeric limit to the default", () => {
-    const url = endpointPoolsQueryUrl({ limit: "lots" });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("endpointPoolsQueryUrl rejects a non-numeric limit", () => {
+    assert.throws(
+      () => endpointPoolsQueryUrl({ limit: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("endpointPoolsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
-    const url = endpointPoolsQueryUrl({ limit: 0 });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("endpointPoolsQueryUrl rejects a sub-minimum limit", () => {
+    assert.throws(
+      () => endpointPoolsQueryUrl({ limit: 0 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
   test("endpointPoolsQueryUrl rejects non-string fields", () => {
@@ -140,9 +144,11 @@ describe("endpoint-pools-mcp", () => {
     );
   });
 
-  test("endpointPoolsQueryUrl clamps limit above the MCP maximum", () => {
-    const url = endpointPoolsQueryUrl({ limit: 500 });
-    assert.equal(url.searchParams.get("limit"), "100");
+  test("endpointPoolsQueryUrl rejects a limit above the MCP maximum", () => {
+    assert.throws(
+      () => endpointPoolsQueryUrl({ limit: 500 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
   test("loadEndpointPoolsList returns filtered rows with pagination meta", async () => {

--- a/tests/evidence-mcp.test.mjs
+++ b/tests/evidence-mcp.test.mjs
@@ -102,14 +102,18 @@ describe("evidence-mcp", () => {
     assert.equal(url.searchParams.get("fields"), "subject,claim");
   });
 
-  test("evidenceQueryUrl clamps a non-numeric limit to the default", () => {
-    const url = evidenceQueryUrl({ limit: "lots" });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("evidenceQueryUrl rejects a non-numeric limit", () => {
+    assert.throws(
+      () => evidenceQueryUrl({ limit: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("evidenceQueryUrl clamps a sub-minimum numeric limit to the default", () => {
-    const url = evidenceQueryUrl({ limit: 0 });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("evidenceQueryUrl rejects a sub-minimum limit", () => {
+    assert.throws(
+      () => evidenceQueryUrl({ limit: 0 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
   test("evidenceQueryUrl rejects a fractional cursor", () => {
@@ -126,9 +130,11 @@ describe("evidence-mcp", () => {
     );
   });
 
-  test("evidenceQueryUrl clamps limit above the MCP maximum", () => {
-    const url = evidenceQueryUrl({ limit: 500 });
-    assert.equal(url.searchParams.get("limit"), "100");
+  test("evidenceQueryUrl rejects a limit above the MCP maximum", () => {
+    assert.throws(
+      () => evidenceQueryUrl({ limit: 500 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
   test("loadEvidenceList returns filtered rows with pagination meta", async () => {

--- a/tests/gaps-mcp.test.mjs
+++ b/tests/gaps-mcp.test.mjs
@@ -113,19 +113,25 @@ describe("gaps-mcp", () => {
     assert.equal(url.searchParams.get("fields"), "netuid,gap_count");
   });
 
-  test("gapsQueryUrl clamps a non-numeric limit to the default", () => {
-    const url = gapsQueryUrl({ limit: "lots" });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("gapsQueryUrl rejects a non-numeric limit", () => {
+    assert.throws(
+      () => gapsQueryUrl({ limit: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("gapsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
-    const url = gapsQueryUrl({ limit: 0 });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("gapsQueryUrl rejects a sub-minimum limit", () => {
+    assert.throws(
+      () => gapsQueryUrl({ limit: 0 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("gapsQueryUrl clamps limit above the MCP maximum", () => {
-    const url = gapsQueryUrl({ limit: 500 });
-    assert.equal(url.searchParams.get("limit"), "100");
+  test("gapsQueryUrl rejects a limit above the MCP maximum", () => {
+    assert.throws(
+      () => gapsQueryUrl({ limit: 500 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
   test("gapsQueryUrl rejects a fractional netuid", () => {

--- a/tests/providers-mcp.test.mjs
+++ b/tests/providers-mcp.test.mjs
@@ -120,14 +120,18 @@ describe("providers-mcp", () => {
     assert.equal(url.searchParams.get("fields"), "id,name");
   });
 
-  test("providersQueryUrl clamps a non-numeric limit to the default", () => {
-    const url = providersQueryUrl({ limit: "lots" });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("providersQueryUrl rejects a non-numeric limit", () => {
+    assert.throws(
+      () => providersQueryUrl({ limit: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("providersQueryUrl clamps a sub-minimum numeric limit to the default", () => {
-    const url = providersQueryUrl({ limit: 0 });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("providersQueryUrl rejects a sub-minimum limit", () => {
+    assert.throws(
+      () => providersQueryUrl({ limit: 0 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
   test("providersQueryUrl rejects a fractional cursor", () => {
@@ -144,9 +148,11 @@ describe("providers-mcp", () => {
     );
   });
 
-  test("providersQueryUrl clamps limit above the MCP maximum", () => {
-    const url = providersQueryUrl({ limit: 500 });
-    assert.equal(url.searchParams.get("limit"), "100");
+  test("providersQueryUrl rejects a limit above the MCP maximum", () => {
+    assert.throws(
+      () => providersQueryUrl({ limit: 500 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
   test("loadProvidersList returns filtered rows with pagination meta", async () => {

--- a/tests/search-index-mcp.test.mjs
+++ b/tests/search-index-mcp.test.mjs
@@ -102,20 +102,24 @@ describe("search-index-mcp", () => {
     assert.equal(url.searchParams.get("fields"), "id,title");
   });
 
-  test("searchIndexQueryUrl clamps a non-numeric limit to the default", () => {
-    const url = searchIndexQueryUrl({ limit: "lots" });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("searchIndexQueryUrl rejects a non-numeric limit", () => {
+    assert.throws(
+      () => searchIndexQueryUrl({ limit: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("searchIndexQueryUrl clamps a sub-minimum numeric limit to the default", () => {
-    const url = searchIndexQueryUrl({ limit: 0 });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("searchIndexQueryUrl rejects a sub-minimum limit", () => {
+    assert.throws(
+      () => searchIndexQueryUrl({ limit: 0 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("searchIndexQueryUrl clamps limit and rejects negative cursor", () => {
-    assert.equal(
-      searchIndexQueryUrl({ limit: 500 }).searchParams.get("limit"),
-      "100",
+  test("searchIndexQueryUrl rejects an out-of-range limit and negative cursor", () => {
+    assert.throws(
+      () => searchIndexQueryUrl({ limit: 500 }),
+      (err) => err.code === "invalid_params",
     );
     assert.throws(
       () => searchIndexQueryUrl({ cursor: -1 }),

--- a/tests/source-snapshots-mcp.test.mjs
+++ b/tests/source-snapshots-mcp.test.mjs
@@ -104,20 +104,24 @@ describe("source-snapshots-mcp", () => {
     assert.equal(url.searchParams.get("fields"), "id,kind");
   });
 
-  test("sourceSnapshotsQueryUrl clamps a non-numeric limit to the default", () => {
-    const url = sourceSnapshotsQueryUrl({ limit: "lots" });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("sourceSnapshotsQueryUrl rejects a non-numeric limit", () => {
+    assert.throws(
+      () => sourceSnapshotsQueryUrl({ limit: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("sourceSnapshotsQueryUrl clamps a sub-minimum numeric limit to the default", () => {
-    const url = sourceSnapshotsQueryUrl({ limit: 0 });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("sourceSnapshotsQueryUrl rejects a sub-minimum limit", () => {
+    assert.throws(
+      () => sourceSnapshotsQueryUrl({ limit: 0 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("sourceSnapshotsQueryUrl clamps limit and rejects negative cursor", () => {
-    assert.equal(
-      sourceSnapshotsQueryUrl({ limit: 500 }).searchParams.get("limit"),
-      "100",
+  test("sourceSnapshotsQueryUrl rejects an out-of-range limit and negative cursor", () => {
+    assert.throws(
+      () => sourceSnapshotsQueryUrl({ limit: 500 }),
+      (err) => err.code === "invalid_params",
     );
     assert.throws(
       () => sourceSnapshotsQueryUrl({ cursor: -1 }),

--- a/tests/surfaces-mcp.test.mjs
+++ b/tests/surfaces-mcp.test.mjs
@@ -118,14 +118,18 @@ describe("surfaces-mcp", () => {
     assert.equal(url.searchParams.get("fields"), "id,kind");
   });
 
-  test("surfacesQueryUrl clamps a non-numeric limit to the default", () => {
-    const url = surfacesQueryUrl({ limit: "lots" });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("surfacesQueryUrl rejects a non-numeric limit", () => {
+    assert.throws(
+      () => surfacesQueryUrl({ limit: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
-  test("surfacesQueryUrl clamps a sub-minimum numeric limit to the default", () => {
-    const url = surfacesQueryUrl({ limit: 0 });
-    assert.equal(url.searchParams.get("limit"), "50");
+  test("surfacesQueryUrl rejects a sub-minimum limit", () => {
+    assert.throws(
+      () => surfacesQueryUrl({ limit: 0 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
   test("surfacesQueryUrl rejects a fractional netuid", () => {
@@ -149,9 +153,11 @@ describe("surfaces-mcp", () => {
     );
   });
 
-  test("surfacesQueryUrl clamps limit above the MCP maximum", () => {
-    const url = surfacesQueryUrl({ limit: 500 });
-    assert.equal(url.searchParams.get("limit"), "100");
+  test("surfacesQueryUrl rejects a limit above the MCP maximum", () => {
+    assert.throws(
+      () => surfacesQueryUrl({ limit: 500 }),
+      (err) => err.code === "invalid_params",
+    );
   });
 
   test("loadSurfacesList returns filtered rows with pagination meta", async () => {


### PR DESCRIPTION
Closes #6569

## Summary

Nine MCP list-tool query builders — `evidence`, `curation`, `gaps`, `endpoint-pools`, `endpoint-incidents`, `search-index`, `source-snapshots`, `surfaces`, `providers` — shared a copy-pasted helper that threw `invalid_params` on a bad `cursor` but **silently coerced** an out-of-range or non-integer `limit` via `clampLimit(args.limit, 50, 100)`. So an agent's `limit: 500` was quietly rewritten to `100` with no signal — asymmetric with `cursor`, and divergent from the REST sibling (`workers/list-query.mjs`'s `validateListQuery`), which returns a 400 for the same input.

## What Changed

- In each of the 9 `src/*-mcp.mjs` files, `limit` validation is now **symmetric with `cursor`**: a non-integer or out-of-range (`< 1` or `> 100`) `limit` throws the same `invalid_params` tool error instead of being clamped. `100` matches each tool's own advertised `inputSchema` bound (`minimum: 1, maximum: 100`), so the message (`limit must be an integer between 1 and 100.`) is honest about the tool's real cap.
- The now-unused copy-pasted `clampLimit` helper is removed from each of the 9 files.
- Each file's existing clamp-behaviour tests are rewritten to assert the throw — covering the three rejection branches (non-integer, `< 1`, `> 100`) plus the unchanged valid path. 244 tests pass across the 9 suites.

Scope is exactly the 9 files named in the issue; other modules sharing the pattern (e.g. `adapter-candidates`, `enrichment-queue`) are intentionally left untouched.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6569`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none — MCP tool error semantics only; matches existing schema bounds)*

## Validation

- [x] `npx vitest run` on all 9 affected suites — 244 passing
- [x] Patch coverage — every added line + all 3 validation branches covered
- [x] `npx prettier --check` / `npx eslint` — clean
- [x] `git diff --check`
