### PR TITLE
feat(scripts): track release-health sessions in the shared batch-script observability helper

### DIFF
--- a/scripts/backfill-registry-postgres.mjs
+++ b/scripts/backfill-registry-postgres.mjs
@@ -41,7 +41,7 @@ import {
 } from "./lib.mjs";
 import { generateBaselineOverlaySet } from "./generated-overlays.mjs";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.mjs";
-import { initSentry } from "./observability.mjs";
+import { initSentry, endSessionAndFlush } from "./observability.mjs";
 
 initSentry("backfill-registry-postgres");
 
@@ -220,3 +220,4 @@ async function currentCommitSha() {
 }
 
 await main();
+await endSessionAndFlush();

--- a/scripts/discover-testnet-surfaces.mjs
+++ b/scripts/discover-testnet-surfaces.mjs
@@ -23,7 +23,11 @@ import {
   repoRoot,
   buildTimestamp,
 } from "./lib.mjs";
-import { initSentry, captureFatalAndExit } from "./observability.mjs";
+import {
+  initSentry,
+  endSessionAndFlush,
+  captureFatalAndExit,
+} from "./observability.mjs";
 
 const SNAPSHOT = path.join(repoRoot, "registry/native/test-subnets.json");
 const PROBE_TIMEOUT_MS = 8000;
@@ -267,13 +271,17 @@ if (
   path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
 ) {
   initSentry("discover-testnet-surfaces");
-  main().catch(async (error) => {
-    console.error(`testnet discovery failed: ${error?.message || error}`);
-    // Explicit capture required here (not left to @sentry/node's default
-    // OnUnhandledRejection integration, see observability.mjs's own
-    // comment): Node stops considering a promise "unhandled" once
-    // something calls .catch() on it, which this script already did
-    // before Sentry instrumentation existed.
-    await captureFatalAndExit(error);
-  });
+  main()
+    .then(async () => {
+      await endSessionAndFlush();
+    })
+    .catch(async (error) => {
+      console.error(`testnet discovery failed: ${error?.message || error}`);
+      // Explicit capture required here (not left to @sentry/node's default
+      // OnUnhandledRejection integration, see observability.mjs's own
+      // comment): Node stops considering a promise "unhandled" once
+      // something calls .catch() on it, which this script already did
+      // before Sentry instrumentation existed.
+      await captureFatalAndExit(error);
+    });
 }

--- a/scripts/export-parquet.mjs
+++ b/scripts/export-parquet.mjs
@@ -34,7 +34,7 @@ import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { sha256Hex, stableStringify } from "./lib.mjs";
-import { initSentry } from "./observability.mjs";
+import { initSentry, endSessionAndFlush } from "./observability.mjs";
 
 initSentry("export-parquet");
 
@@ -245,3 +245,4 @@ function summarize(manifest) {
 }
 
 await main();
+await endSessionAndFlush();

--- a/scripts/observability.mjs
+++ b/scripts/observability.mjs
@@ -11,7 +11,42 @@
 // `metagraphed` Sentry project with a consistent `component` tag --
 // matching scripts/observability.py's own Python-side convention for the
 // chain-fetch scripts.
+import { closeSession } from "@sentry/core";
 import * as Sentry from "@sentry/node";
+
+// Release-health session tracking (Sentry's "Crash Free Sessions/Users"
+// widgets). @sentry/node's own default OnUncaughtException/
+// OnUnhandledRejection integrations do NOT mark the active session as
+// crashed before exiting -- confirmed by reading their actual source
+// (node_modules/@sentry/node-core/build/*/integrations/onuncaughtexception.js
+// touches no session state at all), despite Sentry's own docs implying a
+// crash marks the session automatically. Rather than ship a metric that's
+// silently wrong (always "healthy" even on a real crash), this module owns
+// the crash path itself end-to-end: registers its own handlers BEFORE
+// Sentry.init() runs (Node calls uncaughtException/unhandledRejection
+// listeners in registration order, so this one must fire first), and
+// filters Sentry's own two crash-handling integrations out of the default
+// set so there's no race between two competing exit paths.
+//
+// Session model here is per SCRIPT RUN (start in initSentry, end via
+// endSessionAndFlush on the clean-exit path) -- these are one-shot
+// processes, not request-serving services, so "session" == "did this run
+// complete without an unhandled error," not a user session.
+let sentryInitialized = false;
+
+async function handleFatal(error, exitCode) {
+  console.error("[observability] fatal:", error);
+  if (sentryInitialized) {
+    Sentry.captureException(error);
+    const session = Sentry.getIsolationScope().getSession();
+    if (session) {
+      closeSession(session, "crashed");
+      Sentry.captureSession();
+    }
+    await Sentry.flush(2000);
+  }
+  process.exit(exitCode);
+}
 
 // No-ops silently if SENTRY_DSN is unset, matching every other
 // instrumented process in this rollout (SENTRY_DSN is not a secret in the
