### PR TITLE
feat(ui): surface the network-wide total stake as a headline tile on /subnets (#6271)

### DIFF
--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSuspenseInfiniteQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense, useEffect, useMemo } from "react";
 import { z } from "zod";
-import { Network, Radio, Layers, Activity } from "lucide-react";
+import { Network, Radio, Layers, Activity, Coins } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
@@ -49,6 +49,7 @@ import {
   subnetHealthMapQuery,
   agentCatalogMapQuery,
   economicsQuery,
+  economicsTrendsQuery,
 } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber, formatTao, isStaleFreshness } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
@@ -190,7 +191,8 @@ function SubnetsPage() {
       <QueryErrorBoundary>
         <Suspense
           fallback={
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+              <Skeleton className="h-20" />
               <Skeleton className="h-20" />
               <Skeleton className="h-20" />
               <Skeleton className="h-20" />
@@ -215,6 +217,14 @@ function SubnetsPage() {
 
 function SubnetsStatStrip() {
   const coverage = useSuspenseQuery(coverageQuery()).data.data ?? {};
+  // #6271: the network-wide total-stake series already powers /explorer's trend
+  // chart (GET /api/v1/economics/trends). Surface its latest point as a
+  // headline tile so /subnets carries the same stake context.
+  const trendDays = useSuspenseQuery(economicsTrendsQuery()).data.data?.days ?? [];
+  const latestStake = [...trendDays]
+    .filter((d) => d?.snapshot_date)
+    .sort((a, b) => (a.snapshot_date < b.snapshot_date ? -1 : 1))
+    .at(-1)?.total_stake_tao;
   const health = useSuspenseQuery(healthQuery()).data.data ?? {};
   // Wired to the live /api/v1/coverage shape (same as CoverageFunnel): the older
   // netuids_active/netuids_total/adapter_backed fields are null on the live payload.
@@ -239,7 +249,12 @@ function SubnetsStatStrip() {
   const totalH = health.total;
   const healthyOk = ok != null && totalH != null && totalH > 0 && ok / totalH > 0.9;
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+      <StatTile
+        icon={Coins}
+        eyebrow="Total stake"
+        value={latestStake != null ? formatTao(latestStake) : "—"}
+      />
       <StatTile
         icon={Network}
         eyebrow="Active subnets"


### PR DESCRIPTION
## Summary

`GET /api/v1/economics/trends` already computes and serves the network-wide daily total-stake time series, already consumed by `/explorer`'s trend chart. `/subnets` showed no stake figure at all. This surfaces the series' latest point as a headline "Total stake" stat tile on `subnets.index.tsx`, reusing the existing `economicsTrendsQuery` consumer — no new backend work.

## Changes

- `subnets.index.tsx`
  - `SubnetsStatStrip` fetches `economicsTrendsQuery()` and takes the latest day's `total_stake_tao`
  - a "Total stake" `StatTile` (formatted with the existing `formatTao`) added as the headline (first) tile; the strip grid + its Suspense skeleton go from 4 to 5 columns

## Validation

- `eslint` — 0 errors
- `tsc --noEmit` — 0 errors

## Screenshots

Before: the strip has four tiles. After: a leading "Total stake" tile (e.g. `341.70M τ`) sourced from the same series `/explorer` already shows.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6271-total-stake/6271-total-stake-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6271
