### PR TITLE
docs(skill): require verifying against synced upstream before closing/filing

### DIFF
--- a/.claude/skills/contributor-pipeline-gardening/SKILL.md
+++ b/.claude/skills/contributor-pipeline-gardening/SKILL.md
@@ -33,6 +33,15 @@ was false. Close what's genuinely done (with a comment naming the shipping PR an
 grep confirming the described code/route/page exists); leave partial work open, optionally with a
 scope-clarifying comment.
 
+**Verify against synced upstream, not a stale local checkout.** Before treating any local grep/read
+as evidence that an issue's described work does or doesn't exist, confirm the code you're reading
+matches the default branch's current tip — fetch and fast-forward the checkout (or use a disposable
+worktree off `origin/main` if the primary checkout is dirty or has unpushed work on another branch)
+before doing any verification. A checkout that's merely _clean_ isn't the same as _current_ — a
+stale-but-clean checkout silently produced false "already done"/"not done" conclusions here and in a
+sibling repo's gardening run on 2026-07-17/18, causing duplicate issues to be filed for already-shipped
+work. Confirm sync every run; never assume a previous run's freshness carried over.
+
 **metagraphed-specific things to check while doing this:**
 
 - Milestone **#9 "Wave 3 — Frontend (post-consolidation)"**: checked 2026-07-15, it is **not**


### PR DESCRIPTION
## Summary
- A local checkout that's merely clean isn't the same as current — this repo's gardening automation was verifying "does this issue's described work already exist" against whatever the local checkout happened to have, with no check that it matched `origin/main`'s current tip.
- Confirmed 2026-07-17/18: a stale-but-clean checkout produced false "already done"/"not done" conclusions in this repo and a sibling repo's gardening run, causing duplicate issues to be filed for already-shipped work.
- Adds an explicit rule to Pass 1: fetch + fast-forward (or a disposable worktree off `origin/main` if the checkout is dirty/has unpushed work) before any verification grep, every run.

## Test plan
- [x] `npx prettier --check .claude/skills/contributor-pipeline-gardening/SKILL.md` passes
- Doc-only change, no code/schema/CI-relevant paths touched