### PR TITLE
feat(ui): show subnet age since registration on the detail masthead

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -12,6 +12,7 @@ import {
   Minus,
 } from "lucide-react";
 import { formatNumber } from "@/lib/metagraphed/format";
+import { formatSubnetAge, subnetAgeDays } from "@/lib/metagraphed/subnet-age";
 import {
   Tooltip,
   TooltipContent,
@@ -173,6 +174,12 @@ export function SubnetMasthead({
   const name = profile?.name ?? `Subnet ${netuid}`;
   const description = profile?.description;
   const categories = (profile?.categories ?? []).slice(0, 4);
+
+  // Age since registration, derived from the profile's registration block and
+  // the snapshot's current chain height (no registration timestamp is exposed).
+  // Estimated from Finney's ~12s block time, hence the "~N days old" label; null
+  // when the blocks are missing/inconsistent, in which case the chip is hidden.
+  const ageLabel = formatSubnetAge(subnetAgeDays(profile?.registered_at_block, profile?.block));
 
   // Pull supporting series for the spark tiles. All three queries are already
   // primed by other panels on the page — no additional network hits. The live
@@ -389,6 +396,14 @@ export function SubnetMasthead({
                 {c}
               </span>
             ))}
+            {ageLabel ? (
+              <span
+                className="rounded border border-border/60 bg-paper px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted"
+                title="Estimated from the registration block and current chain height (~12s per Finney block)"
+              >
+                {ageLabel}
+              </span>
+            ) : null}
           </div>
           {description ? (
             <p className="mt-2 text-sm text-ink-muted max-w-3xl leading-relaxed line-clamp-2">

--- a/apps/ui/src/lib/metagraphed/subnet-age.test.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-age.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { FINNEY_BLOCK_SECONDS, formatSubnetAge, subnetAgeDays } from "./subnet-age";
+
+// (currentBlock - registeredAtBlock) * 12s / 86400s-per-day, floored.
+// 7200 blocks/day at 12s, so N days == N * 7200 blocks.
+const BLOCKS_PER_DAY = SECONDS_PER_DAY_BLOCKS();
+function SECONDS_PER_DAY_BLOCKS() {
+  return 86_400 / FINNEY_BLOCK_SECONDS; // 7200
+}
+
+describe("subnetAgeDays", () => {
+  it("converts a block delta to whole days at ~12s/block", () => {
+    expect(subnetAgeDays(1000, 1000 + BLOCKS_PER_DAY)).toBe(1);
+    expect(subnetAgeDays(1000, 1000 + BLOCKS_PER_DAY * 42)).toBe(42);
+  });
+
+  it("floors partial days", () => {
+    expect(subnetAgeDays(0, BLOCKS_PER_DAY + BLOCKS_PER_DAY / 2)).toBe(1);
+    expect(subnetAgeDays(0, BLOCKS_PER_DAY - 1)).toBe(0);
+  });
+
+  it("returns 0 for a same-block registration", () => {
+    expect(subnetAgeDays(500, 500)).toBe(0);
+  });
+
+  it("returns null when the registration block is ahead of the current block", () => {
+    expect(subnetAgeDays(2000, 1000)).toBeNull();
+  });
+
+  it("returns null for missing or non-finite inputs", () => {
+    expect(subnetAgeDays(null, 1000)).toBeNull();
+    expect(subnetAgeDays(1000, undefined)).toBeNull();
+    expect(subnetAgeDays(NaN, 1000)).toBeNull();
+    expect(subnetAgeDays(1000, Infinity)).toBeNull();
+  });
+
+  it("honours a custom block time", () => {
+    // at 6s/block, a day is 14400 blocks
+    expect(subnetAgeDays(0, 14_400, 6)).toBe(1);
+  });
+});
+
+describe("formatSubnetAge", () => {
+  it("formats singular, plural, and sub-day ages", () => {
+    expect(formatSubnetAge(0)).toBe("less than a day old");
+    expect(formatSubnetAge(1)).toBe("~1 day old");
+    expect(formatSubnetAge(42)).toBe("~42 days old");
+  });
+
+  it("thousands-separates large ages", () => {
+    expect(formatSubnetAge(1234)).toBe("~1,234 days old");
+  });
+
+  it("returns null for a null/invalid age so the field can be omitted", () => {
+    expect(formatSubnetAge(null)).toBeNull();
+    expect(formatSubnetAge(-5)).toBeNull();
+    expect(formatSubnetAge(NaN)).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/subnet-age.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-age.ts
@@ -1,0 +1,51 @@
+// #6643: subnet "age since registration" derived client-side from the
+// already-fetched block fields, with no new backend work.
+//
+// The subnet index/detail response carries `registered_at_block` (the block a
+// subnet was registered at) and `block` (the snapshot's current chain height),
+// but no registration *timestamp*. Finney produces a block roughly every 12s,
+// so the age in whole days is (currentBlock - registeredAtBlock) * 12 / 86400.
+// This is an estimate — block time drifts slightly — which is why the label
+// reads "~N days old" rather than a precise date.
+
+/** Nominal Finney block time in seconds (~12s/block). */
+export const FINNEY_BLOCK_SECONDS = 12;
+
+const SECONDS_PER_DAY = 86_400;
+
+/**
+ * Whole days since a subnet was registered, from its registration block and the
+ * snapshot's current block height. Returns null when either input is missing /
+ * non-finite, or when the registration block is ahead of the current block
+ * (a stale or inconsistent snapshot), so callers can hide the field rather than
+ * render a nonsensical negative age.
+ */
+export function subnetAgeDays(
+  registeredAtBlock: number | null | undefined,
+  currentBlock: number | null | undefined,
+  blockSeconds: number = FINNEY_BLOCK_SECONDS,
+): number | null {
+  if (
+    typeof registeredAtBlock !== "number" ||
+    typeof currentBlock !== "number" ||
+    !Number.isFinite(registeredAtBlock) ||
+    !Number.isFinite(currentBlock)
+  ) {
+    return null;
+  }
+  const elapsedBlocks = currentBlock - registeredAtBlock;
+  if (elapsedBlocks < 0) return null;
+  return Math.floor((elapsedBlocks * blockSeconds) / SECONDS_PER_DAY);
+}
+
+/**
+ * Human label for a whole-day age, e.g. "~1 day old" / "~42 days old". Days
+ * below 1 read "less than a day old". Returns null for a null age so callers
+ * can omit the field entirely.
+ */
+export function formatSubnetAge(days: number | null): string | null {
+  if (days == null || !Number.isFinite(days) || days < 0) return null;
+  if (days < 1) return "less than a day old";
+  if (days === 1) return "~1 day old";
+  return `~${days.toLocaleString()} days old`;
+}


### PR DESCRIPTION
## What

Adds a **subnet age** indicator ("~N days old") to the subnet detail masthead, in the identity row alongside the existing symbol / type / category chips. Closes #6643.

## Which field carries the registration time

The deliverable asks to confirm exactly which field exposes the registration timestamp. On the subnet **UI** response there is no registration *timestamp* — the `/api/v1/subnets/{netuid}/profile` payload carries `subnet.registered_at_block` (the block a subnet was registered at) and `subnet.block` (the snapshot's current chain height), but no `registered_at`/ISO field. Both are already normalized onto `SubnetProfile` (`registered_at_block`, `block`), so this is a pure display of already-fetched data — no new backend field or route.

Because there is no timestamp, the age is derived from the block delta at Finney's nominal block time:

```
ageDays = floor((currentBlock - registeredAtBlock) * ~12s / 86400)
```

The label reads "~N days old" (rather than a precise date) to be honest about the block-time estimate. I checked the existing `format.ts` helpers first (`relativeFromDiff` / `formatRelative`) as the issue suggests — those operate on millisecond diffs from ISO timestamps and don't apply to a block delta, so a small dedicated helper is warranted.

## Changes

- **`apps/ui/src/lib/metagraphed/subnet-age.ts`** — `subnetAgeDays(registeredAtBlock, currentBlock)` (block-delta → whole days, floored) and `formatSubnetAge(days)` ("~1 day old" / "~42 days old" / "less than a day old"). Both return `null` for missing / non-finite inputs or a registration block ahead of the current block, so the chip is simply hidden rather than rendering a nonsensical negative age.
- **`apps/ui/src/lib/metagraphed/subnet-age.test.ts`** — 9 tests: block→days math, floor, same-block = 0, negative → null, non-finite → null, custom block time, and the format singular/plural/thousands/null cases.
- **`apps/ui/src/components/metagraphed/subnet-masthead.tsx`** — render the age chip in the identity row when a value is available.

## Scope

The issue's deliverable accepts the badge in the subnet list **and/or** the detail page. This PR does the detail masthead as a focused XS change (one render surface, clean before/after). The subnets index list is a natural follow-up if wanted.

## Screenshots

Real new element, so a full before/after matrix on `/subnets/1` (subnet "Apex"), 3 viewports × 2 themes. The only difference is the new `~992 DAYS OLD` chip after the category chips.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | ![before mobile light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6643-subnet-age/before-mobile-light.png) | ![after mobile light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6643-subnet-age/after-mobile-light.png) |
| Mobile · Dark | ![before mobile dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6643-subnet-age/before-mobile-dark.png) | ![after mobile dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6643-subnet-age/after-mobile-dark.png) |
| Tablet · Light | ![before tablet light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6643-subnet-age/before-tablet-light.png) | ![after tablet light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6643-subnet-age/after-tablet-light.png) |
| Tablet · Dark | ![before tablet dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6643-subnet-age/before-tablet-dark.png) | ![after tablet dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6643-subnet-age/after-tablet-dark.png) |
| Desktop · Light | ![before desktop light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6643-subnet-age/before-desktop-light.png) | ![after desktop light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6643-subnet-age/after-desktop-light.png) |
| Desktop · Dark | ![before desktop dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6643-subnet-age/before-desktop-dark.png) | ![after desktop dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6643-subnet-age/after-desktop-dark.png) |

## Testing

- `vitest run subnet-age.test.ts` — 9/9 pass
- `tsc --noEmit` — clean
- `eslint` (changed files) — clean
- `prettier --check` — clean
