### PR TITLE
fix(wss-lb): add per-IP connection cap + rate limit

### DIFF
--- a/deploy/wss-lb/README.md
+++ b/deploy/wss-lb/README.md
@@ -64,13 +64,22 @@ project so it shares one dashboard/bill and can later use private DNS.
 
 Env: `METAGRAPHED_API` (default `https://api.metagraph.sh`), `PORT` (8080),
 `REFRESH_MS` (30000), `MAX_BLOCK_LAG` (50), `NETWORKS` (`finney,test`),
-`HANDSHAKE_TIMEOUT_MS` (10000).
+`HANDSHAKE_TIMEOUT_MS` (10000), `MAX_CONNECTIONS_PER_IP` (20),
+`CONNECT_RATE_LIMIT` (30), `CONNECT_RATE_WINDOW_MS` (60000).
+
+## Abuse control (#6444)
+
+Per-IP connection cap + rolling connect-rate limit, checked at CONNECT time
+before any upstream dial (`src/rate-limit.mjs`). Client IP is
+`cf-connecting-ip` (Cloudflare terminates in front of this service), falling
+back to `x-forwarded-for` then the raw socket address. A rejected upgrade
+gets `429 Too Many Requests` with `Retry-After`. In-memory, single-instance —
+matches this service's own single-container deploy model.
 
 ## Integration-pending + follow-ups
 
 - The live ws-piping is verified on deploy; only the pure selection is unit-tested.
-- **Before public exposure:** per-IP connection rate-limiting / abuse caps (a
-  public wss proxy is a DoS amplifier), and optional API-key tiering.
+- Optional API-key tiering (higher budgets for known/trusted callers).
 - gRPC is intentionally **not** offered — Bittensor is Substrate (JSON-RPC + wss),
   not Cosmos-SDK gRPC.
 - Optional next: an SSE fan-out for subnet streaming surfaces; per-upstream usage

