### PR TITLE
feat(api): add curated saved-query library (run_saved_query + GET /api/v1/queries/{id})

### DIFF
--- a/schemas/saved-query.schema.json
+++ b/schemas/saved-query.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://metagraph.sh/schemas/saved-query.schema.json",
+  "title": "Metagraphed Saved Query Template",
+  "description": "Maintainer-curated parameterized query template exposed via run_saved_query (MCP) and GET /api/v1/queries/{id} (REST) -- admin-curated only, never user-submitted. Each template's underlying implementation wraps an existing derived-view module (a build*/compose* function already served elsewhere) and runs with elevated query trust, unlike the public GraphQL tool's own per-request depth/complexity sandboxing.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "name", "description", "category", "params"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "Stable identifier: run_saved_query's query_id argument and the REST route's GET /api/v1/queries/{id} path segment."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable template name."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "What the query returns and why it's curated -- shown to callers via list discovery and the MCP tool description."
+    },
+    "category": {
+      "type": "string",
+      "enum": ["leaderboard", "chain-activity"],
+      "description": "Grouping for discovery. Extend this enum, don't bypass it, when a new template doesn't fit an existing category."
+    },
+    "params": {
+      "type": "array",
+      "description": "The template's own parameter shape, validated against a caller's params before the underlying implementation runs. Empty for a template with no inputs.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "type", "required"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*$"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["string", "integer"]
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "enum": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "description": "Allowed values for a string param. Omit for a free-form string or any integer param."
+          },
+          "default": {
+            "description": "Value used when the param is omitted and not required."
+          },
+          "minimum": {
+            "type": "integer",
+            "description": "Inclusive lower bound for an integer param."
+          },
+          "maximum": {
+            "type": "integer",
+            "description": "Inclusive upper bound for an integer param."
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "notes": {
+      "type": "string",
+      "description": "One line on the underlying implementation -- which existing module/function it wraps."
+    }
+  }
+}

--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -1237,7 +1237,34 @@ assert.ok(
   "get_block_events must return ref + block_number:null + events[] on cold D1",
 );
 
+// Curated saved-query library (#6755/#6757): one call per seed template,
+// exercising the same dispatch GET /api/v1/queries/{id} shares.
+const savedLeaderboard = await callOk("run_saved_query", {
+  query_id: "subnet-leaderboard",
+  params: { board: "highest-emission", limit: 5 },
+});
+assert.equal(savedLeaderboard.query_id, "subnet-leaderboard");
+assert.ok(
+  savedLeaderboard.data && typeof savedLeaderboard.data === "object",
+  "run_saved_query(subnet-leaderboard) must return a data object",
+);
+const savedRegistrations = await callOk("run_saved_query", {
+  query_id: "chain-registrations-window",
+  params: { window: "7d", limit: 5 },
+});
+assert.equal(savedRegistrations.query_id, "chain-registrations-window");
+assert.equal(savedRegistrations.data.window, "7d");
+
 // --- Negative paths --------------------------------------------------------
+
+const unknownSavedQuery = await call("run_saved_query", {
+  query_id: "not-a-real-template",
+});
+assert.equal(
+  unknownSavedQuery.isError,
+  true,
+  "run_saved_query with an unknown query_id must return isError",
+);
 
 const unknownMethod = await mcp({
   jsonrpc: "2.0",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -212,6 +212,7 @@ import {
   GET_CHANGELOG_OUTPUT_SCHEMA,
   loadChangelog,
 } from "./changelog-mcp.mjs";
+import { SAVED_QUERY_TEMPLATES, runSavedQuery } from "./saved-queries.mjs";
 import {
   GET_FEED_INSTRUCTIONS,
   GET_FEED_MCP_TOOL,
@@ -10932,6 +10933,62 @@ export const MCP_TOOLS = [
         }),
         connect: workerWebSocketConnector(globalThis.fetch),
       });
