### PR TITLE
feat(indexer): capture subnet-leasing and crowdloan events

### DIFF
--- a/apps/indexer-rs/src/main.rs
+++ b/apps/indexer-rs/src/main.rs
@@ -827,6 +827,80 @@ fn extract(kind: &str, f: &[&Value<()>]) -> Option<Ext> {
             amount_tao: nth(f, 0).and_then(tao_str),
             ..none
         }),
+        // --- subnet leasing (#6718, pallet_subtensor::subnets::leasing) + the standalone
+        // Crowdloan pallet it's built on (per opentensor/subtensor's leasing.rs / crowdloan
+        // pallet's lib.rs, verified against live source 2026-07-18). A crowdfunded,
+        // time-boxed primary market for NEW subnets -- distinct from the
+        // already-curated subnet-ownership-CONTEST events (an existing subnet changing
+        // hands), which this doesn't touch.
+
+        // SubnetLeaseCreated { beneficiary, lease_id, netuid, end_block } —
+        //   a0=beneficiary (coldkey), a2=netuid. lease_id (a1) and end_block (a3,
+        //   Option<BlockNumber>) not curated (no dedicated column).
+        "SubnetLeaseCreated" => {
+            if f.len() < 3 {
+                return None;
+            }
+            Some(Ext {
+                coldkey: acct(f[0]),
+                netuid: nth(f, 2).and_then(idx_of),
+                ..none
+            })
+        }
+        // SubnetLeaseTerminated { beneficiary, netuid } — a0=beneficiary (coldkey), a1=netuid.
+        "SubnetLeaseTerminated" => {
+            if f.len() < 2 {
+                return None;
+            }
+            Some(Ext {
+                coldkey: acct(f[0]),
+                netuid: nth(f, 1).and_then(idx_of),
+                ..none
+            })
+        }
+        // SubnetLeaseDividendsDistributed { lease_id, contributor, alpha } —
+        //   a1=contributor (coldkey), a2=alpha (alpha_amount). lease_id (a0) not curated;
+        //   no netuid on this event directly -- resolving lease_id -> netuid needs a live
+        //   SubnetUidToLeaseId storage lookup, which this positional-only decoder
+        //   deliberately never does (same reasoning StakeSwapped/StakeTransferred already
+        //   apply to their own not-fully-curated fields).
+        "SubnetLeaseDividendsDistributed" => {
+            if f.len() < 3 {
+                return None;
+            }
+            Some(Ext {
+                coldkey: acct(f[1]),
+                alpha_amount: tao_str(f[2]),
+                ..none
+            })
+        }
+        // Crowdloan.Contributed { crowdloan_id, contributor, amount } —
+        //   a1=contributor (coldkey), a2=amount (TAO). crowdloan_id (a0) not curated (no
+        //   netuid equivalent -- a crowdloan can target a not-yet-created subnet). Deliberately
+        //   NOT curating Crowdloan.Created here: it declares a cap/end, no tao actually moves
+        //   until a Contributed follows, so there's no amount to attribute to an account yet.
+        "Contributed" => {
+            if f.len() < 3 {
+                return None;
+            }
+            Some(Ext {
+                coldkey: acct(f[1]),
+                amount_tao: tao_str(f[2]),
+                ..none
+            })
+        }
+        // Crowdloan.Withdrew { crowdloan_id, contributor, amount } — same shape as Contributed
+        // (a contributor pulling their own funds back before finalization).
+        "Withdrew" => {
+            if f.len() < 3 {
+                return None;
+            }
+            Some(Ext {
+                coldkey: acct(f[1]),
+                amount_tao: tao_str(f[2]),
+                ..none
+            })
+        }
         _ => None,
     }
 }
