### PR TITLE
fix(ui): validate the webhook Secret field's 16-256 char bound client-side

### DIFF
--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.test.ts
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseNetuidsInput } from "./webhook-subscription-manager";
+import { parseNetuidsInput, validateSecret } from "./webhook-subscription-manager";
 
 describe("parseNetuidsInput", () => {
   it("returns an empty list for blank input", () => {
@@ -23,5 +23,29 @@ describe("parseNetuidsInput", () => {
 
   it("rejects a negative number (not a bare digit token)", () => {
     expect(parseNetuidsInput("-1").ok).toBe(false);
+  });
+});
+
+describe("validateSecret", () => {
+  it("allows a blank secret (server auto-generates one)", () => {
+    expect(validateSecret("")).toBeNull();
+    expect(validateSecret("   ")).toBeNull();
+  });
+
+  it("accepts a secret at the 16- and 256-char bounds", () => {
+    expect(validateSecret("a".repeat(16))).toBeNull();
+    expect(validateSecret("a".repeat(256))).toBeNull();
+  });
+
+  it("rejects a secret shorter than 16 characters", () => {
+    expect(validateSecret("short")).toContain("16");
+  });
+
+  it("rejects a secret longer than 256 characters", () => {
+    expect(validateSecret("a".repeat(257))).toContain("256");
+  });
+
+  it("validates the trimmed value, so surrounding whitespace does not pad the length", () => {
+    expect(validateSecret(`   ${"a".repeat(5)}   `)).toContain("16");
   });
 });

--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
@@ -36,6 +36,22 @@ export function parseNetuidsInput(
   return { ok: true, value: netuids };
 }
 
+// #6581: the Secret field advertises "16–256 characters" but previously bounded
+// nothing client-side, so a too-short secret only failed after a server
+// round-trip that surfaced as a generic "Request failed". A blank secret stays
+// valid (the server auto-generates one), so the bound applies only once the
+// user has actually typed something.
+const SECRET_MIN = 16;
+const SECRET_MAX = 256;
+export function validateSecret(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (trimmed.length < SECRET_MIN || trimmed.length > SECRET_MAX) {
+    return `Secret must be ${SECRET_MIN}–${SECRET_MAX} characters (or left blank to auto-generate).`;
+  }
+  return null;
+}
+
 /** Distinguishes a 401/503 create rejection, a 404 lookup, and a 403 secret-mismatch delete. */
 function describeApiError(error: unknown): string {
   if (error instanceof ApiError) {
@@ -74,6 +90,7 @@ function CreateSubscriptionSection() {
   const [netuidsError, setNetuidsError] = useState<string | null>(null);
   const [kinds, setKinds] = useState<Set<string>>(new Set());
   const [secret, setSecret] = useState("");
+  const [secretError, setSecretError] = useState<string | null>(null);
 
   const mutation = useMutation({
     mutationFn: async (vars: CreateVariables): Promise<WebhookSubscriptionCreated> => {
@@ -117,6 +134,12 @@ function CreateSubscriptionSection() {
       return;
     }
     setNetuidsError(null);
+    const secretErr = validateSecret(secret);
+    if (secretErr) {
+      setSecretError(secretErr);
+      return;
+    }
+    setSecretError(null);
     mutation.mutate({
       url: url.trim(),
       token: token.trim(),
@@ -198,9 +221,13 @@ function CreateSubscriptionSection() {
             type="password"
             autoComplete="off"
             value={secret}
-            onChange={(e) => setSecret(e.target.value)}
+            onChange={(e) => {
+              setSecret(e.target.value);
+              setSecretError(null);
+            }}
             className={inputCls}
           />
+          {secretError ? <p className="mt-1 text-[11px] text-health-down">{secretError}</p> : null}
         </Field>
         <button
           type="submit"


### PR DESCRIPTION
## What & why

The Secret field's hint advertises "16–256 characters", but `onSubmit` validated only `netuidsRaw` — `secret.trim()` was passed straight through with no bound check. A user who typed a 5-character secret got no feedback until the request round-tripped and the server rejected it, surfacing through `describeApiError`'s fallback as a generic "Request failed" with no hint about the real cause.

## Approach

Mirror the sibling **Netuids filter** field on the same form exactly:

- A `validateSecret` helper (exported, pure) returning an error string or `null`.
- A `secretError` state, cleared on change like `netuidsError`.
- An early return in `onSubmit` before `mutation.mutate`.
- An inline error rendered with the same `mt-1 text-[11px] text-health-down` treatment and placement.

A **blank** secret stays valid (the server auto-generates one), so the bound only applies once the user has actually typed something — the "auto-generated if left blank" behaviour is unchanged.

## Verification

Full Phase C3 preflight (same steps/order as the `ui` CI job):

| Step | Command | Result |
| --- | --- | --- |
| lint | `npm run lint --workspace=apps/ui` | 0 errors |
| format | `npm run format:check --workspace=apps/ui` | clean |
| typecheck | `npm run typecheck --workspace=apps/ui` | clean |
| unit | `npm test --workspace=apps/ui` | 156 files, 1153 tests passed |
| build | `npm run build --workspace=apps/ui` | green |

`validateSecret` is unit-tested (blank, both 16/256 bounds, under, over, and whitespace-trim) in the existing `webhook-subscription-manager.test.ts` alongside `parseNetuidsInput`. Drove `/settings` end to end: typing a 5-char secret and submitting shows the inline error immediately with no network round-trip; a blank secret still submits.

## Screenshots

Phase C2 contract (fixed viewports, never full-page, themes forced via `mg-theme`). Each shot has a too-short secret entered and Create clicked — `before` round-trips (the button reads "Creating…") with no field-level feedback; `after` blocks client-side with the inline "Secret must be 16–256 characters" error.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6581-webhook-secret-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6581
