### PR TITLE
perf(api): edge-cache the chain-events proxy's DATA_API fetch

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -99,6 +99,93 @@ describe("Worker runtime", () => {
     assert.equal(body.meta.source, "data-worker-postgres");
   });
 
+  test("caches a chain-events GET at the edge and skips a second DATA_API fetch (#6767)", async () => {
+    let dataCalls = 0;
+    const store = new Map();
+    globalThis.caches = {
+      default: {
+        async match(request) {
+          const cached = store.get(request.url);
+          return cached ? cached.clone() : undefined;
+        },
+        async put(request, response) {
+          store.set(request.url, response.clone());
+        },
+      },
+    };
+    try {
+      const testEnv = {
+        ...env,
+        DATA_API: {
+          fetch() {
+            dataCalls += 1;
+            return new Response(
+              JSON.stringify({ window_blocks: 500, activity: [] }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
+          },
+        },
+      };
+      const waited = [];
+      const ctx = { waitUntil: (p) => waited.push(p) };
+      const url = "https://metagraph.sh/api/v1/chain-events/stats?blocks=500";
+      const first = await handleRequest(new Request(url), testEnv, ctx);
+      assert.equal(first.status, 200);
+      assert.equal(dataCalls, 1);
+      // The cache.put is scheduled via ctx.waitUntil, not awaited inline --
+      // drain it before the second request expects a warm cache.
+      await Promise.all(waited);
+      assert.equal(store.size, 1);
+
+      const second = await handleRequest(new Request(url), testEnv, ctx);
+      assert.equal(second.status, 200);
+      assert.equal(dataCalls, 1, "second request must not re-fetch DATA_API");
+      const body = await second.json();
+      assert.equal(body.data.window_blocks, 500);
+    } finally {
+      globalThis.caches = undefined;
+    }
+  });
+
+  test("does not cache a non-200 DATA_API response (#6767)", async () => {
+    let dataCalls = 0;
+    const store = new Map();
+    globalThis.caches = {
+      default: {
+        async match(request) {
+          const cached = store.get(request.url);
+          return cached ? cached.clone() : undefined;
+        },
+        async put(request, response) {
+          store.set(request.url, response.clone());
+        },
+      },
+    };
+    try {
+      const testEnv = {
+        ...env,
+        DATA_API: {
+          fetch() {
+            dataCalls += 1;
+            return new Response(JSON.stringify({ error: "boom" }), {
+              status: 502,
+            });
+          },
+        },
+      };
+      const waited = [];
+      const ctx = { waitUntil: (p) => waited.push(p) };
+      const url = "https://metagraph.sh/api/v1/chain-events/stats?blocks=1";
+      const response = await handleRequest(new Request(url), testEnv, ctx);
+      assert.equal(response.status, 502);
+      await Promise.all(waited);
+      assert.equal(store.size, 0, "an error response must never be cached");
+      assert.equal(dataCalls, 1);
+    } finally {
+      globalThis.caches = undefined;
+    }
+  });
+
   test("routes /api/v1/subnets/:netuid/ownership-history through the same DATA_API chain-events proxy (#6637)", async () => {
     let requestedPath = null;
     const response = await handleRequest(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -729,7 +729,28 @@ const CHAIN_EVENTS_CSV_COLUMNS = [
   "observed_at",
 ];
 
-async function handleChainEventsProxy(request, env, url) {
+// Response cache for this proxy's upstream (DATA_API) body, keyed on the
+// request path+search -- every param (netuid, kind, window, limit) fully
+// determines the content. Deliberately caches the parsed upstream JSON, not
+// the final client-facing Response: envelopeResponse's ETag/304 handling and
+// the CSV-vs-JSON format branch below both stay per-request and cheap
+// (no Postgres/Hyperdrive round trip either way), while the one expensive
+// part -- the DATA_API fetch -- gets skipped on a hit. Mirrors the
+// caches.default pattern already proven in request-handlers/rpc-proxy.mjs
+// and request-handlers/analytics.mjs (metagraphed#6767); short, fixed TTL
+// (no freshness-stamp invalidation, unlike analytics.mjs's D1-fallback-aware
+// version) since this tier has no publish-time snapshot to key off of.
+const CHAIN_EVENTS_PROXY_CACHE_TTL_SECONDS = 60;
+
+async function chainEventsProxyCacheKey(env, url) {
+  return new Request(
+    `https://edge-cache.metagraph.sh/chain-events-proxy/${encodeURIComponent(
+      contractVersion(env),
+    )}${url.pathname}${url.search}`,
+  );
+}
+
+async function handleChainEventsProxy(request, env, url, ctx) {
   if (!env.DATA_API) {
     return errorResponse(
       "data_tier_unavailable",
@@ -737,33 +758,61 @@ async function handleChainEventsProxy(request, env, url) {
       503,
     );
   }
-  // DATA_API is GET-only (it 405s any other method), so a HEAD probe must be
-  // forwarded as a GET or it would return a 405 error envelope instead of the
-  // bodiless 200 that HEAD yields on every other GET route (and that this route's
-  // own CORS preflight advertises). envelopeResponse(request, …) below still
-  // strips the body for HEAD, so the client gets the correct empty 200.
-  const upstream = await env.DATA_API.fetch(
-    request.method === "HEAD"
-      ? new Request(request.url, { method: "GET", headers: request.headers })
-      : request,
-  );
+  const cache =
+    request.method === "GET" || request.method === "HEAD"
+      ? globalThis.caches?.default
+      : null;
+  const cacheKey = cache ? await chainEventsProxyCacheKey(env, url) : null;
   let body;
-  try {
-    body = await upstream.json();
-  } catch {
-    return errorResponse(
-      "data_tier_unavailable",
-      "The all-events data tier returned an unreadable response.",
-      502,
+  let upstreamOk = true;
+  let upstreamStatus = 200;
+  const cacheHit = cacheKey ? await cache.match(cacheKey) : null;
+  if (cacheHit) {
+    body = await cacheHit.json();
+  } else {
+    // DATA_API is GET-only (it 405s any other method), so a HEAD probe must be
+    // forwarded as a GET or it would return a 405 error envelope instead of the
+    // bodiless 200 that HEAD yields on every other GET route (and that this route's
+    // own CORS preflight advertises). envelopeResponse(request, …) below still
+    // strips the body for HEAD, so the client gets the correct empty 200.
+    const upstream = await env.DATA_API.fetch(
+      request.method === "HEAD"
+        ? new Request(request.url, { method: "GET", headers: request.headers })
+        : request,
     );
+    try {
+      body = await upstream.json();
+    } catch {
+      return errorResponse(
+        "data_tier_unavailable",
+        "The all-events data tier returned an unreadable response.",
+        502,
+      );
+    }
+    upstreamOk = upstream.ok;
+    upstreamStatus = upstream.status;
+    if (cacheKey && upstreamOk) {
+      ctx?.waitUntil?.(
+        cache.put(
+          cacheKey,
+          new Response(JSON.stringify(body), {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              "cache-control": `public, s-maxage=${CHAIN_EVENTS_PROXY_CACHE_TTL_SECONDS}`,
+            },
+          }),
+        ),
+      );
+    }
   }
-  if (!upstream.ok) {
+  if (!upstreamOk) {
     return errorResponse(
       "data_query_failed",
       typeof body?.error === "string"
         ? body.error
         : "The all-events data tier returned an error.",
-      upstream.status,
+      upstreamStatus,
     );
   }
   // CSV download of the page: the /api/v1/chain-events feed exposes `events`, so
@@ -1292,7 +1341,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         );
       }
     }
-    return handleChainEventsProxy(request, env, url);
+    return handleChainEventsProxy(request, env, url, ctx);
   }
 
   // Change-feed webhooks: subscription management accepts POST/DELETE/GET, so it


### PR DESCRIPTION
## Summary

`handleChainEventsProxy` (serving `/api/v1/chain-events`, `/chain-events/stats`, `/blocks/:n/chain-events`, `/subnets/:id/ownership-history`, `/subnets/:id/conviction`) queried Postgres via Hyperdrive on every single request -- unlike `request-handlers/rpc-proxy.mjs` and `request-handlers/analytics.mjs`, which both already use the Workers Cache API to avoid that round trip on a repeat request.

Caches the parsed upstream (`DATA_API`) JSON body, not the final client-facing `Response`: `envelopeResponse`'s ETag/304 handling and the CSV-vs-JSON format branch both stay per-request and cheap (no Postgres/Hyperdrive round trip either way regardless of output format), while the one expensive part -- the `DATA_API` fetch -- gets skipped on a cache hit. Short, fixed 60s TTL (no freshness-stamp invalidation like `analytics.mjs`'s D1-fallback-aware version, since this tier has no publish-time snapshot to key off of); never caches non-200 responses.

## Test plan

- [x] `tests/worker-runtime.test.mjs` -- two new tests: a cache MISS-then-HIT sequence asserting `DATA_API` is only fetched once, and confirming a non-200 upstream response is never cached
- [x] Full `tests/worker-runtime.test.mjs` suite green (54/54)
- [x] No regression: isolated via `git stash` that this branch introduces no new failures elsewhere