### PR TITLE
fix(ui): add Emissions CSV export to the leaderboards action bar

### DIFF
--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -86,6 +86,7 @@ function LeaderboardsPage() {
               label="Deregistrations CSV"
               bare
             />
+            <DownloadCsvButton url={buildUrl("/api/v1/economics")} label="Emissions CSV" bare />
             <ShareButton bare />
           </ActionBar>
         }


### PR DESCRIPTION
## What

The `/leaderboards` page's `ActionBar` offered CSV export for two of its three boards — **Weight-setting** (`/api/v1/chain/weights`) and **Deregistrations** (`/api/v1/chain/deregistrations`) — but not the **Emissions** board, even though `EmissionsLeaderboard` mirrors the same summary-tiles + table + mobile-card structure and its data source serves CSV. This adds the missing third export so all three boards offer the same affordance. Closes #6577.

## Change

A single `DownloadCsvButton` added to the `ActionBar`, between the Deregistrations button and `ShareButton`, using the same `bare`-prop convention as its siblings:

```tsx
<DownloadCsvButton url={buildUrl("/api/v1/economics")} label="Emissions CSV" bare />
```

- **Endpoint**: `EmissionsLeaderboard` sources from `economicsQuery()` → `GET /api/v1/economics` (a current-block snapshot, no `window` param — unlike the two `chain/*` boards, which is why this button carries no window). I confirmed the endpoint serves CSV: `GET /api/v1/economics?format=csv` → `200 text/csv` with the expected `netuid,name,emission_share,…` header row.
- No changes to `WeightSettingLeaderboard` or `DeregistrationsLeaderboard` or their existing buttons.
- `ApiSourceFooter` already lists `/api/v1/economics`, so the source disclosure was already consistent.

## Screenshots

New at-rest element on `/leaderboards`; the only difference is the added **Emissions CSV** button in the action bar (Weight-setting CSV · Deregistrations CSV · **Emissions CSV** · Share view).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | ![before mobile light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6577-emissions-csv/before-mobile-light.png) | ![after mobile light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6577-emissions-csv/after-mobile-light.png) |
| Mobile · Dark | ![before mobile dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6577-emissions-csv/before-mobile-dark.png) | ![after mobile dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6577-emissions-csv/after-mobile-dark.png) |
| Tablet · Light | ![before tablet light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6577-emissions-csv/before-tablet-light.png) | ![after tablet light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6577-emissions-csv/after-tablet-light.png) |
| Tablet · Dark | ![before tablet dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6577-emissions-csv/before-tablet-dark.png) | ![after tablet dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6577-emissions-csv/after-tablet-dark.png) |
| Desktop · Light | ![before desktop light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6577-emissions-csv/before-desktop-light.png) | ![after desktop light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6577-emissions-csv/after-desktop-light.png) |
| Desktop · Dark | ![before desktop dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6577-emissions-csv/before-desktop-dark.png) | ![after desktop dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6577-emissions-csv/after-desktop-dark.png) |

## Testing

- `tsc --noEmit` — clean
- `eslint` (changed file) — clean (only pre-existing `react-refresh` warnings, unrelated)
- `prettier --check` — clean
- Verified `/api/v1/economics?format=csv` returns `200 text/csv`
