### PR TITLE
fix(registry): reconcile swap.json gap_notes with the TaoFi pool-page 402 outage

### DIFF
--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -19,7 +19,7 @@
   ],
   "curation": {
     "gap_notes": [
-      "Official TaoFi pool page, docs, and Swap source repository are verified live.",
+      "Official TaoFi docs and Swap source repository are verified live; the TaoFi pool page (www.taofi.com/pool, and the rest of www.taofi.com) currently returns HTTP 402 with x-vercel-error: DEPLOYMENT_DISABLED and should appear degraded until the Vercel deployment recovers.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
       "No verified SSE/event stream yet."
     ],


### PR DESCRIPTION
Closes #6591

## Problem

`registry/subnets/swap.json`'s `curation.gap_notes[0]` reads:

> "Official TaoFi pool page, docs, and Swap source repository are verified live."

This directly contradicts the `notes` field two lines below in the same file, which documents that the entire `www.taofi.com` domain (including `/pool`) returns **HTTP 402** with `x-vercel-error: DEPLOYMENT_DISABLED` — the team's Vercel deployment appears disabled. This is the last of the five subnets tracked in #5480 (the other four — `tensorclaw.json`, `ninja.json`, `8-ball.json`, `oneoneone.json` — are already fixed).

## Re-verification (this pass)

| URL | Status |
| --- | --- |
| `https://www.taofi.com/pool` | **402** `x-vercel-error: DEPLOYMENT_DISABLED` (still down) |
| `https://www.taofi.com/` | **402** `x-vercel-error: DEPLOYMENT_DISABLED` (still down) |
| `https://docs.taofi.com/` | **200** (unaffected) |

The outage has **not** recovered since `notes` was written, so this is the "still down" path from the issue.

## Fix

Rewrote **only** the website-page claim in `gap_notes[0]` to describe the known-degraded state, matching the precedent in `taolend.json`'s `curation.gap_notes` ("…should appear degraded until it recovers"). Docs (`docs.taofi.com`) and the Swap source repository remain verified live, so the corrected line walks back only the pool-page claim, not the whole trio. `notes` (line 36) is already accurate and is left untouched.

## Scope

- **One file, one line** — `registry/subnets/swap.json` only. No generated artifacts, no build output, no other files (`gap_notes` does not feed any committed `public/` artifact; the merged precedent #6774 was likewise registry-only).

## Validation

- [x] `npm run validate:surface -- registry/subnets/swap.json` — passed (6 surfaces, 1 file)
- [x] `npm run scan:public-safety` — passed
- [x] `git diff --check` — clean
