### PR TITLE
fix(registry): align swap.json gap_notes with TaoFi pool 402 outage

### DIFF
--- a/registry/subnets/swap.json
+++ b/registry/subnets/swap.json
@@ -19,7 +19,7 @@
   ],
   "curation": {
     "gap_notes": [
-      "Official TaoFi pool page, docs, and Swap source repository are verified live.",
+      "Official TaoFi pool page (www.taofi.com/pool) currently returns HTTP 402 with header x-vercel-error: DEPLOYMENT_DISABLED — the team's Vercel deployment appears disabled; docs.taofi.com and the Swap source repository remain verified live.",
       "Common /api, /health, /openapi.json, and Swagger paths currently return 404.",
       "No verified SSE/event stream yet."
     ],


### PR DESCRIPTION
Fixes #6591

## Summary
- Re-checked `https://www.taofi.com/pool` — still HTTP 402 with `x-vercel-error: DEPLOYMENT_DISABLED`.
- Rewrote `curation.gap_notes[0]` so it no longer claims the pool page is verified live; docs.taofi.com and the Swap source repo remain called out as live.
- Left `notes` untouched (already accurate).

## Validation
- Live probe: `www.taofi.com/pool` → 402 DEPLOYMENT_DISABLED
- Live probe: `docs.taofi.com` → 200

Made with [Cursor](https://cursor.com)