### PR TITLE
fix(registry): correct stale swap.json gap_notes contradicting the notes field

### DIFF
--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -19,7 +19,7 @@
   ],
   "curation": {
     "gap_notes": [
-      "Official TaoFi pool page, docs, and Swap source repository are verified live.",
+      "Official TaoFi pool page currently returns HTTP 402 (Vercel deployment disabled) and should appear degraded until it recovers; docs and Swap source repository remain verified live.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
       "No verified SSE/event stream yet."
     ],


### PR DESCRIPTION
Last one of the five subnets from #5480. `curation.gap_notes[0]` in `registry/subnets/swap.json` still said "Official TaoFi pool page, docs, and Swap source repository are verified live," while `notes` two lines below (written 2026-06-08) already documents that `www.taofi.com/pool` returns HTTP 402 with `x-vercel-error: DEPLOYMENT_DISABLED` — the two fields directly contradicted each other.

I re-checked `https://www.taofi.com/pool` before touching anything: still 402, same `DEPLOYMENT_DISABLED` header, as of today (2026-07-18). Not recovered, so this is the "still down" branch from the issue rather than the smaller "recovered" edit.

Rewrote `gap_notes[0]` to describe the outage instead of claiming it's verified live, using the same pattern `taolend.json`'s gap_notes already uses for a degraded official website ("Official website currently still returns 500/server-error responses..."). Docs and the source repo are unaffected per `notes`, so the corrected line only walks back the pool-page claim and keeps those two as verified. Didn't touch `notes` itself — it was already accurate — or anything else in the file.

Ran `npm run build` then `npm run validate` (129 subnets, 1822 surfaces, 136 providers — clean), `npm run validate:surface`, and the full `npm run test:ci` suite (305 files / 9166 tests, all green, 99%+ patch coverage as usual since this is a pure data edit with no new logic). Prettier's happy with the file too.

Closes #6591
