### PR TITLE
fix(realtime): harden chain-firehose ingest against DO crashes

### DIFF
--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -808,6 +808,54 @@ test("ChainFirehoseHub broadcast: a WebSocket whose send() throws (dead socket) 
   assert.equal(sent.length, 1);
 });
 
+// Sentry METAGRAPHED-3: state.getWebSockets() itself (not a per-socket op)
+// threw a bare Cloudflare "internal error" under concurrent load. Unlike the
+// per-socket guards above, this call had no try/catch at all -- a throw here
+// used to abort the whole broadcast(), losing SSE/GraphQL/MCP/alerter
+// delivery too, not just the WS population.
+test("ChainFirehoseHub broadcast: state.getWebSockets() throwing doesn't crash the broadcast or drop SSE delivery", () => {
+  const throwingState = {
+    getWebSockets: () => {
+      throw new Error("internal error; reference = deadbeef");
+    },
+  };
+  const sseSent = [];
+  const entry = {
+    topics: null,
+    controller: {
+      desiredSize: 1,
+      enqueue: (message) => sseSent.push(message),
+    },
+  };
+  const hub = new ChainFirehoseHub(throwingState, {});
+  hub.sseClients.add(entry);
+  assert.doesNotThrow(() =>
+    hub.broadcast({ table: "blocks", block_number: 1 }),
+  );
+  assert.equal(sseSent.length, 1);
+});
+
+test("ChainFirehoseHub broadcast: state.getWebSockets(tag) throwing for the graphql-ws tag alone doesn't crash the broadcast", () => {
+  const sent = [];
+  const ws = {
+    deserializeAttachment: () => null,
+    send: (message) => sent.push(message),
+  };
+  const partiallyThrowingState = {
+    getWebSockets: (tag) => {
+      if (tag === GRAPHQL_WS_SOCKET_TAG) {
+        throw new Error("internal error; reference = deadbeef");
+      }
+      return [ws];
+    },
+  };
+  const hub = new ChainFirehoseHub(partiallyThrowingState, {});
+  assert.doesNotThrow(() =>
+    hub.broadcast({ table: "blocks", block_number: 1 }),
+  );
+  assert.equal(sent.length, 1);
+});
+
 test("ChainFirehoseHub.webSocketMessage: a no-op for a plain firehose socket (not registered in graphqlWsSockets)", async () => {
   const hub = new ChainFirehoseHub(stubState(), {});
   await assert.doesNotReject(() => hub.webSocketMessage({}, "ignored"));

--- a/tests/chain-firehose-routes.test.mjs
+++ b/tests/chain-firehose-routes.test.mjs
@@ -259,6 +259,30 @@ test("ingest: a wrong token 401s before the limiter is consulted (#5550)", async
   assert.equal(res.status, 401);
 });
 
+// Sentry METAGRAPHED-1: a DO stub call throws "Durable Object reset because
+// its code was updated" when a deploy touching ChainFirehoseHub lands
+// mid-request -- expected/occasional, not a real fault. Left uncaught this
+// was an unhandled Worker exception instead of a clean, retryable response.
+test("ingest: a DO stub call throwing (e.g. a mid-request deploy reset) 503s cleanly instead of throwing (Sentry METAGRAPHED-1)", async () => {
+  const env = {
+    CHAIN_FIREHOSE_SYNC_SECRET: "shh",
+    CHAIN_FIREHOSE_HUB: stubHub(() => {
+      throw new Error("Durable Object reset because its code was updated.");
+    }),
+  };
+  const res = await handleRequest(
+    ingestRequest("{}", { token: "shh" }),
+    env,
+    {},
+  );
+  assert.equal(res.status, 503);
+  assert.equal(
+    (await res.json()).error.code,
+    "chain_firehose_ingest_unavailable",
+  );
+  assert.ok(res.headers.get("retry-after"));
+});
+
 test("ingest: relays a non-2xx upstream status (e.g. 400 from an invalid payload) unchanged", async () => {
   const env = {
     CHAIN_FIREHOSE_SYNC_SECRET: "shh",

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1190,10 +1190,28 @@ async function handleChainFirehoseIngest(request, env) {
   const stub = env.CHAIN_FIREHOSE_HUB.get(
     env.CHAIN_FIREHOSE_HUB.idFromName("global"),
   );
-  const upstream = await stub.fetch(
-    "https://chain-firehose-hub.internal/ingest",
-    { method: "POST", body, headers: { "content-type": "application/json" } },
-  );
+  let upstream;
+  try {
+    upstream = await stub.fetch("https://chain-firehose-hub.internal/ingest", {
+      method: "POST",
+      body,
+      headers: { "content-type": "application/json" },
+    });
+  } catch {
+    // Sentry METAGRAPHED-1: a DO stub call throws "Durable Object reset
+    // because its code was updated" when a deploy touching ChainFirehoseHub
+    // (or a transitive dep) lands mid-request -- expected/occasional, not a
+    // real fault. Left uncaught this was an unhandled Worker exception; a
+    // clean, retryable 503 lets the relay's own retry/backoff (#6451) handle
+    // it the same way it already handles a rate-limited or unavailable hub.
+    return errorResponse(
+      "chain_firehose_ingest_unavailable",
+      "The realtime chain firehose was temporarily unavailable; retry.",
+      503,
+      {},
+      { "retry-after": "1" },
+    );
+  }
   return new Response(await upstream.text(), {
     status: upstream.status,
     headers: { "content-type": "application/json; charset=utf-8" },

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -246,6 +246,25 @@ export function formatChainFirehoseSseFrame(payload) {
   return `event: chain\ndata: ${JSON.stringify(payload)}\n\n`;
 }
 
+// Sentry METAGRAPHED-3: state.getWebSockets() itself -- not a per-socket
+// operation like ws.send()/deserializeAttachment() above, which broadcast()
+// already guards individually -- threw a bare Cloudflare "internal error"
+// under concurrent load (16 occurrences in the same second, lining up with
+// chain-firehose-relay's CHAIN_FIREHOSE_FORWARD_CONCURRENCY=16 hitting this
+// same DO instance's broadcast() at once). Unguarded, that crashed the whole
+// broadcast() call -- losing SSE/GraphQL/MCP/alerter delivery too, not just
+// the WS population -- and surfaced to the relay as a 500 requiring a full
+// retry. Failing open to an empty array skips only this cycle's plain/
+// graphql-ws fanout; every other broadcast population is unaffected, and the
+// next broadcast() retries getWebSockets() fresh.
+function safeGetWebSockets(state, tag) {
+  try {
+    return state.getWebSockets(tag);
+  } catch {
+    return [];
+  }
+}
+
 // graphql-ws's wire protocol accepts ANY operation type over the same
 // `subscribe` message -- query and mutation included, not just subscription
 // (a real client can send `subscription { __typename }`-shaped envelopes
@@ -967,9 +986,9 @@ export class ChainFirehoseHub {
     // it (see closeStaleGraphqlWsSocket's comment for why the two can
     // diverge after a hibernation/reconstruction cycle).
     const graphqlWsTagged = new Set(
-      this.state.getWebSockets(GRAPHQL_WS_SOCKET_TAG),
+      safeGetWebSockets(this.state, GRAPHQL_WS_SOCKET_TAG),
     );
-    for (const ws of this.state.getWebSockets()) {
+    for (const ws of safeGetWebSockets(this.state)) {
       if (graphqlWsTagged.has(ws)) {
         // graphql-ws sockets are NOT plain firehose sockets -- sending a bare
         // JSON payload onto one here would corrupt the graphql-transport-ws


### PR DESCRIPTION
## Summary

Two Sentry-flagged, unresolved crashes in the chain-firehose ingest path, both surfacing as
uncaught exceptions instead of clean, retryable responses:

- **METAGRAPHED-3**: `ChainFirehoseHub.broadcast()`'s `state.getWebSockets()` calls were the only
  unguarded operation in that method (every per-socket op around them already has a try/catch) —
  a bare Cloudflare "internal error" there aborted the *entire* broadcast, losing SSE/GraphQL/MCP/
  alerter delivery too, not just the WS population. 16 occurrences landed in the same second,
  consistent with `chain-firehose-relay`'s `CHAIN_FIREHOSE_FORWARD_CONCURRENCY=16` hitting the same
  DO instance's `broadcast()` at once — a concurrency-triggered platform hiccup, not something tied
  to specific payload content.
- **METAGRAPHED-1**: `handleChainFirehoseIngest`'s `stub.fetch()` call had no try/catch, so a DO
  reset on a mid-request deploy ("Durable Object reset because its code was updated") surfaced as
  an unhandled Worker exception instead of a 503 the relay's existing retry/backoff (#6451) could
  handle cleanly.

## Fix

- `workers/chain-firehose-hub.mjs`: new `safeGetWebSockets(state, tag)` helper wraps both
  `getWebSockets()` calls in `broadcast()`, failing open to `[]` (skip that cycle's plain/graphql-ws
  fanout only — every other broadcast population is unaffected, and the next broadcast retries
  fresh).
- `workers/api.mjs`: `handleChainFirehoseIngest`'s `stub.fetch()` is now try/caught, returning a
  clean `503 chain_firehose_ingest_unavailable` with `retry-after` instead of throwing.

Deliberately narrow: I scoped this to the two call sites Sentry actually evidenced, not every
`state.getWebSockets()` call in the file (e.g. the WS-connection-cap check and
`rebuildWsClientsByIp()` use the same raw API but have no observed failure — left as-is pending
real evidence, per #6679).

## Test plan

- New regression tests: `state.getWebSockets()` throwing (both the untagged and
  `GRAPHQL_WS_SOCKET_TAG` calls) no longer crashes `broadcast()` and SSE delivery still completes;
  a throwing DO stub `fetch()` now 503s cleanly with `retry-after` instead of throwing.
- `npx vitest run tests/chain-firehose-hub.test.mjs tests/chain-firehose-routes.test.mjs` — 135/135
  passing.
- `npm run lint && npm run format:check` — clean.
- `npm run validate` — clean.
- Coverage: every new statement/branch in both files' diffs hit by the new tests (verified via raw
  v8 coverage JSON, not just the file-level aggregate which is diluted by the two-file test scope).

Closes #6679
Closes #6680
