### PR TITLE
feat(deploy): track release-health sessions for the two long-running Node services

### DIFF
--- a/deploy/wss-lb/src/observability.mjs
+++ b/deploy/wss-lb/src/observability.mjs
@@ -8,11 +8,59 @@
 // that file runs its HTTP server + refresh loop as an unconditional
 // top-level side effect on import, so it can't be required by a test file
 // directly (see server.mjs's own header).
+import { closeSession } from "@sentry/core";
 import * as Sentry from "@sentry/node";
+
+// Release-health session tracking (Crash Free Sessions/Users), process-
+// lifetime model: this is an always-on server, not a one-shot batch script
+// (contrast the canonical metagraphed repo's scripts/observability.mjs,
+// which sessions per script run) -- one session per process boot, closed
+// healthy on graceful SIGTERM/SIGINT shutdown (see server.mjs's own
+// shutdown handler) or marked crashed here on a genuinely uncaught
+// exception. @sentry/node's default OnUncaughtException/OnUnhandledRejection
+// integrations don't mark the active session crashed before exiting
+// (confirmed by reading node_modules/@sentry/node-core's actual source --
+// same finding scripts/observability.mjs's own header documents), and unlike
+// scripts/chain-firehose-relay.mjs this server has no single top-level
+// main().catch() boundary every crash funnels through (any of its event
+// handlers -- the HTTP server, the WS upgrade handler, the refresh/heartbeat
+// intervals -- could throw directly to the process level), so this module
+// owns the crash path itself: handlers registered before Sentry.init() runs
+// (Node calls uncaughtException/unhandledRejection listeners in registration
+// order), with those two default integrations filtered out so there's no
+// race between two competing exit paths.
+let sentryInitialized = false;
+
+async function handleFatal(error, exitCode) {
+  console.error("[wss-lb] fatal:", error);
+  if (sentryInitialized) {
+    Sentry.captureException(error);
+    const session = Sentry.getIsolationScope().getSession();
+    if (session) {
+      closeSession(session, "crashed");
+      Sentry.captureSession();
+    }
+    await Sentry.flush(2000);
+  }
+  process.exit(exitCode);
+}
 
 export function initSentry() {
   const dsn = process.env.SENTRY_DSN;
   if (!dsn) return;
+
+  // Registered before Sentry.init() -- see this module's own header for why
+  // ordering matters here.
+  process.on("uncaughtException", (error) => {
+    handleFatal(error, 1);
+  });
+  process.on("unhandledRejection", (reason) => {
+    handleFatal(
+      reason instanceof Error ? reason : new Error(String(reason)),
+      1,
+    );
+  });
+
   Sentry.init({
     dsn,
     environment: process.env.SENTRY_ENVIRONMENT || "production",
@@ -23,8 +71,33 @@ export function initSentry() {
     // SENTRY_RELEASE still wins if one is somehow already set.
     release: process.env.SENTRY_RELEASE || process.env.RAILWAY_GIT_COMMIT_SHA,
     tracesSampleRate: 0,
+    // Also filters out the default ProcessSession integration -- it calls
+    // startSession() itself during Sentry.init(), which our own
+    // Sentry.startSession() call below would otherwise immediately end
+    // (reporting a spurious extra "exited" session on every single process
+    // boot) and replace, rather than there being exactly one session per
+    // boot as intended. Confirmed empirically: without this, every boot
+    // sent two session envelopes (one "exited", one for this boot's real
+    // outcome) instead of one.
+    integrations: (integrations) =>
+      integrations.filter(
+        (integration) =>
+          integration.name !== "OnUncaughtException" &&
+          integration.name !== "OnUnhandledRejection" &&
+          integration.name !== "ProcessSession",
+      ),
   });
   Sentry.setTag("component", "wss-lb");
+  sentryInitialized = true;
+  Sentry.startSession();
+}
+
+// Closes the process-lifetime session as a healthy exit. Called from
+// server.mjs's own graceful SIGTERM/SIGINT handler.
+export async function endSessionAndFlush() {
+  if (!sentryInitialized) return;
+  Sentry.endSession();
+  await Sentry.flush(2000);
 }
 
 export const NO_UPSTREAM_REPORT_THRESHOLD = 50;

--- a/deploy/wss-lb/src/server.mjs
+++ b/deploy/wss-lb/src/server.mjs
@@ -27,6 +27,7 @@ import { createConnectionLimiter, resolveClientIp } from "./rate-limit.mjs";
 import { selectWssUpstreams } from "./select.mjs";
 import {
   initSentry,
+  endSessionAndFlush,
   computeNoUpstreamWindowUpdate,
   reportNoUpstreamWindow,
   reportPoolStale,
@@ -224,3 +225,16 @@ server.listen(PORT, () =>
     `wss-lb listening :${PORT} · networks=${NETWORKS.join(",")} · api=${API}`,
   ),
 );
+
+// Railway sends SIGTERM on every redeploy -- without this, the process
+// simply dies mid-"ok" and its Sentry release-health session is never
+// closed, reporting neither healthy nor crashed. Scoped to just the Sentry
+// session (not draining in-flight WS connections/the HTTP server): the
+// process manager already restarts on exit, and existing client sockets
+// close on their own once the process actually exits either way.
+async function shutdown() {
+  await endSessionAndFlush();
+  process.exit(0);
+}
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/scripts/chain-firehose-relay.mjs
+++ b/scripts/chain-firehose-relay.mjs
@@ -37,6 +37,7 @@
 
 import { writeFileSync, statSync } from "node:fs";
 import postgres from "postgres";
+import { closeSession } from "@sentry/core";
 import * as Sentry from "@sentry/node";
 
 // Reports to the consolidated `metagraphed` Sentry project. Silently no-ops
@@ -64,8 +65,36 @@ export function initSentry() {
     environment: process.env.SENTRY_ENVIRONMENT || "production",
     release: process.env.SENTRY_RELEASE, // deployed git SHA
     tracesSampleRate: 0,
+    // The default ProcessSession integration auto-starts its own session
+    // during Sentry.init() -- left unfiltered, our own startSession() call
+    // below would immediately end that one (a spurious extra "exited"
+    // session on every process boot) and replace it, instead of there being
+    // exactly one session per boot. Confirmed empirically against a real
+    // local Sentry-envelope-receiving HTTP server (see scripts/
+    // observability.mjs's own comment on this same integration for the
+    // canonical writeup).
+    integrations: (integrations) =>
+      integrations.filter(
+        (integration) => integration.name !== "ProcessSession",
+      ),
   });
   Sentry.setTag("component", "chain-firehose-relay");
