### PR TITLE
fix(ui): tokenize account-history-chart's radii, shadow, and accent wash (#6400)

### DIFF
--- a/apps/ui/src/components/metagraphed/account-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-history-chart.tsx
@@ -202,7 +202,7 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
         </div>
       ) : null}
 
-      <div className="overflow-hidden rounded-[1.75rem] border border-border/80 bg-card/95 shadow-[0_32px_100px_-70px_rgba(15,23,42,0.55)]">
+      <div className="overflow-hidden rounded-2xl border border-border/80 bg-card/95 mg-card-glow">
         <div className="grid gap-4 border-b border-border/70 px-5 py-5 md:grid-cols-3">
           <MetricBlock
             label="Total activity"
@@ -223,8 +223,8 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
           />
         </div>
 
-        <div className="bg-[linear-gradient(180deg,rgba(45,212,191,0.08),rgba(45,212,191,0.02)_42%,transparent)] px-4 py-4 md:px-5 md:py-5">
-          <div className="rounded-[1.4rem] border border-border/70 bg-paper/70 px-4 py-4 md:px-5 md:py-5">
+        <div className="bg-[linear-gradient(180deg,color-mix(in_oklab,var(--accent)_8%,transparent),color-mix(in_oklab,var(--accent)_2%,transparent)_42%,transparent)] px-4 py-4 md:px-5 md:py-5">
+          <div className="rounded-xl border border-border/70 bg-paper/70 px-4 py-4 md:px-5 md:py-5">
             <Sparkline
               values={values}
               points={points}


### PR DESCRIPTION
Closes #6400

## Problem

`account-history-chart.tsx`'s card wrapper used `rounded-[1.75rem]` + a raw `shadow-[0_32px_100px_-70px_rgba(15,23,42,0.55)]` (a fixed slate-900 shadow that vanishes on a dark background), and its accent gradient wash was a raw Tailwind teal-400 rgba, not derived from `--accent` — inconsistent with `--color-accent-surface`'s own `color-mix(in oklab, var(--accent) 6%, transparent)` recipe, already used correctly 13 times elsewhere in this scope. The nested sparkline wrapper used a third arbitrary radius (`rounded-[1.4rem]`).

## Fix

This component is only consumed by `accounts.$ss58.tsx`, whose own `DataPanel`/`AccountHeroAside` cards were already reconciled to `rounded-2xl` + `.mg-card-glow` by #6399/#6398 — this PR brings `account-history-chart.tsx` in line with that same settled choice rather than picking new tokens independently:
- Outer card: `rounded-[1.75rem]` → `rounded-2xl`, raw rgba shadow → `.mg-card-glow` (the theme-adaptive `color-mix(in oklab, var(--ink-strong) ...)` shadow #6398 introduced for exactly this vanishing-on-dark problem).
- Accent gradient wash: raw teal-400 rgba stops → `color-mix(in oklab, var(--accent) 8%/2%, transparent)`, matching `--color-accent-surface`'s recipe.
- Nested sparkline wrapper: `rounded-[1.4rem]` → `rounded-xl`, matching this same file's own outer-2xl/inner-xl nesting precedent (`accounts.$ss58.tsx:2454-2455`).

## Screenshots

Visually subtle by design — `--accent`'s hue is close to the raw teal-400 it replaced, and `.mg-card-glow`'s ink-strong-derived tint is close to the raw slate-900 shadow in most lighting. The real fix is token-correctness (adapts with the theme instead of a fixed color) and consistency with the settled #6399/#6398 tokens, not a visible redesign.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/galuis116/metagraphed/screenshots/6400-after-mobile-dark.png)<br><sub>after</sub> |

## Testing

- `npx tsc --noEmit -p apps/ui`: clean
- `npx prettier --check` / `npx eslint` on the changed file: clean, zero warnings
- `npx vitest run` (apps/ui): 162 test files, 1212 tests, all passing
- Manually verified in browser across all three breakpoints and both themes on a real account with indexed history