+    },
+  },
+  {
+    name: "run_saved_query",
+    title: "Run a curated saved query",
+    description:
+      "Run one maintainer-curated, parameterized query template -- a third " +
+      "query modality sitting between the fixed REST-mirror tools above and " +
+      "the open query_graphql tool: narrower than raw GraphQL, but callable " +
+      "without knowing the schema. Mirrors GET /api/v1/queries/{id}. " +
+      "Available query_id values: " +
+      SAVED_QUERY_TEMPLATES.map(
+        (template) =>
+          `"${template.id}" (${template.description})` +
+          (template.params.length
+            ? ` Params: ${template.params
+                .map(
+                  (param) =>
+                    `${param.name}${param.required ? "" : "?"}: ${param.type}` +
+                    (param.enum ? ` [${param.enum.join("|")}]` : ""),
+                )
+                .join(", ")}.`
+            : " No params."),
+      ).join(" | "),
+    inputSchema: {
+      type: "object",
+      required: ["query_id"],
+      properties: {
+        query_id: {
+          type: "string",
+          enum: SAVED_QUERY_TEMPLATES.map((template) => template.id),
+          description: "Which curated template to run.",
+        },
+        params: {
+          type: "object",
+          description:
+            "The chosen template's own params (see the tool description). Omit for a template with no required params.",
+        },
+      },
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["query_id", "params", "data"],
+      properties: {
+        query_id: { type: "string" },
+        params: { type: "object" },
+        data: {},
+      },
+    },
+    async handler(args, ctx) {
+      if (typeof args?.query_id !== "string" || !args.query_id) {
+        throw toolError("invalid_params", "Argument `query_id` is required.");
+      }
+      return runSavedQuery(ctx.env, args.query_id, args?.params);
     },
   },
 ];

