### PR TITLE
fix(build): accept OpenAPI-vendor JSON content-types in the schema index guard

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -30,6 +30,7 @@ import {
   withSurfaceFreshness,
   formatLlmMarkdownText,
   hashJson,
+  isJsonContentType,
   listJsonFilesRecursive,
   loadCandidates,
   loadNativeSnapshot,
@@ -4190,9 +4191,7 @@ function schemaIndexEntryMatchesSurface(entry, surface, capturedDetails) {
       stableStringify(captured.snapshot) === stableStringify(entry.snapshot));
   return (
     entry.path === `/metagraph/schemas/${surface.id}.json` &&
-    typeof entry.content_type === "string" &&
-    entry.content_type.toLowerCase().split(";")[0].trim() ===
-      "application/json" &&
+    isJsonContentType(entry.content_type) &&
     entry.snapshot &&
     typeof entry.snapshot === "object" &&
     entry.snapshot.surface_id === surface.id &&

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -641,6 +641,54 @@ test("artifact build preserves committed schema index without R2 schema details"
   }
 }, 30_000);
 
+test("artifact build accepts an OpenAPI-vendor JSON content-type for a captured schema entry", () => {
+  const schemaIndexPath = artifactFilePath("schemas/index.json");
+  const originalSchemaIndex = readFileSync(schemaIndexPath, "utf8");
+  const supportArtifacts = snapshotSupportArtifacts();
+  const schemaIndex = JSON.parse(originalSchemaIndex);
+  const indexTarget = schemaIndex.schemas?.find(
+    (schema) => schema.status === "captured",
+  );
+  assert(indexTarget, "expected a captured schema index entry to retype");
+
+  // A real subnet (SN-71 Leadpoet) serves its OpenAPI document as
+  // application/vnd.oai.openapi+json rather than plain application/json -- a
+  // spec-valid, OAI-registered media type. schemaIndexEntryMatchesSurface used
+  // to require an exact "application/json" match, so this one entry failed the
+  // reconciler's forgery/staleness guard and wholesale-discarded the entire
+  // committed index down to an empty placeholder (metagraphed#6411).
+  indexTarget.content_type = "application/vnd.oai.openapi+json; charset=utf-8";
+
+  try {
+    writeFileSync(schemaIndexPath, `${JSON.stringify(schemaIndex, null, 2)}\n`);
+    execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: process.env,
+      stdio: "pipe",
+    });
+
+    const rebuiltSchemaIndex = JSON.parse(
+      readFileSync(schemaIndexPath, "utf8"),
+    );
+    assert.equal(rebuiltSchemaIndex.source, "openapi-snapshot");
+    const rebuiltTarget = rebuiltSchemaIndex.schemas.find(
+      (schema) => schema.surface_id === indexTarget.surface_id,
+    );
+    assert.equal(rebuiltTarget?.content_type, indexTarget.content_type);
+    assert.equal(rebuiltTarget?.hash, indexTarget.hash);
+  } finally {
+    writeFileSync(schemaIndexPath, originalSchemaIndex);
+    execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: process.env,
+      stdio: "pipe",
+    });
+    restoreSupportArtifacts(supportArtifacts);
+  }
+}, 30_000);
+
 test("committed R2 manifest does not use fallback history keys", () => {
   // Read the git-committed manifest, not the working-tree copy: the Validate
   // test/checks jobs run `npm run build` before the suite, which regenerates


### PR DESCRIPTION
## Summary

Also required to unblock PR #6411 (the automated `sync-schema-snapshots.yml`
PR updating `public/metagraph/schemas/index.json`, 24 → 60 schemas). After
fixing the `build.mjs` blanket-revert bug (#6681), the `checks` job on that PR
still failed — because `build-artifacts.mjs` itself was wholesale-discarding
the entire committed schema index down to an empty placeholder, independent
of that other bug.

Root cause: `schemaIndexEntryMatchesSurface()` required a captured entry's
`content_type` to equal exactly `"application/json"`. SN-71 (Leadpoet) serves
its OpenAPI document as `application/vnd.oai.openapi+json; charset=utf-8` — a
spec-valid, OAI-registered media type, and exactly what `snapshot-openapi.mjs`
already accepts as JSON on the capture side (`isJsonContentType()`, a broad
"does the string contain 'json'" check). That one mismatched entry failed
`reusableSchemaIndexArtifact()`'s forgery/staleness guard, and that guard
discards the **entire** index (not just the offending entry) on any mismatch
— so a single subnet serving a spec-correct but non-generic content-type
wiped out all 64 committed entries on every build.

## What Changed

- `schemaIndexEntryMatchesSurface()` in `scripts/build-artifacts.mjs` now uses
  the same `isJsonContentType()` classifier the capture side
  (`snapshot-openapi.mjs`) already uses, instead of a stricter one-off exact
  match invented for the verify side.
- Added a regression test in `tests/artifacts.test.mjs`: retypes a real
  captured entry's `content_type` to the OpenAPI-vendor value and asserts the
  full rebuild still preserves it (confirmed it fails without the fix — the
  index collapses to `{"schemas": [], "source": "artifact-build"}`).
- Verified against PR #6411's actual branch: after this fix + #6681,
  `schemas/index.json` rebuilds byte-identical to what the bot committed, and
  `node scripts/ci-verify-submitted-artifacts.mjs` (the exact script the
  failing `checks` step runs) now exits 0.

## Registry Safety

- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (N/A —
      no schema/API change; this is a build-script bugfix.)

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run validate`
- [x] `npm run test:coverage` (306 files, 9142 tests passed)
- [x] `npm run build` (real run; confirmed the new test fails without the fix
      and passes with it)
- [x] `git diff --check`
