### PR TITLE
perf(api): split account summary event scan into two per-column seeks

### DIFF
--- a/src/account-events.mjs
+++ b/src/account-events.mjs
@@ -278,6 +278,40 @@ export function formatAccountActivity(agg, modules) {
   };
 }
 
+// Merge the two per-column account_events scans the summary route runs (one
+// filtered on `hotkey`, one on `coldkey`) back into a single newest-first
+// window, re-capped to the same CAP+1 probe size a single OR'd scan would have
+// produced. The route was split into two branches (#6878) because Postgres
+// evaluates a flat `(hotkey = $1 OR coldkey = $1)` as one combined plan that
+// can't index-seek either column and scans far past the LIMIT for addresses
+// whose rows are sparse relative to the table's block_number order — timing out
+// (Sentry METAGRAPHED-5). Each branch alone is a plain `hotkey`/`coldkey` +
+// `(block_number, event_index)` index seek. A row where hotkey == coldkey ==
+// the queried ss58 shows up in both branches; it's the same physical row, so
+// dedup on (block_number, event_index) — the ORDER BY key, unique per row —
+// before re-sorting and re-capping. Because each branch is already the newest
+// CAP+1 rows of its own column, their union is a superset of the true global
+// newest CAP+1, so this reproduces the OR'd scan's result exactly, minus the
+// timeout risk.
+export function mergeAccountEventScans(hotkeyRows, coldkeyRows, cap) {
+  const byKey = new Map();
+  for (const row of [...(hotkeyRows || []), ...(coldkeyRows || [])]) {
+    if (!row) continue;
+    const key = `${row.block_number}:${row.event_index}`;
+    if (!byKey.has(key)) byKey.set(key, row);
+  }
+  return [...byKey.values()]
+    .sort((a, b) => {
+      const bnA = toBlockNumber(a.block_number) ?? 0;
+      const bnB = toBlockNumber(b.block_number) ?? 0;
+      if (bnA !== bnB) return bnB - bnA;
+      const eiA = toBlockNumber(a.event_index) ?? 0;
+      const eiB = toBlockNumber(b.event_index) ?? 0;
+      return eiB - eiA;
+    })
+    .slice(0, cap);
+}
+
 export function buildAccountSummary(
   ss58,
   { agg, kinds, scanned, registrations, recent, activity, modules } = {},

--- a/tests/account-events.test.mjs
+++ b/tests/account-events.test.mjs
@@ -14,7 +14,56 @@ import {
   loadAccountHistory,
   ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
   buildAccountTransfers,
+  mergeAccountEventScans,
 } from "../src/account-events.mjs";
+
+const scanRow = (block_number, event_index, extra = {}) => ({
+  block_number,
+  event_index,
+  event_kind: "StakeAdded",
+  ...extra,
+});
+
+test("mergeAccountEventScans merges two branches newest-first by (block, event_index)", () => {
+  const hotkey = [scanRow("10", 1), scanRow("8", 0)];
+  const coldkey = [scanRow("9", 2), scanRow("8", 5)];
+  const merged = mergeAccountEventScans(hotkey, coldkey, 10);
+  assert.deepEqual(
+    merged.map((r) => [r.block_number, r.event_index]),
+    [
+      ["10", 1],
+      ["9", 2],
+      ["8", 5],
+      ["8", 0],
+    ],
+  );
+});
+
+test("mergeAccountEventScans dedups the row shared by both branches on (block, event_index)", () => {
+  const shared = scanRow("12", 0, { netuid: 7 });
+  const merged = mergeAccountEventScans([shared], [shared], 10);
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].netuid, 7);
+});
+
+test("mergeAccountEventScans re-caps the merged window to the requested size", () => {
+  const hotkey = [scanRow("5", 0), scanRow("4", 0), scanRow("3", 0)];
+  const coldkey = [scanRow("6", 0), scanRow("2", 0)];
+  const merged = mergeAccountEventScans(hotkey, coldkey, 3);
+  assert.deepEqual(
+    merged.map((r) => r.block_number),
+    ["6", "5", "4"],
+  );
+});
+
+test("mergeAccountEventScans is null-safe on absent branches and junk rows", () => {
+  assert.deepEqual(mergeAccountEventScans(null, undefined, 5), []);
+  const merged = mergeAccountEventScans([null, scanRow("1", 0)], [null], 5);
+  assert.deepEqual(
+    merged.map((r) => r.block_number),
+    ["1"],
+  );
+});
 
 test("INDEXED_EVENT_KINDS covers the core entity events", () => {
   for (const k of [

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -1121,7 +1121,8 @@ test("GET /api/v1/extrinsics/:ref skips the embedded-events query on an unresolv
 test("GET /api/v1/accounts/:ss58 shapes the cross-subnet summary from one bounded event window", async () => {
   mockQueue.current = [
     [], // SET
-    [ACCOUNT_EVENT_ROW, { ...ACCOUNT_EVENT_ROW, netuid: 5 }], // scanRows
+    [ACCOUNT_EVENT_ROW, { ...ACCOUNT_EVENT_ROW, netuid: 5, event_index: 1 }], // hotkeyRows
+    [], // coldkeyRows
     [{ netuid: 4, uid: 1, stake_tao: "10", validator_permit: 1, active: 1 }], // regRows
     [
       {
@@ -1144,14 +1145,20 @@ test("GET /api/v1/accounts/:ss58 shapes the cross-subnet summary from one bounde
   expect(body.recent_events.length).toBe(2);
   expect(body.activity.tx_count).toBe(3);
   expect(body.activity.modules_called[0].call_module).toBe("SubtensorModule");
-  expect(queryText()).toContain("WHERE (hotkey =");
-  expect(queryText()).toContain("OR coldkey =");
+  // Two per-column index-seekable scans (#6878), not one combined OR'd plan.
+  expect(queryText()).toContain("WHERE hotkey =");
+  expect(queryText()).toContain("WHERE coldkey =");
+  expect(queryText()).not.toContain("OR coldkey");
 });
 
 test("GET /api/v1/accounts/:ss58 ignores null netuid events in subnet_count", async () => {
   mockQueue.current = [
     [], // SET
-    [ACCOUNT_EVENT_ROW, { ...ACCOUNT_EVENT_ROW, netuid: null }], // scanRows
+    [
+      { ...ACCOUNT_EVENT_ROW, event_index: 1 },
+      { ...ACCOUNT_EVENT_ROW, netuid: null, event_index: 0 },
+    ], // hotkeyRows
+    [], // coldkeyRows
     [], // regRows
     [], // activityRows
     [], // moduleRows
@@ -1162,6 +1169,52 @@ test("GET /api/v1/accounts/:ss58 ignores null netuid events in subnet_count", as
   expect(body.event_count).toBe(2);
   expect(body.subnet_count).toBe(1);
   expect(body.recent_events.map((event) => event.netuid)).toEqual([4, null]);
+});
+
+test("GET /api/v1/accounts/:ss58 merges hotkey + coldkey scans, deduping the shared row and re-capping newest-first", async () => {
+  // An address active under BOTH columns: the two branches overlap on the row
+  // where hotkey == coldkey == ss58, which must be counted once, and the merged
+  // window must stay ordered by (block_number, event_index) DESC across branches.
+  const both = {
+    ...ACCOUNT_EVENT_ROW,
+    block_number: "8586302",
+    event_index: 0,
+    coldkey: SS58,
+    netuid: 7,
+  };
+  mockQueue.current = [
+    [], // SET
+    [
+      both, // shared row (also in coldkey branch)
+      {
+        ...ACCOUNT_EVENT_ROW,
+        block_number: "8586301",
+        event_index: 3,
+        netuid: 4,
+      },
+    ], // hotkeyRows
+    [
+      both, // same physical row surfaced by the coldkey seek
+      {
+        ...ACCOUNT_EVENT_ROW,
+        block_number: "8586300",
+        event_index: 9,
+        coldkey: SS58,
+        netuid: 5,
+      },
+    ], // coldkeyRows
+    [], // regRows
+    [], // activityRows
+    [], // moduleRows
+  ];
+  const res = await req(`/api/v1/accounts/${SS58}`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.event_count).toBe(3); // shared row deduped, not double-counted
+  expect(body.subnet_count).toBe(3); // netuids 7, 4, 5
+  expect(body.recent_events.map((event) => event.block_number)).toEqual([
+    8586302, 8586301, 8586300,
+  ]);
 });
 
 test("GET /api/v1/accounts/:ss58 with no matching rows returns a schema-stable empty summary", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -40,6 +40,7 @@ import {
   buildAccountSummary,
   buildAccountSubnets,
   buildAccountHistory,
+  mergeAccountEventScans,
   ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
   SUBNET_EVENT_SUMMARY_WINDOWS,
   DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW,
@@ -4206,22 +4207,35 @@ export default {
         // summary -- event aggregates, per-kind counts, 10 newest events,
         // current registrations, and bounded signing activity from the
         // extrinsics tier, mirroring the former src/account-events.mjs
-        // account-summary D1 loader (removed in #4772). Postgres has no INDEXED BY equivalent and
-        // evaluates (hotkey = $1 OR coldkey = $1) as one plan, so the D1
-        // path's two-branch UNION-of-seeks (each capped, then re-merged and
-        // re-capped) collapses to a single bounded ORDER BY/LIMIT scan here --
-        // the aggregate/kind/recent-events fields below all derive from that
-        // one CAP+1-row window, computed once client-side, rather than
+        // account-summary D1 loader (removed in #4772). The event window comes
+        // from two per-column capped scans (one on `hotkey`, one on `coldkey`)
+        // merged + re-sorted + re-capped client-side (#6878), restoring the D1
+        // loader's two-branch shape: a flat `(hotkey = $1 OR coldkey = $1)`
+        // forces Postgres into one combined plan that can't index-seek either
+        // column and scans far past the LIMIT for sparse addresses, timing out
+        // (Sentry METAGRAPHED-5). Each branch alone is a plain index seek. The
+        // aggregate/kind/recent-events fields below all derive from that one
+        // merged CAP+1-row window, computed once client-side, rather than
         // separate SQL aggregates per field.
         const acctSummary = url.pathname.match(
           /^\/api\/v1\/accounts\/([^/]+)$/,
         );
         if (acctSummary) {
           const ss58 = decodeURIComponent(acctSummary[1]);
-          const scanRows = await sql`
+          const scanCap = ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1;
+          const hotkeyRows = await sql`
           SELECT block_number, event_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at, extrinsic_index
-          FROM account_events WHERE (hotkey = ${ss58} OR coldkey = ${ss58})
-          ORDER BY block_number DESC, event_index DESC LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1}`;
+          FROM account_events WHERE hotkey = ${ss58}
+          ORDER BY block_number DESC, event_index DESC LIMIT ${scanCap}`;
+          const coldkeyRows = await sql`
+          SELECT block_number, event_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at, extrinsic_index
+          FROM account_events WHERE coldkey = ${ss58}
+          ORDER BY block_number DESC, event_index DESC LIMIT ${scanCap}`;
+          const scanRows = mergeAccountEventScans(
+            hotkeyRows,
+            coldkeyRows,
+            scanCap,
+          );
           const regRows = await sql`
           SELECT netuid, uid, stake_tao, validator_permit, active FROM neurons
           WHERE hotkey = ${ss58} ORDER BY stake_tao DESC, netuid ASC`;


### PR DESCRIPTION
## What

`GET /api/v1/accounts/{ss58}` (the `#4832` Tier-1c cross-subnet account summary)
built its event window from a single OR'd scan:

```sql
FROM account_events WHERE (hotkey = $1 OR coldkey = $1)
ORDER BY block_number DESC, event_index DESC LIMIT ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1
```

Postgres evaluates `(hotkey = $1 OR coldkey = $1)` as one combined plan that
can't index-seek either column. For an address whose `account_events` rows are
sparse relative to the table's `block_number DESC` order, the planner scans far
more of the table than the `LIMIT` before it's confident it has the top-N —
intermittently tripping the statement timeout in production (Sentry
METAGRAPHED-5).

## Change

Restore the two-branch, per-column bounded scan the removed
`src/account-events.mjs` D1 loader used (see #4772):

- Run two capped queries — one `WHERE hotkey = $1`, one `WHERE coldkey = $1` —
  each `ORDER BY block_number DESC, event_index DESC LIMIT CAP + 1`. Each is a
  plain single-column equality seek backed by the existing
  `idx_ae_hotkey (hotkey, block_number DESC)` / `idx_ae_coldkey (coldkey, block_number DESC)`
  indexes, instead of the un-seekable combined-OR plan.
- Merge + re-sort + re-cap client-side in a new `mergeAccountEventScans` helper.
  A row where `hotkey == coldkey == ss58` surfaces in both branches; it's the
  same physical row, so it's deduped on `(block_number, event_index)` (the
  `ORDER BY` key, unique per row) before re-capping.

Correctness: each branch is already the newest `CAP + 1` rows of its own column,
so their union is a superset of the true global newest `CAP + 1`. Merging both
and re-capping reproduces the OR'd scan's result exactly, minus the timeout
risk. All downstream aggregate/kind/recent-events fields derive from that same
merged window unchanged — the response shape is identical.

## Index-scan rationale (Deliverable 2)

`EXPLAIN ANALYZE` can't be run against the live dataset from here, but the plan
change is structural: `deploy/postgres/schema.sql` already defines
`idx_ae_hotkey (hotkey, block_number DESC)` and
`idx_ae_coldkey (coldkey, block_number DESC)`. A single-column equality
predicate whose sort prefix matches the index (`block_number DESC`) lets each
branch do an index range seek bounded by the `LIMIT`; the previous flat-OR
predicate matched neither index and forced a bitmap/sequential scan.

## Tests

- Existing `/api/v1/accounts/:ss58` summary tests updated to the two-branch query
  shape and stay green.
- Added a route case for an address active under **both** `hotkey` and `coldkey`,
  asserting the shared row is deduped (not double-counted) and the merged window
  stays correctly ordered and capped.
- Added direct unit tests for `mergeAccountEventScans` (merge ordering, dedup,
  re-cap, null-safety).

`npm test` — 558 passing across the two touched suites; changed lines are fully
covered.

Closes #6878
