### PR TITLE
fix(registry): curate auth{} for 13 surfaces declaring auth_required with none

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -392,6 +392,12 @@
       "url": "https://llm.chutes.ai/v1/models"
     },
     {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>"
+      },
       "auth_required": true,
       "authority": "community",
       "id": "sn-64-chutes-sse",

--- a/registry/subnets/data-universe.json
+++ b/registry/subnets/data-universe.json
@@ -234,6 +234,13 @@
       "url": "https://github.com/macrocosm-os/macrocosmos-py"
     },
     {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Macrocosmos SDK Sn13Client/GravityClient credential."
+      },
       "auth_required": true,
       "authority": "community",
       "id": "sn-13-macrocosmos-subnet-api",

--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -140,6 +140,12 @@
       "url": "https://www.desearch.ai/openapi.json"
     },
     {
+      "auth": {
+        "scheme": "api-key",
+        "location": "header",
+        "name": "Authorization",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (ApiKeyAuth)."
+      },
       "auth_required": true,
       "authority": "official",
       "id": "sn-22-desearch-api",

--- a/registry/subnets/efficientfrontier.json
+++ b/registry/subnets/efficientfrontier.json
@@ -54,6 +54,10 @@
       "url": "https://www.signalplus.com/"
     },
     {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Exact credential mechanism not confirmed from public docs -- auth_required is based on an access-state/challenge probe response, not a documented API key/token scheme."
+      },
       "auth_required": true,
       "authority": "official",
       "id": "sn-53-signalplus-mining",

--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -176,6 +176,10 @@
       "url": "https://api.loopover.ai/v1/public/subnet-interface"
     },
     {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Contributor tools are scoped to the authenticated GitHub login (confirmed 401 unauthorized without a credential); exact header/token format is not publicly documented."
+      },
       "auth_required": true,
       "authority": "provider-claimed",
       "id": "gittensory-mcp",

--- a/registry/subnets/gopher.json
+++ b/registry/subnets/gopher.json
@@ -118,6 +118,13 @@
       "url": "https://github.com/gopher-lab/subnet-42"
     },
     {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "gopher-client's own convention names this credential GOPHER_CLIENT_TOKEN."
+      },
       "auth_required": true,
       "authority": "community",
       "id": "sn-42-gopher-ai-subnet-api",

--- a/registry/subnets/green-compute.json
+++ b/registry/subnets/green-compute.json
@@ -69,6 +69,10 @@
       "url": "https://www.green-compute.com/models"
     },
     {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Exact credential mechanism not confirmed -- the endpoint validates the request body before auth, so an auth-specific probe response could not be observed."
+      },
       "auth_required": true,
       "authority": "official",
       "id": "sn-110-green-compute-chat-completions-api",

--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -145,6 +145,13 @@
       "url": "https://tournament-api.nepher.ai/openapi.json"
     },
     {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <token>",
+        "scopes_note": "Derived from the subnet's own OpenAPI securitySchemes (HTTPBearer). Individual endpoints may additionally require admin permissions."
+      },
       "auth_required": true,
       "authority": "official",
       "id": "sn-49-nepher-tournament-api",

--- a/registry/subnets/nodexo.json
+++ b/registry/subnets/nodexo.json
@@ -74,6 +74,10 @@
       "url": "https://docs.nodexo.ai/"
     },
     {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Console workflows may require account sign-in; exact credential mechanism is not publicly documented."
+      },
       "auth_required": true,
       "authority": "official",
       "id": "sn-106-nodexo-console",

--- a/registry/subnets/root.json
+++ b/registry/subnets/root.json
@@ -181,6 +181,10 @@
       "url": "wss://bittensor-finney.api.onfinality.io/public-ws"
     },
     {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Nodies now requires a paid subscription plan (HTTP 403 without one, verified 2026-06-15); exact credential mechanism is not publicly documented."
+      },
       "auth_required": true,
       "authority": "community",
       "id": "nodies-finney-rpc",

--- a/registry/subnets/streetvision-by-natix.json
+++ b/registry/subnets/streetvision-by-natix.json
@@ -153,6 +153,13 @@
       "notes": "Public NATIX Hugging Face organization linked from the StreetVision README."
     },
     {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <hf_token>",
+        "scopes_note": "Hugging Face Hub access token, per HF's own gated-dataset auth convention."
+      },
       "id": "sn-72-natix-roadwork-dataset",
       "name": "StreetVision roadwork image dataset",
       "kind": "data-artifact",