@@ -1044,7 +1118,9 @@ async fn decode_block(api: &Api, height: u64, head: u64) -> Result<DecodedBlock>
     // --- account_events rows (py event_rows_for_events / decode_head)
     let mut event_rows = Vec::new();
     for e in &decoded_events {
-        if e.pallet != "SubtensorModule" && e.pallet != "Balances" {
+        // Crowdloan (#6718): a standalone pallet (pallets/crowdloan/src/lib.rs), not a
+        // SubtensorModule submodule like subnet leasing -- needs its own name here.
+        if e.pallet != "SubtensorModule" && e.pallet != "Balances" && e.pallet != "Crowdloan" {
             continue;
         }
         let f = ordered_fields(&e.fields);
@@ -2153,5 +2229,116 @@ mod netuid_plausibility_tests {
         let revealed = extract("CRV3WeightsRevealed", &revealed_fields)
             .expect("CRV3WeightsRevealed always decodes with >= 2 fields");
         assert_eq!(revealed.netuid, None);
+    }
+}
+
+#[cfg(test)]
+mod subnet_leasing_and_crowdloan_tests {
+    use super::*;
+
+    fn prim_u128(n: u128) -> Value<()> {
+        Value {
+            value: ValueDef::Primitive(Primitive::U128(n)),
+            context: (),
+        }
+    }
+
+    // AccountId32 = newtype over [u8;32] -> Unnamed([ Unnamed([u8;32]) ]), matching
+    // netuid_plausibility_tests' own account_value helper.
+    fn account_value(byte0: u8) -> Value<()> {
+        let mut bytes = vec![prim_u128(byte0 as u128)];
+        bytes.extend((1..32).map(|_| prim_u128(0)));
+        Value {
+            value: ValueDef::Composite(Composite::Unnamed(vec![Value {
+                value: ValueDef::Composite(Composite::Unnamed(bytes)),
+                context: (),
+            }])),
+            context: (),
+        }
+    }
+
+    #[test]
+    fn subnet_lease_created_curates_beneficiary_and_netuid() {
+        let beneficiary = account_value(0x11);
+        let lease_id = prim_u128(7);
+        let netuid = prim_u128(42);
+        let fields: Vec<&Value<()>> = vec![&beneficiary, &lease_id, &netuid];
+        let ext = extract("SubnetLeaseCreated", &fields)
+            .expect("SubnetLeaseCreated always decodes with >= 3 fields");
+        assert!(ext.coldkey.is_some());
+        assert_eq!(ext.netuid, Some(42));
+        assert_eq!(ext.amount_tao, None);
+    }
+
+    #[test]
+    fn subnet_lease_terminated_curates_beneficiary_and_netuid() {
+        let beneficiary = account_value(0x22);
+        let netuid = prim_u128(9);
+        let fields: Vec<&Value<()>> = vec![&beneficiary, &netuid];
+        let ext = extract("SubnetLeaseTerminated", &fields)
+            .expect("SubnetLeaseTerminated always decodes with >= 2 fields");
+        assert!(ext.coldkey.is_some());
+        assert_eq!(ext.netuid, Some(9));
+    }
+
+    #[test]
+    fn subnet_lease_dividends_distributed_curates_contributor_and_alpha_not_netuid() {
+        let lease_id = prim_u128(3);
+        let contributor = account_value(0x33);
+        // 1.5 alpha in rao-equivalent units, matching tao_str's fixed-point convention.
+        let alpha = prim_u128(1_500_000_000);
+        let fields: Vec<&Value<()>> = vec![&lease_id, &contributor, &alpha];
+        let ext = extract("SubnetLeaseDividendsDistributed", &fields)
+            .expect("SubnetLeaseDividendsDistributed always decodes with >= 3 fields");
+        assert!(ext.coldkey.is_some());
+        assert_eq!(ext.alpha_amount, Some("1.5".to_string()));
+        assert_eq!(ext.netuid, None);
+    }
+
+    #[test]
+    fn crowdloan_contributed_curates_contributor_and_amount_not_crowdloan_id() {
+        let crowdloan_id = prim_u128(1);
+        let contributor = account_value(0x44);
+        let amount = prim_u128(10_000_000_000); // 10 TAO
+        let fields: Vec<&Value<()>> = vec![&crowdloan_id, &contributor, &amount];
+        let ext =
+            extract("Contributed", &fields).expect("Contributed always decodes with >= 3 fields");
+        assert!(ext.coldkey.is_some());
+        assert_eq!(ext.amount_tao, Some("10".to_string()));
+        assert_eq!(ext.netuid, None);
+    }
+
+    #[test]
+    fn crowdloan_withdrew_curates_contributor_and_amount() {
+        let crowdloan_id = prim_u128(1);
+        let contributor = account_value(0x55);
+        let amount = prim_u128(2_500_000_000); // 2.5 TAO
+        let fields: Vec<&Value<()>> = vec![&crowdloan_id, &contributor, &amount];
+        let ext = extract("Withdrew", &fields).expect("Withdrew always decodes with >= 3 fields");
+        assert!(ext.coldkey.is_some());
+        assert_eq!(ext.amount_tao, Some("2.5".to_string()));
+    }
+
+    #[test]
+    fn crowdloan_created_is_not_curated_into_account_events() {
+        // Created only declares a cap/end -- no tao has moved yet, so there's
+        // nothing to attribute to an account. Confirms the deliberate omission
+        // documented on extract()'s Crowdloan.Contributed arm.
+        let crowdloan_id = prim_u128(1);
+        let creator = account_value(0x66);
+        let end = prim_u128(9_000_000);
+        let cap = prim_u128(50_000_000_000);
+        let fields: Vec<&Value<()>> = vec![&crowdloan_id, &creator, &end, &cap];
+        assert!(extract("Created", &fields).is_none());
+    }
+
+    #[test]
+    fn underfilled_fields_return_none_not_a_panic() {
+        let only_one = account_value(0x77);
+        let fields: Vec<&Value<()>> = vec![&only_one];
+        assert!(extract("SubnetLeaseCreated", &fields).is_none());
+        assert!(extract("SubnetLeaseDividendsDistributed", &fields).is_none());
+        assert!(extract("Contributed", &fields).is_none());
+        assert!(extract("Withdrew", &fields).is_none());
     }
 }

--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -248,8 +248,17 @@ const patterns = [
     // (coldkey/netuid, per-hotkey/per-coldkey) or followed by an explanatory
     // parenthetical (stored in coldkey (the account...)) -- both common in
     // Rust/SQL comments describing the data model, not suspicious wording.
+    //
+    // Extended again (#6718): Rust's OWN field-access + method-call syntax
+    // (ext.coldkey.is_some(), .coldkey.clone(), .coldkey.unwrap()) wasn't
+    // covered by the coldkey?. optional-chaining case above -- that's TS/JS
+    // syntax specifically, and Rust has no `?.` operator, so every Option-field
+    // check on a real Ext/EventRow struct in apps/indexer-rs's own test code
+    // (an extremely common idiom, not a one-off) false-positived. `coldkey\.` +
+    // a lowercase identifier + `(` matches the method-call shape without
+    // loosening the bare `\bcoldkey\b` trigger itself.
     allow:
-      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bcoldkey\?\.|\bhotkey(?:\s+or\s+|\s*\/\s*)coldkey\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*(?:=|!=|<>|IS\s+(?:NOT\s+)?NULL\b|IN\s*\()|\bcoldkey\s*(?:,|\)|\]|\}|;|`)|\bcoldkey\s+(?:ASC|DESC|AS\b|TEXT|VARCHAR|CHAR|INTEGER|BIGINT|NUMERIC|BOOLEAN)\b|'coldkey'|\bcoldkey\s*\/\s*[a-z_]+\b|\b[a-z_]+\s*\/\s*coldkey\b|\b[a-z]+-coldkey\b|\bcoldkey\s*\(/gi,
+      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bcoldkey\?\.|\bcoldkey\.[a-z_]+\(|\bhotkey(?:\s+or\s+|\s*\/\s*)coldkey\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*(?:=|!=|<>|IS\s+(?:NOT\s+)?NULL\b|IN\s*\()|\bcoldkey\s*(?:,|\)|\]|\}|;|`)|\bcoldkey\s+(?:ASC|DESC|AS\b|TEXT|VARCHAR|CHAR|INTEGER|BIGINT|NUMERIC|BOOLEAN)\b|'coldkey'|\bcoldkey\s*\/\s*[a-z_]+\b|\b[a-z_]+\s*\/\s*coldkey\b|\b[a-z]+-coldkey\b|\bcoldkey\s*\(/gi,
     soft: true,
   },
   {

--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -77,6 +77,16 @@ export const INGESTED_EVENT_KINDS = [
   "Endowed",
   "DustLost",
   "Issued",
+  // Subnet leasing (#6718, pallet_subtensor::subnets::leasing) + the standalone Crowdloan
+  // pallet it's built on -- a crowdfunded, time-boxed primary market for NEW subnets,
+  // distinct from SubnetOwnerHotkeySet (an existing subnet changing hands).
+  "SubnetLeaseCreated",
+  "SubnetLeaseTerminated",
+  "SubnetLeaseDividendsDistributed",
+  // Crowdloan.Created is deliberately excluded (matches indexer-rs's extract() -- it
+  // declares a cap/end with no tao moved yet, so there's no account amount to curate).
+  "Contributed",
+  "Withdrew",
 ];
 
 export const SUBNET_EVENT_SUMMARY_WINDOWS = { "7d": 7, "30d": 30, "90d": 90 };
@@ -123,6 +133,13 @@ const EVENT_KIND_CATEGORIES = {
   Endowed: "transfer",
   DustLost: "transfer",
   Issued: "transfer",
+  // Subnet leasing/crowdloan (#6718) -- same bucket as SubnetOwnerHotkeySet/BurnSet:
+  // who controls/creates a subnet is a governance-adjacent concern.
+  SubnetLeaseCreated: "governance",
+  SubnetLeaseTerminated: "governance",
+  SubnetLeaseDividendsDistributed: "governance",
+  Contributed: "governance",
+  Withdrew: "governance",
 };
 
 function toIso(ms) {

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -84,6 +84,44 @@ test("INGESTED_EVENT_KINDS accepts the kinds found by the 2026-07-14/15 exhausti
   }
 });
 
