### PR TITLE
test(python): cover the providers() convenience method, sync and async (#6585)

### DIFF
--- a/python/tests/test_aio.py
+++ b/python/tests/test_aio.py
@@ -284,6 +284,43 @@ class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(surface.schema_url, "https://api.example.com/openapi.json")
         self.assertEqual(surface.raw["authority"], "official")
 
+    async def test_providers_returns_typed_models(self):
+        # The providers API exposes the slug as `id` (Provider aliases id -> slug).
+        client = self._client(
+            httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "providers": [
+                            {
+                                "id": "macrocosmos",
+                                "name": "Macrocosmos",
+                                "authority": "official",
+                                "surface_count": 12,
+                            }
+                        ]
+                    },
+                    "meta": {
+                        "pagination": {
+                            "collection": "providers",
+                            "next_cursor": None,
+                        }
+                    },
+                },
+            )
+        )
+        providers = await client.providers(authority="official")
+        self.assertEqual(len(providers), 1)
+        provider = providers[0]
+        self.assertIsInstance(provider, Provider)
+        self.assertEqual(provider.slug, "macrocosmos")
+        self.assertEqual(provider.name, "Macrocosmos")
+        self.assertEqual(provider.authority, "official")
+        self.assertEqual(provider.surface_count, 12)
+        self.assertEqual(provider.raw["id"], "macrocosmos")
+        # Query kwargs reach fetch_all's request query.
+        self.assertEqual(client._client.calls[0][2], {"authority": "official"})
+
     async def test_endpoints_returns_typed_models(self):
         client = self._client(
             httpx.Response(

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -753,6 +753,49 @@ class FetchAllAndModelsTest(unittest.TestCase):
         self.assertEqual(surface.schema_url, "https://api.example.com/openapi.json")
         self.assertEqual(surface.raw["authority"], "official")
 
+    def test_providers_convenience_returns_typed_models(self):
+        # The providers API exposes the slug as `id` (Provider aliases id -> slug),
+        # so the typed model must surface `.slug` from the `id` key.
+        captured_urls = []
+        pages = [
+            {
+                "data": {
+                    "providers": [
+                        {
+                            "id": "macrocosmos",
+                            "name": "Macrocosmos",
+                            "authority": "official",
+                            "surface_count": 12,
+                        }
+                    ]
+                },
+                "meta": {
+                    "pagination": {
+                        "collection": "providers",
+                        "next_cursor": None,
+                    }
+                },
+            }
+        ]
+        responses = iter(_FakeResponse(page) for page in pages)
+
+        def fake_urlopen(request, timeout=None):
+            captured_urls.append(request.full_url)
+            return next(responses)
+
+        with mock.patch("metagraphed.client._open_request", fake_urlopen):
+            providers = MetagraphedClient().providers(authority="official")
+        self.assertEqual(len(providers), 1)
+        provider = providers[0]
+        self.assertIsInstance(provider, Provider)
+        self.assertEqual(provider.slug, "macrocosmos")
+        self.assertEqual(provider.name, "Macrocosmos")
+        self.assertEqual(provider.authority, "official")
+        self.assertEqual(provider.surface_count, 12)
+        self.assertEqual(provider.raw["id"], "macrocosmos")
+        # Query kwargs reach fetch_all's request URL.
+        self.assertIn("authority=official", captured_urls[0])
+
     def test_endpoints_convenience_returns_typed_models(self):
         # Realistic EndpointResource shape (schemas/api-components.schema.json):
         # the backend exposes `url`, not `base_url`.


### PR DESCRIPTION
Closes #6585

## Summary

The Python SDK's `providers()` convenience method — on both `MetagraphedClient` (`python/src/metagraphed/client.py:563`) and `AsyncMetagraphedClient` (`python/src/metagraphed/aio.py:311`) — had no client-level test, the only one of the five typed convenience methods (`subnets`, `surfaces`, `endpoints`, `providers`, `agent_catalog`) missing coverage in both suites.

## What Changed

- Added `test_providers_convenience_returns_typed_models` to `python/tests/test_client.py`, mirroring the sibling `test_surfaces_convenience_returns_typed_models` structure.
- Added `test_providers_returns_typed_models` to `python/tests/test_aio.py`, mirroring `test_surfaces_returns_typed_models`.
- Each test mocks a realistic `/api/v1/providers` response, calls `.providers(authority="official")`, and asserts: the response parses into typed `Provider` models with the expected field values, the **`id` → `slug` alias** is applied (providers expose their slug as `id`), and the query kwargs reach `fetch_all`'s request (URL for sync, recorded call args for async).

The suite now runs 72 cases (was 70), all passing under the exact CI command (`python -m unittest discover -s tests`).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6585`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none — test-only)*

## Validation

- [x] `python -m unittest discover -s tests` — `Ran 72 tests ... OK (skipped=1)`
- [x] Both new tests pass (sync + async); no regressions
- [x] `git diff --check` clean
