### PR TITLE
fix(ui): add ShareButton + ApiSourceFooter to subnet & provider detail pages

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-masthead.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-masthead.tsx
@@ -20,6 +20,7 @@ import {
   safeExternalUrl,
   CurationChip,
   HealthPill,
+  ShareButton,
   DailyRollupFreshness,
   StatWithSpark,
   MiniStack,
@@ -395,56 +396,62 @@ export function SubnetMasthead({
               {description}
             </p>
           ) : null}
-          {links.length > 0 ? (
-            <div className="mt-3 flex flex-wrap items-center gap-1.5">
-              {links.map((l) => {
-                const Icon = l.icon;
-                const safeHref = safeExternalUrl(l.href);
-                const className =
-                  "group inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong transition-colors " +
-                  (safeHref
-                    ? "hover:border-accent/50 hover:text-accent"
-                    : "cursor-default opacity-70");
-                const content = (
-                  <>
-                    <Icon
-                      className={
-                        "size-3 text-ink-muted " + (safeHref ? "group-hover:text-accent" : "")
-                      }
-                    />
-                    <span>{l.label}</span>
-                    {safeHref ? (
-                      <ExternalLinkIcon className="size-2.5 text-ink-muted opacity-60" />
-                    ) : null}
-                  </>
-                );
-
-                return (
-                  <Tooltip key={l.label} delayDuration={150}>
-                    <TooltipTrigger asChild>
+          {/* Resource links + the standard ShareButton (#5481) — the masthead's
+              action area, matching every other entity-detail page's "copy a link
+              to what I'm looking at" affordance. Rendered as its own pill so it's
+              always present even when a subnet has no external links. rounded-full
+              matches the link chips beside it. */}
+          <div className="mt-3 flex flex-wrap items-center gap-1.5">
+            {links.length > 0
+              ? links.map((l) => {
+                  const Icon = l.icon;
+                  const safeHref = safeExternalUrl(l.href);
+                  const className =
+                    "group inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong transition-colors " +
+                    (safeHref
+                      ? "hover:border-accent/50 hover:text-accent"
+                      : "cursor-default opacity-70");
+                  const content = (
+                    <>
+                      <Icon
+                        className={
+                          "size-3 text-ink-muted " + (safeHref ? "group-hover:text-accent" : "")
+                        }
+                      />
+                      <span>{l.label}</span>
                       {safeHref ? (
-                        <a
-                          href={safeHref}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className={className}
-                        >
-                          {content}
-                        </a>
-                      ) : (
-                        <span className={className} title="Blocked unsafe external URL">
-                          {content}
-                        </span>
-                      )}
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="font-mono text-[11px]">
-                      {safeHref ? host(safeHref) : "Blocked unsafe external URL"}
-                    </TooltipContent>
-                  </Tooltip>
-                );
-              })}
-            </div>
-          ) : null}
+                        <ExternalLinkIcon className="size-2.5 text-ink-muted opacity-60" />
+                      ) : null}
+                    </>
+                  );
+
+                  return (
+                    <Tooltip key={l.label} delayDuration={150}>
+                      <TooltipTrigger asChild>
+                        {safeHref ? (
+                          <a
+                            href={safeHref}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={className}
+                          >
+                            {content}
+                          </a>
+                        ) : (
+                          <span className={className} title="Blocked unsafe external URL">
+                            {content}
+                          </span>
+                        )}
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" className="font-mono text-[11px]">
+                        {safeHref ? host(safeHref) : "Blocked unsafe external URL"}
+                      </TooltipContent>
+                    </Tooltip>
+                  );
+                })
+              : null}
+            <ShareButton className="rounded-full" />
+          </div>
         </div>
         {/* Desktop/tablet: health + curation beside the identity block. Mobile
             counterpart lives in the status row above so the body column stays wide. */}

--- a/apps/ui/src/routes/detail-page-furniture.test.ts
+++ b/apps/ui/src/routes/detail-page-furniture.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// #5481: the subnet-detail and provider-detail pages were the only two
+// entity-detail routes missing the ShareButton (copy-current-URL) and
+// ApiSourceFooter (data-provenance) affordances every sibling detail page
+// already renders (validators.$hotkey.tsx, blocks.$ref.tsx, etc.). These
+// components need a full router + query client to render, so — like
+// api-source-context.test.tsx — this suite reads the route/component source
+// and asserts the wiring is present rather than rendering it.
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+
+const providers = read("./providers.$slug.tsx");
+const subnets = read("./subnets.$netuid.tsx");
+const masthead = read("../components/metagraphed/subnet-masthead.tsx");
+
+describe("provider detail page has the standard detail-page furniture (#5481)", () => {
+  it("imports ShareButton from the ui-kit and ApiSourceFooter", () => {
+    expect(providers).toContain("ShareButton");
+    expect(providers).toMatch(/from "@jsonbored\/ui-kit"/);
+    expect(providers).toContain("api-source-footer");
+  });
+
+  it("passes actions={<ShareButton />} to the EntityHero call", () => {
+    expect(providers).toMatch(/actions=\{<ShareButton \/>\}/);
+  });
+
+  it("renders an ApiSourceFooter citing the provider detail API paths it reads", () => {
+    expect(providers).toContain("<ApiSourceFooter");
+    expect(providers).toContain("/api/v1/providers/${slug}");
+    expect(providers).toContain("/api/v1/providers/${slug}/endpoints");
+  });
+});
+
+describe("subnet detail page has the standard detail-page furniture (#5481)", () => {
+  it("the masthead renders a ShareButton in its action area", () => {
+    expect(masthead).toContain("ShareButton");
+    expect(masthead).toContain("<ShareButton");
+  });
+
+  it("the route renders an ApiSourceFooter citing the subnet detail API paths it reads", () => {
+    expect(subnets).toContain("api-source-footer");
+    expect(subnets).toContain("<ApiSourceFooter");
+    expect(subnets).toContain("/api/v1/subnets/${netuid}/profile");
+  });
+});

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -10,12 +10,14 @@ import {
   RECOVERY,
 } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import {
   EntityHero,
   BrandIcon,
   PrimaryLinksRail,
   CopyableCode,
   SectionAnchor,
+  ShareButton,
 } from "@jsonbored/ui-kit";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { EndpointsGlance } from "@/components/metagraphed/endpoints-glance";
