### PR TITLE
fix(registry): correct stale swap.json gap_notes claiming TaoFi pool page verified live

### DIFF
--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -19,7 +19,7 @@
   ],
   "curation": {
     "gap_notes": [
-      "Official TaoFi pool page, docs, and Swap source repository are verified live.",
+      "Official TaoFi pool page (www.taofi.com/pool) currently returns HTTP 402 with header x-vercel-error: DEPLOYMENT_DISABLED -- the team's Vercel deployment appears disabled, and should appear degraded until it recovers. Docs (docs.taofi.com) and the Swap source repository remain verified live.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
       "No verified SSE/event stream yet."
     ],


### PR DESCRIPTION
`registry/subnets/swap.json`'s `curation.gap_notes[0]` still said "Official TaoFi pool page, docs, and Swap source repository are verified live" -- but `notes` two lines below (line 36) documents an HTTP 402 `DEPLOYMENT_DISABLED` outage on the whole `www.taofi.com` domain, including `/pool`. Same file, directly contradicting itself.

I re-checked `https://www.taofi.com/pool` before touching anything -- still 402, same `x-vercel-error: DEPLOYMENT_DISABLED` header the existing `notes` field describes, so the outage hasn't recovered since it was written on 2026-06-08. Rewrote `gap_notes[0]` to describe the actual degraded state instead of "verified live", following the same pattern `taolend.json`'s gap_notes already uses for a known-degraded official URL ("Official website currently still returns 500/server-error responses..."). Docs (`docs.taofi.com`) and the Swap source repo are unaffected per `notes`, so the corrected line only walks back the pool-page claim, not the whole trio. `notes` itself is untouched, as the issue asked.

This is the last of the five subnets tracked in #5480 (`tensorclaw.json`, `ninja.json`, `8-ball.json`, `oneoneone.json` were already fixed).

Tested locally: `npm run validate:surface -- registry/subnets/swap.json` and `npm run scan:public-safety` both pass, and after `npm run build`, `npm run validate`, `npm run lint`, `npm run format:check`, `npm run validate:docs`, `npm run validate:intake`, `npm run validate:private-boundary`, and the full `npm run test:ci` suite are all green. `git diff --stat` shows only the one line changed in `registry/subnets/swap.json`.

Closes #6591