@@ -177,6 +184,13 @@
       "notes": "NATIX StreetVision HuggingFace image+text dataset (~8.5k road/roadwork scenes with structured scene/weather/lighting metadata) backing the SN72 roadwork image-classification task. The StreetVision README (source) declares the Bittensor subnet and links the natix-network-org HF org that owns it. Now gated (HF auth required); tracked as a real official artifact pending it becoming public again. Now returns HTTP 401 (Hugging Face auth required) as of 2026-07-15; was public at last review (2026-06-08). Probing disabled since it will always fail while gated."
     },
     {
+      "auth": {
+        "scheme": "bearer",
+        "location": "header",
+        "name": "Authorization",
+        "value_format": "Bearer <hf_token>",
+        "scopes_note": "Hugging Face Hub access token, same gating as the parent dataset."
+      },
       "id": "sn-72-natix-roadwork-rows-api",
       "name": "StreetVision roadwork dataset rows API",
       "kind": "data-artifact",

--- a/registry/subnets/tensorclaw.json
+++ b/registry/subnets/tensorclaw.json
@@ -111,6 +111,10 @@
       "url": "https://github.com/tensorclaw/tensorclaw"
     },
     {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "Gated by a Cloudflare Turnstile challenge to unlock trial requests, not a token/header-based API credential."
+      },
       "auth_required": true,
       "authority": "provider-claimed",
       "id": "sn-92-tensorclaw-dashboard",

--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -116,6 +116,7 @@ const files =
 const errors = [];
 const conventionAdvisories = [];
 const conventionExemptions = [];
+const authAdvisories = [];
 let surfaceCount = 0;
 for (const file of files) {
   let document;
@@ -198,6 +199,20 @@ for (const file of files) {
           "(the /rpc endpoint lane), not per-subnet contributor surfaces.",
       );
     }
