### PR TITLE
fix(ui): document the block-detail arrow-key nav shortcut in the shortcuts panel (#6560)

### DIFF
--- a/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
+++ b/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
@@ -96,6 +96,10 @@ export function ShortcutsPopover() {
           <Row label="Close menus / panels">
             <Kbd>Esc</Kbd>
           </Row>
+          <Row label="Prev / next block (on block pages)">
+            <Kbd>←</Kbd>
+            <Kbd>→</Kbd>
+          </Row>
         </ul>
         <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted mt-4 mb-2">
           Go to


### PR DESCRIPTION
## Summary

`blocks.$ref.tsx` registers a page-level `keydown` listener that navigates to the previous/next block on `ArrowLeft`/`ArrowRight` — a real, working keyboard shortcut — but it's undiscoverable: the visible prev/next links carry no hint, and `ShortcutsPopover` (the app's single documented reference for every other keyboard interaction) has no entry for it.

## Fix

Add one row to `ShortcutsPopover` documenting the shortcut, scoped with an "on block pages" qualifier since it's page-specific:

```
Prev / next block (on block pages)   ←  →
```

Placed in the general shortcuts list (after "Close menus / panels"), using the existing `Row` + `Kbd` pattern. **No change to the navigation behavior** in `blocks.$ref.tsx` — discoverability only. Verified the documented keys match the handler (`ArrowLeft`→prev at `blocks.$ref.tsx:125`, `ArrowRight`→next at `:130`).

## Validation

- `npm run typecheck` / `npm run lint` / `npx prettier --check` (`--workspace=apps/ui`) → clean
- `npm run build --workspace=apps/ui` → clean
- One file, +4 lines; no logic added (a static row), so no unit test applies.

## Screenshots — shortcuts panel open (the new row appears in "after")

Captured with the popover open (`?`) so the change is visible. In **before** the list jumps from "Close menus / panels" straight to "Go to"; in **after** the "Prev / next block" row sits between them.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6560/6560-shortcuts-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6560
