### PR TITLE
refactor(ui): drop the dead #616b6c fallback from subnet-price-ticker's flat color (#6397)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-price-ticker.tsx
@@ -9,7 +9,7 @@ import type { Subnet } from "@/lib/metagraphed/types";
 
 const UP = healthColorVar("ok");
 const DOWN = healthColorVar("down");
-const FLAT = "var(--ink-muted, #616b6c)";
+const FLAT = "var(--ink-muted)";
 
 function priceStr(v?: number) {
   if (v == null || !Number.isFinite(v)) return "—";


### PR DESCRIPTION
## Summary

`subnet-price-ticker.tsx` defines `UP`/`DOWN` via `healthColorVar("ok")`/`("down")` with no hardcoded fallback, but `FLAT` hardcoded `var(--ink-muted, #616b6c)`. `--ink-muted` is a global token always defined app-wide by `packages/ui-kit/src/styles.css`, so the `, #616b6c` fallback is **unreachable** and just diverges from the file's own established pattern.

## What Changed

One line: `const FLAT = "var(--ink-muted, #616b6c)"` -> `"var(--ink-muted)"`, matching `UP`/`DOWN` two lines above. A repo grep for `#616b6c` now returns nothing.

## Screenshots

**No visual change** -- the issue's own Expected Outcome (the fallback was already unreachable, so the resolved color is identical). Before/after on `/` (renders the price ticker) are pixel-identical, documenting no regression:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-before-desktop-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-after-desktop-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-before-desktop-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-after-desktop-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-before-tablet-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-after-tablet-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-after-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-before-tablet-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-before-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-after-tablet-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-after-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-before-mobile-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-after-mobile-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-before-mobile-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-after-mobile-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6397-inkmuted/6397-after-mobile-dark.png) |

## Validation

- `npm run typecheck --workspace=apps/ui` -- 0 errors
- eslint + prettier clean; no `#616b6c` remains
- No test asserts the removed fallback (only the unrelated `--ink-muted, #94a3b8` health-token fallbacks, untouched)

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6397`) -- required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched.

Closes #6397
