### PR TITLE
feat(api): add Total Network Value (root + alpha) rollup to /api/v1/economics

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4757,7 +4757,13 @@ export interface components {
             summary: {
                 registration_open_count: number;
                 subnet_count: number;
+                /** @description Total Network Value -- alpha side (#6641): the sum of every alpha subnet's (netuid > 0) alpha_market_cap_tao (alpha_price_tao x total_stake_tao). Lossless fixed 9-decimal rao-precision TAO string for the same past-2^53 reason as total_stake_tao; parse as an arbitrary-precision decimal if exact fidelity matters. */
+                total_alpha_value_tao: string;
                 total_miners: number;
+                /** @description Total Network Value (#6641): total_alpha_value_tao + total_root_value_tao -- the network-wide top-line economic figure. Lossless fixed 9-decimal rao-precision TAO string. */
+                total_network_value_tao: string;
+                /** @description Total Network Value -- root side (#6641): the root subnet's (netuid 0) staked TAO, valued 1:1 (root has no AMM). 0 when the root subnet has no economics row. Lossless fixed 9-decimal rao-precision TAO string. */
+                total_root_value_tao: string;
                 /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding. */
                 total_stake_tao: string;
                 total_validators: number;
@@ -16775,7 +16781,10 @@ export interface operations {
                      *         "summary": {
                      *           "registration_open_count": 1,
                      *           "subnet_count": 1,
+                     *           "total_alpha_value_tao": "327838334.635978200",
                      *           "total_miners": 1,
+                     *           "total_network_value_tao": "327838334.635978200",
+                     *           "total_root_value_tao": "327838334.635978200",
                      *           "total_stake_tao": "327838334.635978200",
                      *           "total_validators": 1,
                      *           "with_economics_count": 1

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -8428,9 +8428,24 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "total_alpha_value_tao": {
+                    "description": "Total Network Value -- alpha side (#6641): the sum of every alpha subnet's (netuid > 0) alpha_market_cap_tao (alpha_price_tao x total_stake_tao). Lossless fixed 9-decimal rao-precision TAO string for the same past-2^53 reason as total_stake_tao; parse as an arbitrary-precision decimal if exact fidelity matters.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
+                  },
                   "total_miners": {
                     "minimum": 0,
                     "type": "integer"
+                  },
+                  "total_network_value_tao": {
+                    "description": "Total Network Value (#6641): total_alpha_value_tao + total_root_value_tao -- the network-wide top-line economic figure. Lossless fixed 9-decimal rao-precision TAO string.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
+                  },
+                  "total_root_value_tao": {
+                    "description": "Total Network Value -- root side (#6641): the root subnet's (netuid 0) staked TAO, valued 1:1 (root has no AMM). 0 when the root subnet has no economics row. Lossless fixed 9-decimal rao-precision TAO string.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
                   },
                   "total_stake_tao": {
                     "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding.",
@@ -8452,7 +8467,10 @@
                   "total_stake_tao",
                   "total_validators",
                   "total_miners",
-                  "registration_open_count"
+                  "registration_open_count",
+                  "total_alpha_value_tao",
+                  "total_root_value_tao",
+                  "total_network_value_tao"
                 ],
                 "type": "object"
               }
@@ -34101,7 +34119,10 @@
                     "summary": {
                       "registration_open_count": 1,
                       "subnet_count": 1,
+                      "total_alpha_value_tao": "327838334.635978200",
                       "total_miners": 1,
+                      "total_network_value_tao": "327838334.635978200",
+                      "total_root_value_tao": "327838334.635978200",
                       "total_stake_tao": "327838334.635978200",
                       "total_validators": 1,
                       "with_economics_count": 1

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4757,7 +4757,13 @@ export interface components {
             summary: {
                 registration_open_count: number;
                 subnet_count: number;
+                /** @description Total Network Value -- alpha side (#6641): the sum of every alpha subnet's (netuid > 0) alpha_market_cap_tao (alpha_price_tao x total_stake_tao). Lossless fixed 9-decimal rao-precision TAO string for the same past-2^53 reason as total_stake_tao; parse as an arbitrary-precision decimal if exact fidelity matters. */
+                total_alpha_value_tao: string;
                 total_miners: number;
+                /** @description Total Network Value (#6641): total_alpha_value_tao + total_root_value_tao -- the network-wide top-line economic figure. Lossless fixed 9-decimal rao-precision TAO string. */
+                total_network_value_tao: string;
+                /** @description Total Network Value -- root side (#6641): the root subnet's (netuid 0) staked TAO, valued 1:1 (root has no AMM). 0 when the root subnet has no economics row. Lossless fixed 9-decimal rao-precision TAO string. */
+                total_root_value_tao: string;
                 /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding. */
                 total_stake_tao: string;
                 total_validators: number;
@@ -16775,7 +16781,10 @@ export interface operations {
                      *         "summary": {
                      *           "registration_open_count": 1,
                      *           "subnet_count": 1,
+                     *           "total_alpha_value_tao": "327838334.635978200",
                      *           "total_miners": 1,
+                     *           "total_network_value_tao": "327838334.635978200",
+                     *           "total_root_value_tao": "327838334.635978200",
                      *           "total_stake_tao": "327838334.635978200",
                      *           "total_validators": 1,
                      *           "with_economics_count": 1

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -8414,9 +8414,24 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "total_alpha_value_tao": {
+                    "description": "Total Network Value -- alpha side (#6641): the sum of every alpha subnet's (netuid > 0) alpha_market_cap_tao (alpha_price_tao x total_stake_tao). Lossless fixed 9-decimal rao-precision TAO string for the same past-2^53 reason as total_stake_tao; parse as an arbitrary-precision decimal if exact fidelity matters.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
+                  },
                   "total_miners": {
                     "minimum": 0,
                     "type": "integer"
+                  },
+                  "total_network_value_tao": {
+                    "description": "Total Network Value (#6641): total_alpha_value_tao + total_root_value_tao -- the network-wide top-line economic figure. Lossless fixed 9-decimal rao-precision TAO string.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
+                  },
+                  "total_root_value_tao": {
+                    "description": "Total Network Value -- root side (#6641): the root subnet's (netuid 0) staked TAO, valued 1:1 (root has no AMM). 0 when the root subnet has no economics row. Lossless fixed 9-decimal rao-precision TAO string.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
                   },
                   "total_stake_tao": {
                     "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding.",
@@ -8438,7 +8453,10 @@
                   "total_stake_tao",
                   "total_validators",
                   "total_miners",
-                  "registration_open_count"
+                  "registration_open_count",
+                  "total_alpha_value_tao",
+                  "total_root_value_tao",
+                  "total_network_value_tao"
                 ],
                 "type": "object"
               }

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1445,7 +1445,10 @@
                   "total_stake_tao",
                   "total_validators",
                   "total_miners",
-                  "registration_open_count"
+                  "registration_open_count",
+                  "total_alpha_value_tao",
+                  "total_root_value_tao",
+                  "total_network_value_tao"
                 ],
                 "properties": {
                   "subnet_count": { "type": "integer", "minimum": 0 },
@@ -1457,7 +1460,25 @@
                   },
                   "total_validators": { "type": "integer", "minimum": 0 },
                   "total_miners": { "type": "integer", "minimum": 0 },
-                  "registration_open_count": { "type": "integer", "minimum": 0 }
+                  "registration_open_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "total_alpha_value_tao": {
+                    "type": "string",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "description": "Total Network Value -- alpha side (#6641): the sum of every alpha subnet's (netuid > 0) alpha_market_cap_tao (alpha_price_tao x total_stake_tao). Lossless fixed 9-decimal rao-precision TAO string for the same past-2^53 reason as total_stake_tao; parse as an arbitrary-precision decimal if exact fidelity matters."
+                  },
+                  "total_root_value_tao": {
+                    "type": "string",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "description": "Total Network Value -- root side (#6641): the root subnet's (netuid 0) staked TAO, valued 1:1 (root has no AMM). 0 when the root subnet has no economics row. Lossless fixed 9-decimal rao-precision TAO string."
+                  },
+                  "total_network_value_tao": {
+                    "type": "string",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "description": "Total Network Value (#6641): total_alpha_value_tao + total_root_value_tao -- the network-wide top-line economic figure. Lossless fixed 9-decimal rao-precision TAO string."
+                  }
                 },
                 "additionalProperties": false
               },

--- a/scripts/lib/economics-artifacts.mjs
+++ b/scripts/lib/economics-artifacts.mjs
@@ -75,6 +75,12 @@ const RAO_PER_TAO = 1_000_000_000n;
 // quantity (matches the schema's own `minimum: 0`), so a negative sum is
 // unreachable -- unlike a real negative-capable delta, branching on a sign
 // that can never occur here would just be untestable dead code.
+function raoToTaoString(sumRao) {
+  const whole = sumRao / RAO_PER_TAO;
+  const frac = sumRao % RAO_PER_TAO;
+  return `${whole}.${frac.toString().padStart(9, "0")}`;
+}
+
 function sumFieldTaoString(rows, field) {
   let sumRao = 0n;
   for (const row of rows) {
@@ -83,9 +89,40 @@ function sumFieldTaoString(rows, field) {
       sumRao += BigInt(Math.round(value * 1e9));
     }
   }
-  const whole = sumRao / RAO_PER_TAO;
-  const frac = sumRao % RAO_PER_TAO;
-  return `${whole}.${frac.toString().padStart(9, "0")}`;
+  return raoToTaoString(sumRao);
+}
+
+// #6641: Total Network Value (TNV) -- the network-wide root-vs-alpha value split
+// none of the existing economics fields roll up. The alpha side is the sum of each
+// alpha subnet's (netuid > 0) already-computed `alpha_market_cap_tao` (alpha_price_tao
+// x total_stake_tao, the same market-cap proxy each row carries); the root side is the
+// root subnet's (netuid 0) staked TAO, which has no AMM and so is valued 1:1 in TAO;
+// the total is the two summed. Summed in exact rao-integer BigInt space and emitted as
+// fixed 9-decimal strings for the same past-2^53 precision reason sumFieldTaoString
+// documents -- confirmed live at ~328M TAO, well over the exact-double ceiling. Root is
+// sourced from the netuid-0 economics row when present, and is 0 (total == alpha) when
+// the root subnet has no economics row, never fabricated.
+function toRao(value) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? BigInt(Math.round(value * 1e9))
+    : 0n;
+}
+
+export function computeNetworkValue(rows) {
+  let alphaRao = 0n;
+  let rootRao = 0n;
+  for (const row of rows) {
+    if (row.netuid === 0) {
+      rootRao += toRao(row.total_stake_tao);
+    } else {
+      alphaRao += toRao(row.alpha_market_cap_tao);
+    }
+  }
+  return {
+    total_alpha_value_tao: raoToTaoString(alphaRao),
+    total_root_value_tao: raoToTaoString(rootRao),
+    total_network_value_tao: raoToTaoString(alphaRao + rootRao),
+  };
 }
 
 export function buildEconomicsArtifact({
@@ -168,6 +205,7 @@ export function buildEconomicsArtifact({
       total_miners: sumField("miner_count"),
       registration_open_count: rows.filter((row) => row.registration_allowed)
         .length,
+      ...computeNetworkValue(rows),
     },
     subnets: rows,
   };

--- a/tests/economics-artifacts.test.mjs
+++ b/tests/economics-artifacts.test.mjs
@@ -5,8 +5,81 @@ import {
   computeAlphaFdvTao,
   computeAlphaMarketCapTao,
   computeMinerReadiness,
+  computeNetworkValue,
   buildEconomicsArtifact,
 } from "../scripts/lib/economics-artifacts.mjs";
+
+// --- computeNetworkValue (#6641) -------------------------------------------
+
+describe("computeNetworkValue", () => {
+  test("alpha value sums alpha_market_cap_tao across netuid > 0 rows", () => {
+    const v = computeNetworkValue([
+      { netuid: 1, alpha_market_cap_tao: 100.5 },
+      { netuid: 2, alpha_market_cap_tao: 50.25 },
+    ]);
+    assert.equal(v.total_alpha_value_tao, "150.750000000");
+    assert.equal(v.total_root_value_tao, "0.000000000");
+    assert.equal(v.total_network_value_tao, "150.750000000");
+  });
+
+  test("root value is the netuid-0 row's total_stake_tao (1:1, no AMM)", () => {
+    const v = computeNetworkValue([
+      { netuid: 0, total_stake_tao: 1000, alpha_market_cap_tao: 999 },
+      { netuid: 1, alpha_market_cap_tao: 200 },
+    ]);
+    // netuid 0 contributes its stake to root, never to alpha (its own
+    // alpha_market_cap_tao is ignored -- root has no AMM value).
+    assert.equal(v.total_root_value_tao, "1000.000000000");
+    assert.equal(v.total_alpha_value_tao, "200.000000000");
+    assert.equal(v.total_network_value_tao, "1200.000000000");
+  });
+
+  test("null/absent/non-finite values contribute 0, never fabricated", () => {
+    const v = computeNetworkValue([
+      { netuid: 1, alpha_market_cap_tao: null },
+      { netuid: 2 },
+      { netuid: 3, alpha_market_cap_tao: Number.NaN },
+      { netuid: 0 },
+    ]);
+    assert.equal(v.total_alpha_value_tao, "0.000000000");
+    assert.equal(v.total_root_value_tao, "0.000000000");
+    assert.equal(v.total_network_value_tao, "0.000000000");
+  });
+
+  test("empty rows yield a zeroed, schema-shaped result", () => {
+    assert.deepEqual(computeNetworkValue([]), {
+      total_alpha_value_tao: "0.000000000",
+      total_root_value_tao: "0.000000000",
+      total_network_value_tao: "0.000000000",
+    });
+  });
+
+  test("exact rao summation: many representable rows never drift", () => {
+    // Each term is exactly representable at rao precision (value * 1e9 < 2^53),
+    // so the BigInt accumulation is exact where a float `+=` would drift.
+    const rows = Array.from({ length: 1000 }, () => ({
+      netuid: 1,
+      alpha_market_cap_tao: 0.000000001, // one rao
+    }));
+    assert.equal(
+      computeNetworkValue(rows).total_alpha_value_tao,
+      "0.000001000",
+    );
+  });
+
+  test("large network-wide totals stay rao-precision strings, not lossy numbers", () => {
+    // ~328M TAO alpha + ~50M TAO root -- well over the ~9,007,199 TAO exact-double
+    // ceiling, so the output must remain a fixed 9-decimal string.
+    const v = computeNetworkValue([
+      { netuid: 1, alpha_market_cap_tao: 328_000_000 },
+      { netuid: 0, total_stake_tao: 50_000_000 },
+    ]);
+    assert.match(v.total_network_value_tao, /^\d+\.\d{9}$/);
+    assert.equal(v.total_network_value_tao.split(".")[0], "378000000");
+    assert.equal(v.total_alpha_value_tao, "328000000.000000000");
+    assert.equal(v.total_root_value_tao, "50000000.000000000");
+  });
+});
 
 // --- computeMinerReadiness --------------------------------------------------
 
@@ -198,6 +271,9 @@ describe("buildEconomicsArtifact", () => {
       total_validators: 0,
       total_miners: 0,
       registration_open_count: 0,
+      total_alpha_value_tao: "0.000000000",
+      total_root_value_tao: "0.000000000",
+      total_network_value_tao: "0.000000000",
     });
   });
 


### PR DESCRIPTION
## What

Adds a **Total Network Value (TNV)** rollup to the `/api/v1/economics` summary — a single top-line economic figure splitting root TAO value vs. alpha value across the whole network, which none of the existing economics fields expose.

- `total_alpha_value_tao` — Σ each alpha subnet's (netuid > 0) `alpha_market_cap_tao` (`alpha_price_tao × total_stake_tao`, the market-cap proxy each row already carries).
- `total_root_value_tao` — the root subnet's (netuid 0) staked TAO, valued 1:1 (root has no AMM); `0` when the root subnet has no economics row.
- `total_network_value_tao` — the two summed.

## Why

Backprop surfaces TNV as its headline number (#5968 competitive survey). metagraphed already captures per-subnet `alpha_price_tao` + `total_stake_tao` everywhere, so this is **pure aggregation over existing data — no new ingestion, no new route**.

## How

- New pure `computeNetworkValue(rows)` in `scripts/lib/economics-artifacts.mjs`, summed in **exact rao-integer BigInt space** and emitted as fixed 9-decimal strings — matching `total_stake_tao`'s own documented past-2³ ceiling handling (the network-wide total is ~328M TAO, well over the ~9,007,199 TAO exact-double limit).
- Wired into `buildEconomicsArtifact`'s `summary`. That single builder feeds **both** the live economics tier (`scripts/refresh-economics.mjs`) **and** the built artifact (`scripts/build-artifacts.mjs`), so `GET /api/v1/economics` and the `get_economics` MCP tool (whose output schema treats `summary` as an opaque object) both carry the new fields with no separate wiring.
- Schema (`schemas/components/05-subnets.schema.json` → `EconomicsArtifact.summary`) + OpenAPI/types regenerated.

**GraphQL parity:** the GraphQL `EconomicsList` type intentionally exposes only `subnets`/`total`/`next_cursor` (no `summary` block), so there is no summary field there to mirror — REST + MCP are the surfaces that expose the summary, and both now carry TNV.

## Tests

`computeNetworkValue` unit-tested: alpha-only, root split, null/non-finite → 0, empty, exact-rao summation, and large past-2³ magnitudes. All validators green locally: `contract-drift`, `schemas`, `openapi` (162 routes), `openapi-examples` (162/162), `api`.

Closes #6641
