### PR TITLE
fix(ui): return focus to the opener when the schema-drift dialog closes (#6555)

### DIFF
--- a/apps/ui/src/components/metagraphed/schema-drift-detail.test.ts
+++ b/apps/ui/src/components/metagraphed/schema-drift-detail.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { shouldRestoreFocus } from "./schema-drift-detail";
+
+// #6555: SchemaDriftDetail is a URL-param-driven Dialog with no in-tree
+// <DialogTrigger>, so Radix dropped focus to <body> on close. It now records the
+// element focused on open and restores it in onCloseAutoFocus (the api-drawer.tsx
+// #6418 pattern). The component needs the full app shell to render, so — matching
+// api-source-context.test.tsx — the wiring is asserted on source; the pure focus
+// guard is unit-tested directly.
+
+// This suite runs in a plain node environment (no DOM), so exercise the guard
+// with duck-typed stand-ins for the one property it reads (isConnected) rather
+// than real elements.
+const fakeEl = (isConnected: boolean) => ({ isConnected }) as unknown as HTMLElement;
+
+describe("shouldRestoreFocus", () => {
+  it("is false for null", () => {
+    expect(shouldRestoreFocus(null)).toBe(false);
+  });
+
+  it("is false for a detached element (removed from the DOM before close)", () => {
+    expect(shouldRestoreFocus(fakeEl(false))).toBe(false);
+  });
+
+  it("is true for an element still in the document", () => {
+    expect(shouldRestoreFocus(fakeEl(true))).toBe(true);
+  });
+});
+
+const source = readFileSync(
+  fileURLToPath(new URL("./schema-drift-detail.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("SchemaDriftDetail returns focus to its opener on close (#6555)", () => {
+  it("records document.activeElement when the dialog opens", () => {
+    expect(source).toContain("restoreFocusRef");
+    expect(source).toContain("document.activeElement");
+    // the capture is gated on `open` so it happens at open time, not on every render
+    expect(source).toMatch(/if\s*\(open\)/);
+  });
+
+  it("restores focus in the Dialog's onCloseAutoFocus, preventing Radix's default", () => {
+    expect(source).toContain("onCloseAutoFocus");
+    const handler = source.slice(source.indexOf("onCloseAutoFocus"));
+    expect(handler).toContain("shouldRestoreFocus");
+    expect(handler).toContain("event.preventDefault()");
+    expect(handler).toContain(".focus()");
+  });
+});

--- a/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
+++ b/apps/ui/src/components/metagraphed/schema-drift-detail.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { Link } from "@tanstack/react-router";
 import { Copy, Check, ExternalLink as ExternalIcon } from "lucide-react";
 import {
@@ -23,15 +24,41 @@ interface Props {
   onOpenInExplorer?: (id: string) => void;
 }
 
+/** #6555: whether a captured opener element is still worth restoring focus to
+ *  (present and still in the document) — pure so it can be unit-tested. */
+export function shouldRestoreFocus(el: HTMLElement | null): el is HTMLElement {
+  return el != null && el.isConnected;
+}
+
 /**
  * Modal that explains what changed in a drifting schema: a compact field/line
  * diff, a derived compatibility-impact chip row, and evidence links so the
  * user can verify against the underlying snapshots.
  */
 export function SchemaDriftDetail({ schema, open, onOpenChange, onOpenInExplorer }: Props) {
+  // #6555: this Dialog is driven by a URL search param and has no in-tree
+  // <DialogTrigger>, so Radix has no trigger to auto-restore focus to on close
+  // and drops it to <body>. Mirror api-drawer.tsx (#6418): record the element
+  // focused when the dialog opens, and restore it in onCloseAutoFocus.
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (open) {
+      restoreFocusRef.current = (document.activeElement as HTMLElement | null) ?? null;
+    }
+  }, [open]);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl">
+      <DialogContent
+        className="max-w-3xl"
+        onCloseAutoFocus={(event) => {
+          const el = restoreFocusRef.current;
+          if (shouldRestoreFocus(el)) {
+            event.preventDefault();
+            el.focus();
+          }
+        }}
+      >
         {schema ? (
           <DriftBody
             schema={schema}


### PR DESCRIPTION
## Summary

`SchemaDriftDetail` renders a `Dialog` whose `open` state is driven purely by a URL search param (`driftDetail`), with **no in-tree `<DialogTrigger>`**. Radix can only auto-restore focus to a trigger it tracked when the dialog opened; with none here and no manual handler, closing the dialog (Escape, close button, outside click) drops keyboard focus to `<body>` instead of the row that opened it — a regression for keyboard and screen-reader users navigating the drift-activity list.

This is a missed instance of a defect class already fixed three times in this app (`stake-unstake-modal.tsx`, `take-management-modal.tsx`, `api-drawer.tsx`).

## Fix

Mirror the `api-drawer.tsx` pattern (#6418), which the issue names as the right one since this dialog — like `api-drawer` — has no in-tree trigger to wrap:

- Record `document.activeElement` in a ref when the dialog opens (`useEffect` gated on `open`).
- Restore it in `DialogContent`'s `onCloseAutoFocus`, calling `event.preventDefault()` so Radix's default body-focus is overridden.
- The focus guard is factored into a pure, exported `shouldRestoreFocus(el)` (present **and** still connected).

The dialog's open/close URL-state wiring is untouched — only focus restoration is added. This is a focus-behavior-only change with no visual delta; the before/after screenshots below are identical by design and confirm no visual regression.

## Tests

`schema-drift-detail.test.ts`:
- Unit tests for `shouldRestoreFocus` (null / detached / connected), duck-typed to the node test environment this suite uses (no jsdom).
- Source assertions that the component records `document.activeElement` at open time and wires `onCloseAutoFocus` → `shouldRestoreFocus` + `preventDefault()` + `.focus()` — matching the `api-source-context.test.ts` (#6418) precedent, since the component needs the full app shell + router to render.

## Validation

- `npm test --workspace=apps/ui` → full suite passed (5 new)
- `npm run typecheck --workspace=apps/ui` → clean · `npm run lint --workspace=apps/ui` → clean · `npx prettier --check` → clean
- `npm run build --workspace=apps/ui` → clean

## Screenshots (`/schemas` — visually unchanged; focus-behavior-only fix)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6555-schema-drift-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6555