@@ -22,6 +57,19 @@ import * as Sentry from "@sentry/node";
 export function initSentry(component) {
   const dsn = process.env.SENTRY_DSN;
   if (!dsn) return;
+
+  // Registered before Sentry.init() -- see this module's own header for why
+  // ordering matters here.
+  process.on("uncaughtException", (error) => {
+    handleFatal(error, 1);
+  });
+  process.on("unhandledRejection", (reason) => {
+    handleFatal(
+      reason instanceof Error ? reason : new Error(String(reason)),
+      1,
+    );
+  });
+
   Sentry.init({
     dsn,
     environment: process.env.SENTRY_ENVIRONMENT || "production",
@@ -29,24 +77,33 @@ export function initSentry(component) {
     // Error tracking only -- these are short-lived batch scripts run on a
     // 3min/daily/weekly cron, not request-serving services.
     tracesSampleRate: 0,
+    integrations: (integrations) =>
+      integrations.filter(
+        (integration) =>
+          integration.name !== "OnUncaughtException" &&
+          integration.name !== "OnUnhandledRejection",
+      ),
   });
   Sentry.setTag("component", component);
-  // Every script this module is used by is a ONE-SHOT process, not a
-  // long-running poll loop like chain-firehose-relay.mjs -- an error that
-  // propagates uncaught (the common case: most of these scripts have no
-  // top-level try/catch at all, relying on Node's own default "print and
-  // exit 1" behavior) is automatically captured, flushed, and reported by
-  // @sentry/node's own default OnUncaughtException/OnUnhandledRejection
-  // integrations, installed as a side effect of Sentry.init() above -- no
-  // manual process.on() wiring needed here. The one exception is a script
-  // with its OWN explicit top-level `.catch()` (discover-testnet-
-  // surfaces.mjs): Node stops considering a promise "unhandled" once
-  // something calls .catch() on it, so that one script calls
-  // captureFatalAndExit() below directly instead of relying on the default.
+  sentryInitialized = true;
+  Sentry.startSession();
 }
 
-export async function captureFatalAndExit(error, exitCode = 1) {
-  Sentry.captureException(error);
+// Call on the clean-exit path (end of a successful run) so the session
+// reports "exited" (healthy) rather than being left open indefinitely.
+// Safe to call even if initSentry() no-op'd (no DSN) -- Sentry's own
+// endSession()/flush() are documented no-ops before init.
+export async function endSessionAndFlush() {
+  if (!sentryInitialized) return;
+  Sentry.endSession();
   await Sentry.flush(2000);
-  process.exit(exitCode);
+}
+
+// For the one script with its own explicit top-level `.catch()`
+// (discover-testnet-surfaces.mjs): Node stops considering a promise
+// "unhandled" once something calls .catch() on it, so that script calls
+// this directly instead of relying on the uncaughtException/
+// unhandledRejection handlers above.
+export async function captureFatalAndExit(error, exitCode = 1) {
+  await handleFatal(error, exitCode);
 }

--- a/scripts/observability.mjs
+++ b/scripts/observability.mjs
@@ -77,11 +77,19 @@ export function initSentry(component) {
     // Error tracking only -- these are short-lived batch scripts run on a
     // 3min/daily/weekly cron, not request-serving services.
     tracesSampleRate: 0,
+    // Also filters out the default ProcessSession integration -- it calls
+    // startSession() itself during Sentry.init(), which our own
+    // Sentry.startSession() call below would otherwise immediately end
+    // (reporting a spurious extra "exited" session on every single run) and
+    // replace, rather than there being exactly one session per run as
+    // intended. Confirmed empirically: without this, every run sent two
+    // session envelopes instead of one.
     integrations: (integrations) =>
       integrations.filter(
         (integration) =>
           integration.name !== "OnUncaughtException" &&
-          integration.name !== "OnUnhandledRejection",
+          integration.name !== "OnUnhandledRejection" &&
+          integration.name !== "ProcessSession",
       ),
   });
   Sentry.setTag("component", component);

--- a/scripts/reconcile-neurons.mjs
+++ b/scripts/reconcile-neurons.mjs
@@ -29,7 +29,7 @@
 import postgres from "postgres";
 import { readFile } from "node:fs/promises";
 import { stableStringify } from "./lib.mjs";
-import { initSentry } from "./observability.mjs";
+import { initSentry, endSessionAndFlush } from "./observability.mjs";
 
 initSentry("reconcile-neurons");
 
@@ -174,3 +174,4 @@ async function sendAlert(summary, examples) {
 }
 
 await main();
+await endSessionAndFlush();

--- a/scripts/refresh-economics.mjs
+++ b/scripts/refresh-economics.mjs
@@ -26,7 +26,7 @@ import {
 import { CONTRACT_VERSION } from "../src/contracts.mjs";
 import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.mjs";
 import { shouldPublishEconomics } from "./economics-floor.mjs";
-import { initSentry } from "./observability.mjs";
+import { initSentry, endSessionAndFlush } from "./observability.mjs";
 
 initSentry("refresh-economics");
 
@@ -59,6 +59,7 @@ const summary = {
 
 if (!write) {
   console.log(stableStringify({ mode: "dry-run", ...summary }));
+  await endSessionAndFlush();
   process.exit(0);
 }
 
@@ -80,6 +81,7 @@ if (!floor.publish) {
       ...summary,
     }),
   );
+  await endSessionAndFlush();
   process.exit(0);
 }
 