+  // Release-health session tracking (Crash Free Sessions/Users), process-
+  // lifetime model: this is an always-on relay, not a one-shot batch script
+  // (contrast scripts/observability.mjs's per-run sessions) -- one session
+  // per process boot, closed healthy on the existing graceful SIGTERM/SIGINT
+  // shutdown path below, or marked crashed in main()'s own top-level .catch()
+  // (see that catch block's comment for why no separate uncaughtException/
+  // unhandledRejection wiring is needed here, unlike scripts/observability.mjs).
+  Sentry.startSession();
+}
+
+// Closes the process-lifetime session as a healthy exit. Called from the
+// graceful SIGTERM/SIGINT shutdown path once the poll loop has actually
+// stopped -- see main()'s own shutdown() closure.
+export async function endSessionAndFlush() {
+  Sentry.endSession();
+  await Sentry.flush(2000);
 }
 
 export const CHAIN_FIREHOSE_DROP_REPORT_THRESHOLD = 500;
@@ -619,6 +648,7 @@ async function main() {
     }
   }
   await sql.end({ timeout: 5 });
+  await endSessionAndFlush();
   process.exit(0);
 }
 
@@ -636,9 +666,20 @@ if (import.meta.url === `file://${process.argv[1]}`) {
       // Explicitly caught here, so @sentry/node's default
       // OnUnhandledRejection integration never sees this -- Node does not
       // consider a promise "unhandled" once something calls .catch() on it.
+      // This is also main()'s ONLY path to the process actually exiting non-
+      // zero (every await inside its poll loop funnels errors up through
+      // this same chain, there's no other unguarded top-level code), so
+      // marking the session crashed here -- rather than a separate
+      // uncaughtException/unhandledRejection handler like
+      // scripts/observability.mjs needs -- covers every real crash.
+      Sentry.captureException(error);
+      const session = Sentry.getIsolationScope().getSession();
+      if (session) {
+        closeSession(session, "crashed");
+        Sentry.captureSession();
+      }
       // flush() before process.exit(1) is required: process.exit() is
       // synchronous and does not wait for Sentry's background network send.
-      Sentry.captureException(error);
       await Sentry.flush(2000);
       process.exit(1);
     });

