### PR TITLE
obs(sentry): capture the remaining 8 handled-error sites in data-api.mjs

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -116,6 +116,17 @@ const nominatorPositionsSyncFailure = vi.hoisted(() => ({ error: null }));
 // isolation purpose as subnetTemposQueryFailure above, but for
 // loadNominatorPositions' own SELECT.
 const nominatorPositionsQueryFailure = vi.hoisted(() => ({ error: null }));
+// State for the /positions route's second query (#6769 gap-closure) --
+// loadNeuronStakeByHotkeys' own sql.unsafe IN-list SELECT, isolated from
+// nominatorPositionsQueryFailure above so a test can fail just this one
+// without also failing the read it depends on.
+const neuronStakeByHotkeyQueryFailure = vi.hoisted(() => ({ error: null }));
+// State for GET /api/v1/accounts/:ss58/history's own SELECT (#6769
+// gap-closure) -- this route has no per-query try/catch of its own, so a
+// failure here is the one that reaches the router's OUTERMOST generic
+// catch (captureDataApiError(err, url.pathname)), unlike every other flag
+// above which targets a route with its own dedicated fallback.
+const accountHistoryQueryFailure = vi.hoisted(() => ({ error: null }));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -171,6 +182,12 @@ vi.mock("postgres", () => ({
         /INSERT INTO account_events_daily/.test(text)
       ) {
         return Promise.reject(rollupFailure.error);
+      }
+      if (
+        accountHistoryQueryFailure.error &&
+        /FROM account_events_daily\b/.test(text)
+      ) {
+        return Promise.reject(accountHistoryQueryFailure.error);
       }
       if (
         subnetHyperparamsSyncFailure.error &&
@@ -297,6 +314,12 @@ vi.mock("postgres", () => ({
         }
         return Promise.resolve(accountIdentityJoinRows.current);
       }
+      if (/stake_tao FROM neurons WHERE hotkey IN/.test(text)) {
+        if (neuronStakeByHotkeyQueryFailure.error) {
+          return Promise.reject(neuronStakeByHotkeyQueryFailure.error);
+        }
+        return Promise.resolve(mockRows.current);
+      }
       return Promise.resolve(mockRows.current);
     };
     // sql.begin(["read only",] cb) reserves a connection for cb in real
@@ -386,6 +409,8 @@ beforeEach(() => {
   subnetTemposQueryFailure.error = null;
   nominatorPositionsSyncFailure.error = null;
   nominatorPositionsQueryFailure.error = null;
+  neuronStakeByHotkeyQueryFailure.error = null;
+  accountHistoryQueryFailure.error = null;
   subnetIdentitySyncFailure.error = null;
   subnetIdentityLatestHashes.current = [];
   healthChecksSyncFailure.error = null;
@@ -3998,6 +4023,18 @@ test("GET /api/v1/accounts/:ss58/history?limit=1 emits a next_cursor when the pa
   expect(body.next_cursor).not.toBeNull();
 });
 
+test("GET /api/v1/accounts/:ss58/history maps a DB failure to a clean 502 via the router's generic catch (#6769)", async () => {
+  // This route has no per-query try/catch of its own -- a failure here is
+  // the one path in this whole file that reaches the OUTERMOST generic
+  // catch (captureDataApiError(err, url.pathname)) at the bottom of the
+  // route dispatcher, rather than a route-specific fallback.
+  accountHistoryQueryFailure.error = new Error("connection reset");
+  const res = await req(`/api/v1/accounts/${SS58}/history`);
+  expect(res.status).toBe(502);
+  const body = await res.json();
+  expect(body.error).toBe("data query failed");
+});
+
 // #4832 gap-closure: POST /api/v1/internal/subnet-hyperparams-sync -- the
 // write path into subnet_hyperparams/subnet_hyperparams_history (see
 // workers/data-api.mjs's handleSubnetHyperparamsSync), plus its read paths,
@@ -5106,6 +5143,37 @@ test("GET /api/v1/accounts/:ss58/positions still serves an empty card when the n
   const body = await res.json();
   expect(body.position_count).toBe(0);
   expect(body.positions).toEqual([]);
+});
+
+test("GET /api/v1/accounts/:ss58/positions still serves a card (with zeroed stake) when the neurons stake-by-hotkey join fails (#6769)", async () => {
+  // nominator_positions succeeds with a real hotkey, so loadNeuronStakeByHotkeys
+  // actually runs (an empty hotkeys array short-circuits before ever issuing
+  // this query -- see the "no positions" test above).
+  mockQueue.current = [
+    [], // sql.begin's leading `SET statement_timeout`
+    [
+      {
+        coldkey: "5Cold1",
+        hotkey: "5Hk1",
+        netuid: 3,
+        share_fraction: 0.25,
+        captured_at: "1780000000000",
+      },
+    ], // loadNominatorPositions
+  ];
+  neuronStakeByHotkeyQueryFailure.error = new Error("connection reset");
+  const res = await req("/api/v1/accounts/5Cold1/positions");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  // buildAccountPositions drops any position it can't resolve a stake_tao
+  // for (src/account-nominator-positions.mjs: `if (hotkeyStake == null)
+  // continue;`) rather than fabricating a zero -- the join failing for
+  // every hotkey degrades to the same empty card the "no positions" and
+  // "nominator_positions read fails" tests above assert, just reached via
+  // the OTHER query in this route failing instead.
+  expect(body.position_count).toBe(0);
+  expect(body.positions).toEqual([]);
+  expect(body.total_stake_tao).toBe(0);
 });
 
 test("GET /api/v1/accounts/:ss58/identity returns the latest row", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2938,6 +2938,7 @@ async function loadFeaturedHotkeys(sql) {
     return new Set(rows.map((row) => row.hotkey));
   } catch (err) {
     console.error("featured_validators query failed:", err);
+    captureDataApiError(err, "featured-validators-query");
     return new Set();
   }
 }
@@ -2965,6 +2966,7 @@ async function loadAccountIdentitiesByColdkey(sql, coldkeys) {
     return new Map(rows.map((row) => [row.account, row]));
   } catch (err) {
     console.error("account_identity join query failed:", err);
+    captureDataApiError(err, "account-identity-join-query");
     return new Map();
   }
 }
@@ -2993,6 +2995,7 @@ async function loadValidatorNominatorCounts(sql) {
     return nominatorCountsByHotkey(rows);
   } catch (err) {
     console.error("validator_nominator_counts query failed:", err);
+    captureDataApiError(err, "validator-nominator-counts-query");
     return new Map();
   }
 }
@@ -3010,6 +3013,7 @@ async function loadSubnetTempos(sql) {
     return buildTempoByNetuid(rows);
   } catch (err) {
     console.error("subnet_hyperparams tempo query failed:", err);
+    captureDataApiError(err, "subnet-hyperparams-tempo-query");
     return new Map();
   }
 }
