### PR TITLE
feat(alerts): add computed/predicate-condition alert triggers

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -845,6 +845,13 @@ CREATE TABLE IF NOT EXISTS chain_alert_triggers (
   -- shouldn't require the owner to know which leg a given event used).
   account           TEXT,
   min_amount_tao    NUMERIC,
+  -- #6746: a computed/derived-metric predicate ({metric, operator,
+  -- threshold}, validated by src/alert-triggers.mjs's validateAlertCondition)
+  -- rather than a raw event-field match -- narrows whichever event already
+  -- passed the fixed-field checks above, so it carries no separate scope of
+  -- its own. NULL for every pre-#6746 trigger (a fixed-field-only match,
+  -- unaffected by this column's presence).
+  condition         JSONB,
   channel           TEXT NOT NULL CHECK (channel IN ('webhook', 'email', 'telegram', 'discord')),
   -- Shape depends on channel: a public https:// URL (webhook), an email
   -- address (email), a chat id or @channelusername (telegram), or the exact
@@ -858,6 +865,11 @@ CREATE TABLE IF NOT EXISTS chain_alert_triggers (
   last_matched_at   BIGINT,
   match_count       BIGINT NOT NULL DEFAULT 0
 );
+-- #6746: safe on an already-deployed table (a fresh CREATE TABLE above
+-- already includes the column; this is a no-op there) -- adds it to an
+-- existing production table, where CREATE TABLE IF NOT EXISTS alone would
+-- not, since the table already exists.
+ALTER TABLE chain_alert_triggers ADD COLUMN IF NOT EXISTS condition JSONB;
 -- Covers AlerterHub's own "give me every active trigger" cache-refresh scan
 -- (#4984 Part 2) -- the only query pattern against this table that isn't
 -- already a fast primary-key lookup by id.

--- a/src/alert-triggers.mjs
+++ b/src/alert-triggers.mjs
@@ -59,6 +59,111 @@ const MIN_AMOUNT_TAO_CEILING = 1_000_000_000;
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MAX_EMAIL_LENGTH = 254; // RFC 5321 §4.5.3.1.3
 
+// #6746: a trigger's `condition` matches a COMPUTED/derived metric against a
+// threshold, rather than a raw event field -- the extension SubnetAIQ's
+// deregistration-risk monitor pioneers (stripped of its trading framing).
+// Both metrics below are scoped by the SAME payload fields fixed-field
+// matching already reads (netuid, hotkey) -- a condition does not carry its
+// own separate scope, it narrows whichever event already matched. See
+// src/dereg-risk.mjs for how each metric is actually computed into the
+// snapshot triggerMatchesEvent reads from below.
+export const ALERT_CONDITION_METRICS = new Set([
+  // This subnet's rank by alpha_price_tao among all subnets (1 = highest
+  // price) -- keyed by payload.netuid.
+  "subnet_alpha_price_rank",
+  // Blocks remaining until payload.netuid + payload.hotkey's immunity period
+  // expires -- null (never matches) when that neuron isn't currently in its
+  // immunity window. Keyed by `${netuid}:${hotkey}`.
+  "neuron_immunity_countdown_blocks",
+]);
+
+export const ALERT_CONDITION_OPERATORS = new Set([
+  "lt",
+  "lte",
+  "gt",
+  "gte",
+  "eq",
+]);
+
+function compareAlertCondition(value, operator, threshold) {
+  switch (operator) {
+    case "lt":
+      return value < threshold;
+    case "lte":
+      return value <= threshold;
+    case "gt":
+      return value > threshold;
+    case "gte":
+      return value >= threshold;
+    case "eq":
+      return value === threshold;
+    /* v8 ignore next 2 -- unreachable: operator is already validated against
+       ALERT_CONDITION_OPERATORS before a trigger can carry it. */
+    default:
+      return false;
+  }
+}
+
+// Validates the optional `condition` sub-object of a create/update body.
+// `undefined` (the field wasn't provided) is valid and yields `null` --
+// distinct from a present-but-malformed condition, which is rejected.
+function validateAlertCondition(input) {
+  if (input === undefined) return { ok: true, value: null };
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return {
+      ok: false,
+      error: "`condition`, when provided, must be an object.",
+    };
+  }
+  if (!ALERT_CONDITION_METRICS.has(input.metric)) {
+    return {
+      ok: false,
+      error: `\`condition.metric\` must be one of: ${[...ALERT_CONDITION_METRICS].join(", ")}.`,
+    };
+  }
+  if (!ALERT_CONDITION_OPERATORS.has(input.operator)) {
+    return {
+      ok: false,
+      error: `\`condition.operator\` must be one of: ${[...ALERT_CONDITION_OPERATORS].join(", ")}.`,
+    };
+  }
+  if (
+    typeof input.threshold !== "number" ||
+    !Number.isFinite(input.threshold)
+  ) {
+    return {
+      ok: false,
+      error: "`condition.threshold` must be a finite number.",
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      metric: input.metric,
+      operator: input.operator,
+      threshold: input.threshold,
+    },
+  };
+}
+
+// Reads the current value of one condition's metric for the event payload
+// that already matched every fixed-field check -- `null` when the snapshot
+// has no entry for this netuid/hotkey (metric genuinely inapplicable right
+// now, e.g. a neuron outside its immunity window), which triggerMatchesEvent
+// treats as "does not match", never as a thrown error.
+function readConditionMetric(metric, payload, metricSnapshot) {
+  if (metric === "subnet_alpha_price_rank") {
+    const rank = metricSnapshot?.subnetAlphaPriceRank?.get(payload?.netuid);
+    return typeof rank === "number" ? rank : null;
+  }
+  // metric === "neuron_immunity_countdown_blocks" -- the only other value
+  // ALERT_CONDITION_METRICS permits a trigger to carry (validated at
+  // creation/update time), so no further branch/default is reachable here.
+  const key = `${payload?.netuid}:${payload?.hotkey}`;
+  const countdown = metricSnapshot?.neuronImmunityCountdownBlocks?.get(key);
+  return typeof countdown === "number" ? countdown : null;
+}
+
 // Telegram chat ids are either a signed integer (private chat / group) or an
 // `@channelusername` (public channel/supergroup) -- see the Bot API's
 // sendMessage `chat_id` parameter.
@@ -205,11 +310,21 @@ export function validateAlertTriggerInput(input) {
     minAmountTao = input.min_amount_tao;
   }
 