@@ -128,3 +130,4 @@ if (process.env.METAGRAPH_ALLOW_KV_WRITE === "1") {
 }
 
 console.log(stableStringify({ mode: "write", kv: kvStatus, ...summary }));
+await endSessionAndFlush();

--- a/scripts/refresh-native-snapshot.mjs
+++ b/scripts/refresh-native-snapshot.mjs
@@ -14,7 +14,7 @@
 // using the committed snapshot (this step is production-only).
 import { spawnSync } from "node:child_process";
 import { stableStringify } from "./lib.mjs";
-import { initSentry } from "./observability.mjs";
+import { initSentry, endSessionAndFlush } from "./observability.mjs";
 
 initSentry("refresh-native-snapshot");
 
@@ -50,4 +50,5 @@ if (result.status === 0) {
   );
 }
 
+await endSessionAndFlush();
 process.exit(0);

--- a/scripts/refresh-og-image.mjs
+++ b/scripts/refresh-og-image.mjs
@@ -37,7 +37,7 @@ import { html } from "satori-html";
 import { R2_STAGING_RELATIVE_ROOT } from "../src/artifact-storage.mjs";
 import { buildStatParts, renderMarkup } from "../src/og-image.mjs";
 import { repoRoot, stableStringify } from "./lib.mjs";
-import { initSentry } from "./observability.mjs";
+import { initSentry, endSessionAndFlush } from "./observability.mjs";
 import * as Sentry from "@sentry/node";
 
 initSentry("refresh-og-image");
@@ -84,6 +84,7 @@ try {
   );
 }
 