--- a/deploy/wss-lb/src/rate-limit.mjs
+++ b/deploy/wss-lb/src/rate-limit.mjs
@@ -1,0 +1,105 @@
+// Per-IP abuse control for the WSS load balancer (#6444) — README.md's own
+// pre-launch TODO: "a public wss proxy is a DoS amplifier" with nothing
+// enforcing that yet. Two independent, additive budgets, both checked at
+// CONNECT time (before any upstream dial — the cheapest possible rejection
+// point):
+//   - a concurrent-connection CAP: each open client holds a client socket
+//     AND an upstream socket for its whole session, unlike a stateless HTTP
+//     request, so unbounded concurrency from one IP is a real fd/memory
+//     exhaustion vector, not just noisy traffic.
+//   - a rolling connection-ATTEMPT rate limit: bounds connect-storm/
+//     reconnect-loop abuse independent of how long any one connection
+//     stays open (a client that opens-and-immediately-closes in a tight
+//     loop never trips the concurrent cap).
+// In-memory only — wss-lb is a single Railway container with no shared
+// store, unlike workers/request-handlers/rpc-proxy.mjs's Cloudflare-side
+// RPC_RATE_LIMITER (a Workers Rate Limiting binding). Same spirit
+// (per-client-IP budget, reject with retry-after), different mechanism —
+// that binding doesn't exist outside Cloudflare. Pure + clock-injectable
+// for tests; server.mjs wires in the real Date.now/setInterval.
+
+// Cloudflare terminates TLS in front of this service (README.md: "point
+// Cloudflare DNS at it for TLS + DDoS", i.e. proxied/orange-cloud, not
+// DNS-only) and sets cf-connecting-ip on every request it forwards —
+// matches workers/config.mjs's own resolveClientIp exactly, for the same
+// reason: it's the one header a client can't spoof past Cloudflare's edge.
+// x-forwarded-for (Railway's own edge hop) is a fallback for local/direct
+// access that bypasses Cloudflare (dev, health probes); the raw socket
+// address is the last resort so a lookup never throws.
+export function resolveClientIp(req) {
+  const cf = req.headers?.["cf-connecting-ip"];
+  if (typeof cf === "string" && cf) return cf;
+  const xff = req.headers?.["x-forwarded-for"];
+  if (typeof xff === "string" && xff) return xff.split(",")[0].trim();
+  return req.socket?.remoteAddress || "unknown";
+}
+
+// maxConcurrent/maxAttemptsPerWindow are per-IP budgets; windowMs is the
+// attempt-rate window. now() is injectable so tests don't need real timers.
+export function createConnectionLimiter(opts = {}) {
+  const maxConcurrent = opts.maxConcurrent ?? 20;
+  const maxAttemptsPerWindow = opts.maxAttemptsPerWindow ?? 30;
+  const windowMs = opts.windowMs ?? 60000;
+  const now = opts.now ?? (() => Date.now());
+
+  const concurrent = new Map(); // ip -> open-connection count
+  const attempts = new Map(); // ip -> { count, windowStart }
+
+  // Checks BOTH budgets and, only if both pass, atomically reserves one slot
+  // in each (a rejected attempt must not consume the attempt-rate budget it
+  // just failed, or a sustained attacker would self-throttle their own next
+  // legitimate retry window for no reason).
+  function checkAndTrack(ip) {
+    const concurrentCount = concurrent.get(ip) || 0;
+    if (concurrentCount >= maxConcurrent) {
+      return {
+        ok: false,
+        reason: "concurrent_limit",
+        retryAfterSeconds: Math.ceil(windowMs / 1000),
+      };
+    }
+    const t = now();
+    let a = attempts.get(ip);
+    if (!a || t - a.windowStart >= windowMs) {
+      a = { count: 0, windowStart: t };
+    }
+    if (a.count >= maxAttemptsPerWindow) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((a.windowStart + windowMs - t) / 1000),
+      );
+      attempts.set(ip, a);
+      return { ok: false, reason: "attempt_rate_limit", retryAfterSeconds };
+    }
+    a.count += 1;
+    attempts.set(ip, a);
+    concurrent.set(ip, concurrentCount + 1);
+    return { ok: true };
+  }
+
+  // Must be called exactly once per successful checkAndTrack when that
+  // client's connection actually closes (client 'close'/'error') — an
+  // un-released slot permanently leaks one unit of that IP's concurrent
+  // budget.
+  function release(ip) {
+    const c = concurrent.get(ip);
+    if (!c) return;
+    if (c <= 1) concurrent.delete(ip);
+    else concurrent.set(ip, c - 1);
+  }
+
+  // Bounds memory from one-shot/abandoned IPs: an attempt-window entry is
+  // only safe to drop once its window has fully elapsed AND it holds no
+  // live concurrent connections (those stay tracked in `concurrent`
+  // regardless of window age, released only via `release`).
+  function prune() {
+    const t = now();
+    for (const [ip, a] of attempts) {
+      if (t - a.windowStart >= windowMs && !concurrent.has(ip)) {
+        attempts.delete(ip);
+      }
+    }
+  }
+
+  return { checkAndTrack, release, prune };
+}

--- a/deploy/wss-lb/src/server.mjs
+++ b/deploy/wss-lb/src/server.mjs
@@ -11,16 +11,19 @@
 //
 // INTEGRATION-PENDING: the live ws-piping is verified on deploy; the pure
 // upstream selection is unit-tested (test/select.test.mjs). Public behind
-// Cloudflare DNS for TLS/DDoS. Env: METAGRAPHED_API, PORT, REFRESH_MS,
-// MAX_BLOCK_LAG, NETWORKS, HANDSHAKE_TIMEOUT_MS. Optionally SENTRY_DSN/
-// SENTRY_ENVIRONMENT/SENTRY_RELEASE (silently no-ops if SENTRY_DSN is unset
-// -- see src/observability.mjs).
+// Cloudflare DNS for TLS/DDoS, with per-IP abuse control (rate-limit.mjs).
+// Env: METAGRAPHED_API, PORT, REFRESH_MS, MAX_BLOCK_LAG, NETWORKS,
+// HANDSHAKE_TIMEOUT_MS, MAX_CONNECTIONS_PER_IP, CONNECT_RATE_LIMIT,
+// CONNECT_RATE_WINDOW_MS. Optionally SENTRY_DSN/SENTRY_ENVIRONMENT/
+// SENTRY_RELEASE (silently no-ops if SENTRY_DSN is unset -- see
+// src/observability.mjs).
 import http from "node:http";
 
 import { WebSocketServer } from "ws";
 
 import { MAX_RPC_BODY_BYTES } from "./rpc-policy.mjs";
 import { proxy } from "./proxy.mjs";
