### PR TITLE
refactor(ui): drop the dead #00c899 hex fallback from var(--accent) chart props (#6396)

### DIFF
--- a/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
@@ -106,7 +106,7 @@ export function AccountPositionHistoryChart({ ss58, netuid }: { ss58: string; ne
             <HistoryRow
               label="Emission"
               series={series.emission}
-              color="var(--accent, #00c899)"
+              color="var(--accent)"
               format={taoStr}
             />
           ) : null}

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -88,7 +88,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
       ) : (
         <div className="rounded-xl border border-border bg-card p-4 space-y-3">
           {series.neurons.length > 0 ? (
-            <HistoryRow label="Neurons" series={series.neurons} color="var(--accent, #00c899)" />
+            <HistoryRow label="Neurons" series={series.neurons} color="var(--accent)" />
           ) : null}
           {series.validators.length > 0 ? (
             <HistoryRow
@@ -109,7 +109,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
             <HistoryRow
               label="Total emission"
               series={series.emission}
-              color="var(--accent, #00c899)"
+              color="var(--accent)"
               format={formatTao}
             />
           ) : null}

--- a/apps/ui/src/components/metagraphed/validator-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/validator-history-chart.tsx
@@ -104,7 +104,7 @@ export function ValidatorHistoryChart({ hotkey }: { hotkey: string }) {
             <HistoryRow
               label="Rewards / 1k τ"
               series={series.rewards}
-              color="var(--accent, #00c899)"
+              color="var(--accent)"
               format={rewardsStr}
             />
           ) : null}

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -3379,7 +3379,7 @@ function Sparkline({
   points,
   width = 120,
   height = 28,
-  color = "var(--accent, #00c899)",
+  color = "var(--accent)",
   fill = true,
   className,
   ariaLabel,

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -3350,7 +3350,7 @@ function Sparkline({
   points,
   width = 120,
   height = 28,
-  color = "var(--accent, #00c899)",
+  color = "var(--accent)",
   fill = true,
   className,
   ariaLabel,

--- a/packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx
+++ b/packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx
@@ -42,7 +42,7 @@ export function Sparkline({
   points,
   width = 120,
   height = 28,
-  color = "var(--accent, #00c899)",
+  color = "var(--accent)",
   fill = true,
   className,
   ariaLabel,


### PR DESCRIPTION
## Summary

`--accent` is a global token always defined app-wide by `packages/ui-kit/src/styles.css`, so the `, #00c899` fallback in `color="var(--accent, #00c899)"` is **unreachable** -- it only drifts from the real token value. Five chart color props still carried it; the sibling charts (`neuron-history-chart`, `yield-panel`, `concentration-panel`) already use plain `var(--accent)`.

## What Changed

Replaced all 5 `var(--accent, #00c899)` with `var(--accent)`:
- `packages/ui-kit/src/components/metagraphed/charts/sparkline.tsx` (default prop; ui-kit `dist` rebuilt)
- `apps/ui/.../account-position-history-chart.tsx`, `subnet-history-chart.tsx` (x2), `validator-history-chart.tsx`

A repo grep for `#00c899` now returns nothing.

## Screenshots

**No visual change** -- this is the issue's own Expected Outcome (the fallback was already unreachable, so the resolved color is identical). Before/after on `/subnets/1` (renders the accent-colored charts) are pixel-identical, documenting no regression:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-before-desktop-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-after-desktop-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-before-desktop-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-after-desktop-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-before-tablet-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-after-tablet-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-after-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-before-tablet-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-before-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-after-tablet-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-after-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-before-mobile-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-after-mobile-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-before-mobile-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-after-mobile-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6396-accent-fallback/6396-after-mobile-dark.png) |

## Validation

- `npm run typecheck --workspace=apps/ui` -- 0 errors; ui-kit typecheck 0
- `npm test --workspace=packages/ui-kit` -- 75/75; apps/ui suite passes (pre-existing Windows-only CRLF failures in unrelated #6415/#6419 aside)
- `npm run build --workspace=packages/ui-kit` -- rebuilt; `git diff -- packages/ui-kit/dist` empty on fresh rebuild (drift check passes)
- eslint + prettier clean

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6396`) -- required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Only generated artifact touched is `packages/ui-kit/dist` (rebuilt from source).

Closes #6396
