### PR TITLE
feat(mcp): add plan-shaped warnings/ok advisory to get_stake_action_preview

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -673,6 +673,34 @@ const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
 //   - behavioral-only fix (no I/O change) → PATCH
 // Reported in serverInfo.version (initialize) + the generated server-card.json.
 export const MCP_SERVER_VERSION = "1.78.7";
+// Price-impact thresholds for get_stake_action_preview's plan-shaped
+// `warnings`/`ok` advisory (#6894). There is no prior precedent for these in
+// this codebase, so they follow common AMM/DEX slippage conventions: ~1% is the
+// point most swap UIs surface a soft slippage notice, and 5% is the widely-used
+// "high price impact — confirm carefully" hard threshold above which `ok` flips
+// to false. A root (netuid 0) stake is always 1:1 with 0% impact, so it never
+// warns. All units are percent, matching the quote's `price_impact_pct`.
+const STAKE_PREVIEW_IMPACT_NOTICE_PCT = 1;
+const STAKE_PREVIEW_IMPACT_MAX_PCT = 5;
+
+// Derive the plan-shaped advisory (a `plan`-convention `warnings[]` + policy
+// `ok` flag) purely from a computed stake quote's price impact — the one signal
+// the preview already carries that reflects how much this size moves the pool.
+// Additive over get_subnet_stake_quote's numbers; adds no execution capability.
+function computeStakePreviewAdvisory(quote) {
+  const impact = quote.price_impact_pct;
+  const warnings = [];
+  if (impact >= STAKE_PREVIEW_IMPACT_MAX_PCT) {
+    warnings.push(
+      `Estimated price impact ${impact}% meets or exceeds the ${STAKE_PREVIEW_IMPACT_MAX_PCT}% high-impact threshold: this size would move the pool price substantially against you — consider a smaller amount.`,
+    );
+  } else if (impact >= STAKE_PREVIEW_IMPACT_NOTICE_PCT) {
+    warnings.push(
+      `Estimated price impact ${impact}% is non-trivial for this size; a smaller amount would reduce slippage.`,
+    );
+  }
+  return { warnings, ok: impact < STAKE_PREVIEW_IMPACT_MAX_PCT };
+}
 // Window labels accepted by get_chain_transfers — derived from the loader constant
 // so input/output schemas and runtime validation cannot drift.
 const CHAIN_TRANSFER_WINDOW_KEYS = Object.keys(CHAIN_TRANSFER_WINDOWS);
@@ -3178,9 +3206,32 @@ export const MCP_TOOLS = [
         spot_price_tao: { type: "number" },
         effective_price_tao: { type: "number" },
         price_impact_pct: { type: "number" },
+        warnings: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Plan-shaped, non-fatal cautions computed from the preview (e.g. " +
+            "high price impact / slippage). Empty array when none apply, never " +
+            "null or omitted.",
+        },
+        ok: {
+          type: "boolean",
+          description:
+            "Plan-style policy-compliance flag: false when a documented safety " +
+            "threshold is exceeded (estimated price impact >= 5%), true " +
+            "otherwise. Purely advisory — the tool still executes nothing.",
+        },
         disclaimer: { type: "string" },
       },
