### PR TITLE
fix(registry): move misfiled rate_limit_notes prose into notes

### DIFF
--- a/registry/subnets/bitads.json
+++ b/registry/subnets/bitads.json
@@ -49,7 +49,7 @@
       "id": "sn-16-bitads-website",
       "kind": "website",
       "name": "BitAds website",
-      "notes": "Official BitAds website (bitads.ai domain currently unresolvable).",
+      "notes": "Official BitAds website (bitads.ai domain currently unresolvable). Not probe-enabled because bitads.ai currently fails to resolve (DNS lame delegation — the domain's nameservers refuse queries); marked degraded until the domain recovers or a replacement is confirmed.",
       "probe": {
         "enabled": false,
         "expect": "html",
@@ -57,7 +57,6 @@
       },
       "provider": "bitads",
       "public_safe": true,
-      "rate_limit_notes": "Not probe-enabled because bitads.ai currently fails to resolve (DNS lame delegation — the domain's nameservers refuse queries); marked degraded until the domain recovers or a replacement is confirmed.",
       "source_urls": [
         "https://bitads.ai/",
         "https://github.com/FirstTensorLabs/BitAds"
@@ -70,7 +69,7 @@
       "id": "sn-16-bitads-docs",
       "kind": "docs",
       "name": "BitAds docs",
-      "notes": "Official BitAds documentation page (bitads.ai domain currently unresolvable).",
+      "notes": "Official BitAds documentation page (bitads.ai domain currently unresolvable). Not probe-enabled because the bitads.ai domain currently fails to resolve (DNS lame delegation); marked degraded until it recovers or a replacement is confirmed.",
       "probe": {
         "enabled": false,
         "expect": "html",
@@ -78,7 +77,6 @@
       },
       "provider": "bitads",
       "public_safe": true,
-      "rate_limit_notes": "Not probe-enabled because the bitads.ai domain currently fails to resolve (DNS lame delegation); marked degraded until it recovers or a replacement is confirmed.",
       "source_urls": ["https://bitads.ai/docs"],
       "url": "https://bitads.ai/docs"
     },

--- a/registry/subnets/connitoai.json
+++ b/registry/subnets/connitoai.json
@@ -72,7 +72,7 @@
       "id": "sn-102-connito-phase-openapi",
       "kind": "openapi",
       "name": "ConnitoAI SN Owner Phase API OpenAPI schema",
-      "notes": "Machine-readable OpenAPI 3.x schema for the Connito SN102 SN Owner Phase Service (FastAPI title: Phase Service). Served at cycle-api.connito.ai; documents no-auth cycle-coordination routes such as GET /get_phase and GET /blocks_until_next_phase per the official SN Owner Phase API reference.",
+      "notes": "Machine-readable OpenAPI 3.x schema for the Connito SN102 SN Owner Phase Service (FastAPI title: Phase Service). Served at cycle-api.connito.ai; documents no-auth cycle-coordination routes such as GET /get_phase and GET /blocks_until_next_phase per the official SN Owner Phase API reference. Cloudflare WAF in front of cycle-api.connito.ai may challenge simple automated probes from datacenter IPs; miners and validators use this host as the locked owner_url in official configuration.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -81,7 +81,6 @@
       },
       "provider": "connito",
       "public_safe": true,
