### PR TITLE
feat(ui): add a live semantic-search demo to the agents page

### DIFF
--- a/apps/ui/src/components/metagraphed/search-box.test.ts
+++ b/apps/ui/src/components/metagraphed/search-box.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "@/lib/metagraphed/client";
+import type { SemanticSearchResult } from "@/lib/metagraphed/types";
+import { describeSearchError, formatScore, resultLabel, resultMeta } from "./search-box";
+
+function result(overrides: Partial<SemanticSearchResult> = {}): SemanticSearchResult {
+  return {
+    score: 0.5,
+    type: "subnet",
+    netuid: 64,
+    slug: "chutes",
+    title: "Chutes",
+    subtitle: null,
+    url: "https://chutes.ai",
+    categories: [],
+    service_kinds: [],
+    ...overrides,
+  };
+}
+
+describe("describeSearchError", () => {
+  it("describes a 429 as rate-limited, regardless of the server message", () => {
+    expect(
+      describeSearchError(
+        new ApiError("Too many requests", { status: 429, url: "/api/v1/search/semantic" }),
+      ),
+    ).toBe("Rate-limited — try again shortly.");
+  });
+
+  it("describes a 503 using the server message, falling back to a default when empty", () => {
+    expect(
+      describeSearchError(
+        new ApiError("AI unavailable", { status: 503, url: "/api/v1/search/semantic" }),
+      ),
+    ).toBe("AI unavailable");
+    expect(
+      describeSearchError(new ApiError("", { status: 503, url: "/api/v1/search/semantic" })),
+    ).toBe("AI is temporarily unavailable.");
+  });
+
+  it("falls back to the error message for any other ApiError status", () => {
+    expect(
+      describeSearchError(
+        new ApiError("Bad request", { status: 400, url: "/api/v1/search/semantic" }),
+      ),
+    ).toBe("Bad request");
+  });
+
+  it("uses the generic fallback for an ApiError with no message (e.g. a network failure)", () => {
+    expect(
+      describeSearchError(new ApiError("", { status: 0, url: "/api/v1/search/semantic" })),
+    ).toBe("Couldn't search — try again.");
+  });
+
+  it("returns a generic message for a non-ApiError failure", () => {
+    expect(describeSearchError(new Error("network down"))).toBe("Couldn't search — try again.");
+    expect(describeSearchError("not even an error")).toBe("Couldn't search — try again.");
+    expect(describeSearchError(undefined)).toBe("Couldn't search — try again.");
+  });
+});
+
+describe("formatScore", () => {
+  it("renders a mid-range score as a rounded percentage", () => {
+    expect(formatScore(0.87)).toBe("87%");
+    expect(formatScore(0.005)).toBe("1%"); // rounds, doesn't truncate
+  });
+
+  it("renders the 0 and 1 boundaries", () => {
+    expect(formatScore(0)).toBe("0%");
+    expect(formatScore(1)).toBe("100%");
+  });
+
+  it("degrades a non-finite or out-of-schema-range score to an em dash, never NaN%", () => {
+    expect(formatScore(Number.NaN)).toBe("—");
+    expect(formatScore(Number.POSITIVE_INFINITY)).toBe("—");
+    expect(formatScore(-0.1)).toBe("—");
+    expect(formatScore(1.1)).toBe("—");
+  });
+});
+
+describe("resultLabel", () => {
+  it("uses the title when present", () => {
+    expect(resultLabel(result({ title: "Chutes" }))).toBe("Chutes");
+  });
+
+  it("falls back to the slug when title is null", () => {
+    expect(resultLabel(result({ title: null, slug: "chutes" }))).toBe("chutes");
+  });
+
+  it("falls back to a generic label when both title and slug are null", () => {
+    expect(resultLabel(result({ title: null, slug: null }))).toBe("Untitled");
+  });
+});
+
+describe("resultMeta", () => {
+  it("includes the subnet prefix when netuid is present", () => {
+    expect(resultMeta(result({ netuid: 64, score: 0.5 }))).toBe("SN64 · 50%");
+  });
+
+  it("omits the subnet prefix when netuid is null", () => {
+    expect(resultMeta(result({ netuid: null, score: 0.5 }))).toBe("50%");
+  });
+});

