### PR TITLE
fix(registry): reconcile stale curation.gap_notes against registered surfaces

### DIFF
--- a/registry/subnets/academia.json
+++ b/registry/subnets/academia.json
@@ -24,7 +24,6 @@
       "No verified standalone website yet.",
       "No verified docs site yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet."
     ]
   },

--- a/registry/subnets/aurelius.json
+++ b/registry/subnets/aurelius.json
@@ -13,7 +13,6 @@
   "curation": {
     "gap_notes": [
       "The registered website (aureliusaligned.ai) currently fails to connect over both HTTP and HTTPS (DNS resolves, but the connection times out) and is not promoted as a website surface.",
-      "No verified OpenAPI/Swagger schema without an existing surface -- see the tracked openapi surface.",
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",

--- a/registry/subnets/bitads.json
+++ b/registry/subnets/bitads.json
@@ -20,7 +20,6 @@
     "gap_notes": [
       "The bitads.ai website and docs domain currently fails to resolve (DNS lame delegation) and is nulled until it recovers or a replacement domain is confirmed.",
       "Common API, health, OpenAPI, Swagger JSON, and Swagger UI paths return marketing-site HTML rather than API/schema payloads.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified SSE/event stream yet."
     ],

--- a/registry/subnets/cliqueai.json
+++ b/registry/subnets/cliqueai.json
@@ -12,7 +12,6 @@
     "source_count": 6,
     "gap_notes": [
       "cliqueai.toptensor.ai/openapi.json returns HTTP 200 but serves the SPA's HTML fallback, not a real OpenAPI schema -- no machine-readable OpenAPI/Swagger schema verified yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet."
     ]
   },

--- a/registry/subnets/ditto.json
+++ b/registry/subnets/ditto.json
@@ -21,7 +21,6 @@
       "mobiusfund/etf appears unrelated to Ditto and is excluded from promoted source repository evidence.",
       "Common API, health, OpenAPI, Swagger JSON, and Swagger UI paths currently return 404.",
       "Canonical source repository verified: ditto-assistant/dittobench-starter-kit self-declares \"Official DittoBench miner starter kit for Bittensor subnet 118\" (not a fork, ditto-assistant org).",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
       "Diffed the 13-path Ditto Admin API OpenAPI schema for undiscovered public GET endpoints -- every path-level operation explicitly declares AdminKey security (an honest schema, unlike several others in this audit), so no candidates were promotable."
     ],

--- a/registry/subnets/dojo.json
+++ b/registry/subnets/dojo.json
@@ -9,10 +9,7 @@
   ],
   "contact": "jarvis@tensorplex.ai",
   "curation": {
-    "gap_notes": [
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet."
-    ],
+    "gap_notes": ["No verified SSE/event stream yet."],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-07-16T04:10:00.000Z",

--- a/registry/subnets/efficientfrontier.json
+++ b/registry/subnets/efficientfrontier.json
@@ -14,7 +14,6 @@
       "The subnet mining app currently returns a 403/auth-challenge response to simple probes and is expected to appear degraded rather than healthy.",
       "The community source repository (oxylok/53-EfficientFrontier) previously 404d; re-verified live (200) as of this pass.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
       "On-chain SubnetIdentitiesV3 for netuid 53 now reports subnetName \"engy\" / description \"Verified inference for frontier open models.\" -- a completely different identity than the tracked EfficientFrontier/SignalPlus branding, corroborated by two independent indexers (metagraph.sh, TaoMarketCap). The live website and source repository both still describe EfficientFrontier/SignalPlus with no mention of \"engy\", and no GitHub presence for \"engy\" was found. The on-chain snapshot also shows subnet_emission_enabled=false, consistent with a dormant/deregistered subnet possibly being repurposed by a new operator whose infrastructure is not yet discoverable. Deliberately NOT renamed given zero infrastructure corroboration for the new on-chain identity; flagging for close attention on the next pass."
     ],

