### PR TITLE
feat(api): add list-query pagination to /api/v1/rpc/pools + its MCP tool (#6570)

### DIFF
--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -273,6 +273,17 @@ export const API_QUERY_COLLECTIONS = {
     sort: ["eligible_count", "endpoint_count", "id", "kind"],
     rangeFilters: ["eligible_count", "endpoint_count"],
   }),
+  // rpc/pools is the RPC-specific sibling of endpoint-pools; the artifact is the
+  // same pool shape (pools[].{id,kind,eligible_count,endpoint_count}), so it
+  // takes the identical list-query surface (#6570).
+  "rpc-pools": queryCollection("pools", {
+    filters: {
+      id: filterTextSchema,
+      kind: enumSchema(["subtensor-rpc", "subtensor-wss", "archive"]),
+    },
+    sort: ["eligible_count", "endpoint_count", "id", "kind"],
+    rangeFilters: ["eligible_count", "endpoint_count"],
+  }),
   "endpoint-incidents": queryCollection("incidents", {
     filters: {
       netuid: integerSchema,
@@ -3885,6 +3896,7 @@ export const API_ROUTES = [
     "Fetch endpoint pool scores.",
     "short",
     ["rpc"],
+    listQuery("rpc-pools"),
   ),
   route(
     "endpoint-pools",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -162,8 +162,11 @@ import {
   LIST_ENDPOINT_POOLS_INSTRUCTIONS,
   LIST_ENDPOINT_POOLS_MCP_TOOL,
   LIST_ENDPOINT_POOLS_OUTPUT_SCHEMA,
+  endpointPoolsMcpError,
+  endpointPoolsQueryUrl,
   loadEndpointPoolsList,
 } from "./endpoint-pools-mcp.mjs";
+import { applyQueryFilters } from "../workers/list-query.mjs";
 import {
   LIST_ENDPOINT_INCIDENTS_INSTRUCTIONS,
   LIST_ENDPOINT_INCIDENTS_MCP_TOOL,
@@ -8854,10 +8857,13 @@ export const MCP_TOOLS = [
       "GET /api/v1/rpc/pools.",
     inputSchema: {
       type: "object",
-      properties: {},
+      // rpc/pools is the same pool shape as endpoint-pools, so it takes the
+      // identical list-query surface (id/kind filter, count thresholds, sort,
+      // limit/cursor). Reuse that tool's argument schema (#6570).
+      properties: { ...LIST_ENDPOINT_POOLS_MCP_TOOL.inputSchema.properties },
       additionalProperties: false,
     },
-    async handler(_args, ctx) {
+    async handler(args, ctx) {
       const staticData = await loadArtifactData(
         ctx,
         "/metagraph/rpc/pools.json",
@@ -8865,12 +8871,13 @@ export const MCP_TOOLS = [
       const livePool = ctx.readHealthKv
         ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
         : null;
+      let blob = staticData;
       if (
         livePool &&
         Array.isArray(livePool.endpoints) &&
         Array.isArray(staticData?.pools)
       ) {
-        return {
+        blob = {
           ...staticData,
           source: "live-cron-prober",
           operational_observed_at: livePool.last_run_at || null,
@@ -8879,7 +8886,37 @@ export const MCP_TOOLS = [
           ),
         };
       }
-      return staticData;
+      // Page/filter/sort the (possibly live-overlaid) pools with the same
+      // machinery the REST route now uses. Overlay first so eligibility fields
+      // are present before filtering. The arg surface matches
+      // list_endpoint_pools, so its query-url builder is reused (#6570).
+      if (!blob || !Array.isArray(blob.pools)) return blob;
+      const transformed = applyQueryFilters(
+        blob,
+        endpointPoolsQueryUrl(args),
+        "rpc-pools",
+        [],
+      );
+      if (transformed.error) {
+        throw endpointPoolsMcpError(
+          "invalid_params",
+          transformed.error.message,
+        );
+      }
+      const { data, meta } = transformed;
+      const page = meta.pagination || {};
+      const rows = Array.isArray(data.pools) ? data.pools : [];
+      const rowLen = rows.length;
+      return {
+        ...data,
+        total: page.total ?? rowLen,
+        returned: page.returned ?? rowLen,
+        limit: page.limit ?? rowLen,
+        cursor: page.cursor ?? 0,
+        next_cursor: page.next_cursor ?? null,
+        sort: page.sort ?? null,
+        order: page.order ?? null,
+      };
     },
   },
   {
@@ -13483,6 +13520,13 @@ const TOOL_OUTPUT_SCHEMAS = {
       pools: { type: "array", items: { type: "object" } },
       generated_at: NULLABLE_STRING,
       schema_version: { type: ["string", "integer", "null"] },
+      total: { type: "integer" },
+      returned: { type: "integer" },
+      limit: { type: "integer" },
+      cursor: { type: "integer" },
+      next_cursor: NULLABLE_INT,
+      sort: NULLABLE_STRING,
+      order: NULLABLE_STRING,
     },
   },
   list_profile_completeness: {

--- a/tests/rpc-pools-mcp.test.mjs
+++ b/tests/rpc-pools-mcp.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { MCP_TOOLS } from "../src/mcp-server.mjs";
+
+// #6570: list_rpc_pools mirrors GET /api/v1/rpc/pools, which is now listQuery-
+// registered. The tool applies the same filter/sort/paginate machinery over the
+// (optionally live-overlaid) /metagraph/rpc/pools.json pools array.
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  schema_version: 1,
+  notes: "test",
+  pools: [
+    {
+      id: "finney-rpc",
+      kind: "subtensor-rpc",
+      eligible_count: 2,
+      endpoint_count: 5,
+    },
+    {
+      id: "finney-wss",
+      kind: "subtensor-wss",
+      eligible_count: 8,
+      endpoint_count: 10,
+    },
+    {
+      id: "finney-archive",
+      kind: "archive",
+      eligible_count: 0,
+      endpoint_count: 3,
+    },
+  ],
+};
+
+const tool = MCP_TOOLS.find((t) => t.name === "list_rpc_pools");
+
+function ctx(overrides = {}) {
+  return {
+    env: {},
+    readArtifact: async () => ({
+      ok: true,
+      data: structuredClone(SAMPLE_BLOB),
+    }),
+    readHealthKv: async () => null,
+    ...overrides,
+  };
+}
+
+describe("list_rpc_pools list-query support (#6570)", () => {
+  test("exposes pagination/filter arguments (no longer an empty schema)", () => {
+    const props = tool.inputSchema.properties;
+    for (const key of ["id", "kind", "sort", "order", "limit", "cursor"]) {
+      assert.ok(key in props, `expected inputSchema arg \`${key}\``);
+    }
+  });
+
+  test("limit + cursor page the pool list with pagination meta", async () => {
+    const res = await tool.handler({ limit: 1 }, ctx());
+    assert.equal(res.pools.length, 1);
+    assert.equal(res.total, 3);
+    assert.equal(res.returned, 1);
+    assert.equal(res.limit, 1);
+    assert.equal(res.next_cursor, 1);
+    // top-level artifact fields survive the transform
+    assert.equal(res.generated_at, SAMPLE_BLOB.generated_at);
+  });
+
+  test("sort + order orders before paging", async () => {
+    const res = await tool.handler(
+      { sort: "eligible_count", order: "desc" },
+      ctx(),
+    );
+    assert.deepEqual(
+      res.pools.map((p) => p.id),
+      ["finney-wss", "finney-rpc", "finney-archive"],
+    );
+    assert.equal(res.sort, "eligible_count");
+    assert.equal(res.order, "desc");
+  });
+
+  test("kind filter narrows the collection", async () => {
+    const res = await tool.handler({ kind: "archive" }, ctx());
+    assert.deepEqual(
+      res.pools.map((p) => p.id),
+      ["finney-archive"],
+    );
+  });
+
+  test("invalid cursor is rejected (not silently coerced)", async () => {
+    await assert.rejects(() => tool.handler({ cursor: -1 }, ctx()), /cursor/);
+  });
+
+  test("invalid sort field is rejected", async () => {
+    await assert.rejects(
+      () => tool.handler({ sort: "not_a_field" }, ctx()),
+      /sort/,
+    );
+  });
+
+  test("an unknown fields projection surfaces as an invalid-params error", async () => {
+    await assert.rejects(
+      () => tool.handler({ fields: "definitely_not_a_pool_field" }, ctx()),
+      /fields/,
+    );
+  });
+
+  test("a non-list artifact (no pools array) is returned untransformed", async () => {
+    const res = await tool.handler(
+      { limit: 5 },
+      ctx({
+        readArtifact: async () => ({
+          ok: true,
+          data: { generated_at: "2026-07-01T00:00:00.000Z", schema_version: 1 },
+        }),
+      }),
+    );
+    assert.equal(res.pools, undefined);
+    assert.equal(res.generated_at, "2026-07-01T00:00:00.000Z");
+  });
+
+  test("live pool overlay is applied before filtering", async () => {
+    const res = await tool.handler(
+      { limit: 5 },
+      ctx({
+        readHealthKv: async () => ({
+          endpoints: [],
+          last_run_at: "2026-07-01T01:00:00.000Z",
+        }),
+      }),
+    );
+    assert.equal(res.source, "live-cron-prober");
+    assert.equal(res.operational_observed_at, "2026-07-01T01:00:00.000Z");
+    assert.equal(res.pools.length, 3);
+  });
+});


### PR DESCRIPTION
## Summary

 was registered with no `listQuery`, so any `?limit`/`?cursor`/`?sort`/`?q` returned a 400 "unknown query parameter" -- unlike its generalized sibling `/api/v1/endpoint-pools`, which is fully paginated. The `/metagraph/rpc/pools.json` artifact is the same pool shape (`pools[].{id,kind,eligible_count,endpoint_count}`), so it takes the identical list-query surface.

## What Changed

- **contracts.mjs:** added the `"rpc-pools"` `queryCollection` (mirroring `endpoint-pools` -- same filters, sort fields, and range filters) and `listQuery("rpc-pools")` on the route.
- **mcp-server.mjs:** `list_rpc_pools` now exposes the same `id`/`kind`/count-threshold/`sort`/`order`/`limit`/`cursor` args as `list_endpoint_pools`, and applies them via `applyQueryFilters` over the (optionally live-overlaid) pools. The live-eligibility overlay is applied **first**, then paging/filtering, so the results stay consistent with the pre-existing live behavior. Reuses `endpointPoolsQueryUrl` since the argument surface is identical.
- **tests:** `tests/rpc-pools-mcp.test.mjs` covers pagination, sort+order, kind filter, invalid cursor/sort/fields rejection, the non-list-artifact passthrough, and the live-overlay branch.

## Validation

- `npx vitest run` (contracts-mcp, mcp-server, api-coverage, list-query, endpoint-pools-mcp, rpc-pools-mcp) -- 1486 + 9 passed
- eslint clean, prettier clean, blobs LF
- No contract/openapi snapshot changed (the api-coverage + contracts-mcp suites pass unchanged)
- Screenshot-exempt: backend-only, no `apps/ui` changes

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6570`) -- required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched.

Closes #6570
