### PR TITLE
obs(sentry): enable performance tracing at a conservative 5% sample

### DIFF
--- a/workers/api.sentry.mjs
+++ b/workers/api.sentry.mjs
@@ -63,9 +63,17 @@ export default withSentry(
     // documented auto-detection convention. Both undefined is a valid,
     // accepted value (Sentry just omits release tagging), not an error.
     release: env.SENTRY_RELEASE || env.CF_VERSION_METADATA?.id,
-    // Error tracking only, matching every other component in this rollout
-    // -- no performance tracing.
-    tracesSampleRate: 0,
+    // Performance tracing at a conservative 5% sample (metagraphed#6768) --
+    // was 0 ("error tracking only") across this whole rollout, which left
+    // zero visibility into real request volume/latency for anything outside
+    // /mcp (the only route with its own hand-rolled span). 5% is a starting
+    // point chosen without knowing this org's actual Sentry plan/quota
+    // headroom (not visible from the tools available when this was picked);
+    // revisit once real trace volume is observable -- worth moving to a
+    // tracesSampler with per-route weights (e.g. sampling the leaderboard/
+    // chain-events routes higher) once there's real traffic data to
+    // calibrate that against, rather than guessing now.
+    tracesSampleRate: 0.05,
   }),
   handler,
 );

--- a/workers/data-api.sentry.mjs
+++ b/workers/data-api.sentry.mjs
@@ -37,9 +37,12 @@ export default Sentry.withSentry(
     // documented auto-detection convention. Both undefined is a valid,
     // accepted value (Sentry just omits release tagging), not an error.
     release: env.SENTRY_RELEASE || env.CF_VERSION_METADATA?.id,
-    // Error tracking only, matching every other component in this rollout
-    // -- no performance tracing.
-    tracesSampleRate: 0,
+    // Performance tracing at a conservative 5% sample -- see
+    // workers/api.sentry.mjs's own comment (metagraphed#6768) for the full
+    // rationale; this Worker is the one that actually runs the leaderboard/
+    // chain-events Postgres queries this issue's traffic-volume question was
+    // about.
+    tracesSampleRate: 0.05,
   }),
   handler,
 );

--- a/workers/registry-sync-api.sentry.mjs
+++ b/workers/registry-sync-api.sentry.mjs
@@ -37,9 +37,10 @@ export default Sentry.withSentry(
     // documented auto-detection convention. Both undefined is a valid,
     // accepted value (Sentry just omits release tagging), not an error.
     release: env.SENTRY_RELEASE || env.CF_VERSION_METADATA?.id,
-    // Error tracking only, matching every other component in this rollout
-    // -- no performance tracing.
-    tracesSampleRate: 0,
+    // Performance tracing at a conservative 5% sample -- see
+    // workers/api.sentry.mjs's own comment (metagraphed#6768) for the full
+    // rationale.
+    tracesSampleRate: 0.05,
   }),
   handler,
 );


### PR DESCRIPTION
## Summary

`tracesSampleRate: 0` was set explicitly and identically across all three Sentry Workers wrappers (`api.sentry.mjs`, `data-api.sentry.mjs`, `registry-sync-api.sentry.mjs`), each with the same comment: "Error tracking only, matching every other component in this rollout -- no performance tracing." Confirmed via Sentry's `spans` dataset: only 10 transactions/week total, all `/mcp` (which has its own hand-rolled spans) -- zero visibility into the general REST API's real request volume or latency anywhere else.

Turns it up to a conservative 5% across all three. This is a starting point, not a calibrated number -- I don't have visibility into this org's actual Sentry plan/quota headroom from the tools available, so picked something low rather than guess higher. Worth moving to a `tracesSampler` with per-route weights (e.g. sampling `/api/v1/chain/*`/`/api/v1/chain-events*` higher than cheap high-traffic routes) once there's real trace volume to calibrate against.

Does NOT touch `scripts/observability.mjs` or `scripts/chain-firehose-relay.mjs`'s own separate Sentry inits (box-side Node scripts, not Workers) -- out of scope for this issue, and their own `tracesSampleRate: 0` is untouched.

## Test plan

- [x] `node --check` on all three edited files
- [x] No test changes needed: `workers/*.sentry.mjs` is already excluded from coverage tracking (`vitest.config.mjs`) -- thin wrappers that only run in the real workerd runtime, not vitest's Node environment

Closes #6768