-      required: ["netuid", "direction", "amount", "summary", "disclaimer"],
+      required: [
+        "netuid",
+        "direction",
+        "amount",
+        "summary",
+        "warnings",
+        "ok",
+        "disclaimer",
+      ],
       additionalProperties: true,
     },
     async handler(args, ctx) {
@@ -3202,6 +3253,7 @@ export const MCP_TOOLS = [
         throw toolError(result.code, result.error);
       }
       const q = result.quote;
+      const advisory = computeStakePreviewAdvisory(q);
       const inUnit = direction === "stake" ? "TAO" : "alpha";
       const outUnit = q.expected_out_unit === "alpha" ? "alpha" : "TAO";
       const verb = direction === "stake" ? "Staking" : "Unstaking";
@@ -3217,6 +3269,8 @@ export const MCP_TOOLS = [
         spot_price_tao: q.spot_price_tao,
         effective_price_tao: q.effective_price_tao,
         price_impact_pct: q.price_impact_pct,
+        warnings: advisory.warnings,
+        ok: advisory.ok,
         disclaimer:
           "Informational preview only. This does not execute, build, prepare, " +
           "or sign any transaction, produces no signable or extrinsic artifact, " +

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -8831,6 +8831,68 @@ describe("MCP economics + metagraph data tools", () => {
     assert.match(res.body.result.content[0].text, /insufficient_liquidity/);
   });
 
+  test("get_stake_action_preview returns a clean plan-shaped advisory (warnings [] + ok true) for a low-impact size (#6894)", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 64, amount: 10, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.ok(out.price_impact_pct < 1);
+    assert.deepEqual(out.warnings, []);
+    assert.equal(out.ok, true);
+  });
+
+  test("get_stake_action_preview flags a non-trivial (>=1% <5%) impact as a soft warning but keeps ok true (#6894)", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 64, amount: 10000, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.ok(out.price_impact_pct >= 1 && out.price_impact_pct < 5);
+    assert.equal(out.warnings.length, 1);
+    assert.match(out.warnings[0], /non-trivial/);
+    assert.equal(out.ok, true);
+  });
+
+  test("get_stake_action_preview flips ok to false and warns when impact >= the 5% high-impact threshold (#6894)", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 64, amount: 20000, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.ok(out.price_impact_pct >= 5);
+    assert.equal(out.warnings.length, 1);
+    assert.match(out.warnings[0], /high-impact threshold/);
+    assert.equal(out.ok, false);
+  });
+
+  test("get_stake_action_preview root (netuid 0) preview is clean — 0% impact, no warnings, ok true (#6894)", async () => {
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 0, amount: 42, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.price_impact_pct, 0);
+    assert.deepEqual(out.warnings, []);
+    assert.equal(out.ok, true);
+  });
+
   test("get_economics serves the live KV economics tier with REST list-query filters", async () => {
     const blob = {
       ...ECON_BLOB,


### PR DESCRIPTION
## Context

Bittensor's own agent docs formalize a `plan` shape for previewable mutations — `fee`, `effects`, `warnings`, `ok` — surfaced before anything executes. metagraphed's `get_stake_action_preview` is already the same *kind* of tool (strictly read-only, no execution, no wallet/key) and already returns most of the substance (`estimated_out`, spot/effective price, `price_impact_pct`), but it lacked the shared `warnings`/`ok` vocabulary: a high-impact preview and a trivial one came back in the same shape, with no structured signal that one is worth pausing on.

## Change

Two **additive** output fields on `get_stake_action_preview`, computed from data the preview already has — no new economics, **no execution capability**, still strictly read-only:

- `warnings: string[]` — non-fatal cautions; **empty array when none apply**, never `null`/omitted. Populated from the estimated price impact (slippage).
- `ok: boolean` — a policy-style compliance flag; `false` when a documented safety threshold is exceeded, `true` otherwise.

Existing fields are unchanged and nothing is renamed (e.g. `price_impact_pct` is **not** remapped to `fee`) — this adopts the *shape* other `plan`-tooled agents expect, not Bittensor's exact field names where this tool's names are already clear.

## Thresholds (documented)

There's no prior precedent for these in this codebase, so they follow common AMM/DEX slippage conventions:

| Estimated price impact | Effect |
|---|---|
| `< 1%` | clean — `warnings: []`, `ok: true` |
| `>= 1%` and `< 5%` | soft slippage notice in `warnings`, `ok: true` |
| `>= 5%` | high-impact warning in `warnings`, **`ok: false`** |

`~1%` is where most swap UIs surface a soft slippage nudge; `5%` is the widely-used "high price impact — confirm carefully" hard threshold. A root (netuid 0) stake is 1:1 with 0% impact and never warns.

## Deliverables

- [x] `warnings` + `ok` added to `outputSchema` (both `required`) and the handler
- [x] Concrete, documented thresholds justified above
- [x] `MCP_SERVER_VERSION` **not** hand-bumped — `sync-mcp-version` handles the additive MINOR post-merge
- [x] Tests for the clean, soft-notice, high-impact, and root previews

Additive-only: `validate:mcp`, `validate:contract-drift`, and the full `mcp-server` suite pass; build regenerates no committed artifact.

Closes #6894