### PR TITLE
feat(mcp): add plan-shaped warnings + ok to get_stake_action_preview

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -3178,9 +3178,32 @@ export const MCP_TOOLS = [
         spot_price_tao: { type: "number" },
         effective_price_tao: { type: "number" },
         price_impact_pct: { type: "number" },
+        warnings: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Non-fatal cautions the preview computes from data it already has " +
+            "(e.g. high price impact). Empty array when none apply -- never " +
+            "null or omitted.",
+        },
+        ok: {
+          type: "boolean",
+          description:
+            "Policy-style compliance flag in the emerging plan-shaped tool " +
+            "vocabulary: false when a documented threshold (high price impact) " +
+            "is exceeded, true otherwise. Never implies the action was executed.",
+        },
         disclaimer: { type: "string" },
       },
-      required: ["netuid", "direction", "amount", "summary", "disclaimer"],
+      required: [
+        "netuid",
+        "direction",
+        "amount",
+        "summary",
+        "warnings",
+        "ok",
+        "disclaimer",
+      ],
       additionalProperties: true,
     },
     async handler(args, ctx) {
@@ -3208,6 +3231,28 @@ export const MCP_TOOLS = [
       const summary = q.is_root
         ? `${verb} ${amount} ${inUnit} on subnet ${netuid} (root) previews an estimated ${q.expected_out} ${outUnit} at a 1:1 price with no price impact.`
         : `${verb} ${amount} ${inUnit} on subnet ${netuid} previews an estimated ${q.expected_out} ${outUnit} at an effective price of ${q.effective_price_tao} TAO/alpha (spot ${q.spot_price_tao}), with an estimated ${q.price_impact_pct}% price impact (slippage).`;
+      // Adopt the `plan`-shaped tool vocabulary (warnings + a policy-style flag)
+      // agents already expect from previewable-mutation tools, computed only from
+      // data this preview already has. A realized price >= this many percent from
+      // spot is the "worth pausing on" case: 5% mirrors the widely-used DeFi
+      // high-slippage caution line (the level swap UIs like Uniswap surface a
+      // slippage warning at) -- there is no existing threshold in this codebase,
+      // so this adopts that cross-ecosystem convention. Root (netuid 0) is 1:1
+      // with zero impact, so it never warns.
+      const PRICE_IMPACT_WARN_PCT = 5;
+      const warnings = [];
+      if (
+        !q.is_root &&
+        Number.isFinite(q.price_impact_pct) &&
+        q.price_impact_pct >= PRICE_IMPACT_WARN_PCT
+      ) {
+        warnings.push(
+          `High price impact: this ${direction} moves the effective price ${q.price_impact_pct}% away from spot (>= ${PRICE_IMPACT_WARN_PCT}% is considered high slippage); consider a smaller amount.`,
+        );
+      }
+      // false when a documented threshold trips (here: high price impact), true
+      // otherwise. Never implies execution -- this tool stays strictly read-only.
+      const ok = warnings.length === 0;
       return {
         netuid: q.netuid,
         direction: q.direction,
@@ -3217,6 +3262,8 @@ export const MCP_TOOLS = [
         spot_price_tao: q.spot_price_tao,
         effective_price_tao: q.effective_price_tao,
         price_impact_pct: q.price_impact_pct,
+        warnings,
+        ok,
         disclaimer:
           "Informational preview only. This does not execute, build, prepare, " +
           "or sign any transaction, produces no signable or extrinsic artifact, " +

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -8781,6 +8781,46 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.price_impact_pct, 0);
     assert.match(out.summary, /root/);
     assert.match(out.summary, /no price impact/);
+    // Root is 1:1 with zero impact -> plan-shaped fields say "clean".
+    assert.deepEqual(out.warnings, []);
+    assert.equal(out.ok, true);
+  });
+
+  test("get_stake_action_preview flags a high-price-impact stake (warnings + ok:false)", async () => {
+    // ~20k TAO into the ~202k-TAO pool is ~10% price impact (>= the 5%
+    // high-slippage threshold), so the preview must surface a warning and flip
+    // ok to false -- still strictly read-only, no execution.
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 64, amount: 20000, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.ok(out.price_impact_pct >= 5);
+    assert.equal(out.warnings.length, 1);
+    assert.match(out.warnings[0], /High price impact/);
+    assert.equal(out.ok, false);
+    // The flag never implies execution -- the disclaimer still holds.
+    assert.match(out.disclaimer, /does not execute/i);
+  });
+
+  test("get_stake_action_preview returns a clean plan shape for a low-impact stake", async () => {
+    // ~1k TAO into the ~202k-TAO pool is well under 1% impact -> no warnings.
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 64, amount: 1000, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.ok(out.price_impact_pct < 5);
+    assert.deepEqual(out.warnings, []);
+    assert.equal(out.ok, true);
   });
 
   test("get_stake_action_preview output carries NO signable/extrinsic payload — only the human-readable summary", async () => {


### PR DESCRIPTION
Closes #6894

## Summary

`get_stake_action_preview` is already a read-only, informational-only preview tool, but a high-impact and a trivial preview came back in the same shape — no structured signal that one is "worth pausing on." This adopts the `plan`-shaped vocabulary (Bittensor's agent docs: `warnings` + a policy-style `ok`) that agents already expect from previewable-mutation tools.

## What changed (additive — no existing field touched)

- **`warnings: string[]`** — non-fatal cautions computed from data the preview already has (currently: high price impact). Empty array when none apply, never `null`/omitted.
- **`ok: boolean`** — policy-style compliance flag; `false` when a documented threshold trips, `true` otherwise. **Never implies execution.**

Both added to the tool's `outputSchema` (and `required`, since they're always returned) and its handler.

## Threshold (justified)

A realized price **≥ 5%** from spot flips `ok` to `false` and adds a high-price-impact warning. **5%** mirrors the widely-used DeFi high-slippage caution line — the level swap UIs (e.g. Uniswap) surface a slippage warning at. There's no existing precedent in this codebase, so this adopts that cross-ecosystem convention. Root (netuid 0) is 1:1 with zero impact, so it never warns.

## Still strictly read-only

No execution, no signable/extrinsic artifact, no wallet/key involvement — `ok`/`warnings` are informational only; the disclaimer is unchanged.

## Version

`MCP_SERVER_VERSION` intentionally **not** hand-bumped — `sync-mcp-version` handles the minor bump post-merge per repo convention. MCP tool additions don't require a server-card regen (worker-computed).

## Tests

Added coverage for the warning-triggering (high-impact → `warnings` + `ok:false`), clean low-impact (`warnings: []` + `ok:true`), and root (`ok:true`) cases; extended the existing root test.

## Validation

- [x] `npx vitest run tests/mcp-server.test.mjs` — 1175 passed
- [x] Patch coverage: every changed line covered (no miss/partial)
- [x] `npm run lint` · `npx prettier --check` · `npm run scan:public-safety` — clean
- [x] `npm run build` — no committed-artifact drift (diff is the two source files only)
- [x] `git diff --check` — clean
