### PR TITLE
feat(ui): surface the owning coldkey on the validator detail page

### DIFF
--- a/apps/ui/src/routes/validators.$hotkey.coldkey.test.ts
+++ b/apps/ui/src/routes/validators.$hotkey.coldkey.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #6427: validatorDetailQuery already normalizes `coldkey`, but the page used it
+// only for the owner-only `isOwner` check / TakeManagementModal — a regular
+// visitor had no way to see which account controls the hotkey. The fix renders
+// `detail.coldkey` as a public /accounts/$ss58 link (via AccountAddress), gated
+// on the coldkey's presence rather than ownership.
+const source = readFileSync(
+  fileURLToPath(new URL("./validators.$hotkey.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("validator detail surfaces the owning coldkey (#6427)", () => {
+  it("renders detail.coldkey through AccountAddress (the /accounts/$ss58 link idiom)", () => {
+    expect(source).toContain(
+      'import { AccountAddress } from "@/components/metagraphed/account-address";',
+    );
+    expect(source).toContain("ss58={detail.coldkey}");
+  });
+
+  it("gates the coldkey field on its presence, not on isOwner", () => {
+    // The AccountAddress usage must sit inside a `detail.coldkey ?` guard, not
+    // inside the `isOwner ?` block that wraps the owner-only take controls.
+    const coldkeyBlock = source.slice(
+      source.indexOf("{detail.coldkey ?"),
+      source.indexOf("ss58={detail.coldkey}"),
+    );
+    expect(coldkeyBlock).toContain("{detail.coldkey ?");
+    expect(coldkeyBlock).not.toContain("isOwner");
+  });
+
+  it("handles a missing coldkey gracefully (renders nothing, with a fallback dash)", () => {
+    // Present-but-invalid ss58 falls through AccountAddress's own fallback.
+    const coldkeyRender = source.slice(
+      source.indexOf("{detail.coldkey ?"),
+      source.indexOf("{detail.coldkey ?") + 700,
+    );
+    expect(coldkeyRender).toContain("fallback=");
+    expect(coldkeyRender).toMatch(/\)\s*:\s*null}/);
+  });
+});

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -14,6 +14,7 @@ import { PageHero, ShareButton, SectionAnchor, CopyableCode, StatTile } from "@j
 import { ValidatorHistoryChart } from "@/components/metagraphed/validator-history-chart";
 import { ValidatorApyPanel } from "@/components/metagraphed/validator-apy-panel";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
+import { AccountAddress } from "@/components/metagraphed/account-address";
 import { WatchValidatorAlert } from "@/components/metagraphed/watch-validator-alert";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
 import { TakeManagementModal } from "@/components/metagraphed/take-management-modal";
@@ -310,6 +311,22 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
             <span className="inline-flex max-w-full min-w-0 rounded-2xl border border-border/80 bg-card/80 px-3 py-2 mg-card-glow">
               <CopyableCode value={hotkey} truncate={false} className="max-w-full" />
             </span>
+            {/* #6427: the owning coldkey is fetched for the owner-only take
+                controls but was never shown to a regular visitor. Surface it as
+                a public /accounts/$ss58 link (not gated on isOwner) so anyone
+                can discover which account controls this hotkey. */}
+            {detail.coldkey ? (
+              <span className="flex flex-wrap items-center gap-2">
+                <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  Coldkey
+                </span>
+                <AccountAddress
+                  ss58={detail.coldkey}
+                  truncate={false}
+                  fallback={<span className="text-sm text-ink-muted">—</span>}
+                />
+              </span>
+            ) : null}
           </span>
         }
         actions={


### PR DESCRIPTION
## What

Surfaces a validator's **owning coldkey** as a public, linked field on the validator detail page (`/validators/$hotkey`).

## Why

`validatorDetailQuery` already normalizes `coldkey` into `ValidatorDetail`, but the page used it *only* for the owner-only `isOwner` check and the owner-gated `TakeManagementModal` — it was never rendered for a regular visitor. `ValidatorIdentityChip` shows only the self-declared identity name, never the raw coldkey ss58, so a site visitor had **no way to discover which account controls a given validator hotkey**.

## How

- Render `detail.coldkey` through the shared `AccountAddress` component — the app's one idiom for an ss58 value, which links to `/accounts/$ss58` (its own doc notes this route "covers both" hotkey and coldkey) and carries the hover-card + copy-button treatment.
- Placed as a labelled **Coldkey** field in the `PageHero` description, directly under the hotkey.
- **Gated on `detail.coldkey` presence, not `isOwner`** — visible to every visitor. `AccountAddress`'s own `fallback` handles a present-but-invalid value; a null coldkey renders nothing.
- No change to the owner-only take controls.

Adds a source-assertion test pinning the three contract points (rendered via `AccountAddress`, gated on presence not ownership, graceful when absent).

## Screenshots

Named validator `5G9hfkx9…` (1T1B.AI). Before: the coldkey is fetched but never shown (page jumps hotkey → Share view). After: a linked **Coldkey** field appears under the hotkey.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6577-emissions-csv-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6427