--- a/src/saved-queries.mjs
+++ b/src/saved-queries.mjs
@@ -1,0 +1,233 @@
+// Curated parameterized query library -- the third MCP query modality (epic
+// #6755), sitting between the fixed REST-mirror tools and the open GraphQL
+// tool. Admin-curated only: SAVED_QUERY_TEMPLATES describes each template's
+// id/params for discovery, SAVED_QUERY_HANDLERS is the actual dispatch table.
+// Both live in this one file so they can never drift silently -- the
+// self-check at the bottom throws at import time (so a broken pair fails
+// every test and every cold start, not just a CI script) if a template ever
+// ships without a matching handler or vice versa.
+//
+// Every handler wraps an existing, already-served derived-view module rather
+// than authoring new query logic -- exactly the discipline #6756 asked for.
+import { composeLeaderboardsData } from "../workers/request-handlers/analytics-routes.mjs";
+import { LEADERBOARD_BOARDS } from "./health-serving.mjs";
+import { tryPostgresTier } from "../workers/postgres-tier.mjs";
+import {
+  buildChainRegistrations,
+  CHAIN_REGISTRATIONS_WINDOWS,
+  DEFAULT_CHAIN_REGISTRATIONS_WINDOW,
+  CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
+  CHAIN_REGISTRATIONS_LIMIT_MAX,
+} from "./chain-registrations.mjs";
+
+export function savedQueryError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+export const SAVED_QUERY_TEMPLATES = [
+  {
+    id: "subnet-leaderboard",
+    name: "Subnet leaderboard",
+    description:
+      "One registry leaderboard board (healthiest, fastest-rpc, most-complete, " +
+      "most-enriched, fastest-growing, most-reliable, open-slots, " +
+      "cheapest-registration, highest-emission, validator-headroom), or every " +
+      "board when omitted. Same projection as GET /api/v1/registry/leaderboards " +
+      "and get_registry_leaderboards.",
+    category: "leaderboard",
+    params: [
+      {
+        name: "board",
+        type: "string",
+        required: false,
+        enum: [...LEADERBOARD_BOARDS],
+        description: "Which board to return. Omit for every board.",
+      },
+      {
+        name: "limit",
+        type: "integer",
+        required: false,
+        default: 20,
+        minimum: 1,
+        maximum: 100,
+        description: "Max subnets per board (default 20).",
+      },
+    ],
+    notes:
+      "Wraps composeLeaderboardsData (workers/request-handlers/analytics-routes.mjs), " +
+      "the same composer GET /api/v1/registry/leaderboards, " +
+      "get_registry_leaderboards, and the GraphQL registry_leaderboards " +
+      "resolver all share.",
+  },
+  {
+    id: "chain-registrations-window",
+    name: "Chain registrations by window",
+    description:
+      "Per-subnet neuron registration counts and the network-wide registration " +
+      "scorecard over a rolling window. Same projection as " +
+      "GET /api/v1/chain/registrations and get_chain_registrations.",
+    category: "chain-activity",
+    params: [
+      {
+        name: "window",
+        type: "string",
+        required: false,
+        default: DEFAULT_CHAIN_REGISTRATIONS_WINDOW,
+        enum: Object.keys(CHAIN_REGISTRATIONS_WINDOWS),
+        description: `Rolling window (default "${DEFAULT_CHAIN_REGISTRATIONS_WINDOW}").`,
+      },
+      {
+        name: "limit",
+        type: "integer",
+        required: false,
+        default: CHAIN_REGISTRATIONS_LIMIT_DEFAULT,
+        minimum: 1,
+        maximum: CHAIN_REGISTRATIONS_LIMIT_MAX,
+        description: `Max subnets in the leaderboard (default ${CHAIN_REGISTRATIONS_LIMIT_DEFAULT}).`,
+      },
+    ],
+    notes:
+      "Wraps buildChainRegistrations (src/chain-registrations.mjs) behind the " +
+      "same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) cutover the REST " +
+      "route, GraphQL resolver, and MCP tool already share.",
+  },
+];
+
+// Same trick postgresTierRequest (src/graphql.mjs) uses: tryPostgresTier only
+// inspects pathname + search (it forwards the Request as-is to the DATA_API
+// service binding, which routes on pathname), so a fixed internal origin is
+// fine here -- there is no real incoming request to borrow one from when this
+// runs from an MCP tool call.
+function internalTierRequest(pathname, params) {
+  const url = new URL(pathname, "https://internal.metagraphed.workers/");
+  url.search = params.toString();
+  return new Request(url);
+}
+
+export const SAVED_QUERY_HANDLERS = {
+  async "subnet-leaderboard"(env, { board, limit }) {
+    const { data } = await composeLeaderboardsData(env, { board, limit });
+    return data;
+  },
+  async "chain-registrations-window"(env, { window, limit }) {
+    const tierParams = new URLSearchParams();
+    tierParams.set("window", window);
+    tierParams.set("limit", String(limit));
+    return (
+      (await tryPostgresTier(
+        env,
+        internalTierRequest("/api/v1/chain/registrations", tierParams),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ?? buildChainRegistrations([], { window, limit })
+    );
+  },
+};
+
+function coerceAndValidateParams(template, rawParams) {
+  const input = rawParams && typeof rawParams === "object" ? rawParams : {};
+  const known = new Set(template.params.map((spec) => spec.name));
+  for (const key of Object.keys(input)) {
+    if (!known.has(key)) {
+      throw savedQueryError(
+        "invalid_params",
+        `Unknown param "${key}" for "${template.id}". Valid params: ` +
+          `${[...known].join(", ") || "(none)"}.`,
+      );
+    }
+  }
+  const validated = {};
+  for (const spec of template.params) {
+    const raw = input[spec.name];
+    if (raw === undefined || raw === null || raw === "") {
+      if (spec.required) {
+        throw savedQueryError(
+          "invalid_params",
+          `"${template.id}" requires param "${spec.name}".`,
+        );
+      }
+      validated[spec.name] = spec.default ?? null;
+      continue;
+    }
+    if (spec.type === "integer") {
+      const num = typeof raw === "number" ? raw : Number(raw);
+      if (!Number.isInteger(num)) {
+        throw savedQueryError(
+          "invalid_params",
+          `Param "${spec.name}" for "${template.id}" must be an integer.`,
+        );
+      }
+      if (spec.minimum != null && num < spec.minimum) {
+        throw savedQueryError(
+          "invalid_params",
+          `Param "${spec.name}" for "${template.id}" must be >= ${spec.minimum}.`,
+        );
+      }
+      if (spec.maximum != null && num > spec.maximum) {
+        throw savedQueryError(
+          "invalid_params",
+          `Param "${spec.name}" for "${template.id}" must be <= ${spec.maximum}.`,
+        );
+      }
+      validated[spec.name] = num;
+      continue;
+    }
+    const str = String(raw);
+    if (spec.enum && !spec.enum.includes(str)) {
+      throw savedQueryError(
+        "invalid_params",
+        `Param "${spec.name}" for "${template.id}" must be one of: ` +
+          `${spec.enum.join(", ")}.`,
+      );
+    }
+    validated[spec.name] = str;
+  }
+  return validated;
+}
+
+export function findSavedQueryTemplate(queryId) {
+  return SAVED_QUERY_TEMPLATES.find((template) => template.id === queryId);
+}
+
+export async function runSavedQuery(env, queryId, rawParams) {
+  const template = findSavedQueryTemplate(queryId);
+  if (!template) {
+    throw savedQueryError(
+      "not_found",
+      `Unknown saved query "${queryId}". Valid ids: ` +
+        `${SAVED_QUERY_TEMPLATES.map((t) => t.id).join(", ")}.`,
+    );
+  }
+  const params = coerceAndValidateParams(template, rawParams);
+  const data = await SAVED_QUERY_HANDLERS[template.id](env, params);
+  return { query_id: queryId, params, data };
+}
+
+// The admin-curation integrity check #6756 asked for: a template with no
+// handler (or a handler with no template) must fail loudly. Exported as a
+// pure function (rather than an inline import-time block) so a unit test can
+// exercise the throw branch directly with a deliberately-drifted registry --
+// the real call below still runs it at import time, so a genuine drift still
+// fails every cold start and every test that imports this module.
+export function assertSavedQueryRegistryIntegrity(templates, handlers) {
+  const templateIds = templates.map((t) => t.id);
+  const handlerIds = Object.keys(handlers);
+  const templateIdSet = new Set(templateIds);
+  const handlerIdSet = new Set(handlerIds);
+  const drifted =
+    templateIds.length !== templateIdSet.size ||
+    templateIdSet.size !== handlerIdSet.size ||
+    ![...templateIdSet].every((id) => handlerIdSet.has(id));
+  if (drifted) {
+    throw new Error(
+      "src/saved-queries.mjs: SAVED_QUERY_TEMPLATES and SAVED_QUERY_HANDLERS " +
+        "have drifted -- every template id must have exactly one matching " +
+        `handler. templates=[${templateIds.join(", ")}] ` +
+        `handlers=[${handlerIds.join(", ")}]`,
+    );
+  }
+}
+
+assertSavedQueryRegistryIntegrity(SAVED_QUERY_TEMPLATES, SAVED_QUERY_HANDLERS);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4280,6 +4280,85 @@ describe("MCP get_chain_registrations", () => {
   });
 });
 