-  if (netuid === null && !eventKind && !account && minAmountTao === null) {
+  const conditionResult = validateAlertCondition(input.condition);
+  if (!conditionResult.ok) return conditionResult;
+  const condition = conditionResult.value;
+
+  if (
+    netuid === null &&
+    !eventKind &&
+    !account &&
+    minAmountTao === null &&
+    !condition
+  ) {
     return {
       ok: false,
       error:
-        "At least one of netuid, event_kind, account, or min_amount_tao is required.",
+        "At least one of netuid, event_kind, account, min_amount_tao, or condition is required.",
     };
   }
 
@@ -222,6 +337,7 @@ export function validateAlertTriggerInput(input) {
       eventKind,
       account,
       minAmountTao,
+      condition,
       channel: input.channel,
       destination: input.destination,
     },
@@ -232,7 +348,16 @@ export function validateAlertTriggerInput(input) {
 // shape ChainFirehoseHub.broadcast() fans out to SSE/WS/GraphQL/MCP -- see
 // workers/chain-firehose-hub.mjs). Pure, no I/O: the caller owns persistence
 // (match_count/last_matched_at) and delivery.
-export function triggerMatchesEvent(trigger, payload) {
+//
+// `metricSnapshot` (#6746/#6747) is an OPTIONAL, pre-computed cache the
+// caller refreshes on its own bounded schedule (AlerterHub.refreshTriggers(),
+// alongside the trigger list itself) -- this function never fetches or
+// computes a metric itself, only reads whatever snapshot it's handed. A
+// condition trigger with no snapshot available (metricSnapshot omitted, or
+// cold on a fresh evaluator) fails closed -- it never matches -- rather than
+// throwing or silently skipping the condition check, so a stale/missing
+// snapshot can only under-fire, never over-fire, a predicate trigger.
+export function triggerMatchesEvent(trigger, payload, metricSnapshot = null) {
   if (!payload || typeof payload !== "object") return false;
   if (trigger.tableFilter && !trigger.tableFilter.includes(payload.table)) {
     return false;
@@ -258,6 +383,23 @@ export function triggerMatchesEvent(trigger, payload) {
     )
   ) {
     return false;
+  }
+  if (trigger.condition) {
+    const value = readConditionMetric(
+      trigger.condition.metric,
+      payload,
+      metricSnapshot,
+    );
+    if (
+      value === null ||
+      !compareAlertCondition(
+        value,
+        trigger.condition.operator,
+        trigger.condition.threshold,
+      )
+    ) {
+      return false;
+    }
   }
   return true;
 }
@@ -299,6 +441,7 @@ export function ownerAlertTriggerView(record) {
       record.min_amount_tao === undefined || record.min_amount_tao === null
         ? null
         : Number(record.min_amount_tao),
+    condition: record.condition ?? null,
     channel: record.channel,
     destination: record.destination,
     active: record.active !== false,
@@ -328,6 +471,7 @@ export function evaluatorAlertTriggerView(record) {
       record.min_amount_tao === undefined || record.min_amount_tao === null
         ? null
         : Number(record.min_amount_tao),
+    condition: record.condition ?? null,
     channel: record.channel,
     destination: record.destination,
   };

--- a/src/dereg-risk.mjs
+++ b/src/dereg-risk.mjs
@@ -1,0 +1,85 @@
+// Pure computation of the two #6746/#6748 alert-condition metrics -- the
+// protocol-health signals SubnetAIQ's deregistration-risk monitor pioneers
+// (EMA-price-rank-vs-cutoff + immunity-period countdown), stripped of its
+// trading "AVOID/CAUTION" framing and buildable entirely from data
+// metagraphed already captures. No I/O: callers own fetching the underlying
+// rows (the economics tier, formatNeuron's own immunity_expires_at_block
+// output, src/metagraph-neurons.mjs) and the current block number --
+// matches this codebase's other pure-shaping/no-I/O module convention
+// (src/concentration.mjs, src/alpha-volume.mjs).
+//
+// buildDeregRiskSnapshot's return shape is exactly what
+// src/alert-triggers.mjs's readConditionMetric reads from -- see that
+// module's ALERT_CONDITION_METRICS for the two metric names this backs.
+
+// Ranks subnets by alpha_price_tao descending (1 = highest price) -- the
+// "EMA-price-rank" SubnetAIQ's monitor computes, simplified to the raw
+// (non-EMA) rank: metagraphed doesn't capture a price time series cheaply
+// enough for a real moving average yet, and an honestly-labeled raw rank is
+// preferable to fabricating a smoothed figure. A row with a missing/
+// non-finite alpha_price_tao is excluded entirely (never assigned a rank),
+// so a condition referencing it degrades to "no snapshot entry" (never
+// matches) rather than a fabricated rank of 0 or similar.
+export function subnetAlphaPriceRank(economicsRows) {
+  const ranked = (economicsRows || [])
+    .filter(
+      (row) =>
+        Number.isInteger(row?.netuid) &&
+        // typeof-guarded before Number(): Number(null) === 0 (finite), which
+        // would otherwise rank a genuinely-absent price as a real zero price.
+        typeof row?.alpha_price_tao === "number" &&
+        Number.isFinite(row.alpha_price_tao),
+    )
+    .map((row) => ({ netuid: row.netuid, price: row.alpha_price_tao }))
+    .sort((a, b) => b.price - a.price);
+  const rankByNetuid = new Map();
+  ranked.forEach((entry, index) => {
+    rankByNetuid.set(entry.netuid, index + 1);
+  });
+  return rankByNetuid;
+}
+
+// Blocks remaining until each currently-immune neuron's immunity period
+// expires, keyed by "netuid:hotkey" (the same key alert-triggers.mjs's
+// readConditionMetric looks up). `rows` is a flat list drawn from any
+// combination of subnets' already-formatted neuron rows (formatNeuron's own
+// output, src/metagraph-neurons.mjs -- immunity_expires_at_block is only
+// present there when a subnet's live immunity_period hyperparameter was
+// passed in, and only non-null while is_immunity_period is true). A row
+// with no immunity_expires_at_block, or whose countdown has already reached
+// zero/gone negative (expired since the row's own snapshot was captured),
+// contributes no entry -- never a zero/negative countdown that a `lte`
+// condition could wrongly treat as "still counting down".
+export function neuronImmunityCountdownBlocks(rows, currentBlock) {
+  const countdownByKey = new Map();
+  if (!Number.isFinite(currentBlock)) return countdownByKey;
+  for (const row of rows || []) {
+    if (
+      !Number.isInteger(row?.netuid) ||
+      !row?.hotkey ||
+      !Number.isInteger(row?.immunity_expires_at_block)
+    ) {
+      continue;
+    }
+    const countdown = row.immunity_expires_at_block - currentBlock;
+    if (countdown <= 0) continue;
+    countdownByKey.set(`${row.netuid}:${row.hotkey}`, countdown);
+  }
+  return countdownByKey;
+}
+
+// Convenience wrapper composing both metrics into the exact snapshot shape
+// triggerMatchesEvent's metricSnapshot parameter expects.
+export function buildDeregRiskSnapshot({
+  economicsRows,
+  neuronRows,
+  currentBlock,
+} = {}) {
+  return {
+    subnetAlphaPriceRank: subnetAlphaPriceRank(economicsRows),
+    neuronImmunityCountdownBlocks: neuronImmunityCountdownBlocks(
+      neuronRows,
+      currentBlock,
+    ),
+  };
+}

--- a/tests/alert-triggers-route.test.mjs
+++ b/tests/alert-triggers-route.test.mjs
@@ -34,6 +34,11 @@ vi.mock("postgres", () => ({
     }
     sql.begin = (cb) => cb(sql);
     sql.end = () => Promise.resolve();
+    // #6746: condition (JSONB) is bound via sql.json(value) in the real
+    // INSERT/UPDATE -- this mock's tagged-template sql() doesn't need to
+    // know about JSON wrapping (it just records whatever value it's handed
+    // as a template placeholder), so a passthrough is a faithful stand-in.
+    sql.json = (value) => value;
     // sql.unsafe(text, params) -- the #5022 match write-back's batched
     // UPDATE builds its own placeholder text (plain scalar positional
     // binds) rather than a bound JS array, matching workers/data-api.mjs's
@@ -250,6 +255,48 @@ test("create: 201 on success, mints a fresh owner_token distinct from any stored
   assert.ok(sqlCalls[0].values.includes(7));
   assert.ok(sqlCalls[0].values.includes("email"));
   assert.ok(sqlCalls[0].values.includes("a@b.com"));
+});
+
+test("create: 201 with a condition, inserts it as the JSONB value verbatim", async () => {
+  const condition = {
+    metric: "subnet_alpha_price_rank",
+    operator: "gt",
+    threshold: 100,
+  };
+  mockQueue.current.push([row({ condition })]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": CREATE_TOKEN },
+      body: { channel: "email", destination: "a@b.com", netuid: 7, condition },
+    }),
+  );
+  assert.equal(res.status, 201);
+  const body = await res.json();
+  assert.deepEqual(body.condition, condition);
+  assert.match(sqlCalls[0].text, /INSERT INTO chain_alert_triggers/);
+  assert.ok(
+    sqlCalls[0].values.some(
+      (v) =>
+        v && typeof v === "object" && v.metric === "subnet_alpha_price_rank",
+    ),
+  );
+});
+
+test("create: 400 on a malformed condition", async () => {
+  const res = await fetch(
+    req("/api/v1/alerts/triggers", {
+      method: "POST",
+      headers: { "x-alert-trigger-create-token": CREATE_TOKEN },
+      body: {
+        channel: "email",
+        destination: "a@b.com",
+        condition: { metric: "made-up", operator: "lt", threshold: 1 },
+      },
+    }),
+  );
+  assert.equal(res.status, 400);
+  assert.equal(sqlCalls.length, 0);
 });
 
 test("create: 429 when ALERT_TRIGGER_CREATE_RATE_LIMITER rejects the request, without ever touching Postgres", async () => {
@@ -509,6 +556,61 @@ test("update: omitting a field on PATCH keeps the existing row's value (partial-
   assert.ok(sqlCalls[1].values.includes("email"));
   assert.ok(sqlCalls[1].values.includes("a@b.com"));
   assert.ok(sqlCalls[1].values.includes("renamed"));
+});
+
+test("update: omitting condition on PATCH keeps the existing row's condition", async () => {
+  const condition = {
+    metric: "neuron_immunity_countdown_blocks",
+    operator: "lte",
+    threshold: 500,
+  };
+  mockQueue.current.push([
+    row({ owner_token: "correct-token", netuid: 7, condition }),
+  ]);
+  mockQueue.current.push([row({ netuid: 7, condition })]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      method: "PATCH",
+      headers: { "x-alert-trigger-owner-token": "correct-token" },
+      body: { name: "renamed" },
+    }),
+  );
+  assert.equal(res.status, 200);
+  assert.ok(
+    sqlCalls[1].values.some(
+      (v) =>
+        v &&
+        typeof v === "object" &&
+        v.metric === "neuron_immunity_countdown_blocks",
+    ),
+  );
+});
+
+test("update: a resent condition replaces the existing one", async () => {
+  const oldCondition = {
+    metric: "subnet_alpha_price_rank",
+    operator: "gt",
+    threshold: 100,
+  };
+  const newCondition = {
+    metric: "neuron_immunity_countdown_blocks",
+    operator: "lte",
+    threshold: 500,
+  };
+  mockQueue.current.push([
+    row({ owner_token: "correct-token", netuid: 7, condition: oldCondition }),
+  ]);
+  mockQueue.current.push([row({ netuid: 7, condition: newCondition })]);
+  const res = await fetch(
+    req("/api/v1/alerts/triggers/1", {
+      method: "PATCH",
+      headers: { "x-alert-trigger-owner-token": "correct-token" },
+      body: { condition: newCondition },
+    }),
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepEqual(body.condition, newCondition);
 });
 
 test("update: an explicit null on PATCH is a no-op, NOT a clear -- the existing value survives (validateAlertTriggerInput rejects a real null for most fields, so PATCH can't safely route an intentional-clear through the CREATE-shared validator)", async () => {
@@ -785,6 +887,105 @@ test("matched writeback: 502 when the UPDATE itself fails", async () => {
       method: "POST",
       headers: { "x-alert-triggers-internal-token": INTERNAL_TOKEN },
       body: { trigger_ids: ["1"] },
+    }),
+  );
+  assert.equal(res.status, 502);
+});
+
+// --- GET /api/v1/internal/alert-triggers-dereg-risk-snapshot (#6747) --------
+
+test("dereg-risk snapshot: 503 when ALERT_TRIGGERS_INTERNAL_TOKEN is not configured", async () => {
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers-dereg-risk-snapshot"),
+    { ...env, ALERT_TRIGGERS_INTERNAL_TOKEN: undefined },
+  );
+  assert.equal(res.status, 503);
+});
+
+test("dereg-risk snapshot: 401 when the internal token header is entirely absent", async () => {
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers-dereg-risk-snapshot"),
+  );
+  assert.equal(res.status, 401);
+});
+
+test("dereg-risk snapshot: 401 when the internal token is present but wrong", async () => {
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers-dereg-risk-snapshot", {
+      headers: { "x-alert-triggers-internal-token": "wrong" },
+    }),
+  );
+  assert.equal(res.status, 401);
+});
+
+test("dereg-risk snapshot: 200, joins registered_at_block + immunity_period into immunity_expires_at_block, and returns the latest subnet_snapshots row per netuid", async () => {
+  mockQueue.current.push([{ block_number: 12345 }]); // MAX(block_number)
+  mockQueue.current.push([
+    { netuid: 7, immunity_period: 500 },
+    { netuid: 8, immunity_period: 1000 },
+  ]);
+  mockQueue.current.push([
+    { netuid: 7, hotkey: "5Fhot", registered_at_block: 12000 },
+  ]);
+  mockQueue.current.push([
+    { netuid: 7, alpha_price_tao: "1.5" },
+    { netuid: 8, alpha_price_tao: null },
+  ]);
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers-dereg-risk-snapshot", {
+      headers: { "x-alert-triggers-internal-token": INTERNAL_TOKEN },
+    }),
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.current_block, 12345);
+  assert.deepEqual(body.subnets, [
+    { netuid: 7, alpha_price_tao: 1.5 },
+    { netuid: 8, alpha_price_tao: null },
+  ]);
+  assert.deepEqual(body.immune_neurons, [
+    { netuid: 7, hotkey: "5Fhot", immunity_expires_at_block: 12500 },
+  ]);
+  assert.equal(sqlCalls.length, 4);
+});
+
+test("dereg-risk snapshot: an immune neuron on a subnet with no immunity_period hyperparameter row is dropped, not defaulted", async () => {
+  mockQueue.current.push([{ block_number: 100 }]);
+  mockQueue.current.push([]); // no subnet_hyperparams rows at all
+  mockQueue.current.push([
+    { netuid: 7, hotkey: "5Fhot", registered_at_block: 50 },
+  ]);
+  mockQueue.current.push([]);
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers-dereg-risk-snapshot", {
+      headers: { "x-alert-triggers-internal-token": INTERNAL_TOKEN },
+    }),
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepEqual(body.immune_neurons, []);
+});
+
+test("dereg-risk snapshot: current_block is null when the blocks table is empty", async () => {
+  mockQueue.current.push([{ block_number: null }]);
+  mockQueue.current.push([]);
+  mockQueue.current.push([]);
+  mockQueue.current.push([]);
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers-dereg-risk-snapshot", {
+      headers: { "x-alert-triggers-internal-token": INTERNAL_TOKEN },
+    }),
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.current_block, null);
+});
+
+test("dereg-risk snapshot: 502 when a query fails", async () => {
+  failNextQuery.error = new Error("boom");
+  const res = await fetch(
+    req("/api/v1/internal/alert-triggers-dereg-risk-snapshot", {
+      headers: { "x-alert-triggers-internal-token": INTERNAL_TOKEN },
     }),
   );
   assert.equal(res.status, 502);

--- a/tests/alert-triggers.test.mjs
+++ b/tests/alert-triggers.test.mjs
@@ -4,6 +4,8 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 import {
   ALERT_CHANNELS,
+  ALERT_CONDITION_METRICS,
+  ALERT_CONDITION_OPERATORS,
   ALERT_TRIGGER_CREATE_TOKEN_HEADER,
   ALERT_TRIGGER_MAX_BODY_BYTES,
   ALERT_TRIGGER_OWNER_TOKEN_HEADER,
@@ -155,6 +157,114 @@ test("validateAlertTriggerInput: accepts every condition field together", () => 
   assert.equal(result.value.eventKind, "Transfer");
   assert.equal(result.value.account, "5F...");
   assert.equal(result.value.minAmountTao, 100);
+});
+
+test("validateAlertTriggerInput: accepts a valid condition and echoes it structured", () => {
+  const result = validateAlertTriggerInput({
+    channel: "webhook",
+    destination: "https://example.com/hook",
+    netuid: 7,
+    condition: {
+      metric: "neuron_immunity_countdown_blocks",
+      operator: "lte",
+      threshold: 1000,
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.value.condition, {
+    metric: "neuron_immunity_countdown_blocks",
+    operator: "lte",
+    threshold: 1000,
+  });
+});
+
+test("validateAlertTriggerInput: a condition alone (no other narrowing field) is sufficient", () => {
+  const result = validateAlertTriggerInput({
+    channel: "webhook",
+    destination: "https://example.com/hook",
+    condition: {
+      metric: "subnet_alpha_price_rank",
+      operator: "gt",
+      threshold: 100,
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.value.netuid, null);
+});
+
+test("validateAlertTriggerInput: condition omitted entirely defaults to null", () => {
+  const result = validateAlertTriggerInput({
+    channel: "webhook",
+    destination: "https://example.com/hook",
+    netuid: 7,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.value.condition, null);
+});
+
+test("validateAlertTriggerInput: rejects a non-object condition", () => {
+  const result = validateAlertTriggerInput({
+    channel: "webhook",
+    destination: "https://example.com/hook",
+    netuid: 7,
+    condition: "not-an-object",
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /condition/);
+});
+
+test("validateAlertTriggerInput: rejects an unknown condition.metric", () => {
+  const result = validateAlertTriggerInput({
+    channel: "webhook",
+    destination: "https://example.com/hook",
+    netuid: 7,
+    condition: { metric: "made_up_metric", operator: "lt", threshold: 1 },
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /condition\.metric/);
+});
+
+test("validateAlertTriggerInput: rejects an unknown condition.operator", () => {
+  const result = validateAlertTriggerInput({
+    channel: "webhook",
+    destination: "https://example.com/hook",
+    netuid: 7,
+    condition: {
+      metric: "subnet_alpha_price_rank",
+      operator: "startswith",
+      threshold: 1,
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /condition\.operator/);
+});
+
+test("validateAlertTriggerInput: rejects a non-finite condition.threshold", () => {
+  for (const threshold of [NaN, Infinity, -Infinity, "10", null, undefined]) {
+    const result = validateAlertTriggerInput({
+      channel: "webhook",
+      destination: "https://example.com/hook",
+      netuid: 7,
+      condition: {
+        metric: "subnet_alpha_price_rank",
+        operator: "lt",
+        threshold,
+      },
+    });
+    assert.equal(result.ok, false, `threshold=${threshold}`);
+    assert.match(result.error, /condition\.threshold/);
+  }
+});
+
+test("ALERT_CONDITION_METRICS/ALERT_CONDITION_OPERATORS are the documented enums", () => {
+  assert.deepEqual(
+    [...ALERT_CONDITION_METRICS].sort(),
+    ["neuron_immunity_countdown_blocks", "subnet_alpha_price_rank"].sort(),
+  );
+  assert.deepEqual(
+    [...ALERT_CONDITION_OPERATORS].sort(),
+    ["eq", "gt", "gte", "lt", "lte"].sort(),
+  );
 });
 
 test("validateAlertTriggerInput: rejects a non-object body", () => {
@@ -475,6 +585,198 @@ test("triggerMatchesEvent: ALL present conditions must match (AND, not OR)", () 
   );
 });
 
+// --- triggerMatchesEvent: condition predicate (#6746/#6747) -----------------
+
+function snapshot({
+  priceRank = new Map(),
+  immunityCountdown = new Map(),
+} = {}) {
+  return {
+    subnetAlphaPriceRank: priceRank,
+    neuronImmunityCountdownBlocks: immunityCountdown,
+  };
+}
+
+test("triggerMatchesEvent: a subnet_alpha_price_rank condition matches against the snapshot", () => {
+  const trigger = baseTrigger({
+    netuid: 7,
+    condition: {
+      metric: "subnet_alpha_price_rank",
+      operator: "gt",
+      threshold: 100,
+    },
+  });
+  const withinRange = snapshot({ priceRank: new Map([[7, 120]]) });
+  const outOfRange = snapshot({ priceRank: new Map([[7, 50]]) });
+  assert.equal(
+    triggerMatchesEvent(
+      trigger,
+      { table: "account_events", netuid: 7 },
+      withinRange,
+    ),
+    true,
+  );
+  assert.equal(
+    triggerMatchesEvent(
+      trigger,
+      { table: "account_events", netuid: 7 },
+      outOfRange,
+    ),
+    false,
+  );
+});
+
+test("triggerMatchesEvent: a neuron_immunity_countdown_blocks condition is keyed by netuid+hotkey", () => {
+  const trigger = baseTrigger({
+    condition: {
+      metric: "neuron_immunity_countdown_blocks",
+      operator: "lte",
+      threshold: 1000,
+    },
+  });
+  const snap = snapshot({
+    immunityCountdown: new Map([
+      ["7:5Fhot", 500],
+      ["7:5Fother", 5000],
+    ]),
+  });
+  assert.equal(
+    triggerMatchesEvent(
+      trigger,
+      { table: "account_events", netuid: 7, hotkey: "5Fhot" },
+      snap,
+    ),
+    true,
+  );
+  assert.equal(
+    triggerMatchesEvent(
+      trigger,
+      { table: "account_events", netuid: 7, hotkey: "5Fother" },
+      snap,
+    ),
+    false,
+  );
+});
+
+test("triggerMatchesEvent: a condition never matches without a metricSnapshot (fails closed)", () => {
+  const trigger = baseTrigger({
+    condition: {
+      metric: "subnet_alpha_price_rank",
+      operator: "gte",
+      threshold: 0,
+    },
+  });
+  assert.equal(
+    triggerMatchesEvent(trigger, { table: "account_events", netuid: 7 }),
+    false,
+  );
+  assert.equal(
+    triggerMatchesEvent(trigger, { table: "account_events", netuid: 7 }, null),
+    false,
+  );
+});
+
+test("triggerMatchesEvent: a condition never matches when the snapshot has no entry for this key", () => {
+  const trigger = baseTrigger({
+    netuid: 7,
+    condition: {
+      metric: "subnet_alpha_price_rank",
+      operator: "gte",
+      threshold: 0,
+    },
+  });
+  const emptySnapshot = snapshot();
+  assert.equal(
+    triggerMatchesEvent(
+      trigger,
+      { table: "account_events", netuid: 7 },
+      emptySnapshot,
+    ),
+    false,
+  );
+});
+
+test("triggerMatchesEvent: neuron_immunity_countdown_blocks never matches when the snapshot has no entry for this neuron", () => {
+  const trigger = baseTrigger({
+    condition: {
+      metric: "neuron_immunity_countdown_blocks",
+      operator: "gte",
+      threshold: 0,
+    },
+  });
+  // A snapshot present but with no entry for this specific netuid:hotkey key
+  // (e.g. the neuron isn't currently in its immunity window at all).
+  const snap = snapshot({ immunityCountdown: new Map([["1:5Fother", 100]]) });
+  assert.equal(
+    triggerMatchesEvent(
+      trigger,
+      { table: "account_events", netuid: 7, hotkey: "5Fhot" },
+      snap,
+    ),
+    false,
+  );
+});
+
+test("triggerMatchesEvent: a condition is ANDed with fixed-field checks, not a substitute for them", () => {
+  const trigger = baseTrigger({
+    netuid: 7,
+    eventKind: "StakeAdded",
+    condition: {
+      metric: "subnet_alpha_price_rank",
+      operator: "eq",
+      threshold: 1,
+    },
+  });
+  const matchingSnapshot = snapshot({ priceRank: new Map([[7, 1]]) });
+  // Fixed fields match, condition matches -> true.
+  assert.equal(
+    triggerMatchesEvent(
+      trigger,
+      { table: "account_events", netuid: 7, event_kind: "StakeAdded" },
+      matchingSnapshot,
+    ),
+    true,
+  );
+  // Fixed fields DON'T match (wrong event_kind), condition would match -> still false.
+  assert.equal(
+    triggerMatchesEvent(
+      trigger,
+      { table: "account_events", netuid: 7, event_kind: "Transfer" },
+      matchingSnapshot,
+    ),
+    false,
+  );
+});
+
+test("triggerMatchesEvent: every operator compares the metric value correctly", () => {
+  const cases = [
+    ["lt", 5, 10, true],
+    ["lt", 10, 10, false],
+    ["lte", 10, 10, true],
+    ["gt", 15, 10, true],
+    ["gt", 10, 10, false],
+    ["gte", 10, 10, true],
+    ["eq", 10, 10, true],
+    ["eq", 9, 10, false],
+  ];
+  for (const [operator, rank, threshold, expected] of cases) {
+    const trigger = baseTrigger({
+      netuid: 7,
+      condition: { metric: "subnet_alpha_price_rank", operator, threshold },
+    });
+    const snap = snapshot({ priceRank: new Map([[7, rank]]) });
+    assert.equal(
+      triggerMatchesEvent(
+        trigger,
+        { table: "account_events", netuid: 7 },
+        snap,
+      ),
+      expected,
+      `operator=${operator} rank=${rank} threshold=${threshold}`,
+    );
+  }
+});
+
 test("triggerMatchesEvent: a null/undefined payload never matches", () => {
   assert.equal(triggerMatchesEvent(baseTrigger({ netuid: 1 }), null), false);
   assert.equal(
@@ -542,6 +844,22 @@ test("ownerAlertTriggerView: a minimal record (every optional field absent) fall
   assert.equal(view.last_matched_at, null);
   assert.equal(view.match_count, 0);
   assert.equal(view.active, true); // `active !== false` defaults true when absent
+  assert.equal(view.condition, null);
+});
+
+test("ownerAlertTriggerView: echoes a present condition verbatim", () => {
+  const condition = {
+    metric: "subnet_alpha_price_rank",
+    operator: "gt",
+    threshold: 100,
+  };
+  const view = ownerAlertTriggerView({
+    id: 1,
+    channel: "email",
+    destination: "a@b.com",
+    condition,
+  });
+  assert.deepEqual(view.condition, condition);
 });
 
 test("ownerAlertTriggerView: active:false is preserved, not defaulted away", () => {
@@ -578,6 +896,7 @@ test("evaluatorAlertTriggerView: reshapes snake_case columns into triggerMatches
   assert.deepEqual(view.tableFilter, ["account_events"]);
   assert.equal(view.eventKind, "Transfer");
   assert.equal(view.minAmountTao, 10);
+  assert.equal(view.condition, null);
   // Round-trips straight into triggerMatchesEvent without reshaping again.
   assert.equal(
     triggerMatchesEvent(view, {
@@ -587,6 +906,33 @@ test("evaluatorAlertTriggerView: reshapes snake_case columns into triggerMatches
       hotkey: "5F...",
       amount_tao: 10,
     }),
+    true,
+  );
+});
+
+test("evaluatorAlertTriggerView: reshapes a present condition into triggerMatchesEvent's shape", () => {
+  const condition = {
+    metric: "neuron_immunity_countdown_blocks",
+    operator: "lte",
+    threshold: 500,
+  };
+  const view = evaluatorAlertTriggerView({
+    id: 7,
+    channel: "discord",
+    destination: "https://discord.com/api/webhooks/1/t",
+    condition,
+  });
+  assert.deepEqual(view.condition, condition);
+  const snap = {
+    subnetAlphaPriceRank: new Map(),
+    neuronImmunityCountdownBlocks: new Map([["7:5Fhot", 100]]),
+  };
+  assert.equal(
+    triggerMatchesEvent(
+      view,
+      { table: "account_events", netuid: 7, hotkey: "5Fhot" },
+      snap,
+    ),
     true,
   );
 });

--- a/tests/alerter-hub.test.mjs
+++ b/tests/alerter-hub.test.mjs
@@ -373,6 +373,186 @@ test("refreshTriggers: fetches the internal active-list route with the correct U
   assert.notEqual(hub.triggersLoadedAt, 0);
 });
 
+// --- refreshTriggers: metric-snapshot refresh (#6746/#6747) -----------------
+
+test("refreshTriggers: never fetches the metric snapshot when no active trigger has a condition", async () => {
+  const calledUrls = [];
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async (url) => {
+        calledUrls.push(String(url));
+        return new Response(
+          JSON.stringify({ triggers: [triggerRow(), triggerRow({ id: "2" })] }),
+          { status: 200 },
+        );
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  await hub.refreshTriggers();
+  assert.equal(calledUrls.length, 1);
+  assert.ok(calledUrls[0].includes("alert-triggers-active"));
+});
+
+test("refreshTriggers: fetches the dereg-risk snapshot route when an active trigger has a condition, and populates the snapshot", async () => {
+  const calledUrls = [];
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async (url) => {
+        const s = String(url);
+        calledUrls.push(s);
+        if (s.includes("alert-triggers-active")) {
+          return new Response(
+            JSON.stringify({
+              triggers: [
+                triggerRow({
+                  condition: {
+                    metric: "subnet_alpha_price_rank",
+                    operator: "gt",
+                    threshold: 100,
+                  },
+                }),
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            current_block: 1000,
+            subnets: [{ netuid: 7, alpha_price_tao: 1 }],
+            immune_neurons: [
+              { netuid: 7, hotkey: "5Fhot", immunity_expires_at_block: 1500 },
+            ],
+          }),
+          { status: 200 },
+        );
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  await hub.refreshTriggers();
+  assert.equal(calledUrls.length, 2);
+  assert.ok(
+    calledUrls.some((u) => u.includes("alert-triggers-dereg-risk-snapshot")),
+  );
+  assert.equal(hub.metricSnapshot.subnetAlphaPriceRank.get(7), 1);
+  assert.equal(
+    hub.metricSnapshot.neuronImmunityCountdownBlocks.get("7:5Fhot"),
+    500,
+  );
+});
+
+test("refreshTriggers: the metric-snapshot fetch carries the internal token header and a bounded AbortSignal", async () => {
+  let receivedToken;
+  let receivedSignal;
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async (url, init) => {
+        const s = String(url);
+        if (s.includes("alert-triggers-active")) {
+          return new Response(
+            JSON.stringify({
+              triggers: [
+                triggerRow({
+                  condition: {
+                    metric: "subnet_alpha_price_rank",
+                    operator: "gt",
+                    threshold: 0,
+                  },
+                }),
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        receivedToken = init.headers["x-alert-triggers-internal-token"];
+        receivedSignal = init.signal;
+        return new Response(
+          JSON.stringify({ current_block: 1, subnets: [], immune_neurons: [] }),
+          { status: 200 },
+        );
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  await hub.refreshTriggers();
+  assert.equal(receivedToken, INTERNAL_TOKEN);
+  assert.ok(receivedSignal instanceof AbortSignal);
+});
+
+test("refreshTriggers: a failed metric-snapshot fetch keeps the stale/empty snapshot, never throws", async () => {
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async (url) => {
+        const s = String(url);
+        if (s.includes("alert-triggers-active")) {
+          return new Response(
+            JSON.stringify({
+              triggers: [
+                triggerRow({
+                  condition: {
+                    metric: "subnet_alpha_price_rank",
+                    operator: "gt",
+                    threshold: 0,
+                  },
+                }),
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        throw new Error("network down");
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  await assert.doesNotReject(() => hub.refreshTriggers());
+  assert.equal(hub.metricSnapshot.subnetAlphaPriceRank.size, 0);
+  assert.equal(hub.metricSnapshot.neuronImmunityCountdownBlocks.size, 0);
+});
+
+test("refreshTriggers: a non-ok metric-snapshot response keeps the stale/empty snapshot", async () => {
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async (url) => {
+        const s = String(url);
+        if (s.includes("alert-triggers-active")) {
+          return new Response(
+            JSON.stringify({
+              triggers: [
+                triggerRow({
+                  condition: {
+                    metric: "subnet_alpha_price_rank",
+                    operator: "gt",
+                    threshold: 0,
+                  },
+                }),
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response("", { status: 500 });
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+  );
+  await hub.refreshTriggers();
+  assert.equal(hub.metricSnapshot.subnetAlphaPriceRank.size, 0);
+});
+
+test("refreshMetricSnapshot: a no-op when DATA_API/token is unbound, called directly (own defensive guard, independent of refreshTriggers' own check)", async () => {
+  const hub = new AlerterHub({}, {});
+  await assert.doesNotReject(() => hub.refreshMetricSnapshot());
+  assert.equal(hub.metricSnapshot.subnetAlphaPriceRank.size, 0);
+});
+
 test("refreshTriggers: the DATA_API fetch carries a bounded AbortSignal so a slow Postgres query can't stall ChainFirehoseHub's own broadcast()-wide wait", async () => {
   let receivedSignal;
   const hub = new AlerterHub(
@@ -580,6 +760,74 @@ test("matchingTriggers: filters the cache via triggerMatchesEvent", () => {
     matches.map((t) => t.id),
     ["1"],
   );
+});
+
+test("matchingTriggers: a condition trigger matches against the hub's own cached metricSnapshot", () => {
+  const hub = new AlerterHub({}, {});
+  hub.triggers = [
+    triggerRow({
+      id: "1",
+      netuid: 7,
+      condition: {
+        metric: "subnet_alpha_price_rank",
+        operator: "lte",
+        threshold: 5,
+      },
+    }),
+  ];
+  hub.metricSnapshot = {
+    subnetAlphaPriceRank: new Map([[7, 3]]),
+    neuronImmunityCountdownBlocks: new Map(),
+  };
+  const matches = hub.matchingTriggers({ table: "account_events", netuid: 7 });
+  assert.deepEqual(
+    matches.map((t) => t.id),
+    ["1"],
+  );
+});
+
+test("evaluate: an end-to-end condition trigger delivers when refreshTriggers populates a matching metricSnapshot", async () => {
+  const deliver = vi.fn().mockResolvedValue(true);
+  const hub = new AlerterHub(
+    {},
+    {
+      DATA_API: fakeDataApi(async (url) => {
+        const s = String(url);
+        if (s.includes("alert-triggers-active")) {
+          return new Response(
+            JSON.stringify({
+              triggers: [
+                triggerRow({
+                  id: "1",
+                  netuid: 7,
+                  condition: {
+                    metric: "subnet_alpha_price_rank",
+                    operator: "eq",
+                    threshold: 1,
+                  },
+                }),
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            current_block: 1,
+            subnets: [{ netuid: 7, alpha_price_tao: 1 }],
+            immune_neurons: [],
+          }),
+          { status: 200 },
+        );
+      }),
+      ALERT_TRIGGERS_INTERNAL_TOKEN: INTERNAL_TOKEN,
+    },
+    { deliver },
+  );
+  const result = await hub.evaluate({ table: "account_events", netuid: 7 });
+  assert.equal(result.matched, 1);
+  assert.equal(result.delivered, 1);
+  assert.equal(deliver.mock.calls.length, 1);
 });
 
 test("evaluate: returns {matched:0} and never calls deliver when nothing matches", async () => {

--- a/tests/dereg-risk.test.mjs
+++ b/tests/dereg-risk.test.mjs
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  buildDeregRiskSnapshot,
+  neuronImmunityCountdownBlocks,
+  subnetAlphaPriceRank,
+} from "../src/dereg-risk.mjs";
+
+describe("subnetAlphaPriceRank", () => {
+  test("ranks subnets by alpha_price_tao descending, 1 = highest price", () => {
+    const rank = subnetAlphaPriceRank([
+      { netuid: 1, alpha_price_tao: 0.5 },
+      { netuid: 2, alpha_price_tao: 2.0 },
+      { netuid: 3, alpha_price_tao: 1.0 },
+    ]);
+    assert.equal(rank.get(2), 1);
+    assert.equal(rank.get(3), 2);
+    assert.equal(rank.get(1), 3);
+  });
+
+  test("excludes a row with a missing or non-finite alpha_price_tao entirely", () => {
+    const rank = subnetAlphaPriceRank([
+      { netuid: 1, alpha_price_tao: 1 },
+      { netuid: 2, alpha_price_tao: null },
+      { netuid: 3, alpha_price_tao: "not-a-number" },
+      { netuid: 4 },
+    ]);
+    assert.equal(rank.size, 1);
+    assert.equal(rank.get(1), 1);
+    assert.equal(rank.has(2), false);
+    assert.equal(rank.has(3), false);
+    assert.equal(rank.has(4), false);
+  });
+
+  test("excludes a row with a non-integer netuid", () => {
+    const rank = subnetAlphaPriceRank([
+      { netuid: "not-a-number", alpha_price_tao: 1 },
+    ]);
+    assert.equal(rank.size, 0);
+  });
+
+  test("non-array / empty input never throws", () => {
+    assert.equal(subnetAlphaPriceRank([]).size, 0);
+    assert.equal(subnetAlphaPriceRank(null).size, 0);
+    assert.equal(subnetAlphaPriceRank(undefined).size, 0);
+  });
+
+  test("a tie keeps a stable order (Array#sort is spec-stable)", () => {
+    const rank = subnetAlphaPriceRank([
+      { netuid: 1, alpha_price_tao: 1 },
+      { netuid: 2, alpha_price_tao: 1 },
+    ]);
+    assert.equal(rank.get(1), 1);
+    assert.equal(rank.get(2), 2);
+  });
+});
+
+describe("neuronImmunityCountdownBlocks", () => {
+  test("computes the countdown for a neuron still within its immunity window", () => {
+    const countdown = neuronImmunityCountdownBlocks(
+      [{ netuid: 7, hotkey: "5Fhot", immunity_expires_at_block: 1500 }],
+      1000,
+    );
+    assert.equal(countdown.get("7:5Fhot"), 500);
+  });
+
+  test("keys by netuid:hotkey, distinguishing the same hotkey across subnets", () => {
+    const countdown = neuronImmunityCountdownBlocks(
+      [
+        { netuid: 7, hotkey: "5Fhot", immunity_expires_at_block: 1500 },
+        { netuid: 8, hotkey: "5Fhot", immunity_expires_at_block: 2000 },
+      ],
+      1000,
+    );
+    assert.equal(countdown.get("7:5Fhot"), 500);
+    assert.equal(countdown.get("8:5Fhot"), 1000);
+  });
+
+  test("excludes a neuron with no immunity_expires_at_block (not currently in immunity)", () => {
+    const countdown = neuronImmunityCountdownBlocks(
+      [{ netuid: 7, hotkey: "5Fhot" }],
+      1000,
+    );
+    assert.equal(countdown.size, 0);
+  });
+
+  test("excludes a neuron whose countdown has already reached zero or gone negative", () => {
+    const countdown = neuronImmunityCountdownBlocks(
+      [
+        { netuid: 7, hotkey: "5Fexpired", immunity_expires_at_block: 1000 },
+        { netuid: 7, hotkey: "5Fpast", immunity_expires_at_block: 900 },
+      ],
+      1000,
+    );
+    assert.equal(countdown.size, 0);
+  });
+
+  test("excludes a row missing netuid or hotkey", () => {
+    const countdown = neuronImmunityCountdownBlocks(
+      [
+        { hotkey: "5Fhot", immunity_expires_at_block: 1500 },
+        { netuid: 7, immunity_expires_at_block: 1500 },
+      ],
+      1000,
+    );
+    assert.equal(countdown.size, 0);
+  });
+
+  test("returns an empty map for a non-finite currentBlock", () => {
+    const countdown = neuronImmunityCountdownBlocks(
+      [{ netuid: 7, hotkey: "5Fhot", immunity_expires_at_block: 1500 }],
+      NaN,
+    );
+    assert.equal(countdown.size, 0);
+  });
+
+  test("non-array / empty rows never throws", () => {
+    assert.equal(neuronImmunityCountdownBlocks([], 1000).size, 0);
+    assert.equal(neuronImmunityCountdownBlocks(null, 1000).size, 0);
+    assert.equal(neuronImmunityCountdownBlocks(undefined, 1000).size, 0);
+  });
+});
+
+describe("buildDeregRiskSnapshot", () => {
+  test("composes both metrics into the shape triggerMatchesEvent's metricSnapshot expects", () => {
+    const snapshot = buildDeregRiskSnapshot({
+      economicsRows: [{ netuid: 7, alpha_price_tao: 1 }],
+      neuronRows: [
+        { netuid: 7, hotkey: "5Fhot", immunity_expires_at_block: 1500 },
+      ],
+      currentBlock: 1000,
+    });
+    assert.equal(snapshot.subnetAlphaPriceRank.get(7), 1);
+    assert.equal(snapshot.neuronImmunityCountdownBlocks.get("7:5Fhot"), 500);
+  });
+
+  test("no args produces two empty maps, never throws", () => {
+    const snapshot = buildDeregRiskSnapshot();
+    assert.equal(snapshot.subnetAlphaPriceRank.size, 0);
+    assert.equal(snapshot.neuronImmunityCountdownBlocks.size, 0);
+  });
+});

--- a/workers/alerter-hub.mjs
+++ b/workers/alerter-hub.mjs
@@ -21,6 +21,7 @@
 // triggers matched AND whether a match should actually be delivered right
 // now (burst rate-limiting), never how each channel's request is shaped.
 import { triggerMatchesEvent } from "../src/alert-triggers.mjs";
+import { buildDeregRiskSnapshot } from "../src/dereg-risk.mjs";
 import {
   mapBounded,
   resolvedWebhookUrlStatus,
@@ -33,6 +34,18 @@ import {
   buildWebhookDeliveryRequest,
   isDeliveryRateLimited,
 } from "../src/alert-delivery.mjs";
+
+// #6746/#6747: the empty snapshot every AlerterHub starts with and falls
+// back to whenever a metric refresh is skipped/fails -- both of
+// triggerMatchesEvent's own metric lookups already treat a missing map
+// entry as "does not match" (fails closed), so an empty snapshot is a
+// genuinely safe default, not a placeholder that needs special-casing.
+function emptyMetricSnapshot() {
+  return {
+    subnetAlphaPriceRank: new Map(),
+    neuronImmunityCountdownBlocks: new Map(),
+  };
+}
 
 export const ALERTER_HUB_TRIGGER_CACHE_TTL_MS = 5 * 60 * 1000;
 
@@ -173,6 +186,13 @@ export class AlerterHub {
     this.deliver = deliver;
     this.triggers = [];
     this.triggersLoadedAt = 0;
+    // #6746/#6747: the cached snapshot condition-type triggers are matched
+    // against -- refreshed ALONGSIDE the trigger list (same TTL/timeout
+    // budget), never fetched per-event. Starts empty (fails closed: a
+    // condition trigger simply never matches until the first successful
+    // refresh populates real data), matching triggersLoadedAt's own
+    // cold-start convention.
+    this.metricSnapshot = emptyMetricSnapshot();
     // Coalesces concurrent evaluate() calls that all find the cache stale
     // into ONE refresh request rather than one per call -- broadcast()
     // fires one /evaluate POST per chain event, and events can arrive
@@ -247,6 +267,45 @@ export class AlerterHub {
       // Best-effort refresh -- keep serving the stale cache rather than
       // throwing out of evaluate().
     }
+    // #6746/#6747: only fetch the metric snapshot when at least one ACTIVE
+    // trigger actually has a condition -- the overwhelming common case
+    // today is zero (this is a brand-new capability), so this keeps every
+    // existing/fixed-field-only deployment's refresh cycle exactly as cheap
+    // as it already was: one Postgres round trip, not two, unless a
+    // predicate trigger genuinely exists to justify the second one.
+    if (this.triggers.some((trigger) => trigger.condition)) {
+      await this.refreshMetricSnapshot();
+    }
+  }
+
+  async refreshMetricSnapshot() {
+    if (!this.env.DATA_API || !this.env.ALERT_TRIGGERS_INTERNAL_TOKEN) {
+      return;
+    }
+    try {
+      const upstream = await this.env.DATA_API.fetch(
+        "https://data-api.internal/api/v1/internal/alert-triggers-dereg-risk-snapshot",
+        {
+          headers: {
+            "x-alert-triggers-internal-token":
+              this.env.ALERT_TRIGGERS_INTERNAL_TOKEN,
+          },
+          signal: AbortSignal.timeout(ALERT_TRIGGER_REFRESH_TIMEOUT_MS),
+        },
+      );
+      if (!upstream.ok) return;
+      const body = await upstream.json();
+      this.metricSnapshot = buildDeregRiskSnapshot({
+        economicsRows: body?.subnets,
+        neuronRows: body?.immune_neurons,
+        currentBlock: body?.current_block,
+      });
+    } catch {
+      // Best-effort -- keep serving the stale (or empty) snapshot rather
+      // than throwing out of evaluate(); a condition trigger just keeps
+      // failing closed against stale data until the next successful
+      // refresh, never against a thrown error.
+    }
   }
 
   // Pure decision given the CURRENT cache -- exported behavior is really
@@ -254,7 +313,7 @@ export class AlerterHub {
   // this just applies it across every cached trigger.
   matchingTriggers(payload) {
     return this.triggers.filter((trigger) =>
-      triggerMatchesEvent(trigger, payload),
+      triggerMatchesEvent(trigger, payload, this.metricSnapshot),
     );
   }
 

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -3330,10 +3330,11 @@ async function handleAlertTriggerCreate(request, env) {
     const v = validated.value;
     const [row] = await sql`
       INSERT INTO chain_alert_triggers
-        (owner_token, name, table_filter, netuid, event_kind, account, min_amount_tao, channel, destination, created_at, updated_at)
+        (owner_token, name, table_filter, netuid, event_kind, account, min_amount_tao, condition, channel, destination, created_at, updated_at)
       VALUES (
         ${ownerToken}, ${v.name}, ${v.tableFilter}, ${v.netuid}, ${v.eventKind},
-        ${v.account}, ${v.minAmountTao}, ${v.channel}, ${v.destination}, ${now}, ${now}
+        ${v.account}, ${v.minAmountTao}, ${v.condition ? sql.json(v.condition) : null},
+        ${v.channel}, ${v.destination}, ${now}, ${now}
       )
       RETURNING *`;
     return writeJson(
@@ -3422,6 +3423,7 @@ async function handleAlertTriggerUpdate(request, env, id) {
           existing.min_amount_tao === null
             ? null
             : Number(existing.min_amount_tao),
+        condition: existing.condition,
         channel: existing.channel,
         destination: existing.destination,
       }),
@@ -3442,6 +3444,7 @@ async function handleAlertTriggerUpdate(request, env, id) {
         event_kind = ${v.eventKind},
         account = ${v.account},
         min_amount_tao = ${v.minAmountTao},
+        condition = ${v.condition ? sql.json(v.condition) : null},
         channel = ${v.channel},
         destination = ${v.destination},
         updated_at = ${now}
@@ -3557,6 +3560,87 @@ async function handleAlertTriggersMatchedWriteback(request, env) {
       [now, ...ids],
     );
     return writeJson({ updated: updated.length });
+  });
+}
+
+// Internal-only: the #6747 evaluator's METRIC cache-refresh scan -- the raw
+// rows AlerterHub.refreshTriggers() feeds into src/dereg-risk.mjs's
+// buildDeregRiskSnapshot to build the in-memory Maps triggerMatchesEvent's
+// condition check reads from. Gated the SAME way as the active-list/
+// writeback routes above (same ALERT_TRIGGERS_INTERNAL_TOKEN secret, a
+// different capability from the create/owner tokens). Bounded and
+// network-wide in ONE call (not per-subnet) so the evaluator's own refresh
+// stays one round trip, same shape as handleAlertTriggersActiveList.
+//
+// `immune_neurons` is deliberately narrow (only currently-immune rows, via
+// the is_immunity_period index-friendly filter) rather than every neuron on
+// every subnet -- a full network-wide neuron dump would be a genuinely large
+// payload; only-currently-immune neurons is a small, bounded set. `subnets`
+// reads subnet_snapshots' latest row per netuid (DISTINCT ON, the same
+// idiom this file already uses for hyperparams_hash/identity_hash) -- a
+// DAILY cadence table, so alpha_price_tao here can lag up to ~24h behind
+// the live economics tier; acceptable for this protocol-health signal
+// (directional rank), not something a trading decision should lean on.
+async function handleDeregRiskSnapshot(request, env) {
+  const configured = env.ALERT_TRIGGERS_INTERNAL_TOKEN;
+  if (!configured) {
+    return writeJson(
+      {
+        error:
+          "the alert-triggers dereg-risk snapshot is not provisioned on this deployment",
+      },
+      503,
+    );
+  }
+  const provided =
+    request.headers.get(ALERT_TRIGGERS_INTERNAL_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, configured)) {
+    return writeJson(
+      {
+        error: `provide a valid ${ALERT_TRIGGERS_INTERNAL_TOKEN_HEADER} header`,
+      },
+      401,
+    );
+  }
+  return withAlertTriggersSql(env, async (sql) => {
+    const [[block], hyperparamsRows, immuneNeurons, subnetRows] =
+      await Promise.all([
+        sql`SELECT MAX(block_number) AS block_number FROM blocks`,
+        sql`SELECT netuid, immunity_period FROM subnet_hyperparams`,
+        sql`SELECT netuid, hotkey, registered_at_block FROM neurons
+            WHERE is_immunity_period = TRUE AND hotkey IS NOT NULL
+              AND registered_at_block IS NOT NULL`,
+        sql`SELECT DISTINCT ON (netuid) netuid, alpha_price_tao
+            FROM subnet_snapshots
+            ORDER BY netuid, snapshot_date DESC`,
+      ]);
+    const immunityPeriodByNetuid = new Map(
+      hyperparamsRows
+        .filter((row) => Number.isInteger(row.immunity_period))
+        .map((row) => [row.netuid, row.immunity_period]),
+    );
+    const immuneNeuronsWithExpiry = immuneNeurons
+      .map((row) => {
+        const immunityPeriod = immunityPeriodByNetuid.get(row.netuid);
+        if (!Number.isInteger(immunityPeriod)) return null;
+        return {
+          netuid: row.netuid,
+          hotkey: row.hotkey,
+          immunity_expires_at_block: row.registered_at_block + immunityPeriod,
+        };
+      })
+      .filter(Boolean);
+    return writeJson({
+      current_block: Number.isInteger(block?.block_number)
+        ? block.block_number
+        : null,
+      subnets: subnetRows.map((row) => ({
+        netuid: row.netuid,
+        alpha_price_tao:
+          row.alpha_price_tao === null ? null : Number(row.alpha_price_tao),
+      })),
+      immune_neurons: immuneNeuronsWithExpiry,
+    });
   });
 }
 
@@ -3695,6 +3779,14 @@ export default {
       url.pathname === "/api/v1/internal/alert-triggers/matched"
     ) {
       return handleAlertTriggersMatchedWriteback(request, env);
+    }
+    // #6747: the predicate-condition evaluator's own metric-snapshot refresh
+    // -- see handleDeregRiskSnapshot's own header comment.
+    if (
+      request.method === "GET" &&
+      url.pathname === "/api/v1/internal/alert-triggers-dereg-risk-snapshot"
+    ) {
+      return handleDeregRiskSnapshot(request, env);
     }
     if (request.method !== "GET")
       return json({ error: "method not allowed" }, 405);


### PR DESCRIPTION
## Summary

Extends `chain_alert_triggers` beyond fixed-field equality matching with a `condition: {metric, operator, threshold}` shape against a named derived metric — the extension SubnetAIQ's deregistration-risk monitor pioneers (EMA-price-rank-vs-cutoff + immunity-period countdown), stripped of its trading "AVOID/CAUTION" framing into a protocol-health signal buildable entirely from data metagraphed already captures. A condition narrows whichever event already passed the fixed-field checks (`netuid`/`event_kind`/`account`/`min_amount_tao`) — it carries no separate scope of its own.

**The core risk this PR is about avoiding:** `AlerterHub.evaluate()` runs on the *same synchronous path every single firehose event blocks on* (`ChainFirehoseHub.broadcast()`'s `ALERTER_HUB` ping, shared with every other consumer — SSE/WS/GraphQL/MCP). A naive per-event metric fetch would have added real I/O latency to that shared hot path. Instead:

- The metric snapshot is refreshed **alongside the trigger list**, on the exact same 5-minute TTL and `ALERT_TRIGGER_REFRESH_TIMEOUT_MS` bound the trigger-list refresh already uses — never fetched per-event.
- It's **only fetched at all when at least one active trigger actually has a condition** — every existing fixed-field-only deployment (the entire install base today) sees **zero added latency, zero added Postgres round trips**, since this is a brand-new capability with no existing predicate triggers.
- `triggerMatchesEvent`'s fixed-field checks are byte-for-byte unchanged; the condition check is purely in-memory (`Map` lookups against the cached snapshot) and fails closed (no snapshot / no entry for that netuid+hotkey → never matches, never throws).

## What changed

- **`src/alert-triggers.mjs`** (#6746) — `ALERT_CONDITION_METRICS`/`ALERT_CONDITION_OPERATORS` enums, `validateAlertCondition`, and `triggerMatchesEvent`'s new optional `metricSnapshot` parameter.
- **`deploy/postgres/schema.sql`** — adds `condition JSONB` to `chain_alert_triggers` (both the fresh-deploy `CREATE TABLE` and an `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for already-deployed tables).
- **`workers/data-api.mjs`** — wires `condition` through the CREATE/PATCH write path (`sql.json(...)` for the JSONB bind), and adds a new internal-only route `GET /api/v1/internal/alert-triggers-dereg-risk-snapshot` (gated by the same `ALERT_TRIGGERS_INTERNAL_TOKEN` as the existing active-trigger-list scan) that returns the raw rows for both metrics in one bounded round trip: the latest `subnet_snapshots` row per netuid (daily cadence, so `alpha_price_tao` here can lag up to ~24h — fine for a directional protocol-health signal, not something a trading decision should lean on) and only the currently-immune `neurons` rows (a small, bounded set, not a full network-wide neuron dump).
- **`src/dereg-risk.mjs`** (#6748, new) — pure, no-I/O computation of both metrics: `subnetAlphaPriceRank` (rank by `alpha_price_tao` descending) and `neuronImmunityCountdownBlocks` (blocks remaining until a neuron's immunity expires, reusing #6640's `immunity_expires_at_block` convention), composed by `buildDeregRiskSnapshot` into the exact shape `triggerMatchesEvent` reads from.
- **`workers/alerter-hub.mjs`** (#6747) — `refreshTriggers()` conditionally calls a new `refreshMetricSnapshot()`; `matchingTriggers()` passes the cached snapshot through.

## Test plan

- [x] `tests/alert-triggers.test.mjs` — 60 tests (was 51): condition validation, `triggerMatchesEvent` predicate matching/fail-closed/AND-with-fixed-fields, every operator, view round-tripping
- [x] `tests/alert-triggers-route.test.mjs` — 63 tests (was 52): condition CRUD through create/PATCH, the new internal snapshot route (auth, the immunity_period join, empty-blocks-table, query failure)
- [x] `tests/alerter-hub.test.mjs` — 65 tests (was 57): conditional metric-snapshot fetch (skipped when no predicate trigger exists, fetched when one does), auth header + bounded AbortSignal, graceful degradation on fetch failure/non-200, an end-to-end `evaluate()` test proving a condition trigger actually delivers
- [x] `tests/dereg-risk.test.mjs` (new) — 14 tests: both pure metric functions, including a real bug caught and fixed during testing (`Number(null) === 0` was silently ranking a genuinely-missing `alpha_price_tao` as a real zero price)
- [x] Full backend suite (`npx vitest run`) — 9431/9431 passing (1 unrelated pre-existing test — `artifacts.test.mjs`'s build-determinism check — timed out under full-suite resource contention; reproduced in isolation and confirmed it passes cleanly in 5.3s, not a regression from this change)
- [x] `npm run lint` / `npm run format:check` — clean
- [x] Coverage scoped to every changed/new file (`src/alert-triggers.mjs`, `src/dereg-risk.mjs`, `workers/alerter-hub.mjs`, and the new route in `workers/data-api.mjs`) — 100% statement + branch coverage (codecov/patch gate)
- [x] No schema/OpenAPI contract touched — `/api/v1/alerts/triggers` and its new internal route are outside the formal `API_ROUTES`/`PUBLIC_ARTIFACTS` contract (same as webhooks), confirmed via `npm run validate:client-sdk-sync` reporting no contract files changed

Closes #6745
Closes #6746
Closes #6747
Closes #6748