### PR TITLE
test(python): cover the providers() convenience method in both clients

### DIFF
--- a/python/tests/test_aio.py
+++ b/python/tests/test_aio.py
@@ -338,6 +338,43 @@ class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(endpoint.raw["id"], "ep-sn-7-subnet-api")
         self.assertFalse(hasattr(endpoint, "base_url"))
 
+    async def test_providers_returns_typed_models(self):
+        # Providers index rows expose the slug as `id` (Provider aliases it),
+        # plus name / authority / surface_count.
+        client = self._client(
+            httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "providers": [
+                            {
+                                "id": "macrocosmos",
+                                "name": "Macrocosmos",
+                                "authority": "official",
+                                "surface_count": 12,
+                            }
+                        ]
+                    },
+                    "meta": {
+                        "pagination": {
+                            "collection": "providers",
+                            "next_cursor": None,
+                        }
+                    },
+                },
+            )
+        )
+        providers = await client.providers(authority="official")
+        self.assertEqual(len(providers), 1)
+        provider = providers[0]
+        self.assertIsInstance(provider, Provider)
+        self.assertEqual(provider.slug, "macrocosmos")
+        self.assertEqual(provider.name, "Macrocosmos")
+        self.assertEqual(provider.authority, "official")
+        self.assertEqual(provider.surface_count, 12)
+        self.assertEqual(provider.raw["id"], "macrocosmos")
+        self.assertEqual(client._client.calls[0][2], {"authority": "official"})
+
     async def test_get_provider_returns_typed_provider(self):
         client = self._client(
             httpx.Response(

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -834,6 +834,47 @@ class FetchAllAndModelsTest(unittest.TestCase):
         )
         self.assertIs(endpoint.raw["unknown_extra"], True)
 
+    def test_providers_convenience_returns_typed_models(self):
+        # Realistic providers-index row shape: the API exposes the slug as `id`
+        # (Provider aliases it), plus name / authority / surface_count.
+        captured_urls = []
+        page = {
+            "data": {
+                "providers": [
+                    {
+                        "id": "macrocosmos",
+                        "name": "Macrocosmos",
+                        "authority": "official",
+                        "surface_count": 12,
+                    }
+                ]
+            },
+            "meta": {
+                "pagination": {
+                    "collection": "providers",
+                    "next_cursor": None,
+                }
+            },
+        }
+
+        def fake_urlopen(request, timeout=None):
+            captured_urls.append(request.full_url)
+            return _FakeResponse(page)
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            providers = MetagraphedClient().providers(authority="official")
+
+        self.assertEqual(len(providers), 1)
+        provider = providers[0]
+        self.assertIsInstance(provider, Provider)
+        self.assertEqual(provider.slug, "macrocosmos")
+        self.assertEqual(provider.name, "Macrocosmos")
+        self.assertEqual(provider.authority, "official")
+        self.assertEqual(provider.surface_count, 12)
+        self.assertEqual(provider.raw["id"], "macrocosmos")
+        # Query kwargs reach fetch_all and land on the request URL.
+        self.assertIn("authority=official", captured_urls[0])
+
     def test_get_provider_returns_typed_provider(self):
         def fake_urlopen(request, timeout=None):
             self.assertIn("/api/v1/providers/macrocosmos", request.full_url)


### PR DESCRIPTION
## What

Adds the missing client-level test coverage for the Python SDK's `providers()` convenience method on both `MetagraphedClient` and `AsyncMetagraphedClient`.

Before this change, `providers()` was the only one of the five typed convenience methods (`subnets`, `surfaces`, `endpoints`, `providers`, `agent_catalog`) without a matching client-level test in `python/tests/test_client.py` / `python/tests/test_aio.py`. The only existing "providers" test (`test_provider_slug_aliases_the_api_id_key`) exercises `Provider.from_dict` directly, not the client method (which routes through `fetch_all` + `Provider.list_from`).

## Changes

- `python/tests/test_client.py`: `test_providers_convenience_returns_typed_models` — mocks the `/api/v1/providers` list response, calls `.providers(authority="official")`, asserts typed `Provider` instances parse (name / authority / surface_count and the `id`→`slug` alias) and that the query kwarg reaches the request URL.
- `python/tests/test_aio.py`: `test_providers_returns_typed_models` — the async equivalent, additionally asserting the kwarg is forwarded to `fetch_all` via the recorded call params.

Both follow the exact structure of the existing `test_surfaces_*` / `test_endpoints_*` siblings.

## Verification

```
$ cd python && uv run --extra test python -m unittest discover -s tests
Ran 72 tests in 0.360s
OK (skipped=1)
```

Test-only change — no production source touched.

Closes #6585
