### PR TITLE
fix(ui): use AccountAddress's compact prop instead of manual copyButtonClassName

### DIFF
--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -395,7 +395,7 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
                       {eventKindLabel(ev.event_kind)}
                     </td>
                     <td className="px-4 py-2.5 font-mono text-[11px] text-ink-muted">
-                      <AccountAddress ss58={ev.hotkey} copyButtonClassName="-my-3.5" fallback="—" />
+                      <AccountAddress ss58={ev.hotkey} compact fallback="—" />
                     </td>
                     <td className="px-4 py-2.5 text-right font-mono text-[11px] tabular-nums text-ink">
                       {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}


### PR DESCRIPTION
## Summary

`extrinsics.$hash.tsx:398` was the one remaining call site still using `copyButtonClassName="-my-3.5"` — the manual workaround that predates `AccountAddress`'s `compact` prop, which both `AccountAddress`'s and `CopyButton`'s own doc comments explicitly describe as the replacement for exactly this. Every other dense-table `AccountAddress` call site already uses `compact` (`blocks.$ref.tsx`, `blocks.index.tsx`, `extrinsics.index.tsx`). Same class of miss PR #6311 fixed elsewhere.

## What changed

- `apps/ui/src/routes/extrinsics.$hash.tsx`: `<AccountAddress ss58={ev.hotkey} copyButtonClassName="-my-3.5" fallback="—" />` → `<AccountAddress ss58={ev.hotkey} compact fallback="—" />`.

`compact` applies the identical `-my-3.5` negative-margin trick internally, so this is a code-consistency fix with no rendered-output difference — confirmed below.

## Screenshots

Captured before/after on the same running dev server (toggled via `git stash`, so the only variable is the one-line prop swap) at desktop/light. The two captures are pixel-identical except for the elapsed "time ago" text (real time passing between shots, not a rendering difference) — proving the swap is visually invisible. Skipping the other 5 viewport/theme combos: this is a single inline prop change with no CSS/layout branch depending on viewport or theme, so the identical-output proof at one combo generalizes to the rest.

| Before | After |
| --- | --- |
| [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/extrinsics-compact-6337/desktop-light-before.png" width="420">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/extrinsics-compact-6337/desktop-light-before.png) | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/extrinsics-compact-6337/desktop-light-after.png" width="420">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/extrinsics-compact-6337/desktop-light-after.png) |

Closes #6337

## Validation

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm test --workspace=apps/ui` (1168/1168 passed)
- [x] `npm run test:e2e --workspace=apps/ui` (28/28 passed; `/extrinsics/$hash` isn't one of the recorded-HAR checked routes)
- [x] Visual equivalence confirmed via live dev-server before/after capture (see above)