### PR TITLE
fix(ui): use the AA-safe ink-subtle-text token for the top-share caption

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
+++ b/apps/ui/src/components/metagraphed/charts/validator-dominance-chart.tsx
@@ -2,6 +2,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { BarMini, TreemapMini, type TreemapMiniDatum } from "@jsonbored/ui-kit";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { EmptyState } from "@/components/metagraphed/states";
+import { TopShareCaption } from "@/components/metagraphed/top-share-caption";
 import {
   VALIDATOR_DOMINANCE_TOP_N,
   buildValidatorDominanceChartData,
@@ -64,9 +65,7 @@ export function ValidatorDominanceChart() {
         <div className="mt-4 border-t border-border pt-3">
           <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
             Concentration
-            <span className="ml-2 normal-case tracking-normal text-ink-subtle">
-              share within the top {tiles.length}
-            </span>
+            <TopShareCaption n={tiles.length} />
           </div>
           <TreemapMini
             data={tiles}

--- a/apps/ui/src/components/metagraphed/top-share-caption.tsx
+++ b/apps/ui/src/components/metagraphed/top-share-caption.tsx
@@ -1,0 +1,13 @@
+// #6408: validators-panel.tsx and charts/validator-dominance-chart.tsx rendered
+// a byte-identical "share within the top {n}" caption, and the two copies had
+// already drifted onto the wrong token -- `text-ink-subtle` (the lighter
+// border/fill value) rather than `text-ink-subtle-text`, the AA-safe variant
+// meant for exactly this small body text. Extracting the caption to one place
+// fixes the contrast at both sites and stops the copies drifting again.
+export function TopShareCaption({ n }: { n: number }) {
+  return (
+    <span className="ml-2 normal-case tracking-normal text-ink-subtle-text">
+      share within the top {n}
+    </span>
+  );
+}

--- a/apps/ui/src/components/metagraphed/validators-panel.tsx
+++ b/apps/ui/src/components/metagraphed/validators-panel.tsx
@@ -11,6 +11,7 @@ import {
 import { NeuronTable } from "@/components/metagraphed/neuron-table";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { SponsoredValidatorCallout } from "@/components/metagraphed/sponsored-validator-callout";
+import { TopShareCaption } from "@/components/metagraphed/top-share-caption";
 
 const TOP_N = 10;
 
@@ -89,9 +90,7 @@ export function ValidatorsTableLoader({
             <div className="mt-4 border-t border-border pt-3">
               <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
                 Stake dominance
-                <span className="ml-2 normal-case tracking-normal text-ink-subtle">
-                  share within the top {stakeTiles.length}
-                </span>
+                <TopShareCaption n={stakeTiles.length} />
               </div>
               <TreemapMini
                 data={stakeTiles}


### PR DESCRIPTION
## What & why

`validators-panel.tsx` and `charts/validator-dominance-chart.tsx` each rendered a **byte-identical** `share within the top {n}` caption, and both copies had drifted onto `text-ink-subtle` — the lighter border/fill value — rather than `text-ink-subtle-text`, the AA-safe variant the ui-kit token doc (`styles.css:114-117`) reserves for exactly this small body text (already used correctly at `validators.$hotkey.tsx:170` and `neuron-table.tsx:272`).

## Approach

Extract the caption into a shared `TopShareCaption` helper carrying the AA token, and use it at both sites. Fixing it in one place resolves the contrast at **both** and removes the duplication that let the two copies drift onto the wrong token in the first place — the root cause the issue calls out ("consider extracting a shared helper to prevent future drift").

The change is contrast-only, so the before/after are close by design: the caption text is a shade darker in `after` (the AA-safe token) at both the `/validators` dominance chart shown here and the per-subnet validators panel.

## Verification

Full Phase C3 preflight (same steps/order as the `ui` CI job) **plus** the `test` gate's own command:

| Step | Command | Result |
| --- | --- | --- |
| lint | `npm run lint --workspace=apps/ui` | 0 errors |
| format | `npm run format:check --workspace=apps/ui` | clean |
| typecheck | `npm run typecheck --workspace=apps/ui` | clean |
| unit | `npm test --workspace=apps/ui` | 156 files, 1148 tests passed |
| build | `npm run build --workspace=apps/ui` | green |
| test gate | `npm run test:ci` | green (coverage 99.35% stmts) |

## Screenshots

Phase C2 contract (fixed viewports, never full-page, themes forced via `mg-theme`), anchored on the `/validators` dominance section where the caption appears. `before` uses `text-ink-subtle`; `after` the AA-safe `text-ink-subtle-text` — a subtle darkening of the "share within the top N" caption, consistent across both places it renders.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6408-aa-caption-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6408
