### PR TITLE
feat(ui): display subnet age (days since registration)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-profile-panel.tsx
@@ -7,7 +7,7 @@ import {
   subnetEndpointsQuery,
   subnetProfileQuery,
 } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, subnetAgeDays, formatSubnetAge } from "@/lib/metagraphed/format";
 import {
   Tooltip,
   TooltipContent,
@@ -202,11 +202,13 @@ export function SubnetProfilePanel({ netuid }: { netuid: number }) {
             hint="Whether this is the root subnet or an application subnet."
           />
           <Meta
-            label="Reg. block"
-            value={
-              profile?.registration_block != null ? formatNumber(profile.registration_block) : "—"
+            label="Age"
+            value={formatSubnetAge(subnetAgeDays(profile?.registered_at_block, profile?.block))}
+            hint={
+              profile?.registered_at_block != null
+                ? `Registered at block ${formatNumber(profile.registered_at_block)} -- estimated from the block delta to this snapshot's current block, at Bittensor's ~12s/block.`
+                : "Registration block not yet captured for this subnet."
             }
-            hint="Block height at which this subnet was registered."
           />
           <Meta
             label="Mechanisms"

--- a/apps/ui/src/lib/metagraphed/format.test.ts
+++ b/apps/ui/src/lib/metagraphed/format.test.ts
@@ -7,6 +7,8 @@ import {
   relativeFromDiff,
   isStaleFreshness,
   formatTao,
+  subnetAgeDays,
+  formatSubnetAge,
 } from "./format";
 
 describe("isUsableTimestamp", () => {
@@ -195,5 +197,52 @@ describe("formatTao", () => {
     expect(formatTao(-999_999)).toBe("-1000.0k τ"); // still < 1e6 → k-tier
     expect(formatTao(-1_000_000)).toBe("-1.00M τ"); // lower boundary of M-tier
     expect(formatTao(-2_500_000)).toBe("-2.50M τ");
+  });
+});
+
+describe("subnetAgeDays", () => {
+  it("returns null when either input is nullish or non-finite", () => {
+    expect(subnetAgeDays(null, 1000)).toBeNull();
+    expect(subnetAgeDays(1000, null)).toBeNull();
+    expect(subnetAgeDays(undefined, undefined)).toBeNull();
+    expect(subnetAgeDays(Number.NaN, 1000)).toBeNull();
+    expect(subnetAgeDays(1000, Number.NaN)).toBeNull();
+  });
+
+  it("returns null for a negative delta rather than a nonsensical negative age", () => {
+    expect(subnetAgeDays(1000, 500)).toBeNull();
+  });
+
+  it("returns 0 for a subnet registered within the last day", () => {
+    expect(subnetAgeDays(1000, 1000)).toBe(0);
+    // 7199 blocks * 12s = 86,388s, still < 86,400s (1 day)
+    expect(subnetAgeDays(0, 7199)).toBe(0);
+  });
+
+  it("converts a block delta to whole days at ~12s/block", () => {
+    // 7200 blocks * 12s = 86,400s = exactly 1 day
+    expect(subnetAgeDays(0, 7_200)).toBe(1);
+    // 720,000 blocks * 12s = 8,640,000s = 100 days
+    expect(subnetAgeDays(0, 720_000)).toBe(100);
+  });
+});
+
+describe("formatSubnetAge", () => {
+  it("returns the placeholder for null", () => {
+    expect(formatSubnetAge(null)).toBe("—");
+  });
+
+  it("uses singular phrasing for exactly 1 day", () => {
+    expect(formatSubnetAge(1)).toBe("1 day old");
+  });
+
+  it("uses plural phrasing for 0 and >1 days", () => {
+    expect(formatSubnetAge(0)).toBe("0 days old");
+    expect(formatSubnetAge(2)).toBe("2 days old");
+    expect(formatSubnetAge(412)).toBe("412 days old");
+  });
+
+  it("thousands-separates large day counts via formatNumber", () => {
+    expect(formatSubnetAge(1234)).toBe("1,234 days old");
   });
 });

--- a/apps/ui/src/lib/metagraphed/format.ts
+++ b/apps/ui/src/lib/metagraphed/format.ts
@@ -149,3 +149,31 @@ export function durationLabel(start?: string | null, end?: string | null): strin
   const eMs = end ? Date.parse(end) : Date.now();
   return humaniseSeconds(Math.max(0, (eMs - sMs) / 1000));
 }
+
+// Display-only estimate (Bittensor's well-known ~12s block time), mirroring
+// take-extrinsics.ts's own APPROX_SECONDS_PER_BLOCK convention -- never used
+// for anything gating/correctness-critical, only this "roughly how old" label.
+const APPROX_SECONDS_PER_BLOCK = 12;
+
+/**
+ * A subnet's age in whole days, estimated from the block delta between its
+ * registration block and the current chain block (#6643). Null when either
+ * input is missing/non-finite, or when the delta would be negative (a
+ * mid-flight/inconsistent snapshot -- never show a nonsensical negative age).
+ */
+export function subnetAgeDays(
+  registeredAtBlock?: number | null,
+  currentBlock?: number | null,
+): number | null {
+  if (registeredAtBlock == null || currentBlock == null) return null;
+  if (!Number.isFinite(registeredAtBlock) || !Number.isFinite(currentBlock)) return null;
+  const ageBlocks = currentBlock - registeredAtBlock;
+  if (ageBlocks < 0) return null;
+  return Math.floor((ageBlocks * APPROX_SECONDS_PER_BLOCK) / 86400);
+}
+
+/** Formats a day count from {@link subnetAgeDays} as "N days old" ("1 day old" singular). */
+export function formatSubnetAge(days: number | null): string {
+  if (days == null) return "—";
+  return `${formatNumber(days)} day${days === 1 ? "" : "s"} old`;
+}

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -141,7 +141,11 @@ export interface Subnet {
   subnet_type?: "root" | "application" | string;
   participants?: number;
   tempo?: number;
-  registration_block?: number;
+  // registered_at_block/block (the current snapshot block, for #6643's
+  // age-in-days estimate) are the real wire field names (SubnetIndexEntry) --
+  // `registration_block` never matched anything the API actually returns.
+  registered_at_block?: number;
+  block?: number;
   mechanism_count?: number;
   curation_level?: CurationLevel;
   coverage_level?: CoverageLevel;

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -50,7 +50,14 @@ import {
   agentCatalogMapQuery,
   economicsQuery,
 } from "@/lib/metagraphed/queries";
-import { classNames, formatNumber, formatTao, isStaleFreshness } from "@/lib/metagraphed/format";
+import {
+  classNames,
+  formatNumber,
+  formatTao,
+  isStaleFreshness,
+  subnetAgeDays,
+  formatSubnetAge,
+} from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
 import {
   joinEconomics,
@@ -619,293 +626,308 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   }
 
   return (
-    <ListShell
-      filters={filters}
-      isEmpty={rows.length === 0 && !hasNextPage}
-      isStale={isFetching && !isFetchingNextPage}
-      empty={emptyNode}
-      cards={rows.map((s) => (
-        <Link
-          key={s.netuid}
-          to="/subnets/$netuid"
-          params={{ netuid: s.netuid }}
-          className="block rounded border border-border bg-card p-3 min-h-11 active:bg-surface"
-        >
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-3 min-w-0">
-              <BrandIcon
-                url={s.website}
-                repoUrl={s.repo}
-                iconUrl={s.icon_url}
-                netuid={s.netuid}
-                name={s.name}
-                fallback={s.netuid}
-                size={32}
-              />
-              <div className="min-w-0">
-                <div className="font-mono text-[11px] text-ink-muted">
-                  #{String(s.netuid).padStart(3, "0")}
-                  {s.symbol ? ` · ${s.symbol}` : ""}
-                </div>
-                <div className="font-medium text-ink-strong truncate">
-                  {s.name ?? `Subnet ${s.netuid}`}
+    <div id="subnets-list">
+      <ListShell
+        filters={filters}
+        isEmpty={rows.length === 0 && !hasNextPage}
+        isStale={isFetching && !isFetchingNextPage}
+        empty={emptyNode}
+        cards={rows.map((s) => (
+          <Link
+            key={s.netuid}
+            to="/subnets/$netuid"
+            params={{ netuid: s.netuid }}
+            className="block rounded border border-border bg-card p-3 min-h-11 active:bg-surface"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-3 min-w-0">
+                <BrandIcon
+                  url={s.website}
+                  repoUrl={s.repo}
+                  iconUrl={s.icon_url}
+                  netuid={s.netuid}
+                  name={s.name}
+                  fallback={s.netuid}
+                  size={32}
+                />
+                <div className="min-w-0">
+                  <div className="font-mono text-[11px] text-ink-muted">
+                    #{String(s.netuid).padStart(3, "0")}
+                    {s.symbol ? ` · ${s.symbol}` : ""}
+                    {" · "}
+                    {formatSubnetAge(subnetAgeDays(s.registered_at_block, s.block))}
+                  </div>
+                  <div className="font-medium text-ink-strong truncate">
+                    {s.name ?? `Subnet ${s.netuid}`}
+                  </div>
                 </div>
               </div>
+              <HealthPill state={s.health} />
             </div>
-            <HealthPill state={s.health} />
-          </div>
-          <div className="mt-2 flex items-center justify-between text-[11px] font-mono text-ink-muted">
-            <span>{formatNumber(s.participants)} participants</span>
-            <span>{s.surfaces_count ?? 0} surfaces</span>
-            <span>
-              <TimeAgo at={s.updated_at ?? s.freshness} />
-            </span>
-          </div>
-          <div className="mt-1.5">
-            <CurationChip level={s.curation_level} />
-          </div>
-        </Link>
-      ))}
-      table={(() => {
-        const compact = density === "compact";
-        const cellPad = compact ? "px-3 py-1.5" : "px-4 py-2.5";
-        const firstPad = compact ? "pl-3 pr-1 py-1.5" : "pl-4 pr-1 py-2.5";
-        const monoSize = compact ? "text-[11px]" : "text-[12px]";
-        return (
-          <table className="w-full text-left text-sm">
-            <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
-              <tr>
-                <th className={classNames(firstPad, "w-6")} aria-label="Compare" />
-                <th
-                  className={cellPad}
-                  aria-sort={ariaSort(search.sort === "netuid", search.order)}
-                >
-                  <SortHeader
-                    label="UID"
-                    field="netuid"
-                    active={search.sort === "netuid"}
-                    order={search.order}
-                    onSort={onSort}
-                  />
-                </th>
-                <th className={cellPad} aria-sort={ariaSort(search.sort === "name", search.order)}>
-                  <SortHeader
-                    label="Name"
-                    field="name"
-                    active={search.sort === "name"}
-                    order={search.order}
-                    onSort={onSort}
-                  />
-                </th>
-                <th
-                  className={cellPad}
-                  aria-sort={ariaSort(search.sort === "symbol", search.order)}
-                >
-                  <SortHeader
-                    label="Symbol"
-                    field="symbol"
-                    active={search.sort === "symbol"}
-                    order={search.order}
-                    onSort={onSort}
-                  />
-                </th>
-                <th
-                  className={classNames(cellPad, "text-right")}
-                  aria-sort={ariaSort(search.sort === "participants", search.order)}
-                >
-                  <SortHeader
-                    label="Participants"
-                    field="participants"
-                    active={search.sort === "participants"}
-                    order={search.order}
-                    onSort={onSort}
-                    align="right"
-                  />
-                </th>
-                <th
-                  className={cellPad}
-                  aria-sort={ariaSort(search.sort === "curation_level", search.order)}
-                >
-                  <SortHeader
-                    label="Curation"
-                    field="curation_level"
-                    active={search.sort === "curation_level"}
-                    order={search.order}
-                    onSort={onSort}
-                  />
-                </th>
-                <th
-                  className={classNames(cellPad, "text-right")}
-                  aria-sort={ariaSort(search.sort === "surfaces_count", search.order)}
-                >
-                  <SortHeader
-                    label="Surfaces"
-                    field="surfaces_count"
-                    active={search.sort === "surfaces_count"}
-                    order={search.order}
-                    onSort={onSort}
-                    align="right"
-                  />
-                </th>
-                <th
-                  className={classNames(cellPad, "text-right")}
-                  aria-sort={ariaSort(search.sort === "integration_readiness", search.order)}
-                >
-                  <SortHeader
-                    label="Readiness"
-                    field="integration_readiness"
-                    active={search.sort === "integration_readiness"}
-                    order={search.order}
-                    onSort={onSort}
-                    align="right"
-                  />
-                </th>
-                <th
-                  className={classNames(cellPad, "text-right")}
-                  aria-sort={ariaSort(search.sort === "registration_cost_tao", search.order)}
-                >
-                  <SortHeader
-                    label="Registration"
-                    field="registration_cost_tao"
-                    active={search.sort === "registration_cost_tao"}
-                    order={search.order}
-                    onSort={onSort}
-                    align="right"
-                  />
-                </th>
-                <th className={cellPad}>Health</th>
-                <th
-                  className={classNames(cellPad, "text-right")}
-                  aria-sort={ariaSort(search.sort === "emission_share", search.order)}
-                >
-                  <SortHeader
-                    label="Emission"
-                    field="emission_share"
-                    active={search.sort === "emission_share"}
-                    order={search.order}
-                    onSort={onSort}
-                    align="right"
-                  />
-                </th>
-                <th
-                  className={classNames(cellPad, "text-right")}
-                  aria-sort={ariaSort(search.sort === "updated_at", search.order)}
-                >
-                  <SortHeader
-                    label="Updated"
-                    field="updated_at"
-                    active={search.sort === "updated_at"}
-                    order={search.order}
-                    onSort={onSort}
-                    align="right"
-                  />
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {rows.map((s) => (
-                <tr key={s.netuid} className="mg-row-accent hover:bg-surface/40">
-                  <td className={classNames(firstPad, "align-middle")}>
-                    <CompareToggle netuid={s.netuid} />
-                  </td>
-                  <td className={classNames(cellPad, "font-mono text-ink-muted", monoSize)}>
-                    <EntityHoverCard kind="subnet" netuid={s.netuid}>
-                      <Link
-                        to="/subnets/$netuid"
-                        params={{ netuid: s.netuid }}
-                        className="hover:text-ink-strong"
-                      >
-                        {String(s.netuid).padStart(3, "0")}
-                      </Link>
-                    </EntityHoverCard>
-                  </td>
-                  <td className={cellPad}>
-                    <EntityHoverCard kind="subnet" netuid={s.netuid}>
-                      <Link
-                        to="/subnets/$netuid"
-                        params={{ netuid: s.netuid }}
-                        className="inline-flex items-center gap-2 font-medium text-ink-strong hover:underline"
-                      >
-                        <BrandIcon
-                          url={s.website}
-                          repoUrl={s.repo}
-                          iconUrl={s.icon_url}
-                          netuid={s.netuid}
-                          name={s.name}
-                          fallback={s.netuid}
-                          size={compact ? 18 : 20}
-                        />
-                        <span className="truncate">{s.name ?? `Subnet ${s.netuid}`}</span>
-                      </Link>
-                    </EntityHoverCard>
-                  </td>
-                  <td className={classNames(cellPad, "font-mono text-[11px] text-ink-muted")}>
-                    {s.symbol ?? "—"}
-                  </td>
-                  <td className={classNames(cellPad, "text-right")}>
-                    <ParticipantsCell
-                      value={s.participants}
-                      density={density}
-                      updatedAt={s.updated_at ?? s.freshness}
+            <div className="mt-2 flex items-center justify-between text-[11px] font-mono text-ink-muted">
+              <span>{formatNumber(s.participants)} participants</span>
+              <span>{s.surfaces_count ?? 0} surfaces</span>
+              <span>
+                <TimeAgo at={s.updated_at ?? s.freshness} />
+              </span>
+            </div>
+            <div className="mt-1.5">
+              <CurationChip level={s.curation_level} />
+            </div>
+          </Link>
+        ))}
+        table={(() => {
+          const compact = density === "compact";
+          const cellPad = compact ? "px-3 py-1.5" : "px-4 py-2.5";
+          const firstPad = compact ? "pl-3 pr-1 py-1.5" : "pl-4 pr-1 py-2.5";
+          const monoSize = compact ? "text-[11px]" : "text-[12px]";
+          return (
+            <table className="w-full text-left text-sm">
+              <thead className="sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 shadow-[0_1px_0_0_var(--border)]">
+                <tr>
+                  <th className={classNames(firstPad, "w-6")} aria-label="Compare" />
+                  <th
+                    className={cellPad}
+                    aria-sort={ariaSort(search.sort === "netuid", search.order)}
+                  >
+                    <SortHeader
+                      label="UID"
+                      field="netuid"
+                      active={search.sort === "netuid"}
+                      order={search.order}
+                      onSort={onSort}
                     />
-                  </td>
-                  <td className={cellPad}>
-                    <CurationChip level={s.curation_level} />
-                  </td>
-                  <td className={classNames(cellPad, "text-right")}>
-                    <SurfacesCell subnet={s} density={density} />
-                  </td>
-                  <td className={classNames(cellPad, "text-right")}>
-                    <ReadinessCell
-                      score={s.integration_readiness}
-                      tier={s.readiness_tier}
-                      kinds={s.service_kinds}
+                  </th>
+                  <th
+                    className={cellPad}
+                    aria-sort={ariaSort(search.sort === "name", search.order)}
+                  >
+                    <SortHeader
+                      label="Name"
+                      field="name"
+                      active={search.sort === "name"}
+                      order={search.order}
+                      onSort={onSort}
                     />
-                  </td>
-                  <td
-                    className={classNames(
-                      cellPad,
-                      "text-right font-mono text-[11px] tabular-nums",
-                      // #3364: dim the cost only when registration is explicitly
-                      // closed. `registration_allowed === undefined` (economics
-                      // entry present but flag absent, or no entry at all) keeps
-                      // the neutral tone — do NOT read it as "open".
-                      s.registration_allowed === false ? "text-ink-muted" : "text-ink",
-                    )}
-                    title={
-                      s.registration_allowed === false
-                        ? "Registration currently closed"
-                        : s.registration_allowed === true
-                          ? "Registration open"
-                          : undefined
-                    }
+                  </th>
+                  <th
+                    className={cellPad}
+                    aria-sort={ariaSort(search.sort === "symbol", search.order)}
                   >
-                    {formatTao(s.registration_cost_tao)}
-                  </td>
-                  <td className={cellPad}>
-                    <HealthPill state={s.health} />
-                  </td>
-                  <td
-                    className={classNames(cellPad, "text-right font-mono text-[11px] tabular-nums")}
+                    <SortHeader
+                      label="Symbol"
+                      field="symbol"
+                      active={search.sort === "symbol"}
+                      order={search.order}
+                      onSort={onSort}
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(search.sort === "participants", search.order)}
                   >
-                    <EmissionCell share={s.emission_share} />
-                  </td>
-                  <td
-                    className={classNames(
-                      cellPad,
-                      "text-right font-mono text-[11px] text-ink-muted",
-                    )}
+                    <SortHeader
+                      label="Participants"
+                      field="participants"
+                      active={search.sort === "participants"}
+                      order={search.order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th
+                    className={cellPad}
+                    aria-sort={ariaSort(search.sort === "curation_level", search.order)}
                   >
-                    <TimeAgo at={s.updated_at ?? s.freshness} />
-                  </td>
+                    <SortHeader
+                      label="Curation"
+                      field="curation_level"
+                      active={search.sort === "curation_level"}
+                      order={search.order}
+                      onSort={onSort}
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(search.sort === "surfaces_count", search.order)}
+                  >
+                    <SortHeader
+                      label="Surfaces"
+                      field="surfaces_count"
+                      active={search.sort === "surfaces_count"}
+                      order={search.order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(search.sort === "integration_readiness", search.order)}
+                  >
+                    <SortHeader
+                      label="Readiness"
+                      field="integration_readiness"
+                      active={search.sort === "integration_readiness"}
+                      order={search.order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(search.sort === "registration_cost_tao", search.order)}
+                  >
+                    <SortHeader
+                      label="Registration"
+                      field="registration_cost_tao"
+                      active={search.sort === "registration_cost_tao"}
+                      order={search.order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th className={cellPad}>Health</th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(search.sort === "emission_share", search.order)}
+                  >
+                    <SortHeader
+                      label="Emission"
+                      field="emission_share"
+                      active={search.sort === "emission_share"}
+                      order={search.order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th
+                    className={classNames(cellPad, "text-right")}
+                    aria-sort={ariaSort(search.sort === "updated_at", search.order)}
+                  >
+                    <SortHeader
+                      label="Updated"
+                      field="updated_at"
+                      active={search.sort === "updated_at"}
+                      order={search.order}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        );
-      })()}
-      footer={footerNode}
-    />
+              </thead>
+              <tbody className="divide-y divide-border">
+                {rows.map((s) => (
+                  <tr key={s.netuid} className="mg-row-accent hover:bg-surface/40">
+                    <td className={classNames(firstPad, "align-middle")}>
+                      <CompareToggle netuid={s.netuid} />
+                    </td>
+                    <td className={classNames(cellPad, "font-mono text-ink-muted", monoSize)}>
+                      <EntityHoverCard kind="subnet" netuid={s.netuid}>
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: s.netuid }}
+                          className="hover:text-ink-strong"
+                        >
+                          {String(s.netuid).padStart(3, "0")}
+                        </Link>
+                      </EntityHoverCard>
+                      {/* #6643: age-in-days, estimated from the already-fetched
+                        registered_at_block/block delta -- no new backend call. */}
+                      <div className="text-[10px] font-sans text-ink-muted/70 whitespace-nowrap">
+                        {formatSubnetAge(subnetAgeDays(s.registered_at_block, s.block))}
+                      </div>
+                    </td>
+                    <td className={cellPad}>
+                      <EntityHoverCard kind="subnet" netuid={s.netuid}>
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: s.netuid }}
+                          className="inline-flex items-center gap-2 font-medium text-ink-strong hover:underline"
+                        >
+                          <BrandIcon
+                            url={s.website}
+                            repoUrl={s.repo}
+                            iconUrl={s.icon_url}
+                            netuid={s.netuid}
+                            name={s.name}
+                            fallback={s.netuid}
+                            size={compact ? 18 : 20}
+                          />
+                          <span className="truncate">{s.name ?? `Subnet ${s.netuid}`}</span>
+                        </Link>
+                      </EntityHoverCard>
+                    </td>
+                    <td className={classNames(cellPad, "font-mono text-[11px] text-ink-muted")}>
+                      {s.symbol ?? "—"}
+                    </td>
+                    <td className={classNames(cellPad, "text-right")}>
+                      <ParticipantsCell
+                        value={s.participants}
+                        density={density}
+                        updatedAt={s.updated_at ?? s.freshness}
+                      />
+                    </td>
+                    <td className={cellPad}>
+                      <CurationChip level={s.curation_level} />
+                    </td>
+                    <td className={classNames(cellPad, "text-right")}>
+                      <SurfacesCell subnet={s} density={density} />
+                    </td>
+                    <td className={classNames(cellPad, "text-right")}>
+                      <ReadinessCell
+                        score={s.integration_readiness}
+                        tier={s.readiness_tier}
+                        kinds={s.service_kinds}
+                      />
+                    </td>
+                    <td
+                      className={classNames(
+                        cellPad,
+                        "text-right font-mono text-[11px] tabular-nums",
+                        // #3364: dim the cost only when registration is explicitly
+                        // closed. `registration_allowed === undefined` (economics
+                        // entry present but flag absent, or no entry at all) keeps
+                        // the neutral tone — do NOT read it as "open".
+                        s.registration_allowed === false ? "text-ink-muted" : "text-ink",
+                      )}
+                      title={
+                        s.registration_allowed === false
+                          ? "Registration currently closed"
+                          : s.registration_allowed === true
+                            ? "Registration open"
+                            : undefined
+                      }
+                    >
+                      {formatTao(s.registration_cost_tao)}
+                    </td>
+                    <td className={cellPad}>
+                      <HealthPill state={s.health} />
+                    </td>
+                    <td
+                      className={classNames(
+                        cellPad,
+                        "text-right font-mono text-[11px] tabular-nums",
+                      )}
+                    >
+                      <EmissionCell share={s.emission_share} />
+                    </td>
+                    <td
+                      className={classNames(
+                        cellPad,
+                        "text-right font-mono text-[11px] text-ink-muted",
+                      )}
+                    >
+                      <TimeAgo at={s.updated_at ?? s.freshness} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          );
+        })()}
+        footer={footerNode}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Displays subnet age ("N days old") wherever subnet metadata is already shown, per #6643 (#5968
survey, Backprop finding). Pure frontend display of already-fetched data — estimated from the
block delta between `registered_at_block` and the current snapshot `block`, at Bittensor's
well-known ~12s/block (mirrors `take-extrinsics.ts`'s own `APPROX_SECONDS_PER_BLOCK` convention;
same display-only estimate pattern #6640 used for its immunity-window ETA).

## Bug found + fixed along the way

`SubnetProfilePanel`'s "Reg. block" tile read `profile.registration_block` — a field name no
normalize function anywhere in the codebase ever populated, so it always rendered "—". The real
wire field is `registered_at_block` (confirmed against `SubnetIndexEntry`/`SubnetDetail` in
`schemas/components/05-subnets.schema.json`, and already correctly mapped by
`normalizeSubnetProfile`). The tile now reads the right field, and shows the estimated age instead
of a permanently-blank value.

## What changed

- `apps/ui/src/lib/metagraphed/format.ts`: `subnetAgeDays(registeredAtBlock, currentBlock)` +
  `formatSubnetAge(days)`, with unit tests.
- `apps/ui/src/lib/metagraphed/types.ts`: replaced the dead `registration_block` field on `Subnet`
  with the real `registered_at_block`/`block` wire fields.
- `apps/ui/src/components/metagraphed/subnet-profile-panel.tsx`: subnet detail page — the "Reg.
  block" tile is now "Age" (bug fix + new display).
- `apps/ui/src/routes/subnets.index.tsx`: subnet list page — a small muted age subtitle under each
  UID, in both the table and mobile-card views. (Not a sortable column — sorting would need
  backend support, out of scope per the issue's own non-goals.)

## Screenshots

### Subnet detail (`/subnets/{netuid}`) — "Reg. block" (dead) → "Age"

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-detail-after-mobile-dark.png)<br><sub>after</sub> |

### Subnet list (`/subnets`) — age subtitle under each UID

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6643-list-after-mobile-dark.png)<br><sub>after</sub> |

## Validation

- `npx vitest run` — 159 files / 1196 tests passed (apps/ui full suite)
- `npm run typecheck` — clean
- `npx eslint <changed files>` — clean (0 errors; pre-existing fast-refresh warnings only)
- `npm run format:check` — clean
- `npx playwright test tests/e2e/responsive-overflow.spec.ts -g "/subnets/1"` — 4/4 passed, no new overflow regressions
- `npm run build` — clean

Closes #6643
