### PR TITLE
docs(readme): fix stale MCP tool count (26 -> 173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Three ways to use Metagraphed. Pick one.
 
 #### 🤖 AI agent (MCP)
 
-Agent-native, public, read-only, Streamable-HTTP. 26 tools to discover a subnet, check if it's up, read its economics and metagraph, trace what a wallet does across the network, and learn how to call it.
+Agent-native, public, read-only, Streamable-HTTP. 173 tools to discover a subnet, check if it's up, read its economics and metagraph, trace what a wallet does across the network, and learn how to call it.
 
 ```bash
 claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp


### PR DESCRIPTION
## Summary
- README's quickstart said "26 tools" for the MCP server; the live server ships 173. Stale since before the last two days' worth of MCP epics shipped (compound tools, saved queries, alert triggers, etc.) — real credibility cost while wrong, since the only other explorer with live MCP (Taostats, 28 tools) would otherwise look bigger than us.

## Test plan
- [x] Verified live tool count via `grep -oE "name:\s*['\"][a-z_0-9]+['\"]" src/mcp-server.mjs | sort -u | wc -l` = 173