### PR TITLE
feat(ui): surface conviction leaderboard + ownership history on subnet detail

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
@@ -1,0 +1,119 @@
+import { useQuery } from "@tanstack/react-query";
+import { Crown } from "lucide-react";
+import { subnetConvictionQuery } from "@/lib/metagraphed/queries";
+import { CopyableCode } from "@jsonbored/ui-kit";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+
+const UNITS_PER_WHOLE = 1_000_000_000;
+
+// locked_mass/conviction arrive as raw rao-scale integers (mirrors every
+// other on-chain alpha/TAO amount in this codebase) -- divide before display.
+function fmtAlpha(rawUnits: number): string {
+  if (!Number.isFinite(rawUnits)) return "—";
+  const whole = rawUnits / UNITS_PER_WHOLE;
+  const magnitude = Math.abs(whole);
+  if (magnitude >= 1_000_000) return `${(whole / 1_000_000).toFixed(2)}M α`;
+  if (magnitude >= 1_000) return `${(whole / 1_000).toFixed(1)}k α`;
+  if (magnitude >= 1) return `${whole.toFixed(2)} α`;
+  if (whole === 0) return "0 α";
+  return `${whole.toFixed(4)} α`;
+}
+
+/**
+ * Live per-subnet ownership-contest leaderboard (#6638, frontend companion
+ * #6715): who currently holds the most rolled conviction on this subnet --
+ * i.e. how close it is to an automatic ownership flip. See
+ * docs/conviction-lock-mechanism.md for the on-chain mechanism this rolls
+ * forward from. Most subnets have no active challengers, so an empty
+ * leaderboard is the common case, rendered as an EmptyState, not an error.
+ */
+export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
+  const { data: res, isLoading, isError, error, refetch } = useQuery(subnetConvictionQuery(netuid));
+  const data = res?.data;
+
+  if (isError) {
+    return <ErrorState error={error} onRetry={() => refetch()} context="subnet conviction" />;
+  }
+
+  if (isLoading) {
+    return <Skeleton className="h-40 w-full" />;
+  }
+
+  const leaderboard = data?.leaderboard ?? [];
+
+  if (leaderboard.length === 0) {
+    return (
+      <EmptyState
+        title="No active challengers"
+        description="Conviction leaderboard entries appear once an account locks alpha to build conviction on this subnet -- most subnets have none at any given time."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {data?.queried_at_block != null ? (
+        <p className="font-mono text-[11px] text-ink-muted">
+          Rolled forward to block #{formatNumber(data.queried_at_block)}
+          {data.unlock_rate != null ? ` · unlock_rate ${formatNumber(data.unlock_rate)}` : ""}
+          {data.maturity_rate != null ? ` · maturity_rate ${formatNumber(data.maturity_rate)}` : ""}
+        </p>
+      ) : null}
+      <div className="rounded-xl border border-border bg-card overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-surface/40">
+              <tr>
+                <th className="px-4 py-2.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  Hotkey
+                </th>
+                <th className="px-4 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  Locked mass
+                </th>
+                <th className="px-4 py-2.5 text-right font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                  Conviction
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {leaderboard.map((entry) => {
+                const isKing = data?.king != null && entry.hotkey === data.king;
+                return (
+                  <tr key={entry.hotkey} className="mg-row-accent hover:bg-surface/40">
+                    <td className="px-4 py-2.5">
+                      <div className="flex items-center gap-2">
+                        {isKing ? (
+                          <Crown
+                            aria-label="Top-ranked (king)"
+                            className="size-3.5 shrink-0 text-health-warn"
+                          />
+                        ) : null}
+                        <CopyableCode value={entry.hotkey} className="max-w-full" />
+                        {entry.is_owner ? (
+                          <span
+                            className={classNames(
+                              "shrink-0 rounded border border-border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted",
+                            )}
+                          >
+                            owner
+                          </span>
+                        ) : null}
+                      </div>
+                    </td>
+                    <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                      {fmtAlpha(entry.locked_mass)}
+                    </td>
+                    <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                      {fmtAlpha(entry.conviction)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/subnet-ownership-history.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-ownership-history.tsx
@@ -1,0 +1,78 @@
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight } from "lucide-react";
+import { subnetOwnershipHistoryQuery } from "@/lib/metagraphed/queries";
+import { CopyableCode, TimeAgo } from "@jsonbored/ui-kit";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { formatNumber } from "@/lib/metagraphed/format";
+
+/**
+ * Ownership-change history for one subnet (#6637, frontend companion #6715):
+ * every automatic ownership transfer decoded from the chain_events
+ * SubnetOwnerChanged stream, oldest first. See
+ * docs/conviction-lock-mechanism.md -- transfers happen automatically once a
+ * challenger's rolled conviction overtakes the incumbent owner's, no vote
+ * required. A subnet that has never changed hands is the common case,
+ * rendered as an EmptyState, not an error.
+ */
+export function SubnetOwnershipHistory({ netuid }: { netuid: number }) {
+  const {
+    data: res,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(subnetOwnershipHistoryQuery(netuid));
+  const data = res?.data;
+
+  if (isError) {
+    return (
+      <ErrorState error={error} onRetry={() => refetch()} context="subnet ownership history" />
+    );
+  }
+
+  if (isLoading) {
+    return <Skeleton className="h-32 w-full" />;
+  }
+
+  const changes = data?.ownership_changes ?? [];
+
+  if (changes.length === 0) {
+    return (
+      <EmptyState
+        title="Never changed hands"
+        description="This subnet has undergone no automatic ownership transfer since chain-events capture began -- the common case."
+      />
+    );
+  }
+
+  return (
+    <ol className="space-y-2">
+      {changes.map((change, i) => (
+        <li
+          key={`${change.block_number ?? i}-${change.new_coldkey ?? i}`}
+          className="rounded-lg border border-border bg-card p-3"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+              {change.old_coldkey ? (
+                <CopyableCode value={change.old_coldkey} className="max-w-full" />
+              ) : (
+                <span className="font-mono text-[11px] text-ink-muted">unknown</span>
+              )}
+              <ArrowRight aria-hidden className="size-3.5 shrink-0 text-ink-muted" />
+              {change.new_coldkey ? (
+                <CopyableCode value={change.new_coldkey} className="max-w-full" />
+              ) : (
+                <span className="font-mono text-[11px] text-ink-muted">unknown</span>
+              )}
+            </div>
+            <span className="shrink-0 font-mono text-[11px] text-ink-muted">
+              {change.block_number != null ? `block #${formatNumber(change.block_number)} · ` : ""}
+              {change.observed_at ? <TimeAgo at={change.observed_at} /> : "unknown time"}
+            </span>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.subnet-conviction.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-conviction.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import {
+  normalizeSubnetConviction,
+  normalizeSubnetConvictionEntry,
+  subnetConvictionQuery,
+} from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/conviction",
+  });
+}
+
+// Mirrors queries.subnet-ohlc.test.ts's own runQuery helper.
+function runQuery<
+  O extends {
+    queryKey: readonly unknown[];
+    queryFn?: (context: never) => unknown;
+  },
+>(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
+}
+
+const RAW_ENTRY = {
+  hotkey: "5Hot1",
+  is_owner: true,
+  locked_mass: 12_801_009_134,
+  conviction: 12_800_000_000,
+};
+
+describe("normalizeSubnetConvictionEntry", () => {
+  it("passes a well-formed entry through", () => {
+    expect(normalizeSubnetConvictionEntry(RAW_ENTRY)).toEqual(RAW_ENTRY);
+  });
+
+  it("returns null for a non-object row", () => {
+    for (const raw of [null, undefined, 42, "x", []]) {
+      expect(normalizeSubnetConvictionEntry(raw)).toBeNull();
+    }
+  });
+
+  it("returns null when hotkey is missing", () => {
+    expect(normalizeSubnetConvictionEntry({ ...RAW_ENTRY, hotkey: undefined })).toBeNull();
+    expect(normalizeSubnetConvictionEntry({ ...RAW_ENTRY, hotkey: "" })).toBeNull();
+  });
+
+  it("coerces junk numeric fields to 0 and non-true is_owner to false", () => {
+    const entry = normalizeSubnetConvictionEntry({
+      hotkey: "5Hot1",
+      is_owner: "yes",
+      locked_mass: "not-a-number",
+      conviction: undefined,
+    });
+    expect(entry).toEqual({ hotkey: "5Hot1", is_owner: false, locked_mass: 0, conviction: 0 });
+  });
+});
+
+describe("normalizeSubnetConviction", () => {
+  it("passes a well-formed response through", () => {
+    const raw = {
+      schema_version: 1,
+      netuid: 7,
+      queried_at_block: 8_647_000,
+      unlock_rate: 934_866,
+      maturity_rate: 311_622,
+      king: "5Hot1",
+      count: 1,
+      leaderboard: [RAW_ENTRY],
+    };
+    expect(normalizeSubnetConviction(7, raw)).toEqual(raw);
+  });
+
+  it("degrades cold / junk input to a schema-stable empty leaderboard", () => {
+    for (const raw of [{}, null, undefined, "not-an-object"]) {
+      const data = normalizeSubnetConviction(7, raw);
+      expect(data.netuid).toBe(7);
+      expect(data.schema_version).toBe(1);
+      expect(data.queried_at_block).toBeNull();
+      expect(data.unlock_rate).toBeNull();
+      expect(data.maturity_rate).toBeNull();
+      expect(data.king).toBeNull();
+      expect(data.count).toBe(0);
+      expect(data.leaderboard).toEqual([]);
+    }
+  });
+
+  it("drops a malformed leaderboard entry without dropping the rest of the batch", () => {
+    const data = normalizeSubnetConviction(7, {
+      leaderboard: [RAW_ENTRY, { hotkey: "" }, { ...RAW_ENTRY, hotkey: "5Hot2" }],
+    });
+    expect(data.leaderboard).toHaveLength(2);
+  });
+
+  it("falls back to the requested netuid when the server omits it", () => {
+    const data = normalizeSubnetConviction(12, {});
+    expect(data.netuid).toBe(12);
+  });
+});
+
+describe("subnetConvictionQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits its route", async () => {
+    resolveWith({ netuid: 7, leaderboard: [] });
+    const res = await runQuery(subnetConvictionQuery(7));
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/conviction",
+      expect.objectContaining({}),
+    );
+    expect(res.data.netuid).toBe(7);
+  });
+
+  it("normalizes the response through normalizeSubnetConviction", async () => {
+    resolveWith({ leaderboard: [RAW_ENTRY], king: "5Hot1" });
+    const res = await runQuery(subnetConvictionQuery(7));
+    expect(res.data.leaderboard).toEqual([RAW_ENTRY]);
+    expect(res.data.king).toBe("5Hot1");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.subnet-ownership-history.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.subnet-ownership-history.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import {
+  normalizeSubnetOwnershipChange,
+  normalizeSubnetOwnershipHistory,
+  subnetOwnershipHistoryQuery,
+} from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/subnets/7/ownership-history",
+  });
+}
+
+// Mirrors queries.subnet-ohlc.test.ts's own runQuery helper.
+function runQuery<
+  O extends {
+    queryKey: readonly unknown[];
+    queryFn?: (context: never) => unknown;
+  },
+>(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
+}
+
+const RAW_CHANGE = {
+  netuid: 7,
+  old_coldkey: "5Old1",
+  new_coldkey: "5New1",
+  block_number: 8_600_000,
+  observed_at: "2026-07-01T00:00:00.000Z",
+};
+
+describe("normalizeSubnetOwnershipChange", () => {
+  it("passes a well-formed change through", () => {
+    expect(normalizeSubnetOwnershipChange(RAW_CHANGE)).toEqual(RAW_CHANGE);
+  });
+
+  it("returns null for a non-object row", () => {
+    for (const raw of [null, undefined, 42, "x", []]) {
+      expect(normalizeSubnetOwnershipChange(raw)).toBeNull();
+    }
+  });
+
+  it("returns null when old_coldkey, new_coldkey, and block_number are all absent", () => {
+    expect(normalizeSubnetOwnershipChange({ netuid: 7 })).toBeNull();
+  });
+
+  it("keeps a row with at least one identifying field, nulling the rest", () => {
+    const change = normalizeSubnetOwnershipChange({ block_number: 100 });
+    expect(change).toEqual({
+      netuid: null,
+      old_coldkey: null,
+      new_coldkey: null,
+      block_number: 100,
+      observed_at: null,
+    });
+  });
+});
+
+describe("normalizeSubnetOwnershipHistory", () => {
+  it("passes a well-formed response through", () => {
+    const raw = {
+      schema_version: 1,
+      netuid: 7,
+      event_pallet: "SubtensorModule",
+      event_method: "SubnetOwnerChanged",
+      count: 1,
+      ownership_changes: [RAW_CHANGE],
+    };
+    expect(normalizeSubnetOwnershipHistory(7, raw)).toEqual(raw);
+  });
+
+  it("degrades cold / junk input to a schema-stable empty history", () => {
+    for (const raw of [{}, null, undefined, "not-an-object"]) {
+      const data = normalizeSubnetOwnershipHistory(7, raw);
+      expect(data.netuid).toBe(7);
+      expect(data.schema_version).toBe(1);
+      expect(data.event_pallet).toBe("SubtensorModule");
+      expect(data.event_method).toBe("SubnetOwnerChanged");
+      expect(data.count).toBe(0);
+      expect(data.ownership_changes).toEqual([]);
+    }
+  });
+
+  it("drops a malformed change without dropping the rest of the batch", () => {
+    const data = normalizeSubnetOwnershipHistory(7, {
+      ownership_changes: [RAW_CHANGE, {}, { ...RAW_CHANGE, block_number: 8_600_001 }],
+    });
+    expect(data.ownership_changes).toHaveLength(2);
+  });
+
+  it("falls back to the requested netuid when the server omits it", () => {
+    const data = normalizeSubnetOwnershipHistory(12, {});
+    expect(data.netuid).toBe(12);
+  });
+});
+
+describe("subnetOwnershipHistoryQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits its route", async () => {
+    resolveWith({ netuid: 7, ownership_changes: [] });
+    const res = await runQuery(subnetOwnershipHistoryQuery(7));
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/subnets/7/ownership-history",
+      expect.objectContaining({}),
+    );
+    expect(res.data.netuid).toBe(7);
+  });
+
+  it("normalizes the response through normalizeSubnetOwnershipHistory", async () => {
+    resolveWith({ ownership_changes: [RAW_CHANGE] });
+    const res = await runQuery(subnetOwnershipHistoryQuery(7));
+    expect(res.data.ownership_changes).toEqual([RAW_CHANGE]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -200,6 +200,10 @@ import type {
   SubnetAlphaVolume,
   SubnetOhlc,
   SubnetOhlcCandle,
+  SubnetConviction,
+  SubnetConvictionEntry,
+  SubnetOwnershipHistory,
+  SubnetOwnershipChange,
   SubnetMovers,
   SubnetMover,
   MetagraphNeuron,
@@ -4705,6 +4709,116 @@ export const subnetOhlcQuery = (netuid: number, params: SubnetOhlcParams = {}) =
     staleTime: STALE_MED,
   });
 };
+
+// A well-formed leaderboard entry, or null to drop a malformed row rather
+// than poisoning the whole leaderboard -- mirrors normalizeSubnetOhlcCandle.
+export function normalizeSubnetConvictionEntry(raw: unknown): SubnetConvictionEntry | null {
+  if (!isRecord(raw)) return null;
+  const hotkey = firstString(raw.hotkey);
+  if (!hotkey) return null;
+  return {
+    hotkey,
+    is_owner: raw.is_owner === true,
+    locked_mass: coerceFiniteNumber(raw.locked_mass) ?? 0,
+    conviction: coerceFiniteNumber(raw.conviction) ?? 0,
+  };
+}
+
+// Cold/absent store or a subnet with no active challengers both yield a
+// schema-stable empty leaderboard -- never throws, matching the OHLC/volume
+// live-tier convention.
+export function normalizeSubnetConviction(netuid: number, raw: unknown): SubnetConviction {
+  const d = isRecord(raw) ? raw : {};
+  const leaderboard = Array.isArray(d.leaderboard)
+    ? d.leaderboard
+        .map(normalizeSubnetConvictionEntry)
+        .filter((e): e is SubnetConvictionEntry => e != null)
+    : [];
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    netuid: firstFiniteNumber(d.netuid) ?? netuid,
+    queried_at_block: firstFiniteNumber(d.queried_at_block) ?? null,
+    unlock_rate: firstFiniteNumber(d.unlock_rate) ?? null,
+    maturity_rate: firstFiniteNumber(d.maturity_rate) ?? null,
+    king: firstString(d.king) ?? null,
+    count: firstFiniteNumber(d.count) ?? leaderboard.length,
+    leaderboard,
+  };
+}
+
+// GET /api/v1/subnets/{netuid}/conviction (#6638): live ownership-contest
+// leaderboard, rolled forward to query time using the current governance
+// UnlockRate/MaturityRate. Most subnets have no active challengers, so an
+// empty leaderboard is the common case, not an error.
+export const subnetConvictionQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-conviction", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetConviction>>(
+        `/api/v1/subnets/${netuid}/conviction`,
+        { signal },
+      );
+      return { data: normalizeSubnetConviction(netuid, res.data), meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
+// A well-formed ownership-change row, or null to drop a malformed row rather
+// than poisoning the whole history -- mirrors normalizeSubnetOhlcCandle.
+export function normalizeSubnetOwnershipChange(raw: unknown): SubnetOwnershipChange | null {
+  if (!isRecord(raw)) return null;
+  if (raw.old_coldkey == null && raw.new_coldkey == null && raw.block_number == null) return null;
+  return {
+    netuid: firstFiniteNumber(raw.netuid) ?? null,
+    old_coldkey: firstString(raw.old_coldkey) ?? null,
+    new_coldkey: firstString(raw.new_coldkey) ?? null,
+    block_number: firstFiniteNumber(raw.block_number) ?? null,
+    observed_at: firstString(raw.observed_at) ?? null,
+  };
+}
+
+// Cold/absent store or a subnet that has never changed hands both yield a
+// schema-stable empty history -- never throws, matching the OHLC/volume
+// live-tier convention.
+export function normalizeSubnetOwnershipHistory(
+  netuid: number,
+  raw: unknown,
+): SubnetOwnershipHistory {
+  const d = isRecord(raw) ? raw : {};
+  const changes = Array.isArray(d.ownership_changes)
+    ? d.ownership_changes
+        .map(normalizeSubnetOwnershipChange)
+        .filter((c): c is SubnetOwnershipChange => c != null)
+    : [];
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    netuid: firstFiniteNumber(d.netuid) ?? netuid,
+    event_pallet: firstString(d.event_pallet) ?? "SubtensorModule",
+    event_method: firstString(d.event_method) ?? "SubnetOwnerChanged",
+    count: firstFiniteNumber(d.count) ?? changes.length,
+    ownership_changes: changes,
+  };
+}
+
+// GET /api/v1/subnets/{netuid}/ownership-history (#6637): every automatic
+// ownership transfer this subnet has undergone, oldest first. A subnet that
+// has never changed hands is the common case, not an error.
+export const subnetOwnershipHistoryQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-ownership-history", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<SubnetOwnershipHistory>>(
+        `/api/v1/subnets/${netuid}/ownership-history`,
+        { signal },
+      );
+      return {
+        data: normalizeSubnetOwnershipHistory(netuid, res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
 
 export interface SubnetEventsParams {
   /** Filter to one event_kind (e.g. "StakeAdded"). */

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1933,6 +1933,56 @@ export interface SubnetOhlc {
   root_excluded: boolean;
 }
 
+/** One hotkey's current standing in a subnet's ownership contest (#6638),
+ * rolled forward to the query time. locked_mass/conviction are raw alpha
+ * units (rao-scale, /1e9 for whole alpha) -- conviction is the exponentially
+ * smoothed integral of locked_mass, what actually determines the contest. */
+export interface SubnetConvictionEntry {
+  hotkey: string;
+  is_owner: boolean;
+  locked_mass: number;
+  conviction: number;
+}
+
+/** Live per-subnet ownership-contest leaderboard from
+ * /api/v1/subnets/{netuid}/conviction (#6638). king is the top-ranked
+ * hotkey by rolled conviction (or null if the leaderboard is empty -- most
+ * subnets have no active challengers). unlock_rate/maturity_rate are the
+ * live governance values the roll-forward used, never a hardcoded figure. */
+export interface SubnetConviction {
+  schema_version: number;
+  netuid: number;
+  queried_at_block: number | null;
+  unlock_rate: number | null;
+  maturity_rate: number | null;
+  king: string | null;
+  count: number;
+  leaderboard: SubnetConvictionEntry[];
+}
+
+/** One automatic ownership transfer, decoded from a chain_events
+ * SubnetOwnerChanged row (#6637). old_coldkey/new_coldkey are SS58-encoded. */
+export interface SubnetOwnershipChange {
+  netuid: number | null;
+  old_coldkey: string | null;
+  new_coldkey: string | null;
+  block_number: number | null;
+  observed_at: string | null;
+}
+
+/** Every automatic ownership transfer one subnet has undergone, from
+ * /api/v1/subnets/{netuid}/ownership-history (#6637). A subnet that has
+ * never changed hands returns an empty list, not an error -- the common
+ * case, per docs/conviction-lock-mechanism.md's permissionless contest. */
+export interface SubnetOwnershipHistory {
+  schema_version: number;
+  netuid: number;
+  event_pallet: string;
+  event_method: string;
+  count: number;
+  ownership_changes: SubnetOwnershipChange[];
+}
+
 /** One subnet's movement over the comparison window on the /subnets/movers board. */
 export interface SubnetMover {
   netuid: number;

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -53,6 +53,8 @@ import { EconomicsPanel } from "@/components/metagraphed/economics-panel";
 import { EndpointSnippet, apiSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { SubnetHistoryChart } from "@/components/metagraphed/subnet-history-chart";
 import { SubnetOhlcChart } from "@/components/metagraphed/subnet-ohlc-chart";
+import { SubnetConvictionLeaderboard } from "@/components/metagraphed/subnet-conviction-leaderboard";
+import { SubnetOwnershipHistory } from "@/components/metagraphed/subnet-ownership-history";
 import { MetagraphTableLoader } from "@/components/metagraphed/metagraph-panel";
 import { ValidatorsTableLoader } from "@/components/metagraphed/validators-panel";
 import { DistributionPanel } from "@/components/metagraphed/concentration-panel";
@@ -501,6 +503,36 @@ function OverviewPanel({ netuid, profile }: { netuid: number; profile?: SubnetPr
         info="GET /api/v1/subnets/{netuid}/stake-quote?amount=&direction=stake|unstake — a read-only constant-product AMM estimate against the subnet's live pool reserves. Pure math, no chain write, no custody."
       >
         <StakeQuoteCalculator netuid={netuid} />
+      </SectionAnchor>
+
+      {/* 5a4 — Conviction leaderboard (#6638, frontend companion #6715, part
+          of the ownership-contest tracker epic #4302): who currently holds
+          the most rolled conviction on this subnet -- the dynamic extension
+          of SubnetProfilePanel's static "Ownership" block above. */}
+      <SectionAnchor
+        id="conviction"
+        title="Ownership contest"
+        subtitle="Who currently holds the most rolled conviction -- how close this subnet is to an automatic ownership flip."
+        info="GET /api/v1/subnets/{netuid}/conviction — rolled forward from the periodically-captured lock snapshot to query time, using the live UnlockRate/MaturityRate governance values. Most subnets have no active challengers."
+      >
+        <QueryErrorBoundary>
+          <SubnetConvictionLeaderboard netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      {/* 5a5 — Ownership-change history (#6637, frontend companion #6715,
+          part of the ownership-contest tracker epic #4302): every automatic
+          ownership transfer this subnet has undergone, decoded from the
+          chain_events SubnetOwnerChanged stream. */}
+      <SectionAnchor
+        id="ownership-history"
+        title="Ownership history"
+        subtitle="Every automatic ownership transfer this subnet has undergone."
+        info="GET /api/v1/subnets/{netuid}/ownership-history — decoded from the chain_events SubnetOwnerChanged stream. A subnet that has never changed hands returns an empty list, not an error."
+      >
+        <QueryErrorBoundary>
+          <SubnetOwnershipHistory netuid={netuid} />
+        </QueryErrorBoundary>
       </SectionAnchor>
 
       {/* 5b — On-chain network history (#1302): daily neuron/validator counts,


### PR DESCRIPTION
## Summary

Frontend companion to the already-shipped #6637 (ownership-history backfill) and #6638 (live
conviction leaderboard) backend routes, part of the ownership-contest tracker epic #4302. Both
routes shipped backend-only — this closes that gap, mirroring the OHLC epic's own
backend-then-frontend precedent (#5304 → #5655 → #5656).

## What changed

- `apps/ui/src/lib/metagraphed/types.ts`: `SubnetConviction`/`SubnetConvictionEntry` and
  `SubnetOwnershipHistory`/`SubnetOwnershipChange` types, mirroring `SubnetOhlc`.
- `apps/ui/src/lib/metagraphed/queries.ts`: normalize functions + `subnetConvictionQuery`/
  `subnetOwnershipHistoryQuery` hooks, mirroring `normalizeSubnetOhlc*`/`subnetOhlcQuery`.
- `apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx`: ranked table of
  hotkeys by rolled conviction (king badge, owner flag, locked_mass/conviction in alpha units).
- `apps/ui/src/components/metagraphed/subnet-ownership-history.tsx`: ownership-transfer timeline
  (old → new coldkey, block, timestamp).
- `apps/ui/src/routes/subnets.$netuid.tsx`: two new `SectionAnchor` sections ("Ownership contest",
  "Ownership history"), mounted after the stake-quote calculator.

Both follow `SubnetOhlcChart`'s established loading/error/empty-state conventions. Empty states
are the common case (most subnets have no active challengers / have never changed hands) and are
what the screenshots below show — verified live against production, see note below.

## Production bug found + fixed while verifying this

Verifying against the live API surfaced that `GET /api/v1/subnets/{netuid}/conviction` was
502ing in production (`data_query_failed`) for every subnet. Root cause: the `subnet_locks`
table `deploy/postgres/schema.sql` added for #6638 was committed to the repo but never applied
to the live database. Fixed directly (additive `CREATE TABLE IF NOT EXISTS` + index, zero risk
to existing data) — the route now returns `200` with a schema-stable empty leaderboard. The
periodic `fetch-subnet-locks.py` collector that populates real leaderboard rows still needs its
box-side systemd timer deployed via the Ansible `data-refresh-cron` role (mirrors
`subnet-hyperparams`/`self-stake`) — that's infra-repo work, tracked as a known follow-up, not
part of this PR.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6715-conviction-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npx vitest run` — 159 files / 1188 tests passed (apps/ui full suite)
- `npm run typecheck` — clean
- `npx eslint <changed files>` — clean
- `npm run format:check` — clean
- `npx playwright test tests/e2e/responsive-overflow.spec.ts -g "/subnets/1"` — 4/4 passed, no new overflow regressions
- `npm run build` — clean
- `node tests/e2e/capture-pr-screenshots.mjs --route /subnets/7 --section conviction --fallback-section stake-quote` — before/after screenshot matrix (below)

Closes #6715
