### PR TITLE
fix(mcp): migrate list/search tools to cursor pagination

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -41,6 +41,7 @@ import {
 } from "./usage-telemetry.mjs";
 import { resolveClientIp, SS58_ADDRESS_PATTERN } from "../workers/config.mjs";
 import { DAY_PATTERN } from "../workers/request-params.mjs";
+import { applyQueryFilters } from "../workers/list-query.mjs";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 import {
@@ -1829,36 +1830,78 @@ function semanticTypeSchema() {
   };
 }
 
-// Shared pagination for every list/search tool: slice one page and return the
-// envelope (total before slicing, resolved offset/limit, and a next_offset
-// cursor that is null at the end). One implementation keeps the tools in sync.
-function paginate(items, args, fallbackLimit, maxLimit) {
-  const total = items.length;
-  const offset = Number.isFinite(args?.offset)
-    ? Math.max(0, Math.floor(args.offset))
+// Resolve a lenient `cursor` arg into a non-negative offset. Mirrors the old
+// bespoke `offset` handling (floor + clamp to 0, no throw): tools/call does not
+// enforce the inputSchema `minimum`, so a bad cursor degrades to the first page
+// instead of erroring.
+function resolveCursor(args) {
+  return Number.isFinite(args?.cursor)
+    ? Math.max(0, Math.floor(args.cursor))
     : 0;
-  const limit = clampLimit(args?.limit, fallbackLimit, maxLimit);
-  const page = items.slice(offset, offset + limit);
-  const nextOffset = offset + page.length < total ? offset + page.length : null;
-  return { page, total, offset, limit, returned: page.length, nextOffset };
 }
 
-// Shape a keyword-search response: the label (query/capability), the shared
-// pagination envelope, and the mapped page. Both search tools page 1-50/10.
+// Cursor-window an already-filtered/ranked row set through the shared list-query
+// machinery (workers/list-query.mjs) so every MCP list/search tool hands back the
+// same `cursor` / `next_cursor` continuation contract its REST sibling does,
+// replacing the bespoke `offset` / `next_offset` scheme these tools carried. The
+// rows arrive pre-ordered by the caller and are passed under the collection's
+// data_key with only `limit`/`cursor` set, so applyQueryFilters just windows them
+// (no re-filter, no re-sort). A null `limit` means "return the whole list unless
+// the caller pages" (list_candidates / list_endpoints); paginateRows treats a
+// present cursor as paging on its own. The caller pre-resolves both bounds (limit
+// clamped, cursor a non-negative integer), so validateListQuery inside
+// applyQueryFilters cannot fail here and always returns a pagination envelope.
+function cursorWindow(rows, { collection, dataKey, limit, cursor }) {
+  const url = new URL("https://mcp.internal/list");
+  if (limit != null) {
+    url.searchParams.set("limit", String(limit));
+  }
+  if (cursor > 0) {
+    url.searchParams.set("cursor", String(cursor));
+  }
+  const { data, meta } = applyQueryFilters(
+    { [dataKey]: rows },
+    url,
+    collection,
+    [],
+  );
+  const {
+    total,
+    returned,
+    limit: pageLimit,
+    cursor: pageCursor,
+  } = meta.pagination;
+  return {
+    page: data[dataKey],
+    total,
+    returned,
+    limit: pageLimit,
+    cursor: pageCursor,
+    next_cursor: meta.pagination.next_cursor,
+  };
+}
+
+// Shape a keyword-search response: the label (query/capability), the cursor
+// pagination envelope, and the mapped page. Both search tools page 1-50/10 over
+// the ranked match set (windowed via applyQueryFilters, so `cursor`/`next_cursor`
+// match the REST list contract).
 function searchResponse(label, matched, args, mapResult) {
-  const { page, total, offset, limit, returned, nextOffset } = paginate(
+  const { page, total, returned, limit, cursor, next_cursor } = cursorWindow(
     matched,
-    args,
-    10,
-    50,
+    {
+      collection: "subnets",
+      dataKey: "subnets",
+      limit: clampLimit(args?.limit, 10, 50),
+      cursor: resolveCursor(args),
+    },
   );
   return {
     ...label,
     total,
     count: returned,
-    offset,
+    cursor,
     limit,
-    next_offset: nextOffset,
+    next_cursor,
     results: page.map(mapResult),
   };
 }
@@ -2125,9 +2168,9 @@ export const MCP_TOOLS = [
       "Full-text search across Bittensor subnets by name, slug, capability, " +
       "or keyword. Returns ranked matches with netuid, slug, title, and a one-" +
       "line description. Use this to discover subnets before fetching detail. " +
-      "Paginated like list_subnets: pass `offset` to page past the first " +
-      "results; the response carries `total` and a `next_offset` cursor (null " +
-      "at the end) so the whole ranked match set is reachable.",
+      "Paginated like list_subnets: pass `cursor` to page past the first " +
+      "results; the response carries `total` and a `next_cursor` (null at the " +
+      "end) so the whole ranked match set is reachable.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2135,10 +2178,10 @@ export const MCP_TOOLS = [
           type: "string",
           description: "Search terms, e.g. 'image generation' or 'scraping'.",
         },
-        offset: {
+        cursor: {
           type: "integer",
           description:
-            "Pagination offset into the ranked match set. Default 0.",
+            "Pagination cursor from a prior response's next_cursor. Default 0.",
           minimum: 0,
         },
         limit: {
@@ -2182,9 +2225,10 @@ export const MCP_TOOLS = [
     inputSchema: {
       type: "object",
       properties: {
-        offset: {
+        cursor: {
           type: "integer",
-          description: "Pagination offset into the (filtered) list. Default 0.",
+          description:
+            "Pagination cursor from a prior response's next_cursor. Default 0.",
           minimum: 0,
         },
         limit: {
@@ -2366,12 +2410,13 @@ export const MCP_TOOLS = [
       const sort = optionalEnum(args, "sort", LIST_SUBNETS_SORT_FIELDS);
       const order = optionalEnum(args, "order", LIST_SUBNETS_ORDERS) || "asc";
       const ordered = sort ? sortSubnets(filtered, sort, order) : filtered;
-      const { page, total, offset, limit, returned, nextOffset } = paginate(
-        ordered,
-        args,
-        50,
-        100,
-      );
+      const { page, total, returned, limit, cursor, next_cursor } =
+        cursorWindow(ordered, {
+          collection: "subnets",
+          dataKey: "subnets",
+          limit: clampLimit(args?.limit, 50, 100),
+          cursor: resolveCursor(args),
+        });
       const subnets = page.map((subnet) => ({
         netuid: subnet.netuid,
         slug: subnet.slug ?? null,
@@ -2390,13 +2435,13 @@ export const MCP_TOOLS = [
       return {
         total,
         returned,
-        offset,
+        cursor,
         limit,
         // Echo the applied ordering (null when paging in source order) so an
         // agent can confirm what it got, mirroring the REST list meta.
         sort: sort ?? null,
         order: sort ? order : null,
-        next_offset: nextOffset,
+        next_cursor,
         subnets,
       };
     },
@@ -2409,9 +2454,9 @@ export const MCP_TOOLS = [
       "schemas, SSE streams) matching a capability or category. Returns only " +
       "subnets an agent can actually call, ranked by callable-service count. " +
       "Pair with list_subnet_apis to get concrete endpoints. Paginated like " +
-      "list_subnets: pass `offset` to page past the first results; the response " +
-      "carries `total` and a `next_offset` cursor (null at the end) so the " +
-      "whole ranked match set is reachable.",
+      "list_subnets: pass `cursor` to page past the first results; the response " +
+      "carries `total` and a `next_cursor` (null at the end) so the whole " +
+      "ranked match set is reachable.",
     inputSchema: {
       type: "object",
       properties: {
@@ -2420,10 +2465,10 @@ export const MCP_TOOLS = [
           description:
             "Capability/category to match, e.g. 'inference', 'data', 'bitcoin'.",
         },
-        offset: {
+        cursor: {
           type: "integer",
           description:
-            "Pagination offset into the ranked match set. Default 0.",
+            "Pagination cursor from a prior response's next_cursor. Default 0.",
           minimum: 0,
         },
         limit: {
@@ -8580,7 +8625,7 @@ export const MCP_TOOLS = [
       "with its subnet (netuid), kind, provider, and review state. Use it to " +
       "see what enrichment is still pending, versus the promoted catalog in " +
       "list_surfaces. Optionally filter by netuid/kind/provider/state and page " +
-      "with limit/offset — the full catalog can be large. Mirrors " +
+      "with limit/cursor — the full catalog can be large. Mirrors " +
       "GET /api/v1/candidates.",
     inputSchema: {
       type: "object",
@@ -8605,9 +8650,10 @@ export const MCP_TOOLS = [
           description: "Max candidates to return. Omit for the full list.",
           minimum: 1,
         },
-        offset: {
+        cursor: {
           type: "integer",
-          description: "Pagination offset into the (filtered) list. Default 0.",
+          description:
+            "Pagination cursor from a prior response's next_cursor. Default 0.",
           minimum: 0,
         },
       },
@@ -8619,7 +8665,7 @@ export const MCP_TOOLS = [
       const provider = optionalString(args, "provider");
       const state = optionalEnum(args, "state", QUERY_ENUMS.candidateState);
       const limit = optionalPositiveInt(args, "limit");
-      const offset = optionalNonNegativeInt(args, "offset") ?? 0;
+      const cursor = optionalNonNegativeInt(args, "cursor") ?? 0;
       const data = await loadArtifactData(ctx, "/metagraph/candidates.json");
       const all = Array.isArray(data.candidates) ? data.candidates : [];
       const filtered = all.filter(
@@ -8629,16 +8675,20 @@ export const MCP_TOOLS = [
           (provider === null || c.provider === provider) &&
           (state === null || c.state === state),
       );
-      const page =
-        limit === null
-          ? filtered.slice(offset)
-          : filtered.slice(offset, offset + limit);
+      const window = cursorWindow(filtered, {
+        collection: "candidates",
+        dataKey: "candidates",
+        limit,
+        cursor,
+      });
       return {
         ...data,
-        candidates: page,
-        total: filtered.length,
-        returned: page.length,
-        offset,
+        candidates: window.page,
+        total: window.total,
+        returned: window.returned,
+        cursor: window.cursor,
+        limit: window.limit,
+        next_cursor: window.next_cursor,
       };
     },
   },
@@ -8652,7 +8702,7 @@ export const MCP_TOOLS = [
       "probe-derived status/latency/score. Use it to discover live endpoints " +
       "network-wide. Optionally filter by kind/layer/netuid/provider/" +
       "publication_state/status/pool_eligible, bound by min_/max_latency_ms " +
-      "and min_/max_score, and page with limit/offset — the full catalog can " +
+      "and min_/max_score, and page with limit/cursor — the full catalog can " +
       "be large. Mirrors GET /api/v1/endpoints.",
     inputSchema: {
       type: "object",
@@ -8708,9 +8758,10 @@ export const MCP_TOOLS = [
           description: "Max endpoints to return. Omit for the full list.",
           minimum: 1,
         },
-        offset: {
+        cursor: {
           type: "integer",
-          description: "Pagination offset into the (filtered) list. Default 0.",
+          description:
+            "Pagination cursor from a prior response's next_cursor. Default 0.",
           minimum: 0,
         },
       },
@@ -8740,7 +8791,7 @@ export const MCP_TOOLS = [
         .filter(({ arg }) => Number.isFinite(args?.[arg]))
         .map(({ field, op, arg }) => ({ field, op, limit: args[arg] }));
       const limit = optionalPositiveInt(args, "limit");
-      const offset = optionalNonNegativeInt(args, "offset") ?? 0;
+      const cursor = optionalNonNegativeInt(args, "cursor") ?? 0;
       let data = await loadArtifactData(ctx, "/metagraph/endpoints.json");
       // Live per-endpoint health overlay (mirrors workers/api.mjs's raw-
       // artifact serving path): the build-time endpoints.json bakes stale
@@ -8775,16 +8826,20 @@ export const MCP_TOOLS = [
             return op === "min" ? value >= bound : value <= bound;
           }),
       );
-      const page =
-        limit === null
-          ? filtered.slice(offset)
-          : filtered.slice(offset, offset + limit);
+      const window = cursorWindow(filtered, {
+        collection: "endpoints",
+        dataKey: "endpoints",
+        limit,
+        cursor,
+      });
       return {
         ...data,
-        endpoints: page,
-        total: filtered.length,
-        returned: page.length,
-        offset,
+        endpoints: window.page,
+        total: window.total,
+        returned: window.returned,
+        cursor: window.cursor,
+        limit: window.limit,
+        next_cursor: window.next_cursor,
       };
     },
   },
@@ -10276,18 +10331,18 @@ const TOOL_OUTPUT_SCHEMAS = {
       "query",
       "total",
       "count",
-      "offset",
+      "cursor",
       "limit",
-      "next_offset",
+      "next_cursor",
       "results",
     ],
     properties: {
       query: { type: "string" },
       total: { type: "integer" },
       count: { type: "integer" },
-      offset: { type: "integer" },
+      cursor: { type: "integer" },
       limit: { type: "integer" },
-      next_offset: { type: ["integer", "null"] },
+      next_cursor: { type: ["integer", "null"] },
       results: objectItems({
         netuid: { type: "integer" },
         slug: { type: "string" },
@@ -10303,20 +10358,20 @@ const TOOL_OUTPUT_SCHEMAS = {
     required: [
       "total",
       "returned",
-      "offset",
+      "cursor",
       "limit",
-      "next_offset",
+      "next_cursor",
       "subnets",
     ],
     properties: {
       total: { type: "integer" },
       returned: { type: "integer" },
-      offset: { type: "integer" },
+      cursor: { type: "integer" },
       limit: { type: "integer" },
       // Applied ordering, echoed back; null when paging in registry source order.
       sort: NULLABLE_STRING,
       order: NULLABLE_STRING,
-      next_offset: { type: ["integer", "null"] },
+      next_cursor: { type: ["integer", "null"] },
       subnets: objectItems({
         netuid: { type: "integer" },
         slug: NULLABLE_STRING,
@@ -10335,18 +10390,18 @@ const TOOL_OUTPUT_SCHEMAS = {
       "capability",
       "total",
       "count",
-      "offset",
+      "cursor",
       "limit",
-      "next_offset",
+      "next_cursor",
       "results",
     ],
     properties: {
       capability: { type: "string" },
       total: { type: "integer" },
       count: { type: "integer" },
-      offset: { type: "integer" },
+      cursor: { type: "integer" },
       limit: { type: "integer" },
-      next_offset: { type: ["integer", "null"] },
+      next_cursor: { type: ["integer", "null"] },
       results: objectItems({
         netuid: { type: "integer" },
         slug: { type: "string" },
@@ -13387,6 +13442,11 @@ const TOOL_OUTPUT_SCHEMAS = {
     required: [],
     properties: {
       candidates: { type: "array", items: { type: "object" } },
+      total: { type: "integer" },
+      returned: { type: "integer" },
+      cursor: { type: "integer" },
+      limit: { type: "integer" },
+      next_cursor: { type: ["integer", "null"] },
       generated_at: NULLABLE_STRING,
       schema_version: { type: ["string", "integer", "null"] },
     },
@@ -13397,6 +13457,11 @@ const TOOL_OUTPUT_SCHEMAS = {
     required: [],
     properties: {
       endpoints: { type: "array", items: { type: "object" } },
+      total: { type: "integer" },
+      returned: { type: "integer" },
+      cursor: { type: "integer" },
+      limit: { type: "integer" },
+      next_cursor: { type: ["integer", "null"] },
       generated_at: NULLABLE_STRING,
       schema_version: { type: ["string", "integer", "null"] },
     },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1589,12 +1589,12 @@ describe("MCP tools (injected deps)", () => {
     assert.equal(out.results[0].netuid, 7);
     assert.ok(out.results[0].url.includes("/api/v1/subnets/7/overview"));
     assert.ok(out.results.every((r) => r.netuid !== null));
-    // Pagination envelope mirrors list_subnets: total/offset/limit/next_offset.
+    // Pagination envelope mirrors list_subnets: total/cursor/limit/next_cursor.
     assert.equal(out.total, 1);
     assert.equal(out.count, 1);
-    assert.equal(out.offset, 0);
+    assert.equal(out.cursor, 0);
     assert.equal(out.limit, 5);
-    assert.equal(out.next_offset, null);
+    assert.equal(out.next_cursor, null);
   });
 
   test("search_subnets clamps the limit and reports zero matches", async () => {
@@ -1606,7 +1606,7 @@ describe("MCP tools (injected deps)", () => {
     const out = res.body.result.structuredContent;
     assert.equal(out.count, 0);
     assert.equal(out.total, 0);
-    assert.equal(out.next_offset, null);
+    assert.equal(out.next_cursor, null);
     // An out-of-range limit clamps to the 50 max, not the raw 999.
     assert.equal(out.limit, 50);
   });
@@ -1665,11 +1665,11 @@ describe("MCP tools (injected deps)", () => {
       "number",
       "find_subnets_by_capability results must carry integration_readiness",
     );
-    // Pagination envelope mirrors list_subnets: total/offset/limit/next_offset.
+    // Pagination envelope mirrors list_subnets: total/cursor/limit/next_cursor.
     assert.equal(out.total, 1);
-    assert.equal(out.offset, 0);
+    assert.equal(out.cursor, 0);
     assert.equal(out.limit, 10);
-    assert.equal(out.next_offset, null);
+    assert.equal(out.next_cursor, null);
   });
 
   test("find_subnets_by_capability with no match returns empty", async () => {
@@ -1682,7 +1682,7 @@ describe("MCP tools (injected deps)", () => {
     const out = res.body.result.structuredContent;
     assert.equal(out.count, 0);
     assert.equal(out.total, 0);
-    assert.equal(out.next_offset, null);
+    assert.equal(out.next_cursor, null);
   });
 
   test("get_subnet returns the overview artifact", async () => {
@@ -7179,26 +7179,28 @@ describe("list_subnets", () => {
     },
   });
 
-  test("paginates the full registry and reports next_offset", async () => {
+  test("paginates the full registry and reports next_cursor", async () => {
     const res = await callTool("list_subnets", { limit: 2 }, { deps });
     const out = res.body.result.structuredContent;
     assert.equal(out.total, 3);
     assert.equal(out.returned, 2);
-    assert.equal(out.next_offset, 2);
+    assert.equal(out.cursor, 0);
+    assert.equal(out.next_cursor, 2);
     assert.equal(out.subnets[0].netuid, 0);
     assert.equal(out.subnets[0].title, "root");
     assert.equal(out.subnets[0].integration_readiness, 15);
   });
 
-  test("offset reads the tail and clears next_offset", async () => {
+  test("cursor reads the tail and clears next_cursor", async () => {
     const res = await callTool(
       "list_subnets",
-      { offset: 2, limit: 2 },
+      { cursor: 2, limit: 2 },
       { deps },
     );
     const out = res.body.result.structuredContent;
     assert.equal(out.returned, 1);
-    assert.equal(out.next_offset, null);
+    assert.equal(out.cursor, 2);
+    assert.equal(out.next_cursor, null);
     assert.equal(out.subnets[0].netuid, 8);
   });
 
@@ -7566,7 +7568,7 @@ describe("list_subnets", () => {
 
 // The keyword search tools share the list_subnets pagination contract: page
 // through a match set larger than one page and confirm every ranked item is
-// reachable and next_offset clears at the end.
+// reachable and next_cursor clears at the end.
 describe("search tools pagination", () => {
   const MATCH_COUNT = 60; // > the 50-per-page cap, so paging is mandatory
   const searchDocs = Array.from({ length: MATCH_COUNT }, (_, i) => ({
@@ -7592,21 +7594,21 @@ describe("search tools pagination", () => {
     "/metagraph/agent-catalog.json": { subnets: catalogSubnets },
   });
 
-  // Walk every page by following next_offset; returns the concatenated results
-  // and the (offset, next_offset) cursor sequence seen.
+  // Walk every page by following next_cursor; returns the concatenated results
+  // and the (cursor, next_cursor) sequence seen.
   async function walkAll(tool, baseArgs, limit) {
     const all = [];
     const cursors = [];
-    let offset = 0;
+    let cursor = 0;
     let total = null;
     // Guard well above the real page count so a cursor bug fails fast instead
     // of looping forever.
     for (let guard = 0; guard < 100; guard += 1) {
       const out = (
-        await callTool(tool, { ...baseArgs, offset, limit }, { deps })
+        await callTool(tool, { ...baseArgs, cursor, limit }, { deps })
       ).body.result.structuredContent;
       total = out.total;
-      assert.equal(out.offset, offset, `${tool}: echoes the requested offset`);
+      assert.equal(out.cursor, cursor, `${tool}: echoes the requested cursor`);
       assert.equal(out.limit, limit, `${tool}: echoes the requested limit`);
       assert.equal(
         out.count,
@@ -7614,14 +7616,14 @@ describe("search tools pagination", () => {
         `${tool}: count equals the page length`,
       );
       all.push(...out.results);
-      cursors.push({ offset: out.offset, next_offset: out.next_offset });
-      if (out.next_offset === null) break;
+      cursors.push({ cursor: out.cursor, next_cursor: out.next_cursor });
+      if (out.next_cursor === null) break;
       assert.equal(
-        out.next_offset,
-        offset + out.results.length,
-        `${tool}: next_offset is the cursor for the following page`,
+        out.next_cursor,
+        cursor + out.results.length,
+        `${tool}: next_cursor is the cursor for the following page`,
       );
-      offset = out.next_offset;
+      cursor = out.next_cursor;
     }
     return { all, cursors, total };
   }
@@ -7630,33 +7632,33 @@ describe("search tools pagination", () => {
     { tool: "search_subnets", args: { query: "pageable" } },
     { tool: "find_subnets_by_capability", args: { capability: "pageable" } },
   ]) {
-    test(`${tool} pages the whole match set; next_offset clears at the end`, async () => {
+    test(`${tool} pages the whole match set; next_cursor clears at the end`, async () => {
       const { all, cursors, total } = await walkAll(tool, args, 50);
       // total is the full match count, independent of the per-page cap.
       assert.equal(total, MATCH_COUNT);
       // Two pages (60 matches, 50 cap) prove items past page one are reachable.
       assert.deepEqual(cursors, [
-        { offset: 0, next_offset: 50 },
-        { offset: 50, next_offset: null },
+        { cursor: 0, next_cursor: 50 },
+        { cursor: 50, next_cursor: null },
       ]);
       // Every match reached exactly once: no drops, no duplicates across pages.
       assert.equal(all.length, MATCH_COUNT);
       assert.equal(new Set(all.map((r) => r.netuid)).size, MATCH_COUNT);
     });
 
-    test(`${tool} offset past the end returns an empty terminal page`, async () => {
+    test(`${tool} cursor past the end returns an empty terminal page`, async () => {
       const out = (
         await callTool(
           tool,
-          { ...args, offset: MATCH_COUNT, limit: 10 },
+          { ...args, cursor: MATCH_COUNT, limit: 10 },
           { deps },
         )
       ).body.result.structuredContent;
       assert.equal(out.total, MATCH_COUNT);
-      assert.equal(out.offset, MATCH_COUNT);
+      assert.equal(out.cursor, MATCH_COUNT);
       assert.equal(out.count, 0);
       assert.equal(out.results.length, 0);
-      assert.equal(out.next_offset, null);
+      assert.equal(out.next_cursor, null);
     });
   }
 });
@@ -14061,17 +14063,18 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.candidates[0].kind, "openapi");
   });
 
-  test("list_candidates paginates the filtered list with limit/offset", async () => {
+  test("list_candidates paginates the filtered list with limit/cursor", async () => {
     const deps = candidatesDeps();
     const res = await callTool(
       "list_candidates",
-      { limit: 1, offset: 1 },
+      { limit: 1, cursor: 1 },
       { deps },
     );
     const out = res.body.result.structuredContent;
     assert.equal(out.total, 3);
     assert.equal(out.returned, 1);
-    assert.equal(out.offset, 1);
+    assert.equal(out.cursor, 1);
+    assert.equal(out.next_cursor, 2);
     assert.equal(out.candidates[0].provider, "chutes");
   });
 
@@ -14224,17 +14227,18 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.endpoints[0].provider, "datura");
   });
 
-  test("list_endpoints paginates the filtered list with limit/offset", async () => {
+  test("list_endpoints paginates the filtered list with limit/cursor", async () => {
     const deps = endpointsDeps();
     const res = await callTool(
       "list_endpoints",
-      { limit: 1, offset: 1 },
+      { limit: 1, cursor: 1 },
       { deps },
     );
     const out = res.body.result.structuredContent;
     assert.equal(out.total, 3);
     assert.equal(out.returned, 1);
-    assert.equal(out.offset, 1);
+    assert.equal(out.cursor, 1);
+    assert.equal(out.next_cursor, 2);
     assert.equal(out.endpoints[0].provider, "chutes");
   });
 


### PR DESCRIPTION
## Summary

`list_subnets`, `search_subnets`, `find_subnets_by_capability`, `list_candidates`,
and `list_endpoints` each carried their own ad-hoc `offset`/`limit` scheme (a
bespoke `paginate()` helper returning `next_offset`), unlike their REST siblings
(`GET /api/v1/subnets` / `/candidates` / `/endpoints`) which are registered with
cursor-based list-query pagination and the newer `*-mcp.mjs` loaders
(`list_evidence`, `list_surfaces`, …) that page through
`applyQueryFilters`/`workers/list-query.mjs`.

This migrates all five tools to the same cursor windowing, so an agent walking
`list_subnets` gets the same `cursor`-based continuation contract it would get
calling `GET /api/v1/subnets` directly.

Closes #6568.

## What Changed

- Added a shared `cursorWindow()` helper that hands an already-filtered/ranked row
  set to `applyQueryFilters` (only `limit`/`cursor` set — no re-filter, no
  re-sort) and returns the shared `cursor`/`next_cursor` envelope. Removed the
  bespoke `paginate()` helper.
- `search_subnets`, `find_subnets_by_capability`, `list_subnets`,
  `list_candidates`, `list_endpoints`:
  - `inputSchema` now accepts `cursor` (was `offset`), matching the REST route's
    query parameters.
  - Response shape now carries `next_cursor` (was `next_offset`).
  - Each tool's existing filter/rank/sort surface is preserved unchanged — only
    the pagination step moved onto the shared cursor machinery.
- Updated the five tools' output schemas (`TOOL_OUTPUT_SCHEMAS`) and descriptions
  to the cursor contract.
- No change to the REST routes or `workers/list-query.mjs`.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6568`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented (MCP
      tool-internal only; no REST/OpenAPI surface changed).

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate:types`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:contract-drift`
- [x] `npm run validate:mcp`
- [x] `npm test` (304 files, 9076 tests)
- [x] `npm run test:coverage` — 100% patch coverage on the changed lines/branches
- [x] `git diff --check`
