### PR TITLE
fix(registry): set schema_url on 6 openapi surfaces claiming machine-readable

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -218,6 +218,7 @@
       "provider": "chutes",
       "public_safe": true,
       "schema_status": "machine-readable",
+      "schema_url": "https://api.chutes.ai/openapi.json",
       "source_urls": [
         "https://api.chutes.ai/openapi.json",
         "https://github.com/chutesai/chutes"

--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -133,6 +133,7 @@
       "provider": "desearch",
       "public_safe": true,
       "schema_status": "machine-readable",
+      "schema_url": "https://www.desearch.ai/openapi.json",
       "source_urls": [
         "https://www.desearch.ai/openapi.json",
         "https://api.desearch.ai"

--- a/registry/subnets/green-compute.json
+++ b/registry/subnets/green-compute.json
@@ -97,6 +97,7 @@
       "provider": "green-compute",
       "public_safe": true,
       "schema_status": "machine-readable",
+      "schema_url": "https://api.green-compute.com/openapi.json",
       "source_urls": [
         "https://api.green-compute.com/openapi.json",
         "https://www.green-compute.com/"

--- a/registry/subnets/handshake58.json
+++ b/registry/subnets/handshake58.json
@@ -139,6 +139,7 @@
       "provider": "handshake58",
       "public_safe": true,
       "schema_status": "machine-readable",
+      "schema_url": "https://handshake58.com/openapi.json",
       "source_urls": [
         "https://handshake58.com/.well-known/ai-plugin.json",
         "https://handshake58.com/openapi.json"

--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -138,6 +138,7 @@
       "provider": "nepher-robotics",
       "public_safe": true,
       "schema_status": "machine-readable",
+      "schema_url": "https://tournament-api.nepher.ai/openapi.json",
       "source_urls": [
         "https://tournament-api.nepher.ai/docs",
         "https://tournament-api.nepher.ai/openapi.json"

--- a/registry/subnets/verathos.json
+++ b/registry/subnets/verathos.json
@@ -112,6 +112,7 @@
       "provider": "verathos",
       "public_safe": true,
       "schema_status": "machine-readable",
+      "schema_url": "https://verathos.ai/openapi.json",
       "source_urls": [
         "https://verathos.ai/docs",
         "https://verathos.ai/openapi.json"

--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -198,6 +198,17 @@ for (const file of files) {
           "(the /rpc endpoint lane), not per-subnet contributor surfaces.",
       );
     }
+    // #6331: a surface claiming its schema is machine-readable is a claim
+    // about where to fetch it — with no schema_url there is nowhere for a
+    // caller to actually get the spec, so the claim is unverifiable. Found 6
+    // live instances (each an openapi-kind surface) before this check existed.
+    if (surface.schema_status === "machine-readable" && !surface.schema_url) {
+      errors.push(
+        `${label}: schema_status "machine-readable" requires a non-empty ` +
+          "schema_url — set it (usually the surface's own url) or downgrade " +
+          'schema_status to "ui-only"/"not-captured" if no machine-readable spec is actually served.',
+      );
+    }
   }
   for (const [normalizedUrl, ids] of surfaceIdsByUrl) {
     if (

--- a/tests/validate-surface-schema-url.test.mjs
+++ b/tests/validate-surface-schema-url.test.mjs
@@ -1,0 +1,178 @@
+// Regression coverage for #6331: validate-surface.mjs now fails when a
+// surface claims schema_status: "machine-readable" with no schema_url (the
+// mistake #6331's audit found 6 live instances of, each an openapi-kind
+// surface). Mirrors validate-surface-duplicate-url.test.mjs's subprocess-
+// fixture pattern.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, test } from "vitest";
+import { listJsonFiles, repoRoot } from "../scripts/lib.mjs";
+
+function runNode(args) {
+  try {
+    const stdout = execFileSync(process.execPath, args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return { status: 0, output: stdout };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      output: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+    };
+  }
+}
+
+describe("validate-surface.mjs schema_status/schema_url check", () => {
+  let tempDir;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  function writeFixture(surfaces) {
+    const document = {
+      schema_version: 1,
+      netuid: 999,
+      slug: "fixture",
+      name: "Fixture Subnet",
+      status: "active",
+      categories: [],
+      links: [],
+      surfaces,
+    };
+    tempDir = mkdtempSync(
+      `${tmpdir()}/metagraphed-validate-surface-schema-url-`,
+    );
+    const fixturePath = path.join(tempDir, "fixture.json");
+    writeFileSync(fixturePath, JSON.stringify(document, null, 2));
+    return fixturePath;
+  }
+
+  test("fails when schema_status is machine-readable with no schema_url", () => {
+    const fixturePath = writeFixture([
+      {
+        id: "fixture-openapi",
+        kind: "openapi",
+        name: "Fixture OpenAPI schema",
+        url: "https://api.fixture.example/openapi.json",
+        provider: "academia",
+        authority: "community",
+        auth_required: false,
+        public_safe: true,
+        schema_status: "machine-readable",
+        review: { state: "community-submitted" },
+      },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 1);
+    assert.match(output, /fixture-openapi/);
+    assert.match(
+      output,
+      /schema_status "machine-readable" requires a non-empty schema_url/,
+    );
+  });
+
+  test("passes when schema_status is machine-readable and schema_url is set", () => {
+    const fixturePath = writeFixture([
+      {
+        id: "fixture-openapi",
+        kind: "openapi",
+        name: "Fixture OpenAPI schema",
+        url: "https://api.fixture.example/openapi.json",
+        provider: "academia",
+        authority: "community",
+        auth_required: false,
+        public_safe: true,
+        schema_status: "machine-readable",
+        schema_url: "https://api.fixture.example/openapi.json",
+        review: { state: "community-submitted" },
+      },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 0);
+    assert.match(output, /Surface validation passed/);
+  });
+
+  test("passes when schema_status is ui-only or not-captured with no schema_url", () => {
+    for (const schemaStatus of ["ui-only", "not-captured"]) {
+      const fixturePath = writeFixture([
+        {
+          id: "fixture-docs",
+          kind: "docs",
+          name: "Fixture docs",
+          url: "https://docs.fixture.example/",
+          provider: "academia",
+          authority: "community",
+          auth_required: false,
+          public_safe: true,
+          schema_status: schemaStatus,
+          review: { state: "community-submitted" },
+        },
+      ]);
+
+      const { status, output } = runNode([
+        "scripts/validate-surface.mjs",
+        fixturePath,
+      ]);
+
+      assert.equal(status, 0, `${schemaStatus}: ${output}`);
+    }
+  });
+
+  test("passes when a surface has neither field at all", () => {
+    const fixturePath = writeFixture([
+      {
+        id: "fixture-api",
+        kind: "subnet-api",
+        name: "Fixture API",
+        url: "https://api.fixture.example/status",
+        provider: "academia",
+        authority: "community",
+        auth_required: false,
+        public_safe: true,
+        review: { state: "community-submitted" },
+      },
+    ]);
+
+    const { status } = runNode(["scripts/validate-surface.mjs", fixturePath]);
+
+    assert.equal(status, 0);
+  });
+
+  test("the full registry has no unresolved schema_status/schema_url findings", () => {
+    // Sanity check the check itself against real data: after #6331's fix,
+    // running with no file args (validates every subnet file) must be clean.
+    const { status, output } = runNode(["scripts/validate-surface.mjs"]);
+    assert.equal(status, 0, output);
+  });
+});
+
+describe("validate-surface.mjs schema_status/schema_url check does not misfire", () => {
+  test("every real subnet file individually passes (no false positive)", async () => {
+    const files = await listJsonFiles(path.join(repoRoot, "registry/subnets"));
+    assert.ok(files.length > 0);
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...files,
+    ]);
+    assert.equal(status, 0, output);
+  });
+});


### PR DESCRIPTION
## Summary

Sets `schema_url` on the exact 6 `sn-*-openapi` surfaces the issue identifies (`schema_status: "machine-readable"` with no `schema_url` to actually fetch it from), and adds a permanent `validate-surface.mjs` check so this class of mistake fails locally before it reaches the registry again.

## Proof (live-verified against each candidate `schema_url`, before copying)

| File | Surface | Candidate `schema_url` (= surface's own `url`) | HTTP | Body confirms |
| --- | --- | --- | --- | --- |
| `chutes.json` | `sn-64-chutes-openapi` | `api.chutes.ai/openapi.json` | 200 `application/json` | `"openapi":"3.1.0"`, real `info`/`paths` |
| `desearch.json` | `sn-22-desearch-openapi` | `www.desearch.ai/openapi.json` | 200 `application/json` | `"openapi":"3.1.0"`, real `info`/`paths` |
| `green-compute.json` | `sn-110-green-compute-openapi` | `api.green-compute.com/openapi.json` | 200 `application/json` | `"openapi":"3.1.0"`, real `info`/`paths` |
| `handshake58.json` | `sn-58-handshake58-openapi` | `handshake58.com/openapi.json` | 200 `application/json` | `"openapi":"3.0.3"`, real `info`/`paths` |
| `nepher-robotics.json` | `sn-49-nepher-tournament-openapi` | `tournament-api.nepher.ai/openapi.json` | 200 `application/json` | `"openapi":"3.1.0"`, real `info`/`paths` |
| `verathos.json` | `sn-96-verathos-openapi` | `verathos.ai/openapi.json` | 200 `application/json` | `"openapi":"3.1.0"`, real `info`/`paths` |

All 6 candidate URLs resolve to genuine OpenAPI documents (not an HTML page, not a dead link), matching the 56-file precedent (e.g. `numinous.json`'s `sn-6-numinous-swagger` surface) — `schema_url` set to the surface's own `url` in every case. Only `schema_url` was added; nothing else on these 6 surfaces changed.

## Validator addition

`scripts/validate-surface.mjs` now hard-fails when `schema_status: "machine-readable"` is set with no `schema_url` — a surface claiming a machine-readable schema exists but giving callers nowhere to fetch it is an unverifiable claim. Mirrors the existing checks in the same per-surface loop (provider slug, community `review.state`) in both style and severity.

Added `tests/validate-surface-schema-url.test.mjs`, mirroring `validate-surface-duplicate-url.test.mjs`'s subprocess-fixture convention: fails on the bad case, passes when `schema_url` is set, passes when `schema_status` is `ui-only`/`not-captured` with no `schema_url` (not a violation), passes when neither field is present, and sanity-checks the full registry is clean post-fix.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:surface`
- [x] `npm run validate:readme-catalog`
- [x] `npm run scan:public-safety`
- [x] `npx vitest run tests/validate-surface-schema-url.test.mjs tests/validate-surface-duplicate-url.test.mjs tests/validate-surface-reviewed-convention.test.mjs` — 16/16 passing
- [x] Negative-tested the new check locally (temporarily reverted one fix, confirmed it fails with the exact expected message, restored)
- [x] `git diff --check`

Closes #6331
