### PR TITLE
fix(ui): collapse the /endpoints filter toolbar behind a mobile disclosure (#6580)

### DIFF
--- a/apps/ui/src/routes/endpoints.tsx
+++ b/apps/ui/src/routes/endpoints.tsx
@@ -4,7 +4,7 @@ import { Suspense, useEffect, useMemo, useState } from "react";
 
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
-import { Search, X } from "lucide-react";
+import { Search, SlidersHorizontal, X } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton, StaleBanner } from "@/components/metagraphed/states";
@@ -63,6 +63,7 @@ import {
 
 import type { Endpoint, RpcPool, RpcEndpoint, Provider, Subnet } from "@/lib/metagraphed/types";
 import { endpointsFiltersActive } from "@/lib/metagraphed/endpoints-filters";
+import { activeFilterCount, filterToggleLabel } from "@/lib/metagraphed/filter-disclosure";
 
 const endpointsSearchSchema = z.object({
   q: fallback(z.string(), "").default(""),
@@ -775,6 +776,20 @@ function EndpointsTable() {
     page: search.page,
   });
 
+  // Same mobile-disclosure treatment as /blocks and /extrinsics (#5323): this
+  // toolbar has even more controls, so an always-visible filter bar pushed the
+  // first endpoint row down on a 375px viewport (#6580). Count only the six
+  // collapsible text/select filters for the toggle badge.
+  const activeCount = activeFilterCount([
+    search.q,
+    search.netuid,
+    search.provider,
+    search.region,
+    search.health,
+    search.eligibility,
+  ]);
+  const [filtersOpen, setFiltersOpen] = useState(activeCount > 0);
+
   // The table filters client-side over the full fetched list; the CSV export
   // hits the backend route directly (full endpoint snapshot, no client filters).
   const endpointsCsvUrl = buildUrl("/api/v1/endpoints");
@@ -832,51 +847,71 @@ function EndpointsTable() {
         data-scrolled={scrolled ? "true" : "false"}
         className="mg-sticky-toolbar sticky top-14 z-20 -mx-1 px-1 py-2 backdrop-blur bg-paper/90 border-b border-border/60 flex flex-wrap items-center gap-2"
       >
-        <div className="relative flex-1 min-w-[180px] max-w-sm">
-          <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-ink-muted" />
-          <input
-            value={search.q}
-            onChange={(e) => setSearch({ q: e.target.value })}
-            placeholder="Search URL, provider, netuid…"
-            className="w-full rounded border border-border bg-card pl-7 pr-2 py-1.5 text-[12px] focus:outline-none focus:border-ink/30"
-            aria-label="Search endpoints"
+        <button
+          type="button"
+          onClick={() => setFiltersOpen((open) => !open)}
+          aria-expanded={filtersOpen}
+          aria-controls="endpoints-filter-fields"
+          className="md:hidden inline-flex min-h-11 items-center gap-1.5 rounded border border-border bg-card px-2.5 font-mono text-[11px] text-ink-muted hover:border-ink/30 hover:text-ink-strong transition-colors"
+        >
+          <SlidersHorizontal className="size-3" aria-hidden="true" />
+          {filterToggleLabel(activeCount)}
+        </button>
+        {/* `md:contents` dissolves this wrapper at md and up, so the fields lay
+            out as direct children of the toolbar exactly as they did before. */}
+        <div
+          id="endpoints-filter-fields"
+          className={classNames(
+            "w-full flex-wrap items-center gap-2 md:contents",
+            filtersOpen ? "flex" : "hidden",
+          )}
+        >
+          <div className="relative flex-1 min-w-[180px] max-w-sm">
+            <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-ink-muted" />
+            <input
+              value={search.q}
+              onChange={(e) => setSearch({ q: e.target.value })}
+              placeholder="Search URL, provider, netuid…"
+              className="w-full rounded border border-border bg-card pl-7 pr-2 py-1.5 text-[12px] focus:outline-none focus:border-ink/30"
+              aria-label="Search endpoints"
+            />
+          </div>
+          <label className="inline-flex items-center gap-1 text-[11px] text-ink-muted">
+            <span className="font-mono uppercase tracking-widest text-[10px]">Netuid</span>
+            <input
+              value={search.netuid}
+              onChange={(e) => setSearch({ netuid: e.target.value.replace(/[^0-9]/g, "") })}
+              inputMode="numeric"
+              placeholder="any"
+              className="w-16 rounded border border-border bg-card px-1.5 py-1 text-[11px] focus:outline-none focus:border-ink/30"
+              aria-label="Filter by netuid"
+            />
+          </label>
+          <FilterSelect
+            label="Provider"
+            value={search.provider}
+            onChange={(v) => setSearch({ provider: v })}
+            options={providers}
+          />
+          <FilterSelect
+            label="Region"
+            value={search.region}
+            onChange={(v) => setSearch({ region: v })}
+            options={regions}
+          />
+          <FilterSelect
+            label="Health"
+            value={search.health}
+            onChange={(v) => setSearch({ health: v })}
+            options={["ok", "warn", "down", "unknown"]}
+          />
+          <FilterSelect
+            label="Eligibility"
+            value={search.eligibility}
+            onChange={(v) => setSearch({ eligibility: v })}
+            options={["proxy-enabled", "pool-member", "archive-capable", "unassigned"]}
           />
         </div>
-        <label className="inline-flex items-center gap-1 text-[11px] text-ink-muted">
-          <span className="font-mono uppercase tracking-widest text-[10px]">Netuid</span>
-          <input
-            value={search.netuid}
-            onChange={(e) => setSearch({ netuid: e.target.value.replace(/[^0-9]/g, "") })}
-            inputMode="numeric"
-            placeholder="any"
-            className="w-16 rounded border border-border bg-card px-1.5 py-1 text-[11px] focus:outline-none focus:border-ink/30"
-            aria-label="Filter by netuid"
-          />
-        </label>
-        <FilterSelect
-          label="Provider"
-          value={search.provider}
-          onChange={(v) => setSearch({ provider: v })}
-          options={providers}
-        />
-        <FilterSelect
-          label="Region"
-          value={search.region}
-          onChange={(v) => setSearch({ region: v })}
-          options={regions}
-        />
-        <FilterSelect
-          label="Health"
-          value={search.health}
-          onChange={(v) => setSearch({ health: v })}
-          options={["ok", "warn", "down", "unknown"]}
-        />
-        <FilterSelect
-          label="Eligibility"
-          value={search.eligibility}
-          onChange={(v) => setSearch({ eligibility: v })}
-          options={["proxy-enabled", "pool-member", "archive-capable", "unassigned"]}
-        />
         <button
           type="button"
           onClick={resetAll}


### PR DESCRIPTION
Closes #6580

## Summary

`/endpoints`' filter toolbar rendered all its controls in one always-visible `flex-wrap` row — more controls than either `/blocks` or `/extrinsics`, both of which already gate their filter fields behind a `filtersOpen` + `SlidersHorizontal` toggle (#5323) precisely because an always-visible bar "still pushed the first row down on a 375px viewport." `/endpoints` never got that fix.

## What Changed

- Apply the sibling pattern to `endpoints.tsx`: the six text/select filters (search, netuid, provider, region, health, eligibility) collapse behind a `md:hidden` toggle carrying `filterToggleLabel(activeCount)` from the shared `filter-disclosure.ts`. `md:contents` dissolves the wrapper at `md`+, so the desktop/tablet layout is byte-for-byte unchanged.
- The reset / CSV / callable-only / view-mode controls keep their existing visibility (scoped to match the sibling pattern, per the issue).

Mobile-only change — desktop and tablet are intentionally identical before/after (the toggle is `md:hidden`).

## Screenshots — /endpoints (Endpoints tab) filter toolbar

| Viewport · Theme | Before | After |
| --- | --- | --- |
| **Mobile · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-after-mobile-light.png)<br><sub>after</sub> |
| **Mobile · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-after-mobile-dark.png)<br><sub>after</sub> |
| **Tablet · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-after-tablet-light.png)<br><sub>after</sub> |
| **Tablet · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-after-tablet-dark.png)<br><sub>after</sub> |
| **Desktop · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-after-desktop-light.png)<br><sub>after</sub> |
| **Desktop · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6580/6580-disclosure-after-desktop-dark.png)<br><sub>after</sub> |


## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6580`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none — UI-only)*

## Validation

- [x] `npx prettier --check` / `npx eslint` — clean (apps/ui config)
- [x] `npm run typecheck` — no new errors in endpoints.tsx
- [x] `git diff --check` clean
- [x] 12-image before/after matrix (3 viewports x 2 themes); disclosure toggle asserted present (after) / absent (before) per shot
