### PR TITLE
fix(api): drop ungrouped observed_at from stake-moves/transfers subqueries

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -257,8 +257,23 @@ const patterns = [
     // (an extremely common idiom, not a one-off) false-positived. `coldkey\.` +
     // a lowercase identifier + `(` matches the method-call shape without
     // loosening the bare `\bcoldkey\b` trigger itself.
+    //
     allow:
       /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bcoldkey\?\.|\bcoldkey\.[a-z_]+\(|\bhotkey(?:\s+or\s+|\s*\/\s*)coldkey\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*(?:=|!=|<>|IS\s+(?:NOT\s+)?NULL\b|IN\s*\()|\bcoldkey\s*(?:,|\)|\]|\}|;|`)|\bcoldkey\s+(?:ASC|DESC|AS\b|TEXT|VARCHAR|CHAR|INTEGER|BIGINT|NUMERIC|BOOLEAN)\b|'coldkey'|\bcoldkey\s*\/\s*[a-z_]+\b|\b[a-z_]+\s*\/\s*coldkey\b|\b[a-z]+-coldkey\b|\bcoldkey\s*\(/gi,
+    // Extended again (#6877): a single-column `SELECT coldkey FROM ...` wasn't
+    // covered by the SQL-keyword alternation above -- every prior call site
+    // paired coldkey with a second selected column, so it was always
+    // immediately followed by a comma, never directly by FROM. The stake-
+    // moves/stake-transfers distinct-count subqueries fixed here are the
+    // first single-column case. Unlike ASC/DESC/AS/the type keywords above,
+    // FROM is deliberately its OWN case-SENSITIVE-only strip (not folded into
+    // the case-insensitive `allow` alternation): "from" is a common enough
+    // English word that a case-insensitive match would also exempt real
+    // suspicious prose like "extract your coldkey from an untrusted device"
+    // -- requiring the literal uppercase SQL keyword (this codebase's actual
+    // style, confirmed against every FROM clause in workers/data-api.mjs)
+    // keeps that prose caught while still allowing the real query shape.
+    allowCaseSensitive: /\bcoldkey\s+FROM\b/g,
     soft: true,
   },
   {
@@ -481,7 +496,13 @@ async function runScan() {
           // Strip allowlisted spans (e.g. the documented local subtensor RPC
           // endpoint) before testing, so a real leak elsewhere on the same line
           // is still caught.
-          const probe = pattern.allow ? line.replace(pattern.allow, "") : line;
+          let probe = pattern.allow ? line.replace(pattern.allow, "") : line;
+          // A second, deliberately case-SENSITIVE-only strip (see
+          // allowCaseSensitive's own definition above for why this can't just
+          // join the case-insensitive `allow` alternation).
+          if (pattern.allowCaseSensitive) {
+            probe = probe.replace(pattern.allowCaseSensitive, "");
+          }
           if (pattern.regex.test(probe)) {
             findings.push(`${relative}:${index + 1}: ${pattern.name}`);
           }

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -3820,6 +3820,21 @@ test("GET /api/v1/subnets/:netuid/stake-moves with no aggregate row returns the 
   expect(body.movements).toBe(0);
 });
 
+test("GET /api/v1/subnets/:netuid/stake-moves distinct-mover subquery only selects the grouped column (regression #6877)", async () => {
+  // Postgres (unlike MySQL) rejects a selected column that isn't in the
+  // GROUP BY clause or wrapped in an aggregate -- the inner subquery must
+  // select only `coldkey` to match its `GROUP BY 1`.
+  mockRows.current = [
+    { movements: "2", distinct_movers: "1", newest_observed: "1783600000000" },
+  ];
+  await req("/api/v1/subnets/4/stake-moves");
+  const moversSubquery = queryText().match(
+    /\(SELECT COUNT\(\*\) FROM \(\s*SELECT ([^\n]+) FROM account_events[\s\S]*?\) movers\)/,
+  );
+  expect(moversSubquery).not.toBeNull();
+  expect(moversSubquery[1].trim()).toBe("coldkey");
+});
+
 test("GET /api/v1/subnets/:netuid/stake-transfers returns the single-row aggregate", async () => {
   mockRows.current = [
     { transfers: "6", distinct_senders: "2", newest_observed: "1783600000000" },
@@ -3836,6 +3851,20 @@ test("GET /api/v1/subnets/:netuid/stake-transfers with no aggregate row returns 
   expect(res.status).toBe(200);
   const body = await res.json();
   expect(body.transfers).toBe(0);
+});
+
+test("GET /api/v1/subnets/:netuid/stake-transfers distinct-sender subquery only selects the grouped column (regression #6877)", async () => {
+  // Same shape as the stake-moves regression test above -- the sibling
+  // `senders` subquery must select only `coldkey` to match its `GROUP BY 1`.
+  mockRows.current = [
+    { transfers: "3", distinct_senders: "1", newest_observed: "1783600000000" },
+  ];
+  await req("/api/v1/subnets/4/stake-transfers");
+  const sendersSubquery = queryText().match(
+    /\(SELECT COUNT\(\*\) FROM \(\s*SELECT ([^\n]+) FROM account_events[\s\S]*?\) senders\)/,
+  );
+  expect(sendersSubquery).not.toBeNull();
+  expect(sendersSubquery[1].trim()).toBe("coldkey");
 });
 
 const ACCOUNT_FOOTPRINT_ROUTES = [

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -495,6 +495,39 @@ describe("captured-fixture body scan", () => {
     );
   });
 
+  test("allows a single-column 'SELECT coldkey FROM ...' query (#6877)", async () => {
+    // Every prior call site paired coldkey with a second selected column, so
+    // coldkey was always immediately followed by a comma. The stake-moves/
+    // stake-transfers distinct-count subqueries (#6877) are the first
+    // single-column case, where coldkey is directly followed by FROM.
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      "SELECT coldkey FROM account_events WHERE netuid = ${netuid}\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.equal(
+      output.includes(TEST_PUBLIC_FILE),
+      false,
+      `single-column SELECT coldkey FROM should be exempt; got:\n${output}`,
+    );
+  });
+
+  test("does not let 'coldkey from' prose slip past the new FROM allowance", async () => {
+    // The FROM exemption above must require the literal SQL keyword directly
+    // after coldkey -- ordinary prose using "from" must still be flagged.
+    await fs.writeFile(
+      TEST_PUBLIC_PATH,
+      "Never extract your coldkey from an untrusted device.\n",
+      "utf8",
+    );
+    const output = runScanOutput();
+    assert.ok(
+      output.includes(`${TEST_PUBLIC_FILE}:1: Bittensor key terminology`),
+      `prose using "coldkey from" must still be flagged; got:\n${output}`,
+    );
+  });
+
   test("does not let 'coldkey is not' prose without the literal NULL keyword slip past", async () => {
     // The IS [NOT] NULL exemption requires the literal SQL keyword, not just
     // "is"/"is not" -- prose using the same words must still be flagged.

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -6815,7 +6815,7 @@ export default {
           const rows = await sql`
           SELECT COUNT(*) AS movements,
             (SELECT COUNT(*) FROM (
-              SELECT coldkey, observed_at FROM account_events
+              SELECT coldkey FROM account_events
               WHERE netuid = ${netuid} AND event_kind = ${STAKE_MOVED_EVENT_KIND} AND observed_at >= ${cutoff}
               GROUP BY 1
             ) movers) AS distinct_movers,
@@ -6849,7 +6849,7 @@ export default {
           const rows = await sql`
           SELECT COUNT(*) AS transfers,
             (SELECT COUNT(*) FROM (
-              SELECT coldkey, observed_at FROM account_events
+              SELECT coldkey FROM account_events
               WHERE netuid = ${netuid} AND event_kind = ${STAKE_TRANSFERRED_EVENT_KIND} AND observed_at >= ${cutoff}
               GROUP BY 1
             ) senders) AS distinct_senders,


### PR DESCRIPTION
Sentry's been flagging live 500s on `GET /api/v1/subnets/{netuid}/stake-transfers` since yesterday (METAGRAPH-6, ~230 occurrences and climbing). Root cause is in the `senders` subquery at workers/data-api.mjs: it selects both `coldkey` and `observed_at` but only groups by `coldkey` (`GROUP BY 1`). Postgres rejects that outright — every non-aggregated column in the SELECT list has to be in the GROUP BY clause, unlike MySQL which just lets it slide. `observed_at` was never actually read out of that subquery anyway; the outer query does its own `MAX(observed_at)` separately, so it was just dead weight sitting there breaking the query.

The sibling `stake-moves` route has the exact same shape in its `movers` subquery (its own comment even says it copied the pattern from stake-transfers), so it's carrying the identical bug — it just hasn't gotten unlucky with matching traffic yet. Fixed both by dropping the unused `observed_at` column so the subquery only selects `coldkey`, which is what `GROUP BY 1` actually covers.

Added a regression test per route asserting the inner subquery's SELECT list only contains `coldkey` — confirmed both fail against the pre-fix query text (`coldkey, observed_at`) and pass after the fix.

While in there I hit an unrelated snag: `npm run scan:public-safety` flagged the fixed query text as "Bittensor key terminology". Every other `coldkey` SQL usage in the codebase pairs it with a second column, so it's always immediately followed by a comma, which the scanner's allowlist already covers — this is the first single-column `SELECT coldkey FROM ...` in the repo, where coldkey is directly followed by FROM instead. Extended the allowlist to cover it, but deliberately as a separate case-sensitive-only strip rather than folding `FROM` into the existing case-insensitive keyword list: "from" is common enough in plain English that a case-insensitive match would also exempt real suspicious prose like "extract your coldkey from an untrusted device", which the codebase's SQL always spells `FROM` in uppercase anyway. Added tests for both the new SQL exemption and that the prose case still gets flagged.

Ran the full local gate: `npm run test:ci` (9717 tests), `npm run test:ci:artifacts`, `npm run lint`, `npm run format:check`, `npm run validate`, `npm run validate:contract-drift` + friends, `npm run scan:public-safety`, `npm run validate:private-boundary`, and the Python SDK suite — all green.

Closes #6877