@@ -3035,6 +3039,7 @@ async function loadSubnetImmunityPeriod(sql, netuid) {
     return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
   } catch (err) {
     console.error("subnet_hyperparams immunity_period query failed:", err);
+    captureDataApiError(err, "subnet-hyperparams-immunity-period-query");
     return null;
   }
 }
@@ -3051,6 +3056,7 @@ async function loadNominatorPositions(sql, ss58) {
     );
   } catch (err) {
     console.error("nominator_positions query failed:", err);
+    captureDataApiError(err, "nominator-positions-query");
     return [];
   }
 }
@@ -3074,6 +3080,7 @@ async function loadNeuronStakeByHotkeys(sql, hotkeys) {
     return stakeByHotkeyNetuid(rows);
   } catch (err) {
     console.error("neurons stake-by-hotkey join query failed:", err);
+    captureDataApiError(err, "neurons-stake-by-hotkey-query");
     return new Map();
   }
 }
@@ -7533,6 +7540,10 @@ export default {
       // Log internally (Wrangler observability) but NEVER leak DB error details
       // (schema, table, or connection info) to API clients.
       console.error("data-api query failed:", err);
+      // url.pathname (not a static tag) -- this catch is the generic
+      // fallback for the WHOLE route dispatcher above, so the actual
+      // failing route is the only thing that makes the Sentry event useful.
+      captureDataApiError(err, url.pathname);
       return json({ error: "data query failed" }, 502);
     }
     // No sql.end() here: Hyperdrive automatically cleans up the connection


### PR DESCRIPTION
## Summary

Completes #6769. #6781 covered the 15 write-failure paths (the closest analog to #6451's
incident class — data silently failing to persist); this covers the remaining 8 sites, all in
`workers/data-api.mjs` (`workers/api.mjs` has no `console.error` call sites of this class at
all, so the original issue's "23 sites across both files" count is fully accounted for here —
all 23 = 15 + 8).

## What changed

- 6 query-failure catch blocks that already fail soft with a safe fallback (`featured_validators`,
  `account_identity` join, `validator_nominator_counts`, `subnet_hyperparams` tempo/
  immunity_period, `neurons` stake-by-hotkey join) — each gets a
  `captureDataApiError(err, "<route>-query")` tag, reusing the helper #6781 already added.
- The generic handler-level catch-all at the bottom of the route dispatcher — tagged with
  **`url.pathname`**, not a static string, since this one catch is the fallback for every route
  that doesn't have its own try/catch, so the actual failing path is the only thing that makes
  the Sentry event useful.

Worth calling out: that generic catch-all is the *exact* code path a live production bug hit
earlier this session — the #6638 conviction route 502'd through it (a missing Postgres table)
and had to be root-caused manually via SSH + `psql`. With this change, that class of failure
would have shown up in Sentry automatically instead.

## Tests

Two new regression tests in `tests/data-api.test.mjs`:
- `neuronStakeByHotkeyQueryFailure` mock hook + a test confirming the route degrades to an empty
  positions card when the stake join fails (not a fabricated zero-stake row — confirmed against
  `src/account-nominator-positions.mjs`'s own `if (hotkeyStake == null) continue`).
- `accountHistoryQueryFailure` mock hook + a test confirming `GET /api/v1/accounts/:ss58/history`
  (which has no per-query try/catch of its own) returns a clean 502 through the generic catch.

## Validation

- `npx vitest run tests/data-api.test.mjs` — 485/485 passed
- `npx vitest run` (full suite) — 309 files / 9239 tests passed
- Coverage: all 8 new `captureDataApiError` lines confirmed covered (verified via
  `--coverage --coverage.include=workers/data-api.mjs` against `coverage/coverage-final.json`
  directly — 2 of the 8 were genuinely uncovered before the two new tests above)
- `npm run lint && npm run format:check` — clean

Closes #6769
