### PR TITLE
feat(ui): align Settings page visual weight with utility siblings

### DIFF
--- a/apps/ui/src/components/metagraphed/settings-summary-strip.test.ts
+++ b/apps/ui/src/components/metagraphed/settings-summary-strip.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { SettingsSummaryStrip } from "./settings-summary-strip";
+import { buildSettingsSummaryTiles } from "@/lib/metagraphed/settings-summary";
+
+describe("SettingsSummaryStrip", () => {
+  it("exports a renderable component", () => {
+    expect(typeof SettingsSummaryStrip).toBe("function");
+  });
+
+  it("defaults to the three self-service action tiles", () => {
+    const tiles = buildSettingsSummaryTiles();
+    expect(tiles.map((t) => t.id)).toEqual(["create", "lookup", "delete"]);
+  });
+});

--- a/apps/ui/src/components/metagraphed/settings-summary-strip.tsx
+++ b/apps/ui/src/components/metagraphed/settings-summary-strip.tsx
@@ -1,0 +1,49 @@
+import { Webhook, Search, Trash2, type LucideIcon } from "lucide-react";
+import { StatTile } from "@jsonbored/ui-kit";
+import {
+  buildSettingsSummaryTiles,
+  type SettingsSummaryAction,
+  type SettingsSummaryTile,
+} from "@/lib/metagraphed/settings-summary";
+
+const ACTION_ICONS: Record<SettingsSummaryAction["id"], LucideIcon> = {
+  create: Webhook,
+  lookup: Search,
+  delete: Trash2,
+};
+
+export interface SettingsSummaryStripProps {
+  /** Optional override for tests/previews — defaults to the live action set. */
+  tiles?: SettingsSummaryTile[];
+}
+
+/**
+ * Light KPI/status strip above the webhook forms (#5346) so Settings opens
+ * with the same visual weight as sibling utility pages (health / status /
+ * endpoints).
+ */
+export function SettingsSummaryStrip({
+  tiles = buildSettingsSummaryTiles(),
+}: SettingsSummaryStripProps) {
+  return (
+    <div
+      className="mb-8 grid grid-cols-1 gap-3 sm:grid-cols-3"
+      data-testid="settings-summary-strip"
+      aria-label="Webhook subscription actions at a glance"
+    >
+      {tiles.map((tile) => {
+        const Icon = ACTION_ICONS[tile.id];
+        return (
+          <StatTile
+            key={tile.id}
+            icon={Icon}
+            eyebrow={tile.eyebrow}
+            value={tile.value}
+            hint={tile.hint}
+            tone={tile.tone}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
+++ b/apps/ui/src/components/metagraphed/webhook-subscription-manager.tsx
@@ -4,6 +4,8 @@ import { apiFetch, ApiError } from "@/lib/metagraphed/client";
 import { classNames } from "@/lib/metagraphed/format";
 import { CopyableCode, SectionHeading } from "@jsonbored/ui-kit";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
+import { SettingsSummaryStrip } from "@/components/metagraphed/settings-summary-strip";
+import { CHANGE_KINDS } from "@/lib/metagraphed/settings-summary";
 import type {
   WebhookDeliveryStatus,
   WebhookSubscriptionCreated,
@@ -14,8 +16,6 @@ import type {
 // Must match src/webhooks.mjs — WEBHOOK_SUBSCRIPTION_TOKEN_HEADER / WEBHOOK_SECRET_HEADER.
 const SUBSCRIPTION_TOKEN_HEADER = "x-metagraph-webhook-subscription-token";
 const SUBSCRIPTION_SECRET_HEADER = "x-metagraph-webhook-secret";
-
-const CHANGE_KINDS = ["subnets", "artifacts"] as const;
 
 const inputCls =
   "w-full rounded border border-border bg-card px-2.5 py-1.5 text-[13px] text-ink placeholder:text-ink-muted focus:outline-none focus:border-ink/30";
@@ -70,6 +70,7 @@ function describeApiError(error: unknown): string {
 export function WebhookSubscriptionManager() {
   return (
     <div className="space-y-8">
+      <SettingsSummaryStrip />
       <CreateSubscriptionSection />
       <LookupSubscriptionSection />
       <DeleteSubscriptionSection />

--- a/apps/ui/src/lib/metagraphed/settings-summary.test.ts
+++ b/apps/ui/src/lib/metagraphed/settings-summary.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHANGE_KINDS,
+  SETTINGS_SUMMARY_ACTIONS,
+  buildSettingsHeroKpis,
+  buildSettingsSummaryTiles,
+} from "./settings-summary";
+
+describe("settings-summary", () => {
+  it("exposes the three self-service webhook actions", () => {
+    expect(SETTINGS_SUMMARY_ACTIONS).toHaveLength(3);
+    expect(SETTINGS_SUMMARY_ACTIONS.map((a) => a.id)).toEqual(["create", "lookup", "delete"]);
+    expect(SETTINGS_SUMMARY_ACTIONS.map((a) => a.method)).toEqual(["POST", "GET", "DELETE"]);
+  });
+
+  it("exposes the change-feed kinds the forms can filter on", () => {
+    expect(CHANGE_KINDS).toEqual(["subnets", "artifacts"]);
+  });
+
+  it("builds PageHero KPIs with action / kind / auth cells, all short numeric values", () => {
+    const kpis = buildSettingsHeroKpis();
+    expect(kpis).toHaveLength(3);
+    expect(kpis[0]).toEqual({
+      label: "Actions",
+      value: "3",
+      hint: "create · look up · delete",
+    });
+    expect(kpis[1]).toEqual({
+      label: "Change kinds",
+      value: "2",
+      hint: "subnets · artifacts",
+    });
+    expect(kpis[2]).toEqual({
+      label: "Auth modes",
+      value: "2",
+      hint: "token + secret",
+    });
+  });
+
+  it("never emits a KPI value containing a slash (would overflow the KPI grid cell — see #5846)", () => {
+    const kpis = buildSettingsHeroKpis();
+    for (const kpi of kpis) {
+      expect(kpi.value).not.toMatch(/\//);
+      expect(kpi.value.length).toBeLessThanOrEqual(8);
+    }
+  });
+
+  it("honors custom action and kind lists when building hero KPIs", () => {
+    const kpis = buildSettingsHeroKpis(
+      [{ id: "create", label: "Create", method: "POST", hint: "token-gated" }],
+      ["subnets"],
+    );
+    expect(kpis[0]).toMatchObject({ value: "1", hint: "create" });
+    expect(kpis[1]).toMatchObject({ value: "1", hint: "subnets" });
+  });
+
+  it("builds StatTile rows with an accent create tile", () => {
+    const tiles = buildSettingsSummaryTiles();
+    expect(tiles).toHaveLength(3);
+    expect(tiles[0]).toEqual({
+      id: "create",
+      eyebrow: "Create",
+      value: "POST",
+      hint: "token-gated",
+      tone: "accent",
+    });
+    expect(tiles[1]).toMatchObject({
+      id: "lookup",
+      eyebrow: "Look up",
+      value: "GET",
+      tone: "default",
+    });
+    expect(tiles[2]).toMatchObject({
+      id: "delete",
+      eyebrow: "Delete",
+      value: "DELETE",
+      tone: "default",
+    });
+  });
+
+  it("marks only the first tile as accent when given a custom action list", () => {
+    const tiles = buildSettingsSummaryTiles([
+      { id: "lookup", label: "Look up", method: "GET", hint: "by id" },
+      { id: "delete", label: "Delete", method: "DELETE", hint: "secret" },
+    ]);
+    expect(tiles[0].tone).toBe("accent");
+    expect(tiles[1].tone).toBe("default");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/settings-summary.ts
+++ b/apps/ui/src/lib/metagraphed/settings-summary.ts
@@ -26,13 +26,13 @@ export const SETTINGS_SUMMARY_ACTIONS = [
     id: "lookup",
     label: "Look up",
     method: "GET",
-    hint: "by subscription id",
+    hint: "by id",
   },
   {
     id: "delete",
     label: "Delete",
     method: "DELETE",
-    hint: "secret-gated",
+    hint: "secret",
   },
 ] as const;
 

--- a/apps/ui/src/lib/metagraphed/settings-summary.ts
+++ b/apps/ui/src/lib/metagraphed/settings-summary.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure view-models for the Settings page summary strip (#5346).
+ *
+ * There is no subscription list API and no account model — the strip reports
+ * the self-service webhook surface (actions / kinds / auth) so `/settings`
+ * opens with the same KPI/StatTile visual weight as sibling utility pages.
+ * KPI values are kept short and numeric on purpose: a prior attempt used the
+ * literal endpoint path ("/webhooks/subscriptions") as a hero KPI value,
+ * which has no whitespace to wrap on and overflowed the KPI grid cell at
+ * every tested viewport — the endpoint path already has a safe home in
+ * ApiSourceFooter, so it isn't duplicated here.
+ */
+
+export const CHANGE_KINDS = ["subnets", "artifacts"] as const;
+
+export type SettingsChangeKind = (typeof CHANGE_KINDS)[number];
+
+export const SETTINGS_SUMMARY_ACTIONS = [
+  {
+    id: "create",
+    label: "Create",
+    method: "POST",
+    hint: "token-gated",
+  },
+  {
+    id: "lookup",
+    label: "Look up",
+    method: "GET",
+    hint: "by subscription id",
+  },
+  {
+    id: "delete",
+    label: "Delete",
+    method: "DELETE",
+    hint: "secret-gated",
+  },
+] as const;
+
+export type SettingsSummaryAction = (typeof SETTINGS_SUMMARY_ACTIONS)[number];
+
+/** Loose input shape so callers/tests can pass custom action lists. */
+export interface SettingsSummaryActionInput {
+  id: SettingsSummaryAction["id"];
+  label: string;
+  method: string;
+  hint: string;
+}
+
+export interface SettingsHeroKpi {
+  label: string;
+  value: string;
+  hint: string;
+}
+
+export interface SettingsSummaryTile {
+  id: SettingsSummaryAction["id"];
+  eyebrow: string;
+  value: string;
+  hint: string;
+  tone: "default" | "accent";
+}
+
+/**
+ * PageHero KPI cells — hairline strip under the hero copy. Every value is a
+ * short count (never a raw URL/path) so it never has to wrap or truncate in
+ * the hero's large KPI type.
+ */
+export function buildSettingsHeroKpis(
+  actions: readonly SettingsSummaryActionInput[] = SETTINGS_SUMMARY_ACTIONS,
+  kinds: readonly string[] = CHANGE_KINDS,
+): SettingsHeroKpi[] {
+  return [
+    {
+      label: "Actions",
+      value: String(actions.length),
+      hint: actions.map((a) => a.label.toLowerCase()).join(" · "),
+    },
+    {
+      label: "Change kinds",
+      value: String(kinds.length),
+      hint: kinds.join(" · "),
+    },
+    {
+      label: "Auth modes",
+      value: "2",
+      hint: "token + secret",
+    },
+  ];
+}
+
+/** Compact StatTile row between the hero and the subscription forms. */
+export function buildSettingsSummaryTiles(
+  actions: readonly SettingsSummaryActionInput[] = SETTINGS_SUMMARY_ACTIONS,
+): SettingsSummaryTile[] {
+  return actions.map((action, index) => ({
+    id: action.id,
+    eyebrow: action.label,
+    value: action.method,
+    hint: action.hint,
+    tone: index === 0 ? "accent" : "default",
+  }));
+}

--- a/apps/ui/src/routes/settings.tsx
+++ b/apps/ui/src/routes/settings.tsx
@@ -3,6 +3,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { PageHero } from "@jsonbored/ui-kit";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { WebhookSubscriptionManager } from "@/components/metagraphed/webhook-subscription-manager";
+import { buildSettingsHeroKpis } from "@/lib/metagraphed/settings-summary";
 
 export const Route = createFileRoute("/settings")({
   head: () => ({
@@ -23,12 +24,16 @@ export const Route = createFileRoute("/settings")({
 });
 
 function SettingsPage() {
+  const kpis = buildSettingsHeroKpis();
   return (
     <AppShell>
       <PageHero
         eyebrow="Developer"
+        live
         title="Developer settings"
         description="Self-service webhook subscription management against the public subscription API. Nothing here is stored server-side beyond the subscription record itself — there is no account model."
+        caption={<>webhooks / v1</>}
+        kpis={kpis}
       />
       <WebhookSubscriptionManager />
       <ApiSourceFooter paths={["/api/v1/webhooks/subscriptions"]} />


### PR DESCRIPTION
`/settings` was just a `PageHero` title dropped straight into three plain HTML forms — no KPIs, no summary strip, nothing tying it to the rest of the utility-page family (`health`, `status`, `endpoints`, `schemas`). This adds the same PageHero KPI strip + StatTile row those pages use, so it reads as part of that navigation family instead of feeling bolted on. The webhook create/lookup/delete forms themselves are untouched.

There's no subscription-list API and no account model here, so instead of inventing a fake "existing subscriptions" count the strip reports the self-service surface itself: 3 actions, 2 change-feed kinds, 2 auth modes in the hero KPIs, and a Create/Look up/Delete StatTile row (with method + auth hint) above the forms.

Someone tried this exact feature before (#5846, closed) and it turns out the reason `ui` CI failed there wasn't flaky — I pulled the actual check-run annotations and it was a real regression: the hero KPI grid used the literal endpoint path `/webhooks/subscriptions` as a KPI *value*. That string has no whitespace to wrap on, so in the KPI's large font it overflowed the grid cell at every single tested viewport (375/768/1024/1280px), tripping the `responsive-overflow` e2e baseline diff on all four. Every other KPI strip in this app (`health`, `schemas`) only ever puts short counts/percentages in the value slot for exactly this reason — and the endpoint path already has a safe home in `ApiSourceFooter`, which this page already renders, so duplicating it in the hero was redundant anyway. I dropped it and kept the KPI values numeric-only (3 / 2 / 2), and added a regression test (`settings-summary.test.ts`) asserting no KPI value ever contains a slash.

While here I also deduped `CHANGE_KINDS`, which used to be defined once in `settings-summary.ts` and copy-pasted again in `webhook-subscription-manager.tsx` — the manager now imports it from the shared module.

Tested: full `apps/ui` unit suite (1226 tests) plus the new `settings-summary`/`settings-summary-strip` tests, `npm run lint`/`format:check`/`typecheck` clean, and — the part that actually matters here — `npx playwright test` (the `responsive-overflow` e2e suite) green across all 4 viewports on `/settings`, confirming the fix actually holds. Also ran a UI-review pass on the screenshots below; it flagged the StatTile hints truncating at 768px tablet width (`by subscription id` / `secret-gated`), so I shortened them to `by id` / `secret` and reconfirmed — the tablet screenshots below are the corrected capture.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop (1280×800) · Light | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/3c69e5ce279c45f5924b3ccc63ce077a20d000a5/runs/jsonbored-metagraphed/run-16/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/3c69e5ce279c45f5924b3ccc63ce077a20d000a5/runs/jsonbored-metagraphed/run-16/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/0860f297f8030e7c8c670f97f9fd07d07e598151/runs/jsonbored-metagraphed/run-16/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/0860f297f8030e7c8c670f97f9fd07d07e598151/runs/jsonbored-metagraphed/run-16/after-desktop-light.png)<br><sub>after</sub> |
| Desktop (1280×800) · Dark | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/8424b9327151fce975fea86b23095838f7abca30/runs/jsonbored-metagraphed/run-16/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/8424b9327151fce975fea86b23095838f7abca30/runs/jsonbored-metagraphed/run-16/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/f7b944d5a141627516e19a2625f33507ecebc015/runs/jsonbored-metagraphed/run-16/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/f7b944d5a141627516e19a2625f33507ecebc015/runs/jsonbored-metagraphed/run-16/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet (768×1024) · Light | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/15ceee38f0afce198596dd0338e90ed4e7741098/runs/jsonbored-metagraphed/run-16/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/15ceee38f0afce198596dd0338e90ed4e7741098/runs/jsonbored-metagraphed/run-16/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/d1e8316ae6eeec4b7f224aa6e6286aa9213604a0/runs/jsonbored-metagraphed/run-16/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/d1e8316ae6eeec4b7f224aa6e6286aa9213604a0/runs/jsonbored-metagraphed/run-16/after-tablet-light.png)<br><sub>after</sub> |
| Tablet (768×1024) · Dark | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/ff353ecd8f620d5630fb8e195ae78d8344865968/runs/jsonbored-metagraphed/run-16/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/ff353ecd8f620d5630fb8e195ae78d8344865968/runs/jsonbored-metagraphed/run-16/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/4937fee6a0a370b5c230eaf7ac5a644cdb50125d/runs/jsonbored-metagraphed/run-16/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/4937fee6a0a370b5c230eaf7ac5a644cdb50125d/runs/jsonbored-metagraphed/run-16/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile (375×812) · Light | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/f3c2bd1d993cc06c82f6147319eba6a48d0bd64f/runs/jsonbored-metagraphed/run-16/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/f3c2bd1d993cc06c82f6147319eba6a48d0bd64f/runs/jsonbored-metagraphed/run-16/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/a2f2ea2cc704bc3ec10e12fc40850e1f2de9f9fb/runs/jsonbored-metagraphed/run-16/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/a2f2ea2cc704bc3ec10e12fc40850e1f2de9f9fb/runs/jsonbored-metagraphed/run-16/after-mobile-light.png)<br><sub>after</sub> |
| Mobile (375×812) · Dark | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/0dfc935ba1d3cdab0a2e75798bad479317762678/runs/jsonbored-metagraphed/run-16/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/0dfc935ba1d3cdab0a2e75798bad479317762678/runs/jsonbored-metagraphed/run-16/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/1d16b5ac31d72ca03e23efa431e3dc3c973accf8/runs/jsonbored-metagraphed/run-16/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/1d16b5ac31d72ca03e23efa431e3dc3c973accf8/runs/jsonbored-metagraphed/run-16/after-mobile-dark.png)<br><sub>after</sub> |

<sub>Superseded tablet captures from before the hint-shortening fix (kept for the record, replaced by the corrected ones above): [after-tablet-light (pre-fix)](https://raw.githubusercontent.com/nghetien/agentfix-assets/e025dcb718a2005e883e4399acb50f0dee6a9f67/runs/jsonbored-metagraphed/run-16/after-tablet-light.png), [after-tablet-dark (pre-fix)](https://raw.githubusercontent.com/nghetien/agentfix-assets/45f5024a44be62a909f330fef0de8b022334cc9c/runs/jsonbored-metagraphed/run-16/after-tablet-dark.png)</sub>

Closes #5346
Closes #5846