+test("INGESTED_EVENT_KINDS accepts subnet leasing + crowdloan kinds (#6718)", () => {
+  for (const kind of [
+    "SubnetLeaseCreated",
+    "SubnetLeaseTerminated",
+    "SubnetLeaseDividendsDistributed",
+    "Contributed",
+    "Withdrew",
+  ]) {
+    assert.ok(INGESTED_EVENT_KINDS.includes(kind), `missing ${kind}`);
+  }
+});
+
+test("buildSubnetEventSummary categorizes subnet leasing + crowdloan kinds as governance, not other (#6718)", () => {
+  const out = buildSubnetEventSummary(
+    [
+      { event_kind: "SubnetLeaseCreated", event_count: 4 },
+      { event_kind: "SubnetLeaseTerminated", event_count: 1 },
+      { event_kind: "SubnetLeaseDividendsDistributed", event_count: 6 },
+      { event_kind: "Contributed", event_count: 9 },
+      { event_kind: "Withdrew", event_count: 2 },
+    ],
+    [],
+    7,
+  );
+  const byKind = Object.fromEntries(
+    out.event_kinds.map((row) => [row.event_kind, row.category]),
+  );
+  assert.equal(byKind.SubnetLeaseCreated, "governance");
+  assert.equal(byKind.SubnetLeaseTerminated, "governance");
+  assert.equal(byKind.SubnetLeaseDividendsDistributed, "governance");
+  assert.equal(byKind.Contributed, "governance");
+  assert.equal(byKind.Withdrew, "governance");
+  assert.ok(
+    !out.categories.some((row) => row.category === "other"),
+    "none of these kinds should fall into the other category",
+  );
+});
+
 test("buildSubnetEventSummary categorizes the newly-added kinds instead of dumping them in other (2026-07-14/15 audit fix)", () => {
   const out = buildSubnetEventSummary(
     [

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -510,6 +510,45 @@ describe("captured-fixture body scan", () => {
     );
   });
 
+  test("allows Rust field-access + method-call syntax on a coldkey field (#6718)", async () => {
+    // ext.coldkey.is_some() / .clone() / .unwrap() -- Rust has no `?.` operator,
+    // so the existing coldkey?. optional-chaining exemption (TS/JS-specific)
+    // doesn't cover this extremely common Option-field-check idiom in
+    // apps/indexer-rs's own test code.
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      [
+        "assert!(ext.coldkey.is_some());",
+        "let c = row.coldkey.clone();",
+        "let c = row.coldkey.unwrap();",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.equal(
+      output.includes(TEST_PUBLIC_FILE),
+      false,
+      `coldkey.method() Rust syntax should be exempt; got:\n${output}`,
+    );
+  });
+
+  test("does not let 'coldkey.' followed by prose (not a real method call) slip past", async () => {
+    // The new coldkey.[a-z_]+( allowance requires an opening paren -- a
+    // capitalized word or a word with no trailing paren after "coldkey." must
+    // still be flagged, so this can't be used to smuggle real prose past the
+    // guard by appending an unrelated identifier after a dot.
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      "The coldkey.owner field should never be logged in plaintext.\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.ok(
+      output.includes(`${TEST_PUBLIC_FILE}:1: Bittensor key terminology`),
+      `prose after "coldkey." without a real method call must still be flagged; got:\n${output}`,
+    );
+  });
+
   test("flags hyphenated/compound wallet-key wording a literal-space regex would miss", async () => {
     await fs.writeFile(
       TEST_PUBLIC_PATH,


### PR DESCRIPTION
## Summary

First sub-issue of epic #6717 (subnet leasing & crowdloan capture). Subnet leasing/crowdloans are
a crowdfunded, time-boxed primary market for NEW subnets — anyone crowdfunds a lease, contributors
earn pro-rata emission dividends, ownership transfers to a beneficiary at lease end. Distinct from
the already-curated ownership-contest events (`SubnetOwnerHotkeySet` — an EXISTING subnet changing
hands). Zero capture before this.

Verified event field shapes directly against live `opentensor/subtensor` source
(`pallets/subtensor/src/subnets/leasing.rs`, `pallets/crowdloan/src/lib.rs`) before implementing,
not just the earlier research pass's summary.

## Changes

- `apps/indexer-rs/src/main.rs`: widened the `account_events` pallet filter to include `Crowdloan`
  (a standalone pallet, unlike subnet leasing which is a `SubtensorModule` submodule) and added
  `extract()` match arms for `SubnetLeaseCreated`/`SubnetLeaseTerminated`/
  `SubnetLeaseDividendsDistributed` and `Crowdloan.Contributed`/`Withdrew`. Deliberately does NOT
  curate `Crowdloan.Created` — it only declares a cap/end, no tao has moved yet, so there's no
  amount to attribute to an account (matches the existing pattern of not curating purely
  administrative events).
- `src/account-events.mjs`: added the 5 new kinds to `INGESTED_EVENT_KINDS` (so `?kind=` accepts
  them) and `EVENT_KIND_CATEGORIES` (mapped to `governance`, the same bucket as
  `SubnetOwnerHotkeySet`/`BurnSet` — an existing, schema-valid category, so no schema change
  needed).
- `scripts/scan-public-safety.mjs`: extended the coldkey allowlist for Rust's field-access +
  method-call syntax (`ext.coldkey.is_some()`) — the existing `coldkey?.` exemption is TS/JS
  optional-chaining specific and doesn't cover this extremely common Rust idiom, which would have
  false-positived on every future indexer-rs test checking an Option field. Narrow addition
  (requires a real method call, i.e. a trailing `(`), not a loosening of the underlying trigger.

## Test plan

- New Rust test module `subnet_leasing_and_crowdloan_tests` (7 tests) covering each new event
  kind's field extraction, the deliberate `Created` exclusion, and underfilled-fields safety.
  `cargo test` — 22/22 passing (full suite, not just the new module).
- `cargo fmt --check` / `cargo build --locked` — clean (matches `validate-indexer-rs.yml`'s exact
  CI steps).
- New JS tests in `tests/account-events.test.mjs` (allowlist + categorization) and
  `tests/public-safety.test.mjs` (2 tests: the new Rust-syntax exemption, plus a negative control
  proving it doesn't over-broaden — prose after `coldkey.` with no real method call still flags).
  `npx vitest run tests/account-events.test.mjs tests/account-events-branch-coverage.test.mjs
  tests/public-safety.test.mjs` — 115/115 passing.
- `npm run lint && npm run format:check && npm run validate && npm run scan:public-safety` —
  clean.
- Coverage (`src/account-events.mjs`, the only changed file in the `codecov/patch`-gated
  `src/**`/`workers/**` scope): 100% stmts/funcs/lines, 99.49% branch — the one gap is a
  pre-existing line untouched by this diff. `scripts/` is outside the patch-coverage gate per
  CLAUDE.md, but both new scanner tests exercise the changed regex directly.

## Rollout note

`apps/indexer-rs/` is both the review source AND the live deploy source now (cutover verified
2026-07-13, #5150) — but the deploy itself is still a manual, human-gated Docker build + transfer
+ swap (no CI/CD for it). I'll redeploy following the same rm+run-container safety pattern used
for the chain-firehose-relay fixes earlier, once this is merged.

Closes #6718