### PR TITLE
chore(ci): raise openapi.json artifact-size budget

### DIFF
--- a/scripts/artifact-budgets.mjs
+++ b/scripts/artifact-budgets.mjs
@@ -8,7 +8,7 @@ export const ARTIFACT_SIZE_BUDGETS = [
   budget("evidence-ledger.json", 1_000_000, 3_000_000),
   budget("health/history/*.json", 650_000, 1_250_000),
   budget("search.json", 750_000, 2_000_000),
-  budget("openapi.json", 1_400_000, 1_750_000),
+  budget("openapi.json", 1_800_000, 2_500_000),
   // Per-surface schema snapshots now embed the full upstream OpenAPI document.
   budget("schemas/*.json", 1_500_000, 5_000_000),
   budget("profiles.json", 700_000, 1_000_000),


### PR DESCRIPTION
## Summary

The \`Validate artifact size budgets\` CI check hard-fails on \`public/metagraph/openapi.json\` against \`origin/main\` as it stands today — independent of any PR's own diff. The committed file is already 1,751,294 bytes, 1,294 bytes over the 1,750,000 fail threshold, from organic per-merge schema growth (\`ad01cc49\` → \`15dfec5c\`, 6 merges, ~20KB added; #6786 happened to be the one that crossed the line). Confirmed via a byte-identical local rebuild against \`origin/main\` (\`git status --short\` shows no diff after \`npm run build\`).

\`openapi.json\`'s warn/fail spread (1.4M/1.75M, ~25% headroom) is much tighter than every other budget in \`scripts/artifact-budgets.mjs\` (most run 2-3x headroom between warn and fail), so it was going to trip on essentially the next schema-adding PR regardless of which one did it. Widened to warn 1,800,000 / fail 2,500,000, matching the headroom ratio used elsewhere in the same table. No content trimmed — the growth is legitimate schema documentation, not a runaway bug.

## Test plan

- [x] \`npm run build\` then \`npm run validate:artifact-budgets\` — passes (11 pre-existing warnings unrelated to this file, zero failures)
- [x] \`npm run validate\` — passes
- [x] \`npm run lint\` / \`npm run format:check\` (scoped to the changed file) — clean

Closes #6805