### PR TITLE
fix(ui): sanitize /blocks numeric filter inputs to digits only

### DIFF
--- a/apps/ui/src/routes/blocks-index-numeric-filters.test.ts
+++ b/apps/ui/src/routes/blocks-index-numeric-filters.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #6395: the /blocks numeric filters (block_start, block_end, min_extrinsics,
+// min_events) passed the raw SearchInput value straight through, so typing or
+// pasting a non-digit character reached the query string and tripped the
+// backend's strict numeric validation (#2310) as a live 400 through the page's
+// error boundary, instead of being sanitized on input like /endpoints' netuid
+// filter (endpoints.tsx:843) already is.
+//
+// Source assertion: these onChange handlers only run from a live keystroke/paste
+// event, so a rendered test can't reach them without a full router harness;
+// this suite is node-environment, matching validators-index-empty-action.test.ts.
+const blocks = readFileSync(fileURLToPath(new URL("./blocks.index.tsx", import.meta.url)), "utf8");
+
+describe("/blocks numeric filter sanitization (#6395)", () => {
+  it.each(["block_start", "block_end", "min_extrinsics", "min_events"])(
+    "%s's onChange strips non-digit characters before updating search state",
+    (field) => {
+      // `value={search.<field>}` only occurs once, inside the SearchInput JSX --
+      // blocksQueryParams() above references `search.<field>` too, but never as
+      // `value={...}`, so this anchor lands on the onChange right after it.
+      const marker = `value={search.${field}}`;
+      const start = blocks.indexOf(marker);
+      expect(start).toBeGreaterThan(-1);
+      const onChangeSnippet = blocks.slice(start, start + 200);
+      expect(onChangeSnippet).toMatch(
+        new RegExp(
+          `onChange=\\{\\(v\\) => setSearch\\(\\{ ${field}: v\\.replace\\(/\\[\\^0-9\\]/g, ""\\), offset: 0 \\}\\)\\}`,
+        ),
+      );
+    },
+  );
+});

--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -293,28 +293,28 @@ function BlocksTable() {
         />
         <SearchInput
           value={search.block_start}
-          onChange={(v) => setSearch({ block_start: v, offset: 0 })}
+          onChange={(v) => setSearch({ block_start: v.replace(/[^0-9]/g, ""), offset: 0 })}
           placeholder="Block from…"
           inputMode="numeric"
           className="min-w-[120px] max-w-[140px] flex-none"
         />
         <SearchInput
           value={search.block_end}
-          onChange={(v) => setSearch({ block_end: v, offset: 0 })}
+          onChange={(v) => setSearch({ block_end: v.replace(/[^0-9]/g, ""), offset: 0 })}
           placeholder="Block to…"
           inputMode="numeric"
           className="min-w-[120px] max-w-[140px] flex-none"
         />
         <SearchInput
           value={search.min_extrinsics}
-          onChange={(v) => setSearch({ min_extrinsics: v, offset: 0 })}
+          onChange={(v) => setSearch({ min_extrinsics: v.replace(/[^0-9]/g, ""), offset: 0 })}
           placeholder="Min extrinsics…"
           inputMode="numeric"
           className="min-w-[120px] max-w-[140px] flex-none"
         />
         <SearchInput
           value={search.min_events}
-          onChange={(v) => setSearch({ min_events: v, offset: 0 })}
+          onChange={(v) => setSearch({ min_events: v.replace(/[^0-9]/g, ""), offset: 0 })}
           placeholder="Min events…"
           inputMode="numeric"
           className="min-w-[120px] max-w-[140px] flex-none"


### PR DESCRIPTION
## Summary
- `/blocks`'s four numeric filters (`block_start`, `block_end`, `min_extrinsics`, `min_events`) passed the raw `SearchInput` value straight through to `setSearch`, relying only on a cosmetic `inputMode="numeric"` hint that has no effect on desktop typing/paste.
- The backend's numeric-filter validation for `/api/v1/blocks` was hardened by #2310 to reject non-numeric values with a 400 instead of coercing to 0, so a user typing/pasting a letter into any of these four fields today most likely triggers a live 400 surfaced through the page's error boundary.
- `/endpoints`' `netuid` filter already sanitizes on input (`endpoints.tsx:843`: `e.target.value.replace(/[^0-9]/g, "")`), giving a graceful sanitize-as-you-type experience instead.

## Root cause
`blocks.index.tsx`'s four numeric `SearchInput` `onChange` handlers forwarded the typed value unmodified into `setSearch`, unlike `endpoints.tsx`'s netuid input which strips non-digits inline before updating search state.

## Fix
Applied the identical `.replace(/[^0-9]/g, "")` sanitization used by `endpoints.tsx:843` to all 4 numeric filter `onChange` handlers in `blocks.index.tsx`, so non-digit characters are stripped as they're typed/pasted and never reach the query string.

## Why no screenshot table
This changes input-filtering *behavior* only (what characters survive into search state) — no new elements, no CSS, no layout, no change to the default/idle rendered page. It mirrors the existing, unflagged `endpoints.tsx:843` netuid-filter pattern exactly. Per the skill's screenshot-contract carve-out ("no visual change ... isn't rendering anything different"), this is out of scope for the before/after screenshot table.

## Testing
- Added `apps/ui/src/routes/blocks-index-numeric-filters.test.ts` (source-assertion test, matching the existing `validators-index-empty-action.test.ts` convention for route-level assertions that can't be exercised without a full router harness) — asserts each of the 4 `onChange` handlers strips non-digit characters. Verified it fails before the fix and passes after.
- `npm test --workspace=apps/ui` — 157 files / 1152 tests pass.
- `npm run typecheck --workspace=apps/ui` — clean.
- `npm run lint --workspace=apps/ui && npm run format:check --workspace=apps/ui` — clean (0 errors; pre-existing warnings in unrelated files only).

Closes #6395
