### PR TITLE
fix(registry): dedupe SN48/SN63 qbittensorlabs.com health URL cross-file (#6328)

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 557,
+  "surface_count": 556,
   "surfaces": [
     {
       "auth_required": false,
@@ -3521,24 +3521,6 @@
       "surface_id": "sn-47-evolai-validator-config",
       "surface_key": "srf-a9a24073adcde815",
       "url": "https://raw.githubusercontent.com/openevolai/evolai/4cc0040eca74e3541178661ce8b5dd29fa2d343a/evolai/validator/config.py"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "kind": "subnet-api",
-      "netuid": 48,
-      "probe": {
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "qbittensor-labs",
-      "public_safe": true,
-      "subnet_name": "Quantum Compute",
-      "subnet_slug": "sn-48",
-      "surface_id": "sn-48-quantum-compute-health-api",
-      "surface_key": "srf-e10c57f6c6431dfe",
-      "url": "https://www.qbittensorlabs.com/api/health"
     },
     {
       "auth_required": false,

--- a/registry/subnets/quantum-compute.json
+++ b/registry/subnets/quantum-compute.json
@@ -22,7 +22,7 @@
   "dashboard_url": "https://taomarketcap.com/subnets/48",
   "name": "Quantum Compute",
   "netuid": 48,
-  "notes": "Reviewed overlay for SN48 using the official qBittensor Labs website and Quantum Compute source repository. This pass fixed 3 surfaces having no probe config at all -- the registry-wide gap tracked in #5932. Re-checked for an OpenAPI schema (qbittensorlabs.com and openquantum.com both without one) -- gap_notes remain accurate. All 5 surfaces re-verified live.",
+  "notes": "Reviewed overlay for SN48 using the official qBittensor Labs website and Quantum Compute source repository. This pass fixed 3 surfaces having no probe config at all -- the registry-wide gap tracked in #5932. Re-checked for an OpenAPI schema (qbittensorlabs.com and openquantum.com both without one) -- gap_notes remain accurate. All 4 surfaces re-verified live. Dropped the qbittensorlabs.com/api/health surface (#6328): it's a generic site-liveness ping (byte-identical {\"status\":\"ok\"} response, same ETag, served on both www.qbittensorlabs.com and www.openquantum.com) carrying no subnet-specific data, and the quantum-compute repository never references qbittensorlabs.com as SN48's own domain -- kept exclusively on enigma.json (SN63), whose repository does.",
   "schema_version": 1,
   "slug": "sn-48",
   "social": {
@@ -66,31 +66,6 @@
       "public_safe": true,
       "source_urls": ["https://github.com/qbittensor-labs/quantum-compute"],
       "url": "https://github.com/qbittensor-labs/quantum-compute"
-    },
-    {
-      "auth_required": false,
-      "authority": "community",
-      "id": "sn-48-quantum-compute-health-api",
-      "kind": "subnet-api",
-      "name": "Quantum Compute health API",
-      "notes": "Public no-auth GET /api/health on www.qbittensorlabs.com returning JSON liveness (observed: {\"status\":\"ok\"}). Served on the official qBittensor Labs website host alongside the existing website and source-repo surfaces for SN48.",
-      "probe": {
-        "enabled": true,
-        "expect": "json",
-        "method": "GET",
-        "timeout_ms": 10000
-      },
-      "provider": "qbittensor-labs",
-      "public_safe": true,
-      "review": {
-        "state": "community-submitted",
-        "submitted_by": "kiannidev"
-      },
-      "source_urls": [
-        "https://github.com/qbittensor-labs/quantum-compute",
-        "https://www.qbittensorlabs.com/"
-      ],
-      "url": "https://www.qbittensorlabs.com/api/health"
     },
     {
       "auth_required": false,

--- a/scripts/validate-surface.mjs
+++ b/scripts/validate-surface.mjs
@@ -46,6 +46,19 @@ const GRANDFATHERED_DUPLICATE_URLS = new Set([
   "8-ball.json|https://github.com/Barbariandev/8Ball_miner",
 ]);
 
+// Cross-file counterpart to GRANDFATHERED_DUPLICATE_URLS, for the check below
+// (#6328): a normalized URL explicitly allowed to be claimed by 2+ distinct
+// netuids' surfaces, because one operator genuinely runs multiple subnets
+// from shared infrastructure (a single corporate site, a monorepo) — the
+// surface describes the operator, not any one subnet. Confirmed from the
+// resource's own content/structure, not a live probe.
+const SHARED_OPERATOR_URLS = new Set([
+  // qBittensor Labs' single corporate site legitimately fronts both SN48
+  // (Quantum Compute) and SN63 (Enigma) — its own nav/body copy names both
+  // ("SN48: Quantum" / "SN63: Enigma") (#6328).
+  "https://www.qbittensorlabs.com/",
+]);
+
 // Reviewed-tier authorship convention + its acknowledged exemptions (#5739).
 // Files at the `maintainer-reviewed` / `adapter-backed` curation tier normally
 // pair a non-null `curation.verified_at` with their `reviewed_at` and carry a
@@ -118,6 +131,10 @@ const conventionAdvisories = [];
 const conventionExemptions = [];
 const authAdvisories = [];
 let surfaceCount = 0;
+// #6328: normalized URL -> claimant locations, across ALL files in this run
+// (unlike surfaceIdsByUrl below, which resets per-file). Populated in the
+// per-surface loop, checked once after every file has been processed.
+const surfaceLocationsByUrl = new Map();
 for (const file of files) {
   let document;
   try {
@@ -155,6 +172,13 @@ for (const file of files) {
     if (surface.url) {
       const normalized = normalizePublicUrl(surface.url);
       if (normalized) {
+        const locations = surfaceLocationsByUrl.get(normalized) || [];
+        locations.push({
+          file: path.basename(file),
+          id: surface.id,
+          netuid: document.netuid,
+        });
+        surfaceLocationsByUrl.set(normalized, locations);
         const ids = surfaceIdsByUrl.get(normalized) || [];
         ids.push(surface.id);
         surfaceIdsByUrl.set(normalized, ids);
@@ -267,6 +291,33 @@ for (const file of files) {
             "self-referential/pilot manifest.",
         );
       }
+    }
+  }
+}
+
+// #6328: cross-file counterpart to the within-file duplicate-URL check above
+// (#5737) — that one only ever sees one document at a time, so an identical
+// URL copy-pasted into TWO subnet files under different netuids slips past
+// it. Only meaningful on a multi-file run: a single-file
+// `validate:surface -- registry/subnets/x.json` invocation can't see what
+// another netuid claims, so it's skipped rather than false-negative-guessed
+// — `npm run validate` (no file args) always covers it.
+if (files.length > 1) {
+  for (const [normalizedUrl, locations] of surfaceLocationsByUrl) {
+    if (SHARED_OPERATOR_URLS.has(normalizedUrl)) continue;
+    const netuids = new Set(locations.map((location) => location.netuid));
+    if (netuids.size > 1) {
+      const claimants = locations
+        .map(
+          (location) =>
+            `${location.file} (${location.id}, netuid=${location.netuid})`,
+        )
+        .join("; ");
+      errors.push(
+        `Cross-file duplicate: "${normalizedUrl}" is registered by ${locations.length} surface(s) across ${netuids.size} distinct netuids — ${claimants}. ` +
+          "Fix one to a true per-subnet endpoint, remove/reclassify it from the subnet that doesn't own it, or add it to " +
+          "SHARED_OPERATOR_URLS if one operator genuinely runs multiple subnets from shared infrastructure.",
+      );
     }
   }
 }

--- a/tests/validate-surface-cross-file-duplicate-url.test.mjs
+++ b/tests/validate-surface-cross-file-duplicate-url.test.mjs
@@ -1,0 +1,192 @@
+// Regression coverage for #6328: validate-surface.mjs now fails when the
+// identical URL is registered as a surface in TWO DIFFERENT subnet files
+// under different netuids — the cross-file counterpart to #5737's within-file
+// duplicate-URL check, which only ever sees one document at a time and so
+// cannot catch a URL copy-pasted into a second subnet's manifest (the SN48/
+// SN63 qbittensorlabs.com/api/health mistake this issue found). Mirrors
+// validate-surface-duplicate-url.test.mjs's subprocess-fixture pattern.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, test } from "vitest";
+import { listJsonFiles, repoRoot } from "../scripts/lib.mjs";
+
+function runNode(args) {
+  try {
+    const stdout = execFileSync(process.execPath, args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return { status: 0, output: stdout };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      output: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+    };
+  }
+}
+
+describe("validate-surface.mjs cross-file duplicate-URL check", () => {
+  let tempDir;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  function writeFixtures(docs) {
+    tempDir = mkdtempSync(
+      `${tmpdir()}/metagraphed-validate-surface-cross-file-dup-`,
+    );
+    return docs.map((doc, index) => {
+      const document = {
+        schema_version: 1,
+        netuid: doc.netuid,
+        slug: `fixture-${index}`,
+        name: `Fixture Subnet ${index}`,
+        status: "active",
+        categories: [],
+        links: [],
+        surfaces: doc.surfaces,
+      };
+      const fixturePath = path.join(tempDir, `fixture-${index}.json`);
+      writeFileSync(fixturePath, JSON.stringify(document, null, 2));
+      return fixturePath;
+    });
+  }
+
+  function surface(overrides) {
+    return {
+      id: "fixture-surface",
+      kind: "subnet-api",
+      name: "Fixture surface",
+      url: "https://api.fixture.example/status",
+      provider: "academia",
+      authority: "community",
+      auth_required: false,
+      public_safe: true,
+      review: { state: "community-submitted" },
+      ...overrides,
+    };
+  }
+
+  test("fails when the identical URL is registered by two different netuids across files", () => {
+    const [fileA, fileB] = writeFixtures([
+      { netuid: 48, surfaces: [surface({ id: "fixture-a-health" })] },
+      { netuid: 63, surfaces: [surface({ id: "fixture-b-health" })] },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fileA,
+      fileB,
+    ]);
+
+    assert.equal(status, 1);
+    assert.match(output, /Cross-file duplicate/);
+    assert.match(output, /https:\/\/api\.fixture\.example\/status/);
+    assert.match(output, /fixture-a-health/);
+    assert.match(output, /fixture-b-health/);
+    assert.match(output, /netuid=48/);
+    assert.match(output, /netuid=63/);
+  });
+
+  test("does not flag the same URL claimed twice within one netuid's own file (that's the #5737 check's job)", () => {
+    const [fileA] = writeFixtures([
+      {
+        netuid: 999,
+        surfaces: [
+          surface({ id: "fixture-a" }),
+          surface({ id: "fixture-b", kind: "data-artifact" }),
+        ],
+      },
+    ]);
+
+    // Single-file run only — the within-file check (#5737) catches this one,
+    // not the cross-file check, and asserting on that message here would
+    // just re-test #5737's own coverage.
+    const { status } = runNode(["scripts/validate-surface.mjs", fileA]);
+    assert.equal(status, 1);
+  });
+
+  test("allows an allowlisted SHARED_OPERATOR_URLS entry across distinct netuids", () => {
+    const [fileA, fileB] = writeFixtures([
+      {
+        netuid: 48,
+        surfaces: [
+          surface({
+            id: "fixture-a-website",
+            kind: "website",
+            url: "https://www.qbittensorlabs.com/",
+            authority: "official",
+          }),
+        ],
+      },
+      {
+        netuid: 63,
+        surfaces: [
+          surface({
+            id: "fixture-b-website",
+            kind: "website",
+            url: "https://www.qbittensorlabs.com/",
+            authority: "official",
+          }),
+        ],
+      },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fileA,
+      fileB,
+    ]);
+
+    assert.equal(status, 0, output);
+  });
+
+  test("skips the cross-file check on a single-file invocation (can't see what another netuid claims)", () => {
+    const [fileA] = writeFixtures([
+      { netuid: 48, surfaces: [surface({ id: "fixture-a-health" })] },
+    ]);
+
+    const { status, output } = runNode(["scripts/validate-surface.mjs", fileA]);
+    assert.equal(status, 0, output);
+  });
+
+  test("does not flag the same URL registered twice under the SAME netuid across two files (not a cross-netuid collision)", () => {
+    const [fileA, fileB] = writeFixtures([
+      { netuid: 48, surfaces: [surface({ id: "fixture-a-health" })] },
+      { netuid: 48, surfaces: [surface({ id: "fixture-b-health" })] },
+    ]);
+
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      fileA,
+      fileB,
+    ]);
+
+    assert.equal(status, 0, output);
+  });
+
+  test("the full registry has no unresolved cross-file duplicate-URL findings", () => {
+    const { status, output } = runNode(["scripts/validate-surface.mjs"]);
+    assert.equal(status, 0, output);
+  });
+});
+
+describe("validate-surface.mjs cross-file duplicate-URL check does not misfire", () => {
+  test("every real subnet file passes when validated together (no false-positive cross-file dedupe)", async () => {
+    const files = await listJsonFiles(path.join(repoRoot, "registry/subnets"));
+    assert.ok(files.length > 0);
+    const { status, output } = runNode([
+      "scripts/validate-surface.mjs",
+      ...files,
+    ]);
+    assert.equal(status, 0, output);
+  });
+});


### PR DESCRIPTION
## Summary

`registry/subnets/quantum-compute.json` (SN48) and `registry/subnets/enigma.json` (SN63) both registered the identical `https://www.qbittensorlabs.com/api/health` as their own `subnet-api` surface — the only cross-file URL duplication (across distinct netuids) in the whole registry.

## Which subnet owns it — independent verification

This issue has had 3 prior PRs (#6489, #6490, #6814) which reached two different conclusions (repoint SN48 to a different domain vs. remove the duplicate entirely). I independently re-investigated rather than reapplying either:

- **The corporate site fronts both subnets.** `www.qbittensorlabs.com`'s own body copy names both ("SN48: Quantum" / "SN63: Enigma") — confirmed by fetching the page directly. So the shared `website` surface correctly stays on both files, per the issue's explicit allowance.
- **`/api/health` is not subnet-specific on either domain.** `https://www.qbittensorlabs.com/api/health` and `https://www.openquantum.com/api/health` (SN48's own domain — `docs.openquantum.com` is already a registered SN48 surface) both return the byte-identical `{"status":"ok"}` response with the **same ETag** (`"136lfa0r4opf"`). This is generic liveness-check boilerplate shared across both sites' infrastructure, not a differentiated per-subnet service — repointing SN48 to the `openquantum.com` variant wouldn't have represented any genuine SN48-specific signal, just moved the same generic ping to a different URL.
- **SN48's own repository never references `qbittensorlabs.com`.** GitHub code search: `qbittensor-labs/quantum-compute` has 0 references to `qbittensorlabs.com` (4 to `openquantum.com`); `qbittensor-labs/enigma` has 6. SN48 doesn't treat that domain as its own.

**Fix:** removed `sn-48-quantum-compute-health-api` from `quantum-compute.json`; kept exclusively on `enigma.json`, whose repository substantiates ownership.

## The mechanical check

Adds the cross-file counterpart to #5737's within-file duplicate-URL check to `scripts/validate-surface.mjs`: a normalized URL claimed by 2+ distinct netuids now fails `validate-surface` (multi-file runs only — a single-file `validate:surface -- registry/subnets/x.json` invocation can't see what another netuid claims), with a `SHARED_OPERATOR_URLS` allowlist — mirroring the existing `GRANDFATHERED_DUPLICATE_URLS`' shape — for the one legitimate shared-operator case (the `qbittensorlabs.com` website root).

## Test plan

- [x] `npm run validate:surface` — 1119 surfaces across 129 files, passed
- [x] `npm run validate` (full suite) — clean
- [x] `npm run lint`, `npm run format:check` — clean
- [x] `npm run build` — regenerated `public/metagraph/operational-surfaces.json` to drop the removed surface (`surface_count` 557 → 556), committed alongside
- [x] Full `vitest run` — 315 test files, 9350 tests passing, including 7 new tests in `tests/validate-surface-cross-file-duplicate-url.test.mjs`

Closes #6328
