### PR TITLE
fix(deploy): make chain-firehose-relay-entrypoint.sh idempotent against restart

### DIFF
--- a/scripts/chain-firehose-relay-entrypoint.sh
+++ b/scripts/chain-firehose-relay-entrypoint.sh
@@ -4,11 +4,21 @@
 # metagraph-fetch/data-refresh-node/economics-refresh entrypoints, this
 # process is a single always-on daemon, not a periodically re-invoked job,
 # so there's no persistent /repo volume or incremental-refresh branch here:
-# every container start (rare -- a crash-restart, or a deliberate `docker
-# compose up` after the Ansible role rebuilds the image) does one fresh,
-# shallow clone, then execs the relay to run forever. This also means
-# restarting the container (not just rebuilding the image) is enough to pick
-# up whatever is newest on main.
+# every container start does one fresh, shallow clone, then execs the relay
+# to run forever.
+#
+# A `docker run` (a genuinely new container + fresh writable layer) always
+# picks up whatever is newest on main this way. `docker restart` does NOT --
+# it reuses the SAME container and its writable layer, so $REPO_DIR from the
+# PRIOR run is still there; confirmed live (2026-07-17, 2026-07-18) that an
+# earlier version of this script, which cloned straight into $REPO_DIR with
+# no cleanup, hit `fatal: destination path '/tmp/repo' already exists and is
+# not an empty directory` on every restart and crash-looped forever instead
+# of ever reaching the relay process. The `rm -rf "$REPO_DIR"` below exists
+# specifically so a plain `docker restart` is safe too, not just `docker run`
+# -- deploying a merged fix should still prefer `docker stop && docker rm &&
+# docker run` (a cleaner, fully-fresh container), but a restart no longer
+# crash-loops if that's what actually gets reached for.
 set -euo pipefail
 
 GIT_REPO_URL="https://github.com/JSONbored/metagraphed.git"
@@ -22,13 +32,13 @@ GIT_REF="main"
 # runtime entrypoints, the Docker HEALTHCHECK directive (see the Dockerfile)
 # execs `node <path>/scripts/chain-firehose-relay.mjs --healthcheck`
 # directly, baked into the image at build time, so the clone location must
-# be a fixed, known path. Safe to hardcode here specifically because this
-# entrypoint never reuses an existing checkout across container restarts
-# (no persistent volume, see above) -- there is no "was this the leftover of
-# an interrupted clone" ambiguity the other entrypoints' mktemp-then-copy
-# pattern guards against, since the container filesystem itself is fresh
-# every single time this path is written to.
+# be a fixed, known path. The `rm -rf` immediately below (not the other
+# entrypoints' mktemp-then-copy pattern) is what keeps this safe to
+# hardcode: `git clone` itself refuses to write into a non-empty directory,
+# so the wipe has to happen before every clone, not just the first one on a
+# given container.
 REPO_DIR=/tmp/repo
+rm -rf "$REPO_DIR"
 echo "entrypoint: cloning ${GIT_REPO_URL}@${GIT_REF} into ${REPO_DIR}"
 git clone --depth 1 --branch "$GIT_REF" "$GIT_REPO_URL" "$REPO_DIR"
 cd "$REPO_DIR"


### PR DESCRIPTION
## Summary

`scripts/chain-firehose-relay-entrypoint.sh` cloned into a fixed path (`/tmp/repo`) with no
cleanup first. `docker restart` reuses the same container's writable layer, so a plain restart hit
`fatal: destination path '/tmp/repo' already exists and is not an empty directory` on the clone
and crash-looped (`Restarting (128)`) forever instead of ever reaching the relay process --
confirmed live twice (2026-07-17 per PR #6495, again 2026-07-18). The header comment's claim that
a restart alone picks up new code was wrong; only `docker run` (a genuinely fresh container)
actually did.

Checked the three sibling clone-at-runtime entrypoints (`data-refresh-node-entrypoint.sh`,
`economics-refresh-entrypoint.sh`, `metagraph-fetch-entrypoint.sh`) — all three already handle
this correctly via a persistent-volume + existence-check + mktemp-then-copy pattern. Only
`chain-firehose-relay-entrypoint.sh` has the bug (it's architecturally different by design, a
single always-on daemon with no persistent volume), so this is a single-file fix.

## Fix

`rm -rf "$REPO_DIR"` immediately before the `git clone`, plus corrects the header comment's
now-disproven claim. The documented deploy path (`docker stop && docker rm && docker run`) is
still the preferred way to deploy a fix — this just closes the footgun for anyone who reaches for
`docker restart` instead.

## Test plan

- `bash -n scripts/chain-firehose-relay-entrypoint.sh` — syntax OK.
- `shellcheck scripts/chain-firehose-relay-entrypoint.sh` — clean, exit 0.
- This script is intentionally excluded from CI (no shell linting configured, deploy-tier
  standalone script, same convention as its siblings) — verified manually since there's no
  automated gate to rely on.

Closes #6704