### PR TITLE
fix(ui): normalize accounts.$ss58.tsx card radii to rounded-2xl

### DIFF
--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -2381,7 +2381,7 @@ function DataPanel({ children, className }: { children: ReactNode; className?: s
   return (
     <div
       className={classNames(
-        "overflow-x-auto rounded-[1.5rem] border border-border/80 bg-card/95 mg-card-glow",
+        "overflow-x-auto rounded-2xl border border-border/80 bg-card/95 mg-card-glow",
         className,
       )}
     >
@@ -2400,7 +2400,7 @@ function AccountHeroAside({
   firstSeenAt: string | null;
 }) {
   return (
-    <div className="w-[20rem] rounded-[1.75rem] border border-border/80 bg-card/95 p-5 mg-card-glow">
+    <div className="w-[20rem] rounded-2xl border border-border/80 bg-card/95 p-5 mg-card-glow">
       <div className="flex items-center justify-between gap-3">
         <div>
           <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-ink-muted">


### PR DESCRIPTION
## Summary

- `accounts.$ss58.tsx` used three different arbitrary corner radii across its cards
  (`rounded-[1.5rem]` on `DataPanel`, `rounded-[1.75rem]` on `AccountHeroAside`)
  instead of the page's own dominant `rounded-2xl` convention (`KPI_TILE` and every
  other card on this page already use it).

## What Changed

- `DataPanel`: `rounded-[1.5rem]` → `rounded-2xl`
- `AccountHeroAside`: `rounded-[1.75rem]` → `rounded-2xl`
- Both resolve to the same `1rem` radius in this project (no `--radius-2xl`
  override is defined here, so Tailwind's stock `rounded-2xl` default already
  equals `1rem`) — a pure consistency fix, no visual size change.

## Screenshots

### Account signal card (`AccountHeroAside`)

| Viewport · Theme | Before                                                                                                                                    | After                                                                                                                                   |
| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-hero-after-mobile-dark.png)<br><sub>after</sub> |

### Signed extrinsics panel (`DataPanel`)

| Viewport · Theme | Before                                                                                                                                    | After                                                                                                                                   |
| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
| Desktop · Light  | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light   | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark    | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6399-panel-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- [x] `npm run lint --workspace=apps/ui`
- [x] `npm run format:check --workspace=apps/ui`
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `npm run test --workspace=apps/ui`
- [x] `npx playwright test tests/e2e/responsive-overflow.spec.ts`
- [x] `LOVABLE_SANDBOX=1 NITRO_PRESET=cloudflare-module npm run build --workspace=apps/ui`
- [x] `git diff --check`

Closes #6399
