### PR TITLE
fix(ui): extend endpoints Reset filters check to cover sort/order/page (#6579)

### DIFF
--- a/apps/ui/src/lib/metagraphed/endpoints-filters.test.ts
+++ b/apps/ui/src/lib/metagraphed/endpoints-filters.test.ts
@@ -11,9 +11,12 @@ const DEFAULTS: EndpointsFilterState = {
   region: "",
   eligibility: "",
   callable: true,
+  sort: "netuid",
+  order: "asc",
+  page: 1,
 };
 
-describe("endpointsFiltersActive (#6386)", () => {
+describe("endpointsFiltersActive (#6386, #6579)", () => {
   it("is inactive when every filter is at its default", () => {
     expect(endpointsFiltersActive(DEFAULTS)).toBe(false);
   });
@@ -36,6 +39,9 @@ describe("endpointsFiltersActive (#6386)", () => {
     ["netuid", { netuid: "42" }],
     ["region", { region: "us-east" }],
     ["eligibility", { eligibility: "pool-member" }],
+    ["sort", { sort: "latency" }],
+    ["order", { order: "desc" }],
+    ["page", { page: 2 }],
   ] satisfies [string, Partial<EndpointsFilterState>][])(
     "is active when %s alone is set",
     (_name, override) => {
@@ -45,5 +51,21 @@ describe("endpointsFiltersActive (#6386)", () => {
 
   it("is active when a text filter and the toggle are both non-default", () => {
     expect(endpointsFiltersActive({ ...DEFAULTS, q: "rpc", callable: false })).toBe(true);
+  });
+
+  it("is active when only sort/order/page have diverged from default (#6579)", () => {
+    // The regression: resetAll's navigate() omits sort/order/page (so they
+    // fall back to their schema defaults), but the prior check never noticed
+    // they'd diverged -- a user who only changed sort order or paged forward
+    // had no way to reset via this button, despite its title claiming to.
+    expect(endpointsFiltersActive({ ...DEFAULTS, sort: "latency", order: "desc", page: 3 })).toBe(
+      true,
+    );
+  });
+
+  it("stays inactive while sort/order/page are all at their defaults", () => {
+    expect(endpointsFiltersActive({ ...DEFAULTS, sort: "netuid", order: "asc", page: 1 })).toBe(
+      false,
+    );
   });
 });

--- a/apps/ui/src/lib/metagraphed/endpoints-filters.ts
+++ b/apps/ui/src/lib/metagraphed/endpoints-filters.ts
@@ -1,13 +1,19 @@
 /**
- * Whether any non-default filter is currently narrowing the /endpoints table --
- * the enabled state of that page's "Reset filters" button (#6386).
+ * Whether any non-default filter/sort/page state is currently diverged from
+ * the /endpoints table's defaults -- the enabled state of that page's
+ * "Reset filters" button (#6386, extended #6579 to also cover sort/order/page,
+ * which resetAll already restores but hasFilters didn't check).
  *
  * The subtlety is `callable` ("Callable only"), which defaults to `true`: like
  * subnets.index.tsx's `includeRoot` (#6270), it is toggling it OFF that makes it
  * an active filter, so the predicate checks `callable !== true`, not truthiness.
  * The prior inline check omitted `callable` entirely, so with the toggle as the
  * only active filter the Reset button stayed disabled -- even though resetAll
- * would have restored `callable: true` if it could have been clicked.
+ * would have restored `callable: true` if it could have been clicked. #6579
+ * found the same gap for `sort`/`order`/`page`: resetAll's navigate() omits
+ * them (so they fall back to their schema defaults -- "netuid"/"asc"/1) but
+ * the button's own title ("Clear search, filters, sort, and page") already
+ * claimed to reset them.
  *
  * Kept pure (a plain predicate over the URL search state) so it is unit-tested
  * apart from the route/DOM, mirroring filter-disclosure.ts.
@@ -21,6 +27,9 @@ export interface EndpointsFilterState {
   region: string;
   eligibility: string;
   callable: boolean;
+  sort: string;
+  order: string;
+  page: number;
 }
 
 export function endpointsFiltersActive(search: EndpointsFilterState): boolean {
@@ -33,6 +42,12 @@ export function endpointsFiltersActive(search: EndpointsFilterState): boolean {
     search.region !== "" ||
     search.eligibility !== "" ||
     // Defaults to true; hiding directory links is what makes it "active" (#6386).
-    search.callable !== true
+    search.callable !== true ||
+    // resetAll's navigate() omits sort/order/page, so they fall back to these
+    // schema defaults -- matching them here is what keeps the button's claimed
+    // scope ("...sort, and page") and its enabled-state in sync (#6579).
+    search.sort !== "netuid" ||
+    search.order !== "asc" ||
+    search.page !== 1
   );
 }

--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -770,6 +770,9 @@ function EndpointsTable() {
     region: search.region,
     eligibility: search.eligibility,
     callable: search.callable,
+    sort: search.sort,
+    order: search.order,
+    page: search.page,
   });
 
   // The table filters client-side over the full fetched list; the CSV export


### PR DESCRIPTION
Closes #6579

## Problem

On `/endpoints`, the "Reset filters" button's enabled state is driven by `endpointsFiltersActive()`, which only checked the search/select/toggle fields (`q`, `category`, `provider`, `health`, `netuid`, `region`, `eligibility`, `callable`). It never checked `sort`, `order`, or `page`.

The button's own title already claims a broader scope: "Clear search, filters, sort, and page." So a user who only changed the sort column, flipped sort order, or paged forward — with every other filter left at default — saw the Reset button stay disabled, even though clicking it (if it were enabled) would correctly reset those fields back to their `netuid`/`asc`/`1` defaults via `resetAll`'s `navigate()`.

## Fix

- `endpoints-filters.ts`: extended `EndpointsFilterState` with `sort`, `order`, `page`, and added the three missing comparisons (`!== "netuid"`, `!== "asc"`, `!== 1`) to `endpointsFiltersActive`.
- `endpoints.tsx`: extended the call site to pass `sort`, `order`, `page` from the route search state.
- `endpoints-filters.test.ts`: extended `DEFAULTS`, added `sort`/`order`/`page` to the existing `it.each` matrix, and added two dedicated tests for the combined-divergence and combined-default cases.

## Screenshots

Desktop, sorted by NETuid ascending (page 1) vs. sorted by Latency descending (page 2) — Reset filters goes from disabled to enabled purely from the sort/order/page change, no other filter touched.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6579-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

- `npx vitest run` (apps/ui): 156 test files, 1148 tests, all passing
- `npx tsc --noEmit -p apps/ui`: clean
- `npx prettier --check` / `npx eslint` on changed files: clean (no new warnings)
- Manually verified in browser across all three breakpoints and both themes