### PR TITLE
fix(ui): shape the Suspense fallbacks for BlockProductionHeader and the leaderboards (#6388)

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -111,7 +111,19 @@ function BlocksPage() {
         </Suspense>
       </QueryErrorBoundary>
       <QueryErrorBoundary>
-        <Suspense fallback={<Skeleton className="h-28 w-full mb-8" />}>
+        <Suspense
+          fallback={
+            // Shaped to BlockProductionHeader's own 3-tile grid (#6388), matching
+            // subnets.index.tsx's tile-skeleton convention -- a single flat box
+            // here visibly jumps in height/columns once the real 2/3-col grid
+            // of StatTiles resolves.
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
+              <Skeleton className="h-20" />
+              <Skeleton className="h-20" />
+              <Skeleton className="h-20" />
+            </div>
+          }
+        >
           <BlockProductionHeader />
         </Suspense>
       </QueryErrorBoundary>

--- a/apps/ui/src/routes/leaderboards.tsx
+++ b/apps/ui/src/routes/leaderboards.tsx
@@ -60,6 +60,28 @@ const WINDOW_BTN_ACTIVE =
 const WINDOW_BTN =
   "rounded-full border border-border bg-card px-3 py-1 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:border-ink/30";
 
+// Shaped to each board's own layout -- title, one description line, the
+// 3-tile StatTile row, and a table-shaped placeholder -- so the loading
+// state doesn't visibly jump in height/columns once the real content
+// resolves (#6388). All three boards on this route share this exact shape,
+// so one skeleton covers all three Suspense fallbacks.
+function LeaderboardSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div>
+        <Skeleton className="h-3 w-48 mb-2" />
+        <Skeleton className="h-4 w-full max-w-lg" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
+      </div>
+      <Skeleton className="h-64 w-full" />
+    </div>
+  );
+}
+
 // Every board on this route ranks the same 7d/30d window, so the window control lives at the page
 // level and governs both sections rather than each board owning a duplicate toggle.
 function LeaderboardsPage() {
@@ -107,17 +129,17 @@ function LeaderboardsPage() {
       </div>
       <div className="space-y-12">
         <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
+          <Suspense fallback={<LeaderboardSkeleton />}>
             <WeightSettingLeaderboard win={win} />
           </Suspense>
         </QueryErrorBoundary>
         <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
+          <Suspense fallback={<LeaderboardSkeleton />}>
             <DeregistrationsLeaderboard win={win} />
           </Suspense>
         </QueryErrorBoundary>
         <QueryErrorBoundary>
-          <Suspense fallback={<Skeleton className="h-[32rem] w-full" />}>
+          <Suspense fallback={<LeaderboardSkeleton />}>
             <EmissionsLeaderboard />
           </Suspense>
         </QueryErrorBoundary>


### PR DESCRIPTION
Closes #6388

## Problem

`blocks.index.tsx`'s `BlockProductionHeader` (a `grid grid-cols-2 md:grid-cols-3` of 3 `StatTile`s) sits behind a single flat `<Skeleton className="h-28 w-full mb-8" />`. `leaderboards.tsx`'s three boards each render an identical title + description + 3-tile `StatTile` row + ranked table, but all three sit behind an identical flat `<Skeleton className="h-[32rem] w-full" />`. Both visibly jump in height/column count once the real content resolves — unlike the established grid-shaped-tile skeleton convention used elsewhere (`subnets.index.tsx`, `endpoints.tsx`, `accounts.$ss58.tsx`'s `DetailSkeleton`).

## Fix

- `blocks.index.tsx`: `BlockProductionHeader`'s fallback now mirrors its own `grid-cols-2 md:grid-cols-3` 3-tile grid instead of one flat box.
- `leaderboards.tsx`: added a shared `LeaderboardSkeleton` (title line + description line + 3-tile `StatTile` row + a table-shaped placeholder) reused by all three boards' `Suspense` fallbacks, replacing three identical flat `h-[32rem]` boxes.

## Screenshots

Both routes' loading states, captured via a delayed-fetch + client-side-navigation technique (both routes SSR-resolve their data before any HTML reaches the browser on a hard page load, so `useSuspenseQuery` only visibly suspends on a fresh in-browser fetch). `/leaderboards` has no in-app nav link, so the client-side transition was driven via the exposed TanStack Router instance (`window.__TSR_ROUTER__.navigate`) rather than clicking a menu item.

### `/blocks`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-blocks-after-mobile-dark.png)<br><sub>after</sub> |

### `/leaderboards`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6388-leaderboards-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

- `npx tsc --noEmit -p apps/ui`: clean
- `npx prettier --check` / `npx eslint` on changed files: clean (no new warnings)
- `npx vitest run` (apps/ui): 157 test files, 1168 tests, all passing
- Manually verified in browser: forced the loading state via delayed network + client-side nav on both routes, confirmed the shaped skeletons render and loaded content is unchanged