+await endSessionAndFlush();
 process.exit(0);
 
 async function loadStatParts() {

--- a/scripts/sync-registry-to-postgres.mjs
+++ b/scripts/sync-registry-to-postgres.mjs
@@ -49,7 +49,7 @@ import {
   subnetSurfaceKey,
 } from "./lib.mjs";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.mjs";
-import { initSentry } from "./observability.mjs";
+import { initSentry, endSessionAndFlush } from "./observability.mjs";
 
 initSentry("sync-registry-to-postgres");
 
@@ -284,3 +284,4 @@ function parseArgs(argv) {
 }
 
 await main();
+await endSessionAndFlush();

--- a/tests/observability.test.mjs
+++ b/tests/observability.test.mjs
@@ -104,7 +104,7 @@ test("initSentry: calls Sentry.init with dsn/environment/release, tags the compo
   vi.unstubAllEnvs();
 });
 
-test("initSentry: filters Sentry's own OnUncaughtException/OnUnhandledRejection out of the default integrations", () => {
+test("initSentry: filters Sentry's own OnUncaughtException/OnUnhandledRejection/ProcessSession out of the default integrations", () => {
   sentryInit.mockClear();
   vi.stubEnv("SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
   initSentry("some-script");
@@ -113,6 +113,13 @@ test("initSentry: filters Sentry's own OnUncaughtException/OnUnhandledRejection 
   const filtered = integrations([
     { name: "OnUncaughtException" },
     { name: "OnUnhandledRejection" },
+    // The default ProcessSession integration auto-starts its own session
+    // during Sentry.init() -- left unfiltered, our own startSession() call
+    // below would immediately end that one (a spurious extra "exited"
+    // session on every run) and replace it, instead of there being exactly
+    // one session per run. Confirmed empirically against a real local
+    // Sentry-envelope-receiving HTTP server.
+    { name: "ProcessSession" },
     { name: "Http" },
   ]);
   assert.deepEqual(

--- a/tests/observability.test.mjs
+++ b/tests/observability.test.mjs
@@ -1,50 +1,125 @@
 // Unit tests for scripts/observability.mjs -- the shared Sentry init for
-// the box-side data-refresh-economics/data-refresh-node scripts. Mocked the
-// same way tests/chain-firehose-relay.test.mjs mocks @sentry/node.
+// the box-side data-refresh-economics/data-refresh-node scripts, plus the
+// release-health (crash-free session) tracking layered on top of it.
 import assert from "node:assert/strict";
-import { test, vi } from "vitest";
+import { afterEach, beforeEach, test, vi } from "vitest";
 
 const captureException = vi.hoisted(() => vi.fn());
 const sentryInit = vi.hoisted(() => vi.fn());
 const setTag = vi.hoisted(() => vi.fn());
 const flush = vi.hoisted(() => vi.fn(async () => true));
+const startSession = vi.hoisted(() => vi.fn());
+const endSession = vi.hoisted(() => vi.fn());
+const captureSession = vi.hoisted(() => vi.fn());
+const getSession = vi.hoisted(() => vi.fn());
+const getIsolationScope = vi.hoisted(() => vi.fn(() => ({ getSession })));
+const closeSession = vi.hoisted(() => vi.fn());
+
 vi.mock("@sentry/node", () => ({
   init: sentryInit,
   setTag,
   captureException,
   flush,
+  startSession,
+  endSession,
+  captureSession,
+  getIsolationScope,
 }));
+vi.mock("@sentry/core", () => ({ closeSession }));
 
-import { initSentry, captureFatalAndExit } from "../scripts/observability.mjs";
+import {
+  initSentry,
+  endSessionAndFlush,
+  captureFatalAndExit,
+} from "../scripts/observability.mjs";
 
-test("initSentry: no-ops (never calls Sentry.init) when SENTRY_DSN is unset", () => {
+let onSpy;
+beforeEach(() => {
+  // initSentry registers real process.on("uncaughtException"/"unhandledRejection")
+  // handlers as a side effect -- stub the registration itself so tests don't
+  // leak listeners onto the shared vitest worker process, while still letting
+  // us assert on how it was called.
+  onSpy = vi.spyOn(process, "on").mockImplementation(() => process);
+});
+afterEach(() => {
+  onSpy.mockRestore();
+});
+
+test("initSentry: no-ops (never calls Sentry.init, never registers signal handlers) when SENTRY_DSN is unset", () => {
   sentryInit.mockClear();
   setTag.mockClear();
+  startSession.mockClear();
   vi.stubEnv("SENTRY_DSN", "");
   initSentry("some-script");
   assert.equal(sentryInit.mock.calls.length, 0);
   assert.equal(setTag.mock.calls.length, 0);
+  assert.equal(startSession.mock.calls.length, 0);
+  assert.equal(onSpy.mock.calls.length, 0);
   vi.unstubAllEnvs();
 });
 
-test("initSentry: calls Sentry.init with dsn/environment/release and tags the component when SENTRY_DSN is set", () => {
+test("endSessionAndFlush: no-ops when Sentry was never initialized", async () => {
+  endSession.mockClear();
+  flush.mockClear();
+  await endSessionAndFlush();
+  assert.equal(endSession.mock.calls.length, 0);
+  assert.equal(flush.mock.calls.length, 0);
+});
+
+test("initSentry: calls Sentry.init with dsn/environment/release, tags the component, registers crash handlers before init, and starts a session", () => {
   sentryInit.mockClear();
   setTag.mockClear();
+  startSession.mockClear();
+  onSpy.mockClear();
   vi.stubEnv("SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
   vi.stubEnv("SENTRY_ENVIRONMENT", "staging");
   vi.stubEnv("SENTRY_RELEASE", "deadbeef");
   initSentry("sync-registry-to-postgres");
+
   assert.equal(sentryInit.mock.calls.length, 1);
-  assert.deepEqual(sentryInit.mock.calls[0][0], {
-    dsn: "https://abc@o0.ingest.sentry.io/0",
-    environment: "staging",
-    release: "deadbeef",
-    tracesSampleRate: 0,
-  });
+  const initArgs = sentryInit.mock.calls[0][0];
+  assert.equal(initArgs.dsn, "https://abc@o0.ingest.sentry.io/0");
+  assert.equal(initArgs.environment, "staging");
+  assert.equal(initArgs.release, "deadbeef");
+  assert.equal(initArgs.tracesSampleRate, 0);
+  assert.equal(typeof initArgs.integrations, "function");
+
   assert.deepEqual(setTag.mock.calls[0], [
     "component",
     "sync-registry-to-postgres",
   ]);
+  assert.equal(startSession.mock.calls.length, 1);
+
+  // The handlers must be registered before Sentry.init() runs, so that a
+  // custom crash handler wins the race against Sentry's own default ones.
+  const onNames = onSpy.mock.calls.map((call) => call[0]);
+  assert.deepEqual(onNames, ["uncaughtException", "unhandledRejection"]);
+  assert.ok(
+    onSpy.mock.invocationCallOrder[0] < sentryInit.mock.invocationCallOrder[0],
+  );
+  assert.ok(
+    onSpy.mock.invocationCallOrder[1] < sentryInit.mock.invocationCallOrder[0],
+  );
+
+  vi.unstubAllEnvs();
+});
+
+test("initSentry: filters Sentry's own OnUncaughtException/OnUnhandledRejection out of the default integrations", () => {
+  sentryInit.mockClear();
+  vi.stubEnv("SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
+  initSentry("some-script");
+
+  const { integrations } = sentryInit.mock.calls[0][0];
+  const filtered = integrations([
+    { name: "OnUncaughtException" },
+    { name: "OnUnhandledRejection" },
+    { name: "Http" },
+  ]);
+  assert.deepEqual(
+    filtered.map((i) => i.name),
+    ["Http"],
+  );
+
   vi.unstubAllEnvs();
 });
 
@@ -57,9 +132,30 @@ test("initSentry: SENTRY_ENVIRONMENT defaults to 'production' when unset", () =>
   vi.unstubAllEnvs();
 });
 
-test("captureFatalAndExit: captures the exception, flushes, then exits with the given code", async () => {
-  captureException.mockClear();
+test("endSessionAndFlush: ends the session and flushes once initialized", async () => {
+  vi.stubEnv("SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
+  initSentry("some-script");
+  vi.unstubAllEnvs();
+
+  endSession.mockClear();
   flush.mockClear();
+  await endSessionAndFlush();
+  assert.equal(endSession.mock.calls.length, 1);
+  assert.equal(flush.mock.calls.length, 1);
+  assert.equal(flush.mock.calls[0][0], 2000);
+});
+
+test("captureFatalAndExit: captures the exception, marks the active session crashed, flushes, then exits with the given code", async () => {
+  vi.stubEnv("SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
+  initSentry("some-script");
+  vi.unstubAllEnvs();
+
+  captureException.mockClear();
+  captureSession.mockClear();
+  closeSession.mockClear();
+  flush.mockClear();
+  const fakeSession = { status: "ok" };
+  getSession.mockReturnValue(fakeSession);
   const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
   const error = new Error("boom");
 
@@ -67,14 +163,37 @@ test("captureFatalAndExit: captures the exception, flushes, then exits with the 
 
   assert.equal(captureException.mock.calls.length, 1);
   assert.equal(captureException.mock.calls[0][0], error);
+  assert.deepEqual(closeSession.mock.calls[0], [fakeSession, "crashed"]);
+  assert.equal(captureSession.mock.calls.length, 1);
   assert.equal(flush.mock.calls.length, 1);
   assert.equal(exitSpy.mock.calls.length, 1);
   assert.equal(exitSpy.mock.calls[0][0], 2);
   exitSpy.mockRestore();
 });
 
+test("captureFatalAndExit: skips session close/capture when there is no active session", async () => {
+  vi.stubEnv("SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
+  initSentry("some-script");
+  vi.unstubAllEnvs();
+
+  closeSession.mockClear();
+  captureSession.mockClear();
+  getSession.mockReturnValue(undefined);
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
+
+  await captureFatalAndExit(new Error("boom"));
+
+  assert.equal(closeSession.mock.calls.length, 0);
+  assert.equal(captureSession.mock.calls.length, 0);
+  exitSpy.mockRestore();
+});
+
 test("captureFatalAndExit: defaults to exit code 1", async () => {
-  captureException.mockClear();
+  vi.stubEnv("SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
+  initSentry("some-script");
+  vi.unstubAllEnvs();
+
+  getSession.mockReturnValue(undefined);
   const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
 
   await captureFatalAndExit(new Error("boom"));


### PR DESCRIPTION
## Summary
- `scripts/observability.mjs` now tracks a per-run Sentry session across the eight batch scripts it instruments (`backfill-registry-postgres.mjs`, `export-parquet.mjs`, `reconcile-neurons.mjs`, `sync-registry-to-postgres.mjs`, `refresh-economics.mjs`, `refresh-native-snapshot.mjs`, `refresh-og-image.mjs`, `discover-testnet-surfaces.mjs`), enabling Sentry's Crash Free Sessions/Users release-health widgets for this project.
- `@sentry/node`'s default `OnUncaughtException`/`OnUnhandledRejection` integrations don't mark the active session as crashed before exiting (confirmed by reading `node_modules/@sentry/node-core`'s actual source), so this module now owns the crash path end-to-end: it registers its own `process.on("uncaughtException"/"unhandledRejection")` handlers *before* `Sentry.init()` runs (so they win the race against Sentry's own handlers), and filters those two default integrations out of the init config.
- `initSentry()` starts a session; `endSessionAndFlush()` (new export) closes it healthy on each script's clean-exit path; `captureFatalAndExit()` (existing export, now built on the same crash handler) closes it `"crashed"` before exiting.
- This is a `component`/session model of "did this run complete without an unhandled error" per script invocation — not a user session. Long-running services (`deploy/wss-lb`, `scripts/chain-firehose-relay.mjs`) and the Python side (`roles/validator-ops/files/scripts/observability.py` in metagraphed-infra) need a different process-lifetime model and are tracked separately.

## Test plan
- [x] `npm run lint`
- [x] `npx prettier --check` on all changed files
- [x] `tests/observability.test.mjs` rewritten for the new API surface (session start/end, crash-handler registration order, integration filtering, session-close-on-crash) — 9/9 passing
- [x] `npm run test:coverage` — full suite green (303 files, 9031 tests), `scripts/observability.mjs` at 100% line/branch coverage from the new tests