### PR TITLE
fix(realtime): restore #6684's METAGRAPHED-1 fix, reverted by #6700's stale-branch merge

### DIFF
--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -441,7 +441,7 @@ api-reference/**` wasn't regenerated — run `node scripts/generate-openapi-docs
   route with no static file — a `route(...)` entry (API surface metadata) AND a distinct
   `artifact(id, path, description, schemaName)` entry (the schema-ref mapping); omitting the
   `artifact()` call makes `npm run build` throw `No public artifact contract maps API artifact
-  <path>` from `schemaRefForArtifactPath`, since `route()`'s own `artifactPath` argument is just a
+<path>` from `schemaRefForArtifactPath`, since `route()`'s own `artifactPath` argument is just a
   label, not a registration. And the local pre-push guard's `validate:docs` check requires a
   matching prose entry in `docs/backend-artifact-contracts.md` (mirror an existing bullet like the
   `subnet-burn` one) for every artifact path — easy to miss since nothing else in the schema/route

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1190,10 +1190,28 @@ async function handleChainFirehoseIngest(request, env) {
   const stub = env.CHAIN_FIREHOSE_HUB.get(
     env.CHAIN_FIREHOSE_HUB.idFromName("global"),
   );
-  const upstream = await stub.fetch(
-    "https://chain-firehose-hub.internal/ingest",
-    { method: "POST", body, headers: { "content-type": "application/json" } },
-  );
+  let upstream;
+  try {
+    upstream = await stub.fetch("https://chain-firehose-hub.internal/ingest", {
+      method: "POST",
+      body,
+      headers: { "content-type": "application/json" },
+    });
+  } catch {
+    // Sentry METAGRAPHED-1: a DO stub call throws "Durable Object reset
+    // because its code was updated" when a deploy touching ChainFirehoseHub
+    // (or a transitive dep) lands mid-request -- expected/occasional, not a
+    // real fault. Left uncaught this was an unhandled Worker exception; a
+    // clean, retryable 503 lets the relay's own retry/backoff (#6451) handle
+    // it the same way it already handles a rate-limited or unavailable hub.
+    return errorResponse(
+      "chain_firehose_ingest_unavailable",
+      "The realtime chain firehose was temporarily unavailable; retry.",
+      503,
+      {},
+      { "retry-after": "1" },
+    );
+  }
   return new Response(await upstream.text(), {
     status: upstream.status,
     headers: { "content-type": "application/json; charset=utf-8" },


### PR DESCRIPTION
## Summary

`main`'s post-merge CI went red after #6700 merged (#6700's branch predated #6684 and was never
rebased, so its merge diff silently removed #6684's try/catch fix). Restores it verbatim, plus
fixes a prettier violation the same merge introduced in a skill doc.

## Test plan

- `npx vitest run tests/chain-firehose-routes.test.mjs tests/chain-firehose-hub.test.mjs tests/chain-firehose-relay.test.mjs` — 205/205 passing (previously 1 failing on main).
- `npm run lint && npm run format:check` (whole repo) — clean (previously failing on main).
- `npm run validate` — clean.

Closes #6701