### PR TITLE
refactor(ui): make the floating-chrome shadows theme-adaptive (#6401)

### DIFF
--- a/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
+++ b/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
@@ -67,7 +67,7 @@ export function ShortcutsPopover() {
               className={classNames(
                 "hidden md:inline-flex fixed z-40 bottom-5 left-5 md:bottom-7 md:left-7",
                 "items-center justify-center rounded-full border border-border bg-card/95 backdrop-blur",
-                "size-10 text-ink-muted shadow-[0_8px_24px_-12px_rgba(0,0,0,0.35)]",
+                "size-10 text-ink-muted shadow-[0_8px_24px_-12px_color-mix(in_oklab,var(--ink-strong)_35%,transparent)]",
                 "hover:border-accent/60 hover:text-accent transition-colors",
               )}
             >

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -24,7 +24,7 @@ export function SubnetsCompareDrawer() {
       <div className="max-w-shell-max mx-auto px-4 md:px-10 pb-3">
         <div
           className={classNames(
-            "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[0_-8px_32px_-12px_rgba(0,0,0,0.35)]",
+            "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[0_-8px_32px_-12px_color-mix(in_oklab,var(--ink-strong)_35%,transparent)]",
             "mg-fade-in",
           )}
         >


### PR DESCRIPTION
> Resubmit of the prior PR, auto-closed on a `test` CI failure that is unrelated to this diff: this change is CSS class strings in two `apps/ui` components, which the root `test` job doesn't exercise; the `ui` job (apps/ui typecheck/lint/build/tests) passed, and the AI review found no blockers. Re-running CI on a fresh head.

## Summary

`shortcuts-popover.tsx`'s floating help button and `subnets-compare-drawer.tsx`'s compare dock both used a fixed `rgba(0,0,0,0.35)` shadow -- pure black, not the design system's `color-mix(in oklab, var(--ink-strong) N%, transparent)` idiom (`.mg-metric-tile` etc.). Neither adapts with the theme, so both go effectively invisible on a dark background.

## What Changed

Replaced both shadows with `color-mix(in oklab, var(--ink-strong) 35%, transparent)` at the same geometry and matched 0.35 opacity -- the same fix landed for the accounts/validators card shadows in #6398. Inline `color-mix` in the Tailwind arbitrary value, as `providers.index.tsx` already does. No `rgba(0,0,0,...)` shadow remains in either file.

## Screenshots

`/subnets` renders the shortcuts help button (bottom-left, at rest). The shadow is **subtle by design** (large blur, negative spread): in **light** mode `--ink-strong` is dark, so before/after are near-identical; in **dark** mode is where it matters -- the fixed black shadow was invisible, the token renders a faint adaptive elevation. The compare dock uses the identical idiom.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-before-desktop-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-before-desktop-light.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-after-desktop-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-after-desktop-light.png) |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-before-desktop-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-before-desktop-dark.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-after-desktop-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-after-desktop-dark.png) |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-before-tablet-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-before-tablet-light.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-after-tablet-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-after-tablet-light.png) |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-before-tablet-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-before-tablet-dark.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-after-tablet-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-after-tablet-dark.png) |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-before-mobile-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-before-mobile-light.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-after-mobile-light.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-after-mobile-light.png) |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-before-mobile-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-before-mobile-dark.png) | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-after-mobile-dark.png" width="240">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6401-overlay-shadows/6401-after-mobile-dark.png) |

Concrete change: `shadow-[0_8px_24px_-12px_rgba(0,0,0,0.35)]` -> `shadow-[0_8px_24px_-12px_color-mix(in_oklab,var(--ink-strong)_35%,transparent)]` (and the drawer's `0_-8px_32px_-12px` variant).

## Validation

- `npm run typecheck --workspace=apps/ui` -- 0 errors
- eslint + prettier clean; no `rgba(0,0,0` shadow remains in either file
- No behavior change; class strings only

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6401`) -- required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] No generated artifacts touched.

Closes #6401
