### PR TITLE
feat(ui): redesign the validator hero's identity block to surface the owning coldkey

### DIFF
--- a/apps/ui/src/components/metagraphed/account-address.test.ts
+++ b/apps/ui/src/components/metagraphed/account-address.test.ts
@@ -66,6 +66,23 @@ describe("AccountAddress links ss58 values to their account page (#6424)", () =>
     }
   });
 
+  it("valueClassName merges onto the link's own hover:underline class (#6427)", () => {
+    const link = linkIn(
+      AccountAddress({
+        ss58: SS58,
+        fallback: "—",
+        truncate: false,
+        valueClassName: "truncate min-w-0",
+      }),
+    );
+    expect(link?.props.className).toBe("hover:underline truncate min-w-0");
+  });
+
+  it("omits valueClassName from the link's className when not passed", () => {
+    const link = linkIn(AccountAddress({ ss58: SS58, fallback: "—" }));
+    expect(link?.props.className).toBe("hover:underline");
+  });
+
   it("keeps a copy affordance carrying the untruncated value", () => {
     // The issue requires the untruncated copy affordance CopyableCode offered to
     // survive the switch: the copy button must still copy the FULL ss58, even

--- a/apps/ui/src/components/metagraphed/account-address.tsx
+++ b/apps/ui/src/components/metagraphed/account-address.tsx
@@ -22,6 +22,7 @@ export function AccountAddress({
   copyButtonClassName,
   compact,
   truncate = true,
+  valueClassName,
 }: {
   ss58?: string | null;
   fallback: ReactNode;
@@ -37,12 +38,25 @@ export function AccountAddress({
   copyButtonClassName?: string;
   /** Forwarded to the inner CopyButton — pass true inside a dense table/list row. See CopyButton's `compact` doc. */
   compact?: boolean;
+  /**
+   * Extra classes on the link itself (#6427). Combine with `truncate={false}`
+   * and e.g. `"truncate min-w-0"` inside a flex row so the browser ellipsizes
+   * to whatever width the row actually has -- full value on a wide desktop
+   * row, fewer characters on mobile -- instead of a fixed shortHash `keep`
+   * count that either overflows narrow layouts or wastes wide ones.
+   */
+  valueClassName?: string;
 }) {
   if (ss58 && isValidSs58(ss58)) {
     return (
       <span className="inline-flex items-center gap-1 min-w-0">
         <EntityHoverCard kind="account" ss58={ss58}>
-          <Link to="/accounts/$ss58" params={{ ss58 }} className="hover:underline" title={ss58}>
+          <Link
+            to="/accounts/$ss58"
+            params={{ ss58 }}
+            className={valueClassName ? `hover:underline ${valueClassName}` : "hover:underline"}
+            title={ss58}
+          >
             {truncate ? shortHash(ss58, keep) : ss58}
           </Link>
         </EntityHoverCard>

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -13,7 +13,6 @@ import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { PageHero, ShareButton, SectionAnchor, StatTile } from "@jsonbored/ui-kit";
 import { ValidatorHistoryChart } from "@/components/metagraphed/validator-history-chart";
 import { ValidatorApyPanel } from "@/components/metagraphed/validator-apy-panel";
-import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { WatchValidatorAlert } from "@/components/metagraphed/watch-validator-alert";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
@@ -297,25 +296,33 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
               Cross-subnet performance, nominators, and staking history for one Bittensor validator
               hotkey.
             </span>
-            {/* Hotkey + coldkey (#6427) get identical AccountAddress row
-                treatment, mirroring blocks.$ref.tsx/extrinsics.$hash.tsx's
-                FieldRow idiom (#6424). Operator identity renders on the
-                coldkey row, the key it's actually declared on (#5234). */}
+            {/* Hotkey + coldkey (#6427) get identical, symmetric AccountAddress
+                rows -- the operator name is already the page title, so it
+                isn't repeated here. truncate={false} + valueClassName lets
+                the browser ellipsize to whatever width the row actually has
+                (full value on desktop, fewer characters on mobile) instead
+                of a fixed shortHash cutoff that either overflows narrow
+                layouts or wastes wide ones. */}
             <dl className="max-w-2xl divide-y divide-border/80 rounded-2xl border border-border/80 bg-card/80 mg-card-glow-accent">
               <FieldRow label="Hotkey">
-                <AccountAddress ss58={hotkey} truncate={false} fallback="—" />
+                <span className="flex w-full min-w-0 items-center">
+                  <AccountAddress
+                    ss58={hotkey}
+                    truncate={false}
+                    valueClassName="truncate min-w-0"
+                    fallback="—"
+                  />
+                </span>
               </FieldRow>
               <FieldRow label="Coldkey">
-                {detail.coldkey ? (
-                  <span className="flex flex-wrap items-center gap-2">
-                    {hasIdentity ? (
-                      <ValidatorIdentityChip hotkey={hotkey} identity={identity} size={20} />
-                    ) : null}
-                    <AccountAddress ss58={detail.coldkey} truncate={false} fallback="—" />
-                  </span>
-                ) : (
-                  <span className="text-ink-muted">Not reported</span>
-                )}
+                <span className="flex w-full min-w-0 items-center">
+                  <AccountAddress
+                    ss58={detail.coldkey}
+                    truncate={false}
+                    valueClassName="truncate min-w-0"
+                    fallback={<span className="text-ink-muted">Not reported</span>}
+                  />
+                </span>
               </FieldRow>
             </dl>
           </span>
@@ -537,7 +544,7 @@ function FieldRow({ label, children }: { label: string; children: ReactNode }) {
       <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-muted sm:w-20 sm:shrink-0">
         {label}
       </dt>
-      <dd className="min-w-0">{children}</dd>
+      <dd className="min-w-0 w-full sm:flex-1">{children}</dd>
     </div>
   );
 }

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, notFound, useNavigate } from "@tanstack/react-router";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
+import { Suspense, type ReactNode } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { Boxes, Coins, Gauge, Percent, TriangleAlert, Users, Zap } from "lucide-react";
@@ -10,10 +10,11 @@ import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/met
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
-import { PageHero, ShareButton, SectionAnchor, CopyableCode, StatTile } from "@jsonbored/ui-kit";
+import { PageHero, ShareButton, SectionAnchor, StatTile } from "@jsonbored/ui-kit";
 import { ValidatorHistoryChart } from "@/components/metagraphed/validator-history-chart";
 import { ValidatorApyPanel } from "@/components/metagraphed/validator-apy-panel";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
+import { AccountAddress } from "@/components/metagraphed/account-address";
 import { WatchValidatorAlert } from "@/components/metagraphed/watch-validator-alert";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
 import { TakeManagementModal } from "@/components/metagraphed/take-management-modal";
@@ -292,24 +293,31 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         title={displayName}
         description={
           <span className="block space-y-4">
-            {/* With no declared operator identity the chip would only repeat the
-                hotkey already shown as the title and in the copyable field
-                below, so it's dropped when there's nothing extra to show (#5311). */}
-            {hasIdentity ? (
-              <span className="flex flex-wrap items-center gap-3">
-                <ValidatorIdentityChip hotkey={hotkey} identity={identity} size={40} />
-                <span className="text-[11px] text-ink-muted">
-                  Operator identity is declared on the coldkey — not hotkey-specific (#5234).
-                </span>
-              </span>
-            ) : null}
             <span className="block max-w-2xl text-sm text-ink-muted">
               Cross-subnet performance, nominators, and staking history for one Bittensor validator
               hotkey.
             </span>
-            <span className="inline-flex max-w-full min-w-0 rounded-2xl border border-border/80 bg-card/80 px-3 py-2 mg-card-glow">
-              <CopyableCode value={hotkey} truncate={false} className="max-w-full" />
-            </span>
+            {/* Hotkey + coldkey (#6427) get identical AccountAddress row
+                treatment, mirroring blocks.$ref.tsx/extrinsics.$hash.tsx's
+                FieldRow idiom (#6424). Operator identity renders on the
+                coldkey row, the key it's actually declared on (#5234). */}
+            <dl className="max-w-2xl divide-y divide-border/80 rounded-2xl border border-border/80 bg-card/80 mg-card-glow-accent">
+              <FieldRow label="Hotkey">
+                <AccountAddress ss58={hotkey} truncate={false} fallback="—" />
+              </FieldRow>
+              <FieldRow label="Coldkey">
+                {detail.coldkey ? (
+                  <span className="flex flex-wrap items-center gap-2">
+                    {hasIdentity ? (
+                      <ValidatorIdentityChip hotkey={hotkey} identity={identity} size={20} />
+                    ) : null}
+                    <AccountAddress ss58={detail.coldkey} truncate={false} fallback="—" />
+                  </span>
+                ) : (
+                  <span className="text-ink-muted">Not reported</span>
+                )}
+              </FieldRow>
+            </dl>
           </span>
         }
         actions={
@@ -517,5 +525,19 @@ function ValidatorDetail({ hotkey }: { hotkey: string }) {
         ]}
       />
     </>
+  );
+}
+
+// Mirrors blocks.$ref.tsx / extrinsics.$hash.tsx's own FieldRow (#6424) --
+// same label/value dl row idiom, copied rather than shared per this
+// codebase's per-route convention for small local helpers.
+function FieldRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
+      <dt className="font-mono text-[10px] uppercase tracking-widest text-ink-muted sm:w-20 sm:shrink-0">
+        {label}
+      </dt>
+      <dd className="min-w-0">{children}</dd>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

`validatorDetailQuery` already normalizes `coldkey` into `ValidatorDetail`, but `validators.$hotkey.tsx` only ever read it for the owner-only `isOwner` check and the gated `TakeManagementModal` — it was never rendered for a regular visitor. `ValidatorIdentityChip` shows the self-declared operator name, never the raw coldkey ss58.

Five prior PRs for this issue (#6510, #6526, #6541, #6553, #6609) were all closed. Each added a bare `Coldkey: <address>` field next to the existing hotkey pill, and each was rejected for the same reason:

- #6510: "Needs to be redesigned, not a fan of this implementation - feels out of place or just lazily thrown on there in relation to other elements/addresses."
- #6526: "Already declined a PR previously for implementing this in a similar/same way. Not a fan, rejecting. Feels randomly thrown on the page."
- #6541: "...none of the implementations feel like they fit/they just feel awkward. It just looks like it's randomly tossed there, and doesn't feel uniform/clean alongside the rest of the page elements."
- #6553: closed for a non-representative screenshot table.

This PR doesn't add a field — it restructures the hero's identity block. The three-piece stack that used to sit there (identity chip + an explanatory caption + a standalone hotkey pill) collapses into one `dl` with two symmetric, labeled rows (`Hotkey`, `Coldkey`), reusing the app's own established `FieldRow` idiom from `blocks.$ref.tsx`/`extrinsics.$hash.tsx` (#6424) and the `AccountAddress` component (link + hover-card + copy) every other ss58 in the app already gets. The operator name is no longer repeated on the coldkey row since it's already the page's own title — that repetition read as clutter, not clarification, once I looked at it against the title.

Researched how taostats.io's own (open-source) explorer handles this same hotkey/coldkey relationship: a declared name is the primary identity, the raw address is a de-emphasized fallback, and the owning account gets identical row treatment to every other metadata field rather than special/bolted-on styling — the same instinct this redesign follows within this app's own Bone & Ink conventions.

## What changed

- `apps/ui/src/routes/validators.$hotkey.tsx`: replaced the identity-chip + caption + hotkey-pill stack with a `dl`/`FieldRow` "Hotkey"/"Coldkey" block (mirrors `blocks.$ref.tsx`'s own `FieldRow`, copied per this codebase's per-route convention for small local helpers rather than shared). Removed the now-unused `ValidatorIdentityChip` import.
- `apps/ui/src/components/metagraphed/account-address.tsx`: added an optional `valueClassName` prop so a caller can put `truncate` CSS on the link itself. Combined with `truncate={false}`, this ellipsizes the ss58 to whatever width the row genuinely has — full address on a viewport wide enough to fit it, fewer characters on mobile — instead of a fixed `shortHash` character count that either overflows narrow layouts or wastes wide ones. Backward compatible; every other call site is unaffected.
- `apps/ui/src/components/metagraphed/account-address.test.ts`: two new cases covering `valueClassName`.

## Verification

Ran this against the real dev server (not just a mockup) with live production data, across all three required viewports and both themes, and fixed two real bugs it caught along the way:
- The first version overflowed the card horizontally at 375px (full untruncated addresses in a narrow column) — fixed with the `valueClassName`/CSS-ellipsis approach above.
- The first version repeated the operator's name/icon on the coldkey row even though it's already the page title — removed; both rows are now symmetric label+address.

## Screenshots

Captured at the required matrix (375×812 / 768×1024 / 1280×800, both themes forced via `mg-theme`), `before` from a worktree at the PR's merge-base, `after` from this branch — same live validator (`5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5`) in both captures.

| Viewport · Theme | Before | After |
| ---------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------ |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/validator-coldkey-6427/after-mobile-dark.png)<br><sub>after</sub> |

Closes #6427

## Validation

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (1155/1155 passed)
- [x] `npm run test:e2e --workspace=apps/ui` (28/28 passed; `/validators/$hotkey` isn't one of the recorded-HAR checked routes, no re-record needed)
- [x] `npm run build --workspace=apps/ui`
- [x] Bundle size budget: 296 KB / 300 KB gzipped — confirmed identical on an unmodified `main` build, so this PR has zero bundle impact (pre-existing headroom, not a regression introduced here)
- [x] `packages/client/src` untouched, no rebuild needed
- [x] Branch rebased onto current `main` (picks up #6632's health/trends test-flake fix and #6633's docs-drift check)