### PR TITLE
fix(ui): sanitize non-numeric input on /blocks' 4 numeric filters (#6395)

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -293,28 +293,28 @@ function BlocksTable() {
         />
         <SearchInput
           value={search.block_start}
-          onChange={(v) => setSearch({ block_start: v, offset: 0 })}
+          onChange={(v) => setSearch({ block_start: v.replace(/[^0-9]/g, ""), offset: 0 })}
           placeholder="Block from…"
           inputMode="numeric"
           className="min-w-[120px] max-w-[140px] flex-none"
         />
         <SearchInput
           value={search.block_end}
-          onChange={(v) => setSearch({ block_end: v, offset: 0 })}
+          onChange={(v) => setSearch({ block_end: v.replace(/[^0-9]/g, ""), offset: 0 })}
           placeholder="Block to…"
           inputMode="numeric"
           className="min-w-[120px] max-w-[140px] flex-none"
         />
         <SearchInput
           value={search.min_extrinsics}
-          onChange={(v) => setSearch({ min_extrinsics: v, offset: 0 })}
+          onChange={(v) => setSearch({ min_extrinsics: v.replace(/[^0-9]/g, ""), offset: 0 })}
           placeholder="Min extrinsics…"
           inputMode="numeric"
           className="min-w-[120px] max-w-[140px] flex-none"
         />
         <SearchInput
           value={search.min_events}
-          onChange={(v) => setSearch({ min_events: v, offset: 0 })}
+          onChange={(v) => setSearch({ min_events: v.replace(/[^0-9]/g, ""), offset: 0 })}
           placeholder="Min events…"
           inputMode="numeric"
           className="min-w-[120px] max-w-[140px] flex-none"


### PR DESCRIPTION
Closes #6395

## Problem

`blocks.index.tsx`'s four numeric filters (`block_start`, `block_end`, `min_extrinsics`, `min_events`) pass the raw `SearchInput` value straight through on every keystroke: `onChange={(v) => setSearch({ block_start: v, offset: 0 })}`. The `inputMode="numeric"` hint has no effect on desktop typing or paste, so a stray letter reaches the search state and is sent straight to the backend, whose numeric-filter validation (closed #2310) rejects it outright.

In practice this is worse than a surfaced error: with the live dev/prod backend, a single non-numeric character reaching `block_start` (etc.) causes the entire filter toolbar **and** the blocks table to silently disappear — no error message, just blank space where the whole list section used to be (confirmed via screenshots below; verified across desktop/tablet/mobile). `/endpoints`' `netuid` filter already avoids this by sanitizing on input (`e.target.value.replace(/[^0-9]/g, "")`, `endpoints.tsx:843`).

## Fix

Applied the same digit-only sanitization to all 4 fields in `blocks.index.tsx`, stripping non-digit characters as typed instead of letting them reach the search/query state at all.

## Screenshots

Typed `12a34` into the "Block from…" filter. Before: the letter reaches `block_start`, the backend rejects it, and the whole filter+table section vanishes. After: sanitized to `1234`, the filter applies normally and the table stays populated.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6395-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

- `npx tsc --noEmit -p apps/ui`: clean
- `npx prettier --check` / `npx eslint` on the changed file: clean (no new warnings)
- `npx vitest run` (apps/ui): 156 test files, 1143 tests, all passing
- Manually verified in browser across all three breakpoints and both themes: typed non-digit characters into all 4 fields, confirmed digits-only sanitization and no regression to the working filtered-list behavior