### PR TITLE
feat(ui): add an Emissions CSV export to the leaderboards page (#6577)

### DIFF
--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -86,6 +86,10 @@ function LeaderboardsPage() {
               label="Deregistrations CSV"
               bare
             />
+            {/* EmissionsLeaderboard reads the window-agnostic /api/v1/economics
+                snapshot (no `win`), so its CSV takes no window param either — it
+                mirrors exactly what the board renders (#6577). */}
+            <DownloadCsvButton url={buildUrl("/api/v1/economics")} label="Emissions CSV" bare />
             <ShareButton bare />
           </ActionBar>
         }


### PR DESCRIPTION
Closes #6577

## Summary

The leaderboards page's ActionBar wired CSV exports for its weight-setting and deregistrations boards, but not for the third board — `EmissionsLeaderboard`, whose identical summary-tiles + table layout is sourced from `/api/v1/economics`. That route already serves `?format=csv` (`csvListQuery("economics")`, verified live: `Content-Type: text/csv`), so the export just was never wired up.

## What Changed

- Add a third `DownloadCsvButton` to the ActionBar, mirroring the existing two's `bare` prop and placement, labeled "Emissions CSV".
- `EmissionsLeaderboard` reads the **window-agnostic** `/api/v1/economics` snapshot (it takes no `win` prop, and `economicsQuery()` sends no `window`), so — unlike the two windowed siblings — its CSV button takes no `window` param, matching exactly what the board renders. No change to the other two boards.

## Screenshots — /leaderboards ActionBar

Before: two CSV buttons; after: three (the new "Emissions CSV" sits between "Deregistrations CSV" and "Share view").

| Viewport · Theme | Before | After |
| --- | --- | --- |
| **Desktop · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-after-desktop-light.png)<br><sub>after</sub> |
| **Desktop · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-after-desktop-dark.png)<br><sub>after</sub> |
| **Tablet · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-after-tablet-light.png)<br><sub>after</sub> |
| **Tablet · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-after-tablet-dark.png)<br><sub>after</sub> |
| **Mobile · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-after-mobile-light.png)<br><sub>after</sub> |
| **Mobile · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6577/6577-emissions-csv-after-mobile-dark.png)<br><sub>after</sub> |


## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6577`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none — UI-only; the CSV route already exists)*

## Validation

- [x] `npx prettier --check` / `npx eslint` — clean (apps/ui config)
- [x] `npm run typecheck` — no new errors
- [x] Verified `/api/v1/economics?format=csv` returns `text/csv` live
- [x] `git diff --check` clean
- [x] 12-image before/after matrix (3 viewports x 2 themes); Emissions CSV button asserted present (after) / absent (before) per shot
