### PR TITLE
fix(ui): give the Validators directory the canonical ranked-list sort model

### DIFF
--- a/apps/ui/src/components/metagraphed/validator-columns.tsx
+++ b/apps/ui/src/components/metagraphed/validator-columns.tsx
@@ -7,7 +7,7 @@ import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-form
 import { AccountAddress } from "@/components/metagraphed/account-address";
 import { ValidatorIdentityChip } from "@/components/metagraphed/validator-identity-chip";
 import { formatApyPct, formatTakePct } from "@/lib/metagraphed/validator-apy";
-import type { GlobalValidator } from "@/lib/metagraphed/types";
+import type { GlobalValidator, GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 const TH_BASE = "px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-ink-muted";
 const TD_BASE = "px-3 py-2 font-mono text-[11px]";
@@ -25,6 +25,11 @@ export interface ValidatorColumn {
   thClassName: string;
   tdClassName: string;
   cell: (v: GlobalValidator) => ReactNode;
+  /** #5344: the API sort key this column ranks by, when it's a sortable metric.
+   *  Columns without one (identity columns) render a plain, non-interactive
+   *  header. Only the metrics the /api/v1/validators endpoint can sort by get
+   *  a clickable SortHeader. */
+  sortKey?: GlobalValidatorSort;
 }
 
 const numeric = (
@@ -84,9 +89,14 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
     // apy_estimate (#2551) is a 0..1 fraction; formatApyPct takes a percentage.
     cell: (v) => formatApyPct(v.apy_estimate != null ? v.apy_estimate * 100 : null),
   },
-  { ...numeric("Active subnets"), cell: (v) => formatNumber(v.subnet_count) },
+  {
+    ...numeric("Active subnets"),
+    sortKey: "subnet_count",
+    cell: (v) => formatNumber(v.subnet_count),
+  },
   {
     ...numeric("UIDs"),
+    sortKey: "uid_count",
     tdClassName: `${TD_NUM} text-ink-muted`,
     cell: (v) => formatNumber(v.uid_count),
   },
@@ -97,11 +107,13 @@ export const VALIDATOR_COLUMNS: ValidatorColumn[] = [
   },
   {
     ...numeric("Dominance"),
+    sortKey: "stake_dominance",
     cell: (v) => (v.stake_dominance != null ? `${(v.stake_dominance * 100).toFixed(2)}%` : "—"),
   },
-  { ...numeric("Total stake"), cell: (v) => taoCompact(v.total_stake_tao) },
+  { ...numeric("Total stake"), sortKey: "total_stake", cell: (v) => taoCompact(v.total_stake_tao) },
   {
     ...numeric("Total emission"),
+    sortKey: "total_emission",
     tdClassName: `${TD_NUM} text-ink-muted`,
     cell: (v) => taoCompact(v.total_emission_tao),
   },

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -4,14 +4,21 @@ import { Suspense } from "react";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { AppShell } from "@/components/metagraphed/app-shell";
-import { PageHero, ShareButton, DownloadCsvButton, ActionBar } from "@jsonbored/ui-kit";
+import {
+  PageHero,
+  ShareButton,
+  DownloadCsvButton,
+  ActionBar,
+  DensityToggle,
+  type Density,
+} from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { QueryErrorBoundary } from "@/components/metagraphed/error-boundary";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
 import { buildUrl } from "@/lib/metagraphed/client";
-import { formatNumber, isStaleFreshness } from "@/lib/metagraphed/format";
+import { formatNumber, isStaleFreshness, classNames } from "@/lib/metagraphed/format";
 import { shortHash } from "@/lib/metagraphed/blocks";
 import { ValidatorSubnetHeatmap } from "@/components/metagraphed/charts/validator-subnet-heatmap";
 import { ValidatorDominanceChart } from "@/components/metagraphed/charts/validator-dominance-chart";
@@ -19,6 +26,7 @@ import { taoCompact, SponsoredBadge } from "@/components/metagraphed/neuron-form
 import { ValidatorCardList } from "@/components/metagraphed/validator-card-list";
 import { ValidatorGuide } from "@/components/metagraphed/validator-guide";
 import { VALIDATOR_COLUMNS } from "@/components/metagraphed/validator-columns";
+import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
 import type { GlobalValidatorSort } from "@/lib/metagraphed/types";
 
 // The full GlobalValidatorSort set the /api/v1/validators endpoint accepts.
@@ -47,6 +55,11 @@ const SORT_LABELS: Record<GlobalValidatorSort, string> = {
 
 const validatorsSearchSchema = z.object({
   sort: fallback(z.enum(validatorSortKeys), "subnet_count").default("subnet_count"),
+  // #5344: bring Validators up to the canonical ranked-list interaction model
+  // (Subnets) — a sort DIRECTION toggled by clicking a column header, and a row
+  // density control — instead of a bare, single-direction <select>.
+  order: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
+  density: fallback(z.enum(["compact", "comfortable"]), "comfortable").default("comfortable"),
 });
 
 export const Route = createFileRoute("/validators/")({
@@ -73,10 +86,31 @@ function ValidatorsPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
   const sort = search.sort ?? "subnet_count";
+  const order = search.order ?? "desc";
+  const density = search.density ?? "comfortable";
   // Mirror the sibling ranked-list pages (subnets/blocks/surfaces): export the
   // current view as CSV. DownloadCsvButton appends `format=csv`; the backend's
   // handleGlobalValidators already serves it (#5482).
   const validatorsCsvUrl = buildUrl("/api/v1/validators", { sort });
+  // Clicking a column header sorts by it; clicking the active one flips
+  // direction. Metrics default to descending (highest first) — matching the
+  // endpoint's own default order — so the first click on a new column shows the
+  // most-ranked rows, and the toggle reveals the tail.
+  const onSort = (field: string) =>
+    navigate({
+      search: (prev: Record<string, unknown>) =>
+        ({
+          ...prev,
+          sort: field,
+          order: prev.sort === field && prev.order === "desc" ? "asc" : "desc",
+        }) as never,
+      replace: true,
+    });
+  const onDensityChange = (d: Density) =>
+    navigate({
+      search: (prev: Record<string, unknown>) => ({ ...prev, density: d }) as never,
+      replace: true,
+    });
   return (
     <AppShell>
       <PageHero
@@ -98,12 +132,10 @@ function ValidatorsPage() {
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>
           <ValidatorsTable
             sort={sort}
-            onSortChange={(v) =>
-              navigate({
-                search: (prev: Record<string, unknown>) => ({ ...prev, sort: v }) as never,
-                replace: true,
-              })
-            }
+            order={order}
+            density={density}
+            onSort={onSort}
+            onDensityChange={onDensityChange}
           />
         </Suspense>
       </QueryErrorBoundary>
@@ -126,42 +158,25 @@ function ValidatorsPage() {
   );
 }
 
-function SortSelect({
-  value,
-  onChange,
-}: {
-  value: GlobalValidatorSort;
-  onChange: (v: GlobalValidatorSort) => void;
-}) {
-  return (
-    <label className="inline-flex items-center gap-1.5 rounded border border-border bg-paper px-2 py-1 text-xs">
-      <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">Sort</span>
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value as GlobalValidatorSort)}
-        className="bg-transparent text-ink-strong text-xs rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        aria-label="Sort validators"
-      >
-        {validatorSortKeys.map((k) => (
-          <option key={k} value={k}>
-            {SORT_LABELS[k]}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
 function ValidatorsTable({
   sort,
-  onSortChange,
+  order,
+  density,
+  onSort,
+  onDensityChange,
 }: {
   sort: GlobalValidatorSort;
-  onSortChange: (v: GlobalValidatorSort) => void;
+  order: "asc" | "desc";
+  density: Density;
+  onSort: (field: string) => void;
+  onDensityChange: (d: Density) => void;
 }) {
   const res = useSuspenseQuery(validatorsQuery({ sort })).data;
-  const validators = res.data.validators;
+  const serverRanked = res.data.validators;
   const generatedAt = res.meta?.generated_at ?? null;
+  // The endpoint ranks descending by `sort`, so ascending is that list reversed.
+  const validators = order === "asc" ? [...serverRanked].reverse() : serverRanked;
+  const compact = density === "compact";
 
   return (
     <div className="space-y-3">
@@ -176,17 +191,37 @@ function ValidatorsTable({
         <span className="font-mono text-[11px] text-ink-muted">
           {formatNumber(validators.length)} validators · ranked by {SORT_LABELS[sort]}
         </span>
-        <SortSelect value={sort} onChange={onSortChange} />
+        <DensityToggle value={density} onChange={onDensityChange} />
       </div>
 
       {validators.length > 0 ? (
         <div className="hidden md:block overflow-x-auto rounded-lg border border-border">
-          <table className="w-full text-left text-sm">
+          <table
+            className={classNames(
+              "w-full text-left text-sm",
+              compact && "[&_td]:!py-1 [&_th]:!py-1",
+            )}
+          >
             <thead className="bg-surface/50">
               <tr>
                 {VALIDATOR_COLUMNS.map((col) => (
-                  <th key={col.header} className={col.thClassName}>
-                    {col.header}
+                  <th
+                    key={col.header}
+                    className={col.thClassName}
+                    aria-sort={col.sortKey ? ariaSort(sort === col.sortKey, order) : undefined}
+                  >
+                    {col.sortKey ? (
+                      <SortHeader
+                        label={col.header}
+                        field={col.sortKey}
+                        active={sort === col.sortKey}
+                        order={order}
+                        onSort={onSort}
+                        align={col.thClassName.includes("text-right") ? "right" : "left"}
+                      />
+                    ) : (
+                      col.header
+                    )}
                   </th>
                 ))}
               </tr>


### PR DESCRIPTION
## What

Brings the **Validators** directory up to the canonical ranked-list interaction model the sibling pages already use — clickable sort column headers + a density control — replacing its odd-one-out `<select>`.

## Why

Per #5344, the three structurally-identical "ranked list" pages shipped three different levels of polish: **Subnets** (and the metagraph tables) use clickable `SortHeader` column headers with a density toggle; **Validators** used a standalone `<select>` (`SortSelect`) with no direction toggle and non-interactive `<th>`s. This unifies the worst-off page onto the established pattern.

## How

- `validator-columns.tsx`: each sortable metric column declares its `sortKey`; identity columns (Operator/Hotkey/Coldkey) have none.
- `validators.index.tsx`: metric headers are now clickable `SortHeader`s — click to sort, click the active one to flip direction — with a `<DownloadCsvButton>`-adjacent **Comfortable/Compact** `DensityToggle`; the `<select>` is gone. `sort`/`order`/`density` live in the URL exactly like Subnets. The endpoint ranks descending by `sort`, so ascending is that page reversed (no new API surface); `aria-sort` is set on each sortable header.

**Scope:** one focused change — the Validators page (the only one still on a `<select>`). Subnets is already the canonical reference; this is not a rewrite of it.

## Screenshots

`/validators`. **Before:** the `SORT` `<select>` + non-interactive headers. **After:** clickable `SortHeader` columns (note the sort arrow) + the Comfortable/Compact toggle.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/5344-ranked-list-after-mobile-dark.png)<br><sub>after</sub> |

Verified interaction against the live dev server: the old `<select>` is gone, the 5 metric headers are clickable, and clicking one navigates to `?sort=<key>&order=…&density=…`.

Closes #5344
