### PR TITLE
fix(tests): stop the health/trends 7d-window test from rotting with real time

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -6278,12 +6278,20 @@ test("GET /api/v1/chain/fees: call_module filter reuses the same moduleClause ac
 // SQL/routing wiring, matching every other route's test style regardless.
 
 test("GET /api/v1/health/trends: aggregates surface_uptime_daily into 7d/30d windows", async () => {
+  // A date comfortably inside the real 7d window at whenever this test
+  // actually runs -- a hardcoded date rots the moment real wall-clock time
+  // carries it outside handleHealthTrends' own Date.now()-relative window
+  // filter (confirmed live: this test started failing once "now" passed
+  // 2026-07-17, 7 days after the previously-hardcoded 2026-07-10 fixture).
+  const recentDate = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
   mockQueue.current = [
     [], // session-scoped SET statement_timeout
     [
       {
         netuid: 7,
-        date: "2026-07-10",
+        date: recentDate,
         total: 100,
         ok_count: 98,
         latency_samples: 96,


### PR DESCRIPTION
## Summary
Main's CI has been red on the last 2 commits (`26485762`, `16e557c2`) — same failure both times: `GET /api/v1/health/trends: aggregates surface_uptime_daily into 7d/30d windows` throws `TypeError: Cannot read properties of undefined (reading 'netuid')`.

Root cause: `handleHealthTrends`'s bulk-trends handler (`workers/data-api.mjs`) filters `surface_uptime_daily` rows against a window cutoff computed from real `Date.now()`. The test's mocked row used a hardcoded fixture date (`2026-07-10`). That was fine when the test was written, but once real wall-clock time carried "now" past `2026-07-17` (7 days after the fixture date), the row fell outside the real 7d window and got filtered out of the response — `body.windows["7d"].subnets` came back empty, so `subnets[0]` was `undefined`.

This isn't a bug in `handleHealthTrends` itself (filtering by real elapsed time is the intended behavior) — it's the test asserting relative-to-now behavior with an absolute fixture date that inevitably ages out.

## Fix
Compute the fixture date relative to `Date.now()` at test-run time (2 days back, comfortably inside any 7d/30d window) instead of a hardcoded date, so the test doesn't rot again.

Checked for the same pattern elsewhere in `tests/data-api.test.mjs` — other hardcoded-date fixtures (`snapshot_date`, `start_date`/`end_date`) are round-trip assertions (mock echoes the value straight back), not exposed to real-time window filtering, so they're not at risk of the same rot.

## Test plan
- [x] `npx vitest run tests/data-api.test.mjs -t "aggregates surface_uptime_daily into 7d/30d windows"` — passes
- [x] `npm test` (full suite) — 304 files, 9072 tests, all green
- [x] `npm run lint`, `npx prettier --check` — clean