### PR TITLE
fix(build): revert only the deploy-owned artifacts a build actually dirtied

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import {
   DEPLOY_OWNED_ARTIFACTS,
+  dirtyTrackedPaths,
   resolveBaseRemote,
   stableStringify,
 } from "./lib.mjs";
@@ -63,26 +64,34 @@ revertDeployOwnedArtifactsIfChanged();
 function revertDeployOwnedArtifactsIfChanged() {
   // A real publish run (productionBuild) is expected to update these files —
   // leave them alone in that context. Everywhere else (plain local/CI validate
-  // build), these two files are inherently non-deterministic build output
-  // (their *_artifact_size_bytes totals sum the live R2-only artifacts, which
+  // build), r2-manifest.json is inherently non-deterministic build output
+  // (its *_artifact_size_bytes totals sum the live R2-only artifacts, which
   // legitimately vary build-to-build) — never a signal about YOUR change. A
-  // human manually reverting them before every commit was the actual
-  // recurring papercut, so auto-revert them here instead of just warning.
+  // human manually reverting it before every commit was the actual recurring
+  // papercut, so auto-revert here instead of just warning.
+  //
+  // Revert only the DEPLOY_OWNED_ARTIFACTS members that are ACTUALLY dirty,
+  // not the whole set the moment any one member is: schemas/index.json is
+  // deploy-owned in the same sense (its committed copy is a network-capture
+  // cache, not this build's output) but, unlike r2-manifest.json, nothing in
+  // localSteps()/productionSteps() above ever writes it -- the only thing
+  // that legitimately changes it is sync-schema-snapshots.yml's dedicated
+  // `schemas:snapshot` step, committed directly to its own PR. A blanket
+  // revert of the whole array used to stomp that legitimate commit back to
+  // origin/main just because r2-manifest.json also showed dirty in the same
+  // build, which guaranteed ci-verify-submitted-artifacts.mjs would always
+  // see committed != rebuilt and fail that PR's `checks` job.
   if (productionBuild) {
     return;
   }
-  const diff = spawnSync(
-    "git",
-    ["status", "--porcelain", "--", ...DEPLOY_OWNED_ARTIFACTS],
-    { cwd: process.cwd(), encoding: "utf8" },
-  );
-  if (diff.status !== 0 || !diff.stdout.trim()) {
+  const dirty = dirtyTrackedPaths(DEPLOY_OWNED_ARTIFACTS, process.cwd());
+  if (dirty.length === 0) {
     return;
   }
   const baseRemote = resolveBaseRemote(process.cwd());
   const revert = spawnSync(
     "git",
-    ["checkout", `${baseRemote}/main`, "--", ...DEPLOY_OWNED_ARTIFACTS],
+    ["checkout", `${baseRemote}/main`, "--", ...dirty],
     { cwd: process.cwd(), encoding: "utf8" },
   );
   if (revert.status !== 0) {
@@ -93,11 +102,11 @@ function revertDeployOwnedArtifactsIfChanged() {
       [
         "",
         "warning: build modified deploy-owned artifact(s), and auto-revert failed:",
-        ...DEPLOY_OWNED_ARTIFACTS.map((file) => `  - ${file}`),
+        ...dirty.map((file) => `  - ${file}`),
         revert.stderr || "",
         "Revert them manually before committing:",
         "",
-        `  git checkout ${baseRemote}/main -- ${DEPLOY_OWNED_ARTIFACTS.join(" ")}`,
+        `  git checkout ${baseRemote}/main -- ${dirty.join(" ")}`,
         "",
       ].join("\n"),
     );
@@ -108,7 +117,7 @@ function revertDeployOwnedArtifactsIfChanged() {
       "",
       "note: build produced non-deterministic deploy-owned artifact(s), auto-reverted to",
       `${baseRemote}/main (see DEPLOY_OWNED_ARTIFACTS in scripts/lib.mjs):`,
-      ...DEPLOY_OWNED_ARTIFACTS.map((file) => `  - ${file}`),
+      ...dirty.map((file) => `  - ${file}`),
       "",
     ].join("\n"),
   );

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -48,6 +48,26 @@ export function resolveBaseRemote(cwd = process.cwd()) {
   return remotes.includes("upstream") ? "upstream" : "origin";
 }
 
+// Returns the subset of `paths` that `git status --porcelain` reports as
+// modified/added/deleted, so a caller can act on exactly what changed instead
+// of treating the whole watched set as dirty the moment any one member is.
+// Porcelain v1 format is a fixed 2-char status + one space before the path,
+// so `line.slice(3)` reliably extracts it for this fixed, non-renaming set of
+// tracked paths (DEPLOY_OWNED_ARTIFACTS has no rename case to worry about).
+export function dirtyTrackedPaths(paths, cwd = process.cwd()) {
+  const result = spawnSync("git", ["status", "--porcelain", "--", ...paths], {
+    cwd,
+    encoding: "utf8",
+  });
+  if (result.status !== 0 || !result.stdout) {
+    return [];
+  }
+  return result.stdout
+    .split("\n")
+    .map((line) => line.slice(3).trim())
+    .filter(Boolean);
+}
+
 const credentialedUrlParams = new Set([
   "access_key",
   "access-token",

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -43,6 +43,7 @@ import {
   flattenSurfaces,
   withSurfaceFreshness,
   resolveBaseRemote,
+  dirtyTrackedPaths,
 } from "../scripts/lib.mjs";
 import { execFileSync } from "node:child_process";
 
@@ -1835,5 +1836,60 @@ describe("resolveBaseRemote", () => {
     // string on both sides) rather than a non-empty remote list.
     const dir = initRepo();
     assert.equal(resolveBaseRemote(dir), "origin");
+  });
+});
+
+describe("dirtyTrackedPaths", () => {
+  function initRepoWithFiles(files) {
+    const dir = mkdtempSync(path.join(tmpdir(), "wj-dirty-paths-"));
+    execFileSync("git", ["init", "-q"], { cwd: dir });
+    execFileSync("git", ["config", "user.email", "test@example.com"], {
+      cwd: dir,
+    });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+    for (const [relPath, contents] of Object.entries(files)) {
+      writeFileSync(path.join(dir, relPath), contents);
+    }
+    execFileSync("git", ["add", "-A"], { cwd: dir });
+    execFileSync("git", ["commit", "-q", "-m", "initial"], { cwd: dir });
+    return dir;
+  }
+
+  test("returns only the paths that are actually dirty, not the whole watched set", () => {
+    const dir = initRepoWithFiles({ "a.json": "{}\n", "b.json": "{}\n" });
+    writeFileSync(path.join(dir, "a.json"), '{"changed":true}\n');
+    assert.deepEqual(dirtyTrackedPaths(["a.json", "b.json"], dir), ["a.json"]);
+  });
+
+  test("returns an empty array when none of the watched paths are dirty", () => {
+    const dir = initRepoWithFiles({ "a.json": "{}\n", "b.json": "{}\n" });
+    assert.deepEqual(dirtyTrackedPaths(["a.json", "b.json"], dir), []);
+  });
+
+  test("returns every watched path that is dirty when more than one is", () => {
+    const dir = initRepoWithFiles({ "a.json": "{}\n", "b.json": "{}\n" });
+    writeFileSync(path.join(dir, "a.json"), '{"changed":true}\n');
+    writeFileSync(path.join(dir, "b.json"), '{"changed":true}\n');
+    assert.deepEqual(dirtyTrackedPaths(["a.json", "b.json"], dir), [
+      "a.json",
+      "b.json",
+    ]);
+  });
+
+  test("defaults to process.cwd() when called with no cwd argument", () => {
+    const dir = initRepoWithFiles({ "a.json": "{}\n" });
+    writeFileSync(path.join(dir, "a.json"), '{"changed":true}\n');
+    const previousCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      assert.deepEqual(dirtyTrackedPaths(["a.json"]), ["a.json"]);
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  test("returns an empty array when the command fails (not a git repository)", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wj-dirty-paths-not-a-repo-"));
+    assert.deepEqual(dirtyTrackedPaths(["a.json"], dir), []);
   });
 });


### PR DESCRIPTION
## Summary

PR #6411 (the automated `sync-schema-snapshots.yml` workflow's own PR, updating
`public/metagraph/schemas/index.json` from 24 → 60 captured schemas) has been
failing the `checks` job's "Verify submitted public artifacts are
reproducible" step ever since it opened. Root cause is in `scripts/build.mjs`,
not in that PR's content.

`revertDeployOwnedArtifactsIfChanged()` reverted the **entire**
`DEPLOY_OWNED_ARTIFACTS` array (`r2-manifest.json` + `schemas/index.json`) back
to `origin/main` whenever **any one** member showed up dirty in
`git status --porcelain` post-build. `r2-manifest.json`'s artifact-size
totals are always non-deterministic build to build, so this blanket revert
fired on effectively every CI build — silently discarding a legitimate,
intentionally-committed `schemas/index.json` update in the process, even
though nothing in `localSteps()` touched that file for this PR's registry
state. `ci-verify-submitted-artifacts.mjs` then compared the PR's committed
60-schema file against the wiped-back-to-24 working copy and failed the job
every time, unconditionally.

## What Changed

- Added `dirtyTrackedPaths(paths, cwd)` to `scripts/lib.mjs`: returns only the
  subset of `paths` that `git status --porcelain` actually reports as dirty.
- `revertDeployOwnedArtifactsIfChanged()` in `scripts/build.mjs` now reverts
  only that subset instead of blanket-reverting the whole
  `DEPLOY_OWNED_ARTIFACTS` set.
- Verified against a disposable repo reproducing PR #6411's exact scenario
  (schemas/index.json legitimately updated + committed, r2-manifest.json
  independently dirty from a build): only r2-manifest.json is now reverted;
  the legitimate schemas/index.json commit survives untouched. Also verified
  against a real `npm run build` on this repo's current registry state, where
  `build-artifacts.mjs`'s additive placeholder reconciliation (documented in
  `validate.yml`'s "Verify committed derived artifacts are fresh" step) makes
  `schemas/index.json` genuinely dirty — confirmed it's still correctly
  reverted in that case, since it's actually dirty there.

No behavior change for the common contributor case (both files still get
reverted whenever a plain `npm run build` legitimately dirties both); this
only changes the case where just one of the two is dirty.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A —
      no schema/API change; this is a build-script bugfix.)

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate`
- [x] `npm run test:coverage` (306 files, 9141 tests passed; new lines/branches
      in `lib.mjs` at 100% coverage)
- [x] `npm run build` (real run, confirmed fix end-to-end against this repo's
      current registry state)
- [x] `git diff --check`
