### PR TITLE
fix(api): drop unused observed_at from stake-transfers/moves distinct subqueries

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -3838,6 +3838,36 @@ test("GET /api/v1/subnets/:netuid/stake-transfers with no aggregate row returns 
   expect(body.transfers).toBe(0);
 });
 
+// Regression for METAGRAPHED-6 (#6877): the distinct-mover/sender subqueries
+// GROUP BY coldkey (`GROUP BY 1`) but also selected the unused `observed_at`,
+// which Postgres rejects ("column ... must appear in the GROUP BY clause"),
+// 500ing both routes. observed_at is dead weight there (the outer query computes
+// its own MAX), so it must be dropped. Assert the emitted SQL no longer carries
+// it in the inner subquery — the existing tests above canned the aggregate row
+// and never exercised the real query shape, so the bug slipped through.
+test("GET /api/v1/subnets/:netuid/stake-{moves,transfers} inner distinct subquery selects only coldkey (valid Postgres GROUP BY)", async () => {
+  mockRows.current = [
+    { movements: "4", distinct_movers: "3", newest_observed: "1783600000000" },
+  ];
+  const movesRes = await req("/api/v1/subnets/4/stake-moves");
+  expect(movesRes.status).toBe(200);
+  const moversQuery = sqlCalls.find((c) => /AS distinct_movers/.test(c.text));
+  expect(moversQuery).toBeDefined();
+  expect(moversQuery.text).toMatch(/SELECT coldkey FROM account_events/);
+  expect(moversQuery.text).not.toMatch(/SELECT coldkey, observed_at/);
+
+  sqlCalls.length = 0;
+  mockRows.current = [
+    { transfers: "6", distinct_senders: "2", newest_observed: "1783600000000" },
+  ];
+  const transfersRes = await req("/api/v1/subnets/4/stake-transfers");
+  expect(transfersRes.status).toBe(200);
+  const sendersQuery = sqlCalls.find((c) => /AS distinct_senders/.test(c.text));
+  expect(sendersQuery).toBeDefined();
+  expect(sendersQuery.text).toMatch(/SELECT coldkey FROM account_events/);
+  expect(sendersQuery.text).not.toMatch(/SELECT coldkey, observed_at/);
+});
+
 const ACCOUNT_FOOTPRINT_ROUTES = [
   ["registrations", "registrations"],
   ["serving", "announcements"],

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -6396,7 +6396,7 @@ export default {
           const rows = await sql`
           SELECT COUNT(*) AS movements,
             (SELECT COUNT(*) FROM (
-              SELECT coldkey, observed_at FROM account_events
+              SELECT coldkey FROM account_events
               WHERE netuid = ${netuid} AND event_kind = ${STAKE_MOVED_EVENT_KIND} AND observed_at >= ${cutoff}
               GROUP BY 1
             ) movers) AS distinct_movers,
@@ -6430,7 +6430,7 @@ export default {
           const rows = await sql`
           SELECT COUNT(*) AS transfers,
             (SELECT COUNT(*) FROM (
-              SELECT coldkey, observed_at FROM account_events
+              SELECT coldkey FROM account_events
               WHERE netuid = ${netuid} AND event_kind = ${STAKE_TRANSFERRED_EVENT_KIND} AND observed_at >= ${cutoff}
               GROUP BY 1
             ) senders) AS distinct_senders,


### PR DESCRIPTION
Closes #6877

## Problem

`GET /api/v1/subnets/{netuid}/stake-transfers` 500s with (Sentry METAGRAPHED-6, ~230 occurrences, still firing):

```
PostgresError: column "account_events.observed_at" must appear in the GROUP BY clause or be used in an aggregate function
```

The distinct-sender count is a grouped subquery — `SELECT coldkey, observed_at FROM account_events ... GROUP BY 1` — but `observed_at` is neither grouped nor aggregated, which Postgres (unlike MySQL) rejects. It's dead weight there: the subquery is only `COUNT(*)`-ed, and the outer query computes its own `MAX(observed_at)`.

The sibling `/stake-moves` route (`movers` subquery) has the **identical** shape and the same latent bug — it just hasn't been hit with matching traffic yet. The failure is deterministic (query shape, not data), so it would 500 on its first real hit too.

## Fix

Drop the unused `observed_at` from **both** inner subqueries' `SELECT` list:
- `workers/data-api.mjs` — stake-moves `movers` subquery
- `workers/data-api.mjs` — stake-transfers `senders` subquery

Each becomes `SELECT coldkey FROM account_events WHERE ... GROUP BY 1`, a valid Postgres group.

## Test

Added a regression test asserting **both** routes return **200** and that the emitted SQL's inner subquery selects only `coldkey` (never `coldkey, observed_at`). The existing tests canned the aggregate row and never exercised the real query shape, which is why the bug slipped through.

## Validation

- [x] `npx vitest run tests/data-api.test.mjs` — 492 passed (incl. the new regression test)
- [x] `npm run lint` · `npx prettier --check` — clean
- [x] `git diff --check` — clean
- [x] Scope: `workers/data-api.mjs` (SQL fix) + `tests/data-api.test.mjs` only; no schema/contract change.
