### PR TITLE
feat(api,mcp): add listQuery pagination to /api/v1/rpc/pools and list_rpc_pools

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -21339,7 +21339,21 @@ export interface operations {
     };
     rpcPools: {
         parameters: {
-            query?: never;
+            query?: {
+                id?: string;
+                kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
+                min_eligible_count?: number;
+                max_eligible_count?: number;
+                min_endpoint_count?: number;
+                max_endpoint_count?: number;
+                fields?: string;
+                limit?: number;
+                cursor?: number;
+                /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
+                sort?: "eligible_count" | "endpoint_count" | "id" | "kind";
+                /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
+                order?: "asc" | "desc";
+            };
             header?: never;
             path?: never;
             cookie?: never;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -9257,9 +9257,100 @@
       "method": "GET",
       "path": "/api/v1/rpc/pools",
       "public": true,
-      "query_collection": null,
-      "query_filter_names": [],
-      "query_parameters": []
+      "query_collection": "rpc-pools",
+      "query_filter_names": [
+        "id",
+        "kind"
+      ],
+      "query_parameters": [
+        {
+          "name": "id",
+          "schema": {
+            "maxLength": 100,
+            "type": "string"
+          }
+        },
+        {
+          "name": "kind",
+          "schema": {
+            "enum": [
+              "subtensor-rpc",
+              "subtensor-wss",
+              "archive"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "min_eligible_count",
+          "schema": {
+            "type": "number"
+          }
+        },
+        {
+          "name": "max_eligible_count",
+          "schema": {
+            "type": "number"
+          }
+        },
+        {
+          "name": "min_endpoint_count",
+          "schema": {
+            "type": "number"
+          }
+        },
+        {
+          "name": "max_endpoint_count",
+          "schema": {
+            "type": "number"
+          }
+        },
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+            "type": "string"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "cursor",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+          "name": "sort",
+          "schema": {
+            "enum": [
+              "eligible_count",
+              "endpoint_count",
+              "id",
+              "kind"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+          "name": "order",
+          "schema": {
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/endpoint-pools.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -42016,7 +42016,117 @@
     "/api/v1/rpc/pools": {
       "get": {
         "operationId": "rpcPools",
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "maxLength": 100,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "subtensor-rpc",
+                "subtensor-wss",
+                "archive"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_eligible_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "max_eligible_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_endpoint_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "max_endpoint_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[A-Za-z_][A-Za-z0-9_]*(,[A-Za-z_][A-Za-z0-9_]*)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "eligible_count",
+                "endpoint_count",
+                "id",
+                "kind"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -21339,7 +21339,21 @@ export interface operations {
     };
     rpcPools: {
         parameters: {
-            query?: never;
+            query?: {
+                id?: string;
+                kind?: "subtensor-rpc" | "subtensor-wss" | "archive";
+                min_eligible_count?: number;
+                max_eligible_count?: number;
+                min_endpoint_count?: number;
+                max_endpoint_count?: number;
+                fields?: string;
+                limit?: number;
+                cursor?: number;
+                /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_tao`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
+                sort?: "eligible_count" | "endpoint_count" | "id" | "kind";
+                /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
+                order?: "asc" | "desc";
+            };
             header?: never;
             path?: never;
             cookie?: never;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -273,6 +273,17 @@ export const API_QUERY_COLLECTIONS = {
     sort: ["eligible_count", "endpoint_count", "id", "kind"],
     rangeFilters: ["eligible_count", "endpoint_count"],
   }),
+  // #6570: rpc-pools is the Bittensor-RPC-scoped predecessor of the
+  // generalized endpoint-pools collection above — same pools[] row shape,
+  // same filter/sort/range surface, distinct artifact (rpc/pools.json).
+  "rpc-pools": queryCollection("pools", {
+    filters: {
+      id: filterTextSchema,
+      kind: enumSchema(["subtensor-rpc", "subtensor-wss", "archive"]),
+    },
+    sort: ["eligible_count", "endpoint_count", "id", "kind"],
+    rangeFilters: ["eligible_count", "endpoint_count"],
+  }),
   "endpoint-incidents": queryCollection("incidents", {
     filters: {
       netuid: integerSchema,
@@ -3885,6 +3896,7 @@ export const API_ROUTES = [
     "Fetch endpoint pool scores.",
     "short",
     ["rpc"],
+    listQuery("rpc-pools"),
   ),
   route(
     "endpoint-pools",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -165,6 +165,11 @@ import {
   loadEndpointPoolsList,
 } from "./endpoint-pools-mcp.mjs";
 import {
+  LIST_RPC_POOLS_MCP_TOOL,
+  LIST_RPC_POOLS_OUTPUT_SCHEMA,
+  loadRpcPoolsList,
+} from "./rpc-pools-mcp.mjs";
+import {
   LIST_ENDPOINT_INCIDENTS_INSTRUCTIONS,
   LIST_ENDPOINT_INCIDENTS_MCP_TOOL,
   LIST_ENDPOINT_INCIDENTS_OUTPUT_SCHEMA,
@@ -8844,42 +8849,9 @@ export const MCP_TOOLS = [
     },
   },
   {
-    name: "list_rpc_pools",
-    title: "List Bittensor RPC pools",
-    description:
-      "Fetch the load-balanced Bittensor RPC pool scores: each pool with its " +
-      "network and probe-derived score/health, as used to route the public " +
-      "RPC proxy. Complements list_rpc_endpoints (the individual endpoints) and " +
-      "get_best_rpc_endpoint (the pick-one shortcut). Mirrors " +
-      "GET /api/v1/rpc/pools.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-    async handler(_args, ctx) {
-      const staticData = await loadArtifactData(
-        ctx,
-        "/metagraph/rpc/pools.json",
-      );
-      const livePool = ctx.readHealthKv
-        ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
-        : null;
-      if (
-        livePool &&
-        Array.isArray(livePool.endpoints) &&
-        Array.isArray(staticData?.pools)
-      ) {
-        return {
-          ...staticData,
-          source: "live-cron-prober",
-          operational_observed_at: livePool.last_run_at || null,
-          pools: staticData.pools.map((pool) =>
-            overlayRpcPoolEligibility(pool, livePool),
-          ),
-        };
-      }
-      return staticData;
+    ...LIST_RPC_POOLS_MCP_TOOL,
+    async handler(args, ctx) {
+      return loadRpcPoolsList(ctx, args);
     },
   },
   {
@@ -13475,16 +13447,7 @@ const TOOL_OUTPUT_SCHEMAS = {
     },
   },
   list_subnet_endpoints: LIST_SUBNET_ENDPOINTS_OUTPUT_SCHEMA,
-  list_rpc_pools: {
-    type: "object",
-    additionalProperties: true,
-    required: [],
-    properties: {
-      pools: { type: "array", items: { type: "object" } },
-      generated_at: NULLABLE_STRING,
-      schema_version: { type: ["string", "integer", "null"] },
-    },
-  },
+  list_rpc_pools: LIST_RPC_POOLS_OUTPUT_SCHEMA,
   list_profile_completeness: {
     type: "object",
     additionalProperties: true,

--- a/src/rpc-pools-mcp.mjs
+++ b/src/rpc-pools-mcp.mjs
@@ -1,0 +1,271 @@
+// RPC pool list loader for MCP parity on GET /api/v1/rpc/pools (#6570).
+// Applies the same list-query transforms as the REST route over the baked
+// /metagraph/rpc/pools.json artifact, after the live 15-minute cron overlay
+// (overlayRpcPoolEligibility) — same order REST's liveHealthOverlay ->
+// applyQueryFilters pipeline uses, so a filter like min_eligible_count reads
+// live eligibility, not a stale baked value. Structurally mirrors
+// endpoint-pools-mcp.mjs (the generalized sibling collection), which has no
+// live-overlay step of its own.
+
+import { applyQueryFilters } from "../workers/list-query.mjs";
+import { API_QUERY_COLLECTIONS } from "./contracts.mjs";
+import { KV_HEALTH_RPC_POOL } from "./health-prober.mjs";
+import { overlayRpcPoolEligibility } from "./health-serving.mjs";
+
+export const RPC_POOLS_ARTIFACT = "/metagraph/rpc/pools.json";
+
+const POOL_SORT_FIELDS = API_QUERY_COLLECTIONS["rpc-pools"].sort_fields;
+const POOL_KINDS = ["subtensor-rpc", "subtensor-wss", "archive"];
+
+export function rpcPoolsMcpError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+function optionalString(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw rpcPoolsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string when provided.`,
+    );
+  }
+  return value.trim();
+}
+
+function optionalEnum(args, key, allowed) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    throw rpcPoolsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+function optionalRangeBound(args, key) {
+  const value = args?.[key];
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw rpcPoolsMcpError(
+      "invalid_params",
+      `Argument \`${key}\` must be a finite number when provided.`,
+    );
+  }
+  return value;
+}
+
+export function rpcPoolsQueryUrl(args) {
+  const url = new URL("https://mcp.internal/rpc-pools");
+  const id = optionalString(args, "id");
+  if (id) url.searchParams.set("id", id);
+  const kind = optionalEnum(args, "kind", POOL_KINDS);
+  if (kind) url.searchParams.set("kind", kind);
+  const sort = optionalEnum(args, "sort", POOL_SORT_FIELDS);
+  if (sort) url.searchParams.set("sort", sort);
+  const order = optionalEnum(args, "order", ["asc", "desc"]);
+  if (order) url.searchParams.set("order", order);
+  const fields = optionalString(args, "fields");
+  if (fields) url.searchParams.set("fields", fields);
+  const minEligible = optionalRangeBound(args, "min_eligible_count");
+  if (minEligible !== null) {
+    url.searchParams.set("min_eligible_count", String(minEligible));
+  }
+  const maxEligible = optionalRangeBound(args, "max_eligible_count");
+  if (maxEligible !== null) {
+    url.searchParams.set("max_eligible_count", String(maxEligible));
+  }
+  const minEndpoint = optionalRangeBound(args, "min_endpoint_count");
+  if (minEndpoint !== null) {
+    url.searchParams.set("min_endpoint_count", String(minEndpoint));
+  }
+  const maxEndpoint = optionalRangeBound(args, "max_endpoint_count");
+  if (maxEndpoint !== null) {
+    url.searchParams.set("max_endpoint_count", String(maxEndpoint));
+  }
+  if (args?.limit !== undefined) {
+    if (!Number.isInteger(args.limit) || args.limit < 1 || args.limit > 100) {
+      throw rpcPoolsMcpError(
+        "invalid_params",
+        "limit must be an integer between 1 and 100.",
+      );
+    }
+    url.searchParams.set("limit", String(args.limit));
+  }
+  if (args?.cursor !== undefined) {
+    if (!Number.isInteger(args.cursor) || args.cursor < 0) {
+      throw rpcPoolsMcpError(
+        "invalid_params",
+        "cursor must be a non-negative integer.",
+      );
+    }
+    url.searchParams.set("cursor", String(args.cursor));
+  }
+  return url;
+}
+
+export async function loadRpcPoolsList(ctx, args, { readArtifact } = {}) {
+  const queryUrl = rpcPoolsQueryUrl(args);
+  const read = readArtifact ?? ctx.readArtifact;
+  const result = await read(ctx.env, RPC_POOLS_ARTIFACT);
+  if (!result?.ok) {
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      throw rpcPoolsMcpError("not_found", "RPC pool snapshot unavailable.");
+    }
+    throw rpcPoolsMcpError(
+      code,
+      `Could not load ${RPC_POOLS_ARTIFACT} (${code}).`,
+    );
+  }
+  const blob = result.data;
+  if (!blob || typeof blob !== "object") {
+    throw rpcPoolsMcpError("not_found", "RPC pool snapshot unavailable.");
+  }
+
+  // Live 15-minute cron overlay, matching REST's liveHealthOverlay for the
+  // "rpc-pools" route id — applied before filtering so a live-derived field
+  // like eligible_count reflects the current snapshot, not the baked one.
+  let overlaid = blob;
+  const livePool = ctx.readHealthKv
+    ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
+    : null;
+  if (
+    livePool &&
+    Array.isArray(livePool.endpoints) &&
+    Array.isArray(blob.pools)
+  ) {
+    overlaid = {
+      ...blob,
+      source: "live-cron-prober",
+      operational_observed_at: livePool.last_run_at || null,
+      pools: blob.pools.map((pool) =>
+        overlayRpcPoolEligibility(pool, livePool),
+      ),
+    };
+  }
+
+  const transformed = applyQueryFilters(overlaid, queryUrl, "rpc-pools", []);
+  if (transformed.error) {
+    throw rpcPoolsMcpError("invalid_params", transformed.error.message);
+  }
+  const { data, meta } = transformed;
+  const page = meta.pagination || {};
+  const rows = Array.isArray(data.pools) ? data.pools : [];
+  const rowLen = rows.length;
+  return {
+    generated_at: data.generated_at ?? null,
+    notes: data.notes ?? null,
+    source: data.source ?? null,
+    operational_observed_at: data.operational_observed_at ?? null,
+    pools: rows,
+    total: page.total ?? rowLen,
+    returned: page.returned ?? rowLen,
+    limit: page.limit ?? rowLen,
+    cursor: page.cursor ?? 0,
+    next_cursor: page.next_cursor ?? null,
+    sort: page.sort ?? null,
+    order: page.order ?? null,
+  };
+}
+
+export const LIST_RPC_POOLS_MCP_TOOL = {
+  name: "list_rpc_pools",
+  title: "List Bittensor RPC pools",
+  description:
+    "Fetch the load-balanced Bittensor RPC pool scores: each pool's kind, " +
+    "eligible endpoint count, total endpoint count, and probe-derived routing " +
+    "score, as used to route the public RPC proxy. Filter by id or kind, " +
+    "threshold with min_/max_eligible_count and min_/max_endpoint_count, sort " +
+    "with sort + order, and page with limit (1-100) / cursor. Complements " +
+    "list_rpc_endpoints (the individual endpoints), get_best_rpc_endpoint (the " +
+    "pick-one shortcut), and list_endpoint_pools (the generalized sibling). " +
+    "Mirrors GET /api/v1/rpc/pools.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "Filter to one pool id, e.g. 'finney-rpc'.",
+      },
+      kind: {
+        type: "string",
+        enum: POOL_KINDS,
+        description: "Filter by pool kind.",
+      },
+      min_eligible_count: {
+        type: "number",
+        description: "Keep pools with eligible_count >= this bound.",
+      },
+      max_eligible_count: {
+        type: "number",
+        description: "Keep pools with eligible_count <= this bound.",
+      },
+      min_endpoint_count: {
+        type: "number",
+        description: "Keep pools with endpoint_count >= this bound.",
+      },
+      max_endpoint_count: {
+        type: "number",
+        description: "Keep pools with endpoint_count <= this bound.",
+      },
+      sort: {
+        type: "string",
+        enum: POOL_SORT_FIELDS,
+        description: "Field to sort by before paging.",
+      },
+      order: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Sort direction for sort (default asc).",
+      },
+      fields: {
+        type: "string",
+        description: "Comma-separated projection of pool row fields to return.",
+      },
+      limit: {
+        type: "integer",
+        description: "Max rows to return (1-100). Enables pagination.",
+        minimum: 1,
+        maximum: 100,
+      },
+      cursor: {
+        type: "integer",
+        description: "Pagination cursor from a prior response's next_cursor.",
+        minimum: 0,
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+const NULLABLE_STRING = { type: ["string", "null"] };
+const NULLABLE_INT = { type: ["integer", "null"] };
+
+export const LIST_RPC_POOLS_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+  required: ["pools"],
+  properties: {
+    generated_at: NULLABLE_STRING,
+    notes: {
+      type: ["array", "string", "null"],
+      items: { type: "string" },
+    },
+    source: NULLABLE_STRING,
+    operational_observed_at: NULLABLE_STRING,
+    pools: { type: "array", items: { type: "object" } },
+    total: { type: "integer" },
+    returned: { type: "integer" },
+    limit: { type: "integer" },
+    cursor: { type: "integer" },
+    next_cursor: NULLABLE_INT,
+    sort: NULLABLE_STRING,
+    order: NULLABLE_STRING,
+  },
+};

--- a/tests/list-query.test.mjs
+++ b/tests/list-query.test.mjs
@@ -851,9 +851,10 @@ describe("list-query integration_readiness (#2085)", () => {
   });
 });
 
-// #2587: endpoint-pools and pools are duplicate collection configs (same data_key,
-// same filters/sort/rangeFilters). REST exposes endpoint-pools; pools is the
-// canonical id for the artifact data_key. Both must accept min_/max_ on counts.
+// #2587/#6570: endpoint-pools, pools, and rpc-pools are duplicate collection
+// configs (same data_key, same filters/sort/rangeFilters). REST exposes
+// endpoint-pools and rpc-pools; pools is the canonical id for the artifact
+// data_key. All three must accept min_/max_ on counts identically.
 describe("list-query endpoint pool count range filters (#2587)", () => {
   const data = {
     pools: [
@@ -866,7 +867,7 @@ describe("list-query endpoint pool count range filters (#2587)", () => {
   };
   const poolIds = (result) => result.data.pools.map((r) => r.id);
 
-  for (const collection of ["endpoint-pools", "pools"]) {
+  for (const collection of ["endpoint-pools", "pools", "rpc-pools"]) {
     test(`${collection}: min_eligible_count keeps rows >= the bound and drops absent/non-numeric`, () => {
       const result = applyQueryFilters(
         data,

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -14645,6 +14645,133 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(res.body.result.isError, true);
   });
 
+  // #6570: list_rpc_pools gained the same limit/cursor/sort/filter surface
+  // list_endpoint_pools already has, applied after the live-eligibility
+  // overlay so filters/sorts see live values, not the baked snapshot.
+  test("list_rpc_pools filters by kind and reports total/returned", async () => {
+    const deps = makeDeps({
+      "/metagraph/rpc/pools.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        pools: [
+          {
+            id: "finney-rpc",
+            kind: "subtensor-rpc",
+            eligible_count: 2,
+            endpoint_count: 5,
+          },
+          {
+            id: "finney-wss",
+            kind: "subtensor-wss",
+            eligible_count: 8,
+            endpoint_count: 10,
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_rpc_pools",
+      { kind: "subtensor-rpc" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.total, 1);
+    assert.equal(out.returned, 1);
+    assert.equal(out.pools[0].id, "finney-rpc");
+  });
+
+  test("list_rpc_pools sorts by eligible_count and pages with limit/cursor", async () => {
+    const deps = makeDeps({
+      "/metagraph/rpc/pools.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        pools: [
+          {
+            id: "a",
+            kind: "subtensor-rpc",
+            eligible_count: 1,
+            endpoint_count: 5,
+          },
+          {
+            id: "b",
+            kind: "subtensor-rpc",
+            eligible_count: 9,
+            endpoint_count: 5,
+          },
+          {
+            id: "c",
+            kind: "subtensor-rpc",
+            eligible_count: 4,
+            endpoint_count: 5,
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_rpc_pools",
+      { sort: "eligible_count", order: "desc", limit: 2 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(
+      out.pools.map((p) => p.id),
+      ["b", "c"],
+    );
+    assert.equal(out.total, 3);
+    assert.equal(out.returned, 2);
+    assert.equal(out.next_cursor, 2);
+  });
+
+  test("list_rpc_pools min_/max_eligible_count bound the live-overlaid eligible_count", async () => {
+    const deps = makeDeps({
+      "/metagraph/rpc/pools.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        pools: [
+          {
+            id: "low",
+            kind: "subtensor-rpc",
+            eligible_count: 1,
+            endpoint_count: 5,
+          },
+          {
+            id: "high",
+            kind: "subtensor-rpc",
+            eligible_count: 9,
+            endpoint_count: 5,
+          },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_rpc_pools",
+      { min_eligible_count: 5 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(
+      out.pools.map((p) => p.id),
+      ["high"],
+    );
+  });
+
+  test("list_rpc_pools rejects an invalid sort value", async () => {
+    const res = await callTool("list_rpc_pools", { sort: "not-a-field" });
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("list_rpc_pools payload validates against its declared outputSchema", async () => {
+    const schema = listToolDefinitions().find(
+      (t) => t.name === "list_rpc_pools",
+    )?.outputSchema;
+    const deps = makeDeps({
+      "/metagraph/rpc/pools.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        pools: [{ id: "finney-rpc", kind: "subtensor-rpc", eligible_count: 2 }],
+      },
+    });
+    const res = await callTool("list_rpc_pools", { limit: 1 }, { deps });
+    const validate = new Ajv2020({ strict: false }).compile(schema);
+    assert.ok(validate(res.body.result.structuredContent));
+  });
+
   test("get_subnet_endpoints returns one subnet's endpoints artifact", async () => {
     const deps = makeDeps({
       "/metagraph/endpoints/5.json": {

--- a/tests/rpc-pools-mcp.test.mjs
+++ b/tests/rpc-pools-mcp.test.mjs
@@ -1,0 +1,353 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import * as listQuery from "../workers/list-query.mjs";
+import {
+  RPC_POOLS_ARTIFACT,
+  LIST_RPC_POOLS_MCP_TOOL,
+  LIST_RPC_POOLS_OUTPUT_SCHEMA,
+  rpcPoolsMcpError,
+  rpcPoolsQueryUrl,
+  loadRpcPoolsList,
+} from "../src/rpc-pools-mcp.mjs";
+import { MCP_TOOLS } from "../src/mcp-server.mjs";
+
+const SAMPLE_BLOB = {
+  generated_at: "2026-07-01T00:00:00.000Z",
+  notes: "test",
+  pools: [
+    {
+      id: "finney-rpc",
+      kind: "subtensor-rpc",
+      eligible_count: 2,
+      endpoint_count: 5,
+    },
+    {
+      id: "finney-wss",
+      kind: "subtensor-wss",
+      eligible_count: 8,
+      endpoint_count: 10,
+    },
+    {
+      id: "finney-archive",
+      kind: "archive",
+      eligible_count: 0,
+      endpoint_count: 3,
+    },
+  ],
+};
+
+function readArtifact(_env, path) {
+  if (path === RPC_POOLS_ARTIFACT) {
+    return Promise.resolve({ ok: true, data: SAMPLE_BLOB });
+  }
+  return Promise.resolve({ ok: false, code: "artifact_not_found" });
+}
+
+describe("rpc-pools-mcp", () => {
+  test("rpcPoolsMcpError is shaped for MCP toolError handling", () => {
+    const err = rpcPoolsMcpError("invalid_params", "bad sort");
+    assert.equal(err.code, "invalid_params");
+    assert.equal(err.toolError, true);
+  });
+
+  test("rpcPoolsQueryUrl validates filters, range bounds, and cursor", () => {
+    const url = rpcPoolsQueryUrl({
+      id: "finney-rpc",
+      kind: "subtensor-rpc",
+      min_eligible_count: 2,
+      max_eligible_count: 8,
+      min_endpoint_count: 4,
+      max_endpoint_count: 10,
+      sort: "eligible_count",
+      order: "desc",
+      limit: 10,
+      cursor: 5,
+    });
+    assert.equal(url.searchParams.get("id"), "finney-rpc");
+    assert.equal(url.searchParams.get("kind"), "subtensor-rpc");
+    assert.equal(url.searchParams.get("min_eligible_count"), "2");
+    assert.equal(url.searchParams.get("max_eligible_count"), "8");
+    assert.equal(url.searchParams.get("min_endpoint_count"), "4");
+    assert.equal(url.searchParams.get("max_endpoint_count"), "10");
+    assert.equal(url.searchParams.get("sort"), "eligible_count");
+    assert.equal(url.searchParams.get("limit"), "10");
+    assert.equal(url.searchParams.get("cursor"), "5");
+  });
+
+  test("rpcPoolsQueryUrl rejects invalid kind", () => {
+    assert.throws(
+      () => rpcPoolsQueryUrl({ kind: "bogus" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcPoolsQueryUrl rejects empty id", () => {
+    assert.throws(
+      () => rpcPoolsQueryUrl({ id: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcPoolsQueryUrl rejects non-string id", () => {
+    assert.throws(
+      () => rpcPoolsQueryUrl({ id: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcPoolsQueryUrl rejects non-numeric range bounds", () => {
+    assert.throws(
+      () => rpcPoolsQueryUrl({ min_eligible_count: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcPoolsQueryUrl rejects negative cursor", () => {
+    assert.throws(
+      () => rpcPoolsQueryUrl({ cursor: -1 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcPoolsQueryUrl rejects a non-integer cursor", () => {
+    assert.throws(
+      () => rpcPoolsQueryUrl({ cursor: 1.5 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcPoolsQueryUrl rejects empty fields projection", () => {
+    assert.throws(
+      () => rpcPoolsQueryUrl({ fields: "   " }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcPoolsQueryUrl trims and forwards a fields projection", () => {
+    const url = rpcPoolsQueryUrl({ fields: " id,kind " });
+    assert.equal(url.searchParams.get("fields"), "id,kind");
+  });
+
+  test("rpcPoolsQueryUrl rejects non-string fields", () => {
+    assert.throws(
+      () => rpcPoolsQueryUrl({ fields: 42 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcPoolsQueryUrl rejects a non-numeric limit", () => {
+    assert.throws(
+      () => rpcPoolsQueryUrl({ limit: "lots" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcPoolsQueryUrl rejects a sub-minimum limit", () => {
+    assert.throws(
+      () => rpcPoolsQueryUrl({ limit: 0 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("rpcPoolsQueryUrl rejects a limit above the MCP maximum", () => {
+    assert.throws(
+      () => rpcPoolsQueryUrl({ limit: 500 }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadRpcPoolsList returns filtered rows with pagination meta", async () => {
+    const out = await loadRpcPoolsList(
+      { env: {}, readArtifact },
+      { id: "finney-rpc" },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.pools[0].id, "finney-rpc");
+    assert.equal(out.pools[0].eligible_count, 2);
+  });
+
+  test("loadRpcPoolsList applies range filters", async () => {
+    const out = await loadRpcPoolsList(
+      { env: {}, readArtifact },
+      { min_eligible_count: 2 },
+    );
+    assert.equal(out.returned, 2);
+    assert.deepEqual(
+      out.pools.map((p) => p.id),
+      ["finney-rpc", "finney-wss"],
+    );
+  });
+
+  test("loadRpcPoolsList sorts and pages the collection", async () => {
+    const out = await loadRpcPoolsList(
+      { env: {}, readArtifact },
+      { sort: "eligible_count", order: "desc", limit: 1 },
+    );
+    assert.equal(out.returned, 1);
+    assert.equal(out.total, 3);
+    assert.equal(out.pools[0].id, "finney-wss");
+    assert.equal(out.next_cursor, 1);
+  });
+
+  test("loadRpcPoolsList applies the live eligibility overlay before filtering", async () => {
+    const out = await loadRpcPoolsList(
+      {
+        env: {},
+        readArtifact,
+        readHealthKv: async () => ({
+          last_run_at: "2026-07-02T00:00:00.000Z",
+          endpoints: [],
+        }),
+      },
+      {},
+    );
+    assert.equal(out.source, "live-cron-prober");
+    assert.equal(out.operational_observed_at, "2026-07-02T00:00:00.000Z");
+  });
+
+  test("loadRpcPoolsList skips the overlay when no readHealthKv dep is provided", async () => {
+    const out = await loadRpcPoolsList({ env: {}, readArtifact }, {});
+    assert.equal(out.source, null);
+  });
+
+  test("loadRpcPoolsList skips the overlay when the live snapshot has no endpoints array", async () => {
+    const out = await loadRpcPoolsList(
+      {
+        env: {},
+        readArtifact,
+        readHealthKv: async () => ({ last_run_at: "2026-07-02T00:00:00.000Z" }),
+      },
+      {},
+    );
+    assert.equal(out.source, null);
+  });
+
+  test("loadRpcPoolsList uses an injected readArtifact dep", async () => {
+    const out = await loadRpcPoolsList(
+      { env: {}, readArtifact: async () => ({ ok: false }) },
+      {},
+      {
+        readArtifact: async () => ({
+          ok: true,
+          data: { pools: [{ id: "test" }] },
+        }),
+      },
+    );
+    assert.equal(out.pools[0].id, "test");
+  });
+
+  test("loadRpcPoolsList maps artifact_not_found to not_found", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcPoolsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_not_found",
+            }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadRpcPoolsList surfaces other artifact failures", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcPoolsList(
+          {
+            env: {},
+            readArtifact: async () => ({
+              ok: false,
+              code: "artifact_timeout",
+            }),
+          },
+          {},
+        ),
+      (err) =>
+        err.code === "artifact_timeout" && /rpc\/pools\.json/.test(err.message),
+    );
+  });
+
+  test("loadRpcPoolsList rejects invalid list-query params from REST parity", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcPoolsList({ env: {}, readArtifact }, { fields: "not_a_column" }),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadRpcPoolsList rejects contradictory range bounds", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcPoolsList(
+          { env: {}, readArtifact },
+          { min_eligible_count: 9, max_eligible_count: 2 },
+        ),
+      (err) => err.code === "invalid_params",
+    );
+  });
+
+  test("loadRpcPoolsList rejects a malformed artifact payload", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcPoolsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: true, data: null }),
+          },
+          {},
+        ),
+      (err) => err.code === "not_found",
+    );
+  });
+
+  test("loadRpcPoolsList defaults code when the read result is bare", async () => {
+    await assert.rejects(
+      () =>
+        loadRpcPoolsList(
+          {
+            env: {},
+            readArtifact: async () => ({ ok: false }),
+          },
+          {},
+        ),
+      (err) => err.code === "artifact_unavailable",
+    );
+  });
+
+  test("loadRpcPoolsList falls back when pagination meta is absent", async () => {
+    const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
+      data: { pools: [{ id: "a" }, { id: "b" }] },
+      meta: {},
+    });
+    try {
+      const out = await loadRpcPoolsList({ env: {}, readArtifact }, {});
+      assert.equal(out.total, 2);
+      assert.equal(out.returned, 2);
+      assert.equal(out.limit, 2);
+      assert.equal(out.cursor, 0);
+      assert.equal(out.next_cursor, null);
+      assert.equal(out.sort, null);
+      assert.equal(out.order, null);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("MCP tool metadata and outputSchema compile", () => {
+    assert.equal(LIST_RPC_POOLS_MCP_TOOL.name, "list_rpc_pools");
+    assert.ok(
+      new Ajv2020({ strict: false }).compile(LIST_RPC_POOLS_OUTPUT_SCHEMA),
+    );
+  });
+
+  test("MCP server exports wire list_rpc_pools", () => {
+    const tool = MCP_TOOLS.find((t) => t.name === "list_rpc_pools");
+    assert.ok(tool);
+    assert.equal(tool.title, "List Bittensor RPC pools");
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /api/v1/rpc/pools` was registered in `src/contracts.mjs` with no `listQuery(...)` argument at all, so any `?limit=`/`?cursor=`/`?sort=`/`?q=` 400'd as `"unknown query parameter"` — unlike its generalized sibling `GET /api/v1/endpoint-pools`, which fully supports pagination/filter/sort via `listQuery("endpoint-pools")`. The underlying artifact is genuinely list-shaped (`pools: [...]`), confirmed by reading the live route/handler wiring, not just the issue text.
- Added a new `"rpc-pools"` collection to `API_QUERY_COLLECTIONS` (mirroring `endpoint-pools`'s exact filter/sort/range shape — same `data_key: "pools"`) and wired `listQuery("rpc-pools")` into the route registration. REST now goes through the existing generic dispatcher (`applyQueryFilters(baseData, ...)`), applied *after* the live 15-minute cron eligibility overlay, so filters like `min_eligible_count` read live values, not the baked snapshot — verified by tracing `workers/api.mjs`'s `liveHealthOverlay` → `applyQueryFilters` ordering directly.
- The `list_rpc_pools` MCP tool had the identical gap (empty `inputSchema`, no filtering at all). Extracted its logic into a new `src/rpc-pools-mcp.mjs` module (mirroring the established `endpoint-pools-mcp.mjs` sibling-file + `applyQueryFilters`-delegation pattern used elsewhere in this codebase), preserving the existing live-overlay behavior exactly while adding the same `id`/`kind`/`min_`/`max_eligible_count`/`min_`/`max_endpoint_count`/`sort`/`order`/`fields`/`limit`/`cursor` parity `list_endpoint_pools` already has.
- Mid-implementation, a parallel upstream PR (#6569/#6600) changed sibling MCP list tools' `limit` handling from silently-clamping an out-of-range value to explicitly rejecting it. Updated `rpc-pools-mcp.mjs`'s `limit` validation to match that convention exactly, so this new tool doesn't reintroduce the anti-pattern #6569 just eliminated elsewhere.

Closes #6570

## Test plan
- [x] `npx vitest run tests/rpc-pools-mcp.test.mjs` — 30 new tests pass (query-URL construction, all filter/range/sort/cursor/limit validation branches, live-overlay ordering, artifact-error mapping, MCP tool/schema wiring)
- [x] `npx vitest run tests/mcp-server.test.mjs` — 1089 tests pass, including 6 new `list_rpc_pools` filter/sort/pagination/outputSchema tests alongside the 7 pre-existing overlay/fallback tests (all still pass unchanged)
- [x] `npx vitest run tests/list-query.test.mjs` — REST-side `rpc-pools` collection covered by extending the existing `#2587` shared-collection range-filter test to include it alongside `endpoint-pools`/`pools`
- [x] `npx vitest run` (full suite) — 304 files / 9070 tests pass
- [x] Targeted coverage check on `src/rpc-pools-mcp.mjs` — 100% statements/branches/functions/lines
- [x] `npm run validate:contract-drift` / `validate:openapi` / `validate:mcp` / `validate` — all pass
- [x] `npm run lint` / `npm run format:check` — clean