### PR TITLE
fix(ui): validate the webhook secret length client-side before submit (#6581)

### DIFF
--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.test.ts
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseNetuidsInput } from "./webhook-subscription-manager";
+import { parseNetuidsInput, validateSecretInput } from "./webhook-subscription-manager";
 
 describe("parseNetuidsInput", () => {
   it("returns an empty list for blank input", () => {
@@ -23,5 +23,34 @@ describe("parseNetuidsInput", () => {
 
   it("rejects a negative number (not a bare digit token)", () => {
     expect(parseNetuidsInput("-1").ok).toBe(false);
+  });
+});
+
+describe("validateSecretInput", () => {
+  it("treats blank/whitespace-only input as valid (auto-generated server-side)", () => {
+    expect(validateSecretInput("")).toEqual({ ok: true });
+    expect(validateSecretInput("   ")).toEqual({ ok: true });
+  });
+
+  it("accepts a secret within the 16–256 character bound", () => {
+    expect(validateSecretInput("a".repeat(16))).toEqual({ ok: true });
+    expect(validateSecretInput("a".repeat(256))).toEqual({ ok: true });
+  });
+
+  it("rejects a too-short secret with its length in the error", () => {
+    const result = validateSecretInput("short");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("5");
+  });
+
+  it("rejects a too-long secret", () => {
+    expect(validateSecretInput("a".repeat(257)).ok).toBe(false);
+  });
+
+  it("validates the trimmed value, matching what onSubmit sends", () => {
+    // 16 real chars padded with surrounding whitespace still passes.
+    expect(validateSecretInput(`   ${"a".repeat(16)}   `)).toEqual({ ok: true });
+    // 8 real chars in surrounding whitespace is still too short.
+    expect(validateSecretInput(`   ${"a".repeat(8)}   `).ok).toBe(false);
   });
 });

--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
@@ -36,6 +36,24 @@ export function parseNetuidsInput(
   return { ok: true, value: netuids };
 }
 
+/**
+ * Optional webhook secret (#6581): an empty value is valid — the server
+ * auto-generates one — but a value the user actually types must be 16–256
+ * characters, matching the field hint and the server-side bound. Validated on
+ * the trimmed value, mirroring what `onSubmit` sends.
+ */
+export function validateSecretInput(raw: string): { ok: true } | { ok: false; error: string } {
+  const secret = raw.trim();
+  if (secret === "") return { ok: true };
+  if (secret.length < 16 || secret.length > 256) {
+    return {
+      ok: false,
+      error: `Secret must be 16–256 characters when set (currently ${secret.length}).`,
+    };
+  }
+  return { ok: true };
+}
+
 /** Distinguishes a 401/503 create rejection, a 404 lookup, and a 403 secret-mismatch delete. */
 function describeApiError(error: unknown): string {
   if (error instanceof ApiError) {
@@ -74,6 +92,7 @@ function CreateSubscriptionSection() {
   const [netuidsError, setNetuidsError] = useState<string | null>(null);
   const [kinds, setKinds] = useState<Set<string>>(new Set());
   const [secret, setSecret] = useState("");
+  const [secretError, setSecretError] = useState<string | null>(null);
 
   const mutation = useMutation({
     mutationFn: async (vars: CreateVariables): Promise<WebhookSubscriptionCreated> => {
@@ -117,6 +136,12 @@ function CreateSubscriptionSection() {
       return;
     }
     setNetuidsError(null);
+    const secretCheck = validateSecretInput(secret);
+    if (!secretCheck.ok) {
+      setSecretError(secretCheck.error);
+      return;
+    }
+    setSecretError(null);
     mutation.mutate({
       url: url.trim(),
       token: token.trim(),
@@ -198,9 +223,13 @@ function CreateSubscriptionSection() {
             type="password"
             autoComplete="off"
             value={secret}
-            onChange={(e) => setSecret(e.target.value)}
+            onChange={(e) => {
+              setSecret(e.target.value);
+              setSecretError(null);
+            }}
             className={inputCls}
           />
+          {secretError ? <p className="mt-1 text-[11px] text-health-down">{secretError}</p> : null}
         </Field>
         <button
           type="submit"


### PR DESCRIPTION
## Summary

The webhook Secret field advertises a "16–256 characters" bound in its hint but had no client-side validation: `onSubmit` validated only the netuids and passed `secret.trim()` straight through, so a user who typed a too-short secret got no feedback until the request round-tripped to the server and failed with a generic "Request failed" message (`describeApiError` has no case for that rejection).

This adds client-side length validation mirroring the sibling Netuids field: a new pure, unit-tested `validateSecretInput` helper, a `secretError` state, a submit guard, and an inline error rendered with the same styling/placement as the Netuids error. The "auto-generated if left blank" behavior is unchanged — validation only applies to a non-empty value.

## Changes

- `apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx`
  - `validateSecretInput(raw)` — empty is valid; otherwise 16–256 chars on the trimmed value (matching what `onSubmit` sends)
  - `secretError` state, cleared on input; submit blocked with an inline error when out of range
- `apps/ui/src/components/metagraphed/webhook-subscription-manager.test.ts`
  - 5 cases for `validateSecretInput` (blank, in-range, too short, too long, trimmed)

## Validation

- `eslint` — 0 errors
- `tsc --noEmit` — 0 errors
- `vitest` — 17/17 pass (10 in this file, incl. the 5 new cases)

## Screenshots

Repro: fill the required Webhook URL + Subscription token, type a 5-character Secret, submit. Before: no inline feedback (submit proceeds to the network). After: an inline "Secret must be 16–256 characters when set (currently 5)" error under the field, submit blocked.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6581-webhook-secret/6581-webhook-secret-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6581
