### PR TITLE
feat(api,graphql): total network value (root + alpha) rollup

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4757,7 +4757,13 @@ export interface components {
             summary: {
                 registration_open_count: number;
                 subnet_count: number;
+                /** @description Sum of every non-root subnet's alpha_market_cap_tao (alpha_price_tao times the total_stake_tao circulating-alpha proxy), lossless fixed 9-decimal rao-precision string (#6641). Excludes netuid 0 so root stake isn't double-counted as alpha value. */
+                total_alpha_value_tao: string;
                 total_miners: number;
+                /** @description total_root_value_tao plus total_alpha_value_tao, summed in exact rao-integer space (#6641) -- Backprop's "Total Network Value" (TNV): the network's single top-line economic figure. */
+                total_network_value_tao: string;
+                /** @description Root (netuid 0) TAO-denominated stake, lossless fixed 9-decimal rao-precision string (#6641). Root has no AMM/alpha token, so this is total_stake_tao read directly, not price-multiplied. */
+                total_root_value_tao: string;
                 /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding. */
                 total_stake_tao: string;
                 total_validators: number;
@@ -16775,7 +16781,10 @@ export interface operations {
                      *         "summary": {
                      *           "registration_open_count": 1,
                      *           "subnet_count": 1,
+                     *           "total_alpha_value_tao": "327838334.635978200",
                      *           "total_miners": 1,
+                     *           "total_network_value_tao": "327838334.635978200",
+                     *           "total_root_value_tao": "327838334.635978200",
                      *           "total_stake_tao": "327838334.635978200",
                      *           "total_validators": 1,
                      *           "with_economics_count": 1

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -8428,9 +8428,24 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "total_alpha_value_tao": {
+                    "description": "Sum of every non-root subnet's alpha_market_cap_tao (alpha_price_tao times the total_stake_tao circulating-alpha proxy), lossless fixed 9-decimal rao-precision string (#6641). Excludes netuid 0 so root stake isn't double-counted as alpha value.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
+                  },
                   "total_miners": {
                     "minimum": 0,
                     "type": "integer"
+                  },
+                  "total_network_value_tao": {
+                    "description": "total_root_value_tao plus total_alpha_value_tao, summed in exact rao-integer space (#6641) -- Backprop's \"Total Network Value\" (TNV): the network's single top-line economic figure.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
+                  },
+                  "total_root_value_tao": {
+                    "description": "Root (netuid 0) TAO-denominated stake, lossless fixed 9-decimal rao-precision string (#6641). Root has no AMM/alpha token, so this is total_stake_tao read directly, not price-multiplied.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
                   },
                   "total_stake_tao": {
                     "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding.",
@@ -8452,7 +8467,10 @@
                   "total_stake_tao",
                   "total_validators",
                   "total_miners",
-                  "registration_open_count"
+                  "registration_open_count",
+                  "total_root_value_tao",
+                  "total_alpha_value_tao",
+                  "total_network_value_tao"
                 ],
                 "type": "object"
               }
@@ -34101,7 +34119,10 @@
                     "summary": {
                       "registration_open_count": 1,
                       "subnet_count": 1,
+                      "total_alpha_value_tao": "327838334.635978200",
                       "total_miners": 1,
+                      "total_network_value_tao": "327838334.635978200",
+                      "total_root_value_tao": "327838334.635978200",
                       "total_stake_tao": "327838334.635978200",
                       "total_validators": 1,
                       "with_economics_count": 1

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4757,7 +4757,13 @@ export interface components {
             summary: {
                 registration_open_count: number;
                 subnet_count: number;
+                /** @description Sum of every non-root subnet's alpha_market_cap_tao (alpha_price_tao times the total_stake_tao circulating-alpha proxy), lossless fixed 9-decimal rao-precision string (#6641). Excludes netuid 0 so root stake isn't double-counted as alpha value. */
+                total_alpha_value_tao: string;
                 total_miners: number;
+                /** @description total_root_value_tao plus total_alpha_value_tao, summed in exact rao-integer space (#6641) -- Backprop's "Total Network Value" (TNV): the network's single top-line economic figure. */
+                total_network_value_tao: string;
+                /** @description Root (netuid 0) TAO-denominated stake, lossless fixed 9-decimal rao-precision string (#6641). Root has no AMM/alpha token, so this is total_stake_tao read directly, not price-multiplied. */
+                total_root_value_tao: string;
                 /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding. */
                 total_stake_tao: string;
                 total_validators: number;
@@ -16775,7 +16781,10 @@ export interface operations {
                      *         "summary": {
                      *           "registration_open_count": 1,
                      *           "subnet_count": 1,
+                     *           "total_alpha_value_tao": "327838334.635978200",
                      *           "total_miners": 1,
+                     *           "total_network_value_tao": "327838334.635978200",
+                     *           "total_root_value_tao": "327838334.635978200",
                      *           "total_stake_tao": "327838334.635978200",
                      *           "total_validators": 1,
                      *           "with_economics_count": 1

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -8414,9 +8414,24 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "total_alpha_value_tao": {
+                    "description": "Sum of every non-root subnet's alpha_market_cap_tao (alpha_price_tao times the total_stake_tao circulating-alpha proxy), lossless fixed 9-decimal rao-precision string (#6641). Excludes netuid 0 so root stake isn't double-counted as alpha value.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
+                  },
                   "total_miners": {
                     "minimum": 0,
                     "type": "integer"
+                  },
+                  "total_network_value_tao": {
+                    "description": "total_root_value_tao plus total_alpha_value_tao, summed in exact rao-integer space (#6641) -- Backprop's \"Total Network Value\" (TNV): the network's single top-line economic figure.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
+                  },
+                  "total_root_value_tao": {
+                    "description": "Root (netuid 0) TAO-denominated stake, lossless fixed 9-decimal rao-precision string (#6641). Root has no AMM/alpha token, so this is total_stake_tao read directly, not price-multiplied.",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "type": "string"
                   },
                   "total_stake_tao": {
                     "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet -- a JSON number (double) is only exact up to 2^53-1, ~9,007,199 TAO at rao precision; this network-wide total already exceeds that ceiling (#2924). Parse as an arbitrary-precision decimal, not Number(), if exact-rao fidelity matters; Number() is safe for display rounding.",
@@ -8438,7 +8453,10 @@
                   "total_stake_tao",
                   "total_validators",
                   "total_miners",
-                  "registration_open_count"
+                  "registration_open_count",
+                  "total_root_value_tao",
+                  "total_alpha_value_tao",
+                  "total_network_value_tao"
                 ],
                 "type": "object"
               }

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1445,7 +1445,10 @@
                   "total_stake_tao",
                   "total_validators",
                   "total_miners",
-                  "registration_open_count"
+                  "registration_open_count",
+                  "total_root_value_tao",
+                  "total_alpha_value_tao",
+                  "total_network_value_tao"
                 ],
                 "properties": {
                   "subnet_count": { "type": "integer", "minimum": 0 },
@@ -1457,7 +1460,25 @@
                   },
                   "total_validators": { "type": "integer", "minimum": 0 },
                   "total_miners": { "type": "integer", "minimum": 0 },
-                  "registration_open_count": { "type": "integer", "minimum": 0 }
+                  "registration_open_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "total_root_value_tao": {
+                    "type": "string",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "description": "Root (netuid 0) TAO-denominated stake, lossless fixed 9-decimal rao-precision string (#6641). Root has no AMM/alpha token, so this is total_stake_tao read directly, not price-multiplied."
+                  },
+                  "total_alpha_value_tao": {
+                    "type": "string",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "description": "Sum of every non-root subnet's alpha_market_cap_tao (alpha_price_tao times the total_stake_tao circulating-alpha proxy), lossless fixed 9-decimal rao-precision string (#6641). Excludes netuid 0 so root stake isn't double-counted as alpha value."
+                  },
+                  "total_network_value_tao": {
+                    "type": "string",
+                    "pattern": "^\\d+\\.\\d{9}$",
+                    "description": "total_root_value_tao plus total_alpha_value_tao, summed in exact rao-integer space (#6641) -- Backprop's \"Total Network Value\" (TNV): the network's single top-line economic figure."
+                  }
                 },
                 "additionalProperties": false
               },

--- a/scripts/lib/economics-artifacts.mjs
+++ b/scripts/lib/economics-artifacts.mjs
@@ -75,17 +75,50 @@ const RAO_PER_TAO = 1_000_000_000n;
 // quantity (matches the schema's own `minimum: 0`), so a negative sum is
 // unreachable -- unlike a real negative-capable delta, branching on a sign
 // that can never occur here would just be untestable dead code.
+function taoNumberToRao(value) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? BigInt(Math.round(value * 1e9))
+    : 0n;
+}
+
+function raoToTaoString(rao) {
+  const whole = rao / RAO_PER_TAO;
+  const frac = rao % RAO_PER_TAO;
+  return `${whole}.${frac.toString().padStart(9, "0")}`;
+}
+
 function sumFieldTaoString(rows, field) {
   let sumRao = 0n;
   for (const row of rows) {
-    const value = row[field];
-    if (typeof value === "number" && Number.isFinite(value)) {
-      sumRao += BigInt(Math.round(value * 1e9));
+    sumRao += taoNumberToRao(row[field]);
+  }
+  return raoToTaoString(sumRao);
+}
+
+// #6641: Backprop's "Total Network Value" split -- root (netuid 0) stake is
+// TAO-denominated with no AMM/price exposure, exactly like
+// buildGlobalValidatorEntry's root_stake_tao/alpha_stake_tao split in
+// src/metagraph-neurons.mjs and the root-has-no-AMM carve-out stake-quote.mjs
+// documents -- just applied to the network-wide rollup instead of a
+// per-entity one. Root's own alpha_market_cap_tao (its ~1.0 moving_price
+// times its TAO stake) is deliberately excluded from the alpha rollup so its
+// stake isn't counted as both "root value" and "alpha value"; total_network
+// is the rao-exact sum of the two, not a re-parsed string addition.
+export function computeNetworkValueSummary(rows) {
+  let rootRao = 0n;
+  let alphaRao = 0n;
+  for (const row of rows) {
+    if (row.netuid === 0) {
+      rootRao += taoNumberToRao(row.total_stake_tao);
+    } else {
+      alphaRao += taoNumberToRao(row.alpha_market_cap_tao);
     }
   }
-  const whole = sumRao / RAO_PER_TAO;
-  const frac = sumRao % RAO_PER_TAO;
-  return `${whole}.${frac.toString().padStart(9, "0")}`;
+  return {
+    total_root_value_tao: raoToTaoString(rootRao),
+    total_alpha_value_tao: raoToTaoString(alphaRao),
+    total_network_value_tao: raoToTaoString(rootRao + alphaRao),
+  };
 }
 
 export function buildEconomicsArtifact({
@@ -168,6 +201,7 @@ export function buildEconomicsArtifact({
       total_miners: sumField("miner_count"),
       registration_open_count: rows.filter((row) => row.registration_allowed)
         .length,
+      ...computeNetworkValueSummary(rows),
     },
     subnets: rows,
   };

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -553,6 +553,22 @@ export const SDL = `
     subnets: [SubnetEconomics!]!
     total: Int!
     next_cursor: String
+    summary: EconomicsSummary
+  }
+
+  type EconomicsSummary {
+    subnet_count: Int!
+    with_economics_count: Int!
+    total_stake_tao: String!
+    total_validators: Int!
+    total_miners: Int!
+    registration_open_count: Int!
+    "Root (netuid 0) TAO-denominated stake -- rao-precision decimal string (#6641)."
+    total_root_value_tao: String!
+    "Sum of every non-root subnet's alpha_market_cap_tao -- rao-precision decimal string (#6641)."
+    total_alpha_value_tao: String!
+    "total_root_value_tao + total_alpha_value_tao -- Backprop's Total Network Value (#6641)."
+    total_network_value_tao: String!
   }
 
   type SubnetEconomics {
@@ -4226,7 +4242,12 @@ const rootValue = {
       cursor,
       (s) => s.netuid,
     );
-    return { subnets: page, total, next_cursor: nextCursor };
+    return {
+      subnets: page,
+      total,
+      next_cursor: nextCursor,
+      summary: data?.summary ?? null,
+    };
   },
 
   surfaces({ netuid, limit, cursor }, context) {

--- a/tests/economics-artifacts.test.mjs
+++ b/tests/economics-artifacts.test.mjs
@@ -5,6 +5,7 @@ import {
   computeAlphaFdvTao,
   computeAlphaMarketCapTao,
   computeMinerReadiness,
+  computeNetworkValueSummary,
   buildEconomicsArtifact,
 } from "../scripts/lib/economics-artifacts.mjs";
 
@@ -168,6 +169,69 @@ describe("computeAlphaFdvTao", () => {
   });
 });
 
+// --- computeNetworkValueSummary (#6641) --------------------------------------
+
+describe("computeNetworkValueSummary", () => {
+  test("empty rows yield all-zero rao-precision strings", () => {
+    assert.deepEqual(computeNetworkValueSummary([]), {
+      total_root_value_tao: "0.000000000",
+      total_alpha_value_tao: "0.000000000",
+      total_network_value_tao: "0.000000000",
+    });
+  });
+
+  test("root (netuid 0) contributes total_stake_tao directly, not price-multiplied", () => {
+    // Root's own alpha_market_cap_tao would be huge (price ~1.0 x its TAO
+    // stake) if it were ever included in the alpha sum -- it must not be.
+    const result = computeNetworkValueSummary([
+      { netuid: 0, total_stake_tao: 500, alpha_market_cap_tao: 499.5 },
+    ]);
+    assert.deepEqual(result, {
+      total_root_value_tao: "500.000000000",
+      total_alpha_value_tao: "0.000000000",
+      total_network_value_tao: "500.000000000",
+    });
+  });
+
+  test("non-root rows sum alpha_market_cap_tao, ignoring their total_stake_tao", () => {
+    const result = computeNetworkValueSummary([
+      { netuid: 1, total_stake_tao: 1000, alpha_market_cap_tao: 40 },
+      { netuid: 2, total_stake_tao: 2000, alpha_market_cap_tao: 60 },
+    ]);
+    assert.deepEqual(result, {
+      total_root_value_tao: "0.000000000",
+      total_alpha_value_tao: "100.000000000",
+      total_network_value_tao: "100.000000000",
+    });
+  });
+
+  test("root + alpha rows sum into a single network total", () => {
+    const result = computeNetworkValueSummary([
+      { netuid: 0, total_stake_tao: 500 },
+      { netuid: 1, alpha_market_cap_tao: 40 },
+      { netuid: 2, alpha_market_cap_tao: 60 },
+    ]);
+    assert.deepEqual(result, {
+      total_root_value_tao: "500.000000000",
+      total_alpha_value_tao: "100.000000000",
+      total_network_value_tao: "600.000000000",
+    });
+  });
+
+  test("null/non-finite values contribute zero, not NaN or a thrown error", () => {
+    const result = computeNetworkValueSummary([
+      { netuid: 0, total_stake_tao: null },
+      { netuid: 1, alpha_market_cap_tao: null },
+      { netuid: 2, alpha_market_cap_tao: Number.NaN },
+    ]);
+    assert.deepEqual(result, {
+      total_root_value_tao: "0.000000000",
+      total_alpha_value_tao: "0.000000000",
+      total_network_value_tao: "0.000000000",
+    });
+  });
+});
+
 // --- buildEconomicsArtifact -------------------------------------------------
 
 function econSubnet(netuid, overrides = {}) {
@@ -198,6 +262,9 @@ describe("buildEconomicsArtifact", () => {
       total_validators: 0,
       total_miners: 0,
       registration_open_count: 0,
+      total_root_value_tao: "0.000000000",
+      total_alpha_value_tao: "0.000000000",
+      total_network_value_tao: "0.000000000",
     });
   });
 
@@ -236,6 +303,33 @@ describe("buildEconomicsArtifact", () => {
     assert.equal(artifact.summary.total_validators, 9);
     assert.equal(artifact.summary.total_miners, 200);
     assert.equal(artifact.summary.registration_open_count, 1);
+    // No netuid-0 row -- entirely alpha value, no root value.
+    assert.equal(artifact.summary.total_root_value_tao, "0.000000000");
+    assert.equal(artifact.summary.total_alpha_value_tao, "40.000000000");
+    assert.equal(artifact.summary.total_network_value_tao, "40.000000000");
+  });
+
+  test("root's own chain-derived alpha_market_cap_tao is excluded from the network-value alpha rollup (#6641)", () => {
+    // Root (netuid 0) reports a moving_price near 1.0 on-chain even though it
+    // has no AMM/alpha token (#2550) -- buildEconomicsArtifact still computes
+    // a row-level alpha_market_cap_tao for it like any other row. The summary
+    // rollup must carve root out by netuid, not by that row happening to have
+    // no price, or root's TAO stake would double-count as alpha value too.
+    const artifact = buildEconomicsArtifact({
+      subnets: [econSubnet(0), econSubnet(1)],
+      economicsByNetuid: new Map([
+        [0, { alpha_price_tao: 1.0, total_stake_tao: 500 }],
+        [1, { alpha_price_tao: 0.04, total_stake_tao: 1000 }],
+      ]),
+      generatedAt: "2026-06-25T00:00:00.000Z",
+    });
+    const root = artifact.subnets.find((row) => row.netuid === 0);
+    // Root's own row still gets its ordinary alpha_market_cap_tao (500) --
+    // untouched, only the network-value rollup treats it specially.
+    assert.equal(root.alpha_market_cap_tao, 500);
+    assert.equal(artifact.summary.total_root_value_tao, "500.000000000");
+    assert.equal(artifact.summary.total_alpha_value_tao, "40.000000000");
+    assert.equal(artifact.summary.total_network_value_tao, "540.000000000");
   });
 
   test("subnets with no economics entry are omitted but still counted", () => {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -745,6 +745,53 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     assert.equal(body.data.economics.subnets[0].netuid, 1);
     assert.equal(body.data.economics.subnets[0].emission_share, 0.05);
   });
+
+  test("economics exposes the network-value summary rollup (#6641)", async () => {
+    const env = fixtureEnv({
+      "/metagraph/economics.json": {
+        subnets: [{ netuid: 1, name: "Alpha", emission_share: 1 }],
+        summary: {
+          subnet_count: 1,
+          with_economics_count: 1,
+          total_stake_tao: "1000.000000000",
+          total_validators: 9,
+          total_miners: 200,
+          registration_open_count: 1,
+          total_root_value_tao: "500.000000000",
+          total_alpha_value_tao: "40.000000000",
+          total_network_value_tao: "540.000000000",
+        },
+      },
+    });
+    const { status, body } = await gql(
+      `{ economics { summary {
+          total_root_value_tao total_alpha_value_tao total_network_value_tao
+          subnet_count
+        } } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(body.data.economics.summary, {
+      total_root_value_tao: "500.000000000",
+      total_alpha_value_tao: "40.000000000",
+      total_network_value_tao: "540.000000000",
+      subnet_count: 1,
+    });
+  });
+
+  test("economics.summary is null when the source artifact has none", async () => {
+    const env = fixtureEnv({
+      "/metagraph/economics.json": {
+        subnets: [{ netuid: 1, name: "Alpha" }],
+      },
+    });
+    const { status, body } = await gql(
+      "{ economics { summary { subnet_count } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.economics.summary, null);
+  });
 });
 
 describe("handleGraphQLRequest — error envelope is never cacheable", () => {


### PR DESCRIPTION
## Summary

- Adds Backprop's "Total Network Value" (TNV) rollup — a single top-line network
  economic figure split into root (TAO-denominated) and alpha value — to the
  existing `/api/v1/economics` summary, `get_economics` MCP tool, and GraphQL's
  `economics.summary`.

## What Changed

- `scripts/lib/economics-artifacts.mjs`: new pure `computeNetworkValueSummary(rows)`,
  wired into `buildEconomicsArtifact`'s `summary`. Root (netuid 0) has no AMM/alpha
  token (same distinction `stake-quote.mjs` and `metagraph-neurons.mjs`'s
  `root_stake_tao`/`alpha_stake_tao` split already draw) — carved out by netuid so
  its TAO-denominated `total_stake_tao` isn't double-counted as alpha value via its
  own ~1.0 `alpha_price_tao` (`moving_price`). Alpha value sums every non-root row's
  existing `alpha_market_cap_tao`. Both sums, plus their total, are computed in
  exact rao-integer space and formatted as the same lossless fixed 9-decimal TAO
  string `total_stake_tao` already uses (#2924) — never a float re-parse.
- `schemas/components/05-subnets.schema.json`: added `total_root_value_tao`,
  `total_alpha_value_tao`, `total_network_value_tao` to `EconomicsArtifact.summary`
  (required, same rao-precision string pattern as `total_stake_tao`).
- `src/graphql.mjs`: new `EconomicsSummary` type + `summary` field on `EconomicsList`
  (previously unexposed via GraphQL at all), resolver passes through `data.summary`.
- REST (`GET /api/v1/economics`) and MCP (`get_economics`) need no code change —
  both already pass the artifact's `summary` object through generically, so the
  three new fields appear automatically once the artifact builder emits them.
- Regenerated `openapi.json`, `packages/contract/index.d.ts`, `public/metagraph/types.d.ts`,
  `schemas/api-components.schema.json` via `npm run build`.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6641`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:contract-drift`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run test:coverage` — 100% lines/branches/statements/functions on
      `scripts/lib/economics-artifacts.mjs`; the new `src/graphql.mjs` lines are
      100% branch-covered (the file's aggregate 99.71% branch figure is a
      pre-existing, unrelated gap untouched by this diff)
- [x] `git diff --check`

Closes #6641
