### PR TITLE
fix(ui): theme account-history-chart with design-system tokens

### DIFF
--- a/apps/ui/src/components/metagraphed/account-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-history-chart.tsx
@@ -202,7 +202,7 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
         </div>
       ) : null}
 
-      <div className="overflow-hidden rounded-[1.75rem] border border-border/80 bg-card/95 shadow-[0_32px_100px_-70px_rgba(15,23,42,0.55)]">
+      <div className="overflow-hidden rounded-2xl border border-border/80 bg-card/95 mg-card-glow">
         <div className="grid gap-4 border-b border-border/70 px-5 py-5 md:grid-cols-3">
           <MetricBlock
             label="Total activity"
@@ -223,8 +223,8 @@ export function AccountHistoryChart({ ss58 }: { ss58: string }) {
           />
         </div>
 
-        <div className="bg-[linear-gradient(180deg,rgba(45,212,191,0.08),rgba(45,212,191,0.02)_42%,transparent)] px-4 py-4 md:px-5 md:py-5">
-          <div className="rounded-[1.4rem] border border-border/70 bg-paper/70 px-4 py-4 md:px-5 md:py-5">
+        <div className="bg-accent-surface px-4 py-4 md:px-5 md:py-5">
+          <div className="rounded-2xl border border-border/70 bg-paper/70 px-4 py-4 md:px-5 md:py-5">
             <Sparkline
               values={values}
               points={points}


### PR DESCRIPTION
## Summary

Fresh PR replacing #6798 (LoopOver closed that one for base-branch conflicts while it sat in manual review).

- Outer chart card: `rounded-2xl` + `mg-card-glow` (matches account-detail cards from #6705) instead of `rounded-[1.75rem]` + raw `rgba(15,23,42,*)` shadow.
- Chart wash: `bg-accent-surface` instead of hardcoded teal-400 gradient.
- Nested sparkline panel: `rounded-2xl` instead of `rounded-[1.4rem]`.
- Single-file UI change only (openapi budget already raised on main).

Fixes #6400

## Screenshots

Captured from `/accounts/5GrwvaEF5zXb26Fz9rcQpDWSLRtG5P9exNzGo5zYt7EGiJtQ#history` (same matrix as #6798).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6400-history-after-mobile-dark.png)<br><sub>after</sub> |

## Test plan

- [x] Token classes align with account-detail `rounded-2xl` / `mg-card-glow` / `bg-accent-surface`
- [x] 12-image before/after matrix hosted on fork `screenshots` branch
- [ ] Upstream Validate green

Made with [Cursor](https://cursor.com)