### PR TITLE
fix(ui): add ShareButton + ApiSourceFooter to the subnet and provider detail pages (#5481)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -20,6 +20,7 @@ import {
   safeExternalUrl,
   CurationChip,
   HealthPill,
+  ShareButton,
   DailyRollupFreshness,
   StatWithSpark,
   MiniStack,
@@ -347,6 +348,7 @@ export function SubnetMasthead({
           </span>
         ) : null}
         <div className="ml-auto flex md:hidden items-center gap-1.5">
+          <ShareButton />
           <HealthPill state={probeHealth} />
           <CurationChip level={profile?.curation_level} />
         </div>
@@ -449,6 +451,7 @@ export function SubnetMasthead({
         {/* Desktop/tablet: health + curation beside the identity block. Mobile
             counterpart lives in the status row above so the body column stays wide. */}
         <div className="hidden md:flex shrink-0 flex-col items-end gap-1.5">
+          <ShareButton />
           <HealthPill state={probeHealth} />
           <CurationChip level={profile?.curation_level} />
         </div>

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -16,7 +16,9 @@ import {
   PrimaryLinksRail,
   CopyableCode,
   SectionAnchor,
+  ShareButton,
 } from "@jsonbored/ui-kit";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { EndpointsGlance } from "@/components/metagraphed/endpoints-glance";
 import { EndpointList } from "@/components/metagraphed/endpoint-list";
@@ -132,6 +134,7 @@ function ProviderShell({ slug }: { slug: string }) {
         title={p?.name ?? slug}
         subtitle={shouldShowProviderSlugSubtitle(p?.name, slug) ? <>· {slug}</> : null}
         description={p?.notes}
+        actions={<ShareButton />}
         links={
           <PrimaryLinksRail website={p?.website ?? p?.homepage} docs={p?.docs} repo={p?.repo} />
         }
@@ -175,6 +178,10 @@ function ProviderShell({ slug }: { slug: string }) {
           {summary?.by_layer ? <BreakdownCard title="By layer" data={summary.by_layer} /> : null}
         </aside>
       </div>
+
+      <ApiSourceFooter
+        paths={[`/api/v1/providers/${slug}`, `/api/v1/providers/${slug}/endpoints`]}
+      />
     </>
   );
 }

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -106,6 +106,7 @@ import type {
 import { IncidentTimeline } from "@/components/metagraphed/incident-timeline";
 import { TimeRangeProvider } from "@/components/metagraphed/analytics/time-range-context";
 import { SubnetMasthead } from "@/components/metagraphed/subnet-masthead";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { OperationalPanel } from "@/components/metagraphed/operational-panel";
 import { ResourceExplorer } from "@/components/metagraphed/resource-explorer";
 import { GittensorRegisteredRepos } from "@/components/metagraphed/gittensor-registered-repos";
@@ -377,6 +378,8 @@ function ProfileShell({ netuid }: { netuid: number }) {
             ← All subnets
           </Link>
         </div>
+
+        <ApiSourceFooter paths={[`/api/v1/subnets/${netuid}/profile`]} />
       </SubnetFilterProvider>
     </TimeRangeProvider>
   );


### PR DESCRIPTION
## Summary

Every other entity-detail route renders both a `ShareButton` (copy-current-URL affordance) and an `ApiSourceFooter` (data-provenance footer) — `accounts.$ss58.tsx`, `blocks.$ref.tsx`, `extrinsics.$hash.tsx`, `validators.$hotkey.tsx`. The two remaining detail pages didn't:

- `subnets.$netuid.tsx` renders `SubnetMasthead` (no `ShareButton`) and never rendered `ApiSourceFooter`.
- `providers.$slug.tsx` renders `EntityHero` but never passed its supported `actions` prop, and never rendered `ApiSourceFooter`.

This adds that standard page furniture to both, matching the peers — no hero-layout redesign (that was #5342's separate, closed scope).

## Changes

- `subnet-masthead.tsx`: `ShareButton` in the masthead's existing action areas (the mobile status row + the desktop identity-side column, beside the health/curation chips)
- `subnets.$netuid.tsx`: `ApiSourceFooter paths={[/api/v1/subnets/{netuid}/profile]}` at the end of the page
- `providers.$slug.tsx`: `actions={<ShareButton />}` on the existing `EntityHero`; `ApiSourceFooter` citing `/api/v1/providers/{slug}` + `/api/v1/providers/{slug}/endpoints`

## Validation

- `eslint` — 0 errors
- `tsc --noEmit` — 0 errors
- `vite build` — success

## Screenshots

The subnet masthead now carries a "Share view" button (before: none), shown below. The provider `EntityHero` and both `ApiSourceFooter`s get the same treatment (visible in the diff).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/5481-detail-furniture/5481-detail-furniture-after-mobile-dark.png)<br><sub>after</sub> |

Closes #5481