+    // #6330: auth_required makes a promise ("this needs a credential") the
+    // structured auth{} field is what makes caller-actionable ("...and here's
+    // how"). Advisory, not a hard error: the credential mechanism is
+    // sometimes genuinely undocumented by the provider (auth.scheme:
+    // "custom" is the honest answer there, not a blocker), unlike the
+    // reviewed-tier convention above this mirrors in shape.
+    if (surface.auth_required === true && !surface.auth) {
+      authAdvisories.push(
+        `${label}: auth_required is true with no structured auth{} object — ` +
+          "curate one (scheme at minimum; location/name/value_format where knowable " +
+          'from the surface\'s own docs, or scheme: "custom" with a scopes_note if the ' +
+          "exact mechanism isn't publicly documented).",
+      );
+    }
   }
   for (const [normalizedUrl, ids] of surfaceIdsByUrl) {
     if (
@@ -269,6 +284,13 @@ if (conventionAdvisories.length > 0) {
     `\nReviewed-tier convention advisory (${conventionAdvisories.length} — not blocking):`,
   );
   for (const advisory of conventionAdvisories) console.warn(`- ${advisory}`);
+}
+// #6330 — auth_required with no auth{} object, non-blocking.
+if (authAdvisories.length > 0) {
+  console.warn(
+    `\nauth_required advisory (${authAdvisories.length} — not blocking):`,
+  );
+  for (const advisory of authAdvisories) console.warn(`- ${advisory}`);
 }
 
 // ajv.errorsText() collapses every error to its bare `message`, which for an

--- a/tests/validate-surface-auth-object.test.mjs
+++ b/tests/validate-surface-auth-object.test.mjs
@@ -1,0 +1,191 @@
+// Regression coverage for #6330: validate-surface.mjs now warns (advisory,
+// not blocking) when a surface declares auth_required: true with no
+// structured auth{} object -- the mistake #6330's audit found 13 live
+// instances of across 12 files. Mirrors validate-surface-reviewed-convention
+// .test.mjs's subprocess-fixture pattern (spawnSync, not execFileSync, so
+// stderr is captured even on a passing run -- the advisory itself is written
+// via console.warn).
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, test } from "vitest";
+import { listJsonFiles, repoRoot } from "../scripts/lib.mjs";
+
+function runNode(args) {
+  const result = spawnSync(process.execPath, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  return {
+    status: result.status ?? 1,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+describe("validate-surface.mjs auth_required/auth{} advisory", () => {
+  let tempDir;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  function writeFixture(surfaces) {
+    const document = {
+      schema_version: 1,
+      netuid: 999,
+      slug: "fixture",
+      name: "Fixture Subnet",
+      status: "active",
+      categories: [],
+      links: [],
+      surfaces,
+    };
+    tempDir = mkdtempSync(`${tmpdir()}/metagraphed-validate-surface-auth-`);
+    const fixturePath = path.join(tempDir, "fixture.json");
+    writeFileSync(fixturePath, JSON.stringify(document, null, 2));
+    return fixturePath;
+  }
+
+  test("warns (advisory, still exits 0) when auth_required is true with no auth object", () => {
+    const fixturePath = writeFixture([
+      {
+        id: "fixture-api",
+        kind: "subnet-api",
+        name: "Fixture API",
+        url: "https://api.fixture.example/status",
+        provider: "academia",
+        authority: "community",
+        auth_required: true,
+        public_safe: true,
+        review: { state: "community-submitted" },
+      },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 0, output);
+    assert.match(output, /auth_required advisory/);
+    assert.match(output, /fixture-api/);
+    assert.match(
+      output,
+      /auth_required is true with no structured auth\{\} object/,
+    );
+  });
+
+  test("does not warn when auth_required is true and auth is set", () => {
+    const fixturePath = writeFixture([
+      {
+        id: "fixture-api",
+        kind: "subnet-api",
+        name: "Fixture API",
+        url: "https://api.fixture.example/status",
+        provider: "academia",
+        authority: "community",
+        auth_required: true,
+        auth: { scheme: "bearer" },
+        public_safe: true,
+        review: { state: "community-submitted" },
+      },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 0, output);
+    assert.doesNotMatch(output, /auth_required advisory/);
+  });
+
+  test("does not warn when auth_required is false or absent", () => {
+    const fixturePath = writeFixture([
+      {
+        id: "fixture-a",
+        kind: "subnet-api",
+        name: "Fixture A",
+        url: "https://api.fixture.example/a",
+        provider: "academia",
+        authority: "community",
+        auth_required: false,
+        public_safe: true,
+        review: { state: "community-submitted" },
+      },
+      {
+        id: "fixture-b",
+        kind: "docs",
+        name: "Fixture B",
+        url: "https://docs.fixture.example/",
+        provider: "academia",
+        authority: "community",
+        auth_required: false,
+        public_safe: true,
+        review: { state: "community-submitted" },
+      },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 0, output);
+    assert.doesNotMatch(output, /auth_required advisory/);
+  });
+
+  test('auth: { scheme: "custom" } with no location/name satisfies the advisory (custom is a valid honest fallback)', () => {
+    const fixturePath = writeFixture([
+      {
+        id: "fixture-api",
+        kind: "subnet-api",
+        name: "Fixture API",
+        url: "https://api.fixture.example/status",
+        provider: "academia",
+        authority: "community",
+        auth_required: true,
+        auth: {
+          scheme: "custom",
+          scopes_note: "Exact mechanism not publicly documented.",
+        },
+        public_safe: true,
+        review: { state: "community-submitted" },
+      },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 0, output);
+    assert.doesNotMatch(output, /auth_required advisory/);
+  });
+
+  test("the full registry has no unresolved auth_required/auth{} advisories", () => {
+    // Sanity check the check itself against real data: after #6330's fix,
+    // running with no file args (validates every subnet file) must be clean.
+    const { status, output } = runNode(["scripts/validate-surface.mjs"]);
+    assert.equal(status, 0, output);
+    assert.doesNotMatch(output, /auth_required advisory/);
+  });
+});
+
+describe("validate-surface.mjs auth_required/auth{} advisory does not misfire", () => {
+  test("every real subnet file individually passes with no advisory (no false positive)", async () => {
+    const files = await listJsonFiles(path.join(repoRoot, "registry/subnets"));
+    assert.ok(files.length > 0);
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...files,
+    ]);
+    assert.equal(status, 0, output);
+    assert.doesNotMatch(output, /auth_required advisory/);
+  });
+});


### PR DESCRIPTION
## Summary

Curates a structured `auth{}` object for the exact 13 surfaces / 12 files the issue identifies (`auth_required: true` with no `auth` object), and adds a permanent non-blocking `validate-surface.mjs` advisory so a future instance of this gap is flagged rather than silent.

## Classification

`auth` is `{ scheme, location?, name?, value_format?, token_url?, scopes_note? }` — per the schema's own description, "derived from the OpenAPI securitySchemes when present, else curated." I treated that as the actual priority order: check the surface's own OpenAPI spec first, then fall back to whatever the registry's own text already says, and only use `scheme: "custom"` (with an honest `scopes_note`) when neither source confirms a specific mechanism — never guessing `bearer` vs `api-key` without evidence.

**Confirmed scheme** (5 surfaces):

| Surface | Scheme | Evidence |
| --- | --- | --- |
| `chutes.json` :: `sn-64-chutes-sse` | `bearer` | Surface's own notes: `"requires an Authorization: Bearer token"` |
| `data-universe.json` :: `sn-13-macrocosmos-subnet-api` | `bearer` | Surface's own notes: `"requires a Bearer API key"` |
| `desearch.json` :: `sn-22-desearch-api` | `api-key` (header, `Authorization`) | Live-fetched the subnet's own OpenAPI spec: `components.securitySchemes.ApiKeyAuth = {type: "apiKey", in: "header", name: "Authorization"}` |
| `nepher-robotics.json` :: `sn-49-nepher-tournament-api` | `bearer` | Live-fetched the subnet's own OpenAPI spec: `components.securitySchemes.HTTPBearer = {type: "http", scheme: "bearer"}` |
| `gopher.json` :: `sn-42-gopher-ai-subnet-api` | `bearer` | Surface's own notes (already merged by #6567): `"Bearer API key required (GOPHER_CLIENT_TOKEN)"` |

**Unconfirmed mechanism → `scheme: "custom"`** with an honest `scopes_note` (6 surfaces):

- `efficientfrontier.json` :: `sn-53-signalplus-mining` — only known as an access-state/challenge probe response, no documented credential type.
- `gittensor.json` :: `gittensory-mcp` — confirmed 401 without a credential, GitHub-login-scoped per its own notes, but the exact header/token format isn't publicly documented.
- `green-compute.json` :: `sn-110-green-compute-chat-completions-api` — the endpoint validates the request body before checking auth, so a live probe couldn't surface the mechanism either.
- `nodexo.json` :: `sn-106-nodexo-console` — "authentication may be required," no specifics.
- `root.json` :: `nodies-finney-rpc` — confirmed paid-subscription-gated (HTTP 403, per #6567), exact credential mechanism undocumented.
- `tensorclaw.json` :: `sn-92-tensorclaw-dashboard` — gated by a Cloudflare Turnstile challenge to unlock trial requests. This genuinely isn't a token/header credential at all — `custom` (with a `scopes_note` explaining the Turnstile gate) is the honest classification, not a guess dressed up as `bearer`/`api-key`.

**Reasonably confident inference** (2 surfaces, both `streetvision-by-natix.json`):

- `sn-72-natix-roadwork-dataset` and `sn-72-natix-roadwork-rows-api` — both HuggingFace-gated (per their own notes). `bearer` per HF Hub's own well-documented, stable, public access-token convention — not a guess about an obscure/unconfirmed provider, but a known fact about a major third-party platform.

## Validator addition

`scripts/validate-surface.mjs` now emits a **non-blocking advisory** (never a hard error — the issue explicitly allows either, and unlike #6331's schema_url check, the credential mechanism can be genuinely undocumented by the provider, which `scheme: "custom"` already satisfies honestly) when `auth_required: true` has no `auth` object. Mirrors the existing reviewed-tier convention advisory in shape (`conventionAdvisories` → `authAdvisories`).

Added `tests/validate-surface-auth-object.test.mjs`, mirroring `validate-surface-reviewed-convention.test.mjs`'s subprocess-fixture pattern (`spawnSync`, not `execFileSync`, so the advisory — written via `console.warn` to stderr — is captured even on a passing/exit-0 run): fires on the bad case, silent when `auth` is set (including a bare `{scheme: "custom"}`), silent when `auth_required` is false/absent, and sanity-checks the full registry is clean post-fix.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:surface`
- [x] `npm run validate:readme-catalog`
- [x] `npm run scan:public-safety`
- [x] `npx vitest run tests/validate-surface-auth-object.test.mjs tests/validate-surface-duplicate-url.test.mjs tests/validate-surface-reviewed-convention.test.mjs` — 16/16 passing
- [x] Negative-tested the new advisory locally (temporarily reverted one fix, confirmed it fires with the exact expected message and still exits 0, restored)
- [x] `git diff --check`

Closes #6330
