### PR TITLE
fix(ui): tokenize the account-history chart card's wash, shadow, and radii

### DIFF
--- a/apps/ui/src/components/metagraphed/account-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-history-chart.tsx
@@ -202,7 +202,7 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
         </div>
       ) : null}
 
-      <div className="overflow-hidden rounded-[1.75rem] border border-border/80 bg-card/95 shadow-[0_32px_100px_-70px_rgba(15,23,42,0.55)]">
+      <div className="overflow-hidden rounded-2xl border border-border/80 bg-card/95 mg-card-glow">
         <div className="grid gap-4 border-b border-border/70 px-5 py-5 md:grid-cols-3">
           <MetricBlock
             label="Total activity"
@@ -223,8 +223,8 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
           />
         </div>
 
-        <div className="bg-[linear-gradient(180deg,rgba(45,212,191,0.08),rgba(45,212,191,0.02)_42%,transparent)] px-4 py-4 md:px-5 md:py-5">
-          <div className="rounded-[1.4rem] border border-border/70 bg-paper/70 px-4 py-4 md:px-5 md:py-5">
+        <div className="bg-accent-surface px-4 py-4 md:px-5 md:py-5">
+          <div className="rounded-xl border border-border/70 bg-paper/70 px-4 py-4 md:px-5 md:py-5">
             <Sparkline
               values={values}
               points={points}


### PR DESCRIPTION
## What & why

`account-history-chart.tsx` hardcoded three things that don't adapt with the theme:
- **`:205`** a raw `rgba(15,23,42,…)` drop shadow, and `rounded-[1.75rem]`.
- **`:226`** a raw teal `linear-gradient` wash (`rgba(45,212,191,…)` — the old accent hex, not derived from `--accent`).
- **`:227`** a second arbitrary radius, `rounded-[1.4rem]`, on the nested wrapper.

This component is only consumed by `accounts.$ss58.tsx`, whose other cards were just normalized (#6399 → #6705) to `rounded-2xl` + the shared `mg-card-glow` shadow class — so the history card was left visually inconsistent with its own page.

## Approach

Bring it onto the same tokens:
- `rounded-[1.75rem]` + raw shadow → **`rounded-2xl` + `mg-card-glow`** (exactly the pattern #6705 applied to the sibling cards).
- teal gradient wash → **`bg-accent-surface`** (`color-mix(in oklab, var(--accent) 6%, transparent)`, the established accent-wash recipe already used ~13× in this scope, e.g. `rpc-proxy.tsx`, `agents.tsx`, `extrinsics.$hash.tsx`).
- nested `rounded-[1.4rem]` → **`rounded-xl`**, so the two radii are a consistent scale step rather than two one-off values.

Scope is the three sites the issue names; nothing else in the file changed. The diff is small and the difference is subtle by design (a theme-adaptive token swap) — most visible in dark mode, where the raw light-mode `rgba` shadow/gradient previously didn't adapt.

## Verification

Full Phase C3 preflight (same steps/order as the `ui` CI job) **plus** the two gates that guard against a broken base:

| Step | Command | Result |
| --- | --- | --- |
| lint | `npm run lint --workspace=apps/ui` | 0 errors |
| format | `npm run format:check --workspace=apps/ui` | clean |
| typecheck | `npm run typecheck --workspace=apps/ui` | clean |
| unit | `npm test --workspace=apps/ui` | 157 files, 1168 tests passed |
| build | `npm run build --workspace=apps/ui` | green |
| test gate | `npx vitest run tests/data-api.test.mjs` | 474 passed |
| docs drift | `generate-openapi-docs.mjs` → `git diff` | clean |

## Screenshots

Phase C2 contract (fixed viewports, never full-page, themes forced via `mg-theme`), captured on `/accounts/5E2LP…TKeZ5u` (a hotkey with 100 days of history so the card renders). `before` uses the raw radii/shadow/teal-gradient; `after` the tokenized `rounded-2xl` + `mg-card-glow` + `bg-accent-surface`.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/jaytbarimbao-collab/metagraphed/screenshots/6400-history-card-tokens-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6400
