### PR TITLE
fix(registry): reconcile top-level identity URLs shadowing curated surfaces (#6329)

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "test:ci:artifacts": "vitest run tests/artifacts.test.mjs tests/discovery-artifacts.test.mjs tests/public-safety.test.mjs tests/validate-error-messages.test.mjs tests/refresh-build-summary.test.mjs",
     "curation:brief": "node scripts/curation-brief.mjs",
     "curation:stale-notes": "node scripts/stale-gap-notes.mjs",
+    "curation:identity-divergence": "node scripts/identity-field-divergence.mjs",
     "endpoint:brief": "node scripts/endpoint-ops-brief.mjs"
   },
   "dependencies": {

--- a/registry/subnets/bitstarter-1.json
+++ b/registry/subnets/bitstarter-1.json
@@ -35,7 +35,7 @@
     "source_count": 7,
     "verified_at": "2026-07-15T00:00:00.000Z"
   },
-  "dashboard_url": "https://taomarketcap.com/subnets/91",
+  "dashboard_url": "https://app.bitstarter.ai/",
   "name": "Bitstarter #1",
   "netuid": 91,
   "notes": "Reviewed overlay for SN91 using the public Bitstarter website, app surface, how-it-works page, project submission page, AlphaCore source repository, and universal TaoMarketCap dashboard. Common docs/API/OpenAPI paths currently return 404 and no verified machine-readable schema, safe public subnet API endpoint, or SSE surface has been found yet. Re-review pass (2026-07-15): updated the website surface to the canonical www.bitstarter.ai URL after bitstarter.ai started 307-redirecting.",
@@ -192,5 +192,5 @@
       "url": "https://raw.githubusercontent.com/AlphaCoreBittensor/alphacore/main/modules/task_config.yaml"
     }
   ],
-  "website_url": "https://bitstarter.ai/"
+  "website_url": "https://www.bitstarter.ai/"
 }

--- a/registry/subnets/compelle.json
+++ b/registry/subnets/compelle.json
@@ -17,7 +17,7 @@
     "source_count": 4,
     "verified_at": "2026-06-08T10:10:00.000Z"
   },
-  "dashboard_url": "https://taomarketcap.com/subnets/82",
+  "dashboard_url": "https://compelle.com/status",
   "name": "Compelle",
   "netuid": 82,
   "notes": "Reviewed overlay for SN82 using the official Compelle website and validator repository.",

--- a/registry/subnets/hone.json
+++ b/registry/subnets/hone.json
@@ -34,7 +34,7 @@
     "source_count": 6,
     "verified_at": "2026-06-08T20:25:00.000Z"
   },
-  "dashboard_url": "https://taomarketcap.com/subnets/5",
+  "dashboard_url": "https://www.hone.training/network",
   "name": "Hone",
   "netuid": 5,
   "notes": "Reviewed overlay for SN5 Hone using the official Hone website, source repository, and public network pages. Common docs/API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational interfaces.",

--- a/registry/subnets/itsai.json
+++ b/registry/subnets/itsai.json
@@ -17,7 +17,7 @@
     "source_count": 4,
     "verified_at": "2026-07-16T00:20:00.000Z"
   },
-  "dashboard_url": "https://taomarketcap.com/subnets/32",
+  "dashboard_url": "https://wandb.ai/itsai-dev/subnet32",
   "name": "ItsAI",
   "netuid": 32,
   "notes": "Reviewed overlay for SN32 using the official ItsAI website and LLM-detection source repository. This pass fixed 5 surfaces having no probe config at all -- the registry-wide gap tracked in #5932. All 8 surfaces re-verified live.",

--- a/registry/subnets/mainframe.json
+++ b/registry/subnets/mainframe.json
@@ -22,7 +22,7 @@
     "source_count": 4,
     "verified_at": "2026-06-08T09:50:00.000Z"
   },
