### PR TITLE
fix(ui): make the block/extrinsic "Observed at" timestamp tooltip-only (#6433)

### DIFF
--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -291,9 +291,6 @@ function ValidBlockDetail({ refValue }: { refValue: string }) {
           <FieldRow label="Observed at">
             <span className="font-mono text-[12px] text-ink-muted">
               <TimeAgo at={block.observed_at} />
-              {block.observed_at ? (
-                <span className="ml-2 opacity-70">{block.observed_at}</span>
-              ) : null}
             </span>
           </FieldRow>
         </dl>

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -283,9 +283,6 @@ function ValidExtrinsicDetail({ hash }: { hash: string }) {
           <FieldRow label="Observed at">
             <span className="font-mono text-[12px] text-ink-muted">
               <TimeAgo at={extrinsic.observed_at} />
-              {extrinsic.observed_at ? (
-                <span className="ml-2 opacity-70">{extrinsic.observed_at}</span>
-              ) : null}
             </span>
           </FieldRow>
         </dl>


### PR DESCRIPTION
Closes #6433

## Summary

`blocks.$ref.tsx` and `extrinsics.$hash.tsx` rendered the "Observed at" field as `<TimeAgo>` **plus** the raw ISO timestamp string always visible alongside it. The other four detail pages — accounts' "Last seen" / "First indexed", subnets' "Captured" — show only `<TimeAgo>`, with the absolute time available via its hover tooltip. That's an inconsistency across the six detail pages.

## What Changed

- Drop the redundant always-visible raw ISO string from these two pages, so all six detail pages share **one** convention: the tooltip-only treatment the majority already use. `<TimeAgo>` already exposes the exact timestamp on hover (`title` attribute), so no information is lost — only the duplicated, always-on string is removed.

Resolves the inconsistency toward the pattern the four other detail pages were already built with. The extrinsic-detail page gets the identical change; screenshots below show the block-detail page (representative).

## Screenshots — block detail "Observed at" field

Before: `4m ago 2026-07-18T10:13:48.000Z`. After: `4m ago` (absolute time on hover).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| **Desktop · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-after-desktop-light.png)<br><sub>after</sub> |
| **Desktop · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-after-desktop-dark.png)<br><sub>after</sub> |
| **Tablet · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-after-tablet-light.png)<br><sub>after</sub> |
| **Tablet · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-after-tablet-dark.png)<br><sub>after</sub> |
| **Mobile · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-after-mobile-light.png)<br><sub>after</sub> |
| **Mobile · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6433/6433-observed-at-after-mobile-dark.png)<br><sub>after</sub> |


## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6433`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none — UI-only)*

## Validation

- [x] `npx prettier --check` / `npx eslint` — clean (apps/ui config)
- [x] `npm run typecheck` — no new errors
- [x] `git diff --check` clean
- [x] 12-image before/after matrix (3 viewports x 2 themes); raw-ISO string asserted present (before) / absent (after) per shot
