### PR TITLE
fix(mcp): stream-bound POST /mcp bodies so missing Content-Length cannot DoS the Worker

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -14897,6 +14897,64 @@ function bodyTooLargeResponse() {
   );
 }
 
+function invalidContentLengthResponse() {
+  return jsonResponse(
+    rpcError(null, RPC_INVALID_REQUEST, "Invalid Content-Length header."),
+    400,
+  );
+}
+
+// Stream-read the POST body with a hard byte cap, mirroring GraphQL's
+// `readLimitedJson`. A present Content-Length must be a pure decimal integer
+// (`/^\d+$/`) so Number() coercion cannot accept "", "1.5", "0x10", or "1e3"
+// (the defect that closed #3205). Missing Content-Length still cannot bypass
+// the cap: we cancel mid-read as soon as total exceeds MAX_MCP_BODY_BYTES
+// instead of buffering via request.text() first.
+async function readLimitedMcpBody(request) {
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^\d+$/.test(declaredLength)) {
+      return { error: invalidContentLengthResponse() };
+    }
+    const length = Number(declaredLength);
+    if (length > MAX_MCP_BODY_BYTES) {
+      return { error: bodyTooLargeResponse() };
+    }
+  }
+
+  if (!request.body) {
+    return { text: "" };
+  }
+
+  const reader = request.body.getReader();
+  const chunks = [];
+  let total = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_MCP_BODY_BYTES) {
+        await reader.cancel();
+        return { error: bodyTooLargeResponse() };
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return { text: new TextDecoder().decode(bytes) };
+}
+
 // MCP-Protocol-Version header (2025-06-18+): every request after the first
 // carries this; the first (`initialize`) negotiates the version in its BODY
 // instead, since the client has nothing to declare in a header yet. Per spec,
@@ -15071,18 +15129,12 @@ export async function handleMcpRequest(request, env = {}, deps = {}) {
     );
   }
 
-  const contentLength = Number(request.headers.get("content-length") || 0);
-  if (contentLength > MAX_MCP_BODY_BYTES) {
-    return bodyTooLargeResponse();
-  }
+  const limited = await readLimitedMcpBody(request);
+  if (limited.error) return limited.error;
 
   let body;
   try {
-    const bodyText = await request.text();
-    if (new TextEncoder().encode(bodyText).length > MAX_MCP_BODY_BYTES) {
-      return bodyTooLargeResponse();
-    }
-    body = JSON.parse(bodyText);
+    body = JSON.parse(limited.text);
   } catch {
     return jsonResponse(
       rpcError(null, RPC_PARSE_ERROR, "Request body is not valid JSON."),

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -1117,6 +1117,47 @@ describe("handleMcpRequest — rate limiter success + content-length guard", () 
     assert.equal(body.error.code, -32600);
     assert.match(body.error.message, /too large/);
   });
+
+  test("a POST with Content-Length 0 and no body yields a JSON parse error", async () => {
+    // Covers readLimitedMcpBody's !request.body arm (empty POST, no stream).
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "0",
+      },
+    });
+    assert.equal(request.body, null);
+    const response = await handleMcpRequest(request, {}, makeDeps());
+    assert.equal(response.status, 400);
+    const body = await response.json();
+    assert.equal(body.error.code, -32700);
+  });
+
+  test("a valid streamed body without Content-Length is accepted", async () => {
+    const payload = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" });
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        // Two chunks so the accumulate loop runs more than once under the cap.
+        const bytes = encoder.encode(payload);
+        controller.enqueue(bytes.slice(0, 8));
+        controller.enqueue(bytes.slice(8));
+        controller.close();
+      },
+    });
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: stream,
+      duplex: "half",
+    });
+    assert.equal(request.headers.get("content-length"), null);
+    const response = await handleMcpRequest(request, {}, makeDeps());
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.deepEqual(body.result, {});
+  });
 });
 
 // ── resolveNetuid index fallback ───────────────────────────────────────

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import {
+  handleMcpRequest,
+  MAX_MCP_BODY_BYTES,
+} from "../src/mcp-server.mjs";
 
 const MCP_URL = "https://api.metagraph.sh/mcp";
 