-  "dashboard_url": "https://taomarketcap.com/subnets/25",
+  "dashboard_url": "https://wandb.ai/macrocosmos/folding-openmm",
   "name": "Mainframe",
   "netuid": 25,
   "notes": "Reviewed overlay for SN25 using the official Mainframe source repository. Previously discovered Mainframe docs/API URLs currently return 404 and the old dashboard URL redirects to the general Macrocosmos homepage, so they are not promoted. Re-tested live this pass: also found the registered website_url now redirects to the same generic homepage, so it is not promoted as a website surface either. 1 community-submitted surface (wandb dashboard) had no probe config at all -- the registry-wide gap tracked in #5932 -- fixed. All 4 tracked surfaces re-verified live.",

--- a/registry/subnets/mvtrx.json
+++ b/registry/subnets/mvtrx.json
@@ -18,7 +18,7 @@
     "source_count": 5,
     "verified_at": "2026-07-15T00:00:00.000Z"
   },
-  "dashboard_url": "https://taomarketcap.com/subnets/79",
+  "dashboard_url": "https://taos.simulate.trading/",
   "docs_url": "https://simulate.trading/taos-im-paper",
   "name": "MVTRX",
   "netuid": 79,

--- a/registry/subnets/nexisgen.json
+++ b/registry/subnets/nexisgen.json
@@ -142,5 +142,5 @@
       "url": "https://api.nexisgen.ai/v1/get_latest_total_score"
     }
   ],
-  "website_url": "https://nexisgen.ai/"
+  "website_url": "https://www.nexisgen.ai/"
 }

--- a/registry/subnets/ninja.json
+++ b/registry/subnets/ninja.json
@@ -197,24 +197,6 @@
     },
     {
       "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-66-taomarketcap-dashboard",
-      "kind": "dashboard",
-      "name": "ninja TaoMarketCap dashboard",
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/66"],
-      "url": "https://taomarketcap.com/subnets/66"
-    },
-    {
-      "auth_required": false,
       "authority": "community",
       "id": "sn-66-unarbos-data-artifact",
       "kind": "data-artifact",

--- a/registry/subnets/sparket.json
+++ b/registry/subnets/sparket.json
@@ -21,7 +21,7 @@
     "source_count": 4,
     "verified_at": "2026-07-16T05:00:00.000Z"
   },
-  "dashboard_url": "https://taomarketcap.com/subnets/57",
+  "dashboard_url": "https://dashboard.sparket.ai/leaderboard",
   "name": "Sparket",
   "netuid": 57,
   "notes": "Reviewed overlay for SN57 using the official Sparket website and source repository. No official docs/API/OpenAPI surface is verified yet. This re-review pass re-verified all 5 surfaces live (no missing-probe gap found); confirmed sparket.ai/openapi.json is not a real schema (SPA HTML fallback). Observed the backend health endpoint reporting a real degraded/stale sync state and a single-source on-chain identity discrepancy (\"gaia\") uncorroborated by any live infrastructure -- see gap_notes.",