-      "rate_limit_notes": "Cloudflare WAF in front of cycle-api.connito.ai may challenge simple automated probes from datacenter IPs; miners and validators use this host as the locked owner_url in official configuration.",
       "review": {
         "state": "community-submitted",
         "submitted_by": "bohdansolovie"
@@ -101,7 +100,7 @@
       "id": "sn-102-connito-phase-get-phase",
       "kind": "subnet-api",
       "name": "ConnitoAI SN Owner phase API",
-      "notes": "Public no-auth GET /get_phase on cycle-api.connito.ai returning the current training-cycle phase JSON (block height, phase_name, cycle_length, blocks_remaining_in_phase). Default owner_url in official Connito CycleCfg (config.py) and hard-pinned in miner-config.md; documented in the SN Owner Phase API reference.",
+      "notes": "Public no-auth GET /get_phase on cycle-api.connito.ai returning the current training-cycle phase JSON (block height, phase_name, cycle_length, blocks_remaining_in_phase). Default owner_url in official Connito CycleCfg (config.py) and hard-pinned in miner-config.md; documented in the SN Owner Phase API reference. Cloudflare WAF in front of cycle-api.connito.ai may challenge simple automated probes from datacenter IPs; the endpoint is the official phase oracle queried by miners and validators.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -110,7 +109,6 @@
       },
       "provider": "connito",
       "public_safe": true,
-      "rate_limit_notes": "Cloudflare WAF in front of cycle-api.connito.ai may challenge simple automated probes from datacenter IPs; the endpoint is the official phase oracle queried by miners and validators.",
       "review": {
         "state": "community-submitted",
         "submitted_by": "bohdansolovie"
@@ -128,7 +126,7 @@
       "id": "sn-102-connito-data-artifact",
       "kind": "data-artifact",
       "name": "ConnitoAI previous phase block ranges",
-      "notes": "Public no-auth GET /previous_phase_blocks on cycle-api.connito.ai returning the block-height range of each named phase (Distribute, Train, MinerCommit1/2, Submission, Validate, Merge, ValidatorCommit1/2) in the prior training cycle. Documented in the subnet's own OpenAPI schema (already-registered sn-102-connito-phase-openapi surface); same cycle-api.connito.ai host as the existing /get_phase surface.",
+      "notes": "Public no-auth GET /previous_phase_blocks on cycle-api.connito.ai returning the block-height range of each named phase (Distribute, Train, MinerCommit1/2, Submission, Validate, Merge, ValidatorCommit1/2) in the prior training cycle. Documented in the subnet's own OpenAPI schema (already-registered sn-102-connito-phase-openapi surface); same cycle-api.connito.ai host as the existing /get_phase surface. Cloudflare WAF in front of cycle-api.connito.ai may challenge simple automated probes from datacenter IPs; the endpoint is on the official phase-oracle host queried by miners and validators.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -137,7 +135,6 @@
       },
       "provider": "connito",
       "public_safe": true,
-      "rate_limit_notes": "Cloudflare WAF in front of cycle-api.connito.ai may challenge simple automated probes from datacenter IPs; the endpoint is on the official phase-oracle host queried by miners and validators.",
       "review": {
         "state": "community-submitted",
         "submitted_by": "philluiz2323"
@@ -217,7 +214,7 @@
       "id": "sn-102-connito-phase-status",
       "kind": "subnet-api",
       "name": "Connito phase service status",
-      "notes": "Public no-auth GET / on cycle-api.connito.ai returning a service-status payload with the static training-cycle configuration (cycle_length, ordered phases array with name/length per phase). Documented in the subnet's own OpenAPI schema. Distinct from /get_phase (the current live phase) and /blocks_until_next_phase (a countdown) -- this is the static cycle-shape definition plus a liveness message.",
+      "notes": "Public no-auth GET / on cycle-api.connito.ai returning a service-status payload with the static training-cycle configuration (cycle_length, ordered phases array with name/length per phase). Documented in the subnet's own OpenAPI schema. Distinct from /get_phase (the current live phase) and /blocks_until_next_phase (a countdown) -- this is the static cycle-shape definition plus a liveness message. Cloudflare WAF in front of cycle-api.connito.ai may challenge simple automated probes from datacenter IPs; the endpoint is on the official phase-oracle host queried by miners and validators.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -226,7 +223,6 @@
       },
       "provider": "connito",
       "public_safe": true,
