### PR TITLE
fix(ui): add an Emissions CSV export to the leaderboards action bar

### DIFF
--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -86,6 +86,11 @@ function LeaderboardsPage() {
               label="Deregistrations CSV"
               bare
             />
+            {/* #6577: EmissionsLeaderboard mirrors the weight-setting/dereg board
+                structure but its /api/v1/economics source had no export button.
+                Unlike the two above it is not window-scoped (the endpoint 400s on
+                a window param), so no window is passed. */}
+            <DownloadCsvButton url={buildUrl("/api/v1/economics")} label="Emissions CSV" bare />
             <ShareButton bare />
           </ActionBar>
         }


### PR DESCRIPTION
## What & why

`/leaderboards` renders three boards but wires CSV export for only two of them. The page `ActionBar` has a **Weight-setting CSV** (`/api/v1/chain/weights`) and a **Deregistrations CSV** (`/api/v1/chain/deregistrations`), but `EmissionsLeaderboard` — whose own comment notes it "mirrors the weight-setting/deregistrations board structure" and which sources from `/api/v1/economics` — had no export. (`/api/v1/economics` is already listed in the page's `ApiSourceFooter`, so the page already knew the endpoint; it just wasn't exportable.)

## Approach

Add a third `DownloadCsvButton` to the `ActionBar`, pointed at `/api/v1/economics`, labeled **Emissions CSV**, with the same `bare` prop and placement as the two existing buttons.

One deliberate difference from its siblings: it passes **no** `window` param. `economicsQuery()` takes no window, and `/api/v1/economics?window=…` returns `400` — the emissions board isn't window-scoped — so the export matches exactly what the board shows. Verified `/api/v1/economics?format=csv` returns `text/csv` (200), same as the sibling endpoints.

## Verification

Full Phase C3 preflight (same steps/order as the `ui` CI job):

| Step | Command | Result |
| --- | --- | --- |
| lint | `npm run lint --workspace=apps/ui` | 0 errors |
| format | `npm run format:check --workspace=apps/ui` | clean |
| typecheck | `npm run typecheck --workspace=apps/ui` | clean |
| unit | `npm test --workspace=apps/ui` | 155 files, 1138 tests passed |
| build | `npm run build --workspace=apps/ui` | green |

Drove `/leaderboards` end to end: the action bar now shows all three CSV buttons and the Emissions one resolves to `/api/v1/economics?format=csv`.

## Screenshots

Phase C2 contract (fixed viewports, never full-page, themes forced via `mg-theme`), anchored on the page-top `ActionBar` — `before` has two CSV buttons, `after` has the third **Emissions CSV**.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6577-emissions-csv-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6577