+describe("MCP run_saved_query (#6755/#6757)", () => {
+  test("runs the subnet-leaderboard template", async () => {
+    const res = await callTool(
+      "run_saved_query",
+      { query_id: "subnet-leaderboard", params: { limit: 5 } },
+      {},
+    );
+    assert.equal(res.body.result.isError, false);
+    const out = res.body.result.structuredContent;
+    assert.equal(out.query_id, "subnet-leaderboard");
+    assert.deepEqual(out.params, { board: null, limit: 5 });
+    assert.ok(out.data && typeof out.data === "object");
+  });
+
+  test("runs the chain-registrations-window template on a cold Postgres tier", async () => {
+    const res = await callTool(
+      "run_saved_query",
+      { query_id: "chain-registrations-window", params: { window: "30d" } },
+      {},
+    );
+    assert.equal(res.body.result.isError, false);
+    const out = res.body.result.structuredContent;
+    assert.equal(out.query_id, "chain-registrations-window");
+    assert.equal(out.params.window, "30d");
+    assert.equal(out.data.subnet_count, 0);
+  });
+
+  test("omitting params runs the template with every default", async () => {
+    const res = await callTool(
+      "run_saved_query",
+      { query_id: "chain-registrations-window" },
+      {},
+    );
+    assert.equal(res.body.result.isError, false);
+    assert.equal(res.body.result.structuredContent.params.window, "7d");
+  });
+
+  test("rejects a missing query_id", async () => {
+    const res = await callTool("run_saved_query", {}, {});
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /query_id/);
+  });
+
+  test("rejects an unknown query_id", async () => {
+    const res = await callTool(
+      "run_saved_query",
+      { query_id: "not-a-real-template" },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(res.body.result.structuredContent.error.code, "not_found");
+  });
+
+  test("rejects an invalid param", async () => {
+    const res = await callTool(
+      "run_saved_query",
+      {
+        query_id: "subnet-leaderboard",
+        params: { board: "not-a-board" },
+      },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "invalid_params",
+    );
+  });
+
+  test("rejects an unrecognized top-level argument", async () => {
+    const res = await callTool(
+      "run_saved_query",
+      { query_id: "subnet-leaderboard", unexpected: true },
+      {},
+    );
+    assert.equal(res.body.result.isError, true);
+  });
+});
+
 describe("MCP get_chain_transfers", () => {
   function chainTransfersD1(
     {

--- a/tests/saved-queries-handler.test.mjs
+++ b/tests/saved-queries-handler.test.mjs
@@ -1,0 +1,134 @@
+// Handler tests for GET /api/v1/queries/{id} (#6755/#6757).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  handleSavedQueryRequest,
+  SAVED_QUERIES_PATH_PREFIX,
+} from "../workers/request-handlers/saved-queries.mjs";
+import { handleRequest } from "../workers/api.mjs";
+import { SAVED_QUERY_HANDLERS } from "../src/saved-queries.mjs";
+
+function req(path) {
+  return new Request(`https://api.metagraph.sh${path}`);
+}
+
+async function json(res, expectedStatus = 200) {
+  assert.equal(
+    res.status,
+    expectedStatus,
+    `expected ${expectedStatus}, got ${res.status}`,
+  );
+  return res.json();
+}
+
+describe("handleSavedQueryRequest", () => {
+  test("SAVED_QUERIES_PATH_PREFIX matches the documented route", () => {
+    assert.equal(SAVED_QUERIES_PATH_PREFIX, "/api/v1/queries/");
+  });
+
+  test("runs a known template and returns the envelope", async () => {
+    const body = await json(
+      await handleSavedQueryRequest(
+        req(
+          "/api/v1/queries/subnet-leaderboard?board=highest-emission&limit=5",
+        ),
+        {},
+        new URL(
+          "https://api.metagraph.sh/api/v1/queries/subnet-leaderboard?board=highest-emission&limit=5",
+        ),
+      ),
+    );
+    assert.equal(body.ok, true);
+    assert.equal(body.data.query_id, "subnet-leaderboard");
+    assert.deepEqual(body.data.params, { board: "highest-emission", limit: 5 });
+    assert.equal(body.meta.contract_version.length > 0, true);
+  });
+
+  test("404s on an unknown query id", async () => {
+    const body = await json(
+      await handleSavedQueryRequest(
+        req("/api/v1/queries/not-a-real-template"),
+        {},
+        new URL("https://api.metagraph.sh/api/v1/queries/not-a-real-template"),
+      ),
+      404,
+    );
+    assert.equal(body.ok, false);
+    assert.equal(body.error.code, "not_found");
+  });
+
+  test("404s with no query id segment", async () => {
+    const body = await json(
+      await handleSavedQueryRequest(
+        req("/api/v1/queries/"),
+        {},
+        new URL("https://api.metagraph.sh/api/v1/queries/"),
+      ),
+      404,
+    );
+    assert.equal(body.error.code, "not_found");
+  });
+
+  test("400s on an invalid param", async () => {
+    const body = await json(
+      await handleSavedQueryRequest(
+        req("/api/v1/queries/subnet-leaderboard?board=not-a-board"),
+        {},
+        new URL(
+          "https://api.metagraph.sh/api/v1/queries/subnet-leaderboard?board=not-a-board",
+        ),
+      ),
+      400,
+    );
+    assert.equal(body.error.code, "invalid_params");
+  });
+
+  test("rejects non-GET/HEAD methods", async () => {
+    const res = await handleSavedQueryRequest(
+      new Request(
+        "https://api.metagraph.sh/api/v1/queries/subnet-leaderboard",
+        {
+          method: "POST",
+        },
+      ),
+      {},
+      new URL("https://api.metagraph.sh/api/v1/queries/subnet-leaderboard"),
+    );
+    assert.equal(res.status, 405);
+    assert.equal(res.headers.get("allow"), "GET, HEAD, OPTIONS");
+  });
+
+  test("rethrows an unexpected (non-toolError) failure", async () => {
+    const original = SAVED_QUERY_HANDLERS["subnet-leaderboard"];
+    SAVED_QUERY_HANDLERS["subnet-leaderboard"] = async () => {
+      throw new Error("boom");
+    };
+    try {
+      await assert.rejects(
+        () =>
+          handleSavedQueryRequest(
+            req("/api/v1/queries/subnet-leaderboard"),
+            {},
+            new URL(
+              "https://api.metagraph.sh/api/v1/queries/subnet-leaderboard",
+            ),
+          ),
+        /boom/,
+      );
+    } finally {
+      SAVED_QUERY_HANDLERS["subnet-leaderboard"] = original;
+    }
+  });
+
+  test("full router dispatch reaches the saved-query handler", async () => {
+    const body = await json(
+      await handleRequest(
+        req("/api/v1/queries/chain-registrations-window?window=30d"),
+        {},
+        {},
+      ),
+    );
+    assert.equal(body.data.query_id, "chain-registrations-window");
+    assert.equal(body.data.params.window, "30d");
+  });
+});

--- a/tests/saved-queries.test.mjs
+++ b/tests/saved-queries.test.mjs
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+// Side-effect only: workers/api.mjs calls configureAnalyticsRoutes() at load
+// time, which composeLeaderboardsData (used by the subnet-leaderboard
+// template) requires before it can run.
+import "../workers/api.mjs";
+import {
+  SAVED_QUERY_TEMPLATES,
+  SAVED_QUERY_HANDLERS,
+  assertSavedQueryRegistryIntegrity,
+  findSavedQueryTemplate,
+  runSavedQuery,
+  savedQueryError,
+} from "../src/saved-queries.mjs";
+
+const SCHEMA = JSON.parse(
+  readFileSync(
+    new URL("../schemas/saved-query.schema.json", import.meta.url),
+    "utf8",
+  ),
+);
+const validateTemplate = new Ajv2020({ strict: false }).compile(SCHEMA);
+
+describe("saved-queries", () => {
+  test("savedQueryError is shaped for MCP toolError handling", () => {
+    const err = savedQueryError("not_found", "missing");
+    assert.equal(err.code, "not_found");
+    assert.equal(err.toolError, true);
+    assert.equal(err.message, "missing");
+  });
+
+  test("every template validates against schemas/saved-query.schema.json", () => {
+    for (const template of SAVED_QUERY_TEMPLATES) {
+      assert.ok(
+        validateTemplate(template),
+        `${template.id}: ${JSON.stringify(validateTemplate.errors)}`,
+      );
+    }
+  });
+
+  test("every template has exactly one matching handler", () => {
+    const templateIds = SAVED_QUERY_TEMPLATES.map((t) => t.id).sort();
+    const handlerIds = Object.keys(SAVED_QUERY_HANDLERS).sort();
+    assert.deepEqual(templateIds, handlerIds);
+  });
+
+  test("template ids are unique", () => {
+    const ids = SAVED_QUERY_TEMPLATES.map((t) => t.id);
+    assert.equal(new Set(ids).size, ids.length);
+  });
+
+  test("findSavedQueryTemplate looks up by id", () => {
+    assert.equal(
+      findSavedQueryTemplate("subnet-leaderboard")?.id,
+      "subnet-leaderboard",
+    );
+    assert.equal(findSavedQueryTemplate("no-such-template"), undefined);
+  });
+
+  test("runSavedQuery rejects an unknown query_id", async () => {
+    await assert.rejects(
+      () => runSavedQuery({}, "no-such-template", {}),
+      (err) =>
+        err.code === "not_found" &&
+        err.toolError === true &&
+        /no-such-template/.test(err.message),
+    );
+  });
+
+  test("runSavedQuery rejects an unknown param", async () => {
+    await assert.rejects(
+      () => runSavedQuery({}, "subnet-leaderboard", { not_a_real_param: "x" }),
+      (err) =>
+        err.code === "invalid_params" && /not_a_real_param/.test(err.message),
+    );
+  });
+
+  test("runSavedQuery rejects a bad enum value", async () => {
+    await assert.rejects(
+      () => runSavedQuery({}, "subnet-leaderboard", { board: "not-a-board" }),
+      (err) =>
+        err.code === "invalid_params" && /must be one of/.test(err.message),
+    );
+  });
+
+  test("runSavedQuery rejects a non-integer limit", async () => {
+    await assert.rejects(
+      () => runSavedQuery({}, "subnet-leaderboard", { limit: "not-a-number" }),
+      (err) =>
+        err.code === "invalid_params" && /must be an integer/.test(err.message),
+    );
+  });
+
+  test("runSavedQuery rejects an over-maximum limit", async () => {
+    await assert.rejects(
+      () => runSavedQuery({}, "subnet-leaderboard", { limit: "500" }),
+      (err) =>
+        err.code === "invalid_params" && /must be <= 100/.test(err.message),
+    );
+  });
+
+  test("runSavedQuery rejects an under-minimum limit", async () => {
+    await assert.rejects(
+      () => runSavedQuery({}, "subnet-leaderboard", { limit: "0" }),
+      (err) =>
+        err.code === "invalid_params" && /must be >= 1/.test(err.message),
+    );
+  });
+
+  test("assertSavedQueryRegistryIntegrity accepts a matched registry", () => {
+    assert.doesNotThrow(() =>
+      assertSavedQueryRegistryIntegrity([{ id: "a" }, { id: "b" }], {
+        a: () => {},
+        b: () => {},
+      }),
+    );
+  });
+
+  test("assertSavedQueryRegistryIntegrity throws on a template with no handler", () => {
+    assert.throws(
+      () => assertSavedQueryRegistryIntegrity([{ id: "a" }], {}),
+      /have drifted/,
+    );
+  });
+
+  test("assertSavedQueryRegistryIntegrity throws on a handler with no template", () => {
+    assert.throws(
+      () => assertSavedQueryRegistryIntegrity([], { a: () => {} }),
+      /have drifted/,
+    );
+  });
+
+  test("assertSavedQueryRegistryIntegrity throws on a duplicate template id", () => {
+    assert.throws(
+      () =>
+        assertSavedQueryRegistryIntegrity([{ id: "a" }, { id: "a" }], {
+          a: () => {},
+        }),
+      /have drifted/,
+    );
+  });
+
+  test('an unknown param on a no-param template reports "(none)"', async () => {
+    const template = {
+      id: "__test_no_params__",
+      name: "test",
+      description: "test",
+      category: "chain-activity",
+      params: [],
+    };
+    SAVED_QUERY_TEMPLATES.push(template);
+    SAVED_QUERY_HANDLERS[template.id] = async () => ({});
+    try {
+      await assert.rejects(
+        () => runSavedQuery({}, template.id, { extra: "x" }),
+        (err) => err.code === "invalid_params" && /\(none\)/.test(err.message),
+      );
+    } finally {
+      SAVED_QUERY_TEMPLATES.pop();
+      delete SAVED_QUERY_HANDLERS[template.id];
+    }
+  });
+
+  test("the real registry is self-consistent", () => {
+    assert.doesNotThrow(() =>
+      assertSavedQueryRegistryIntegrity(
+        SAVED_QUERY_TEMPLATES,
+        SAVED_QUERY_HANDLERS,
+      ),
+    );
+  });
+
+  test("an optional param with no explicit default falls back to null", async () => {
+    // chain-registrations-window's own params both declare a default, so
+    // exercise the null-fallback branch (board on subnet-leaderboard has no
+    // declared default) via an explicitly-blank value.
+    const result = await runSavedQuery({}, "subnet-leaderboard", {
+      board: "",
+    });
+    assert.equal(result.params.board, null);
+  });
+
+  test("runSavedQuery rejects a missing required param", async () => {
+    // None of the shipped templates declare a required param today -- register
+    // a synthetic one to exercise coerceAndValidateParams' required branch.
+    const template = {
+      id: "__test_required_param__",
+      name: "test",
+      description: "test",
+      category: "chain-activity",
+      params: [{ name: "netuid", type: "integer", required: true }],
+    };
+    SAVED_QUERY_TEMPLATES.push(template);
+    SAVED_QUERY_HANDLERS[template.id] = async (_env, params) => params;
+    try {
+      await assert.rejects(
+        () => runSavedQuery({}, template.id, {}),
+        (err) =>
+          err.code === "invalid_params" &&
+          /requires param "netuid"/.test(err.message),
+      );
+      const result = await runSavedQuery({}, template.id, { netuid: 7 });
+      assert.deepEqual(result.params, { netuid: 7 });
+    } finally {
+      SAVED_QUERY_TEMPLATES.pop();
+      delete SAVED_QUERY_HANDLERS[template.id];
+    }
+  });
+
+  test("subnet-leaderboard applies defaults and coerces string params", async () => {
+    const env = {};
+    const calls = [];
+    const original = SAVED_QUERY_HANDLERS["subnet-leaderboard"];
+    SAVED_QUERY_HANDLERS["subnet-leaderboard"] = async (e, params) => {
+      calls.push(params);
+      return { boards: {} };
+    };
+    try {
+      const result = await runSavedQuery(env, "subnet-leaderboard", {
+        board: "highest-emission",
+        limit: "5",
+      });
+      assert.deepEqual(calls[0], { board: "highest-emission", limit: 5 });
+      assert.equal(result.query_id, "subnet-leaderboard");
+      assert.deepEqual(result.params, { board: "highest-emission", limit: 5 });
+      assert.deepEqual(result.data, { boards: {} });
+    } finally {
+      SAVED_QUERY_HANDLERS["subnet-leaderboard"] = original;
+    }
+  });
+
+  test("subnet-leaderboard omits board and limit to their defaults", async () => {
+    const result = await runSavedQuery({}, "subnet-leaderboard", {});
+    assert.equal(result.params.board, null);
+    assert.equal(result.params.limit, 20);
+  });
+
+  test("chain-registrations-window falls back to buildChainRegistrations cold", async () => {
+    const result = await runSavedQuery({}, "chain-registrations-window", {
+      window: "30d",
+      limit: 10,
+    });
+    assert.equal(result.query_id, "chain-registrations-window");
+    assert.equal(result.params.window, "30d");
+    assert.equal(result.params.limit, 10);
+    assert.equal(result.data.schema_version, 1);
+    assert.equal(result.data.window, "30d");
+    assert.deepEqual(result.data.subnets, []);
+  });
+
+  test("chain-registrations-window defaults window and limit", async () => {
+    const result = await runSavedQuery({}, "chain-registrations-window", {});
+    assert.equal(result.params.window, "7d");
+    assert.equal(result.params.limit, 20);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -281,6 +281,10 @@ import { handleOgImage } from "../src/og-image.mjs";
 import { handleIconProxy } from "../src/icon-proxy.mjs";
 import { handleGraphQLRequest } from "../src/graphql.mjs";
 import {
+  handleSavedQueryRequest,
+  SAVED_QUERIES_PATH_PREFIX,
+} from "./request-handlers/saved-queries.mjs";
+import {
   aiEnabled,
   askQuestion,
   runEmbeddingSync,
@@ -1565,6 +1569,16 @@ export async function handleRequest(request, env = {}, ctx = {}) {
           headers: response.headers,
         })
       : response;
+  }
+
+  // Curated parameterized query library (#6755/#6757): GET /api/v1/queries/{id}
+  // runs one maintainer-curated saved-query template (src/saved-queries.mjs),
+  // the REST mirror of the run_saved_query MCP tool. Live per-request result
+  // with no fixed response shape across templates -- same reason /api/v1/graphql
+  // above sits outside the API_ROUTES/contracts.mjs registry rather than a
+  // route()+artifact() pair.
+  if (url.pathname.startsWith(SAVED_QUERIES_PATH_PREFIX)) {
+    return handleSavedQueryRequest(request, env, url);
   }
 
   // Embeddable SVG badges at /api/v1/{subnets/{netuid}|providers/{slug}}/

--- a/workers/request-handlers/saved-queries.mjs
+++ b/workers/request-handlers/saved-queries.mjs
@@ -1,0 +1,54 @@
+// GET /api/v1/queries/{id}: run one maintainer-curated saved-query template
+// (epic #6755/#6757) -- the REST mirror of the run_saved_query MCP tool, both
+// backed by src/saved-queries.mjs's shared runSavedQuery(). A live per-request
+// result with no fixed response shape across templates, the same "no static
+// artifact" category as /api/v1/graphql -- see workers/api.mjs's own comment
+// on why this sits outside the API_ROUTES/contracts.mjs registry.
+import { errorResponse } from "../http.mjs";
+import { dataResponse } from "../responses.mjs";
+import { runSavedQuery } from "../../src/saved-queries.mjs";
+
+export const SAVED_QUERIES_PATH_PREFIX = "/api/v1/queries/";
+
+function paramsFromSearch(url) {
+  const params = {};
+  for (const [key, value] of url.searchParams) {
+    params[key] = value;
+  }
+  return params;
+}
+
+export async function handleSavedQueryRequest(request, env, url) {
+  if (!["GET", "HEAD"].includes(request.method)) {
+    return errorResponse(
+      "method_not_allowed",
+      "Only GET, HEAD, and OPTIONS are supported.",
+      405,
+      {},
+      { allow: "GET, HEAD, OPTIONS" },
+    );
+  }
+  const queryId = decodeURIComponent(
+    url.pathname.slice(SAVED_QUERIES_PATH_PREFIX.length),
+  );
+  if (!queryId) {
+    return errorResponse(
+      "not_found",
+      "GET /api/v1/queries/{id} requires a query id.",
+      404,
+    );
+  }
+  try {
+    const result = await runSavedQuery(env, queryId, paramsFromSearch(url));
+    return dataResponse(env, result);
+  } catch (error) {
+    if (error?.toolError) {
+      return errorResponse(
+        error.code,
+        error.message,
+        error.code === "not_found" ? 404 : 400,
+      );
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

- Third MCP query modality (epic #6755), sitting between the fixed REST-mirror tools and the open GraphQL tool: a maintainer-curated, parameterized template set callable without knowing the GraphQL schema.

## What Changed

- `schemas/saved-query.schema.json`: JSON Schema for a SavedQueryTemplate (id, name, description, category, params[], notes).
- `src/saved-queries.mjs`: `SAVED_QUERY_TEMPLATES` (2 seed templates: `subnet-leaderboard`, `chain-registrations-window`) + `SAVED_QUERY_HANDLERS` dispatch table, both in one file so they can never drift silently — `assertSavedQueryRegistryIntegrity` runs at import time and fails every cold start (not just a CI script) if a template ships without a matching handler or vice versa. Each handler wraps an existing, already-served derived-view module (`composeLeaderboardsData`, `buildChainRegistrations`) rather than authoring new query logic.
- `workers/request-handlers/saved-queries.mjs` + `workers/api.mjs`: `GET /api/v1/queries/{id}`, dispatched as a special-cased route the same way `/api/v1/graphql` is — deliberately outside the `API_ROUTES`/`contracts.mjs` registry, since neither endpoint has one fixed response shape a static schema-ref could describe.
- `src/mcp-server.mjs`: `run_saved_query` MCP tool sharing the same `runSavedQuery` dispatch as the REST route.
- Tests: `tests/saved-queries.test.mjs`, `tests/saved-queries-handler.test.mjs`, plus `run_saved_query` coverage added to the centralized `tests/mcp-server.test.mjs`, and a `run_saved_query` `callOk` exercise in `scripts/validate-mcp.mjs`. 100% statement/branch/function/line coverage on both new source files.

Closes #6755
Closes #6756
Closes #6757

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none touched — this route intentionally sits outside the contract/artifact system, same as `/api/v1/graphql`).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API change is intentional (`GET /api/v1/queries/{id}` + `run_saved_query`) and documented above.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check` (targeted at changed files)
- [x] `npm run validate`
- [x] `npm run validate:schemas`
- [x] `npm run validate:api`
- [x] `npm run validate:openapi`
- [x] `npm run validate:types`
- [x] `npm run validate:artifact-budgets`
- [x] `npm run validate:docs`
- [x] `npm run validate:intake`
- [x] `npm run validate:workflows`
- [x] `npm run worker:test`
- [x] `npm run test:coverage` (full suite: 9607/9608 passing — the one failure, `lib-helpers.test.mjs`'s `dirtyTrackedPaths`, is a pre-existing timing-sensitive test unrelated to this change; passes in isolation)
- [x] `npm run scan:public-safety`
- [x] `git diff --check`