-      "rate_limit_notes": "Cloudflare WAF in front of cycle-api.connito.ai may challenge simple automated probes from datacenter IPs; the endpoint is on the official phase-oracle host queried by miners and validators.",
       "review": {
         "state": "community-submitted",
         "submitted_by": "jsonbored"

--- a/registry/subnets/efficientfrontier.json
+++ b/registry/subnets/efficientfrontier.json
@@ -60,7 +60,7 @@
       "id": "sn-53-signalplus-mining",
       "kind": "dashboard",
       "name": "EfficientFrontier mining app",
-      "notes": "SignalPlus mining/app surface linked by public SN53 references.",
+      "notes": "SignalPlus mining/app surface linked by public SN53 references. Simple probes currently receive an auth/challenge-style response; endpoint health should be interpreted as access-state, not app correctness.",
       "probe": {
         "enabled": true,
         "expect": "html",
@@ -69,7 +69,6 @@
       },
       "provider": "signalplus",
       "public_safe": true,
-      "rate_limit_notes": "Simple probes currently receive an auth/challenge-style response; endpoint health should be interpreted as access-state, not app correctness.",
       "source_urls": [
         "https://t.signalplus.com/mining",
         "https://www.signalplus.com/"

--- a/registry/subnets/gopher.json
+++ b/registry/subnets/gopher.json
@@ -123,7 +123,7 @@
       "id": "sn-42-gopher-ai-subnet-api",
       "kind": "subnet-api",
       "name": "Gopher Data API live search",
-      "notes": "Official SN42 Gopher Data API live search (POST data.gopher-ai.com/api/v1/search/live). gopher-client defines jobEndpoint /v1/search/live on default base https://data.gopher-ai.com/api; gopher-mcp-server posts to /search/live on https://data.gopher-ai.com/api/v1.",
+      "notes": "Official SN42 Gopher Data API live search (POST data.gopher-ai.com/api/v1/search/live). gopher-client defines jobEndpoint /v1/search/live on default base https://data.gopher-ai.com/api; gopher-mcp-server posts to /search/live on https://data.gopher-ai.com/api/v1. Bearer API key required (GOPHER_CLIENT_TOKEN). POST-only credentialed endpoint; recurring read probes are intentionally disabled.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -131,7 +131,6 @@
       },
       "provider": "gopher-ai",
       "public_safe": true,
-      "rate_limit_notes": "Bearer API key required (GOPHER_CLIENT_TOKEN). POST-only credentialed endpoint; recurring read probes are intentionally disabled.",
       "review": {
         "state": "community-submitted",
         "submitted_by": "claytonlin1110"

--- a/registry/subnets/green-compute.json
+++ b/registry/subnets/green-compute.json
@@ -74,10 +74,9 @@
       "id": "sn-110-green-compute-chat-completions-api",
       "kind": "subnet-api",
       "name": "Green Compute chat completions API",
-      "notes": "Official API endpoint advertised by the Green Compute website. The endpoint is POST-only, so recurring read probes are intentionally disabled until a safe health or schema endpoint is confirmed.",
+      "notes": "Official API endpoint advertised by the Green Compute website. The endpoint is POST-only, so recurring read probes are intentionally disabled until a safe health or schema endpoint is confirmed. Auth and request-shape details need maintainer review before monitoring or proxy eligibility.",
       "provider": "green-compute",
       "public_safe": true,
-      "rate_limit_notes": "Auth and request-shape details need maintainer review before monitoring or proxy eligibility.",
       "source_urls": ["https://www.green-compute.com/"],
       "url": "https://api.green-compute.com/v1/chat/completions"
     },

--- a/registry/subnets/luminar-network.json
+++ b/registry/subnets/luminar-network.json
@@ -115,7 +115,7 @@
       "id": "sn-87-taopedia-article",
       "kind": "docs",
       "name": "Luminar Network Taopedia article",
-      "notes": "Discovered from the public Taopedia article repository. Not verified as an operational interface.",
+      "notes": "Discovered from the public Taopedia article repository. Not verified as an operational interface. Candidate only; no recurring probe is configured until maintainer review.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -132,7 +132,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_87/index.mdx"
       ],
