### PR TITLE
feat(ui): surface the existing network-wide sentiment reading as a mood gauge

### DIFF
--- a/apps/ui/src/components/metagraphed/network-mood-gauge.tsx
+++ b/apps/ui/src/components/metagraphed/network-mood-gauge.tsx
@@ -1,0 +1,80 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { chainAlphaVolumeQuery } from "@/lib/metagraphed/queries";
+import { healthColorVar } from "@/lib/health-tokens";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import { InfoTooltip } from "@jsonbored/ui-kit";
+
+const BULLISH_COLOR = healthColorVar("ok");
+const BEARISH_COLOR = healthColorVar("down");
+const NEUTRAL_COLOR = "var(--ink-muted)";
+
+const SENTIMENT_META = {
+  bullish: { label: "Bullish", Icon: TrendingUp, color: BULLISH_COLOR },
+  bearish: { label: "Bearish", Icon: TrendingDown, color: BEARISH_COLOR },
+  neutral: { label: "Neutral", Icon: Minus, color: NEUTRAL_COLOR },
+} as const;
+
+/**
+ * Network-wide "mood" gauge (#6642, #5968 survey -- Tao.app's Fear & Greed-
+ * style index finding): a first-class surfacing of the network.sentiment_ratio/
+ * sentiment fields GET /api/v1/chain/alpha-volume already computes as a
+ * byproduct of its 24h volume leaderboard -- no new sentiment math here, just
+ * a dedicated widget for a figure that was previously buried on a different
+ * route. Renders null while loading/on error/with no volume this window,
+ * matching the home hero rail's own "never clutter a cold first paint"
+ * convention (SubnetPriceTicker, HeroSubnetChips).
+ */
+export function NetworkMoodGauge() {
+  const { data: res, isLoading, isError } = useQuery(chainAlphaVolumeQuery());
+  if (isLoading || isError || !res) return null;
+
+  const { network, subnet_count } = res.data;
+  const { sentiment, sentiment_ratio } = network;
+  if (sentiment_ratio == null) return null;
+
+  const meta = SENTIMENT_META[sentiment];
+  const Icon = meta.Icon;
+  // Map -1..1 to 0..100% for the marker position on the bearish->bullish bar.
+  const markerPct = ((Math.max(-1, Math.min(1, sentiment_ratio)) + 1) / 2) * 100;
+
+  return (
+    <Link
+      id="network-mood-gauge"
+      to="/subnets"
+      className="mg-fade-in mg-fade-in-delay-3 mt-3 flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5 hover:border-ink/30 transition-colors"
+      title={`Network mood: ${meta.label} (ratio ${sentiment_ratio.toFixed(2)}) -- net/gross 24h alpha buy vs sell volume across ${formatNumber(subnet_count)} subnets.`}
+    >
+      <Icon aria-hidden className="size-4 shrink-0" style={{ color: meta.color }} />
+      <div className="min-w-0">
+        <div className="font-mono text-[9px] uppercase tracking-[0.18em] text-ink-muted">
+          Network mood
+        </div>
+        <div className="font-display text-sm font-semibold" style={{ color: meta.color }}>
+          {meta.label}
+        </div>
+      </div>
+      <div className="flex-1 min-w-[80px] max-w-[160px]">
+        <div className="relative h-1.5 rounded-full bg-gradient-to-r from-[var(--health-down)] via-[var(--ink-muted)] to-[var(--health-ok)] opacity-70">
+          <span
+            aria-hidden
+            className="absolute top-1/2 size-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-card bg-ink-strong"
+            style={{ left: `${markerPct}%` }}
+          />
+        </div>
+      </div>
+      <span
+        className={classNames(
+          "shrink-0 font-mono text-[11px] tabular-nums",
+          sentiment === "neutral" ? "text-ink-muted" : "",
+        )}
+        style={sentiment !== "neutral" ? { color: meta.color } : undefined}
+      >
+        {sentiment_ratio >= 0 ? "+" : ""}
+        {(sentiment_ratio * 100).toFixed(0)}%
+      </span>
+      <InfoTooltip label="Net vs. gross 24h alpha buy/sell volume across every active subnet -- the same sentiment reading GET /api/v1/chain/alpha-volume already computes for its volume leaderboard, surfaced here as a first-class figure. Not a technical-analysis indicator." />
+    </Link>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.chain-alpha-volume.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-alpha-volume.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { normalizeChainAlphaVolume, chainAlphaVolumeQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: "/api/v1/chain/alpha-volume",
+  });
+}
+
+// Mirrors queries.subnet-ohlc.test.ts's own runQuery helper.
+function runQuery<
+  O extends {
+    queryKey: readonly unknown[];
+    queryFn?: (context: never) => unknown;
+  },
+>(opts: O): ReturnType<NonNullable<O["queryFn"]>> {
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as never) as ReturnType<NonNullable<O["queryFn"]>>;
+}
+
+const RAW_NETWORK = {
+  buy_volume_alpha: 1000,
+  sell_volume_alpha: 400,
+  total_volume_alpha: 1400,
+  buy_volume_tao: 40,
+  sell_volume_tao: 16,
+  total_volume_tao: 56,
+  buy_count: 20,
+  sell_count: 8,
+  net_volume_alpha: 600,
+  sentiment_ratio: 0.4286,
+  sentiment: "bullish",
+};
+
+describe("normalizeChainAlphaVolume", () => {
+  it("passes a well-formed response through", () => {
+    const raw = {
+      schema_version: 1,
+      window: "24h",
+      observed_at: "2026-07-18T00:00:00.000Z",
+      subnet_count: 42,
+      network: RAW_NETWORK,
+      volume_distribution: {
+        count: 42,
+        mean: 10,
+        min: 1,
+        p25: 5,
+        median: 8,
+        p75: 12,
+        p90: 20,
+        max: 100,
+      },
+      subnets: [],
+    };
+    expect(normalizeChainAlphaVolume(raw)).toEqual(raw);
+  });
+
+  it("degrades cold / junk input to a schema-stable zeroed neutral reading", () => {
+    for (const raw of [{}, null, undefined, "not-an-object"]) {
+      const data = normalizeChainAlphaVolume(raw);
+      expect(data.schema_version).toBe(1);
+      expect(data.window).toBe("24h");
+      expect(data.observed_at).toBeNull();
+      expect(data.subnet_count).toBe(0);
+      expect(data.network).toEqual({
+        buy_volume_alpha: 0,
+        sell_volume_alpha: 0,
+        total_volume_alpha: 0,
+        buy_volume_tao: 0,
+        sell_volume_tao: 0,
+        total_volume_tao: 0,
+        buy_count: 0,
+        sell_count: 0,
+        net_volume_alpha: 0,
+        sentiment_ratio: null,
+        sentiment: "neutral",
+      });
+      expect(data.volume_distribution).toBeNull();
+      expect(data.subnets).toEqual([]);
+    }
+  });
+
+  it("coerces a junk sentiment string to neutral rather than passing it through", () => {
+    const data = normalizeChainAlphaVolume({ network: { ...RAW_NETWORK, sentiment: "moon" } });
+    expect(data.network.sentiment).toBe("neutral");
+  });
+
+  it("passes through bearish sentiment", () => {
+    const data = normalizeChainAlphaVolume({
+      network: { ...RAW_NETWORK, sentiment: "bearish", sentiment_ratio: -0.6 },
+    });
+    expect(data.network.sentiment).toBe("bearish");
+    expect(data.network.sentiment_ratio).toBe(-0.6);
+  });
+});
+
+describe("chainAlphaVolumeQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits its route with no params", async () => {
+    resolveWith({ network: RAW_NETWORK });
+    const res = await runQuery(chainAlphaVolumeQuery());
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      "/api/v1/chain/alpha-volume",
+      expect.objectContaining({}),
+    );
+    expect(res.data.network.sentiment).toBe("bullish");
+  });
+
+  it("normalizes the response through normalizeChainAlphaVolume", async () => {
+    resolveWith({ network: RAW_NETWORK, subnet_count: 7 });
+    const res = await runQuery(chainAlphaVolumeQuery());
+    expect(res.data.subnet_count).toBe(7);
+    expect(res.data.network.sentiment_ratio).toBe(0.4286);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -198,6 +198,9 @@ import type {
   SubnetRegistrations,
   SubnetStakeFlow,
   SubnetAlphaVolume,
+  ChainAlphaVolume,
+  ChainAlphaVolumeNetwork,
+  ChainAlphaVolumeDistribution,
   SubnetOhlc,
   SubnetOhlcCandle,
   SubnetConviction,
@@ -4638,6 +4641,59 @@ export const subnetAlphaVolumeQuery = (netuid: number) =>
         signal,
       });
       return { data: normalizeSubnetAlphaVolume(netuid, res.data), meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
+// Network-wide rollup of the same sentiment_ratio/sentiment reading
+// normalizeSubnetAlphaVolume computes per-subnet, just summed across the
+// whole network first (#6642's "network mood" gauge). A cold store returns
+// zeroed totals + a "neutral" reading, never throws.
+function normalizeChainAlphaVolumeNetwork(raw: unknown): ChainAlphaVolumeNetwork {
+  const d = isRecord(raw) ? raw : {};
+  const sentiment = firstString(d.sentiment);
+  return {
+    buy_volume_alpha: coerceFiniteNumber(d.buy_volume_alpha) ?? 0,
+    sell_volume_alpha: coerceFiniteNumber(d.sell_volume_alpha) ?? 0,
+    total_volume_alpha: coerceFiniteNumber(d.total_volume_alpha) ?? 0,
+    buy_volume_tao: coerceFiniteNumber(d.buy_volume_tao) ?? 0,
+    sell_volume_tao: coerceFiniteNumber(d.sell_volume_tao) ?? 0,
+    total_volume_tao: coerceFiniteNumber(d.total_volume_tao) ?? 0,
+    buy_count: firstFiniteNumber(d.buy_count) ?? 0,
+    sell_count: firstFiniteNumber(d.sell_count) ?? 0,
+    net_volume_alpha: coerceFiniteNumber(d.net_volume_alpha) ?? 0,
+    sentiment_ratio: coerceFiniteNumber(d.sentiment_ratio) ?? null,
+    sentiment: sentiment === "bullish" || sentiment === "bearish" ? sentiment : "neutral",
+  };
+}
+
+export function normalizeChainAlphaVolume(raw: unknown): ChainAlphaVolume {
+  const d = isRecord(raw) ? raw : {};
+  return {
+    schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+    window: firstString(d.window) ?? "24h",
+    observed_at: firstString(d.observed_at) ?? null,
+    subnet_count: firstFiniteNumber(d.subnet_count) ?? 0,
+    network: normalizeChainAlphaVolumeNetwork(d.network),
+    volume_distribution: isRecord(d.volume_distribution)
+      ? (d.volume_distribution as unknown as ChainAlphaVolumeDistribution)
+      : null,
+    subnets: Array.isArray(d.subnets) ? (d.subnets as SubnetAlphaVolume[]) : [],
+  };
+}
+
+// GET /api/v1/chain/alpha-volume (#4339/8.2): network-wide rolling 24h
+// buy/sell alpha volume, ranked by total_volume_tao -- the network.sentiment_ratio/
+// sentiment fields are the "network mood" gauge's data source (#6642), reused
+// as-is rather than recomputed client-side.
+export const chainAlphaVolumeQuery = () =>
+  queryOptions({
+    queryKey: k("chain-alpha-volume"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Partial<ChainAlphaVolume>>("/api/v1/chain/alpha-volume", {
+        signal,
+      });
+      return { data: normalizeChainAlphaVolume(res.data), meta: res.meta, url: res.url };
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1912,6 +1912,51 @@ export interface SubnetAlphaVolume {
   vol_mcap_ratio: number | null;
 }
 
+/** Network-wide rollup of every subnet's 24h buy/sell alpha volume, the
+ * "network mood" signal (#6642) -- net_volume_alpha / gross, same
+ * sentiment_ratio/sentiment math as one subnet's own SubnetAlphaVolume,
+ * just summed across the whole network first. */
+export interface ChainAlphaVolumeNetwork {
+  buy_volume_alpha: number;
+  sell_volume_alpha: number;
+  total_volume_alpha: number;
+  buy_volume_tao: number;
+  sell_volume_tao: number;
+  total_volume_tao: number;
+  buy_count: number;
+  sell_count: number;
+  net_volume_alpha: number;
+  sentiment_ratio: number | null;
+  sentiment: "bullish" | "bearish" | "neutral";
+}
+
+/** Spread of per-subnet total_volume_tao across every subnet with volume in
+ * the window; null when no subnet had volume. */
+export interface ChainAlphaVolumeDistribution {
+  count: number;
+  mean: number;
+  min: number;
+  p25: number;
+  median: number;
+  p75: number;
+  p90: number;
+  max: number;
+}
+
+/** Network-wide rolling 24h buy/sell alpha-volume leaderboard from
+ * /api/v1/chain/alpha-volume -- the network mood gauge (#6642) reads only
+ * `network`; `subnets`/`volume_distribution` exist for the (not yet built)
+ * full leaderboard view. */
+export interface ChainAlphaVolume {
+  schema_version: number;
+  window: string;
+  observed_at: string | null;
+  subnet_count: number;
+  network: ChainAlphaVolumeNetwork;
+  volume_distribution: ChainAlphaVolumeDistribution | null;
+  subnets: SubnetAlphaVolume[];
+}
+
 /** One open/high/low/close/volume candle from /api/v1/subnets/{netuid}/ohlc. */
 export interface SubnetOhlcCandle {
   bucket_start: number;

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -35,6 +35,7 @@ import {
 import { TimeRangeProvider } from "@/components/metagraphed/analytics/time-range-context";
 import { TimeRangeScrub } from "@/components/metagraphed/analytics/time-range-scrub";
 import { SubnetPriceTicker } from "@/components/metagraphed/subnet-price-ticker";
+import { NetworkMoodGauge } from "@/components/metagraphed/network-mood-gauge";
 import { HeroSubnetChips } from "@/components/metagraphed/hero-subnet-chips";
 import { QuickActionsRow } from "@/components/metagraphed/quick-actions-row";
 import { RecentIdentityChanges } from "@/components/metagraphed/recent-identity-changes";
@@ -88,6 +89,12 @@ function OverviewPage() {
         <Suspense fallback={null}>
           <SubnetPriceTicker />
         </Suspense>
+      </QueryErrorBoundary>
+
+      {/* #6642: network-wide sentiment reading, surfaced as its own widget --
+          self-manages loading/error via useQuery (no Suspense needed). */}
+      <QueryErrorBoundary fallback={() => null}>
+        <NetworkMoodGauge />
       </QueryErrorBoundary>
 
       <QueryErrorBoundary fallback={() => null}>


### PR DESCRIPTION
## Summary

Surfaces the network-wide sentiment reading `GET /api/v1/chain/alpha-volume` already computes
(`network.sentiment_ratio`/`network.sentiment`, a byproduct of its 24h volume leaderboard) as a
first-class "Network mood" widget, per #6642 (#5968 survey, Tao.app's Fear & Greed-style index
finding). Confirmed the existing fields are reasonably consumable as-is — no new backend route,
alias, or sentiment computation; this is purely a surfacing/discoverability gap, matching the
issue's own non-goals.

## What changed

- `apps/ui/src/lib/metagraphed/types.ts`: `ChainAlphaVolume`/`ChainAlphaVolumeNetwork`/
  `ChainAlphaVolumeDistribution` types for `GET /api/v1/chain/alpha-volume` (no frontend query
  existed for this route before).
- `apps/ui/src/lib/metagraphed/queries.ts`: `chainAlphaVolumeQuery` + normalize functions, with
  unit tests.
- `apps/ui/src/components/metagraphed/network-mood-gauge.tsx`: the widget — bullish/bearish/
  neutral label, a bearish→bullish gauge bar with a marker at the live `sentiment_ratio`, and a
  tooltip explaining the reading. Renders null while loading/on error/with no ratio, matching the
  home hero rail's own "never clutter a cold first paint" convention (`SubnetPriceTicker`,
  `HeroSubnetChips`).
- `apps/ui/src/routes/index.tsx`: mounted right after the alpha-price ticker on the homepage.

## Screenshots

### Homepage hero rail — new "Network mood" widget

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/JSONbored/metagraphed/screenshots/6642-mood-after-mobile-dark.png)<br><sub>after</sub> |

(Live data at capture time: Neutral, ratio 0.00 — the "before" shots fall back to page top since
the widget's anchor id doesn't exist on `main`.)

## Validation

- `npx vitest run` — 161 files / 1207 tests passed (apps/ui full suite)
- `npm run typecheck` — clean
- `npx eslint <changed files>` — clean (0 errors; 1 pre-existing unrelated warning)
- `npm run format:check` — clean
- `npx playwright test tests/e2e/responsive-overflow.spec.ts` (full run, all 6 tracked routes including `/`) — 24/24 passed, no new overflow regressions
- `npm run build` — clean

Closes #6642
