### PR TITLE
fix(ui): toggle at-a-glance missing-kind into the multi-select instead of overwriting it (#6582)

### DIFF
--- a/apps/ui/src/routes/gaps.tsx
+++ b/apps/ui/src/routes/gaps.tsx
@@ -407,13 +407,22 @@ function MissingKindsAtAGlance() {
               <button
                 type="button"
                 onClick={() => {
+                  // Toggle k into the existing multi-select (matching the
+                  // Open-gaps panel's additive-Set logic) instead of
+                  // overwriting it with a single kind (#6582). Only snap
+                  // status/sort to the "open by priority" view on a fresh jump
+                  // (nothing previously selected) -- an in-progress multi-select
+                  // keeps the user's own status/sort choices.
+                  const next = new Set(activeMissing);
+                  if (next.has(k)) next.delete(k);
+                  else next.add(k);
+                  const wasEmpty = activeMissing.size === 0;
                   navigate({
                     search: (prev: Record<string, unknown>) =>
                       ({
                         ...prev,
-                        missing: k,
-                        status: "open",
-                        sort: "priority",
+                        missing: Array.from(next).join(","),
+                        ...(wasEmpty ? { status: "open", sort: "priority" } : {}),
                       }) as never,
                     replace: true,
                   });


### PR DESCRIPTION
## Summary

`gaps.tsx` has two controls that both write the `missing` search param but with incompatible semantics. The "Open gaps" filter panel treats `missing` as a genuine multi-select (additive `Set` — add/remove one kind at a time). The "Missing kinds across the registry" at-a-glance bar above it instead did a single-value **overwrite** on click (`missing: k`, plus `status: "open"`, `sort: "priority"`). So a user who built a multi-kind selection in the panel, then clicked any row in the at-a-glance bar, had their whole selection — and their `status`/`sort` choices — silently discarded and collapsed to that one kind.

This makes the at-a-glance bar agree with the panel: clicking a row **toggles** that kind into the existing `missing` set instead of overwriting it. The `status`/`sort` snap-to-"open by priority" is kept only for a fresh jump (nothing previously selected), so an in-progress multi-select preserves the user's own status/sort.

## Changes

- `apps/ui/src/routes/gaps.tsx` — at-a-glance row click handler:
  - toggle `k` into `activeMissing` (matching the Open-gaps panel's additive-`Set` logic) instead of `missing: k`
  - only apply `status: "open"` / `sort: "priority"` when `missing` was previously empty

The at-a-glance highlighting already derives from `activeMissing.has(k)`, so it stays consistent with the corrected multi-select automatically.

## Validation

- `eslint` — 0 errors
- `tsc --noEmit` — 0 errors

## Screenshots

Repro: pre-select one kind, then click a *different* kind's row in the at-a-glance bar; the click scrolls to the Open-gaps panel whose chips show the resulting selection. Before: only the just-clicked kind is active (the pre-selected kind was silently dropped). After: both kinds are active (the pre-selection is preserved).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6582-gaps-toggle/6582-gaps-toggle-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6582
