### PR TITLE
fix(registry): align swap.json gap_notes with TaoFi pool 402 outage

### DIFF
--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -19,7 +19,7 @@
   ],
   "curation": {
     "gap_notes": [
-      "Official TaoFi pool page, docs, and Swap source repository are verified live.",
+      "Official TaoFi docs and Swap source repository are verified live; the TaoFi pool page (www.taofi.com/pool, and the rest of www.taofi.com) currently returns HTTP 402 with x-vercel-error: DEPLOYMENT_DISABLED and should appear degraded until the Vercel deployment recovers.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
       "No verified SSE/event stream yet."
     ],


### PR DESCRIPTION
## Summary

- Re-checked `https://www.taofi.com/pool` live: still **HTTP 402** with `x-vercel-error: DEPLOYMENT_DISABLED`.
- Rewrote `curation.gap_notes[0]` in `registry/subnets/swap.json` so it no longer claims the TaoFi pool page is "verified live" while `notes` already documents the outage.
- Left `notes` untouched (already accurate). Docs + source repo remain described as live.

Fixes #6591

## Test plan

- [x] Live HEAD to `www.taofi.com/pool` → 402 / `DEPLOYMENT_DISABLED`
- [x] `JSON.parse` on `registry/subnets/swap.json`
- [ ] Upstream Validate CI green

Made with [Cursor](https://cursor.com)