### PR TITLE
feat(api,graphql): per-neuron immunity-window countdown

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5528,6 +5528,13 @@ export interface components {
             emission_tao?: number | null;
             featured?: boolean;
             hotkey: string | null;
+            /**
+             * Format: date-time
+             * @description Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block_number/captured_at at ~12s/block (the same block-time assumption apy_estimate depends on). Only present alongside immunity_expires_at_block; null when that snapshot anchor is unavailable or the window has already elapsed (#6640).
+             */
+            immunity_expires_at?: string | null;
+            /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period). Only present while is_immunity_period is true and both inputs are known (#6640) -- omitted, not null, otherwise. */
+            immunity_expires_at_block?: number;
             incentive?: number | null;
             is_immunity_period?: boolean;
             rank?: number | null;
@@ -25719,6 +25726,8 @@ export interface operations {
                      *           "emission_tao": 0.5,
                      *           "featured": false,
                      *           "hotkey": "example",
+                     *           "immunity_expires_at": "2026-06-01T00:00:00.000Z",
+                     *           "immunity_expires_at_block": 5000000,
                      *           "incentive": 0.5,
                      *           "is_immunity_period": false,
                      *           "rank": 0.5,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -11519,6 +11519,18 @@
               "null"
             ]
           },
+          "immunity_expires_at": {
+            "description": "Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block_number/captured_at at ~12s/block (the same block-time assumption apy_estimate depends on). Only present alongside immunity_expires_at_block; null when that snapshot anchor is unavailable or the window has already elapsed (#6640).",
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "immunity_expires_at_block": {
+            "description": "The block immunity ends (registered_at_block + the subnet's live immunity_period). Only present while is_immunity_period is true and both inputs are known (#6640) -- omitted, not null, otherwise.",
+            "type": "integer"
+          },
           "incentive": {
             "type": [
               "number",
@@ -48637,6 +48649,8 @@
                       "emission_tao": 0.5,
                       "featured": false,
                       "hotkey": "example",
+                      "immunity_expires_at": "2026-06-01T00:00:00.000Z",
+                      "immunity_expires_at_block": 5000000,
                       "incentive": 0.5,
                       "is_immunity_period": false,
                       "rank": 0.5,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5528,6 +5528,13 @@ export interface components {
             emission_tao?: number | null;
             featured?: boolean;
             hotkey: string | null;
+            /**
+             * Format: date-time
+             * @description Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block_number/captured_at at ~12s/block (the same block-time assumption apy_estimate depends on). Only present alongside immunity_expires_at_block; null when that snapshot anchor is unavailable or the window has already elapsed (#6640).
+             */
+            immunity_expires_at?: string | null;
+            /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period). Only present while is_immunity_period is true and both inputs are known (#6640) -- omitted, not null, otherwise. */
+            immunity_expires_at_block?: number;
             incentive?: number | null;
             is_immunity_period?: boolean;
             rank?: number | null;
@@ -25719,6 +25726,8 @@ export interface operations {
                      *           "emission_tao": 0.5,
                      *           "featured": false,
                      *           "hotkey": "example",
+                     *           "immunity_expires_at": "2026-06-01T00:00:00.000Z",
+                     *           "immunity_expires_at_block": 5000000,
                      *           "incentive": 0.5,
                      *           "is_immunity_period": false,
                      *           "rank": 0.5,

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -11497,6 +11497,18 @@
               "null"
             ]
           },
+          "immunity_expires_at": {
+            "description": "Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block_number/captured_at at ~12s/block (the same block-time assumption apy_estimate depends on). Only present alongside immunity_expires_at_block; null when that snapshot anchor is unavailable or the window has already elapsed (#6640).",
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "immunity_expires_at_block": {
+            "description": "The block immunity ends (registered_at_block + the subnet's live immunity_period). Only present while is_immunity_period is true and both inputs are known (#6640) -- omitted, not null, otherwise.",
+            "type": "integer"
+          },
           "incentive": {
             "type": [
               "number",

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1492,6 +1492,15 @@
           "stake_tao": { "type": ["number", "null"] },
           "registered_at_block": { "type": ["integer", "null"] },
           "is_immunity_period": { "type": "boolean" },
+          "immunity_expires_at_block": {
+            "type": "integer",
+            "description": "The block immunity ends (registered_at_block + the subnet's live immunity_period). Only present while is_immunity_period is true and both inputs are known (#6640) -- omitted, not null, otherwise."
+          },
+          "immunity_expires_at": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block_number/captured_at at ~12s/block (the same block-time assumption apy_estimate depends on). Only present alongside immunity_expires_at_block; null when that snapshot anchor is unavailable or the window has already elapsed (#6640)."
+          },
           "axon": { "type": ["string", "null"] },
           "featured": { "type": "boolean" },
           "take": {

--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -2194,6 +2194,10 @@ export const SDL = `
     stake_tao: Float
     registered_at_block: Int
     is_immunity_period: Boolean
+    "The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640)."
+    immunity_expires_at_block: Int
+    "Estimated wall-clock ETA for immunity_expires_at_block, extrapolated from this snapshot's own block/timestamp at ~12s/block; null if that anchor is unavailable (#6640)."
+    immunity_expires_at: String
     "Axon endpoint as host:port, or null when not served."
     axon: String
     "Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture."

--- a/src/metagraph-neurons.mjs
+++ b/src/metagraph-neurons.mjs
@@ -166,7 +166,53 @@ function toD1Flag(value) {
 // validator-list builders below -- buildSubnetMetagraph/buildNeuronDetail/
 // buildValidatorDetail never pass one, so `featured` is simply omitted from
 // their Neuron output, leaving those artifacts' shape unchanged.
-export function formatNeuron(row, featuredHotkeys) {
+// #6640 (TaoSwap finding, #5968 survey): a neuron still inside its immunity
+// window can't be pruned for low incentive yet -- a deregistration-risk
+// signal. immunity_period is a governance-adjustable per-subnet hyperparameter
+// (never hardcoded -- mirrors the MaxDelegateTake/TxDelegateTakeRateLimit
+// convention, #5229; see also docs/conviction-lock-mechanism.md's UnlockRate
+// caveat), so the caller live-reads it (subnet_hyperparams) and passes it in
+// -- this does no I/O of its own. Anchors the wall-clock ETA off the row's OWN
+// block_number/captured_at, not "now": every response is itself a
+// point-in-time snapshot, so the estimate is reproducible from that snapshot
+// alone rather than drifting with whenever the API happens to be called.
+// Reuses APY_SECONDS_PER_BLOCK, the same ~12s/block assumption apy_estimate
+// already depends on. Exported for direct unit testing, mirroring
+// src/concentration.mjs's pure-statistics convention; formatNeuron is its only
+// real caller.
+export function computeImmunityWindow(row, neuron, immunityPeriod) {
+  if (!neuron.is_immunity_period || neuron.registered_at_block == null) {
+    return {};
+  }
+  const expiresAtBlock = neuron.registered_at_block + immunityPeriod;
+  const snapshotBlock = nonNegativeInt(row.block_number);
+  const capturedAtMs = row.captured_at == null ? null : Number(row.captured_at);
+  let expiresAt = null;
+  if (
+    snapshotBlock != null &&
+    Number.isFinite(capturedAtMs) &&
+    capturedAtMs > 0
+  ) {
+    const blocksRemaining = expiresAtBlock - snapshotBlock;
+    if (blocksRemaining > 0) {
+      expiresAt = toIso(
+        capturedAtMs + blocksRemaining * APY_SECONDS_PER_BLOCK * 1000,
+      );
+    }
+  }
+  return {
+    immunity_expires_at_block: expiresAtBlock,
+    immunity_expires_at: expiresAt,
+  };
+}
+
+// immunityPeriod (optional) is the subnet's live immunity_period hyperparameter
+// (#6640) -- only buildSubnetMetagraph/buildNeuronDetail pass one; every other
+// caller (buildSubnetValidators/buildGlobalValidators/buildValidatorDetail)
+// omits it, so their rows get no immunity_expires_at* keys at all (not
+// null-valued ones), keeping their own additionalProperties:false schemas
+// untouched by this change.
+export function formatNeuron(row, featuredHotkeys, immunityPeriod) {
   if (!row || typeof row !== "object") return null;
   const hotkey = row.hotkey ?? null;
   const neuron = {
@@ -202,6 +248,9 @@ export function formatNeuron(row, featuredHotkeys) {
   if (featuredHotkeys) {
     neuron.featured = Boolean(hotkey && featuredHotkeys.has(hotkey));
   }
+  if (Number.isSafeInteger(immunityPeriod) && immunityPeriod >= 0) {
+    Object.assign(neuron, computeImmunityWindow(row, neuron, immunityPeriod));
+  }
   return neuron;
 }
 
@@ -218,14 +267,16 @@ function snapshotStamp(rows) {
   };
 }
 
-export function buildSubnetMetagraph(rows, netuid) {
+export function buildSubnetMetagraph(rows, netuid, { immunityPeriod } = {}) {
   const { captured_at, block_number } = snapshotStamp(rows);
   // Drop any malformed row (formatNeuron → null) so the array only holds real
   // Neuron objects, mirroring the blocks/extrinsics feed builders; the count
   // tracks the array, so callers can rely on neuron_count === neurons.length.
   // Wrapped (not a bare `rows.map(formatNeuron)`) so Array#map's index arg
   // never lands in formatNeuron's featuredHotkeys parameter.
-  const neurons = rows.map((row) => formatNeuron(row)).filter(Boolean);
+  const neurons = rows
+    .map((row) => formatNeuron(row, undefined, immunityPeriod))
+    .filter(Boolean);
   return {
     schema_version: 1,
     netuid,
@@ -259,7 +310,7 @@ export function buildSubnetValidators(
   };
 }
 
-export function buildNeuronDetail(row, netuid) {
+export function buildNeuronDetail(row, netuid, { immunityPeriod } = {}) {
   return {
     schema_version: 1,
     netuid,
@@ -267,7 +318,7 @@ export function buildNeuronDetail(row, netuid) {
     // Same D1 numeric-string coercion as snapshotStamp / buildGlobalValidators
     // (#2611): keep the top-level block_number an integer or null, never a string.
     block_number: nonNegativeInt(row?.block_number),
-    neuron: formatNeuron(row),
+    neuron: formatNeuron(row, undefined, immunityPeriod),
   };
 }
 

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -1491,6 +1491,18 @@ test("GET /api/v1/subnets/:netuid/metagraph omits immunity_expires_at* when subn
   expect("immunity_expires_at_block" in body.neurons[0]).toBe(false);
 });
 
+test("GET /api/v1/subnets/:netuid/metagraph omits immunity_expires_at* for a negative immunity_period value (defensive, shouldn't occur on real chain data)", async () => {
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [IMMUNE_ROW],
+    [{ immunity_period: -1 }], // loadSubnetImmunityPeriod
+  ];
+  const res = await req("/api/v1/subnets/7/metagraph");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect("immunity_expires_at_block" in body.neurons[0]).toBe(false);
+});
+
 test("GET /api/v1/subnets/:netuid/metagraph still serves neurons when the immunity_period read fails (#6640)", async () => {
   subnetTemposQueryFailure.error = new Error(
     'relation "subnet_hyperparams" does not exist',

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -1453,6 +1453,72 @@ test("GET /api/v1/subnets/:netuid/neurons/:uid on an unknown uid returns neuron:
   expect(body.neuron).toBeNull();
 });
 
+// #6640: deregistration-risk signal -- immunity_period is read live from
+// subnet_hyperparams (never hardcoded, #5229 convention) alongside the
+// neurons query, same Promise.all + savepoint-isolated shape as loadSubnetTempos
+// (#2551).
+const IMMUNE_ROW = {
+  ...NEURON_ROW,
+  is_immunity_period: true,
+  registered_at_block: "5000000",
+  block_number: "5000100",
+  captured_at: "1780000000000",
+};
+
+test("GET /api/v1/subnets/:netuid/metagraph computes immunity_expires_at* from a live subnet_hyperparams read (#6640)", async () => {
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [IMMUNE_ROW], // main neurons query
+    [{ immunity_period: 7200 }], // loadSubnetImmunityPeriod
+  ];
+  const res = await req("/api/v1/subnets/7/metagraph");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(queryText()).toMatch(/SELECT immunity_period FROM subnet_hyperparams/);
+  expect(body.neurons[0].immunity_expires_at_block).toBe(5007200);
+  expect(typeof body.neurons[0].immunity_expires_at).toBe("string");
+});
+
+test("GET /api/v1/subnets/:netuid/metagraph omits immunity_expires_at* when subnet_hyperparams has no row yet (cold)", async () => {
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [IMMUNE_ROW],
+    [], // loadSubnetImmunityPeriod -- no row for this netuid
+  ];
+  const res = await req("/api/v1/subnets/7/metagraph");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect("immunity_expires_at_block" in body.neurons[0]).toBe(false);
+});
+
+test("GET /api/v1/subnets/:netuid/metagraph still serves neurons when the immunity_period read fails (#6640)", async () => {
+  subnetTemposQueryFailure.error = new Error(
+    'relation "subnet_hyperparams" does not exist',
+  );
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [IMMUNE_ROW],
+  ];
+  const res = await req("/api/v1/subnets/7/metagraph");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.neurons[0].uid).toBe(3);
+  expect("immunity_expires_at_block" in body.neurons[0]).toBe(false);
+});
+
+test("GET /api/v1/subnets/:netuid/neurons/:uid computes immunity_expires_at* from a live subnet_hyperparams read (#6640)", async () => {
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [IMMUNE_ROW], // main neuron-detail query
+    [{ immunity_period: 7200 }], // loadSubnetImmunityPeriod
+  ];
+  const res = await req("/api/v1/subnets/7/neurons/3");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.neuron.immunity_expires_at_block).toBe(5007200);
+  expect(typeof body.neuron.immunity_expires_at).toBe("string");
+});
+
 test("GET /api/v1/subnets/:netuid/validators ranks validator_permit rows by stake", async () => {
   mockRows.current = [NEURON_ROW];
   const res = await req("/api/v1/subnets/7/validators");

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -5947,6 +5947,42 @@ describe("graphql — neuron (#5900, Postgres-tier + neuron:null fallback)", () 
     });
   });
 
+  test("exposes immunity_expires_at_block/immunity_expires_at when the REST tier returns them (#6640)", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          captured_at: "2026-07-01T00:00:00.000Z",
+          block_number: 8621331,
+          neuron: {
+            uid: 12,
+            hotkey: "5Hot",
+            registered_at_block: 8000000,
+            is_immunity_period: true,
+            immunity_expires_at_block: 8007200,
+            immunity_expires_at: "2026-07-02T00:00:00.000Z",
+          },
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ neuron(netuid: 5, uid: 12) {
+          neuron { uid is_immunity_period immunity_expires_at_block immunity_expires_at }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.neuron.neuron, {
+      uid: 12,
+      is_immunity_period: true,
+      immunity_expires_at_block: 8007200,
+      immunity_expires_at: "2026-07-02T00:00:00.000Z",
+    });
+  });
+
   test("hits /api/v1/subnets/{netuid}/neurons/{uid} on the Postgres tier", async () => {
     let capturedUrl;
     const env = {

--- a/tests/metagraph-neurons.test.mjs
+++ b/tests/metagraph-neurons.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   formatNeuron,
+  computeImmunityWindow,
   buildSubnetMetagraph,
   buildSubnetValidators,
   buildGlobalValidators,
@@ -318,6 +319,120 @@ describe("metagraph-neurons builders", () => {
     assert.equal(formatNeuron(MINER, featured).featured, false);
     // An empty (but real) set still yields a real boolean, not an omission.
     assert.equal(formatNeuron(ROW, new Set()).featured, false);
+  });
+
+  // --- computeImmunityWindow / formatNeuron's immunityPeriod param (#6640) --
+
+  const IMMUNE_ROW = {
+    ...ROW,
+    is_immunity_period: 1,
+    registered_at_block: 8450000,
+    block_number: 8454388,
+    captured_at: 1750000000000,
+  };
+
+  test("computeImmunityWindow returns {} when the neuron isn't in its immunity window", () => {
+    assert.deepEqual(computeImmunityWindow(ROW, formatNeuron(ROW), 7200), {});
+  });
+
+  test("computeImmunityWindow returns {} when registered_at_block is unknown", () => {
+    const row = { ...IMMUNE_ROW, registered_at_block: null };
+    assert.deepEqual(computeImmunityWindow(row, formatNeuron(row), 7200), {});
+  });
+
+  test("computeImmunityWindow computes the expiry block and a wall-clock ETA anchored on the snapshot", () => {
+    const immunityPeriod = 7200;
+    const blocksRemaining =
+      IMMUNE_ROW.registered_at_block + immunityPeriod - IMMUNE_ROW.block_number;
+    const result = computeImmunityWindow(
+      IMMUNE_ROW,
+      formatNeuron(IMMUNE_ROW),
+      immunityPeriod,
+    );
+    assert.equal(
+      result.immunity_expires_at_block,
+      IMMUNE_ROW.registered_at_block + immunityPeriod,
+    );
+    assert.equal(
+      result.immunity_expires_at,
+      new Date(
+        IMMUNE_ROW.captured_at + blocksRemaining * 12 * 1000,
+      ).toISOString(),
+    );
+  });
+
+  test("computeImmunityWindow still returns the expiry block, but a null ETA, once the window has already elapsed", () => {
+    // registered_at_block + immunityPeriod is BEFORE the snapshot's own block --
+    // is_immunity_period says yes (chain-authoritative, trusted as-is) but the
+    // block math says the window ended before this snapshot was captured.
+    const result = computeImmunityWindow(
+      IMMUNE_ROW,
+      formatNeuron(IMMUNE_ROW),
+      1,
+    );
+    assert.equal(result.immunity_expires_at_block, 8450001);
+    assert.equal(result.immunity_expires_at, null);
+  });
+
+  test("computeImmunityWindow omits the wall-clock ETA when the snapshot has no usable block_number/captured_at", () => {
+    for (const row of [
+      { ...IMMUNE_ROW, block_number: null },
+      { ...IMMUNE_ROW, captured_at: null },
+      { ...IMMUNE_ROW, block_number: "" },
+    ]) {
+      const result = computeImmunityWindow(row, formatNeuron(row), 7200);
+      assert.equal(result.immunity_expires_at_block, 8457200);
+      assert.equal(result.immunity_expires_at, null, JSON.stringify(row));
+    }
+  });
+
+  test("formatNeuron omits immunity_expires_at* when no immunityPeriod is passed", () => {
+    // Mirrors the `featured` omission test above -- buildSubnetValidators/
+    // buildGlobalValidators/buildValidatorDetail never pass immunityPeriod, so
+    // their Neuron-shaped rows keep their existing shape unchanged, and their
+    // additionalProperties:false schemas stay valid untouched.
+    const n = formatNeuron(IMMUNE_ROW);
+    assert.equal("immunity_expires_at_block" in n, false);
+    assert.equal("immunity_expires_at" in n, false);
+  });
+
+  test("formatNeuron omits immunity_expires_at* when immunityPeriod is invalid", () => {
+    for (const bad of [-1, 1.5, Number.NaN, "7200", null, undefined]) {
+      const n = formatNeuron(IMMUNE_ROW, undefined, bad);
+      assert.equal(
+        "immunity_expires_at_block" in n,
+        false,
+        JSON.stringify(bad),
+      );
+    }
+  });
+
+  test("formatNeuron includes immunity_expires_at* when immunityPeriod is a valid non-negative integer", () => {
+    const n = formatNeuron(IMMUNE_ROW, undefined, 7200);
+    assert.equal(n.immunity_expires_at_block, 8457200);
+    assert.equal(typeof n.immunity_expires_at, "string");
+  });
+
+  test("formatNeuron omits immunity_expires_at* for a neuron outside its immunity window even with a valid immunityPeriod", () => {
+    const n = formatNeuron(ROW, undefined, 7200);
+    assert.equal("immunity_expires_at_block" in n, false);
+  });
+
+  test("buildSubnetMetagraph threads immunityPeriod through to every row", () => {
+    const data = buildSubnetMetagraph([IMMUNE_ROW], 7, {
+      immunityPeriod: 7200,
+    });
+    assert.equal(data.neurons[0].immunity_expires_at_block, 8457200);
+  });
+
+  test("buildSubnetMetagraph omits immunity_expires_at* when immunityPeriod isn't passed (back-compat)", () => {
+    const data = buildSubnetMetagraph([IMMUNE_ROW], 7);
+    assert.equal("immunity_expires_at_block" in data.neurons[0], false);
+  });
+
+  test("buildNeuronDetail threads immunityPeriod through", () => {
+    const data = buildNeuronDetail(IMMUNE_ROW, 7, { immunityPeriod: 7200 });
+    assert.equal(data.neuron.immunity_expires_at_block, 8457200);
   });
 
   test("buildSubnetValidators always includes `featured`, matched by hotkey", () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2811,6 +2811,31 @@ async function loadSubnetTempos(sql) {
   }
 }
 
+// One netuid's live immunity_period hyperparameter (#6640) -- never
+// hardcoded, mirrors the MaxDelegateTake/TxDelegateTakeRateLimit convention
+// (#5229). Same savepoint-isolated-failure shape as loadSubnetTempos just
+// above: a subnet_hyperparams read failure degrades the immunity-window
+// fields to omitted (formatNeuron's immunityPeriod-undefined no-op) rather
+// than failing the neurons/metagraph response. Same null-guard as
+// subnet-hyperparams.mjs's own nonNegativeInt -- Number(null) is 0, not
+// NaN -- written inline rather than imported since each domain file owns its
+// small D1/Postgres cell-coercion copies (see that file's own header).
+async function loadSubnetImmunityPeriod(sql, netuid) {
+  try {
+    const rows = await sql.savepoint(
+      (sql) =>
+        sql`SELECT immunity_period FROM subnet_hyperparams WHERE netuid = ${netuid} LIMIT 1`,
+    );
+    const value = rows[0]?.immunity_period;
+    if (value == null) return null;
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+  } catch (err) {
+    console.error("subnet_hyperparams immunity_period query failed:", err);
+    return null;
+  }
+}
+
 // Raw nominator_positions rows for one coldkey (#5233) -- savepoint-isolated
 // like the loaders above, so a cold/absent table degrades this specific
 // route to an empty positions card rather than failing the request.
@@ -6402,14 +6427,17 @@ export default {
           const netuid = Number(subnetMetagraph[1]);
           const validatorsOnly =
             url.searchParams.get("validator_permit") === "true";
-          const rows = validatorsOnly
-            ? await sql`
+          const [rows, immunityPeriod] = await Promise.all([
+            validatorsOnly
+              ? sql`
               SELECT uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at, take
               FROM neurons WHERE netuid = ${netuid} AND validator_permit = TRUE ORDER BY uid`
-            : await sql`
+              : sql`
               SELECT uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at, take
-              FROM neurons WHERE netuid = ${netuid} ORDER BY uid`;
-          return json(buildSubnetMetagraph(rows, netuid));
+              FROM neurons WHERE netuid = ${netuid} ORDER BY uid`,
+            loadSubnetImmunityPeriod(sql, netuid),
+          ]);
+          return json(buildSubnetMetagraph(rows, netuid, { immunityPeriod }));
         }
 
         // GET /api/v1/subnets/:netuid/neurons/:uid (#4771): per-UID detail,
@@ -6421,10 +6449,15 @@ export default {
         if (neuronDetail) {
           const netuid = Number(neuronDetail[1]);
           const uid = Number(neuronDetail[2]);
-          const rows = await sql`
+          const [rows, immunityPeriod] = await Promise.all([
+            sql`
           SELECT uid, hotkey, coldkey, active, validator_permit, rank, trust, validator_trust, consensus, incentive, dividends, emission_tao, stake_tao, registered_at_block, is_immunity_period, axon, block_number, captured_at, take
-          FROM neurons WHERE netuid = ${netuid} AND uid = ${uid} LIMIT 1`;
-          return json(buildNeuronDetail(rows[0] ?? null, netuid));
+          FROM neurons WHERE netuid = ${netuid} AND uid = ${uid} LIMIT 1`,
+            loadSubnetImmunityPeriod(sql, netuid),
+          ]);
+          return json(
+            buildNeuronDetail(rows[0] ?? null, netuid, { immunityPeriod }),
+          );
         }
 
         // GET /api/v1/subnets/:netuid/validators (#4771): validator_permit=1


### PR DESCRIPTION
## Summary

- Adds TaoSwap's "deregistration risk assessment with immunity timelines"
  (#5968 competitive survey) — a per-neuron countdown to when its immunity
  window ends, so a neuron that's about to become prunable is visible before
  it happens.

## What Changed

- `src/metagraph-neurons.mjs`: new `computeImmunityWindow(row, neuron, immunityPeriod)`
  — while `is_immunity_period` is true, `immunity_expires_at_block` is
  `registered_at_block + immunityPeriod`; `immunity_expires_at` extrapolates a
  wall-clock ETA from that response's own snapshot `block_number`/`captured_at`
  at ~12s/block (the same block-time assumption `apy_estimate` already
  depends on) rather than "now", so it's reproducible from the snapshot
  alone. `immunity_period` is a governance-adjustable per-subnet
  hyperparameter — never hardcoded, mirrors the
  `MaxDelegateTake`/`TxDelegateTakeRateLimit` convention (#5229; see also
  `docs/conviction-lock-mechanism.md`'s `UnlockRate` caveat).
- `formatNeuron` takes an optional third `immunityPeriod` param and only
  attaches the two new keys when it's a valid non-negative integer — mirrors
  the existing `featured`-param conditional-attach idiom exactly. Every
  caller that doesn't pass one (`buildSubnetValidators`,
  `buildGlobalValidators`, `buildValidatorDetail`) is unaffected: no new keys
  at all, not null-valued ones, so their own `additionalProperties:false`
  schemas stay valid untouched.
- `buildSubnetMetagraph`/`buildNeuronDetail` take a new `{ immunityPeriod }`
  option and forward it.
- `workers/data-api.mjs`: the `/metagraph` and `/neurons/:uid` handlers fetch
  the subnet's live `immunity_period` from `subnet_hyperparams` alongside the
  neurons query (`Promise.all`, savepoint-isolated like the existing
  `loadSubnetTempos` — a hyperparams read failure degrades to the fields
  being omitted, never fails the neurons response).
- `src/graphql.mjs`: `NeuronState` gets the two new fields. No resolver
  change needed — GraphQL's `neuron` query already forwards to
  `GET /api/v1/subnets/{netuid}/neurons/{uid}` internally
  (`tryPostgresTier`), same as MCP's `get_subnet_metagraph`/`get_neuron`
  forward to the REST routes — so REST is the single source of truth and
  both already get this for free once REST has it.
- `schemas/components/05-subnets.schema.json`: the shared `Neuron` component
  (used by both `SubnetMetagraphArtifact` and `NeuronDetailArtifact`) gets
  the two new optional properties.
- No new route — slots into the existing per-neuron response, as the issue's
  own deliverable preferred.
- Regenerated `openapi.json`, `packages/contract/index.d.ts`,
  `public/metagraph/types.d.ts`, `schemas/api-components.schema.json` via
  `npm run build`.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6640`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or
      validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:contract-drift`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npx vitest run tests/metagraph-neurons.test.mjs tests/data-api.test.mjs tests/graphql.test.mjs` —
      all passing (91/480/600 respectively), including new tests for every
      new branch: in/out of immunity window, missing `registered_at_block`,
      missing snapshot anchor, already-elapsed window, invalid/omitted
      `immunityPeriod`, and a `subnet_hyperparams` read failure degrading
      gracefully
- [x] `git diff --check`

Closes #6640