@@ -132,6 +134,7 @@ function ProviderShell({ slug }: { slug: string }) {
         title={p?.name ?? slug}
         subtitle={shouldShowProviderSlugSubtitle(p?.name, slug) ? <>· {slug}</> : null}
         description={p?.notes}
+        actions={<ShareButton />}
         links={
           <PrimaryLinksRail website={p?.website ?? p?.homepage} docs={p?.docs} repo={p?.repo} />
         }
@@ -175,6 +178,11 @@ function ProviderShell({ slug }: { slug: string }) {
           {summary?.by_layer ? <BreakdownCard title="By layer" data={summary.by_layer} /> : null}
         </aside>
       </div>
+
+      <ApiSourceFooter
+        paths={[`/api/v1/providers/${slug}`, `/api/v1/providers/${slug}/endpoints`]}
+        artifacts={[`/metagraph/providers/${slug}.json`]}
+      />
     </>
   );
 }

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -25,6 +25,7 @@ import {
   RECOVERY,
 } from "@/components/metagraphed/states";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
+import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EvidencePanel } from "@/components/metagraphed/evidence-panel";
 import { ProfileTabs, useActiveTab } from "@/components/metagraphed/profile-tabs";
 import { SchemaDriftSummary } from "@/components/metagraphed/schema-drift";
@@ -379,6 +380,16 @@ function ProfileShell({ netuid }: { netuid: number }) {
             ← All subnets
           </Link>
         </div>
+
+        <ApiSourceFooter
+          paths={[
+            `/api/v1/subnets/${netuid}/profile`,
+            `/api/v1/subnets/${netuid}/surfaces`,
+            `/api/v1/subnets/${netuid}/endpoints`,
+            `/api/v1/subnets/${netuid}/health`,
+          ]}
+          artifacts={[`/metagraph/subnets/${netuid}.json`]}
+        />
       </SubnetFilterProvider>
     </TimeRangeProvider>
   );


### PR DESCRIPTION
Every entity-detail route already gives you a "Share view" button and a data-sources footer — `validators.$hotkey.tsx`, `blocks.$ref.tsx`, `extrinsics.$hash.tsx`, `accounts.$ss58.tsx` all do — except the two busiest ones, subnet and provider detail. This wires those two missing pieces into just those pages. It stays deliberately narrow and does not touch the masthead-layout redesign that #5342 was about.

On the provider page the `EntityHero` was already built to take an `actions` slot (the same shared hero the validator page uses), it just wasn't being handed one, so it now gets `actions={<ShareButton />}` — same `@jsonbored/ui-kit` import the sibling routes use. I also added an `ApiSourceFooter` citing the two paths the page actually reads (`providerQuery` → `/api/v1/providers/{slug}` and `providerEndpointsQuery` → `/api/v1/providers/{slug}/endpoints`) plus the provider artifact, the same `paths`/`artifacts` shape `blocks.$ref.tsx` uses.

The subnet page renders `SubnetMasthead` instead of the shared hero, so rather than move it onto `EntityHero` I dropped the `ShareButton` straight into the masthead's existing link/action row — as a `rounded-full` pill so it sits naturally alongside the Website/Docs/Repo chips, and rendered outside the links conditional so it's always present even for a subnet with no external links. The route then renders an `ApiSourceFooter` for the core paths it reads (`subnetProfileQuery` → profile, plus surfaces/endpoints/health) and the subnet artifact.

Screenshots: I captured full-page before/after for both pages at desktop (1440, light + dark) and mobile (390, light) against a local dev server on the live API. Before shows neither affordance (the provider hero ends at Website/Repo, the page ends at the site footer); after shows the "Share view" pill in the hero/masthead and a "DATA SOURCES" footer listing the cited endpoints + artifact, with no new responsive overflow at any viewport. Heads up: the screenshot-asset upload channel isn't configured in my environment, so I couldn't embed the raw image URLs inline here — happy to attach them on request.

Testing: `npm test` (both apps/ui and packages/ui-kit) pass, including a new `apps/ui/src/routes/detail-page-furniture.test.ts` that asserts the wiring on both routes and the masthead. Typecheck, ESLint + Prettier, and the production build are clean, and `npm run test:e2e` (responsive-overflow) is 28/28 green with `/subnets/1` covered at every viewport.

Closes #5481