### PR TITLE
feat(mcp): add compound get_subnet_snapshot / get_account_snapshot tools

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -2674,6 +2674,107 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_subnet_snapshot",
+    title: "Get one subnet's compound snapshot (5 views in one call)",
+    description:
+      "Fan out to five of a subnet's live views in a single round trip: " +
+      "hyperparameters, stake/emission concentration, reward-distribution " +
+      "performance, the top validators by stake (default 10, cap with " +
+      "top_validators_limit), and the most recent chain events (default 10, " +
+      "cap with recent_events_limit). Equivalent to calling get_subnet_hyperparams " +
+      "+ get_subnet_concentration + get_subnet_performance + " +
+      "list_subnet_validators + get_subnet_events separately -- use this instead " +
+      "when an agent needs a broad picture of one subnet's current state rather " +
+      "than drilling into just one facet (which the individual tools remain " +
+      "better suited for, since each carries its own full parameter set this " +
+      "compound view intentionally simplifies).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+        top_validators_limit: {
+          type: "integer",
+          description:
+            "Max validators in the top-validators slice. Default 10.",
+          minimum: 1,
+        },
+        recent_events_limit: {
+          type: "integer",
+          description: "Max events in the recent-events slice. Default 10.",
+          minimum: 1,
+          maximum: 1000,
+        },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const topValidatorsLimit =
+        optionalPositiveInt(args, "top_validators_limit") ?? 10;
+      const recentEventsLimit = clampLimit(args?.recent_events_limit, 10, 1000);
+      const [hyperparams, concentration, performance, validators, events] =
+        await Promise.all([
+          tryPostgresTier(
+            ctx.env,
+            mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/hyperparameters`),
+            "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
+          ).then((data) => data ?? buildSubnetHyperparams(null, netuid)),
+          tryPostgresTier(
+            ctx.env,
+            mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/concentration`),
+            "METAGRAPH_NEURONS_SOURCE",
+          ).then((data) => data ?? buildConcentration([], netuid)),
+          tryPostgresTier(
+            ctx.env,
+            mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/performance`),
+            "METAGRAPH_NEURONS_SOURCE",
+          ).then((data) => data ?? buildSubnetPerformance([], netuid)),
+          tryPostgresTier(
+            ctx.env,
+            mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/validators`),
+            "METAGRAPH_NEURONS_SOURCE",
+          ).then((data) => data ?? buildSubnetValidators([], netuid)),
+          tryPostgresTier(
+            ctx.env,
+            mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/events`, {
+              limit: recentEventsLimit,
+              offset: 0,
+            }),
+            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+          ).then(
+            (data) =>
+              data ??
+              buildSubnetEvents([], netuid, {
+                limit: recentEventsLimit,
+                offset: 0,
+                nextCursor: null,
+              }),
+          ),
+        ]);
+      // list_subnet_validators' own limit post-filter (the loader already
+      // ranks by stake_tao DESC, so slicing after is a no-op re-sort) --
+      // mirrored here rather than exported, since it's three lines.
+      const slicedValidators = (validators?.validators ?? []).slice(
+        0,
+        topValidatorsLimit,
+      );
+      const topValidators = {
+        ...validators,
+        validator_count: slicedValidators.length,
+        validators: slicedValidators,
+      };
+      return {
+        netuid,
+        hyperparameters: hyperparams,
+        concentration,
+        performance,
+        top_validators: topValidators,
+        recent_events: events,
+      };
+    },
+  },
+  {
     ...GET_NETWORK_HEALTH_MCP_TOOL,
     async handler(_args, ctx) {
       return loadGlobalOperationalHealth(
@@ -6331,6 +6432,111 @@ export const MCP_TOOLS = [
           "METAGRAPH_NEURONS_SOURCE",
         )) ?? buildAccountPositions([], new Map(), ss58)
       );
+    },
+  },
+  {
+    name: "get_account_snapshot",
+    title: "Get one account's compound snapshot (5 views in one call)",
+    description:
+      "Fan out to five of an account's live views in a single round trip: " +
+      "live TAO balance, cross-subnet portfolio (hotkey-scoped), cross-subnet " +
+      "footprint (registered subnets), nominator-side positions (coldkey-scoped), " +
+      "and the most recent chain events (default 10, cap with recent_events_limit). " +
+      "The same ss58 is used for every view -- portfolio/subnets are only " +
+      "meaningful if it's a hotkey, positions only if it's a coldkey, so a card " +
+      "for the 'other' role degrades to its own natural empty state rather than " +
+      "erroring. Equivalent to calling get_account_balance + get_account_portfolio " +
+      "+ get_account_subnets + get_account_positions + get_account_events " +
+      "separately -- use this instead when an agent needs a broad picture of one " +
+      "wallet rather than drilling into just one facet.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        ss58: {
+          type: "string",
+          description:
+            "The account's SS58 address, base58, 47-48 chars. Hotkey or " +
+            "coldkey -- see the role note above.",
+          pattern: SS58_PATTERN_SOURCE,
+        },
+        recent_events_limit: {
+          type: "integer",
+          description: "Max events in the recent-events slice. Default 10.",
+          minimum: 1,
+          maximum: 1000,
+        },
+      },
+      required: ["ss58"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const ss58 = requireSs58(args);
+      const recentEventsLimit = clampLimit(args?.recent_events_limit, 10, 1000);
+      // balance is a live RPC call (its own rate limiter + address-network
+      // check, mirroring get_account_balance's handler exactly) -- every
+      // other slice is a Postgres-tier read with its own graceful fallback,
+      // so a live RPC/rate-limit failure is the only thing that can make
+      // this whole compound call throw instead of degrading one section.
+      if (!isFinneySs58Address(ss58)) {
+        throw toolError(
+          "invalid_params",
+          "Argument `ss58` must be a valid finney SS58 account address.",
+        );
+      }
+      if (ctx.env.RPC_RATE_LIMITER?.limit) {
+        const { success } = await ctx.env.RPC_RATE_LIMITER.limit({
+          key: `balance:mcp:${ctx.clientIp}`,
+        });
+        if (!success) {
+          throw toolError(
+            "rate_limited",
+            "Too many live balance requests from this client; slow down.",
+          );
+        }
+      }
+      const [balance, portfolio, subnets, positions, events] =
+        await Promise.all([
+          loadAccountBalance(ctx.env, ss58),
+          tryPostgresTier(
+            ctx.env,
+            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/portfolio`),
+            "METAGRAPH_NEURONS_SOURCE",
+          ).then((data) => data ?? buildAccountPortfolio([], ss58)),
+          tryPostgresTier(
+            ctx.env,
+            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/subnets`),
+            "METAGRAPH_NEURONS_SOURCE",
+          ).then((data) => data ?? buildAccountSubnets([], ss58)),
+          tryPostgresTier(
+            ctx.env,
+            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/positions`),
+            "METAGRAPH_NEURONS_SOURCE",
+          ).then((data) => data ?? buildAccountPositions([], new Map(), ss58)),
+          tryPostgresTier(
+            ctx.env,
+            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/events`, {
+              limit: recentEventsLimit,
+              offset: 0,
+            }),
+            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+          ).then(
+            (data) =>
+              data ??
+              buildAccountEvents([], ss58, {
+                limit: recentEventsLimit,
+                offset: 0,
+                nextCursor: null,
+              }),
+          ),
+        ]);
+      return {
+        ss58,
+        balance,
+        portfolio,
+        subnets,
+        positions,
+        recent_events: events,
+      };
     },
   },
   {
@@ -10651,6 +10857,26 @@ const TOOL_OUTPUT_SCHEMAS = {
       economics: { type: ["object", "null"] },
     },
   },
+  get_subnet_snapshot: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "netuid",
+      "hyperparameters",
+      "concentration",
+      "performance",
+      "top_validators",
+      "recent_events",
+    ],
+    properties: {
+      netuid: { type: "integer" },
+      hyperparameters: { type: "object" },
+      concentration: { type: "object" },
+      performance: { type: "object" },
+      top_validators: { type: "object" },
+      recent_events: { type: "object" },
+    },
+  },
   get_subnet_health: {
     type: "object",
     additionalProperties: true,
@@ -12622,6 +12848,26 @@ const TOOL_OUTPUT_SCHEMAS = {
       position_count: { type: "integer" },
       total_stake_tao: { type: "number" },
       positions: { type: "array", items: { type: "object" } },
+    },
+  },
+  get_account_snapshot: {
+    type: "object",
+    additionalProperties: true,
+    required: [
+      "ss58",
+      "balance",
+      "portfolio",
+      "subnets",
+      "positions",
+      "recent_events",
+    ],
+    properties: {
+      ss58: { type: "string" },
+      balance: { type: "object" },
+      portfolio: { type: "object" },
+      subnets: { type: "object" },
+      positions: { type: "object" },
+      recent_events: { type: "object" },
     },
   },
   get_account_identity: {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -3610,6 +3610,169 @@ describe("MCP get_subnet_performance", () => {
   });
 });
 
+describe("MCP get_subnet_snapshot", () => {
+  // No Postgres-tier flags set and no DATA_API bound -- every one of the five
+  // component tryPostgresTier calls degrades to its own schema-stable empty
+  // fallback (get_subnet_performance's own precedent above), and the compound
+  // handler just merges the five cold cards under their named keys.
+  test("degrades to five schema-stable empty cards when every Postgres tier is cold", async () => {
+    const res = await callTool("get_subnet_snapshot", { netuid: 7 }, {});
+    assert.equal(res.body.result.isError, false);
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.hyperparameters.netuid, 7);
+    assert.equal(out.concentration.netuid, 7);
+    assert.equal(out.concentration.neuron_count, 0);
+    assert.equal(out.performance.netuid, 7);
+    assert.equal(out.performance.neuron_count, 0);
+    assert.equal(out.top_validators.netuid, 7);
+    assert.equal(out.top_validators.validator_count, 0);
+    assert.deepEqual(out.top_validators.validators, []);
+    assert.equal(out.recent_events.netuid, 7);
+    assert.equal(out.recent_events.event_count, 0);
+    assert.deepEqual(out.recent_events.events, []);
+  });
+
+  // A DATA_API stub that dispatches on pathname, mirroring the compare_subnets
+  // multi-path mock pattern above -- one binding standing in for the five
+  // distinct /api/v1/subnets/:netuid/* routes the compound handler fans out to.
+  function subnetSnapshotPostgresEnv() {
+    const calls = [];
+    return {
+      calls,
+      env: {
+        METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
+        METAGRAPH_NEURONS_SOURCE: "postgres",
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        DATA_API: {
+          fetch: async (request) => {
+            const url = new URL(request.url);
+            calls.push(url);
+            if (url.pathname === "/api/v1/subnets/7/hyperparameters") {
+              return Response.json({
+                schema_version: 1,
+                netuid: 7,
+                captured_at: "2026-07-18T00:00:00.000Z",
+                block_number: 1000,
+                hyperparameters: { tempo: 99 },
+              });
+            }
+            if (url.pathname === "/api/v1/subnets/7/concentration") {
+              return Response.json({
+                schema_version: 1,
+                netuid: 7,
+                neuron_count: 3,
+                entity_count: 2,
+              });
+            }
+            if (url.pathname === "/api/v1/subnets/7/performance") {
+              return Response.json({
+                schema_version: 1,
+                netuid: 7,
+                neuron_count: 3,
+                validator_count: 2,
+                incentive: 0.5,
+                trust: 0.6,
+              });
+            }
+            if (url.pathname === "/api/v1/subnets/7/validators") {
+              return Response.json({
+                schema_version: 1,
+                netuid: 7,
+                validator_count: 3,
+                captured_at: "2026-07-18T00:00:00.000Z",
+                block_number: 1000,
+                validators: [
+                  { hotkey: "5A", stake_tao: 300 },
+                  { hotkey: "5B", stake_tao: 200 },
+                  { hotkey: "5C", stake_tao: 100 },
+                ],
+              });
+            }
+            if (url.pathname === "/api/v1/subnets/7/events") {
+              assert.equal(url.searchParams.get("limit"), "10");
+              return Response.json({
+                schema_version: 1,
+                netuid: 7,
+                event_count: 1,
+                limit: 10,
+                offset: 0,
+                next_cursor: null,
+                events: [{ kind: "Transfer" }],
+              });
+            }
+            throw new Error(`unexpected DATA_API path: ${url.pathname}`);
+          },
+        },
+      },
+    };
+  }
+
+  test("composes all five live Postgres-tier views under their named keys", async () => {
+    const { env } = subnetSnapshotPostgresEnv();
+    const res = await callTool("get_subnet_snapshot", { netuid: 7 }, { env });
+    assert.equal(res.body.result.isError, false);
+    const out = res.body.result.structuredContent;
+    assert.equal(out.netuid, 7);
+    assert.equal(out.hyperparameters.hyperparameters.tempo, 99);
+    assert.equal(out.concentration.entity_count, 2);
+    assert.equal(out.performance.incentive, 0.5);
+    assert.equal(out.top_validators.validator_count, 3);
+    assert.equal(out.recent_events.events[0].kind, "Transfer");
+  });
+
+  test("top_validators_limit slices the validator list and recomputes validator_count", async () => {
+    const { env } = subnetSnapshotPostgresEnv();
+    const res = await callTool(
+      "get_subnet_snapshot",
+      { netuid: 7, top_validators_limit: 2 },
+      { env },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.top_validators.validator_count, 2);
+    assert.equal(out.top_validators.validators.length, 2);
+    assert.equal(out.top_validators.validators[0].hotkey, "5A");
+    assert.equal(out.top_validators.validators[1].hotkey, "5B");
+  });
+
+  test("recent_events_limit is forwarded to the events route", async () => {
+    const { env, calls } = subnetSnapshotPostgresEnv();
+    await callTool(
+      "get_subnet_snapshot",
+      { netuid: 7, recent_events_limit: 25 },
+      {
+        env: {
+          ...env,
+          DATA_API: {
+            fetch: async (request) => {
+              const url = new URL(request.url);
+              calls.push(url);
+              if (url.pathname === "/api/v1/subnets/7/events") {
+                assert.equal(url.searchParams.get("limit"), "25");
+                return Response.json({
+                  schema_version: 1,
+                  netuid: 7,
+                  event_count: 0,
+                  limit: 25,
+                  offset: 0,
+                  next_cursor: null,
+                  events: [],
+                });
+              }
+              return Response.json({ netuid: 7 });
+            },
+          },
+        },
+      },
+    );
+  });
+
+  test("rejects a missing netuid", async () => {
+    const res = await callTool("get_subnet_snapshot", {}, {});
+    assert.equal(res.body.result.isError, true);
+  });
+});
+
 describe("MCP get_chain_signers", () => {
   // #4772 D1 retirement: the `extrinsics` D1 table is dropped in production,
   // so loadMcpChainSigners (src/mcp-server.mjs) never issues a live D1 read
@@ -16453,6 +16616,225 @@ describe("MCP account identity/position-history tools (#5225 parity)", () => {
     });
     assert.equal(res.body.result.isError, true);
     assert.match(res.body.result.content[0].text, /ss58/);
+  });
+});
+
+describe("MCP get_account_snapshot", () => {
+  const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
+
+  // No Postgres-tier flags/DATA_API bound, and the finney RPC fetch fails --
+  // every one of the five component loads degrades to its own schema-stable
+  // empty/null fallback (balance_tao:null exactly like get_account_balance's
+  // own "returns balance_tao:null on RPC failure" precedent above).
+  test("degrades to five schema-stable empty cards when every tier is cold", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw new Error("rpc down");
+    };
+    try {
+      const res = await callTool("get_account_snapshot", { ss58: SS58 }, {});
+      assert.equal(res.body.result.isError, false);
+      const out = res.body.result.structuredContent;
+      assert.equal(out.ss58, SS58);
+      assert.equal(out.balance.balance_tao, null);
+      assert.equal(out.portfolio.ss58, SS58);
+      assert.equal(out.portfolio.position_count, 0);
+      assert.equal(out.subnets.ss58, SS58);
+      assert.equal(out.subnets.subnet_count, 0);
+      assert.equal(out.positions.ss58, SS58);
+      assert.equal(out.positions.position_count, 0);
+      assert.equal(out.recent_events.ss58, SS58);
+      assert.equal(out.recent_events.event_count, 0);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  test("rejects a malformed ss58", async () => {
+    const res = await callTool(
+      "get_account_snapshot",
+      { ss58: "not-an-address" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /ss58/);
+  });
+
+  // A base58-valid address that isn't finney-prefixed passes the inputSchema
+  // pattern (so it reaches the handler) but must still fail the handler's own
+  // isFinneySs58Address guard -- same well-known non-finney address as
+  // get_account_balance's own "rejects a non-finney ss58 prefix" test above.
+  test("rejects a non-finney ss58 prefix", async () => {
+    const res = await callTool(
+      "get_account_snapshot",
+      { ss58: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXc6TYeyZ1km1" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /finney/i);
+  });
+
+  test("applies the RPC rate limiter before any component fetch", async () => {
+    let dataApiCalled = false;
+    const orig = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw new Error("balance RPC should not fire");
+    };
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      // MCP_RATE_LIMITER must succeed so the transport-level limiter (which
+      // falls back to RPC_RATE_LIMITER when MCP_RATE_LIMITER is absent, per
+      // get_account_balance's own "applies the RPC rate limiter" test above)
+      // doesn't consume RPC_RATE_LIMITER's quota before the tool handler runs.
+      MCP_RATE_LIMITER: {
+        async limit() {
+          return { success: true };
+        },
+      },
+      RPC_RATE_LIMITER: {
+        async limit() {
+          return { success: false };
+        },
+      },
+      DATA_API: {
+        fetch: async () => {
+          dataApiCalled = true;
+          return Response.json({});
+        },
+      },
+    };
+    try {
+      const res = await callTool(
+        "get_account_snapshot",
+        { ss58: SS58 },
+        { env },
+      );
+      assert.equal(res.body.result.isError, true);
+      assert.match(res.body.result.content[0].text, /rate_limited/);
+      assert.equal(dataApiCalled, false);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  test("composes all five live views under their named keys", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        jsonrpc: "2.0",
+        id: 1,
+        // Same SCALE AccountInfo encoding as get_account_balance's own live
+        // test above: free 2_000_000_000 + reserved 500_000_000 rao = 2.5 TAO.
+        result:
+          "0x" +
+          "00000000".repeat(4) +
+          "00943577000000000000000000000000" +
+          "0065cd1d000000000000000000000000",
+      }),
+    });
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      // A passing RPC_RATE_LIMITER here exercises the handler's own
+      // success-path branch, distinct from the no-limiter-bound cold test
+      // above and the failing-limiter test below.
+      RPC_RATE_LIMITER: {
+        async limit() {
+          return { success: true };
+        },
+      },
+      DATA_API: {
+        fetch: async (request) => {
+          const url = new URL(request.url);
+          if (url.pathname === `/api/v1/accounts/${SS58}/portfolio`) {
+            return Response.json({
+              schema_version: 1,
+              ss58: SS58,
+              position_count: 2,
+              positions: [],
+            });
+          }
+          if (url.pathname === `/api/v1/accounts/${SS58}/subnets`) {
+            return Response.json({
+              schema_version: 1,
+              ss58: SS58,
+              subnet_count: 3,
+              subnets: [],
+            });
+          }
+          if (url.pathname === `/api/v1/accounts/${SS58}/positions`) {
+            return Response.json({
+              schema_version: 1,
+              ss58: SS58,
+              position_count: 1,
+              total_stake_tao: 42,
+              positions: [],
+            });
+          }
+          if (url.pathname === `/api/v1/accounts/${SS58}/events`) {
+            assert.equal(url.searchParams.get("limit"), "10");
+            return Response.json({
+              schema_version: 1,
+              ss58: SS58,
+              event_count: 1,
+              limit: 10,
+              offset: 0,
+              next_cursor: null,
+              events: [{ kind: "Transfer" }],
+            });
+          }
+          throw new Error(`unexpected DATA_API path: ${url.pathname}`);
+        },
+      },
+    };
+    try {
+      const res = await callTool(
+        "get_account_snapshot",
+        { ss58: SS58 },
+        { env },
+      );
+      assert.equal(res.body.result.isError, false);
+      const out = res.body.result.structuredContent;
+      assert.equal(out.ss58, SS58);
+      assert.equal(out.balance.balance_tao, 2.5);
+      assert.equal(out.portfolio.position_count, 2);
+      assert.equal(out.subnets.subnet_count, 3);
+      assert.equal(out.positions.total_stake_tao, 42);
+      assert.equal(out.recent_events.events[0].kind, "Transfer");
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  test("recent_events_limit is forwarded to the events route", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (request) => {
+          const url = new URL(request.url);
+          if (url.pathname === `/api/v1/accounts/${SS58}/events`) {
+            assert.equal(url.searchParams.get("limit"), "25");
+            return Response.json({
+              schema_version: 1,
+              ss58: SS58,
+              event_count: 0,
+              limit: 25,
+              offset: 0,
+              next_cursor: null,
+              events: [],
+            });
+          }
+          return Response.json({ ss58: SS58 });
+        },
+      },
+    };
+    await callTool(
+      "get_account_snapshot",
+      { ss58: SS58, recent_events_limit: 25 },
+      { env },
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Adds two compound MCP tools that fan out to five live views in a single round trip each, following `get_subnet_detail`'s existing composition precedent (structural detail + live economics merged into one response) as the pattern to extend:

- **`get_subnet_snapshot(netuid, top_validators_limit?, recent_events_limit?)`** — merges `hyperparameters`, `concentration`, `performance`, `top_validators` (default 10, capped by `top_validators_limit`), and `recent_events` (default 10, capped by `recent_events_limit`) under one response. Equivalent to calling `get_subnet_hyperparams` + `get_subnet_concentration` + `get_subnet_performance` + `list_subnet_validators` + `get_subnet_events` separately.
- **`get_account_snapshot(ss58, recent_events_limit?)`** — merges live `balance`, `portfolio` (hotkey-scoped), `subnets` (registered-subnet footprint), `positions` (coldkey-scoped nominator positions), and `recent_events`. The balance leg mirrors `get_account_balance`'s own handler exactly (finney-address validation + `RPC_RATE_LIMITER` check), since it's the only live RPC call among five Postgres-tier reads that each already degrade gracefully via `tryPostgresTier(...) ?? buildXxx([])`.

Both tools compose existing loaders/builders — no new data sources, no schema/contract changes (MCP tool additions don't require a server-card regen; confirmed no contract files changed via `validate:client-sdk-sync`).

## Test plan

- [x] `npx vitest run tests/mcp-server.test.mjs` — 1119/1119 passing (cold-degradation, happy-path composition, `top_validators_limit`/`recent_events_limit` forwarding, invalid-ss58, non-finney-prefix, and RPC-rate-limiter coverage for both tools)
- [x] `npx vitest run` — full backend suite, 9250/9250 passing
- [x] `npm run lint` / `npm run format:check` — clean
- [x] Coverage scoped to `src/mcp-server.mjs` — 100% statement + branch coverage on both new tool handlers and their `TOOL_OUTPUT_SCHEMAS` entries (codecov/patch gate)
- [x] `npm run validate:client-sdk-sync` — no contract files changed, gate N/A

Closes #6752
Closes #6753
Closes #6754