### PR TITLE
feat(ui): recognize composite extrinsic refs in the command palette (#6578)

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -43,6 +43,7 @@ import { searchQuery, semanticSearchQuery } from "@/lib/metagraphed/queries";
 import { classNames } from "@/lib/metagraphed/format";
 import { isValidSs58 } from "@/lib/metagraphed/accounts";
 import { shortHash } from "@/lib/metagraphed/blocks";
+import { isCompositeExtrinsicRef } from "@/lib/metagraphed/extrinsics";
 import { isCopySelectedKey } from "@/lib/metagraphed/command-palette-keys";
 import { getDocsNav } from "@/lib/docs-nav.functions";
 import {
@@ -461,6 +462,19 @@ export function CommandPaletteBody({ open, onOpenChange }: CommandPaletteProps) 
         target: { to: "/blocks/$ref", params: { ref: q } },
         kind: "block",
         icon: Hash,
+      });
+    }
+    // Parity with nav-omnibox (#6578): a composite extrinsic ref like "123#4"
+    // (block-number#index) is a direct-nav target there but fell through to
+    // keyword search here. It can't collide with the decimal-block or 0x-hash
+    // branches above -- the "#index" segment excludes it from both.
+    if (isCompositeExtrinsicRef(q)) {
+      targets.push({
+        label: `Extrinsic ${q}`,
+        hint: "jump to extrinsic by block#index",
+        target: { to: "/extrinsics/$hash", params: { hash: q } },
+        kind: "extrinsic",
+        icon: ArrowRightLeft,
       });
     }
     const netuidMatch = /^(?:sn\s*(\d+)|netuid\s*(\d+))$/i.exec(q);


### PR DESCRIPTION
## Summary

The navbar omnibox (`nav-omnibox.tsx`) recognizes a composite extrinsic reference like `123#4` (block-number#index) and offers a direct "Go to extrinsic" target for it. The ⌘K command palette builds the same class of "Go to" targets (ss58 account, decimal block, `0x` hash, `sn<n>`/`netuid<n>`) but never checked for the composite ref — so pasting `123#4` into the palette fell through to a plain keyword search instead of offering the jump the omnibox already provides for the identical input.

This brings the palette to parity with the omnibox: it imports the existing, already-tested `isCompositeExtrinsicRef` helper and pushes the same `/extrinsics/$hash` target, in the palette's own target shape.

## Changes

- `apps/ui/src/components/metagraphed/command-palette-body.tsx`
  - import `isCompositeExtrinsicRef` from `@/lib/metagraphed/extrinsics`
  - in `navigateTargets`, add a composite-extrinsic-ref target mirroring `nav-omnibox.tsx` (label `Extrinsic <ref>`, `to: "/extrinsics/$hash"`, `params: { hash: q }`, `ArrowRightLeft` icon)

The new branch can't collide with the decimal-block or `0x`-hash branches — the `#index` segment excludes `123#4` from both.

## Validation

- `eslint` — 0 errors
- `tsc --noEmit` — 0 errors
- `vitest run src/lib/metagraphed/extrinsics` — 32/32 pass (covers `isCompositeExtrinsicRef`)
- `vite build` — success

## Screenshots

Command palette with `123#4` typed. Before: "No matches" + keyword-filter fallbacks only. After: a "Go to · Extrinsic 123#4" direct-nav target appears.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6578-palette-extrinsic-ref/6578-palette-extrinsic-ref-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6578
