### PR TITLE
fix(data-api): drop ungrouped observed_at from stake-moves/transfers subqueries

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -3810,6 +3810,17 @@ test("GET /api/v1/subnets/:netuid/stake-moves returns the single-row aggregate",
   const body = await res.json();
   expect(body.movements).toBe(4);
   expect(body.distinct_movers).toBe(3);
+  // #6877: the distinct-movers subquery groups by coldkey only (GROUP BY 1), so it
+  // must NOT also SELECT the ungrouped `observed_at` — Postgres 500s on a selected
+  // column that is neither grouped nor aggregated. `observed_at` is unused inside the
+  // subquery (the outer query computes its own MAX(observed_at)).
+  const movesSql = queryText();
+  expect(movesSql).not.toMatch(
+    /SELECT\s+coldkey\s*,\s*observed_at\s+FROM\s+account_events/i,
+  );
+  expect(movesSql).toMatch(
+    /SELECT\s+coldkey\s+AS\s+\w+\s+FROM\s+account_events/i,
+  );
 });
 
 test("GET /api/v1/subnets/:netuid/stake-moves with no aggregate row returns the zeroed card, not a throw", async () => {
@@ -3828,6 +3839,17 @@ test("GET /api/v1/subnets/:netuid/stake-transfers returns the single-row aggrega
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.transfers).toBe(6);
+  expect(body.distinct_senders).toBe(2);
+  // #6877: identical grouped-subquery fix for the distinct-senders count — the
+  // `senders` subquery must SELECT only the grouped coldkey, never the ungrouped
+  // `observed_at` (same Postgres GROUP BY 500 as the sibling stake-moves route).
+  const transfersSql = queryText();
+  expect(transfersSql).not.toMatch(
+    /SELECT\s+coldkey\s*,\s*observed_at\s+FROM\s+account_events/i,
+  );
+  expect(transfersSql).toMatch(
+    /SELECT\s+coldkey\s+AS\s+\w+\s+FROM\s+account_events/i,
+  );
 });
 
 test("GET /api/v1/subnets/:netuid/stake-transfers with no aggregate row returns the zeroed card, not a throw", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -6389,14 +6389,17 @@ export default {
           );
           // The distinct-mover count is a correlated subquery (grouped rows,
           // then COUNT(*) of the groups) rather than COUNT(DISTINCT <col>) so
-          // the delegating account's column is only ever named once, in the
-          // one already-established safe form (bare identifier immediately
-          // before a comma) the public-safety scanner's SQL-usage allowlist
-          // covers.
+          // the delegating account's column is only ever named once, in a
+          // scanner-safe form: a bare identifier immediately before `AS` (the
+          // public-safety scanner's SQL-usage allowlist covers `coldkey AS`).
+          // The subquery selects ONLY the grouped `coldkey` — an earlier copy
+          // also selected `observed_at`, which Postgres rejects (neither in
+          // GROUP BY 1 nor aggregated) and which was unused here anyway, the
+          // outer query computing its own MAX(observed_at) (#6877).
           const rows = await sql`
           SELECT COUNT(*) AS movements,
             (SELECT COUNT(*) FROM (
-              SELECT coldkey, observed_at FROM account_events
+              SELECT coldkey AS mover FROM account_events
               WHERE netuid = ${netuid} AND event_kind = ${STAKE_MOVED_EVENT_KIND} AND observed_at >= ${cutoff}
               GROUP BY 1
             ) movers) AS distinct_movers,
@@ -6430,7 +6433,7 @@ export default {
           const rows = await sql`
           SELECT COUNT(*) AS transfers,
             (SELECT COUNT(*) FROM (
-              SELECT coldkey, observed_at FROM account_events
+              SELECT coldkey AS sender FROM account_events
               WHERE netuid = ${netuid} AND event_kind = ${STAKE_TRANSFERRED_EVENT_KIND} AND observed_at >= ${cutoff}
               GROUP BY 1
             ) senders) AS distinct_senders,


### PR DESCRIPTION
## Problem

`GET /api/v1/subnets/{netuid}/stake-transfers` 500s in production (Sentry METAGRAPHED-6, 230+ occurrences, still recurring). The `distinct_senders` subquery runs:

```sql
SELECT coldkey, observed_at FROM account_events WHERE ... GROUP BY 1
```

Postgres rejects `observed_at`: it is neither in `GROUP BY 1` nor aggregated. It is also **unused** inside the subquery — the outer query computes its own `MAX(observed_at)` — so the correct fix is to drop it. The sibling `stake-moves` route's `distinct_movers` subquery has the identical shape and will 500 on its first matching hit (deterministic, query-shape only), so both are fixed.

## Fix

Drop `observed_at` from both inner subqueries. Crucially, `coldkey` is kept in a form the **public-safety scanner's SQL-usage allowlist covers** — `coldkey AS mover` / `coldkey AS sender` — rather than a bare `SELECT coldkey FROM …` (which `scripts/scan-public-safety.mjs` flags as bare key terminology, since `workers/` is a scan root). The subquery still groups distinct coldkeys via `GROUP BY 1`; the alias is unused, matching the existing `) movers`/`) senders` subquery aliasing.

## Tests

Extended both routes' existing tests to assert the emitted SQL selects only the grouped `coldkey` and never the ungrouped `observed_at`. Both assertions **fail on the un-fixed query** and pass after the fix (the prior tests canned the aggregate row and never checked the query shape, which is how the bug shipped).

Local gate: full `tests/data-api.test.mjs` (491 passing), `npm run validate`, `prettier --check`, `eslint`, `worker:bundle:budget`, and `scan-public-safety` all pass; no contract/artifact drift.

Closes #6877