@@ -144,7 +143,7 @@
       "id": "sn-87-tensorplex-docs",
       "kind": "docs",
       "name": "Luminar Network Tensorplex subnet docs",
-      "notes": "Discovered from Tensorplex subnet-docs. Useful as documentation enrichment, not verified operational authority.",
+      "notes": "Discovered from Tensorplex subnet-docs. Useful as documentation enrichment, not verified operational authority. Candidate only; no recurring probe is configured until maintainer review.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -161,7 +160,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/87/subnet.json"
       ],
@@ -173,7 +171,7 @@
       "id": "sn-87-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Luminar Network TaoMarketCap dashboard",
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority. Candidate only; no recurring probe is configured until maintainer review.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -190,7 +188,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/87"],
       "url": "https://taomarketcap.com/subnets/87"
     },

--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -150,10 +150,9 @@
       "id": "sn-49-nepher-tournament-api",
       "kind": "subnet-api",
       "name": "Nepher tournament API",
-      "notes": "Public tournament API host with machine-readable OpenAPI. Individual endpoints may require authentication or admin permissions, so proxy eligibility requires separate review.",
+      "notes": "Public tournament API host with machine-readable OpenAPI. Individual endpoints may require authentication or admin permissions, so proxy eligibility requires separate review. Schema is public; method-level auth must be reviewed before enabling health probes beyond schema fetches.",
       "provider": "nepher-robotics",
       "public_safe": true,
-      "rate_limit_notes": "Schema is public; method-level auth must be reviewed before enabling health probes beyond schema fetches.",
       "schema_status": "machine-readable",
       "schema_url": "https://tournament-api.nepher.ai/openapi.json",
       "source_urls": [

--- a/registry/subnets/nodexo.json
+++ b/registry/subnets/nodexo.json
@@ -67,10 +67,9 @@
       "id": "sn-106-nodexo-docs",
       "kind": "docs",
       "name": "Nodexo docs",
-      "notes": "Official Nodexo Compute documentation.",
+      "notes": "Official Nodexo Compute documentation. Not probe-enabled because simple Node/HEAD probes currently receive connection resets from the origin.",
       "provider": "nodexo",
       "public_safe": true,
-      "rate_limit_notes": "Not probe-enabled because simple Node/HEAD probes currently receive connection resets from the origin.",
       "source_urls": ["https://nodexo.ai/", "https://docs.nodexo.ai/"],
       "url": "https://docs.nodexo.ai/"
     },
@@ -80,10 +79,9 @@
       "id": "sn-106-nodexo-console",
       "kind": "dashboard",
       "name": "Nodexo console",
-      "notes": "Official Nodexo console surface. Authentication may be required for account-specific workflows.",
+      "notes": "Official Nodexo console surface. Authentication may be required for account-specific workflows. Not probe-enabled because simple Node/HEAD probes currently receive connection resets from the origin.",
       "provider": "nodexo",
       "public_safe": true,
-      "rate_limit_notes": "Not probe-enabled because simple Node/HEAD probes currently receive connection resets from the origin.",
       "source_urls": ["https://nodexo.ai/", "https://docs.nodexo.ai/"],
       "url": "https://console.nodexo.ai/"
     },

--- a/registry/subnets/root.json
+++ b/registry/subnets/root.json
@@ -108,6 +108,7 @@
       "id": "opentensor-archive-wss",
       "kind": "subtensor-wss",
       "name": "OpenTensor archive WSS",
+      "notes": "Official archive endpoint. Archive support is verified through read-only historical RPC probes.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -116,7 +117,6 @@
       },
       "provider": "opentensor",
       "public_safe": true,
