### PR TITLE
fix(registry): set schema_url on 6 openapi surfaces claiming machine-readable (#6331)

### DIFF
--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -218,6 +218,7 @@
       "provider": "chutes",
       "public_safe": true,
       "schema_status": "machine-readable",
+      "schema_url": "https://api.chutes.ai/openapi.json",
       "source_urls": [
         "https://api.chutes.ai/openapi.json",
         "https://github.com/chutesai/chutes"

--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -133,6 +133,7 @@
       "provider": "desearch",
       "public_safe": true,
       "schema_status": "machine-readable",
+      "schema_url": "https://www.desearch.ai/openapi.json",
       "source_urls": [
         "https://www.desearch.ai/openapi.json",
         "https://api.desearch.ai"

--- a/registry/subnets/green-compute.json
+++ b/registry/subnets/green-compute.json
@@ -100,6 +100,7 @@
       "provider": "green-compute",
       "public_safe": true,
       "schema_status": "machine-readable",
+      "schema_url": "https://api.green-compute.com/openapi.json",
       "source_urls": [
         "https://api.green-compute.com/openapi.json",
         "https://www.green-compute.com/"

--- a/registry/subnets/handshake58.json
+++ b/registry/subnets/handshake58.json
@@ -139,6 +139,7 @@
       "provider": "handshake58",
       "public_safe": true,
       "schema_status": "machine-readable",
+      "schema_url": "https://handshake58.com/openapi.json",
       "source_urls": [
         "https://handshake58.com/.well-known/ai-plugin.json",
         "https://handshake58.com/openapi.json"

--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -138,6 +138,7 @@
       "provider": "nepher-robotics",
       "public_safe": true,
       "schema_status": "machine-readable",
+      "schema_url": "https://tournament-api.nepher.ai/openapi.json",
       "source_urls": [
         "https://tournament-api.nepher.ai/docs",
         "https://tournament-api.nepher.ai/openapi.json"

--- a/registry/subnets/verathos.json
+++ b/registry/subnets/verathos.json
@@ -112,6 +112,7 @@
       "provider": "verathos",
       "public_safe": true,
       "schema_status": "machine-readable",
+      "schema_url": "https://verathos.ai/openapi.json",
       "source_urls": [
         "https://verathos.ai/docs",
         "https://verathos.ai/openapi.json"

--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -199,6 +199,18 @@ for (const file of files) {
           "(the /rpc endpoint lane), not per-subnet contributor surfaces.",
       );
     }
+    // #6331: schema_status: "machine-readable" is a claim that a schema is
+    // fetchable somewhere — schema_url is where. Hard error, not advisory:
+    // unlike auth's structured object below (sometimes genuinely undocumented
+    // by the provider), a machine-readable schema is either served at a URL
+    // or the status is simply wrong.
+    if (surface.schema_status === "machine-readable" && !surface.schema_url) {
+      errors.push(
+        `${label}: schema_status "machine-readable" requires a non-empty ` +
+          "schema_url — set it (usually the surface's own url) or downgrade " +
+          'schema_status to "ui-only"/"not-captured" if no machine-readable spec is actually served.',
+      );
+    }
     // #6330: auth_required makes a promise ("this needs a credential") the
     // structured auth{} field is what makes caller-actionable ("...and here's
     // how"). Advisory, not a hard error: the credential mechanism is

--- a/tests/validate-surface-schema-url.test.mjs
+++ b/tests/validate-surface-schema-url.test.mjs
@@ -1,0 +1,154 @@
+// Regression coverage for #6331: validate-surface.mjs now fails when a
+// surface declares schema_status: "machine-readable" with no schema_url —
+// the claim ("a schema is fetchable") needs the URL that backs it up.
+// Mirrors validate-surface-duplicate-url.test.mjs's subprocess-fixture pattern.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, test } from "vitest";
+import { listJsonFiles, repoRoot } from "../scripts/lib.mjs";
+
+function runNode(args) {
+  try {
+    const stdout = execFileSync(process.execPath, args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return { status: 0, output: stdout };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      output: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+    };
+  }
+}
+
+describe("validate-surface.mjs schema_url check", () => {
+  let tempDir;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  function writeFixture(surfaces) {
+    const document = {
+      schema_version: 1,
+      netuid: 999,
+      slug: "fixture",
+      name: "Fixture Subnet",
+      status: "active",
+      categories: [],
+      links: [],
+      surfaces,
+    };
+    tempDir = mkdtempSync(
+      `${tmpdir()}/metagraphed-validate-surface-schema-url-`,
+    );
+    const fixturePath = path.join(tempDir, "fixture.json");
+    writeFileSync(fixturePath, JSON.stringify(document, null, 2));
+    return fixturePath;
+  }
+
+  test("fails when schema_status is machine-readable with no schema_url", () => {
+    const fixturePath = writeFixture([
+      {
+        id: "fixture-openapi",
+        kind: "openapi",
+        name: "Fixture OpenAPI schema",
+        url: "https://api.fixture.example/openapi.json",
+        provider: "academia",
+        authority: "official",
+        auth_required: false,
+        public_safe: true,
+        schema_status: "machine-readable",
+      },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 1);
+    assert.match(output, /fixture-openapi/);
+    assert.match(
+      output,
+      /schema_status "machine-readable" requires a non-empty schema_url/,
+    );
+  });
+
+  test("passes when schema_status is machine-readable and schema_url is set", () => {
+    const fixturePath = writeFixture([
+      {
+        id: "fixture-openapi",
+        kind: "openapi",
+        name: "Fixture OpenAPI schema",
+        url: "https://api.fixture.example/openapi.json",
+        provider: "academia",
+        authority: "official",
+        auth_required: false,
+        public_safe: true,
+        schema_status: "machine-readable",
+        schema_url: "https://api.fixture.example/openapi.json",
+      },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 0);
+    assert.match(output, /Surface validation passed/);
+  });
+
+  test("passes when schema_status is not machine-readable and schema_url is absent", () => {
+    const fixturePath = writeFixture([
+      {
+        id: "fixture-subnet-api",
+        kind: "subnet-api",
+        name: "Fixture API",
+        url: "https://api.fixture.example/status",
+        provider: "academia",
+        authority: "community",
+        auth_required: false,
+        public_safe: true,
+        review: { state: "community-submitted" },
+        schema_status: "not-captured",
+      },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fixturePath,
+    ]);
+
+    assert.equal(status, 0);
+    assert.match(output, /Surface validation passed/);
+  });
+
+  test("the full registry has no unresolved schema_url findings", () => {
+    // Sanity check the check itself against real data: running with no file
+    // args (validates every subnet file) must be clean.
+    const { status, output } = runNode(["scripts/validate-surface.mjs"]);
+    assert.equal(status, 0, output);
+  });
+});
+
+describe("validate-surface.mjs schema_url check does not misfire", () => {
+  test("every real subnet file individually passes (no false-positive schema_url findings)", async () => {
+    const files = await listJsonFiles(path.join(repoRoot, "registry/subnets"));
+    assert.ok(files.length > 0);
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...files,
+    ]);
+    assert.equal(status, 0, output);
+  });
+});


### PR DESCRIPTION
## Summary

- Sets `schema_url` on the 6 `openapi`-kind surfaces flagged by #6331 as declaring `schema_status: "machine-readable"` with no `schema_url`: `chutes.json`, `desearch.json`, `green-compute.json`, `handshake58.json`, `nepher-robotics.json`, `verathos.json`. In every case the value is the surface's own `url` — the same pattern already used by 56/62 other `openapi` surfaces in the registry (e.g. `numinous.json`'s `sn-6-numinous-swagger` surface).
- Adds a `validate-surface.mjs` hard-error check so `schema_status: "machine-readable"` without a `schema_url` fails validation going forward, with regression test coverage in `tests/validate-surface-schema-url.test.mjs` mirroring the existing duplicate-URL test's subprocess-fixture pattern.

## Proof — each schema_url is live and genuine

| Surface | URL | Verified |
| ---- | ---- | ---- |
| `sn-64-chutes-openapi` | `https://api.chutes.ai/openapi.json` | HTTP 200, `openapi: 3.1.0`, title "FastAPI" |
| `sn-22-desearch-openapi` | `https://www.desearch.ai/openapi.json` | HTTP 200, `openapi: 3.1.0`, title "Desearch API" |
| `sn-110-green-compute-openapi` | `https://api.green-compute.com/openapi.json` | HTTP 200, `openapi: 3.1.0`, title "GreenCompute Gateway" |
| `sn-58-handshake58-openapi` | `https://handshake58.com/openapi.json` | HTTP 200, `openapi: 3.0.3`, title "Handshake58 DRAIN Protocol API" |
| `sn-49-nepher-tournament-openapi` | `https://tournament-api.nepher.ai/openapi.json` | HTTP 200, `openapi: 3.1.0`, title "Tournament Backend API" |
| `sn-96-verathos-openapi` | `https://verathos.ai/openapi.json` | HTTP 200, `openapi: 3.1.0`, title "Verathos" |

## Note on the prior attempt

This issue was previously attempted in #6780. That PR's content was sound (the AI review was fully positive with zero blocking nits), but it went stale: a separate, later PR of mine (#6783, for #6330) touched 4 of the same 6 subnet files, merged first, and left #6780 conflicting with the new `main`, so it was closed by the automated gate with a request to resubmit. This PR is a clean redo, rebased on current `main` (which already includes #6783's `auth{}` additions to those files) — no overlap with any other open PR.

## Test plan

- [x] `npm run validate:surface -- registry/subnets/{chutes,desearch,green-compute,handshake58,nepher-robotics,verathos}.json`
- [x] `npm run validate` (full suite — 129 native subnets, 1822 surfaces, clean)
- [x] `npm run lint`, `npm run format:check` — clean
- [x] `npm run build` (schema/script change requires regenerated artifacts; no diff beyond deploy-owned artifacts, which are excluded per house rules)
- [x] Full `vitest run` — 310 test files, 9242 tests passing, including 5 new tests in `tests/validate-surface-schema-url.test.mjs`

Closes #6331