--- a/apps/ui/src/components/metagraphed/search-box.tsx
+++ b/apps/ui/src/components/metagraphed/search-box.tsx
@@ -1,0 +1,144 @@
+import { useState, type FormEvent } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { ApiError } from "@/lib/metagraphed/client";
+import { semanticSearchQuery } from "@/lib/metagraphed/queries";
+import { classNames } from "@/lib/metagraphed/format";
+import type { SemanticSearchResult } from "@/lib/metagraphed/types";
+
+const RESULT_LIMIT = 8;
+
+/** Distinguishes a 429 (rate-limited) and 503 (AI disabled/unavailable) search rejection from a generic failure — same AI-endpoint family as ask-box's describeAskError. */
+export function describeSearchError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 429) return "Rate-limited — try again shortly.";
+    if (error.status === 503) return error.message || "AI is temporarily unavailable.";
+    return error.message || "Couldn't search — try again.";
+  }
+  return "Couldn't search — try again.";
+}
+
+/** Relevance score (0-1) as a rounded percentage; "—" for a non-finite/out-of-range value. */
+export function formatScore(score: number): string {
+  return Number.isFinite(score) && score >= 0 && score <= 1 ? `${Math.round(score * 100)}%` : "—";
+}
+
+/** A result's display title, falling back to its subnet slug when the registry has no title. */
+export function resultLabel(result: SemanticSearchResult): string {
+  return result.title ?? result.slug ?? "Untitled";
+}
+
+/** The netuid + score meta string next to a result, omitting the netuid segment when it's null. */
+export function resultMeta(result: SemanticSearchResult): string {
+  const netuidPrefix = result.netuid != null ? `SN${result.netuid} · ` : "";
+  return `${netuidPrefix}${formatScore(result.score)}`;
+}
+
+function ResultRow({ result }: { result: SemanticSearchResult }) {
+  const tags = [...result.categories, ...result.service_kinds].slice(0, 3);
+  const content = (
+    <div className="flex items-center justify-between gap-3 px-3 py-2.5">
+      <div className="min-w-0">
+        <p className="truncate text-[13px] text-ink-strong">{resultLabel(result)}</p>
+        {result.subtitle ? (
+          <p className="truncate text-[11px] text-ink-muted">{result.subtitle}</p>
+        ) : null}
+        {tags.length > 0 ? (
+          <div className="mt-1 flex flex-wrap gap-1">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-ink-muted"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+      <span className="shrink-0 font-mono text-[10px] text-ink-muted">{resultMeta(result)}</span>
+    </div>
+  );
+
+  if (result.netuid != null) {
+    return (
+      <li>
+        <Link
+          to="/subnets/$netuid"
+          params={{ netuid: result.netuid }}
+          className="block hover:bg-card"
+        >
+          {content}
+        </Link>
+      </li>
+    );
+  }
+  return <li>{content}</li>;
+}
+
+function SearchResults({ results }: { results: SemanticSearchResult[] }) {
+  if (results.length === 0) {
+    return <p className="mt-3 text-[12px] text-ink-muted">No matches — try a different phrase.</p>;
+  }
+  return (
+    <ul className="mt-4 divide-y divide-border rounded-lg border border-border bg-card">
+      {results.map((r, i) => (
+        // Results have no stable id in the schema; index is safe since this list
+        // is fully replaced (not reordered/filtered in place) on every new query.
+        <ResultRow key={i} result={r} />
+      ))}
+    </ul>
+  );
+}
+
+export function SearchBox() {
+  const [query, setQuery] = useState("");
+  const [submitted, setSubmitted] = useState("");
+  const { data, isFetching, isError, error } = useQuery({
+    ...semanticSearchQuery(submitted, RESULT_LIMIT),
+    retry: 0,
+  });
+
+  function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    setSubmitted(trimmed);
+  }
+
+  return (
+    <div>
+      <form onSubmit={onSubmit} className="flex flex-col gap-2 sm:flex-row sm:items-start">
+        <label className="flex-1">
+          <span className="sr-only">Search the subnet registry</span>
+          <input
+            type="text"
+            required
+            placeholder="video generation"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="w-full rounded-lg border border-border bg-card px-3 py-2 text-[13px] text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={isFetching || !query.trim()}
+          className={classNames(
+            "shrink-0 rounded-lg border border-accent/40 bg-accent/10 px-4 py-2 text-[13px] font-medium text-accent hover:bg-accent/15",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+          )}
+        >
+          {isFetching ? "Searching…" : "Search"}
+        </button>
+      </form>
+
+      {isError ? (
+        <p role="alert" className="mt-3 font-mono text-[12px] text-health-warn">
+          {describeSearchError(error)}
+        </p>
+      ) : null}
+
+      {!isError && submitted && data ? <SearchResults results={data.data.results} /> : null}
+    </div>
+  );
+}

--- a/apps/ui/src/routes/agents.tsx
+++ b/apps/ui/src/routes/agents.tsx
@@ -24,6 +24,7 @@ import {
   SectionHeading,
 } from "@jsonbored/ui-kit";
 import { AskBox } from "@/components/metagraphed/ask-box";
+import { SearchBox } from "@/components/metagraphed/search-box";
 import { Skeleton } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { agentResourcesQuery } from "@/lib/metagraphed/queries";
@@ -89,10 +90,6 @@ const QUICKSTART: { label: string; cmd: string }[] = [
     label: "List every callable service",
     cmd: "curl -s https://api.metagraph.sh/api/v1/agent-catalog",
   },
-  {
-    label: "Semantic search the registry",
-    cmd: "curl -s 'https://api.metagraph.sh/api/v1/search/semantic?q=video+generation'",
-  },
 ];
 
 function AgentsPage() {
@@ -157,6 +154,15 @@ function AgentsBody() {
           intro="Ask a question in plain English and get a grounded answer with citations back to the registry."
         />
         <AskBox />
+      </section>
+
+      {/* Semantic search — vector-similarity ranking over the registry, not a synthesized answer */}
+      <section>
+        <SectionHeading
+          title="Search the registry"
+          intro="Vector-similarity search over subnets and their surfaces — for finding candidates, not a single answer."
+        />
+        <SearchBox />
       </section>
 
       {/* Two calmer alternatives, side by side */}


### PR DESCRIPTION
## Summary
- #3500's own body deferred spec details to visibility-only ("Published under Wave 4... Size: M"), so scope came from the title ("replace curl-only snippet") plus tracing the sibling #3501 pattern already shipped on the same page.
- Replaces the static `curl -s '.../search/semantic?q=video+generation'` quickstart example with a live, interactive `SearchBox` — vector-similarity results ranked by relevance, each linking back to its subnet, mirroring `AskBox`'s exact form/loading/error/result structure (`apps/ui/src/components/metagraphed/ask-box.tsx`) but adapted to `semanticSearchQuery`'s query-based (not mutation-based) shape — that query function and its `SemanticSearchResult`/`SemanticSearchResponse` types already existed (already used by the command palette), so this is UI-only, no backend/contract change.
- Removed the now-redundant curl entry from the `QUICKSTART` array in `agents.tsx` — same precedent as how Ask's own curl-equivalent was fully replaced when #3501 shipped.

## Screenshots
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/3500-semantic-search-demo-after-mobile-dark.png)<br><sub>after</sub> |

## Validation
- `npm run lint --workspace=apps/ui` — 0 errors (pre-existing warnings only)
- `npm run typecheck --workspace=apps/ui` — clean (after rebuilding `packages/ui-kit`, a pre-existing stale-dist issue unrelated to this change)
- `npm test --workspace=apps/ui` — 157 files, 1166 tests passed (18 new tests for `search-box.tsx`'s pure helpers)
- Manually exercised the live demo in-browser against the real `api.metagraph.sh` API: submitted "video generation", got ranked real results (TalkHead SN108 80%, ChronoGPT/ChronoLLM SN38, Actual Computer SN95, AlphaCore SN91, 404—GEN SN17, ReadyAI SN33) with correct score/netuid/category rendering

Closes #3500