-      "rate_limit_notes": "Official archive endpoint. Archive support is verified through read-only historical RPC probes.",
       "source_urls": [
         "https://docs.learnbittensor.org/concepts/bittensor-networks",
         "https://docs.learnbittensor.org/subtensor-nodes/subtensor-node-requirements"
@@ -129,6 +129,7 @@
       "id": "opentensor-lite-wss",
       "kind": "subtensor-wss",
       "name": "OpenTensor lite WSS",
+      "notes": "Official lite endpoint. Lite endpoints are not assumed to support deep historical archive queries.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -137,7 +138,6 @@
       },
       "provider": "opentensor",
       "public_safe": true,
-      "rate_limit_notes": "Official lite endpoint. Lite endpoints are not assumed to support deep historical archive queries.",
       "source_urls": [
         "https://docs.learnbittensor.org/concepts/bittensor-networks",
         "https://docs.learnbittensor.org/subtensor-nodes/subtensor-node-requirements"
@@ -186,6 +186,7 @@
       "id": "nodies-finney-rpc",
       "kind": "subtensor-rpc",
       "name": "Nodies Finney HTTPS RPC",
+      "notes": "No longer a free public endpoint: returns HTTP 403 'requires a paid subscription plan' (verified 2026-06-15). Demoted out of the public RPC pool; probe disabled.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -194,7 +195,6 @@
       },
       "provider": "nodies",
       "public_safe": false,
-      "rate_limit_notes": "No longer a free public endpoint: returns HTTP 403 'requires a paid subscription plan' (verified 2026-06-15). Demoted out of the public RPC pool; probe disabled.",
       "review": {
         "state": "maintainer-reviewed"
       },
@@ -230,6 +230,7 @@
       "id": "opentensor-lite-rpc",
       "kind": "subtensor-rpc",
       "name": "OpenTensor lite HTTPS RPC",
+      "notes": "Official lite host also serving HTTPS JSON-RPC. Lite endpoints are not assumed to support deep historical archive queries.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -238,7 +239,6 @@
       },
       "provider": "opentensor",
       "public_safe": true,
-      "rate_limit_notes": "Official lite host also serving HTTPS JSON-RPC. Lite endpoints are not assumed to support deep historical archive queries.",
       "source_urls": [
         "https://docs.learnbittensor.org/concepts/bittensor-networks",
         "https://docs.learnbittensor.org/subtensor-nodes/subtensor-node-requirements"
@@ -251,6 +251,7 @@
       "id": "opentensor-archive-rpc",
       "kind": "subtensor-rpc",
       "name": "OpenTensor archive HTTPS RPC",
+      "notes": "Official archive host also serving HTTPS JSON-RPC. Archive support is verified through read-only historical RPC probes.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -259,7 +260,6 @@
       },
       "provider": "opentensor",
       "public_safe": true,
-      "rate_limit_notes": "Official archive host also serving HTTPS JSON-RPC. Archive support is verified through read-only historical RPC probes.",
       "source_urls": [
         "https://docs.learnbittensor.org/concepts/bittensor-networks",
         "https://docs.learnbittensor.org/subtensor-nodes/subtensor-node-requirements"

--- a/registry/subnets/streetvision-by-natix.json
+++ b/registry/subnets/streetvision-by-natix.json
@@ -170,12 +170,11 @@
         "expect": "html",
         "method": "HEAD"
       },
-      "rate_limit_notes": "Now returns HTTP 401 (Hugging Face auth required) as of 2026-07-15; was public at last review (2026-06-08). Probing disabled since it will always fail while gated.",
       "review": {
         "state": "community-submitted",
         "submitted_by": "glorydavid03023"
       },
-      "notes": "NATIX StreetVision HuggingFace image+text dataset (~8.5k road/roadwork scenes with structured scene/weather/lighting metadata) backing the SN72 roadwork image-classification task. The StreetVision README (source) declares the Bittensor subnet and links the natix-network-org HF org that owns it. Now gated (HF auth required); tracked as a real official artifact pending it becoming public again."
+      "notes": "NATIX StreetVision HuggingFace image+text dataset (~8.5k road/roadwork scenes with structured scene/weather/lighting metadata) backing the SN72 roadwork image-classification task. The StreetVision README (source) declares the Bittensor subnet and links the natix-network-org HF org that owns it. Now gated (HF auth required); tracked as a real official artifact pending it becoming public again. Now returns HTTP 401 (Hugging Face auth required) as of 2026-07-15; was public at last review (2026-06-08). Probing disabled since it will always fail while gated."
     },
     {
       "id": "sn-72-natix-roadwork-rows-api",
@@ -195,12 +194,11 @@
         "expect": "json",
         "method": "GET"
       },
