### PR TITLE
fix(registry): correct stale gap_notes claim for SN10 TaoFi pool outage

### DIFF
--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -19,7 +19,7 @@
   ],
   "curation": {
     "gap_notes": [
-      "Official TaoFi pool page, docs, and Swap source repository are verified live.",
+      "Official TaoFi pool page (www.taofi.com/pool) currently returns HTTP 402 with header x-vercel-error: DEPLOYMENT_DISABLED -- the team's Vercel deployment appears disabled, likely a billing lapse rather than a code issue. Docs (docs.taofi.com) and the Swap source repository are unaffected and verified live.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
       "No verified SSE/event stream yet."
     ],


### PR DESCRIPTION
`registry/subnets/swap.json`'s `curation.gap_notes[0]` still said "Official TaoFi pool page, docs, and Swap source repository are verified live." — but the file's own `notes` field two lines below already documents that `www.taofi.com/pool` has been returning HTTP 402 `DEPLOYMENT_DISABLED` (the team's Vercel deployment looks disabled, likely a billing lapse). The two fields directly contradicted each other.

I re-checked `https://www.taofi.com/pool` before touching anything — still 402 with the same `x-vercel-error: DEPLOYMENT_DISABLED` header as when `notes` was written, so this is still the down case described in the issue, not a recovered one.

Rewrote `gap_notes[0]` to describe the actual state instead of "verified live," following the tone `taolend.json`'s gap_notes already uses for a degraded official URL (say what's down and why, keep it factual). Per the issue, docs.taofi.com and the source repo are unaffected, so I only walked back the website-page claim rather than rewriting the whole line. Left `notes` (line 36) untouched since it's already accurate — this is a single-line edit to `curation.gap_notes[0]`.

Closes #6591

Ran the full `validate.yml` suite locally (build, `test:ci` + coverage, `test:ci:artifacts`, lint/format, all `validate:*` contract/schema/registry/safety checks, worker dry-runs, Python SDK suite). Everything passes except `validate:artifact-budgets`, which fails on `openapi.json` (1,751,294 bytes vs. a 1,750,000-byte budget) — I confirmed this by stashing my change and re-running the same check against unmodified `origin/main`: identical failure, byte-for-byte. `openapi.json` isn't even touched by this diff (it's generated from `schemas/`, not `registry/`), so this is a pre-existing budget overrun on main, unrelated to this fix.