### PR TITLE
feat(ui): add a "your positions" portfolio view for the connected wallet

### DIFF
--- a/apps/ui/src/components/metagraphed/wallet-connect.tsx
+++ b/apps/ui/src/components/metagraphed/wallet-connect.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "@tanstack/react-router";
 import {
   Wallet,
   Check,
@@ -254,6 +255,14 @@ function ConnectedView({
           </button>
         </div>
       </div>
+      {/* #5243: the connected wallet's read-side entry point into its portfolio. */}
+      <Link
+        to="/portfolio"
+        className="w-full inline-flex items-center justify-center gap-1.5 rounded border border-accent/40 bg-primary-soft px-3 py-1.5 text-[11px] font-medium text-ink-strong hover:bg-primary-soft/80 transition-colors"
+      >
+        <Wallet className="size-3.5" aria-hidden="true" />
+        Your positions
+      </Link>
       <button
         type="button"
         onClick={onDisconnect}

--- a/apps/ui/src/components/metagraphed/your-positions-panel.test.ts
+++ b/apps/ui/src/components/metagraphed/your-positions-panel.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { buildUnifiedPositions } from "./your-positions-panel";
+
+// #5243: the "your positions" panel folds the two position feeds (hotkey-owned
+// portfolio + coldkey-delegated nominator positions) into one list, deriving
+// each alpha holding from the per-subnet price so a slippage-aware exit quote
+// can be requested. buildUnifiedPositions is the pure core of that.
+describe("buildUnifiedPositions (#5243)", () => {
+  const prices = new Map<number, number>([
+    [1, 0.5],
+    [2, 2],
+  ]);
+
+  it("merges owned + delegated feeds, sorted by spot value descending", () => {
+    const rows = buildUnifiedPositions(
+      [{ netuid: 1, uid: 5, stake_tao: 10, yield: 0.03 }],
+      [{ netuid: 2, hotkey: "5Gvalidator", stake_tao: 40 }],
+      prices,
+    );
+    expect(rows.map((r) => [r.source, r.netuid, r.spotTao])).toEqual([
+      ["delegated", 2, 40],
+      ["owned", 1, 10],
+    ]);
+  });
+
+  it("derives alpha = spot / price for alpha subnets, carrying owned yield", () => {
+    const [owned] = buildUnifiedPositions(
+      [{ netuid: 1, uid: 5, stake_tao: 10, yield: 0.03 }],
+      [],
+      prices,
+    );
+    expect(owned.alpha).toBe(20); // 10 / 0.5
+    expect(owned.yield).toBe(0.03);
+    expect(owned.isRoot).toBe(false);
+  });
+
+  it("treats root (netuid 0) as TAO 1:1 — no alpha, no exit quote", () => {
+    const [root] = buildUnifiedPositions([{ netuid: 0, uid: 1, stake_tao: 7 }], [], prices);
+    expect(root.isRoot).toBe(true);
+    expect(root.alpha).toBeNull();
+  });
+
+  it("leaves alpha null when the subnet price is unknown or non-positive", () => {
+    const rows = buildUnifiedPositions(
+      [
+        { netuid: 9, uid: 1, stake_tao: 5 }, // no price entry
+        { netuid: 1, uid: 2, stake_tao: 5 },
+      ],
+      [],
+      new Map([
+        [1, 0],
+        [9, undefined as unknown as number],
+      ]),
+    );
+    for (const r of rows) expect(r.alpha).toBeNull();
+  });
+
+  it("delegated positions carry the validator hotkey and no yield", () => {
+    const [d] = buildUnifiedPositions([], [{ netuid: 1, hotkey: "5Gval", stake_tao: 3 }], prices);
+    expect(d.hotkey).toBe("5Gval");
+    expect(d.yield).toBeNull();
+    expect(d.source).toBe("delegated");
+  });
+});
+
+const routeSrc = readFileSync(
+  fileURLToPath(new URL("../../routes/portfolio.tsx", import.meta.url)),
+  "utf8",
+);
+const panelSrc = readFileSync(fileURLToPath(new URL("./your-positions-panel.tsx", import.meta.url)), "utf8");
+
+describe("portfolio route + panel wiring (#5243)", () => {
+  it("gates the whole view behind a connected wallet", () => {
+    expect(routeSrc).toContain("useWallet()");
+    expect(routeSrc).toContain("<WalletConnectButton />");
+    expect(routeSrc).toContain("wallet ? (");
+  });
+
+  it("sources both position feeds and the exit-quote endpoint", () => {
+    expect(panelSrc).toContain("accountPortfolioQuery(address)");
+    expect(panelSrc).toContain("accountPositionsQuery(address)");
+    expect(panelSrc).toContain('subnetStakeQuoteQuery(p.netuid, p.alpha, "unstake")');
+  });
+
+  it("offers a per-position Manage (unstake/move-stake) entry via the shared modal", () => {
+    expect(panelSrc).toContain("<StakeUnstakeModal");
+    expect(panelSrc).toContain("ManageButton");
+  });
+});

--- a/apps/ui/src/components/metagraphed/your-positions-panel.tsx
+++ b/apps/ui/src/components/metagraphed/your-positions-panel.tsx
@@ -1,0 +1,312 @@
+import { useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import { Coins } from "lucide-react";
+import { useQueries, useSuspenseQuery } from "@tanstack/react-query";
+import { CopyButton, StatTile } from "@jsonbored/ui-kit";
+import {
+  accountPortfolioQuery,
+  accountPositionsQuery,
+  economicsQuery,
+  subnetStakeQuoteQuery,
+} from "@/lib/metagraphed/queries";
+import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
+import { EmptyState } from "@/components/metagraphed/states";
+import { taoCompact } from "@/components/metagraphed/neuron-format";
+import { classNames } from "@/lib/metagraphed/format";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import type { SubnetEconomics } from "@/lib/metagraphed/types";
+
+/** One row of the portfolio, unified across the hotkey-owned and delegated feeds. */
+export interface UnifiedPosition {
+  key: string;
+  /** `owned` = the wallet's own neuron (hotkey portfolio); `delegated` = stake nominated to a validator. */
+  source: "owned" | "delegated";
+  netuid: number;
+  /** The validator hotkey the stake sits with (delegated), or the owned neuron's hotkey when present. */
+  hotkey: string | null;
+  /** Spot mark: the position's current TAO value (alpha x price). */
+  spotTao: number;
+  /** Emission-per-stake return; only the owned feed carries it. */
+  yield: number | null;
+  /** Derived alpha amount (spotTao / alpha price); null for root (netuid 0, TAO 1:1) or an unknown price. */
+  alpha: number | null;
+  isRoot: boolean;
+}
+
+/** #5243: fold the two position feeds into one spot-sorted list, deriving each
+ *  alpha holding from the per-subnet price so an exit quote can be requested. */
+export function buildUnifiedPositions(
+  ownedPositions: ReadonlyArray<Record<string, unknown>>,
+  delegatedPositions: ReadonlyArray<Record<string, unknown>>,
+  priceByNetuid: ReadonlyMap<number, number>,
+): UnifiedPosition[] {
+  const derive = (netuid: number, spotTao: number) => {
+    const price = priceByNetuid.get(netuid);
+    return netuid === 0 || !price || price <= 0 ? null : spotTao / price;
+  };
+  const owned = ownedPositions.map((p, i) => {
+    const netuid = Number(p.netuid);
+    const spotTao = typeof p.stake_tao === "number" ? p.stake_tao : 0;
+    return {
+      key: `owned-${netuid}-${p.uid ?? i}`,
+      source: "owned" as const,
+      netuid,
+      hotkey: typeof p.hotkey === "string" ? p.hotkey : null,
+      spotTao,
+      yield: typeof p.yield === "number" ? p.yield : null,
+      alpha: derive(netuid, spotTao),
+      isRoot: netuid === 0,
+    };
+  });
+  const delegated = delegatedPositions.map((p, i) => {
+    const netuid = Number(p.netuid);
+    const spotTao = typeof p.stake_tao === "number" ? p.stake_tao : 0;
+    return {
+      key: `deleg-${typeof p.hotkey === "string" ? p.hotkey : i}-${netuid}`,
+      source: "delegated" as const,
+      netuid,
+      hotkey: typeof p.hotkey === "string" ? p.hotkey : null,
+      spotTao,
+      yield: null,
+      alpha: derive(netuid, spotTao),
+      isRoot: netuid === 0,
+    };
+  });
+  return [...owned, ...delegated].sort((a, b) => b.spotTao - a.spotTao);
+}
+
+const pct = (v: number | null) =>
+  v != null && Number.isFinite(v) ? `${(v * 100).toFixed(2)}%` : "—";
+
+export function YourPositionsPanel({ address }: { address: string }) {
+  const portfolio = useSuspenseQuery(accountPortfolioQuery(address)).data.data;
+  const nominator = useSuspenseQuery(accountPositionsQuery(address)).data.data;
+  const economics = useSuspenseQuery(economicsQuery()).data.data as SubnetEconomics[];
+
+  const priceByNetuid = useMemo(() => {
+    const m = new Map<number, number>();
+    for (const e of economics ?? []) {
+      if (typeof e.alpha_price_tao === "number") m.set(e.netuid, e.alpha_price_tao);
+    }
+    return m;
+  }, [economics]);
+
+  const positions = useMemo(
+    () =>
+      buildUnifiedPositions(
+        (portfolio.positions ?? []) as Record<string, unknown>[],
+        (nominator.positions ?? []) as unknown as Record<string, unknown>[],
+        priceByNetuid,
+      ),
+    [portfolio, nominator, priceByNetuid],
+  );
+
+  // Simulated exit: unstaking the derived alpha through the AMM (fee + slippage),
+  // per position. Root positions have no AMM (TAO 1:1), so their exit == spot and
+  // no quote is fetched.
+  const quotes = useQueries({
+    queries: positions.map((p) =>
+      p.alpha && p.alpha > 0
+        ? subnetStakeQuoteQuery(p.netuid, p.alpha, "unstake")
+        : { queryKey: ["stake-quote-skip", p.key], queryFn: async () => null, enabled: false },
+    ),
+  });
+
+  const exitTaoFor = (index: number, p: UnifiedPosition): number | null => {
+    if (p.isRoot) return p.spotTao; // no AMM, 1:1
+    const out = quotes[index]?.data?.data?.expected_out;
+    return typeof out === "number" ? out : null;
+  };
+
+  const totals = useMemo(() => {
+    let spot = 0;
+    let exit = 0;
+    let root = 0;
+    let alpha = 0;
+    positions.forEach((p, i) => {
+      spot += p.spotTao;
+      exit += exitTaoFor(i, p) ?? p.spotTao;
+      if (p.isRoot) root += p.spotTao;
+      else alpha += p.spotTao;
+    });
+    return { spot, exit, root, alpha };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [positions, quotes]);
+
+  if (positions.length === 0) {
+    return (
+      <EmptyState
+        title="No positions for this wallet"
+        description="This wallet holds no stake on any subnet — neither a registered neuron nor a delegation. Positions appear here once it stakes."
+        lastChecked={portfolio.captured_at ?? undefined}
+      />
+    );
+  }
+
+  const rootPct = totals.spot > 0 ? totals.root / totals.spot : null;
+
+  return (
+    <div className="space-y-8">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatTile
+          icon={Coins}
+          eyebrow="Total value (spot)"
+          value={`${taoCompact(totals.spot)} τ`}
+          hint={`${positions.length} position${positions.length === 1 ? "" : "s"}`}
+          tone="accent"
+        />
+        <StatTile
+          icon={Coins}
+          eyebrow="Simulated exit"
+          value={`${taoCompact(totals.exit)} τ`}
+          hint="after fee + slippage"
+        />
+        <StatTile
+          icon={Coins}
+          eyebrow="Root / Alpha split"
+          value={`${taoCompact(totals.root)} / ${taoCompact(totals.alpha)} τ`}
+          hint={rootPct != null ? `${(rootPct * 100).toFixed(1)}% root` : "—"}
+        />
+      </div>
+
+      {/* Desktop table */}
+      <div className="hidden overflow-x-auto rounded-xl border border-border bg-card md:block">
+        <table className="w-full text-sm">
+          <thead className="bg-surface/50 text-[10px] font-mono uppercase tracking-widest text-ink-muted">
+            <tr>
+              <th className="px-3 py-2.5 text-left">Subnet</th>
+              <th className="px-3 py-2.5 text-left">Source</th>
+              <th className="px-3 py-2.5 text-left">Hotkey</th>
+              <th className="px-3 py-2.5 text-right">Spot τ</th>
+              <th className="px-3 py-2.5 text-right">Exit τ</th>
+              <th className="px-3 py-2.5 text-right">Yield</th>
+              <th className="px-3 py-2.5 text-right">Manage</th>
+            </tr>
+          </thead>
+          <tbody>
+            {positions.map((p, i) => (
+              <tr key={p.key} className="mg-row-hover border-t border-border/60">
+                <td className="px-3 py-2.5 font-mono text-[12px]">
+                  <Link
+                    to="/subnets/$netuid"
+                    params={{ netuid: p.netuid }}
+                    className="text-ink-strong hover:text-accent hover:underline"
+                  >
+                    {p.isRoot ? "Root" : `SN${p.netuid}`}
+                  </Link>
+                </td>
+                <td className="px-3 py-2.5">
+                  <SourceBadge source={p.source} />
+                </td>
+                <td className="px-3 py-2.5 font-mono text-[11px] text-ink-muted">
+                  {p.hotkey ? <HotkeyCell hotkey={p.hotkey} /> : "—"}
+                </td>
+                <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                  {taoCompact(p.spotTao)}
+                </td>
+                <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                  {taoCompact(exitTaoFor(i, p))}
+                </td>
+                <td className="px-3 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-muted">
+                  {pct(p.yield)}
+                </td>
+                <td className="px-3 py-2.5 text-right">
+                  <ManageButton hotkey={p.hotkey} netuid={p.netuid} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile cards */}
+      <div className="space-y-3 md:hidden">
+        {positions.map((p, i) => (
+          <div key={p.key} className="space-y-2 rounded-lg border border-border bg-card p-3">
+            <div className="flex items-center justify-between gap-2">
+              <Link
+                to="/subnets/$netuid"
+                params={{ netuid: p.netuid }}
+                className="font-mono text-[12px] text-ink-strong hover:text-accent hover:underline"
+              >
+                {p.isRoot ? "Root" : `SN${p.netuid}`}
+              </Link>
+              <SourceBadge source={p.source} />
+            </div>
+            {p.hotkey ? (
+              <div className="font-mono text-[11px] text-ink-muted">
+                <HotkeyCell hotkey={p.hotkey} />
+              </div>
+            ) : null}
+            <dl className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-[11px]">
+              <Stat label="Spot τ" value={taoCompact(p.spotTao)} />
+              <Stat label="Exit τ" value={taoCompact(exitTaoFor(i, p))} />
+              <Stat label="Yield" value={pct(p.yield)} />
+            </dl>
+            <ManageButton hotkey={p.hotkey} netuid={p.netuid} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SourceBadge({ source }: { source: "owned" | "delegated" }) {
+  return (
+    <span
+      className={classNames(
+        "inline-flex items-center rounded border px-1.5 py-0.5 text-[9.5px] font-mono uppercase tracking-wider",
+        source === "owned"
+          ? "border-accent/40 bg-accent-surface text-accent-text"
+          : "border-border bg-surface/40 text-ink-muted",
+      )}
+    >
+      {source === "owned" ? "Owned" : "Delegated"}
+    </span>
+  );
+}
+
+function HotkeyCell({ hotkey }: { hotkey: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <Link
+        to="/validators/$hotkey"
+        params={{ hotkey }}
+        title={hotkey}
+        className="hover:text-ink hover:underline"
+      >
+        {shortHash(hotkey) ?? hotkey}
+      </Link>
+      <CopyButton value={hotkey} label="hotkey" compact />
+    </span>
+  );
+}
+
+function ManageButton({ hotkey, netuid }: { hotkey: string | null; netuid: number }) {
+  if (!hotkey) return <span className="font-mono text-[10px] text-ink-subtle-text">—</span>;
+  return (
+    <StakeUnstakeModal
+      hotkey={hotkey}
+      netuid={netuid}
+      trigger={(open) => (
+        <button
+          type="button"
+          onClick={open}
+          className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong transition-colors hover:border-accent/50 hover:text-accent"
+        >
+          <Coins className="size-3 text-ink-muted" aria-hidden />
+          Manage
+        </button>
+      )}
+    />
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <dt className="text-ink-muted">{label}</dt>
+      <dd className="font-mono tabular-nums text-ink">{value}</dd>
+    </div>
+  );
+}

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SurfacesRouteImport } from './routes/surfaces'
 import { Route as StatusRouteImport } from './routes/status'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as SchemasRouteImport } from './routes/schemas'
+import { Route as PortfolioRouteImport } from './routes/portfolio'
 import { Route as LeaderboardsRouteImport } from './routes/leaderboards'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as GapsRouteImport } from './routes/gaps'
@@ -62,6 +63,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const SchemasRoute = SchemasRouteImport.update({
   id: '/schemas',
   path: '/schemas',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PortfolioRoute = PortfolioRouteImport.update({
+  id: '/portfolio',
+  path: '/portfolio',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LeaderboardsRoute = LeaderboardsRouteImport.update({
@@ -224,6 +230,7 @@ export interface FileRoutesByFullPath {
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
+  '/portfolio': typeof PortfolioRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -260,6 +267,7 @@ export interface FileRoutesByTo {
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
+  '/portfolio': typeof PortfolioRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -297,6 +305,7 @@ export interface FileRoutesById {
   '/gaps': typeof GapsRoute
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
+  '/portfolio': typeof PortfolioRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -335,6 +344,7 @@ export interface FileRouteTypes {
     | '/gaps'
     | '/health'
     | '/leaderboards'
+    | '/portfolio'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -371,6 +381,7 @@ export interface FileRouteTypes {
     | '/gaps'
     | '/health'
     | '/leaderboards'
+    | '/portfolio'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -407,6 +418,7 @@ export interface FileRouteTypes {
     | '/gaps'
     | '/health'
     | '/leaderboards'
+    | '/portfolio'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -444,6 +456,7 @@ export interface RootRouteChildren {
   GapsRoute: typeof GapsRoute
   HealthRoute: typeof HealthRoute
   LeaderboardsRoute: typeof LeaderboardsRoute
+  PortfolioRoute: typeof PortfolioRoute
   SchemasRoute: typeof SchemasRoute
   SettingsRoute: typeof SettingsRoute
   StatusRoute: typeof StatusRoute
@@ -500,6 +513,13 @@ declare module '@tanstack/react-router' {
       path: '/schemas'
       fullPath: '/schemas'
       preLoaderRoute: typeof SchemasRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/portfolio': {
+      id: '/portfolio'
+      path: '/portfolio'
+      fullPath: '/portfolio'
+      preLoaderRoute: typeof PortfolioRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/leaderboards': {
@@ -724,6 +744,7 @@ const rootRouteChildren: RootRouteChildren = {
   GapsRoute: GapsRoute,
   HealthRoute: HealthRoute,
   LeaderboardsRoute: LeaderboardsRoute,
+  PortfolioRoute: PortfolioRoute,
   SchemasRoute: SchemasRoute,
   SettingsRoute: SettingsRoute,
   StatusRoute: StatusRoute,

--- a/apps/ui/src/routes/portfolio.tsx
+++ b/apps/ui/src/routes/portfolio.tsx
@@ -1,0 +1,80 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Suspense } from "react";
+import { Wallet } from "lucide-react";
+import { AppShell } from "@/components/metagraphed/app-shell";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { Skeleton } from "@/components/metagraphed/states";
+import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { PageHero } from "@jsonbored/ui-kit";
+import { useWallet } from "@/hooks/use-wallet";
+import { WalletConnectButton } from "@/components/metagraphed/wallet-connect";
+import { YourPositionsPanel } from "@/components/metagraphed/your-positions-panel";
+
+export const Route = createFileRoute("/portfolio")({
+  head: () => ({
+    meta: [
+      { title: "Your positions — Metagraphed" },
+      {
+        name: "description",
+        content:
+          "Your Bittensor staking positions across every subnet for the connected wallet — hotkey-owned and delegated, valued at spot and at a slippage-aware simulated exit.",
+      },
+      { property: "og:title", content: "Your positions — Metagraphed" },
+      {
+        property: "og:description",
+        content:
+          "Cross-subnet staking positions for the connected wallet — spot vs. simulated-exit value, root/alpha split, and yield.",
+      },
+    ],
+  }),
+  component: PortfolioPage,
+});
+
+// #5243: the read-side payoff of the staking epic (#5229) — the portfolio view
+// for a connected wallet. Read-only: it links into the unstake/move-stake modals
+// but never constructs a transaction itself. Wallet state is client-only, so the
+// whole page is gated behind a connected wallet rather than a route param.
+function PortfolioPage() {
+  const { wallet } = useWallet();
+
+  return (
+    <AppShell>
+      <PageHero
+        eyebrow="Wallet"
+        live
+        title="Your positions"
+        description="Your staking positions across every subnet for the connected wallet — hotkey-owned and delegated — valued two ways: a spot mark and a slippage-aware simulated exit."
+      />
+
+      {wallet ? (
+        <QueryErrorBoundary>
+          <Suspense fallback={<Skeleton className="h-96 w-full" />}>
+            <YourPositionsPanel address={wallet.address} />
+          </Suspense>
+        </QueryErrorBoundary>
+      ) : (
+        <div className="rounded border border-dashed border-ink-subtle bg-surface/30 p-8 text-center">
+          <Wallet className="mx-auto mb-3 size-6 text-ink-muted" aria-hidden />
+          <h2 className="text-sm font-medium text-ink-strong">
+            Connect a wallet to see your positions
+          </h2>
+          <p className="mx-auto mt-1 mb-4 max-w-md text-[13px] text-ink-muted">
+            This app is read-only — it never constructs or signs a transaction. Connecting only reads
+            your public on-chain positions from a browser wallet extension.
+          </p>
+          <div className="flex justify-center">
+            <WalletConnectButton />
+          </div>
+        </div>
+      )}
+
+      <ApiSourceFooter
+        paths={[
+          "/api/v1/accounts/{ss58}/portfolio",
+          "/api/v1/accounts/{ss58}/positions",
+          "/api/v1/subnets/{netuid}/stake-quote",
+        ]}
+      />
+    </AppShell>
+  );
+}


### PR DESCRIPTION
## What

The read-side payoff of the staking epic (#5229): a new **`/portfolio`** route — **Your positions** — that aggregates the connected wallet's staking positions across every subnet and values each two ways.

## Deliverables (#5243)

- **Aggregate positions** across subnets for the connected address — both **hotkey-owned** (`/accounts/{ss58}/portfolio`) and **coldkey-delegated** nominator positions (`/accounts/{ss58}/positions`), folded into one spot-sorted list.
- **Per position, value two ways:** a **spot mark** (the position's TAO value, `alpha × price`) and a **simulated exit** including fee + slippage — the subnet **stake-quote**'s expected TAO out for unstaking the derived alpha (root / netuid-0 is TAO 1:1, no AMM, so its exit == spot). Plus a **root / alpha value split** and **realized yield**.
- **Entry points** into unstake / move-stake per position via the existing `StakeUnstakeModal` — this panel never constructs a transaction itself.

## How

- `apps/ui/src/routes/portfolio.tsx` — gated behind a connected wallet (client-only `useWallet`), with a connect prompt otherwise; reachable from the wallet menu.
- `your-positions-panel.tsx` — `buildUnifiedPositions` (pure, unit-tested) folds the two feeds and derives each alpha holding from the per-subnet price (`economicsQuery`); `useQueries` fetches an unstake `stake-quote` per alpha position for the exit value. Responsive table (md:+) / cards (mobile).
- No backend change — every endpoint already exists (its deps #2550/#5233/#5236 are merged).

Tests: `buildUnifiedPositions` (merge/sort, alpha derivation, root 1:1, unknown-price null) + route/panel wiring. tsc + all validators green.

## Screenshots

`/portfolio` — **before**: the connect-wallet prompt (no wallet). **after**: the populated panel (a connected wallet with owned + delegated positions, stubbed for capture).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5243-portfolio-after-mobile-dark.png)<br><sub>after</sub> |

Closes #5243
