### PR TITLE
fix(ui): give the Validators table coldkey the shared AccountAddress hover-card (#6338)

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-card-list.tsx
+++ b/apps/ui/src/components/metagraphed/validator-card-list.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { CopyButton } from "@jsonbored/ui-kit";
 
 import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
+import { AccountAddress } from "@/components/metagraphed/account-address";
 import { resolveValidatorCard } from "@/lib/metagraphed/validator-card-fields";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
 
@@ -45,21 +46,8 @@ export function ValidatorCardList({ validators, className }: ValidatorCardListPr
                 back into the row so it does not add vertical spacing. */}
             <div className="flex min-w-0 items-center gap-1.5 font-mono text-[11px] text-ink-muted">
               <span className="uppercase tracking-widest text-[10px]">coldkey</span>
-              {v.coldkey ? (
-                <>
-                  <Link
-                    to="/accounts/$ss58"
-                    params={{ ss58: v.coldkey }}
-                    title={v.coldkey}
-                    className="truncate hover:text-accent hover:underline"
-                  >
-                    {f.coldkeyShort}
-                  </Link>
-                  <CopyButton value={v.coldkey} label="coldkey" compact />
-                </>
-              ) : (
-                "—"
-              )}
+              {/* Same AccountAddress hover-card treatment as the desktop column (#6338). */}
+              <AccountAddress ss58={v.coldkey} compact fallback="—" />
             </div>
             <dl className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-[11px]">
               <Stat label="Active subnets" value={f.subnetsLabel} />

--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -4,6 +4,7 @@ import { CopyButton } from "@jsonbored/ui-kit";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { formatNumber } from "@/lib/metagraphed/format";
 import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-format";
+import { AccountAddress } from "@/components/metagraphed/account-address";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
 import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
@@ -68,22 +69,10 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     header: "Coldkey",
     thClassName: TH_BASE,
     tdClassName: `${TD_BASE} text-ink-muted`,
-    cell: (v) =>
-      v.coldkey ? (
-        <div className="flex items-center gap-1.5">
-          <Link
-            to="/accounts/$ss58"
-            params={{ ss58: v.coldkey }}
-            className="hover:text-accent hover:underline"
-            title={v.coldkey}
-          >
-            {shortHash(v.coldkey) ?? v.coldkey}
-          </Link>
-          <CopyButton value={v.coldkey} label="coldkey" compact />
-        </div>
-      ) : (
-        "—"
-      ),
+    // Route the coldkey through AccountAddress so it gets the same
+    // EntityHoverCard account-preview every other /accounts/$ss58 link has
+    // (block author, signer, …) instead of a hand-rolled bare link (#6338).
+    cell: (v) => <AccountAddress ss58={v.coldkey} compact fallback="—" />,
   },
   {
     ...numeric("Take"),


### PR DESCRIPTION
## Summary

The Validators table's Coldkey column (desktop `validator-columns.tsx` and the mobile `validator-card-list.tsx`) hand-rolled a `<Link>` + `shortHash` + `<CopyButton>`, instead of the shared `AccountAddress` component. Every other cell that links an ss58 to `/accounts/$ss58` (block author, signer, …) goes through `AccountAddress`, which wraps the link in `EntityHoverCard kind="account"` for a hover preview — so the coldkey was the only such link missing it.

This routes both the desktop column and the mobile card row through `AccountAddress` (a drop-in, per the issue), giving the coldkey the same account hover-card as every other account link and removing the duplicated markup.

## Changes

- `apps/ui/src/components/metagraphed/validator-columns.tsx` — Coldkey cell → `<AccountAddress ss58={v.coldkey} compact fallback="—" />`
- `apps/ui/src/components/metagraphed/validator-card-list.tsx` — mobile coldkey row → the same (net -23 lines)

## Validation

- `eslint` — 0 errors
- `tsc --noEmit` — 0 errors

## Screenshots

Desktop/tablet: hovering a coldkey now shows the account preview card (before: a bare link, hover shows nothing). Mobile has no pointer hover, so the card list renders the same link+copy either way.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6338-coldkey-hovercard/6338-coldkey-hovercard-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6338
