### PR TITLE
fix(registry): set schema_status on 7 surfaces missing the classification

### DIFF
--- a/registry/subnets/adtao.json
+++ b/registry/subnets/adtao.json
@@ -112,6 +112,7 @@
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
+      "schema_status": "machine-readable",
       "schema_url": "https://validator.adtao.io/openapi.json",
       "source_urls": [
         "https://github.com/ippcteam/SN21-adtao",

--- a/registry/subnets/lium-io.json
+++ b/registry/subnets/lium-io.json
@@ -108,6 +108,7 @@
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
+      "schema_status": "machine-readable",
       "schema_url": "https://lium.io/api/openapi.json",
       "source_urls": [
         "https://lium.io/api/machines",
@@ -134,6 +135,7 @@
         "state": "community-submitted",
         "submitted_by": "jimcody1995"
       },
+      "schema_status": "machine-readable",
       "schema_url": "https://lium.io/api/openapi.json",
       "source_urls": ["https://lium.io/api/openapi.json", "https://lium.io/"],
       "url": "https://lium.io/api/version"
@@ -157,6 +159,7 @@
         "state": "community-submitted",
         "submitted_by": "kiannidev"
       },
+      "schema_status": "machine-readable",
       "schema_url": "https://lium.io/api/openapi.json",
       "source_urls": ["https://lium.io/api/openapi.json", "https://lium.io/"],
       "url": "https://lium.io/api/reclaims"
@@ -205,6 +208,7 @@
         "state": "community-submitted",
         "submitted_by": "ultrahighsuper"
       },
+      "schema_status": "machine-readable",
       "schema_url": "https://lium.io/api/openapi.json",
       "source_urls": [
         "https://lium.io/api/openapi.json",

--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -142,6 +142,7 @@
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
+      "schema_status": "machine-readable",
       "schema_url": "https://taofi-doc.web.app/openapi.yaml",
       "source_urls": [
         "https://docs.taofi.com/",

--- a/registry/subnets/synth.json
+++ b/registry/subnets/synth.json
@@ -131,6 +131,7 @@
         "state": "community-submitted",
         "submitted_by": "rust-toml"
       },
+      "schema_status": "machine-readable",
       "schema_url": "https://api.synthdata.co/swagger.json",
       "source_urls": [
         "https://api.synthdata.co/swagger.json",


### PR DESCRIPTION
## Summary

Sets `schema_status` on the 7 surfaces the issue identified as carrying a live
`schema_url` with no classification at all — the exact 4-file, 7-surface scope
the issue itself defines.

## Proof (live-verified against each `schema_url`)

| Surface | `schema_url` | HTTP | Body confirms |
| --- | --- | --- | --- |
| `sn-21-adtao-validator-api` (adtao.json) | validator.adtao.io/openapi.json | 200 `application/json` | `"openapi":"3.1.0"`, real `info`/`paths` |
| `sn-51-lium-io-machines-api`, `sn-51-lium-health`, `sn-51-lium-reclaims-api`, `sn-51-lium-machines-capacity-api` (lium-io.json) | lium.io/api/openapi.json | 200 `application/json` | `"openapi":"3.1.0"`, real `info`/`paths` |
| `sn-10-taofi-api` (swap.json) | taofi-doc.web.app/openapi.yaml | 200 `text/yaml` | `openapi: 3.0.4`, real `info`/`paths` |
| `sn-50-synth-validation-scores` (synth.json) | api.synthdata.co/swagger.json | 200 `application/json` | `"swagger":"2.0"`, real `info`/`paths` |

All 7 resolve to genuine machine-readable OpenAPI/Swagger documents (not an
HTML doc page, not a dead link), so all get `schema_status: "machine-readable"`.
None needed `ui-only` or `not-captured` — no dead/HTML-only cases in this
batch. `schema_url` itself is untouched on all 7; only the missing
`schema_status` key was added, placed immediately before `schema_url` on each
surface, matching the existing key-ordering convention already used
elsewhere in these same 4 files (e.g. the sibling `*-openapi` surface in each
file that already had `schema_status` set correctly).

## Scope

Exactly the 4 files / 7 surfaces the issue names — no other subnet files
touched, no `schema_url` values changed, no other fields on these surfaces
edited.

## Validation

- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:surface`
- [x] `npm run validate:readme-catalog`
- [x] `npm run scan:public-safety`
- [x] `git diff --check`
- [x] `npx prettier --check` on all 4 edited files

Closes #6565