--- a/scripts/identity-field-divergence.mjs
+++ b/scripts/identity-field-divergence.mjs
@@ -1,0 +1,133 @@
+// Advisory (report-only) check: does a subnet's top-level identity field
+// (`website_url` / `dashboard_url`) diverge from its own same-kind surface? The
+// build (scripts/build-artifacts.mjs) resolves a profile's primary links as
+// `subnet.<field> || firstSurfaceUrl(surfaces, kind)`, so a stale/generic
+// top-level value (e.g. a third-party TaoMarketCap link) silently SHADOWS a
+// more-specific curated surface of the same kind sitting in the same file
+// (#6329). This flags that shadowing so the top-level field can be reconciled
+// with — or nulled to defer to — the curated surface.
+//
+// This never fails the process — it is a hygiene report for a human to act on,
+// not a registry validity check. `npm run validate:surface` stays the pass/fail
+// gate for surface data; this is a separate advisory script so a divergent
+// identity field never blocks a contributor PR.
+//
+//   npm run curation:identity-divergence
+//   npm run curation:identity-divergence -- --json
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { listJsonFiles, loadProviders, readJson, repoRoot } from "./lib.mjs";
+
+// Top-level identity fields and the surface kind each falls back to, mirroring
+// the `primaryLinks` resolution in build-artifacts.mjs
+// (`subnet.<field> || firstSurfaceUrl(surfaces, kind)`).
+const IDENTITY_FIELDS = [
+  { field: "website_url", kind: "website" },
+  { field: "dashboard_url", kind: "dashboard" },
+];
+
+// Only the subnet's OWN first-party surface is the "curated link" the served
+// profile should prefer. A third-party aggregator's same-kind surface (e.g.
+// TaoMarketCap's generic per-subnet dashboard) is not — and is sometimes
+// deliberately retained as a directory entry (see tensorclaw.json's
+// TaoMarketCap dashboard), so comparing against it would false-positive. Same
+// reasoning as stale-gap-notes' isFirstPartySurface.
+export function isFirstPartySurface(surface, providersById) {
+  const provider = providersById.get(surface.provider);
+  return provider?.kind === "subnet-team";
+}
+
+// Returns the divergent identity fields for a single subnet document, or [] if
+// none. A field diverges when it is set (a falsy/absent field already defers to
+// the surface fallback) AND the file has a first-party same-kind surface AND
+// the top-level URL differs from it — i.e. the served profile shows something
+// other than the subnet's own curated link (#6329).
+export function findDivergentIdentityFields(document, providersById) {
+  const surfaces = document.surfaces || [];
+  const findings = [];
+  for (const { field, kind } of IDENTITY_FIELDS) {
+    const topLevel = document[field];
+    if (!topLevel) continue;
+    const surface = surfaces.find(
+      (candidate) =>
+        candidate.kind === kind &&
+        isFirstPartySurface(candidate, providersById),
+    );
+    if (!surface) continue;
+    if (surface.url !== topLevel) {
+      findings.push({
+        field,
+        kind,
+        top_level_url: topLevel,
+        surface_id: surface.id,
+        surface_url: surface.url,
+      });
+    }
+  }
+  return findings;
+}
+
+export async function collectDivergentIdentityFields() {
+  const providersById = new Map(
+    (await loadProviders()).map((provider) => [provider.id, provider]),
+  );
+  const files = await listJsonFiles(path.join(repoRoot, "registry/subnets"));
+  const subnets = [];
+  for (const file of files) {
+    const document = await readJson(file);
+    const findings = findDivergentIdentityFields(document, providersById);
+    if (findings.length > 0) {
+      subnets.push({
+        slug: document.slug,
+        netuid: document.netuid,
+        name: document.name,
+        file: path.basename(file),
+        findings,
+      });
+    }
+  }
+  const findingCount = subnets.reduce(
+    (sum, subnet) => sum + subnet.findings.length,
+    0,
+  );
+  return {
+    subnet_count: subnets.length,
+    finding_count: findingCount,
+    subnets,
+  };
+}
+
+function renderReport(report) {
+  if (report.subnets.length === 0) {
+    return "No divergent identity fields found.\n";
+  }
+  const lines = [
+    `Divergent identity fields: ${report.finding_count} across ${report.subnet_count} subnet file(s).`,
+    "This is an advisory report — it does not fail CI. Reconcile each top-level field with its curated surface, or null it to defer to the surface.",
+    "",
+  ];
+  for (const subnet of report.subnets) {
+    lines.push(`SN${subnet.netuid} ${subnet.name} (${subnet.file})`);
+    for (const entry of subnet.findings) {
+      lines.push(
+        `  - ${entry.field}="${entry.top_level_url}" shadows surface "${entry.surface_id}" (${entry.surface_url})`,
+      );
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+if (isCliEntrypoint()) {
+  const report = await collectDivergentIdentityFields();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(renderReport(report));
+  }
+}
+
+function isCliEntrypoint() {
+  return process.argv[1]
+    ? import.meta.url === pathToFileURL(process.argv[1]).href
+    : false;
+}

--- a/tests/identity-field-divergence.test.mjs
+++ b/tests/identity-field-divergence.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  collectDivergentIdentityFields,
+  findDivergentIdentityFields,
+  isFirstPartySurface,
+} from "../scripts/identity-field-divergence.mjs";
+
+const providersById = new Map([
+  ["compelle", { id: "compelle", kind: "subnet-team" }],
+  ["nexisgen", { id: "nexisgen", kind: "subnet-team" }],
+  ["tensorclaw", { id: "tensorclaw", kind: "subnet-team" }],
+  ["taomarketcap", { id: "taomarketcap", kind: "data-provider" }],
+]);
+
+describe("isFirstPartySurface", () => {
+  test("true for a subnet-team provider, false for a third-party aggregator", () => {
+    assert.equal(
+      isFirstPartySurface({ provider: "compelle" }, providersById),
+      true,
+    );
+    assert.equal(
+      isFirstPartySurface({ provider: "taomarketcap" }, providersById),
+      false,
+    );
+    assert.equal(
+      isFirstPartySurface({ provider: "unregistered" }, providersById),
+      false,
+    );
+  });
+});
+
+describe("findDivergentIdentityFields", () => {
+  test("flags a top-level dashboard_url that shadows a first-party same-kind surface (#6329)", () => {
+    const document = {
+      dashboard_url: "https://taomarketcap.com/subnets/82",
+      surfaces: [
+        {
+          id: "sn-82-compelle-status-dashboard",
+          kind: "dashboard",
+          provider: "compelle",
+          url: "https://compelle.com/status",
+        },
+      ],
+    };
+    assert.deepEqual(findDivergentIdentityFields(document, providersById), [
+      {
+        field: "dashboard_url",
+        kind: "dashboard",
+        top_level_url: "https://taomarketcap.com/subnets/82",
+        surface_id: "sn-82-compelle-status-dashboard",
+        surface_url: "https://compelle.com/status",
+      },
+    ]);
+  });
+
+  test("flags a website_url www-mismatch against its first-party website surface", () => {
+    const document = {
+      website_url: "https://nexisgen.ai/",
+      surfaces: [
+        {
+          id: "sn-70-nexisgen-website",
+          kind: "website",
+          provider: "nexisgen",
+          url: "https://www.nexisgen.ai/",
+        },
+      ],
+    };
+    const finding = findDivergentIdentityFields(document, providersById);
+    assert.equal(finding.length, 1);
+    assert.equal(finding[0].surface_url, "https://www.nexisgen.ai/");
+  });
+
+  test("does not flag when the top-level field matches its first-party surface (post-fix)", () => {
+    const document = {
+      dashboard_url: "https://compelle.com/status",
+      surfaces: [
+        {
+          id: "sn-82-compelle-status-dashboard",
+          kind: "dashboard",
+          provider: "compelle",
+          url: "https://compelle.com/status",
+        },
+      ],
+    };
+    assert.deepEqual(findDivergentIdentityFields(document, providersById), []);
+  });
+
+  test("ignores a third-party aggregator surface; only first-party is the curated link (tensorclaw case)", () => {
+    // Top-level is already the real first-party dashboard; the TaoMarketCap
+    // dashboard is a deliberately-retained third-party directory entry sitting
+    // first in surfaces[]. Comparing against it would be a false positive.
+    const document = {
+      dashboard_url: "https://www.tensorclaw.ai/dashboard",
+      surfaces: [
+        {
+          id: "sn-92-taomarketcap-dashboard",
+          kind: "dashboard",
+          provider: "taomarketcap",
+          url: "https://taomarketcap.com/subnets/92",
+        },
+        {
+          id: "sn-92-tensorclaw-dashboard",
+          kind: "dashboard",
+          provider: "tensorclaw",
+          url: "https://www.tensorclaw.ai/dashboard",
+        },
+      ],
+    };
+    assert.deepEqual(findDivergentIdentityFields(document, providersById), []);
+  });
+
+  test("does not flag an absent top-level field (it already defers to the surface)", () => {
+    const document = {
+      surfaces: [
+        {
+          id: "x",
+          kind: "dashboard",
+          provider: "compelle",
+          url: "https://example.com/",
+        },
+      ],
+    };
+    assert.deepEqual(findDivergentIdentityFields(document, providersById), []);
+  });
+
+  test("does not flag when there is no first-party same-kind surface to diverge from", () => {
+    const document = {
+      dashboard_url: "https://example.com/dash",
+      surfaces: [
+        {
+          id: "x",
+          kind: "dashboard",
+          provider: "taomarketcap",
+          url: "https://taomarketcap.com/x",
+        },
+      ],
+    };
+    assert.deepEqual(findDivergentIdentityFields(document, providersById), []);
+  });
+
+  test("handles a document with no surfaces block", () => {
+    assert.deepEqual(
+      findDivergentIdentityFields(
+        { dashboard_url: "https://example.com/" },
+        providersById,
+      ),
+      [],
+    );
+  });
+});
+
+describe("collectDivergentIdentityFields (real registry)", () => {
+  test("the #6329 files are reconciled — none still shadow their curated surface", async () => {
+    const report = await collectDivergentIdentityFields();
+    const fixed = new Set([
+      "bitstarter-1.json",
+      "compelle.json",
+      "hone.json",
+      "itsai.json",
+      "mainframe.json",
+      "mvtrx.json",
+      "sparket.json",
+      "nexisgen.json",
+      "ninja.json",
+    ]);
+    const stillFlagged = report.subnets.filter((s) => fixed.has(s.file));
+    assert.deepEqual(stillFlagged, []);
+  });
+});


### PR DESCRIPTION
Closes #6329

## Summary

`scripts/build-artifacts.mjs` resolves a profile's primary links as `subnet.dashboard_url || firstSurfaceUrl(surfaces, "dashboard")` (same for `website_url`), so a top-level field **always wins** — even a stale generic TaoMarketCap link shadowing a more-specific curated surface of the same kind already sitting in the same file. A scan found 10 divergences across 9 files; in the 7 taomarketcap-vs-curated cases the served profile / completeness score / SN74 signal shows the generic aggregator link while burying the maintainer-curated official dashboard.

## What Changed

**The 9 files** — each divergent top-level field now points at its own curated surface's URL (already present in the file, so no unverified URLs introduced):
- `dashboard_url` → curated dashboard surface: `bitstarter-1` (`app.bitstarter.ai`), `compelle` (`compelle.com/status`), `hone` (`www.hone.training/network`), `itsai` (`wandb.ai/itsai-dev/subnet32`), `mainframe` (`wandb.ai/macrocosmos/folding-openmm`), `mvtrx` (`taos.simulate.trading`), `sparket` (`dashboard.sparket.ai/leaderboard`).
- `website_url` www-mismatch → canonical `www.` form: `bitstarter-1`, `nexisgen`.
- `ninja` (reverse case): the top-level `dashboard_url` was already the real `ninja66.ai`; dropped the stale generic TaoMarketCap `dashboard` surface it supersedes.

**The advisory** — `scripts/identity-field-divergence.mjs` (+ `npm run curation:identity-divergence`), a non-blocking report-only check in the same pattern as `stale-gap-notes.mjs`, flagging a top-level identity field diverging from its own **first-party** same-kind surface so this shadowing is caught going forward. It compares against the first-party surface only — a third-party aggregator's same-kind surface (sometimes deliberately retained, e.g. `tensorclaw`'s TaoMarketCap directory dashboard) is not the curated link and must not false-positive. Ships with a unit test (`tests/identity-field-divergence.test.mjs`).

After this change the advisory reports **clean** across all 129 files.

## Deliverables
- [x] Corrected `dashboard_url`/`website_url` fields in the 9 listed files
- [x] Non-blocking divergence advisory added to the registry tooling (+ test)

## Registry Safety
- [x] Links a tracked, currently-open issue (`Closes #6329`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited. *(source registry files + a new script only; no generated artifacts committed)*
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none)*

## Validation
- [x] `npm run validate:surface` — passed (1120 surfaces across 129 files)
- [x] `npm run validate:intake` — passed
- [x] `npm run curation:identity-divergence` — "No divergent identity fields found."
- [x] `npx vitest run tests/identity-field-divergence.test.mjs` — 9 passing
- [x] `npx prettier --check` / `npx eslint` — clean
- [x] `git diff --check` clean

*(Note: `validate:schemas` reports 3 pre-existing `economics/summary` failures on clean `main`, unrelated to this change — a stale local artifact from the new total-network-value schema field.)*