-      "rate_limit_notes": "Now returns HTTP 401 (Hugging Face auth required) as of 2026-07-15, same gating as the parent roadwork dataset; was public at last review (2026-06-08). Probing disabled since it will always fail while gated.",
       "review": {
         "state": "community-submitted",
         "submitted_by": "galuis116"
       },
-      "notes": "Hugging Face Datasets Server rows API for the official StreetVision roadwork dataset — machine-readable JSON (schema + row records with image/id/width/height/scene metadata), a distinct callable endpoint from the HF dataset webpage surface above. Previously filled the file's gap note for a verified safe public subnet API endpoint; now gated along with the parent dataset."
+      "notes": "Hugging Face Datasets Server rows API for the official StreetVision roadwork dataset — machine-readable JSON (schema + row records with image/id/width/height/scene metadata), a distinct callable endpoint from the HF dataset webpage surface above. Previously filled the file's gap note for a verified safe public subnet API endpoint; now gated along with the parent dataset. Now returns HTTP 401 (Hugging Face auth required) as of 2026-07-15, same gating as the parent roadwork dataset; was public at last review (2026-06-08). Probing disabled since it will always fail while gated."
     },
     {
       "auth_required": false,


### PR DESCRIPTION
## Summary

Moves misfiled `rate_limit_notes` prose into `notes` on the exact 22 surfaces / 10 files the issue identifies — audited programmatically against the exact regex the issue names, not by hand.

## Audit

Scanned every `registry/subnets/*.json` surface with a non-empty `rate_limit_notes`, classifying against `rate.?limit|requests? per|throttl|quota|per (second|minute|hour|day)`:

- **29** surfaces registry-wide carry a non-empty `rate_limit_notes`.
- **7** genuinely describe a rate limit — left untouched.
- **22**, across **10 files**, contain no rate-limit vocabulary at all:
  `bitads` (2), `connitoai` (4), `efficientfrontier` (1), `gopher` (1), `green-compute` (1), `luminar-network` (3), `nepher-robotics` (1), `nodexo` (2), `root` (5), `streetvision-by-natix` (2).

29 / 7 / 22 / 10 — all match the issue's own stated counts exactly.

## What Changed

For each of the 22 misfiled surfaces:

- The `rate_limit_notes` text is **merged into `notes`**, appended after the existing content (not overwritten) — 17 of the 22 already had a `notes` field.
- The 5 `root.json` RPC/WSS surfaces (`opentensor-archive-wss`, `opentensor-lite-wss`, `nodies-finney-rpc`, `opentensor-lite-rpc`, `opentensor-archive-rpc`) had no `notes` field at all — added fresh, placed in its usual alphabetical key position (right after `name`, before `probe`), matching every other surface's own key order.
- `rate_limit_notes` is cleared (key removed) on all 22.
- The 7 genuinely rate-limit-related surfaces, and every other field on the 22 edited surfaces (probe config, auth_required, review state, etc.), are untouched — this is a field-placement fix only, per the issue's own explicit scope: "do not change probe/auth/review-state behavior itself."

## Validation

- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:surface`
- [x] `npm run validate:readme-catalog`
- [x] `npm run scan:public-safety`
- [x] `npx prettier --check` on all 10 edited files
- [x] `git diff --check`
- [x] Verified every edited file is still valid JSON
- [x] Re-scanned post-fix: exactly 7 `rate_limit_notes` remain registry-wide, all genuine; zero misfiled

Closes #6567