--- a/registry/subnets/endure-network.json
+++ b/registry/subnets/endure-network.json
@@ -38,10 +38,8 @@
       "Common /docs, /api, /health, /openapi.json, and Swagger paths on endure.network currently return 404 and are explicitly excluded from promoted surfaces.",
       "Generic email-protection pages are not listed as subnet interfaces.",
       "No verified source repository yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified OpenAPI/Swagger schema yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ]
   },
   "surfaces": [

--- a/registry/subnets/for-sale-burn-to-uid1.json
+++ b/registry/subnets/for-sale-burn-to-uid1.json
@@ -12,8 +12,7 @@
       "No verified official docs site yet beyond public directory/community pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",

--- a/registry/subnets/groundlayer.json
+++ b/registry/subnets/groundlayer.json
@@ -21,7 +21,6 @@
       "No verified live source repository yet.",
       "No verified docs site yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",

--- a/registry/subnets/hashichain.json
+++ b/registry/subnets/hashichain.json
@@ -10,7 +10,6 @@
       "No verified standalone website yet.",
       "No verified docs site yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",

--- a/registry/subnets/infinitehash.json
+++ b/registry/subnets/infinitehash.json
@@ -11,7 +11,6 @@
       "Project homepage (infinitehash.xyz) has regressed further since last review: it no longer returns HTTP 402 -- the TLS handshake now fails entirely (\"unrecognized name\"), and plain HTTP redirects to /lander, characteristic of a lapsed/parked domain. Not promoted as a monitored surface.",
       "The subnet auction incentive mechanism is documented in the public source repository.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",

--- a/registry/subnets/metahash.json
+++ b/registry/subnets/metahash.json
@@ -29,9 +29,7 @@
       "No verified official website yet.",
       "No verified live source repository yet.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ]
   },
   "surfaces": [

--- a/registry/subnets/oneoneone.json
+++ b/registry/subnets/oneoneone.json
@@ -11,7 +11,6 @@
   "curation": {
     "gap_notes": [
       "No verified official docs URL yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified OpenAPI/Swagger schema yet.",
       "No verified SSE/event stream yet.",
       "The official website (oneoneone.io) currently returns Cloudflare error 1016 (\"origin DNS error\") on every attempt as of 2026-07-16 -- Cloudflare cannot resolve the origin server behind the proxied domain. The source repository remains active (pushed 2026-06-11, not archived), so this looks like a website-hosting misconfiguration rather than full project abandonment. Probe disabled until it recovers; surface kept tracked."

--- a/registry/subnets/ralph.json
+++ b/registry/subnets/ralph.json
@@ -11,7 +11,6 @@
   "curation": {
     "gap_notes": [
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
       "The README mentions a Streamlit monitoring dashboard (\"Ralph Live\"), but it is a locally-run tool (streamlit run dashboard/app.py), not a hosted public URL, so it is not tracked."
     ],

--- a/registry/subnets/satori.json
+++ b/registry/subnets/satori.json
@@ -9,8 +9,7 @@
       "No verified official docs site yet beyond public directory/community pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",

--- a/registry/subnets/subnet-86.json
+++ b/registry/subnets/subnet-86.json
@@ -27,8 +27,7 @@
       "No verified official docs site yet beyond public directory/community pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
-      "No verified SSE/event stream yet.",
-      "No verified standalone static data artifact yet."
+      "No verified SSE/event stream yet."
     ]
   },
   "surfaces": [

--- a/registry/subnets/taolend.json
+++ b/registry/subnets/taolend.json
@@ -14,7 +14,6 @@
       "Official website currently still returns 500/server-error responses to simple probes (unchanged since the last review) and should appear degraded until it recovers.",
       "Previously discovered GitHub source repository currently returns 404.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",

--- a/registry/subnets/tensorclaw.json
+++ b/registry/subnets/tensorclaw.json
@@ -16,7 +16,6 @@
       "Website, source-repo, and live-demo surfaces kept tracked despite being dead (521/404) rather than removed, consistent with how outages are handled elsewhere in this registry -- their existing probes will correctly report the ongoing outage.",
       "No verified docs site yet beyond directory pages.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
-      "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet."
     ],
     "level": "maintainer-reviewed",


### PR DESCRIPTION
## Summary

Reconciles `curation.gap_notes` against each file's own `surfaces[]` on the exact 18 files (plus `aurelius.json`'s garbled note as a 19th, separately-scoped fix) the issue identifies — audited programmatically, not by hand, so the counts match exactly.

## Audit

A subnet file's `gap_notes` contradicts its own `surfaces[]` when it claims a surface *kind* is still unverified while a non-`rejected` surface of that exact kind already exists in the same file. Scanning every `registry/subnets/*.json` for the two exact note strings the issue names:

- **15 files** carried `"No verified safe public subnet API endpoint yet."` while already having a `kind: "subnet-api"` surface: `academia`, `bitads`, `cliqueai`, `ditto`, `dojo`, `efficientfrontier`, `endure-network`, `groundlayer`, `hashichain`, `infinitehash`, `metahash`, `oneoneone`, `ralph`, `taolend`, `tensorclaw`.
- **5 files** carried `"No verified standalone static data artifact yet."` while already having a `kind: "data-artifact"` surface: `endure-network`, `for-sale-burn-to-uid1`, `metahash`, `satori`, `subnet-86`.
- `endure-network.json` and `metahash.json` hit both patterns.

15 + 5 − 2 overlap = **18 files**, matching the issue's own stated count exactly.

`aurelius.json` is a 19th, separately-scoped fix (the issue lists it under its own deliverable bullet, not folded into "the 18"): its `"No verified OpenAPI/Swagger schema without an existing surface -- see the tracked openapi surface."` note is a garbled half-edited sentence, and `sn-37-aurelius-openapi` is already `schema_status: "machine-readable"` — removed outright, no residual gap to describe.

## Scope

Only the two exact contradicted note strings (plus the one garbled aurelius note) were removed. Every other gap note — website, source-repo, SSE/event-stream, OpenAPI, etc. — is untouched, including on the 19 edited files themselves (e.g. `metahash.json` still correctly notes it has no verified website/source-repo/OpenAPI/SSE surface — those gaps are real). No `surfaces[]` array touched on any file.

## Validation

- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:surface`
- [x] `npm run validate:readme-catalog`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check` on all 19 edited files
- [x] `git diff --check`
- [x] Verified every edited file is still valid JSON

Closes #6566