@@ -1069,6 +1072,49 @@ describe("handleMcpRequest — rate limiter success + content-length guard", () 
     assert.equal(response.status, 413);
     const body = await response.json();
     assert.equal(body.error.code, -32600);
+  });
+
+  test("malformed Content-Length values are rejected with 400 before any body read", async () => {
+    // Strict decimal-integer grammar — Number() coercion must not accept these.
+    for (const value of ["", " ", "abc", "1.5", "0x10", "1e3", "-1"]) {
+      const request = new Request(MCP_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": value,
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+      });
+      const response = await handleMcpRequest(request, {}, makeDeps());
+      assert.equal(response.status, 400, `content-length=${JSON.stringify(value)}`);
+      const body = await response.json();
+      assert.equal(body.error.code, -32600);
+      assert.match(body.error.message, /Invalid Content-Length/);
+    }
+  });
+
+  test("an oversized streamed body without Content-Length is rejected mid-read", async () => {
+    // Chunked / stream bodies omit Content-Length; the reader must cancel once
+    // the running byte count exceeds MAX_MCP_BODY_BYTES instead of buffering.
+    const oversized = "x".repeat(MAX_MCP_BODY_BYTES + 1);
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(oversized));
+        controller.close();
+      },
+    });
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: stream,
+      duplex: "half",
+    });
+    assert.equal(request.headers.get("content-length"), null);
+    const response = await handleMcpRequest(request, {}, makeDeps());
+    assert.equal(response.status, 413);
+    const body = await response.json();
+    assert.equal(body.error.code, -32600);
+    assert.match(body.error.message, /too large/);
   });
 });
 

--- a/tests/mcp-server-branch-coverage.test.mjs
+++ b/tests/mcp-server-branch-coverage.test.mjs
@@ -1,9 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import {
-  handleMcpRequest,
-  MAX_MCP_BODY_BYTES,
-} from "../src/mcp-server.mjs";
+import { handleMcpRequest, MAX_MCP_BODY_BYTES } from "../src/mcp-server.mjs";
 
 const MCP_URL = "https://api.metagraph.sh/mcp";
 
@@ -1086,7 +1083,11 @@ describe("handleMcpRequest — rate limiter success + content-length guard", () 
         body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
       });
       const response = await handleMcpRequest(request, {}, makeDeps());
-      assert.equal(response.status, 400, `content-length=${JSON.stringify(value)}`);
+      assert.equal(
+        response.status,
+        400,
+        `content-length=${JSON.stringify(value)}`,
+      );
       const body = await response.json();
       assert.equal(body.error.code, -32600);
       assert.match(body.error.message, /Invalid Content-Length/);


### PR DESCRIPTION
## Summary

- **Root cause:** Public `POST /mcp` only soft-checked `Content-Length` via `Number(...)`, then fully buffered with `request.text()` before applying `MAX_MCP_BODY_BYTES`. Missing/chunked bodies and malformed lengths (`abc`, `1.5`, `0x10`, `1e3`, `-1`) skipped the pre-read guard, so an unauthenticated client could force multi-MiB Worker buffering despite the 64 KiB policy.
- **Fix:** Add `readLimitedMcpBody` that (1) requires present `Content-Length` to match `/^\d+$/` (strict HTTP decimal grammar — addresses the defect that closed #3205), (2) 413s oversized declared lengths before any read, and (3) stream-reads with mid-stream `cancel()` when the running byte count exceeds the cap — parity with GraphQL's `readLimitedJson`.
- **Impact:** Closes an unauthenticated memory/CPU exhaustion path on the primary agent MCP surface without changing valid-client behavior.

## Why this is unique

- Completes #270's incomplete post-`text()` cap.
- Supersedes closed #3205 (invalid-CL only; still used unbounded `request.text()`; permissive `Number()` parsing).
- No open PR currently covers MCP streaming body bounds (verified against open upstream PRs).

## No linked issue

Fork lacks `CreateIssue` permission on this repo; a self-authored issue would also fail the anti-self-issue gate. Happy to retarget onto a maintainer-filed issue if preferred.

## Test plan

- [x] `npm test -- tests/mcp-server-branch-coverage.test.mjs tests/mcp-server.test.mjs` (1169 passed)
- [x] `npm run validate:mcp`
- [x] `prettier --check` on touched files
- [x] Fork Validate `checks` job green (lint/format/validators)
- [x] Fork suite: 9139 tests passed (Codecov upload fails on fork without token — expected)
- [ ] Upstream Validate CI green on this PR

Made with [Cursor](https://cursor.com)