### PR TITLE
fix(ui): return focus to the opener when the command palette closes (#6417)

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/lib/metagraphed/config";
 import { useApiBase } from "@/hooks/use-api-base";
 import { useEndpointHealth, type EndpointHealth } from "@/hooks/use-endpoint-health";
+import { useRestoreFocus } from "@/hooks/use-restore-focus";
 import { NetworkSwitcher } from "./network-switcher";
 import {
   Tooltip,
@@ -94,6 +95,21 @@ export function AppShell({
   // hamburger is this Sheet's only opener, so a direct ref is enough.)
   const hamburgerRef = useRef<HTMLButtonElement | null>(null);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  // #6417: the command palette opens from discrete buttons (mobile search icon,
+  // the omnibox "Full search" entry) that aren't in-tree Radix triggers, so on
+  // close Radix drops focus to <body>. Capture the opener on those paths and
+  // restore it when the palette closes. The global ⌘K / "/" keydown paths
+  // intentionally don't capture — there's no single trigger element, so leaving
+  // focus wherever it was is the correct fallback.
+  const paletteFocus = useRestoreFocus();
+  const openPaletteFromButton = () => {
+    paletteFocus.capture();
+    setPaletteOpen(true);
+  };
+  const onPaletteOpenChange = (next: boolean) => {
+    setPaletteOpen(next);
+    if (!next) paletteFocus.restore();
+  };
   const [scrolled, setScrolled] = useState(false);
   const crumbs = useMemo(() => buildCrumbs(pathname), [pathname]);
   const parent = useMemo(() => parentCrumb(crumbs), [crumbs]);
@@ -166,7 +182,7 @@ export function AppShell({
               <span aria-hidden className="hidden lg:inline-block h-5 w-px bg-border mx-1" />
               <NavMegaMenu />
               <div className="flex-1 min-w-0 flex justify-end">
-                <NavOmnibox onOpenPalette={() => setPaletteOpen(true)} />
+                <NavOmnibox onOpenPalette={openPaletteFromButton} />
                 {/* Below md the omnibox is hidden (#5034), which left the palette
                     reachable only via ⌘K / Ctrl+K / "/" — none of which exist on a
                     touch device, so mobile had no way into global search at all.
@@ -175,7 +191,7 @@ export function AppShell({
                     (#5319). */}
                 <button
                   type="button"
-                  onClick={() => setPaletteOpen(true)}
+                  onClick={openPaletteFromButton}
                   aria-label="Open search"
                   title="Search"
                   className="md:hidden inline-flex items-center justify-center rounded border border-border bg-card p-1.5 min-h-11 min-w-11 text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors"
@@ -327,7 +343,7 @@ export function AppShell({
 
           <SiteFooter />
           <ApiDrawer />
-          <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+          <CommandPalette open={paletteOpen} onOpenChange={onPaletteOpenChange} />
           <ShortcutsPopover />
           <BackToTop />
         </div>

--- a/apps/ui/src/hooks/use-restore-focus.test.ts
+++ b/apps/ui/src/hooks/use-restore-focus.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { canRestoreFocusTo } from "./use-restore-focus";
+
+// #6417: capture-and-restore focus for the command palette's discrete-button
+// open paths, factored into a shared hook (the #6548 review asked for exactly
+// this instead of a fourth copy). This suite runs in a node environment, so the
+// pure guard is tested with duck-typed stand-ins and the app-shell wiring is
+// asserted on source (the component needs the full app shell + router to render).
+
+const el = (isConnected: boolean) => ({ isConnected }) as unknown as Element;
+
+describe("canRestoreFocusTo", () => {
+  it("is false for null", () => {
+    expect(canRestoreFocusTo(null)).toBe(false);
+  });
+
+  it("is false for a detached element (opener unmounted while overlay was open)", () => {
+    expect(canRestoreFocusTo(el(false))).toBe(false);
+  });
+
+  it("is true for an element still in the document", () => {
+    expect(canRestoreFocusTo(el(true))).toBe(true);
+  });
+});
+
+const appShell = readFileSync(
+  fileURLToPath(new URL("../components/metagraphed/app-shell.tsx", import.meta.url)),
+  "utf8",
+);
+
+describe("app-shell wires the command palette focus-restore (#6417)", () => {
+  it("uses the shared useRestoreFocus hook", () => {
+    expect(appShell).toContain("useRestoreFocus");
+    expect(appShell).toContain("use-restore-focus");
+  });
+
+  it("captures the opener on the discrete-button open paths", () => {
+    // The mobile search icon and the omnibox "Full search" entry both open via a
+    // capture-then-open helper, not a bare setPaletteOpen(true).
+    expect(appShell).toContain("openPaletteFromButton");
+    expect(appShell).toContain("paletteFocus.capture()");
+    expect(appShell).toContain("onClick={openPaletteFromButton}");
+    expect(appShell).toContain("onOpenPalette={openPaletteFromButton}");
+  });
+
+  it("restores focus when the palette closes, via onOpenChange", () => {
+    expect(appShell).toContain("onPaletteOpenChange");
+    expect(appShell).toContain("paletteFocus.restore()");
+    expect(appShell).toContain("onOpenChange={onPaletteOpenChange}");
+  });
+});

--- a/apps/ui/src/hooks/use-restore-focus.ts
+++ b/apps/ui/src/hooks/use-restore-focus.ts
@@ -1,0 +1,45 @@
+import { useCallback, useRef } from "react";
+
+// #6417: several overlays (the ⌘K command palette, the API drawer #6418, the
+// mobile nav sheet) open from a discrete button but have no in-tree Radix
+// trigger, so on close focus falls to <body> instead of the control that opened
+// them. #6548's review asked for the repeated capture-and-restore pattern to be
+// factored into one hook rather than copied a fourth time — this is that hook.
+
+/** True when `el` is a real element still in the document, so focusing it is
+ *  meaningful. Pure, so it can be unit-tested without a DOM. */
+export function canRestoreFocusTo(el: Element | null): el is HTMLElement {
+  return el != null && (el as HTMLElement).isConnected === true;
+}
+
+interface RestoreFocus {
+  /** Record the currently-focused element as the one to return focus to on close. */
+  capture: () => void;
+  /** Return focus to the captured element if it's still connected; no-op otherwise. */
+  restore: () => void;
+}
+
+/**
+ * Capture the element focused when an overlay opens and restore focus to it when
+ * the overlay closes. Call `capture()` in the open path (before the overlay
+ * takes focus) and `restore()` in the close path (e.g. `onOpenChange(false)`).
+ *
+ * Restores only to a still-connected element — if the opener was unmounted while
+ * the overlay was open, focus is left where the overlay's own logic put it,
+ * never forced onto a detached node.
+ */
+export function useRestoreFocus(): RestoreFocus {
+  const ref = useRef<HTMLElement | null>(null);
+
+  const capture = useCallback(() => {
+    ref.current = (document.activeElement as HTMLElement | null) ?? null;
+  }, []);
+
+  const restore = useCallback(() => {
+    const el = ref.current;
+    if (canRestoreFocusTo(el)) el.focus();
+    ref.current = null;
+  }, []);
+
+  return { capture, restore };
+}


### PR DESCRIPTION
## Summary

The ⌘K command palette opens from discrete buttons — the mobile search icon (`app-shell.tsx`) and the omnibox "Full search" entry (`NavOmnibox`) — that are **not** composed as in-tree Radix `<Dialog.Trigger>`s. So closing the palette dropped keyboard focus to `<body>` instead of returning it to the control that opened it, a regression for keyboard and screen-reader users. (Same defect class already fixed for the API drawer #6418, the mobile nav sheet #6544, and the schema-drift dialog #6555.)

## Fix

Add a shared **`useRestoreFocus`** hook (`apps/ui/src/hooks/use-restore-focus.ts`): `capture()` records `document.activeElement` on open, `restore()` returns focus to it on close (only if still connected). Wire it into `app-shell.tsx`:

- The mobile search icon and the omnibox "Full search" entry now open via `openPaletteFromButton` (capture → open).
- The palette's `onOpenChange` is wrapped by `onPaletteOpenChange`, which calls `restore()` on close.
- The global **⌘K / "/" keydown paths intentionally do not capture** — there's no single trigger element, so leaving focus where it was is the correct fallback (per the issue).

The prior attempt at this issue (#6548) was asked in review to factor the repeated capture/restore pattern (#6416/#6417/#6418) into one hook rather than copy it a fourth time — `useRestoreFocus` is that shared primitive, so this also pays down that duplication.

**No visual change:** only focus behavior on palette close is affected; the before/after screenshots below are identical by design and confirm no visual regression.

## Tests

`apps/ui/src/hooks/use-restore-focus.test.ts`:
- Unit tests for the pure `canRestoreFocusTo` guard (null / detached / connected), duck-typed to this suite's node environment.
- Source assertions that `app-shell.tsx` uses the hook, captures on both discrete-button paths (`openPaletteFromButton` on the icon `onClick` and `NavOmnibox onOpenPalette`), and restores via `onPaletteOpenChange` on the palette's `onOpenChange` — matching the `api-source-context.test.ts` precedent (the component needs the full app shell + router to render).

## Validation

- `npm test --workspace=apps/ui` → full suite passed (6 new)
- `npm run typecheck` / `npm run lint` / `npx prettier --check` (`--workspace=apps/ui`) → clean
- `npm run test:e2e --workspace=apps/ui` → responsive-overflow specs for `/` and `/settings` (which render app-shell) pass
- `npm run build --workspace=apps/ui` → clean

## Screenshots (`/` — visually unchanged; focus-behavior-only fix)

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6417-palette-focus-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6417
