### PR TITLE
fix(ui): document the block-detail arrow-key shortcut in ShortcutsPopover (#6560)

### DIFF
--- a/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
+++ b/apps/ui/src/components/metagraphed/shortcuts-popover.tsx
@@ -109,6 +109,19 @@ export function ShortcutsPopover() {
             </Row>
           ))}
         </ul>
+        {/* #6560: blocks.$ref.tsx's own keydown handler walks to the prev/next
+            block on ArrowLeft/ArrowRight -- page-scoped, unlike every other
+            shortcut above, so it gets its own labeled section instead of
+            reading as a global binding. */}
+        <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted mt-4 mb-2">
+          On block pages
+        </div>
+        <ul className="space-y-1.5 text-[12px]">
+          <Row label="Previous / next block">
+            <Kbd>←</Kbd>
+            <Kbd>→</Kbd>
+          </Row>
+        </ul>
       </PopoverContent>
     </Popover>
   );


### PR DESCRIPTION
Closes #6560

## Problem

`blocks.$ref.tsx` registers a page-level `keydown` listener that navigates to the previous/next block on `ArrowLeft`/`ArrowRight` — a real, working shortcut. The visible "Previous/Next block" links carry no hint text, and `ShortcutsPopover` — the app's single documented reference for every other keyboard interaction (`/` search focus, `?` toggle, `Esc`, the full `g s`/`g u`/`g e`/`g p`/`g h`/`g x`/`g g` go-to list) — has no entry for it. A user has no way to discover this shortcut short of trying arrow keys at random.

## Fix

Added a new "On block pages" section to `ShortcutsPopover`, listed separately from the existing global "Shortcuts"/"Go to" sections so the page-scoped nature of this one binding isn't misread as a global shortcut — no change to the actual keyboard-navigation behavior in `blocks.$ref.tsx`, this is discoverability only.

## Screenshots

Opened via the `?` keyboard shortcut (works at every viewport; the trigger button itself is desktop-only). Before: popover ends at "Gaps". After: a new "On block pages" section lists "Previous / next block" with ←/→.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6560-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

- `npx tsc --noEmit -p apps/ui`: clean
- `npx prettier --check` / `npx eslint` on the changed file: clean, zero warnings
- `npx vitest run` (apps/ui): 161 test files, 1207 tests, all passing
- Manually verified in browser: opened the popover via `?` across all three breakpoints and both themes, confirmed the new section renders and the arrow-key navigation itself is unchanged