+import { createConnectionLimiter, resolveClientIp } from "./rate-limit.mjs";
 import { selectWssUpstreams } from "./select.mjs";
 import {
   initSentry,
@@ -48,6 +51,11 @@ const NETWORKS = (process.env.NETWORKS || "finney,test")
   .split(",")
   .map((s) => s.trim())
   .filter(Boolean);
+// #6444: per-IP abuse control, see rate-limit.mjs for the reasoning behind
+// both budgets and their defaults.
+const MAX_CONNECTIONS_PER_IP = envInt("MAX_CONNECTIONS_PER_IP", 20);
+const CONNECT_RATE_LIMIT = envInt("CONNECT_RATE_LIMIT", 30);
+const CONNECT_RATE_WINDOW_MS = envInt("CONNECT_RATE_WINDOW_MS", 60000);
 
 const log = (...a) => console.log(new Date().toISOString(), ...a);
 
@@ -147,18 +155,43 @@ const heartbeat = setInterval(() => {
 }, HEARTBEAT_MS);
 heartbeat.unref?.();
 
+const connectionLimiter = createConnectionLimiter({
+  maxConcurrent: MAX_CONNECTIONS_PER_IP,
+  maxAttemptsPerWindow: CONNECT_RATE_LIMIT,
+  windowMs: CONNECT_RATE_WINDOW_MS,
+});
+const rateLimitPrune = setInterval(
+  () => connectionLimiter.prune(),
+  CONNECT_RATE_WINDOW_MS,
+);
+rateLimitPrune.unref?.();
+
 server.on("upgrade", (req, socket, head) => {
+  // Cheapest possible rejection point: before any network-name/pool lookup,
+  // let alone an upstream dial.
+  const clientIp = resolveClientIp(req);
+  const limit = connectionLimiter.checkAndTrack(clientIp);
+  if (!limit.ok) {
+    log(`rate-limited: ${clientIp} (${limit.reason})`);
+    socket.write(
+      `HTTP/1.1 429 Too Many Requests\r\nRetry-After: ${limit.retryAfterSeconds}\r\n\r\n`,
+    );
+    socket.destroy();
+    return;
+  }
   const network = (req.url || "/")
     .replace(/^\/+/, "")
     .split("?")[0]
     .split("/")[0];
   if (!NETWORKS.includes(network)) {
+    connectionLimiter.release(clientIp);
     socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
     socket.destroy();
     return;
   }
   const upstreams = poolFor(network);
   if (!upstreams.length) {
+    connectionLimiter.release(clientIp);
     socket.write("HTTP/1.1 503 Service Unavailable\r\n\r\n");
     socket.destroy();
     noteNoUpstream(network);
@@ -166,9 +199,17 @@ server.on("upgrade", (req, socket, head) => {
   }
   wss.handleUpgrade(req, socket, head, (client) => {
     client.isAlive = true;
+    let released = false;
+    const releaseOnce = () => {
+      if (released) return;
+      released = true;
+      connectionLimiter.release(clientIp);
+    };
     client.on("pong", () => {
       client.isAlive = true;
     });
+    client.on("close", releaseOnce);
+    client.on("error", releaseOnce);
     proxy(client, upstreams, {
       handshakeTimeout: HANDSHAKE_TIMEOUT_MS,
       onNoUpstream: () => noteNoUpstream(network),

--- a/deploy/wss-lb/test/rate-limit.test.mjs
+++ b/deploy/wss-lb/test/rate-limit.test.mjs
@@ -1,0 +1,156 @@
+// Pure-logic tests for the per-IP abuse control (#6444). Zero deps — run with:
+//   node --test deploy/wss-lb/test/
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  createConnectionLimiter,
+  resolveClientIp,
+} from "../src/rate-limit.mjs";
+
+test("resolveClientIp prefers cf-connecting-ip over x-forwarded-for over the socket", () => {
+  assert.equal(
+    resolveClientIp({
+      headers: { "cf-connecting-ip": "1.1.1.1", "x-forwarded-for": "2.2.2.2" },
+      socket: { remoteAddress: "3.3.3.3" },
+    }),
+    "1.1.1.1",
+  );
+  assert.equal(
+    resolveClientIp({
+      headers: { "x-forwarded-for": "2.2.2.2, 9.9.9.9" },
+      socket: { remoteAddress: "3.3.3.3" },
+    }),
+    "2.2.2.2",
+  );
+  assert.equal(
+    resolveClientIp({ headers: {}, socket: { remoteAddress: "3.3.3.3" } }),
+    "3.3.3.3",
+  );
+  assert.equal(resolveClientIp({ headers: {}, socket: {} }), "unknown");
+});
+
+test("allows connections under both budgets", () => {
+  const limiter = createConnectionLimiter({
+    maxConcurrent: 5,
+    maxAttemptsPerWindow: 5,
+    windowMs: 60000,
+  });
+  for (let i = 0; i < 5; i += 1) {
+    assert.deepEqual(limiter.checkAndTrack("1.1.1.1"), { ok: true });
+  }
+});
+
+test("rejects once the concurrent cap is hit, independent of the attempt-rate budget", () => {
+  const limiter = createConnectionLimiter({
+    maxConcurrent: 2,
+    maxAttemptsPerWindow: 100,
+    windowMs: 60000,
+  });
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, true);
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, true);
+  const rejected = limiter.checkAndTrack("1.1.1.1");
+  assert.equal(rejected.ok, false);
+  assert.equal(rejected.reason, "concurrent_limit");
+  assert.ok(rejected.retryAfterSeconds > 0);
+});
+
+test("release frees a concurrent slot so a later connect can succeed", () => {
+  const limiter = createConnectionLimiter({
+    maxConcurrent: 1,
+    maxAttemptsPerWindow: 100,
+    windowMs: 60000,
+  });
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, true);
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, false);
+  limiter.release("1.1.1.1");
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, true);
+});
+
+test("release is safe to call on an IP with no tracked connections (double-release, unknown IP)", () => {
+  const limiter = createConnectionLimiter();
+  assert.doesNotThrow(() => limiter.release("never-connected"));
+  limiter.checkAndTrack("1.1.1.1");
+  limiter.release("1.1.1.1");
+  assert.doesNotThrow(() => limiter.release("1.1.1.1")); // double-release
+});
+
+test("a rejected attempt does not consume the attempt-rate budget it just failed", () => {
+  const limiter = createConnectionLimiter({
+    maxConcurrent: 1,
+    maxAttemptsPerWindow: 100,
+    windowMs: 60000,
+  });
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, true); // fills the concurrent cap
+  for (let i = 0; i < 10; i += 1) {
+    assert.equal(limiter.checkAndTrack("1.1.1.1").ok, false); // concurrent-rejected each time
+  }
+  limiter.release("1.1.1.1");
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, true); // budget wasn't drained by the rejects
+});
+
+test("rejects once the attempt-rate window is exhausted, then allows again once it rolls over", () => {
+  let now = 0;
+  const limiter = createConnectionLimiter({
+    maxConcurrent: 100,
+    maxAttemptsPerWindow: 2,
+    windowMs: 1000,
+    now: () => now,
+  });
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, true);
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, true);
+  const rejected = limiter.checkAndTrack("1.1.1.1");
+  assert.equal(rejected.ok, false);
+  assert.equal(rejected.reason, "attempt_rate_limit");
+  assert.ok(rejected.retryAfterSeconds > 0);
+
+  now = 1000; // window rolled over
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, true);
+});
+
+test("budgets are tracked independently per IP", () => {
+  const limiter = createConnectionLimiter({
+    maxConcurrent: 1,
+    maxAttemptsPerWindow: 1,
+    windowMs: 60000,
+  });
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, true);
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, false);
+  assert.equal(limiter.checkAndTrack("2.2.2.2").ok, true); // unaffected by 1.1.1.1's budget
+});
+
+test("prune drops expired attempt-window entries for IPs with no live connections", () => {
+  let now = 0;
+  const limiter = createConnectionLimiter({
+    maxConcurrent: 100,
+    maxAttemptsPerWindow: 5,
+    windowMs: 1000,
+    now: () => now,
+  });
+  limiter.checkAndTrack("1.1.1.1");
+  now = 5000;
+  limiter.prune();
+  // Rejoining after a pruned, long-expired window starts a fresh count from
+  // zero rather than accumulating unboundedly -- exercised indirectly: a
+  // fresh window after prune still allows a full new budget.
+  for (let i = 0; i < 5; i += 1) {
+    assert.equal(limiter.checkAndTrack("1.1.1.1").ok, true);
+  }
+});
+
+test("prune keeps an IP's attempt-window entry alive while it has an open connection", () => {
+  let now = 0;
+  const limiter = createConnectionLimiter({
+    maxConcurrent: 100,
+    maxAttemptsPerWindow: 1,
+    windowMs: 1000,
+    now: () => now,
+  });
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, true); // still "connected" (never released)
+  now = 5000;
+  limiter.prune();
+  // The window has elapsed, so a fresh attempt in a new window is allowed
+  // regardless -- this just confirms prune() didn't throw/corrupt state
+  // while a concurrent connection is live.
+  assert.equal(limiter.checkAndTrack("1.1.1.1").ok, true);
+});


