### PR TITLE
feat(ui): move / re-delegate stake flow

### DIFF
--- a/apps/ui/src/components/metagraphed/move-stake-destination-input.tsx
+++ b/apps/ui/src/components/metagraphed/move-stake-destination-input.tsx
@@ -1,0 +1,174 @@
+import { AlertCircle, AlertTriangle, Loader2 } from "lucide-react";
+import { SearchInput } from "@/components/metagraphed/table-controls";
+import { formatQuoteHint } from "@/components/metagraphed/stake-amount-input";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import type { SubnetStakeQuote, Subnet } from "@/lib/metagraphed/types";
+import type { MoveStakeAxis } from "@/hooks/use-move-stake-flow";
+
+// The "amount" step for the move/re-delegate flow (#5244's destination
+// picker): origin summary + destination hotkey/subnet fields + amount, wired
+// to useMoveStakeFlow's already-tested pure logic rather than owning any
+// fund-safety-relevant computation itself -- mirrors StakeAmountInput's own
+// posture for the original stake/unstake flow.
+
+export interface MoveStakeDestinationInputProps {
+  originHotkey: string;
+  originNetuid: number;
+  originValidatorName?: string;
+  originSubnetName?: string;
+
+  destinationHotkeyInput: string;
+  onDestinationHotkeyChange: (value: string) => void;
+  destinationNetuidInput: string;
+  onDestinationNetuidChange: (value: string) => void;
+  knownSubnets: Subnet[];
+
+  amountInput: string;
+  onAmountInputChange: (value: string) => void;
+  maxAmountInput: string | null;
+  onApplyMax: () => void;
+
+  axis: MoveStakeAxis | "unchanged" | "both";
+  axisIssueMessage: string | null;
+
+  quote: SubnetStakeQuote | null;
+  quoteIsPending: boolean;
+  quoteError: string | null;
+  validationMessages: string[];
+}
+
+export function MoveStakeDestinationInput({
+  originHotkey,
+  originNetuid,
+  originValidatorName,
+  originSubnetName,
+  destinationHotkeyInput,
+  onDestinationHotkeyChange,
+  destinationNetuidInput,
+  onDestinationNetuidChange,
+  knownSubnets,
+  amountInput,
+  onAmountInputChange,
+  maxAmountInput,
+  onApplyMax,
+  axis,
+  axisIssueMessage,
+  quote,
+  quoteIsPending,
+  quoteError,
+  validationMessages,
+}: MoveStakeDestinationInputProps) {
+  const hasValidAmount =
+    amountInput.trim() !== "" && Number.isFinite(Number(amountInput)) && Number(amountInput) > 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded border border-border bg-surface/40 px-2.5 py-2 text-[11px] text-ink-muted">
+        Moving from{" "}
+        <span className="font-medium text-ink-strong">
+          {originValidatorName ?? shortHash(originHotkey, 6)}
+        </span>{" "}
+        on{" "}
+        <span className="font-medium text-ink-strong">
+          {originSubnetName ? `${originSubnetName} (SN${originNetuid})` : `SN${originNetuid}`}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          Destination hotkey
+        </span>
+        <SearchInput
+          value={destinationHotkeyInput}
+          onChange={onDestinationHotkeyChange}
+          placeholder="5…"
+          className="font-mono"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          Destination subnet
+        </span>
+        <select
+          value={destinationNetuidInput}
+          onChange={(e) => onDestinationNetuidChange(e.target.value)}
+          className="h-9 rounded border border-border bg-card px-2 font-mono text-[12px] text-ink-strong"
+        >
+          {knownSubnets.map((s) => (
+            <option key={s.netuid} value={s.netuid}>
+              {s.netuid === 0 ? "Root" : `SN${s.netuid}`}
+              {s.name ? ` — ${s.name}` : ""}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-col gap-1">
+          <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+            Amount (α)
+          </span>
+          <SearchInput
+            value={amountInput}
+            onChange={onAmountInputChange}
+            placeholder="0.00 α"
+            inputMode="decimal"
+            className="w-40 flex-none font-mono tabular-nums"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={onApplyMax}
+          disabled={maxAmountInput == null}
+          className="min-h-8 rounded border border-border bg-card px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest text-ink-muted hover:text-ink-strong hover:border-ink/30 transition-colors disabled:opacity-50"
+        >
+          Max
+        </button>
+      </div>
+
+      {axisIssueMessage ? (
+        <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down">
+          <AlertTriangle className="size-3.5 shrink-0" aria-hidden />
+          {axisIssueMessage}
+        </p>
+      ) : null}
+
+      {axis === "subnet" && hasValidAmount ? (
+        quoteError ? (
+          <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down">
+            <AlertCircle className="size-3.5 shrink-0" aria-hidden />
+            {quoteError}
+          </p>
+        ) : quoteIsPending ? (
+          <p className="inline-flex items-center gap-1.5 font-mono text-[11px] text-ink-muted">
+            <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden />
+            Calculating…
+          </p>
+        ) : quote ? (
+          <p className="font-mono text-[11px] text-ink-strong">{formatQuoteHint(quote)}</p>
+        ) : null
+      ) : null}
+
+      {axis === "hotkey" ? (
+        <p className="font-mono text-[10px] text-ink-muted">
+          Same-subnet hotkey moves are a pure reassignment — no AMM, no slippage.
+        </p>
+      ) : null}
+
+      {validationMessages.length > 0 ? (
+        <ul className="space-y-1">
+          {validationMessages.map((message) => (
+            <li
+              key={message}
+              className="inline-flex items-center gap-1.5 font-mono text-[11px] text-health-down"
+            >
+              <AlertCircle className="size-3.5 shrink-0" aria-hidden />
+              {message}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/move-stake-modal.tsx
+++ b/apps/ui/src/components/metagraphed/move-stake-modal.tsx
@@ -1,0 +1,318 @@
+import { useRef, useState, type ReactNode } from "react";
+import { Link } from "@tanstack/react-router";
+import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@jsonbored/ui-kit";
+import { WalletConnectPanel } from "@/components/metagraphed/wallet-connect";
+import { MoveStakeDestinationInput } from "@/components/metagraphed/move-stake-destination-input";
+import { PreSignConfirmation } from "@/components/metagraphed/pre-sign-confirmation";
+import { broadcastStatusLabel } from "@/components/metagraphed/stake-unstake-modal";
+import { shortHash } from "@/lib/metagraphed/blocks";
+import { rawAlphaToAlpha } from "@/lib/metagraphed/units";
+import type { BroadcastStatus } from "@/lib/metagraphed/broadcast";
+import type { DecodedTxError } from "@/lib/metagraphed/tx-errors";
+import {
+  useMoveStakeFlow,
+  formatSpotValueTao,
+  type UseMoveStakeFlowResult,
+} from "@/hooks/use-move-stake-flow";
+
+// #5244: the move/re-delegate stake flow -- a "Move this position" entry
+// point from the your-positions panel. Structurally mirrors
+// stake-unstake-modal.tsx / take-management-modal.tsx (same trigger-render-
+// prop pattern, same hook-mounted-above-<Sheet> lifetime, same close-guard,
+// same reentrancy guard on the confirm button) but its "amount" step is
+// bespoke (a destination hotkey+subnet picker, not an action tablist) while
+// its "confirm" step reuses PreSignConfirmation completely unchanged -- see
+// use-move-stake-flow.ts's header comment for why a single-axis move maps
+// cleanly onto that screen's existing single-hotkey/single-netuid shape.
+//
+// No new signing logic: useMoveStakeFlow composes the same buildExtrinsic /
+// broadcast.ts / useTxStatus primitives every other flow in this app uses,
+// unchanged.
+
+export interface MoveStakeModalProps {
+  hotkey: string;
+  netuid: number;
+  subnetName?: string;
+  validatorName?: string;
+  positionAlpha: number | null;
+  positionSpotTao: number;
+  trigger: (open: () => void) => ReactNode;
+}
+
+export function MoveStakeModal({
+  hotkey,
+  netuid,
+  subnetName,
+  validatorName,
+  positionAlpha,
+  positionSpotTao,
+  trigger,
+}: MoveStakeModalProps) {
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  // Same rationale as StakeUnstakeModal's confirmInFlightRef: a synchronous
+  // ref, not just React state, closes the double-click window before the
+  // batched state update would.
+  const confirmInFlightRef = useRef(false);
+  const flow = useMoveStakeFlow(hotkey, netuid, positionAlpha, positionSpotTao);
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      setOpen(true);
+      return;
+    }
+    if (!flow.canClose) return; // signAndSend runs outside React's control -- see useMoveStakeFlow's canClose doc comment
+    flow.close();
+    setOpen(false);
+  };
+
+  const handleConfirm = async () => {
+    if (confirmInFlightRef.current) return;
+    confirmInFlightRef.current = true;
+    setSubmitting(true);
+    try {
+      await flow.submit();
+    } finally {
+      confirmInFlightRef.current = false;
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      {/* Same focus-restoration fix as StakeUnstakeModal (#6415)/TakeManagementModal (#6419): wrap the
+          render-prop trigger in <SheetTrigger asChild> inside <Sheet> so Radix has a node to return
+          focus to on close. */}
+      <SheetTrigger asChild>{trigger(() => setOpen(true))}</SheetTrigger>
+      <SheetContent side="right" className="flex w-full flex-col overflow-y-auto sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle className="font-display text-lg">
+            Move stake · {validatorName ?? shortHash(hotkey, 6)}
+          </SheetTitle>
+          <SheetDescription>
+            {subnetName ? `${subnetName} (SN${netuid})` : `Subnet ${netuid}`}
+            {!flow.canClose ? " — this can't be closed while a signature is in flight." : ""}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="mt-4 flex-1">
+          <MoveStakeFlowBody
+            hotkey={hotkey}
+            netuid={netuid}
+            subnetName={subnetName}
+            validatorName={validatorName}
+            flow={flow}
+            submitting={submitting}
+            onConfirm={handleConfirm}
+            onClose={() => handleOpenChange(false)}
+          />
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function MoveStakeFlowBody({
+  hotkey,
+  netuid,
+  subnetName,
+  validatorName,
+  flow,
+  submitting,
+  onConfirm,
+  onClose,
+}: {
+  hotkey: string;
+  netuid: number;
+  subnetName?: string;
+  validatorName?: string;
+  flow: UseMoveStakeFlowResult;
+  submitting: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  switch (flow.phase) {
+    case "connect":
+      return <WalletConnectPanel />;
+
+    case "amount":
+      return (
+        <div className="flex h-full flex-col">
+          <div className="flex-1">
+            <MoveStakeDestinationInput
+              originHotkey={hotkey}
+              originNetuid={netuid}
+              originValidatorName={validatorName}
+              originSubnetName={subnetName}
+              destinationHotkeyInput={flow.destinationHotkeyInput}
+              onDestinationHotkeyChange={flow.setDestinationHotkeyInput}
+              destinationNetuidInput={flow.destinationNetuidInput}
+              onDestinationNetuidChange={flow.setDestinationNetuidInput}
+              knownSubnets={flow.knownSubnets}
+              amountInput={flow.amountInput}
+              onAmountInputChange={flow.setAmountInput}
+              maxAmountInput={flow.maxAmountInput}
+              onApplyMax={flow.applyMax}
+              axis={flow.axis}
+              axisIssueMessage={flow.axisIssueMessage}
+              quote={flow.quote}
+              quoteIsPending={flow.quoteIsPending}
+              quoteError={flow.quoteError}
+              validationMessages={flow.validationMessages}
+            />
+          </div>
+          <SheetFooter className="mt-4">
+            <button
+              type="button"
+              onClick={flow.confirm}
+              disabled={!flow.canConfirm}
+              className="w-full rounded border border-ink-strong/40 bg-surface px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink-strong/60 disabled:opacity-50"
+            >
+              Review move
+            </button>
+          </SheetFooter>
+        </div>
+      );
+
+    case "confirm":
+      return (
+        <PreSignConfirmation
+          action="move"
+          amountTao={confirmAmountTao(flow)}
+          amountAlpha={confirmAmountAlpha(flow)}
+          hotkey={confirmHotkey(flow)}
+          validatorName={flow.axis === "hotkey" ? undefined : validatorName}
+          netuid={confirmNetuid(flow)}
+          subnetName={flow.axis === "subnet" ? undefined : subnetName}
+          feeTao={flow.feeTao}
+          expectedOut={
+            flow.axis === "subnet" && flow.quote
+              ? { amount: String(flow.quote.expected_out), unit: flow.quote.expected_out_unit }
+              : undefined
+          }
+          priceImpactPct={flow.axis === "subnet" ? flow.quote?.price_impact_pct : undefined}
+          tolerancePct={flow.tolerancePct}
+          confirming={submitting}
+          onConfirm={onConfirm}
+          onCancel={flow.editAmount}
+        />
+      );
+
+    case "signing":
+    case "broadcasting":
+      return (
+        <StatusView
+          icon={<Loader2 className="size-6 animate-spin text-ink-muted" aria-hidden />}
+          message={
+            flow.phase === "signing"
+              ? "Awaiting your signature…"
+              : broadcastStatusLabel(flow.txStatus.status as BroadcastStatus)
+          }
+          txHash={flow.txStatus.txHash}
+        />
+      );
+
+    case "failed":
+      return (
+        <div className="flex flex-col items-center gap-4 py-10 text-center">
+          <AlertTriangle className="size-6 text-health-down" aria-hidden />
+          <p className="text-[13px] text-ink-strong">{describeTxError(flow.txStatus.error)}</p>
+          <button
+            type="button"
+            onClick={flow.editAmount}
+            className="rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink/30"
+          >
+            Edit and try again
+          </button>
+        </div>
+      );
+
+    case "done":
+      return (
+        <StatusView
+          icon={<CheckCircle2 className="size-6 text-health-ok" aria-hidden />}
+          message="Finalized."
+          txHash={flow.txStatus.txHash}
+          onClose={onClose}
+        />
+      );
+  }
+}
+
+function StatusView({
+  icon,
+  message,
+  txHash,
+  onClose,
+}: {
+  icon: ReactNode;
+  message: string;
+  txHash: string | null;
+  onClose?: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-4 py-10 text-center">
+      {icon}
+      <p className="text-[13px] text-ink-strong">{message}</p>
+      {txHash ? (
+        <div className="space-y-1">
+          <Link
+            to="/extrinsics/$hash"
+            params={{ hash: txHash }}
+            className="font-mono text-[11px] text-accent hover:underline"
+          >
+            {shortHash(txHash, 8)}
+          </Link>
+          <p className="text-[10px] text-ink-muted">
+            May take a few moments to appear once indexed.
+          </p>
+        </div>
+      ) : null}
+      {onClose ? (
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded border border-border bg-card px-3 py-2 text-[12px] font-medium text-ink-strong transition-colors hover:border-ink/30"
+        >
+          Done
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function describeTxError(error: DecodedTxError | null): string {
+  return error?.message ?? "The transaction failed.";
+}
+
+/** The confirm screen's single hotkey -- always the destination, which equals the origin hotkey unchanged when only the subnet axis moved. */
+function confirmHotkey(flow: UseMoveStakeFlowResult): string {
+  return flow.destinationHotkeyInput.trim() || flow.originHotkey;
+}
+
+/** The confirm screen's single netuid -- always the destination, which equals the origin netuid unchanged when only the hotkey axis moved. */
+function confirmNetuid(flow: UseMoveStakeFlowResult): number {
+  const parsed = Number(flow.destinationNetuidInput);
+  return Number.isFinite(parsed) ? parsed : flow.originNetuid;
+}
+
+/** The confirm screen's TAO display -- the live unstake-direction quote's TAO estimate for a subnet move (the leg limit_price actually protects), or a spot-mark estimate for a riskless hotkey-only move (no AMM, no quote). canConfirm already requires originSpotPriceTao to be resolved before "confirm" is reachable, so the fallback below is never actually exercised with a null price -- it's a defensive default, not a silent-wrong-number path. */
+function confirmAmountTao(flow: UseMoveStakeFlowResult): string {
+  if (flow.axis === "subnet" && flow.quote) return String(flow.quote.expected_out);
+  if (flow.originSpotPriceTao == null) return "0";
+  return formatSpotValueTao(Number(flow.amountInput) || 0, flow.originSpotPriceTao);
+}
+
+/** The confirm screen's alpha display -- reconstructed from the exact RawAlpha this params object will submit (never a re-derived estimate), so what's shown is exactly what gets signed. */
+function confirmAmountAlpha(flow: UseMoveStakeFlowResult): string | undefined {
+  return flow.params ? rawAlphaToAlpha(flow.params.alphaAmount) : undefined;
+}

--- a/apps/ui/src/components/metagraphed/your-positions-panel.tsx
+++ b/apps/ui/src/components/metagraphed/your-positions-panel.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Link } from "@tanstack/react-router";
-import { Coins } from "lucide-react";
+import { ArrowRightLeft, Coins } from "lucide-react";
 import { useQueries, useSuspenseQuery } from "@tanstack/react-query";
 import { CopyButton, StatTile } from "@jsonbored/ui-kit";
 import {
@@ -10,6 +10,7 @@ import {
   subnetStakeQuoteQuery,
 } from "@/lib/metagraphed/queries";
 import { StakeUnstakeModal } from "@/components/metagraphed/stake-unstake-modal";
+import { MoveStakeModal } from "@/components/metagraphed/move-stake-modal";
 import { EmptyState } from "@/components/metagraphed/states";
 import { taoCompact } from "@/components/metagraphed/neuron-format";
 import { classNames } from "@/lib/metagraphed/format";
@@ -213,7 +214,15 @@ export function YourPositionsPanel({ address }: { address: string }) {
                   {pct(p.yield)}
                 </td>
                 <td className="px-3 py-2.5 text-right">
-                  <ManageButton hotkey={p.hotkey} netuid={p.netuid} />
+                  <div className="inline-flex items-center gap-1.5">
+                    <ManageButton hotkey={p.hotkey} netuid={p.netuid} />
+                    <MoveButton
+                      hotkey={p.hotkey}
+                      netuid={p.netuid}
+                      positionAlpha={p.alpha}
+                      positionSpotTao={p.spotTao}
+                    />
+                  </div>
                 </td>
               </tr>
             ))}
@@ -245,7 +254,15 @@ export function YourPositionsPanel({ address }: { address: string }) {
               <Stat label="Exit τ" value={taoCompact(exitTaoFor(i, p))} />
               <Stat label="Yield" value={pct(p.yield)} />
             </dl>
-            <ManageButton hotkey={p.hotkey} netuid={p.netuid} />
+            <div className="flex items-center gap-1.5">
+              <ManageButton hotkey={p.hotkey} netuid={p.netuid} />
+              <MoveButton
+                hotkey={p.hotkey}
+                netuid={p.netuid}
+                positionAlpha={p.alpha}
+                positionSpotTao={p.spotTao}
+              />
+            </div>
           </div>
         ))}
       </div>
@@ -298,6 +315,39 @@ function ManageButton({ hotkey, netuid }: { hotkey: string | null; netuid: numbe
         >
           <Coins className="size-3 text-ink-muted" aria-hidden />
           Manage
+        </button>
+      )}
+    />
+  );
+}
+
+/** #5244: "Move this position" -- a second entry point alongside Manage, opening the move/re-delegate flow for this exact (hotkey, netuid) position. */
+function MoveButton({
+  hotkey,
+  netuid,
+  positionAlpha,
+  positionSpotTao,
+}: {
+  hotkey: string | null;
+  netuid: number;
+  positionAlpha: number | null;
+  positionSpotTao: number;
+}) {
+  if (!hotkey) return null;
+  return (
+    <MoveStakeModal
+      hotkey={hotkey}
+      netuid={netuid}
+      positionAlpha={positionAlpha}
+      positionSpotTao={positionSpotTao}
+      trigger={(open) => (
+        <button
+          type="button"
+          onClick={open}
+          className="inline-flex items-center gap-1 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium text-ink-strong transition-colors hover:border-accent/50 hover:text-accent"
+        >
+          <ArrowRightLeft className="size-3 text-ink-muted" aria-hidden />
+          Move
         </button>
       )}
     />

--- a/apps/ui/src/hooks/use-move-stake-flow.test.ts
+++ b/apps/ui/src/hooks/use-move-stake-flow.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+import { alphaToRawAlpha, taoToRao } from "@/lib/metagraphed/units";
+import {
+  deriveMoveStakeFlowPhase,
+  canCloseMoveStakeFlow,
+  resolveMoveStakeAxis,
+  describeMoveStakeAxisIssue,
+  resolveMoveStakeMaxAmountInput,
+  resolveOriginSpotPriceTao,
+  formatSpotValueTao,
+  buildMoveStakeCallParams,
+  confirmAlphaAmount,
+} from "./use-move-stake-flow";
+
+const HOTKEY_A = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const HOTKEY_B = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+describe("deriveMoveStakeFlowPhase", () => {
+  it("is 'connect' whenever the wallet isn't connected, regardless of confirmed/txStatus", () => {
+    expect(deriveMoveStakeFlowPhase("idle", false, "idle")).toBe("connect");
+    expect(deriveMoveStakeFlowPhase("connecting", true, "finalized")).toBe("connect");
+    expect(deriveMoveStakeFlowPhase("no-extension", true, "signing")).toBe("connect");
+  });
+
+  it("is 'amount' whenever not yet confirmed, once connected", () => {
+    expect(deriveMoveStakeFlowPhase("connected", false, "idle")).toBe("amount");
+    expect(deriveMoveStakeFlowPhase("connected", false, "finalized")).toBe("amount");
+  });
+
+  it("is 'confirm' once confirmed with an idle tx", () => {
+    expect(deriveMoveStakeFlowPhase("connected", true, "idle")).toBe("confirm");
+  });
+
+  it("is 'signing' while the extension is prompting for a signature", () => {
+    expect(deriveMoveStakeFlowPhase("connected", true, "signing")).toBe("signing");
+  });
+
+  it("is 'failed' for a decoded on-chain failure or a rejected/pre-dispatch submission", () => {
+    expect(deriveMoveStakeFlowPhase("connected", true, "failed")).toBe("failed");
+    expect(deriveMoveStakeFlowPhase("connected", true, "submit-error")).toBe("failed");
+  });
+
+  it("is 'done' once finalized", () => {
+    expect(deriveMoveStakeFlowPhase("connected", true, "finalized")).toBe("done");
+  });
+
+  it("is 'broadcasting' for every other in-flight broadcast status", () => {
+    for (const status of [
+      "future",
+      "ready",
+      "broadcast",
+      "in-block",
+      "retracted",
+      "finality-timeout",
+      "usurped",
+      "dropped",
+      "invalid",
+      "error",
+    ] as const) {
+      expect(deriveMoveStakeFlowPhase("connected", true, status)).toBe("broadcasting");
+    }
+  });
+});
+
+describe("canCloseMoveStakeFlow", () => {
+  it("allows closing from idle, failed, submit-error, and finalized", () => {
+    expect(canCloseMoveStakeFlow("idle")).toBe(true);
+    expect(canCloseMoveStakeFlow("failed")).toBe(true);
+    expect(canCloseMoveStakeFlow("submit-error")).toBe(true);
+    expect(canCloseMoveStakeFlow("finalized")).toBe(true);
+  });
+
+  it("blocks closing while signing or mid-broadcast", () => {
+    expect(canCloseMoveStakeFlow("signing")).toBe(false);
+    expect(canCloseMoveStakeFlow("broadcast")).toBe(false);
+    expect(canCloseMoveStakeFlow("in-block")).toBe(false);
+    expect(canCloseMoveStakeFlow("future")).toBe(false);
+  });
+});
+
+describe("resolveMoveStakeAxis", () => {
+  it("is 'hotkey' when only the hotkey differs", () => {
+    expect(resolveMoveStakeAxis(HOTKEY_A, 4, HOTKEY_B, 4)).toBe("hotkey");
+  });
+
+  it("is 'subnet' when only the netuid differs", () => {
+    expect(resolveMoveStakeAxis(HOTKEY_A, 4, HOTKEY_A, 7)).toBe("subnet");
+  });
+
+  it("is 'both' when hotkey AND netuid differ", () => {
+    expect(resolveMoveStakeAxis(HOTKEY_A, 4, HOTKEY_B, 7)).toBe("both");
+  });
+
+  it("is 'unchanged' when neither differs", () => {
+    expect(resolveMoveStakeAxis(HOTKEY_A, 4, HOTKEY_A, 4)).toBe("unchanged");
+  });
+
+  it("trims whitespace before comparing the hotkey", () => {
+    expect(resolveMoveStakeAxis(HOTKEY_A, 4, `  ${HOTKEY_A}  `, 4)).toBe("unchanged");
+  });
+});
+
+describe("describeMoveStakeAxisIssue", () => {
+  it("has distinct copy for 'both' vs 'unchanged'", () => {
+    expect(describeMoveStakeAxisIssue("both")).toMatch(/one step, not both/);
+    expect(describeMoveStakeAxisIssue("unchanged")).toMatch(/Choose a different/);
+  });
+});
+
+describe("resolveMoveStakeMaxAmountInput", () => {
+  it("uses the position's TAO figure for root (alpha IS TAO, 1:1)", () => {
+    expect(resolveMoveStakeMaxAmountInput(true, null, 12.5)).toBe("12.500000000");
+  });
+
+  it("returns null for root when the position has no TAO value", () => {
+    expect(resolveMoveStakeMaxAmountInput(true, null, 0)).toBeNull();
+  });
+
+  it("uses the position's alpha figure for a non-root subnet", () => {
+    expect(resolveMoveStakeMaxAmountInput(false, 20, 10)).toBe("20.000000000");
+  });
+
+  it("returns null for a non-root subnet when alpha is unknown or non-positive", () => {
+    expect(resolveMoveStakeMaxAmountInput(false, null, 10)).toBeNull();
+    expect(resolveMoveStakeMaxAmountInput(false, 0, 10)).toBeNull();
+  });
+});
+
+describe("resolveOriginSpotPriceTao", () => {
+  it("is fixed at 1.0 for root regardless of the position data", () => {
+    expect(resolveOriginSpotPriceTao(true, null, 999)).toBe(1);
+  });
+
+  it("derives price = spotTao / alpha for a non-root subnet", () => {
+    expect(resolveOriginSpotPriceTao(false, 20, 10)).toBe(0.5);
+  });
+
+  it("is null for a non-root subnet when alpha is unknown or non-positive", () => {
+    expect(resolveOriginSpotPriceTao(false, null, 10)).toBeNull();
+    expect(resolveOriginSpotPriceTao(false, 0, 10)).toBeNull();
+    expect(resolveOriginSpotPriceTao(false, -1, 10)).toBeNull();
+  });
+});
+
+describe("formatSpotValueTao", () => {
+  it("multiplies alpha by the spot price, rounded through the standard 9-decimal path", () => {
+    expect(formatSpotValueTao(10, 2)).toBe("20");
+    expect(formatSpotValueTao(1, 0.333333333)).toBe("0.333333333");
+  });
+
+  it("floors at zero rather than a negative display value", () => {
+    expect(formatSpotValueTao(-5, 2)).toBe("0");
+  });
+
+  it("falls back to zero for non-finite inputs rather than propagating NaN", () => {
+    expect(formatSpotValueTao(NaN, 2)).toBe("0");
+    expect(formatSpotValueTao(5, NaN)).toBe("0");
+  });
+});
+
+describe("buildMoveStakeCallParams (#5244's fund-safety-critical seam)", () => {
+  it("axis 'hotkey' builds move_stake at the ORIGIN netuid, ignoring destinationNetuid entirely", () => {
+    const params = buildMoveStakeCallParams({
+      axis: "hotkey",
+      originHotkey: HOTKEY_A,
+      originNetuid: 4,
+      destinationHotkey: HOTKEY_B,
+      destinationNetuid: 999, // must be ignored for this axis -- same-subnet only
+      alphaAmountInput: "3",
+      originSpotPriceTao: null, // move_stake needs no price at all
+      tolerancePct: 5,
+    });
+    expect(params).toEqual({
+      call: "move_stake",
+      originHotkey: HOTKEY_A,
+      destinationHotkey: HOTKEY_B,
+      netuid: 4,
+      alphaAmount: alphaToRawAlpha("3"),
+    });
+  });
+
+  it("axis 'subnet' builds swap_stake_limit with limitPrice from the ORIGIN spot price, 'remove' direction", () => {
+    const params = buildMoveStakeCallParams({
+      axis: "subnet",
+      originHotkey: HOTKEY_A,
+      originNetuid: 4,
+      destinationHotkey: HOTKEY_A,
+      destinationNetuid: 7,
+      alphaAmountInput: "2",
+      originSpotPriceTao: 10,
+      tolerancePct: 5,
+    });
+    expect(params).toEqual({
+      call: "swap_stake_limit",
+      hotkey: HOTKEY_A,
+      originNetuid: 4,
+      destinationNetuid: 7,
+      alphaAmount: alphaToRawAlpha("2"),
+      limitPrice: taoToRao("9.5"), // 10 * (1 - 5/100), same "remove" math as computeLimitPrice elsewhere
+      allowPartial: false,
+    });
+  });
+
+  it("axis 'subnet' returns null when the origin spot price isn't resolved yet, rather than guessing", () => {
+    expect(
+      buildMoveStakeCallParams({
+        axis: "subnet",
+        originHotkey: HOTKEY_A,
+        originNetuid: 4,
+        destinationHotkey: HOTKEY_A,
+        destinationNetuid: 7,
+        alphaAmountInput: "2",
+        originSpotPriceTao: null,
+        tolerancePct: 5,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for a non-positive amount rather than throwing, for either axis", () => {
+    expect(
+      buildMoveStakeCallParams({
+        axis: "hotkey",
+        originHotkey: HOTKEY_A,
+        originNetuid: 4,
+        destinationHotkey: HOTKEY_B,
+        destinationNetuid: 4,
+        alphaAmountInput: "0",
+        originSpotPriceTao: null,
+        tolerancePct: 5,
+      }),
+    ).toBeNull();
+    expect(
+      buildMoveStakeCallParams({
+        axis: "subnet",
+        originHotkey: HOTKEY_A,
+        originNetuid: 4,
+        destinationHotkey: HOTKEY_A,
+        destinationNetuid: 7,
+        alphaAmountInput: "-1",
+        originSpotPriceTao: 10,
+        tolerancePct: 5,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for an unparseable amount string rather than throwing", () => {
+    expect(
+      buildMoveStakeCallParams({
+        axis: "hotkey",
+        originHotkey: HOTKEY_A,
+        originNetuid: 4,
+        destinationHotkey: HOTKEY_B,
+        destinationNetuid: 4,
+        alphaAmountInput: "not-a-number",
+        originSpotPriceTao: null,
+        tolerancePct: 5,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for an invalid tolerance on the 'subnet' axis (would otherwise throw inside computeLimitPrice)", () => {
+    expect(
+      buildMoveStakeCallParams({
+        axis: "subnet",
+        originHotkey: HOTKEY_A,
+        originNetuid: 4,
+        destinationHotkey: HOTKEY_A,
+        destinationNetuid: 7,
+        alphaAmountInput: "2",
+        originSpotPriceTao: 10,
+        tolerancePct: -1,
+      }),
+    ).toBeNull();
+  });
+
+  it("never builds a call with identical origin/destination netuids for the 'subnet' axis (buildSwapStakeLimitParams' own guard)", () => {
+    expect(
+      buildMoveStakeCallParams({
+        axis: "subnet",
+        originHotkey: HOTKEY_A,
+        originNetuid: 4,
+        destinationHotkey: HOTKEY_A,
+        destinationNetuid: 4,
+        alphaAmountInput: "2",
+        originSpotPriceTao: 10,
+        tolerancePct: 5,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("confirmAlphaAmount", () => {
+  it("reconstructs the exact alpha display from either params shape's alphaAmount field", () => {
+    expect(
+      confirmAlphaAmount({
+        call: "move_stake",
+        originHotkey: HOTKEY_A,
+        destinationHotkey: HOTKEY_B,
+        netuid: 4,
+        alphaAmount: alphaToRawAlpha("3"),
+      }),
+    ).toBe("3");
+  });
+
+  it("returns undefined for a null params object", () => {
+    expect(confirmAlphaAmount(null)).toBeUndefined();
+  });
+});

--- a/apps/ui/src/hooks/use-move-stake-flow.ts
+++ b/apps/ui/src/hooks/use-move-stake-flow.ts
@@ -1,0 +1,521 @@
+// The composition seam for the move/re-delegate stake flow (#5244, native-
+// staking epic #5229). Mirrors use-stake-flow.ts's structure and conventions
+// closely (same phase-derivation shape, same SSR-safe session id, same
+// exported-pure-function testing convention) but composes a DIFFERENT pair of
+// already-built, already-reviewed extrinsics instead of add/remove_stake_limit
+// -- see buildMoveStakeCallParams below for the fund-safety-critical seam this
+// hook exists to get right. No new signing logic: every chain-facing call
+// still goes through stake-extrinsics.ts / chain-connection.ts / broadcast.ts
+// unchanged.
+//
+// Scope: a single-axis move only -- either the hotkey changes (same subnet,
+// via move_stake) or the subnet changes (same hotkey, via swap_stake_limit).
+// stake-extrinsics.ts's own header comment documents why there is no single
+// safe call for changing both at once (it would need a new two-leg
+// remove_stake_limit + add_stake_limit composition) -- this flow refuses that
+// case rather than approximating it.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { ApiPromise } from "@polkadot/api";
+import { useWallet } from "./use-wallet";
+import { useTxStatus, type TxUiStatus, type UseTxStatusResult } from "./use-tx-status";
+import { DEFAULT_TOLERANCE_PCT } from "./use-stake-flow";
+import { subnetStakeQuoteQuery, subnetsQuery } from "@/lib/metagraphed/queries";
+import type { SubnetStakeQuote, Subnet } from "@/lib/metagraphed/types";
+import {
+  taoToRao,
+  raoToTao,
+  alphaToRawAlpha,
+  rawAlphaToAlpha,
+  type Rao,
+} from "@/lib/metagraphed/units";
+import {
+  computeLimitPrice,
+  buildMoveStakeParams,
+  buildSwapStakeLimitParams,
+  validateStakeInputs,
+  describeStakeValidationIssue,
+  type MoveStakeParams,
+  type SwapStakeLimitParams,
+  type StakeValidationIssue,
+} from "@/lib/metagraphed/stake-extrinsics";
+import {
+  getApi,
+  getMinStake,
+  getNextNonce,
+  buildExtrinsic,
+} from "@/lib/metagraphed/chain-connection";
+import { getSigner } from "@/lib/metagraphed/wallet-injected";
+import { computeIdempotencyKey } from "@/lib/metagraphed/broadcast";
+import { estimateFee } from "@/lib/metagraphed/tx-fee";
+
+export type MoveStakeFlowPhase =
+  "connect" | "amount" | "confirm" | "signing" | "broadcasting" | "failed" | "done";
+
+/** Identical shape to deriveStakeFlowPhase (use-stake-flow.ts) -- see that function's doc comment for the phase-transition rationale, unchanged here. */
+export function deriveMoveStakeFlowPhase(
+  walletStatus: string,
+  confirmed: boolean,
+  txStatus: TxUiStatus,
+): MoveStakeFlowPhase {
+  if (walletStatus !== "connected") return "connect";
+  if (!confirmed) return "amount";
+  if (txStatus === "idle") return "confirm";
+  if (txStatus === "signing") return "signing";
+  if (txStatus === "failed" || txStatus === "submit-error") return "failed";
+  if (txStatus === "finalized") return "done";
+  return "broadcasting";
+}
+
+/** Identical to canCloseStakeFlow (use-stake-flow.ts). */
+export function canCloseMoveStakeFlow(txStatus: TxUiStatus): boolean {
+  return (
+    txStatus === "idle" ||
+    txStatus === "failed" ||
+    txStatus === "submit-error" ||
+    txStatus === "finalized"
+  );
+}
+
+export type MoveStakeAxis = "hotkey" | "subnet";
+
+/**
+ * Which single axis a proposed destination changes relative to the origin
+ * position -- "hotkey" (re-delegate, same subnet), "subnet" (move to a
+ * different subnet, same hotkey), "unchanged" (nothing to do yet), or "both"
+ * (changing hotkey AND subnet at once). Only "hotkey" and "subnet" are
+ * buildable -- see this module's header comment for why "both" is refused
+ * rather than approximated.
+ */
+export function resolveMoveStakeAxis(
+  originHotkey: string,
+  originNetuid: number,
+  destinationHotkey: string,
+  destinationNetuid: number,
+): MoveStakeAxis | "unchanged" | "both" {
+  const hotkeyChanged = destinationHotkey.trim() !== originHotkey.trim();
+  const netuidChanged = destinationNetuid !== originNetuid;
+  if (hotkeyChanged && netuidChanged) return "both";
+  if (hotkeyChanged) return "hotkey";
+  if (netuidChanged) return "subnet";
+  return "unchanged";
+}
+
+/** Human-readable copy for the two non-buildable axis states, for the destination-picker step. */
+export function describeMoveStakeAxisIssue(axis: "unchanged" | "both"): string {
+  if (axis === "both") {
+    return "Move a hotkey or a subnet in one step, not both — do this as two separate moves.";
+  }
+  return "Choose a different hotkey or subnet to move this position to.";
+}
+
+/** Root (netuid 0) has no AMM -- its alpha is TAO 1:1, so the position's own TAO figure IS the moveable amount. Mirrors buildUnifiedPositions'/computeLimitPrice's existing root-as-1.0 treatment. */
+export function resolveMoveStakeMaxAmountInput(
+  isRoot: boolean,
+  positionAlpha: number | null,
+  positionSpotTao: number,
+): string | null {
+  if (isRoot) return positionSpotTao > 0 ? positionSpotTao.toFixed(9) : null;
+  return positionAlpha != null && positionAlpha > 0 ? positionAlpha.toFixed(9) : null;
+}
+
+/** The origin subnet's spot price (TAO per alpha), derived from the position data the caller already has -- no extra fetch. Root is fixed 1.0 (no AMM); an alpha subnet derives price = spotTao / alpha, null if that position's alpha is itself unknown. */
+export function resolveOriginSpotPriceTao(
+  isRoot: boolean,
+  positionAlpha: number | null,
+  positionSpotTao: number,
+): number | null {
+  if (isRoot) return 1;
+  if (positionAlpha == null || positionAlpha <= 0) return null;
+  return positionSpotTao / positionAlpha;
+}
+
+/**
+ * A spot-mark TAO-value estimate for an alpha amount (the same "current
+ * value" math YourPositionsPanel already displays per row) -- used for the
+ * axis-"hotkey" confirm screen, which has no AMM quote to draw from since a
+ * same-subnet hotkey move is a pure reassignment. Rounded through a fixed
+ * 9-decimal string via taoToRao/raoToTao, the same rounding path every other
+ * display amount in this app takes, rather than a raw toFixed with ad hoc
+ * trailing-zero trimming.
+ */
+export function formatSpotValueTao(alphaAmount: number, spotPriceTao: number): string {
+  const value =
+    Number.isFinite(alphaAmount) && Number.isFinite(spotPriceTao) ? alphaAmount * spotPriceTao : 0;
+  return raoToTao(taoToRao(Math.max(value, 0).toFixed(9)));
+}
+
+export interface BuildMoveStakeCallParamsInput {
+  axis: MoveStakeAxis;
+  originHotkey: string;
+  originNetuid: number;
+  destinationHotkey: string;
+  destinationNetuid: number;
+  alphaAmountInput: string;
+  /** Only read for axis "subnet" -- the ORIGIN netuid's live spot price, the leg swap_stake_limit's limit_price actually protects (see doc comment below). */
+  originSpotPriceTao: number | null;
+  tolerancePct: number;
+}
+
+/**
+ * The one place a resolved axis + amount turns into an actual extrinsic-param
+ * object -- this flow's equivalent of use-stake-flow.ts's buildStakeCallParams
+ * fund-safety-critical seam. Never throws: any malformed/incomplete input
+ * (an unparseable amount, a still-loading spot price) resolves to null rather
+ * than crashing mid-render, since this is called on every render while the
+ * user is still typing/picking.
+ *
+ * limitPrice direction for axis "subnet": computeLimitPrice's "remove"
+ * direction (spot price MINUS tolerance -- "willing to accept down to this
+ * much"), against the ORIGIN netuid's spot price. A cross-subnet swap gives
+ * up origin-subnet alpha value to receive destination-subnet alpha -- the
+ * origin leg is where an adverse price move actually costs the user value,
+ * the same case computeLimitPrice's "remove" direction protects against for
+ * use-stake-flow.ts's own remove_stake_limit path.
+ */
+export function buildMoveStakeCallParams(
+  input: BuildMoveStakeCallParamsInput,
+): MoveStakeParams | SwapStakeLimitParams | null {
+  const {
+    axis,
+    originHotkey,
+    originNetuid,
+    destinationHotkey,
+    destinationNetuid,
+    alphaAmountInput,
+    originSpotPriceTao,
+    tolerancePct,
+  } = input;
+  try {
+    const alphaAmount = alphaToRawAlpha(alphaAmountInput);
+    if (alphaAmount <= 0n) return null;
+
+    if (axis === "hotkey") {
+      return buildMoveStakeParams({
+        originHotkey,
+        destinationHotkey,
+        netuid: originNetuid,
+        alphaAmount,
+      });
+    }
+
+    if (originSpotPriceTao == null) return null;
+    const limitPrice = computeLimitPrice({
+      spotPriceTao: originSpotPriceTao,
+      tolerancePct,
+      direction: "remove",
+    });
+    return buildSwapStakeLimitParams({
+      hotkey: originHotkey,
+      originNetuid,
+      destinationNetuid,
+      alphaAmount,
+      limitPrice,
+      allowPartial: false,
+    });
+  } catch {
+    return null;
+  }
+}
+
+export interface UseMoveStakeFlowResult {
+  phase: MoveStakeFlowPhase;
+  wallet: ReturnType<typeof useWallet>;
+
+  originHotkey: string;
+  originNetuid: number;
+
+  destinationHotkeyInput: string;
+  setDestinationHotkeyInput: (value: string) => void;
+  destinationNetuidInput: string;
+  setDestinationNetuidInput: (value: string) => void;
+  amountInput: string;
+  setAmountInput: (value: string) => void;
+  tolerancePct: number;
+  setTolerancePct: (value: number) => void;
+
+  axis: MoveStakeAxis | "unchanged" | "both";
+  axisIssueMessage: string | null;
+
+  /** TAO per alpha for the ORIGIN subnet, derived from the position data the caller passed in -- null only for a real data gap (a non-root position with an unresolved price). */
+  originSpotPriceTao: number | null;
+
+  knownSubnets: Subnet[];
+
+  quote: SubnetStakeQuote | null;
+  quoteIsPending: boolean;
+  quoteError: string | null;
+
+  maxAmountInput: string | null;
+  applyMax: () => void;
+
+  params: MoveStakeParams | SwapStakeLimitParams | null;
+  feeTao: string | null;
+  validationIssues: StakeValidationIssue[];
+  validationMessages: string[];
+  canConfirm: boolean;
+  confirm: () => void;
+  editAmount: () => void;
+
+  txStatus: UseTxStatusResult;
+  submit: () => Promise<void>;
+  canClose: boolean;
+  close: () => void;
+}
+
+/** #5244's composition seam for one origin (hotkey, netuid) position's move/re-delegate flow. */
+export function useMoveStakeFlow(
+  originHotkey: string,
+  originNetuid: number,
+  positionAlpha: number | null,
+  positionSpotTao: number,
+): UseMoveStakeFlowResult {
+  const wallet = useWallet();
+  const txStatus = useTxStatus();
+  const isRoot = originNetuid === 0;
+
+  const [destinationHotkeyInput, setDestinationHotkeyInput] = useState(originHotkey);
+  const [destinationNetuidInput, setDestinationNetuidInput] = useState(String(originNetuid));
+  const [amountInput, setAmountInput] = useState("");
+  const [tolerancePct, setTolerancePct] = useState(DEFAULT_TOLERANCE_PCT);
+  const [confirmed, setConfirmed] = useState(false);
+
+  // Generated client-only -- see use-stake-flow.ts's identical pattern for
+  // why (avoids an SSR/CSR hydration mismatch).
+  const [sessionId, setSessionId] = useState("");
+  useEffect(() => {
+    setSessionId(crypto.randomUUID());
+  }, []);
+
+  const [api, setApi] = useState<ApiPromise | null>(null);
+  useEffect(() => {
+    if (wallet.status !== "connected") return;
+    let cancelled = false;
+    getApi()
+      .then((connected) => {
+        if (!cancelled) setApi(connected);
+      })
+      .catch(() => {
+        /* best-effort; minStake/submit simply stay unavailable */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [wallet.status]);
+
+  const [minStakeRao, setMinStakeRao] = useState<Rao | null>(null);
+  useEffect(() => {
+    if (!api) return;
+    let cancelled = false;
+    getMinStake(api)
+      .then((min) => {
+        if (!cancelled) setMinStakeRao(min);
+      })
+      .catch(() => {
+        /* best-effort; the min-stake validation issue just stays unavailable */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api]);
+
+  const subnetsQ = useQuery(subnetsQuery());
+  const knownSubnets = useMemo(
+    () => (subnetsQ.data?.data ?? []).slice().sort((a, b) => a.netuid - b.netuid),
+    [subnetsQ.data],
+  );
+  const knownNetuids = useMemo(() => knownSubnets.map((s) => s.netuid), [knownSubnets]);
+
+  const destinationHotkey = destinationHotkeyInput.trim();
+  const destinationNetuid = Number(destinationNetuidInput);
+  const destinationNetuidValid = Number.isFinite(destinationNetuid);
+
+  const axis = useMemo(() => {
+    if (!destinationNetuidValid) return "unchanged" as const;
+    return resolveMoveStakeAxis(originHotkey, originNetuid, destinationHotkey, destinationNetuid);
+  }, [originHotkey, originNetuid, destinationHotkey, destinationNetuid, destinationNetuidValid]);
+
+  const axisIssueMessage =
+    axis === "unchanged" || axis === "both" ? describeMoveStakeAxisIssue(axis) : null;
+
+  const originSpotPriceTao = resolveOriginSpotPriceTao(isRoot, positionAlpha, positionSpotTao);
+
+  const hasValidAmountInput =
+    amountInput.trim() !== "" && Number.isFinite(Number(amountInput)) && Number(amountInput) > 0;
+
+  const quoteQ = useQuery({
+    ...subnetStakeQuoteQuery(
+      originNetuid,
+      hasValidAmountInput ? Number(amountInput) : 0,
+      "unstake",
+    ),
+    enabled: axis === "subnet" && hasValidAmountInput,
+  });
+  const quote = axis === "subnet" ? (quoteQ.data?.data ?? null) : null;
+
+  const params = useMemo(() => {
+    if (axis !== "hotkey" && axis !== "subnet") return null;
+    if (!hasValidAmountInput) return null;
+    return buildMoveStakeCallParams({
+      axis,
+      originHotkey,
+      originNetuid,
+      destinationHotkey,
+      destinationNetuid,
+      alphaAmountInput: amountInput,
+      originSpotPriceTao,
+      tolerancePct,
+    });
+  }, [
+    axis,
+    hasValidAmountInput,
+    originHotkey,
+    originNetuid,
+    destinationHotkey,
+    destinationNetuid,
+    amountInput,
+    originSpotPriceTao,
+    tolerancePct,
+  ]);
+
+  const validationIssues = useMemo(() => {
+    if (!params || minStakeRao == null) return [];
+    // Skip the floor/self-consistency pre-check (rather than fabricating a
+    // zero-price estimate that would falsely read as "amount_not_positive")
+    // when the origin price isn't resolved yet -- this is a UX convenience,
+    // not the safety boundary (validateStakeInputs' own doc comment): the
+    // chain re-validates and remains authoritative either way.
+    if (!isRoot && originSpotPriceTao == null) return [];
+    return validateStakeInputs({
+      hotkey: destinationHotkey,
+      netuid: destinationNetuid,
+      knownNetuids,
+      amountRao: taoToRao(((Number(amountInput) || 0) * (originSpotPriceTao ?? 1)).toFixed(9)),
+      minStakeRao,
+      // No availableBalanceRao: a move/swap draws from existing stake, never the free balance.
+    });
+  }, [
+    params,
+    minStakeRao,
+    isRoot,
+    destinationHotkey,
+    destinationNetuid,
+    knownNetuids,
+    amountInput,
+    originSpotPriceTao,
+  ]);
+
+  const validationMessages = useMemo(
+    () => validationIssues.map(describeStakeValidationIssue),
+    [validationIssues],
+  );
+
+  const canConfirm =
+    params != null &&
+    validationIssues.length === 0 &&
+    originSpotPriceTao != null &&
+    (axis !== "subnet" || (quoteQ.isSuccess && !quoteQ.isFetching));
+
+  const maxAmountInput = resolveMoveStakeMaxAmountInput(isRoot, positionAlpha, positionSpotTao);
+  const applyMax = useCallback(() => {
+    if (maxAmountInput != null) setAmountInput(maxAmountInput);
+  }, [maxAmountInput]);
+
+  // Fee dry-run for the PreSignConfirmation screen -- identical posture to
+  // use-stake-flow.ts's: only fetched once the user has reached "confirm"
+  // with a resolved, idle tx.
+  const [feeRao, setFeeRao] = useState<Rao | null>(null);
+  useEffect(() => {
+    setFeeRao(null);
+    if (!confirmed || txStatus.status !== "idle") return;
+    if (!api || !wallet.wallet || !params) return;
+    let cancelled = false;
+    const extrinsic = buildExtrinsic(api, params);
+    estimateFee(extrinsic, wallet.wallet.address)
+      .then((fee) => {
+        if (!cancelled) setFeeRao(fee);
+      })
+      .catch(() => {
+        /* best-effort; the confirm screen just keeps showing "Estimating..." */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [confirmed, txStatus.status, api, wallet.wallet, params]);
+
+  const confirm = useCallback(() => setConfirmed(true), []);
+  const editAmount = useCallback(() => {
+    setConfirmed(false);
+    txStatus.reset();
+  }, [txStatus]);
+
+  const close = useCallback(() => {
+    txStatus.reset();
+    setConfirmed(false);
+    setAmountInput("");
+    setDestinationHotkeyInput(originHotkey);
+    setDestinationNetuidInput(String(originNetuid));
+  }, [txStatus, originHotkey, originNetuid]);
+
+  const submit = useCallback(async () => {
+    if (!api || !wallet.wallet || !params) return;
+    const nonce = await getNextNonce(api, wallet.wallet.address);
+    const idempotencyKey = computeIdempotencyKey(params, nonce, sessionId);
+    const extrinsic = buildExtrinsic(api, params);
+    const signer = await getSigner(wallet.wallet.source);
+    await txStatus.submit(api, extrinsic, {
+      signerAddress: wallet.wallet.address,
+      signer,
+      idempotencyKey,
+    });
+  }, [api, wallet.wallet, params, sessionId, txStatus]);
+
+  const phase = deriveMoveStakeFlowPhase(wallet.status, confirmed, txStatus.status);
+
+  return {
+    phase,
+    wallet,
+    originHotkey,
+    originNetuid,
+    destinationHotkeyInput,
+    setDestinationHotkeyInput,
+    destinationNetuidInput,
+    setDestinationNetuidInput,
+    amountInput,
+    setAmountInput,
+    tolerancePct,
+    setTolerancePct,
+    axis,
+    axisIssueMessage,
+    originSpotPriceTao,
+    knownSubnets,
+    quote,
+    quoteIsPending: quoteQ.isPending,
+    quoteError: quoteQ.isError
+      ? quoteQ.error instanceof Error
+        ? quoteQ.error.message
+        : "Could not compute a quote."
+      : null,
+    maxAmountInput,
+    applyMax,
+    params,
+    feeTao: feeRao != null ? raoToTao(feeRao) : null,
+    validationIssues,
+    validationMessages,
+    canConfirm,
+    confirm,
+    editAmount,
+    txStatus,
+    submit,
+    canClose: canCloseMoveStakeFlow(txStatus.status),
+    close,
+  };
+}
+
+/** The confirm screen's alpha display -- the exact RawAlpha this params object will submit, never a re-derived estimate. */
+export function confirmAlphaAmount(
+  params: MoveStakeParams | SwapStakeLimitParams | null,
+): string | undefined {
+  return params ? rawAlphaToAlpha(params.alphaAmount) : undefined;
+}


### PR DESCRIPTION
## Summary

- Adds a "Move this position" entry point to the your-positions panel (`YourPositionsPanel`), opening a new move/re-delegate stake flow next to the existing Manage button.
- Supports two single-axis moves, each reusing Phase 2 plumbing (extrinsic construction, broadcast, confirmation, status/error, idempotency) completely unchanged: re-delegate to a different hotkey on the same subnet (`move_stake`, a riskless reassignment, no AMM), and move to a different subnet with the same hotkey (`swap_stake_limit`, AMM-protected via `limit_price`).
- No new signing logic: `buildMoveStakeParams`/`buildSwapStakeLimitParams` (already built, tested, and covered by the #5251 pre-launch security review) are called as-is from a new pure dispatch function (`buildMoveStakeCallParams` in `use-move-stake-flow.ts`), which only decides *which* existing builder to call based on which single field changed.
- Changing both hotkey and subnet at once is explicitly refused (not approximated) — `stake-extrinsics.ts`'s own header comment documents why a single safe call doesn't exist for that case (it would need a new two-leg `remove_stake_limit` + `add_stake_limit` composition, out of scope here). The picker surfaces a clear message directing the user to do it as two separate moves instead.
- The existing `PreSignConfirmation` screen (#5239) is reused with zero changes: since only one axis ever differs from the origin position, showing "destination hotkey + destination netuid" as its single hotkey/netuid pair is always an accurate summary of what's being signed.

## Files touched

- `apps/ui/src/hooks/use-move-stake-flow.ts` (new) — the composition seam, mirroring `use-stake-flow.ts`/`use-take-flow.ts`'s existing shape.
- `apps/ui/src/components/metagraphed/move-stake-destination-input.tsx` (new) — the destination hotkey/subnet/amount picker.
- `apps/ui/src/components/metagraphed/move-stake-modal.tsx` (new) — the composition component, mirroring `stake-unstake-modal.tsx`/`take-management-modal.tsx`.
- `apps/ui/src/components/metagraphed/your-positions-panel.tsx` — adds the "Move" entry point next to the existing "Manage" button (desktop table + mobile cards).

## Verification

- `npm run lint --workspace=apps/ui` && `npm run format:check --workspace=apps/ui` — clean (0 errors on the changed files; pre-existing warnings elsewhere untouched).
- `npm run typecheck --workspace=apps/ui` — clean.
- `npm test --workspace=apps/ui` — 167 files / 1269 tests passing, including 34 new tests for `use-move-stake-flow.ts`'s pure functions (axis resolution, the params-builder dispatch for both call shapes, spot-value estimation, phase derivation).
- `npm run build --workspace=apps/ui` — succeeds. The new code is only reachable via the lazy `/portfolio` route chunk (confirmed by import-graph grep), so it cannot affect the "/" route's initial-bundle budget check.
- `npm run test:e2e --workspace=apps/ui` — 3 pre-existing failures (`evidence-deep-link.spec.ts`, `multisig-related-error.spec.ts`), reproduced identically with this branch's changes stashed against a clean `upstream/main` checkout — confirmed unrelated to this PR.
- Manually smoke-tested the full flow in a real browser against the **live** production API and the **live** Bittensor chain (real WebSocket connection, real `paymentInfo()` fee dry-run): entering a destination hotkey correctly builds `move_stake` params, the confirmation screen shows the destination hotkey, the unchanged origin subnet, the exact alpha amount, a spot-value TAO estimate, and a real network fee.

## Screenshot table

3 viewports × 2 themes × before/after, `/portfolio` with a connected wallet (real live position data), scrolled to the position row so the new entry point is visible.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/5244-mobile-dark-after.png)<br><sub>after</sub> |

Closes #5244
