### PR TITLE
fix(ui): add StaleBanner to blocks.$ref.tsx and extrinsics.$hash.tsx (#6557)

### DIFF
--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -5,7 +5,7 @@ import { ChevronLeft, ChevronRight, Boxes, FileText, Zap } from "lucide-react";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
+import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import {
   CopyableCode,
@@ -26,7 +26,7 @@ import {
   blockExtrinsicsQuery,
   blockQuery,
 } from "@/lib/metagraphed/queries";
-import { formatNumber } from "@/lib/metagraphed/format";
+import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { blockRefPathSegment, isValidBlockRef, shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall } from "@/lib/metagraphed/extrinsics";
@@ -105,7 +105,9 @@ function BlockDetail({ refValue }: { refValue: string }) {
 function ValidBlockDetail({ refValue }: { refValue: string }) {
   const navigate = useNavigate();
   const sourceRef = blockRefPathSegment(refValue);
-  const block = useSuspenseQuery(blockQuery(refValue)).data.data;
+  const blockResult = useSuspenseQuery(blockQuery(refValue)).data;
+  const block = blockResult.data;
+  const generatedAt = blockResult.meta?.generated_at ?? null;
   const extrinsicsQuery = useQuery(blockExtrinsicsQuery(refValue, { limit: 100 }));
   const eventsQuery = useQuery(blockEventsQuery(refValue, { limit: 100 }));
   const chainEventsQuery = useQuery(blockChainEventsQuery(refValue));
@@ -176,9 +178,18 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
           )
         }
         actions={
-          <ActionBar>
-            <ShareButton bare />
-          </ActionBar>
+          <>
+            <ActionBar>
+              <ShareButton bare />
+            </ActionBar>
+            {isStaleFreshness(generatedAt) ? (
+              <StaleBanner
+                compact
+                generatedAt={generatedAt}
+                refreshQueryKeys={[blockQuery(refValue).queryKey]}
+              />
+            ) : null}
+          </>
         }
         caption="explorer / v1"
       />

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -5,7 +5,7 @@ import { Boxes, Clock, FileText, Link2, UserCog } from "lucide-react";
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
-import { EmptyState, PageHeading, Skeleton } from "@/components/metagraphed/states";
+import { EmptyState, PageHeading, Skeleton, StaleBanner } from "@/components/metagraphed/states";
 import { EndpointSnippet } from "@/components/metagraphed/endpoint-snippet";
 import {
   CopyableCode,
@@ -19,7 +19,7 @@ import {
 } from "@jsonbored/ui-kit";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { extrinsicQuery, extrinsicsQuery } from "@/lib/metagraphed/queries";
-import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+import { formatNumber, formatTao, isStaleFreshness } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { unwrapByteArray, decodeBytesField } from "@/lib/metagraphed/bytes";
 import { eventKindLabel } from "@/lib/metagraphed/event-kinds";
@@ -107,7 +107,9 @@ function ExtrinsicDetail({ hash }: { hash: string }) {
 
 function ValidExtrinsicDetail({ hash }: { hash: string }) {
   const sourceRef = extrinsicHashPathSegment(hash);
-  const extrinsic = useSuspenseQuery(extrinsicQuery(hash)).data.data;
+  const extrinsicResult = useSuspenseQuery(extrinsicQuery(hash)).data;
+  const extrinsic = extrinsicResult.data;
+  const generatedAt = extrinsicResult.meta?.generated_at ?? null;
   const callArgs = extrinsic?.call_args;
   const events = (extrinsic?.events ?? []).slice(0, 100);
   // #3423: the events/call-args lists are sliced to bound render cost on an
@@ -181,9 +183,18 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
           </span>
         }
         actions={
-          <ActionBar>
-            <ShareButton bare />
-          </ActionBar>
+          <>
+            <ActionBar>
+              <ShareButton bare />
+            </ActionBar>
+            {isStaleFreshness(generatedAt) ? (
+              <StaleBanner
+                compact
+                generatedAt={generatedAt}
+                refreshQueryKeys={[extrinsicQuery(hash).queryKey]}
+              />
+            ) : null}
+          </>
         }
         caption="explorer / v1"
       />


### PR DESCRIPTION
Closes #6557

## Problem

Every structurally-identical entity-detail page (`accounts.$ss58.tsx`, `validators.$hotkey.tsx`, `subnets.$netuid.tsx`, `providers.$slug.tsx`) computes staleness from its response's `generated_at` and conditionally renders a `StaleBanner` in the hero. `blocks.$ref.tsx` and `extrinsics.$hash.tsx` never did this — verified directly against source: neither imported `StaleBanner` or called `isStaleFreshness` anywhere, despite both rendering a payload backed by the same periodically-refreshed poller as the other four pages. A visitor viewing a stale block or extrinsic had no signal at all.

## Fix

Both pages previously discarded their query's `meta` via `.data.data` — extracted `meta.generated_at` alongside `data` and render the same `compact` `StaleBanner` in the hero's `actions` row (next to the existing `ShareButton`) when `isStaleFreshness(generatedAt)` is true, wired to refetch the page's own query key on refresh. This mirrors `accounts.$ss58.tsx`'s exact precedent, reusing the existing `StaleBanner`/`isStaleFreshness` helpers — no new staleness UI invented.

## Screenshots

Since neither route's live data happens to be stale right now, I forced the `>12h` threshold by mutating each page's own API response's `meta.generated_at` to 20h-ago via Playwright response interception (client-side navigated, since both routes fully resolve their data server-side on a hard page load — the mock only applies to a genuine in-browser fetch). Same forced-stale data on both branches: before shows no signal at all; after shows the compact \"Snapshot 20h ago\" banner with a refresh action.

### `blocks.$ref.tsx`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-blocks-after-mobile-dark.png)<br><sub>after</sub> |

### `extrinsics.$hash.tsx`

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6557-extrinsics-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

- `npx tsc --noEmit -p apps/ui`: clean
- `npx prettier --check` / `npx eslint` on changed files: clean (no new warnings)
- `npx vitest run` (apps/ui): 160 test files, 1201 tests, all passing
- Manually verified in browser: forced staleness via response mocking, confirmed the banner appears/refetches correctly on both routes and that fresh data shows no banner (unchanged from before)