### PR TITLE
docs(skill): scope contributor-pipeline-gardening off registry enrichment

### DIFF
--- a/.claude/skills/contributor-pipeline-gardening/SKILL.md
+++ b/.claude/skills/contributor-pipeline-gardening/SKILL.md
@@ -15,6 +15,17 @@ description: >-
 
 # Contributor pipeline gardening — metagraphed
 
+## Scope boundary — no registry enrichment (reinforced 2026-07-19)
+
+**This pipeline covers code/feature/bug work only.** Registry surface/subnet data work of any
+kind — new-subnet intake (Enrich-SNxx), accuracy passes, probe-config fixes, or any other edit to
+`registry/subnets/<slug>.json` content — is **out of scope entirely**, not just the already-documented
+Enrich-SNxx exclusion below. A separate, dedicated automation owns registry enrichment end to end.
+This was reinforced by the maintainer 2026-07-19 after this pipeline generated 34 registry
+probe-config issues (decomposing #5932) that had to be reverted mid-run. If Pass 1's stale-sweep or
+Pass 2's top-up work surfaces a real registry data gap, name it in the digest for the dedicated
+registry automation to pick up — do not file issues or PRs against `registry/` from this pipeline.
+
 metagraphed is a Bittensor subnet registry / block-explorer product. Unlike gittensory/loopover,
 **a linked issue is optional here** — the gate judges a PR on its own merit when nothing is linked,
 it only auto-closes for a missing link if a linked issue was claimed and doesn't hold up (see
@@ -91,11 +102,12 @@ Hardening`) same as before.
    `gittensor:priority` as a **standalone** points label (54 of 59 `gittensor:priority` issues here
    carry no `gittensor:feature`/`gittensor:bug` pairing, as of 2026-07-14). Don't "fix" this to match
    gittensory's scarcer convention unless asked — it's this repo's own established norm.
-3. Real, concrete gaps worth scoping from first: the **"Docs page: <endpoint>" family** in
-   `Wave 4 — Docs & Dev Surface` (docs for existing shipped API surfaces — `/rpc/*`, `/api/v1/search`,
-   `/api/v1/webhooks/*`, etc.) are currently `maintainer-only` but look like exactly the kind of
-   low-risk, precedent-following, no-business-judgment work this framework says is safe to unlock —
-   worth a first-pass review to confirm and relabel rather than only generating net-new issues.
+3. **The "Docs page: <endpoint>" family is fully resolved as of 2026-07-19 — don't look here anymore.**
+   #6225 (the fumadocs-mdx port issue) closed as superseded 2026-07-16: the docs pipeline shipped via
+   a native `fumadocs-mdx` + `fumadocs-ui` + `fumadocs-openapi` integration (not Scalar as originally
+   proposed), and all 10 paused issues (#3504-#3511, #3514, #3516) plus #3512/#3513/#3515 are written
+   and closed. This bullet previously pointed here as a top-up source; it no longer applies — source
+   Pass 2 issues elsewhere.
 4. **Every new issue gets a real milestone — no issue ships unmilestoned.** A `gittensor:bug`/
    `gittensor:feature`/`gittensor:priority` label (this repo's own convention — priority isn't scarce
    here the way it is in gittensory, but still means "the maintainer actually wants this soon," don't

--- a/.claude/skills/contributor-pipeline-gardening/reference.md
+++ b/.claude/skills/contributor-pipeline-gardening/reference.md
@@ -1,28 +1,26 @@
 # Contributor pipeline gardening — reference (metagraphed)
 
-## Docs architecture migration — spike landed on loopover 2026-07-15, metagraphed port issue filed 2026-07-16
+## Scope boundary — registry enrichment is a separate automation (see SKILL.md)
 
-metagraphed's website docs (currently hand-built TanStack Router route files, one full React
-component per page — see the shipped `Docs page: X` precedents like #3512/#3513/#3515) are migrating
-to a shared MDX pipeline: **`fumadocs-core`/`fumadocs-mdx` (headless, not `fumadocs-ui`'s component
-shell) for content/structure/search, rendered through existing ui-kit primitives, plus Scalar
-(`@scalar/api-reference`) for the API playground.**
+Don't file, triage, or fix anything under `registry/subnets/*.json` from this pipeline — not just the
+Enrich-SNxx new-subnet-intake family, but registry data work of any kind (accuracy passes,
+probe-config gaps, curation fields, etc). See SKILL.md's "Scope boundary" section for the 2026-07-19
+incident that established this.
 
-**Status as of 2026-07-16:** the loopover spike (JSONbored/loopover#6037) landed 2026-07-15 and
-JSONbored/loopover#6271 (merged same day) already migrated every existing loopover-ui docs page onto
-the new pattern — proven, not just spiked. Loopover's own AMS-docs epic (#6012 + sub-issues
-#6022-#6032) was fully closed as a result. The metagraphed-side port is now tracked as **#6225**
-(`maintainer-only`, filed 2026-07-16) and #3504/3505/3506/3507/3508/3509/3510/3511/3514/3516 are all
-linked `addBlockedBy` #6225.
+## Docs architecture migration — RESOLVED 2026-07-16, fully shipped
 
-**Until #6225 lands:**
+metagraphed's website docs migrated off hand-built TanStack Router route files (one full React
+component per page — the old `docs.*.tsx` pattern) onto a shared MDX pipeline. **#6225** (the port
+issue, filed 2026-07-16 after loopover's own spike/rollout — JSONbored/loopover#6037 + #6271) closed
+the same day as **superseded**: the pipeline shipped via a native `fumadocs-mdx` + `fumadocs-ui` +
+`fumadocs-openapi` integration (not the originally-proposed Scalar `@scalar/api-reference`) — content
+now lives in `content/docs/*.mdx` behind a single `docs.$.tsx` catch-all route, and the API-reference
+half is generated straight from `openapi.json` via `fumadocs-openapi` (#6210) rather than an embedded
+Scalar component.
 
-- Don't file new issues asking a contributor to hand-build a `docs.*.tsx` route. If a genuine docs
-  gap is found during Pass 2, note it in the digest instead of filing it under the old pattern.
-- Don't "fix" the `maintainer-only` labeling on the "Docs page: X" family in a future stale-sweep
-  pass — check #6225's state first. Once it lands, those issues need their Requirements rewritten to
-  target a `content/docs/*.mdx` file instead of a hand-built route, then `maintainer-only` removed —
-  see JSONbored/loopover#6012's family for the precedent of that exact follow-up rewrite.
+**All 10 previously-paused "Docs page: X" issues (#3504-#3511, #3514, #3516) plus the earlier
+#3512/#3513/#3515 are written and closed (#6232).** This family is fully drained — don't look here
+for Pass 2 top-up material, and don't re-open or re-triage any of these issues; they're done.
 
 ## Product shape
 


### PR DESCRIPTION
## Summary
- Registry enrichment (new-subnet intake, accuracy passes, probe-config fixes) is now explicitly out of scope for the contributor-pipeline-gardening automation — a separate dedicated automation owns that queue. This pass generated 34 registry probe-config issues (decomposing #5932) before this boundary was made explicit; all 34 were closed/reverted.
- Corrects a stale section: the fumadocs-mdx docs migration (#6225) actually shipped via a native fumadocs-mdx/fumadocs-ui/fumadocs-openapi integration and closed as superseded 2026-07-16 — the whole "Docs page: X" family is written and closed, not still paused.

## Test plan
- [x] `npx prettier --check` on both edited files