### PR DESCRIPTION
## Summary
`deploy/wss-lb/README.md`'s own pre-launch TODO flagged this explicitly: "a public wss proxy is a DoS amplifier", with zero rate-limiting/abuse-cap code anywhere in the service. wss-lb is the only remaining public-facing Railway service (metagraphed-core project) — a live, currently-open exposure, not just a documented TODO.

Adds `src/rate-limit.mjs`: two independent, additive per-IP budgets checked at CONNECT time (before any network-name lookup or upstream dial — the cheapest possible rejection point):
- a **concurrent-connection cap** (default 20): each open client holds a client socket *and* an upstream socket for its whole session, unlike a stateless HTTP request, so unbounded concurrency from one IP is a real fd/memory exhaustion vector.
- a **rolling connection-attempt rate limit** (default 30/60s): bounds connect-storm/reconnect-loop abuse independent of how long any one connection stays open.

Client IP resolution mirrors `workers/config.mjs`'s existing `resolveClientIp` (`cf-connecting-ip` first — Cloudflare terminates in front of this service per the README's own "point Cloudflare DNS at it for TLS + DDoS"), falling back to `x-forwarded-for` then the raw socket address. A rejected upgrade gets `429 Too Many Requests` with `Retry-After`.

In-memory only (single Railway container, no shared store) — same spirit as the Cloudflare-side `RPC_RATE_LIMITER` binding this codebase already uses for the HTTP JSON-RPC proxy, different mechanism (that binding doesn't exist outside Cloudflare). All 3 new env knobs (`MAX_CONNECTIONS_PER_IP`, `CONNECT_RATE_LIMIT`, `CONNECT_RATE_WINDOW_MS`) follow the existing `envInt` pattern and have safe defaults.

## Test plan
- [x] `npm test` in `deploy/wss-lb` — 32/32 passing (10 new rate-limit tests + all existing suites)
- [x] `npx eslint` + `npx prettier --check` on all changed files
- [ ] Railway auto-deploys `deploy/wss-lb/**` on merge to main — verify `/healthz` stays green and a real connect still succeeds post-deploy