### PR TITLE
fix(ui): add Suspense + shaped skeleton to EmissionYieldPanel on /status (#6389)

### DIFF
--- a/apps/ui/src/components/metagraphed/emission-yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/emission-yield-panel.tsx
@@ -1,25 +1,42 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { TrendingUp, Server, Users, Coins } from "lucide-react";
 import { chainYieldQuery } from "@/lib/metagraphed/queries";
 import { StatTile } from "@jsonbored/ui-kit";
-import { EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import { formatNumber } from "@/lib/metagraphed/format";
 
 // #3472: network emission-yield summary — the return-rate companion to the
 // decentralization scorecard, from the newly-wired chainYieldQuery. Aggregate
 // network return (total emission / total stake) split by validator/miner role,
 // plus the per-neuron return spread. The data layer is untouched; this only
-// consumes the normalized shape via useQuery.
+// consumes the normalized shape via useSuspenseQuery.
 
 function fmtPct(v: number | null): string {
   if (v == null) return "—";
   return `${(v * 100).toFixed(4)}%`;
 }
 
-function Notice({ children }: { children: string }) {
+// Suspense fallback that mirrors the panel's own two 3-tile rows (network/
+// validator/miner yield, then median/75th/90th per-neuron return) so the
+// skeleton occupies the same height as the loaded content -- matches
+// NetworkDecentralizationSkeleton's convention for its sibling section
+// immediately above this one on the status page (#6389).
+export function EmissionYieldSkeleton() {
   return (
-    <div className="rounded-lg border border-border bg-card p-4 text-xs text-ink-muted">
-      {children}
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-[76px]" />
+        ))}
+      </div>
+      <div>
+        <Skeleton className="mb-3 h-3 w-48" />
+        <div className="grid gap-3 sm:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-[76px]" />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }
@@ -30,18 +47,16 @@ function Notice({ children }: { children: string }) {
  * return distribution (median and upper-percentile spread). The return-rate
  * companion to the decentralization scorecard, at network scope. Fetches the
  * chain-yield snapshot once and renders a KPI-tile grid.
+ *
+ * Suspense-driven loading (the Suspense fallback in status.tsx renders
+ * EmissionYieldSkeleton) and QueryErrorBoundary-driven errors, matching
+ * every sibling section on the status page -- so a fetch error surfaces as a
+ * distinct error state rather than being conflated with a legitimately-empty
+ * result below (#6389, mirroring #3966's fix for this page's other panels).
  */
 export function EmissionYieldPanel() {
-  const { data: res, isPending, isError, error, refetch } = useQuery(chainYieldQuery());
+  const { data: res } = useSuspenseQuery(chainYieldQuery());
   const y = res?.data;
-
-  if (isError) {
-    return <ErrorState error={error} onRetry={() => refetch()} context="network emission yield" />;
-  }
-
-  if (isPending && !y) {
-    return <Notice>Loading network emission yield…</Notice>;
-  }
 
   if (!y || y.neuron_count === 0) {
     return (

--- a/apps/ui/src/routes/status.tsx
+++ b/apps/ui/src/routes/status.tsx
@@ -32,7 +32,10 @@ import {
   NetworkDecentralizationPanel,
   NetworkDecentralizationSkeleton,
 } from "@/components/metagraphed/network-decentralization-panel";
-import { EmissionYieldPanel } from "@/components/metagraphed/emission-yield-panel";
+import {
+  EmissionYieldPanel,
+  EmissionYieldSkeleton,
+} from "@/components/metagraphed/emission-yield-panel";
 
 const SURFACES_INITIAL = 10;
 // A downtime event whose last failure is within this of the latest snapshot is
@@ -163,7 +166,9 @@ function StatusPage() {
             intro="Chain-wide emission yield — total emission over total stake, split by validator/miner role — plus the per-neuron return distribution, computed across every neuron from the metagraph snapshot."
           />
           <QueryErrorBoundary>
-            <EmissionYieldPanel />
+            <Suspense fallback={<EmissionYieldSkeleton />}>
+              <EmissionYieldPanel />
+            </Suspense>
           </QueryErrorBoundary>
         </section>
 


### PR DESCRIPTION
Closes #6389

## Problem

`status.tsx` wraps every section in `<QueryErrorBoundary><Suspense fallback={<Skeleton .../>}>...` except `EmissionYieldPanel`, which gets only the error boundary. The panel itself uses `useQuery` (not `useSuspenseQuery`) and renders a bare, unstyled `<Notice>Loading network emission yield…</Notice>` on pending — a single-line text box instead of a shaped skeleton, directly beneath `NetworkDecentralizationPanel`'s properly-shaped skeleton (its immediate sibling section, added earlier by #3966 for a different panel). `EmissionYieldPanel` was added later via #3472 and never received that fix.

## Fix

- Converted `EmissionYieldPanel` to `useSuspenseQuery`. Errors now surface via the existing `QueryErrorBoundary` wrapper instead of a manual `isError` branch, matching every sibling section.
- Added `EmissionYieldSkeleton`, shaped to the panel's own two 3-tile rows (network/validator/miner yield, then median/75th/90th per-neuron return) — same convention as `NetworkDecentralizationSkeleton` for the section right above it.
- Wrapped the panel in `status.tsx` with `<Suspense fallback={<EmissionYieldSkeleton />}>`.

## Screenshots

Captured the actual loading state (not just the loaded state) by client-side-navigating to `/status` with the `/api/v1/chain/yield` request delayed via Playwright route interception — a hard page load resolves this query during SSR before any HTML reaches the browser, so a soft/client navigation is needed to observe `useSuspenseQuery` actually suspend.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6389-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

- `npx tsc --noEmit -p apps/ui`: clean
- `npx prettier --check` / `npx eslint` on changed files: clean (no new warnings)
- `npx vitest run` (apps/ui): 157 test files, 1168 tests, all passing
- Manually verified in browser: forced the loading state via delayed network + client-side nav, confirmed the shaped skeleton renders and the loaded content matches the pre-existing layout with no regression