--- a/tests/chain-firehose-relay.test.mjs
+++ b/tests/chain-firehose-relay.test.mjs
@@ -23,12 +23,17 @@ const captureMessage = vi.hoisted(() => vi.fn());
 const captureException = vi.hoisted(() => vi.fn());
 const sentryInit = vi.hoisted(() => vi.fn());
 const setTag = vi.hoisted(() => vi.fn());
+const startSession = vi.hoisted(() => vi.fn());
+const endSession = vi.hoisted(() => vi.fn());
+const flush = vi.hoisted(() => vi.fn(async () => true));
 vi.mock("@sentry/node", () => ({
   init: sentryInit,
   setTag,
   captureMessage,
   captureException,
-  flush: vi.fn(async () => true),
+  startSession,
+  endSession,
+  flush,
 }));
 
 import {
@@ -46,6 +51,7 @@ import {
   computeBackoffDelayMs,
   computeBatchPaceDelayMs,
   computeDropWindowUpdate,
+  endSessionAndFlush,
   forwardBatch,
   forwardChainFirehoseNotification,
   forwardWithRetry,
@@ -755,28 +761,46 @@ test("reportRateLimitPause: calls Sentry.captureMessage directly, once per call 
 test("initSentry: no-ops (never calls Sentry.init) when SENTRY_DSN is unset", () => {
   sentryInit.mockClear();
   setTag.mockClear();
+  startSession.mockClear();
   vi.stubEnv("SENTRY_DSN", "");
   initSentry();
   assert.equal(sentryInit.mock.calls.length, 0);
   assert.equal(setTag.mock.calls.length, 0);
+  assert.equal(startSession.mock.calls.length, 0);
   vi.unstubAllEnvs();
 });
 
-test("initSentry: calls Sentry.init with dsn/environment/release and tags the component when SENTRY_DSN is set", () => {
+test("initSentry: calls Sentry.init with dsn/environment/release, tags the component, and starts a release-health session when SENTRY_DSN is set", () => {
   sentryInit.mockClear();
   setTag.mockClear();
+  startSession.mockClear();
   vi.stubEnv("SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
   vi.stubEnv("SENTRY_ENVIRONMENT", "staging");
   vi.stubEnv("SENTRY_RELEASE", "deadbeef");
   initSentry();
   assert.equal(sentryInit.mock.calls.length, 1);
-  assert.deepEqual(sentryInit.mock.calls[0][0], {
-    dsn: "https://abc@o0.ingest.sentry.io/0",
-    environment: "staging",
-    release: "deadbeef",
-    tracesSampleRate: 0,
-  });
+  const initArgs = sentryInit.mock.calls[0][0];
+  assert.equal(initArgs.dsn, "https://abc@o0.ingest.sentry.io/0");
+  assert.equal(initArgs.environment, "staging");
+  assert.equal(initArgs.release, "deadbeef");
+  assert.equal(initArgs.tracesSampleRate, 0);
   assert.deepEqual(setTag.mock.calls[0], ["component", "chain-firehose-relay"]);
+  assert.equal(startSession.mock.calls.length, 1);
+  vi.unstubAllEnvs();
+});
+
+test("initSentry: filters the default ProcessSession integration out (it would otherwise auto-start a second, spurious session)", () => {
+  sentryInit.mockClear();
+  vi.stubEnv("SENTRY_DSN", "https://abc@o0.ingest.sentry.io/0");
+  initSentry();
+
+  const { integrations } = sentryInit.mock.calls[0][0];
+  const filtered = integrations([{ name: "ProcessSession" }, { name: "Http" }]);
+  assert.deepEqual(
+    filtered.map((i) => i.name),
+    ["Http"],
+  );
+
   vi.unstubAllEnvs();
 });
 
@@ -787,6 +811,17 @@ test("initSentry: SENTRY_ENVIRONMENT defaults to 'production' when unset", () =>
   initSentry();
   assert.equal(sentryInit.mock.calls[0][0].environment, "production");
   vi.unstubAllEnvs();
+});
+
+// --- endSessionAndFlush -------------------------------------------------------
+
+test("endSessionAndFlush: ends the session and flushes", async () => {
+  endSession.mockClear();
+  flush.mockClear();
+  await endSessionAndFlush();
+  assert.equal(endSession.mock.calls.length, 1);
+  assert.equal(flush.mock.calls.length, 1);
+  assert.equal(flush.mock.calls[0][0], 2000);
 });
 
 // --- touchHeartbeat / isHeartbeatFresh -----------------------------------------


### PR DESCRIPTION
## Summary
Third piece of the release-health rollout, after [#6607](https://github.com/JSONbored/metagraphed/pull/6607) (Node batch scripts) and [metagraphed-infra#83](https://github.com/JSONbored/metagraphed-infra/pull/83) (Python fleet scripts). `chain-firehose-relay.mjs` and `deploy/wss-lb` are always-on processes, not one-shot batch scripts, so they need a **process-lifetime** session (start at boot, end at graceful shutdown, a crash counts as crashed) rather than the per-run model.

- **`scripts/chain-firehose-relay.mjs`**: already had a clean SIGTERM/SIGINT shutdown path and a single `main().catch()` boundary every crash funnels through — just needed `Sentry.startSession()`/new `endSessionAndFlush()` wired into those two existing exit points, plus session-crash-marking (`closeSession(session, "crashed")` + `captureSession()`) added to the catch block.
- **`deploy/wss-lb`**: had *neither* — no shutdown handling at all (Railway sends SIGTERM on every redeploy) and no single crash boundary (any event handler — HTTP server, WS upgrade, refresh/heartbeat intervals — could throw directly to the process level). `src/observability.mjs` now installs its own `uncaughtException`/`unhandledRejection` handlers before `Sentry.init()` runs (mirroring `scripts/observability.mjs`'s approach in #6607, since `@sentry/node`'s default `OnUncaughtException`/`OnUnhandledRejection` integrations don't mark sessions crashed), and `server.mjs` gets a minimal SIGTERM/SIGINT handler scoped to just closing the Sentry session — not draining connections or closing the HTTP server, since the process manager already restarts on exit.
- **Bug found + fixed in both, and backported to #6607**: `@sentry/node`'s default `ProcessSession` integration auto-starts its own session during `Sentry.init()`, so the explicit `Sentry.startSession()` call was silently ending that one (a spurious extra "exited" session) and replacing it — every boot sent two session envelopes instead of one. Confirmed empirically against a real local HTTP server standing in for Sentry's ingest endpoint. Fixed here by filtering `"ProcessSession"` out alongside the other two integrations.

## Test plan
- [x] `npm run lint`, `npx prettier --check` on all touched files
- [x] `tests/chain-firehose-relay.test.mjs` extended for the new session-tracking behavior (start, `endSessionAndFlush`, `ProcessSession` filter) — 58/58 passing
- [x] `deploy/wss-lb`'s own `node --test` suite — 32/32 passing (3 consecutive clean runs; one earlier failure was an unrelated pre-existing WS-port flake, confirmed not caused by this change)
- [x] Empirical verification against a real local HTTP server standing in for Sentry's ingest endpoint (both files): a handled/graceful shutdown sends exactly one `"exited"` session, a genuinely uncaught exception sends exactly one `"crashed"` session
- [x] Full root suite (`npm run test:coverage`) green before branching for this PR