### PR TITLE
feat(realtime): batch chain-firehose ingest requests to close the capacity gap

### DIFF
--- a/docs/realtime-firehose.md
+++ b/docs/realtime-firehose.md
@@ -48,15 +48,23 @@ re-fetches by primary key. The function inserts that payload into
 `delivered_at IS NULL` view of the table and then forwards them.
 
 Row-level, not statement-level: simpler for a first cut, at the cost of one
-outbox row per source row rather than one per batch insert. If per-block volume
-becomes a real bottleneck, the documented fast-follow is a statement-level
-trigger with a `REFERENCING NEW TABLE AS new_rows` transition table.
+outbox row per source row rather than one per batch insert. Per-block volume
+DID become a real bottleneck (#6672: sustained production outgrew the
+ingest endpoint's rate limit by ~3.5-4x) — the fix taken was downstream
+request-level batching (see the relay section below), not a statement-level
+trigger; the row-level outbox design here is unchanged. A
+`REFERENCING NEW TABLE AS new_rows` transition table remains a possible
+future fast-follow if outbox INSERT volume itself (not ingest-request volume)
+ever becomes the bottleneck instead.
 
 ## The relay (#4981, live)
 
 A new, small, self-hosted process on the indexer box polls and claims pending
-`chain_firehose_outbox` rows, forwards each payload to the Durable Object over
-HTTP, and uses bounded retry/drop-oldest behavior under sustained
+`chain_firehose_outbox` rows, groups them into `CHAIN_FIREHOSE_INGEST_BATCH_SIZE`-sized
+chunks and forwards each chunk as one JSON-array POST body to the Durable
+Object over HTTP (#6672 -- the ingest rate limit costs by request, not
+payload size, so batching multiplies effective throughput without touching
+that limit), and uses bounded retry/drop-oldest behavior under sustained
 Cloudflare-side unavailability. It does **not** `LISTEN` on a Postgres channel:
 PostgreSQL delivers `NOTIFY` at transaction commit and its global notification
 queue can be held back by a listener that remains in a transaction; if that
@@ -90,7 +98,11 @@ One global instance (`idFromName("global")`) owns two endpoints:
   isn't provisioned, 401 if the token is missing/wrong. The auth check lives
   in `workers/api.mjs`, not inside the Durable Object itself — a DO is never
   internet-addressable on its own, so this Worker's binding is the only path
-  in, and the one place a forged request could be rejected.
+  in, and the one place a forged request could be rejected. The body is
+  either one payload object (broadcast once) or a JSON array of up to
+  `CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE` payload objects (#6672, broadcast
+  in order, sequentially) — additive, so older single-object callers are
+  unaffected.
 - `GET /api/v1/chain/stream` — the public read side, no auth (the same
   public data `/api/v1/chain-events` already serves, pushed instead of
   polled). SSE by default (`event: chain` frames, JSON payload matching the

--- a/scripts/chain-firehose-relay.mjs
+++ b/scripts/chain-firehose-relay.mjs
@@ -282,7 +282,32 @@ export const CHAIN_FIREHOSE_FORWARD_TIMEOUT_MS = 10_000;
 // after downtime.
 export const CHAIN_FIREHOSE_FORWARD_CONCURRENCY = 16;
 
+// #6672: how many outbox rows go into ONE ingest POST body (a JSON array),
+// instead of one row per request. The ingest rate limit
+// (workers/api.mjs's CHAIN_FIREHOSE_INGEST_RATE_LIMIT, enforced via a
+// Cloudflare Workers Rate Limiting binding) costs by REQUEST, not payload
+// size, so batching multiplies effective row throughput by this factor
+// without touching that limit or CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S's
+// own pacing at all -- the actual lever #6451's two incident rounds
+// established as dangerous to touch carelessly. MUST match (or stay ≤)
+// workers/chain-firehose-hub.mjs's CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE --
+// tests/chain-firehose-relay.test.mjs asserts the two stay in sync, since
+// this script deploys standalone (no runtime import of workers/) and can't
+// enforce that via a shared import.
+export const CHAIN_FIREHOSE_INGEST_BATCH_SIZE = 10;
+
 // --- pure, unit-tested logic ----------------------------------------------------
+
+// Splits `items` into consecutive groups of at most `size`, preserving
+// order. Pure and tiny -- kept separate from forwardBatch below so the
+// grouping itself is directly testable without a fetch mock.
+export function chunkRows(items, size) {
+  const chunks = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
 
 // Bounded-concurrency map: drains `items` through at most `concurrency`
 // in-flight `fn` calls. Duplicated from src/webhooks.mjs's own mapBounded
@@ -476,41 +501,72 @@ export async function forwardWithRetry(
   return false;
 }
 
-// Forwards every row in a claimed batch with bounded concurrency (see
+// Forwards every row in a claimed batch, grouped into CHAIN_FIREHOSE_INGEST_BATCH_SIZE-sized
+// chunks (#6672) with bounded concurrency across chunks (see
 // CHAIN_FIREHOSE_FORWARD_CONCURRENCY's own comment for why this isn't
 // sequential). `rows` are already claimed (delivered_at stamped) by the
 // caller's UPDATE ... RETURNING before this runs -- forwarding failure after
 // exhausting retries still counts as "handled" (best-effort, not
 // at-least-once, same as the old design), not re-queued.
 //
-// rateLimitedForMs (new): the MAX pause duration reported by any row in this
-// batch, if any hit a 429 -- the caller (main()'s poll loop) sleeps this long
-// before its NEXT poll rather than immediately re-claiming a fresh batch and
-// firing CHAIN_FIREHOSE_FORWARD_CONCURRENCY more requests straight into the
-// same rate limit. This is the actual fix for the real 2026-07 incident: 16
-// concurrent requests times however many batches per second the old
-// immediate-reloop behavior fired is trivially over the ingest endpoint's
-// own 120-req/60s limit the moment there's any real backlog, and every prior
-// design only backed off PER ROW, never paused the batch/poll level that was
-// the true source of the overload.
-export async function forwardBatch(rows, config, options = {}) {
+// A chunk succeeds or fails as ONE unit (a single POST, one response) -- if
+// it's dropped after exhausting retries, every row in that chunk is dropped
+// together (there's no way to know which individual row within a failed
+// batch request might have succeeded alone). This trades a little precision
+// for the whole point of batching: fewer, larger requests under the same
+// rate limit. `rows` already share a best-effort (not at-least-once)
+// contract, so a coarser failure unit doesn't change the delivery guarantee,
+// just its granularity.
+//
+// rateLimitedForMs (unchanged behavior, now per-chunk not per-row): the MAX
+// pause duration reported by any chunk in this batch, if any hit a 429 -- the
+// caller (main()'s poll loop) sleeps this long before its NEXT poll rather
+// than immediately re-claiming a fresh batch and firing more requests
+// straight into the same rate limit. This is the actual fix for the real
+// 2026-07 incident: every prior design only backed off PER ROW/PER CHUNK,
+// never paused the batch/poll level that was the true source of the
+// overload.
+//
+// options.chunkSize defaults to the real CHAIN_FIREHOSE_INGEST_BATCH_SIZE --
+// it's a test seam (isolating "one chunk fails, another succeeds" without a
+// test needing CHAIN_FIREHOSE_INGEST_BATCH_SIZE-many rows), not a knob main()
+// ever overrides in production.
+export async function forwardBatch(
+  rows,
+  config,
+  { chunkSize = CHAIN_FIREHOSE_INGEST_BATCH_SIZE, ...options } = {},
+) {
   let rateLimitedForMs = 0;
-  const results = await mapBounded(
-    rows,
+  const chunks = chunkRows(rows, chunkSize);
+  const chunkResults = await mapBounded(
+    chunks,
     CHAIN_FIREHOSE_FORWARD_CONCURRENCY,
-    (row) =>
-      forwardWithRetry(JSON.stringify(row.payload), config, {
-        ...options,
-        onRateLimited: (pauseMs) => {
-          rateLimitedForMs = Math.max(rateLimitedForMs, pauseMs);
-          options.onRateLimited?.(pauseMs);
+    (chunk) =>
+      forwardWithRetry(
+        JSON.stringify(chunk.map((row) => row.payload)),
+        config,
+        {
+          ...options,
+          // Fires once per DROPPED ROW (not once per dropped chunk), so
+          // callers counting drops (e.g. main()'s droppedInBatch) see the
+          // same per-row granularity they did before batching.
+          onDrop: (_payload, status) => {
+            for (const row of chunk) options.onDrop?.(row.payload, status);
+          },
+          onRateLimited: (pauseMs) => {
+            rateLimitedForMs = Math.max(rateLimitedForMs, pauseMs);
+            options.onRateLimited?.(pauseMs);
+          },
         },
-      }),
+      ),
   );
-  const forwarded = results.filter(Boolean).length;
+  const forwarded = chunks.reduce(
+    (sum, chunk, i) => sum + (chunkResults[i] ? chunk.length : 0),
+    0,
+  );
   return {
     forwarded,
-    dropped: results.length - forwarded,
+    dropped: rows.length - forwarded,
     ...(rateLimitedForMs > 0 && { rateLimitedForMs }),
   };
 }

--- a/tests/chain-firehose-hub.test.mjs
+++ b/tests/chain-firehose-hub.test.mjs
@@ -20,6 +20,7 @@ import {
   CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS,
   CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_IP,
   CHAIN_FIREHOSE_MAX_GRAPHQL_SUBSCRIPTIONS_PER_SOCKET,
+  CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE,
   CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES,
   CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS,
   CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK,
@@ -367,10 +368,56 @@ test("validateChainFirehoseIngestPayload: rejects invalid JSON", () => {
   assert.match(result.error, /not valid JSON/);
 });
 
-test("validateChainFirehoseIngestPayload: rejects a JSON array", () => {
+// #6672: a JSON array is now a BATCH of payloads (closes the ingest capacity
+// gap without touching the rate limit -- see CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE's
+// own comment), not an automatic reject -- but each element still has to be
+// a well-formed payload object.
+test("validateChainFirehoseIngestPayload: rejects a JSON array of non-object elements", () => {
   const result = validateChainFirehoseIngestPayload("[1,2,3]");
   assert.equal(result.ok, false);
+  assert.match(result.error, /batch\[0\]/);
   assert.match(result.error, /JSON object/);
+});
+
+test("validateChainFirehoseIngestPayload: accepts a batch array of well-formed payloads", () => {
+  const result = validateChainFirehoseIngestPayload(
+    JSON.stringify([
+      { table: "blocks", block_number: 1 },
+      { table: "blocks", block_number: 2 },
+    ]),
+  );
+  assert.equal(result.ok, true);
+  assert.ok(Array.isArray(result.payload));
+  assert.equal(result.payload.length, 2);
+  assert.equal(result.payload[1].block_number, 2);
+});
+
+test("validateChainFirehoseIngestPayload: rejects an empty batch array", () => {
+  const result = validateChainFirehoseIngestPayload("[]");
+  assert.equal(result.ok, false);
+  assert.match(result.error, /must not be empty/);
+});
+
+test("validateChainFirehoseIngestPayload: rejects a batch array over CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE", () => {
+  const oversized = Array.from(
+    { length: CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE + 1 },
+    (_, i) => ({ table: "blocks", block_number: i }),
+  );
+  const result = validateChainFirehoseIngestPayload(JSON.stringify(oversized));
+  assert.equal(result.ok, false);
+  assert.match(result.error, /exceeds/);
+});
+
+test("validateChainFirehoseIngestPayload: a batch stops at the first invalid element and reports its index", () => {
+  const result = validateChainFirehoseIngestPayload(
+    JSON.stringify([
+      { table: "blocks", block_number: 1 },
+      { table: "not-a-real-table", block_number: 2 },
+    ]),
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.error, /batch\[1\]/);
+  assert.match(result.error, /table must be one of/);
 });
 
 test("validateChainFirehoseIngestPayload: rejects an unrecognized table", () => {
@@ -420,7 +467,7 @@ test("validateChainFirehoseIngestPayload: rejects a nested object/array field", 
   assert.match(result.error, /unsupported value type/);
 });
 
-test("validateChainFirehoseIngestPayload: rejects a body over the size cap", () => {
+test("validateChainFirehoseIngestPayload: rejects a body over the size cap (via the per-field cap, well under the #6672 batch-scaled raw-body cap)", () => {
   const result = validateChainFirehoseIngestPayload(
     JSON.stringify({
       table: "blocks",
@@ -429,6 +476,21 @@ test("validateChainFirehoseIngestPayload: rejects a body over the size cap", () 
     }),
   );
   assert.equal(result.ok, false);
+  assert.match(result.error, /exceeds the field size limit/);
+});
+
+// #6672: the raw-body byte cap itself is now sized for a full batch
+// (CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE payloads), not a single payload -- a
+// body genuinely over THAT is rejected before JSON.parse is even attempted.
+test("validateChainFirehoseIngestPayload: rejects a raw body over the batch-scaled byte cap", () => {
+  const oversizedRaw = "x".repeat(
+    CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES *
+      CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE +
+      1,
+  );
+  const result = validateChainFirehoseIngestPayload(oversizedRaw);
+  assert.equal(result.ok, false);
+  assert.match(result.error, /exceeds \d+ bytes/);
 });
 
 test("validateChainFirehoseIngestPayload: null fields are accepted (skipped)", () => {
@@ -533,6 +595,31 @@ test("ChainFirehoseHub.handleIngest: 202s and broadcasts a valid payload", async
   assert.equal(res.status, 202);
   assert.deepEqual(await res.json(), { ok: true });
   assert.equal(broadcast.block_number, 42);
+});
+
+// #6672: a batch-array body broadcasts every element, in order, sequentially.
+test("ChainFirehoseHub.handleIngest: 202s and broadcasts every element of a batch payload, in order", async () => {
+  const hub = new ChainFirehoseHub(stubState(), {});
+  const broadcasts = [];
+  hub.broadcast = async (payload) => {
+    broadcasts.push(payload);
+  };
+  const res = await hub.fetch(
+    new Request("https://chain-firehose-hub.internal/ingest", {
+      method: "POST",
+      body: JSON.stringify([
+        { table: "blocks", block_number: 1 },
+        { table: "blocks", block_number: 2 },
+        { table: "blocks", block_number: 3 },
+      ]),
+    }),
+  );
+  assert.equal(res.status, 202);
+  assert.deepEqual(await res.json(), { ok: true });
+  assert.deepEqual(
+    broadcasts.map((p) => p.block_number),
+    [1, 2, 3],
+  );
 });
 
 test("ChainFirehoseHub /subscribe (SSE): responds with a text/event-stream and an initial comment frame", async () => {

--- a/tests/chain-firehose-relay.test.mjs
+++ b/tests/chain-firehose-relay.test.mjs
@@ -43,11 +43,13 @@ import {
   CHAIN_FIREHOSE_DROP_REPORT_INTERVAL_MS,
   CHAIN_FIREHOSE_DROP_REPORT_THRESHOLD,
   CHAIN_FIREHOSE_FORWARD_TIMEOUT_MS,
+  CHAIN_FIREHOSE_INGEST_BATCH_SIZE,
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
   CHAIN_FIREHOSE_MAX_FORWARD_ATTEMPTS,
   CHAIN_FIREHOSE_MAX_RATE_LIMIT_PAUSE_MS,
   CHAIN_FIREHOSE_POLL_BATCH_SIZE,
   CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S,
+  chunkRows,
   computeBackoffDelayMs,
   computeBatchPaceDelayMs,
   computeDropWindowUpdate,
@@ -63,6 +65,33 @@ import {
   reportRateLimitPause,
   touchHeartbeat,
 } from "../scripts/chain-firehose-relay.mjs";
+import { CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE } from "../workers/chain-firehose-hub.mjs";
+
+// #6672: this script deploys standalone (see CHAIN_FIREHOSE_INGEST_BATCH_SIZE's
+// own comment) and can't import workers/chain-firehose-hub.mjs at runtime, so
+// nothing at the source level stops these two constants drifting apart --
+// this cross-file test is the only thing that does. A batch this relay sends
+// larger than the Worker accepts would 400 on every request.
+test("CHAIN_FIREHOSE_INGEST_BATCH_SIZE matches the Worker's CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE", () => {
+  assert.equal(
+    CHAIN_FIREHOSE_INGEST_BATCH_SIZE,
+    CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE,
+  );
+});
+
+// --- chunkRows ------------------------------------------------------------------
+
+test("chunkRows: splits into groups of at most `size`, preserving order", () => {
+  assert.deepEqual(chunkRows([1, 2, 3, 4, 5], 2), [[1, 2], [3, 4], [5]]);
+});
+
+test("chunkRows: a single chunk when items.length <= size", () => {
+  assert.deepEqual(chunkRows([1, 2], 5), [[1, 2]]);
+});
+
+test("chunkRows: an empty array yields no chunks", () => {
+  assert.deepEqual(chunkRows([], 5), []);
+});
 
 // --- mapBounded ---------------------------------------------------------------
 
@@ -382,56 +411,87 @@ test("forwardWithRetry: never sleeps after the final attempt (no wasted delay be
 
 // --- forwardBatch --------------------------------------------------------------
 
-test("forwardBatch: forwards every row concurrently, JSON-stringifying the already-parsed payload", async () => {
-  const seen = new Set();
-  const rows = [
-    { id: 1, payload: { table: "blocks", block_number: 1 } },
-    { id: 2, payload: { table: "blocks", block_number: 2 } },
-  ];
+test("forwardBatch: groups rows into CHAIN_FIREHOSE_INGEST_BATCH_SIZE-sized chunks, one POST body (JSON array) per chunk", async () => {
+  const seenBodies = [];
+  // One row over a full chunk, so this exercises exactly 2 chunks: one full
+  // (CHAIN_FIREHOSE_INGEST_BATCH_SIZE rows) and one with the remainder (1 row).
+  const rows = Array.from(
+    { length: CHAIN_FIREHOSE_INGEST_BATCH_SIZE + 1 },
+    (_, i) => ({ id: i, payload: { table: "blocks", block_number: i } }),
+  );
   const result = await forwardBatch(
     rows,
     { ingestUrl: "u", syncSecret: "s" },
     {
       fetchImpl: async (_url, init) => {
-        seen.add(init.body);
+        seenBodies.push(JSON.parse(init.body));
         return new Response("{}", { status: 202 });
       },
       sleepImpl: async () => {},
     },
   );
-  assert.equal(result.forwarded, 2);
+  assert.equal(result.forwarded, rows.length);
   assert.equal(result.dropped, 0);
-  // Concurrent dispatch (CHAIN_FIREHOSE_FORWARD_CONCURRENCY), not strictly
-  // sequential -- assert both were sent, not the order they arrived in.
-  assert.deepEqual(
-    [...seen].sort(),
-    [
-      '{"table":"blocks","block_number":1}',
-      '{"table":"blocks","block_number":2}',
-    ].sort(),
+  assert.equal(seenBodies.length, 2);
+  const sizes = seenBodies.map((body) => body.length).sort((a, b) => a - b);
+  assert.deepEqual(sizes, [1, CHAIN_FIREHOSE_INGEST_BATCH_SIZE]);
+  // Every chunk body is a JSON array of the ALREADY-PARSED payload objects
+  // (not the row wrapper), same shape validateChainFirehoseIngestPayload's
+  // batch branch expects.
+  const fullChunk = seenBodies.find(
+    (body) => body.length === CHAIN_FIREHOSE_INGEST_BATCH_SIZE,
   );
+  assert.equal(fullChunk[0].table, "blocks");
+  assert.equal(typeof fullChunk[0].block_number, "number");
 });
 
-test("forwardBatch: counts a row dropped after exhausting retries separately from forwarded rows", async () => {
+test("forwardBatch: a chunk dropped after exhausting retries drops EVERY row in that chunk together", async () => {
+  // Two single-row chunks (batch size 1) is the smallest case that isolates
+  // "one chunk fails, the other succeeds" without depending on
+  // CHAIN_FIREHOSE_INGEST_BATCH_SIZE's real value.
   const rows = [
     { id: 1, payload: { table: "blocks", block_number: 1 } }, // always fails
     { id: 2, payload: { table: "blocks", block_number: 2 } }, // always succeeds
   ];
+  const dropped = [];
   const result = await forwardBatch(
     rows,
     { ingestUrl: "u", syncSecret: "s" },
     {
-      // Keyed by payload body, not a shared call counter -- rows forward
+      chunkSize: 1,
+      // Keyed by payload body, not a shared call counter -- chunks forward
       // concurrently, so interleaving between the two isn't deterministic.
       fetchImpl: async (_url, init) =>
         new Response("{}", {
           status: init.body.includes('"block_number":1') ? 500 : 202,
         }),
       sleepImpl: async () => {},
+      onDrop: (payload) => dropped.push(payload.block_number),
     },
   );
   assert.equal(result.forwarded, 1);
   assert.equal(result.dropped, 1);
+  assert.deepEqual(dropped, [1]);
+});
+
+test("forwardBatch: a dropped multi-row chunk fires onDrop once per row in that chunk, not once per chunk", async () => {
+  const rows = [
+    { id: 1, payload: { table: "blocks", block_number: 1 } },
+    { id: 2, payload: { table: "blocks", block_number: 2 } },
+  ];
+  const dropped = [];
+  const result = await forwardBatch(
+    rows,
+    { ingestUrl: "u", syncSecret: "s" },
+    {
+      fetchImpl: async () => new Response("{}", { status: 500 }),
+      sleepImpl: async () => {},
+      onDrop: (payload) => dropped.push(payload.block_number),
+    },
+  );
+  assert.equal(result.forwarded, 0);
+  assert.equal(result.dropped, 2);
+  assert.deepEqual(dropped.sort(), [1, 2]);
 });
 
 test("forwardBatch: an empty batch forwards nothing and drops nothing", async () => {
@@ -640,7 +700,7 @@ test("forwardWithRetry: a 429 followed by a thrown network error does not leak t
 
 // --- forwardBatch: rate-limit aggregation ------------------------------------
 
-test("forwardBatch: surfaces rateLimitedForMs as the MAX pause seen across the batch's rows", async () => {
+test("forwardBatch: surfaces rateLimitedForMs as the MAX pause seen across the batch's chunks", async () => {
   const rows = [
     { id: 1, payload: { table: "blocks", block_number: 1 } },
     { id: 2, payload: { table: "blocks", block_number: 2 } },
@@ -649,6 +709,7 @@ test("forwardBatch: surfaces rateLimitedForMs as the MAX pause seen across the b
     rows,
     { ingestUrl: "u", syncSecret: "s" },
     {
+      chunkSize: 1, // isolate 2 separate chunks/requests, one per row
       fetchImpl: async (_url, init) =>
         new Response("{}", {
           status: 429,

--- a/workers/chain-firehose-hub.mjs
+++ b/workers/chain-firehose-hub.mjs
@@ -68,6 +68,20 @@ export const CHAIN_FIREHOSE_TABLES = new Set([
 // payload is already far smaller than this -- see the trigger's comment).
 export const CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES = 16_000;
 
+// #6672: the ingest rate limit (workers/api.mjs's CHAIN_FIREHOSE_INGEST_RATE_LIMIT)
+// costs by REQUEST, not payload size -- one POST always consumes exactly one
+// unit of the Workers Rate Limiting binding, regardless of body size. Batching
+// N rows into a single request's array body therefore multiplies effective
+// throughput by N WITHOUT touching that rate limit or chain-firehose-relay's
+// own conservative client-side pacing at all -- the actual lever #6451's two
+// incident rounds established as dangerous to touch carelessly. 10 comfortably
+// closes the ~3.5-4x production/ingest gap #6672 measured (~3,600-3,700
+// rows/min production vs. ~960-1,200 rows/min single-payload-per-request
+// capacity) with headroom for growth, without over-sizing a single request/
+// response cycle. The raw-body byte cap below is sized to this batch size
+// times the existing single-payload cap -- see that constant's own comment.
+export const CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE = 10;
+
 // Found by adversarial review: bounds how long broadcast() will WAIT on the
 // #4984 AlerterHub singleton's own /evaluate call (see below), independent
 // of whatever AlerterHub's own internal timeouts add up to (a worst-case
@@ -185,30 +199,17 @@ export function chainFirehoseMatchesTopics(payload, topics) {
   return topics.has(payload?.table);
 }
 
-// Validates a raw ingest body against the shape notify_chain_firehose()
-// actually emits. Deliberately loose on which optional fields are present
-// (the three tables carry different columns) but strict on: valid JSON, a
-// known `table`, a well-formed `block_number`, and every field being a
-// bounded scalar (never nested JSON) -- an oversized or malformed payload is
-// rejected here as a clean 400 rather than reaching SSE/WS fanout.
-export function validateChainFirehoseIngestPayload(raw) {
-  if (typeof raw !== "string" || raw.length === 0) {
-    return { ok: false, error: "request body must be a non-empty JSON string" };
-  }
-  if (utf8ByteLength(raw) > CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES) {
-    return {
-      ok: false,
-      error: `request body exceeds ${CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES} bytes`,
-    };
-  }
-  let parsed;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return { ok: false, error: "request body is not valid JSON" };
-  }
+// Validates ONE already-parsed payload object against the shape
+// notify_chain_firehose() actually emits. Deliberately loose on which
+// optional fields are present (the three tables carry different columns) but
+// strict on: a known `table`, a well-formed `block_number`, and every field
+// being a bounded scalar (never nested JSON) -- an oversized or malformed
+// payload is rejected as a clean 400 rather than reaching SSE/WS fanout.
+// Factored out of validateChainFirehoseIngestPayload (#6672) so a batch-array
+// body can run every element through the exact same rules as a lone object.
+function validateSingleChainFirehoseIngestPayload(parsed) {
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return { ok: false, error: "request body must be a JSON object" };
+    return { ok: false, error: "each payload must be a JSON object" };
   }
   if (!CHAIN_FIREHOSE_TABLES.has(parsed.table)) {
     return {
@@ -240,6 +241,58 @@ export function validateChainFirehoseIngestPayload(raw) {
     return { ok: false, error: `${key} has an unsupported value type` };
   }
   return { ok: true, payload: parsed };
+}
+
+// Validates a raw ingest body: either ONE JSON object (the original shape --
+// see validateSingleChainFirehoseIngestPayload above) or a JSON array of up
+// to CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE such objects (#6672's batching --
+// see that constant's own comment for why this closes the ingest capacity
+// gap without touching the rate limit). Returns `payload` as a single object
+// for the former (unchanged shape/behavior for every existing single-object
+// caller) or an array for the latter -- handleIngest below dispatches on
+// Array.isArray(payload) to broadcast one or many.
+export function validateChainFirehoseIngestPayload(raw) {
+  if (typeof raw !== "string" || raw.length === 0) {
+    return { ok: false, error: "request body must be a non-empty JSON string" };
+  }
+  // Sized for the batch case (a lone object can't realistically approach
+  // this on its own -- its own per-field caps already bound it far below a
+  // single CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES share of this).
+  const maxBodyBytes =
+    CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES * CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE;
+  if (utf8ByteLength(raw) > maxBodyBytes) {
+    return {
+      ok: false,
+      error: `request body exceeds ${maxBodyBytes} bytes`,
+    };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, error: "request body is not valid JSON" };
+  }
+  if (Array.isArray(parsed)) {
+    if (parsed.length === 0) {
+      return { ok: false, error: "batch array must not be empty" };
+    }
+    if (parsed.length > CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE) {
+      return {
+        ok: false,
+        error: `batch array exceeds ${CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE} payloads`,
+      };
+    }
+    const payloads = [];
+    for (const [index, item] of parsed.entries()) {
+      const result = validateSingleChainFirehoseIngestPayload(item);
+      if (!result.ok) {
+        return { ok: false, error: `batch[${index}]: ${result.error}` };
+      }
+      payloads.push(result.payload);
+    }
+    return { ok: true, payload: payloads };
+  }
+  return validateSingleChainFirehoseIngestPayload(parsed);
 }
 
 export function formatChainFirehoseSseFrame(payload) {
@@ -620,7 +673,19 @@ export class ChainFirehoseHub {
         headers: { "content-type": "application/json" },
       });
     }
-    await this.broadcast(result.payload);
+    // #6672: a batch-array payload broadcasts each element in turn, not
+    // concurrently -- broadcast() iterates shared mutable state (sseClients,
+    // mcpSubscribedSessions) and awaits an external AlerterHub call; there's
+    // no established concurrent-broadcast precedent in this class, and a
+    // batch is small (CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE) so the added
+    // latency is bounded. A single-object payload's behavior is unchanged.
+    if (Array.isArray(result.payload)) {
+      for (const payload of result.payload) {
+        await this.broadcast(payload);
+      }
+    } else {
+      await this.broadcast(result.payload);
+    }
     return new Response(JSON.stringify({ ok: true }), {
       status: 202,
       headers: { "content-type": "application/json" },


### PR DESCRIPTION
## Summary

#6672: `chain_firehose_outbox` had a standing ~220k-row backlog (oldest pending row over an hour
stale). Root cause is a capacity mismatch, not a bug: total production into the outbox runs
~3,600-3,700 rows/min at current chain activity, but `chain-firehose-relay` forwards one outbox
row per HTTP POST, self-paced to `CHAIN_FIREHOSE_SAFE_FORWARD_RATE_PER_60S = 960` (80% of the
Worker's `CHAIN_FIREHOSE_INGEST_RATE_LIMIT = {limit: 1200, windowSeconds: 60}`) — a ~3.5-4x
shortfall. This is the same class of issue #6451's two incident rounds already fixed once (raising
the cap 120→1200/min helped but still sits well below sustained production).

**I did not raise the rate limit again.** #6451's own history shows that's dangerous in isolation
— it was reopened once already after exactly that kind of raise, because the relay's burst shape
re-exceeded the new ceiling within hours.

## Fix: batch requests, not raise the limit

The Cloudflare Workers Rate Limiting binding (`CHAIN_FIREHOSE_INGEST_RATE_LIMITER`) costs by
**request**, not payload size — confirmed via `CHAIN_FIREHOSE_MAX_INGEST_BODY_BYTES` being sized
for exactly one NOTIFY-sized payload. Grouping multiple outbox rows into one POST body (a JSON
array) lets the *same* conservative per-request rate/pacing carry N× the data, closing the gap
**without touching the rate limit or its 80% safety margin at all**.

- `scripts/chain-firehose-relay.mjs`: new `chunkRows()` groups claimed rows into
  `CHAIN_FIREHOSE_INGEST_BATCH_SIZE` (10)-sized chunks; `forwardBatch()` sends each chunk as one
  POST (array body) instead of one POST per row. A chunk succeeds or fails as one unit — if
  dropped after exhausting retries, every row in that chunk drops together (this relay is
  already best-effort, not at-least-once, so this only changes failure *granularity*, not the
  delivery guarantee). `onDrop` still fires once per dropped row, not once per chunk, so existing
  drop-counting/Sentry-aggregation semantics are unchanged.
- `workers/chain-firehose-hub.mjs`: `validateChainFirehoseIngestPayload` now accepts either one
  JSON object (unchanged shape/behavior for every existing single-object caller) or a JSON array
  of up to `CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE` payloads, each validated with the same rules
  (factored into `validateSingleChainFirehoseIngestPayload`). `handleIngest` broadcasts a batch's
  elements in order, sequentially (not concurrently — `broadcast()` iterates shared mutable state
  and awaits an external AlerterHub call; there's no established concurrent-broadcast precedent in
  this class, and a batch of 10 keeps the added latency bounded).
- Cross-file consistency: `CHAIN_FIREHOSE_INGEST_BATCH_SIZE` (relay) and
  `CHAIN_FIREHOSE_MAX_INGEST_BATCH_SIZE` (Worker) must match — the relay deploys standalone and
  can't import `workers/` at runtime, so a new test in `tests/chain-firehose-relay.test.mjs`
  asserts the two stay in sync (importing both modules, test-only).
- **Deploy-order safe**: single-object requests are unchanged, so this doesn't require the relay
  and Worker to deploy atomically — the Worker accepting batches is purely additive.
- `docs/realtime-firehose.md` updated to describe the batched wire format and correct its own
  earlier prediction (a statement-level trigger) with what was actually done.

## Test plan

- New/updated tests: batch acceptance/validation (empty, oversized, per-element errors with
  index), `handleIngest` broadcasting a batch in order, `chunkRows`, `forwardBatch` grouping into
  chunks and sending one array-body POST per chunk, a dropped chunk dropping every row in it
  together, `onDrop` firing per-row not per-chunk, rate-limit aggregation across chunks, and the
  cross-file constant-sync assertion.
- `npx vitest run tests/chain-firehose-relay.test.mjs tests/chain-firehose-hub.test.mjs
  tests/chain-firehose-routes.test.mjs` — 204/204 passing.
- `npm run lint && npm run format:check` — clean.
- `npm run validate` — clean.
- `npm run build` — clean (full production build pipeline, all 6 steps pass).
- `npx wrangler deploy --dry-run` — clean (real bundling, every binding/Durable Object resolves).
- Coverage (scoped to the two changed source files, v8 report): 99.51%/99.16%/97.01%/99.74%
  stmts/branch/funcs/lines; the two remaining gaps are pre-existing lines untouched by this diff
  (verified by diffing against origin/main).

## Rollout note (not part of this PR)

Once merged, `chain-firehose-relay`'s container on the indexer box needs a restart to pick up the
new image (it clones `main` fresh at container start) — I'll do that once this is green, watching
the outbox backlog to confirm it actually drains.

Closes #6672
