### PR TITLE
feat(mcp): add warnings/ok fields to get_stake_action_preview

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -623,7 +623,11 @@ import {
   DEFAULT_OHLC_WINDOW_DAYS,
   MAX_OHLC_WINDOW_DAYS,
 } from "./subnet-ohlc.mjs";
-import { computeStakeQuote, STAKE_QUOTE_DIRECTIONS } from "./stake-quote.mjs";
+import {
+  computeStakeQuote,
+  STAKE_QUOTE_DIRECTIONS,
+  HIGH_PRICE_IMPACT_WARNING_PCT,
+} from "./stake-quote.mjs";
 import { buildAccountPositionHistory } from "./account-position-history.mjs";
 import { buildAccountIdentity } from "./account-identity.mjs";
 import { buildAccountIdentityHistory } from "./account-identity-history.mjs";
@@ -3178,9 +3182,34 @@ export const MCP_TOOLS = [
         spot_price_tao: { type: "number" },
         effective_price_tao: { type: "number" },
         price_impact_pct: { type: "number" },
+        warnings: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Non-fatal cautions computed from this preview's own data " +
+            "(currently: price impact at or above the high-impact " +
+            "threshold). Empty when none apply -- never omitted or null.",
+        },
+        ok: {
+          type: "boolean",
+          description:
+            "Policy-style compliance flag: false when the preview trips a " +
+            "documented threshold (currently: price impact >= " +
+            `${HIGH_PRICE_IMPACT_WARNING_PCT}%, matching this codebase's ` +
+            "own default slippage tolerance, ADR 0018 §3). Does not " +
+            "block or alter the preview -- informational only.",
+        },
         disclaimer: { type: "string" },
       },
-      required: ["netuid", "direction", "amount", "summary", "disclaimer"],
+      required: [
+        "netuid",
+        "direction",
+        "amount",
+        "summary",
+        "warnings",
+        "ok",
+        "disclaimer",
+      ],
       additionalProperties: true,
     },
     async handler(args, ctx) {
@@ -3208,6 +3237,15 @@ export const MCP_TOOLS = [
       const summary = q.is_root
         ? `${verb} ${amount} ${inUnit} on subnet ${netuid} (root) previews an estimated ${q.expected_out} ${outUnit} at a 1:1 price with no price impact.`
         : `${verb} ${amount} ${inUnit} on subnet ${netuid} previews an estimated ${q.expected_out} ${outUnit} at an effective price of ${q.effective_price_tao} TAO/alpha (spot ${q.spot_price_tao}), with an estimated ${q.price_impact_pct}% price impact (slippage).`;
+      const warnings = [];
+      if (q.price_impact_pct >= HIGH_PRICE_IMPACT_WARNING_PCT) {
+        warnings.push(
+          `Estimated price impact (${q.price_impact_pct.toFixed(2)}%) meets ` +
+            `or exceeds the ${HIGH_PRICE_IMPACT_WARNING_PCT}% default ` +
+            "slippage tolerance (ADR 0018 §3) -- the realized price may " +
+            "differ materially from spot.",
+        );
+      }
       return {
         netuid: q.netuid,
         direction: q.direction,
@@ -3217,6 +3255,8 @@ export const MCP_TOOLS = [
         spot_price_tao: q.spot_price_tao,
         effective_price_tao: q.effective_price_tao,
         price_impact_pct: q.price_impact_pct,
+        warnings,
+        ok: warnings.length === 0,
         disclaimer:
           "Informational preview only. This does not execute, build, prepare, " +
           "or sign any transaction, produces no signable or extrinsic artifact, " +

--- a/src/stake-quote.mjs
+++ b/src/stake-quote.mjs
@@ -15,6 +15,13 @@ export const STAKE_QUOTE_DIRECTIONS = ["stake", "unstake"];
 // insufficient-liquidity error instead of a degenerate ~100%-impact quote.
 export const MAX_INPUT_RESERVE_MULTIPLE = 1000;
 
+// A preview whose price impact meets or exceeds this codebase's own default
+// slippage-protection tolerance (ADR 0018 §3: 5%, the same band
+// pre-sign-confirmation.tsx already protects live transactions to) is worth
+// flagging as non-fatal but noteworthy -- the realized price is materially
+// worse than spot. Used by get_stake_action_preview's warnings/ok fields.
+export const HIGH_PRICE_IMPACT_WARNING_PCT = 5;
+
 function isFinitePositive(n) {
   return typeof n === "number" && Number.isFinite(n) && n > 0;
 }

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -8737,6 +8737,30 @@ describe("MCP economics + metagraph data tools", () => {
     assert.match(out.summary, /Staking 1000 TAO on subnet 64/);
     assert.match(out.summary, /price impact \(slippage\)/);
     assert.match(out.disclaimer, /does not execute/i);
+    // Low price impact (~0.5%, well under the 5% warning threshold): clean
+    // preview, no warnings, ok.
+    assert.deepEqual(out.warnings, []);
+    assert.equal(out.ok, true);
+  });
+
+  test("get_stake_action_preview flags a warning and ok:false when price impact meets the 5% threshold", async () => {
+    // 15000 TAO against a ~201960 TAO pool is ~7.4% price impact -- over the
+    // ADR 0018 §3 default 5% slippage tolerance this tool's ok/warnings fields
+    // are keyed to.
+    const res = await callTool(
+      "get_stake_action_preview",
+      { netuid: 64, amount: 15000, direction: "stake" },
+      {
+        deps: makeDeps({ "/metagraph/economics.json": STAKE_QUOTE_BLOB }, {}),
+        env: {},
+      },
+    );
+    const out = res.body.result.structuredContent;
+    assert.ok(out.price_impact_pct >= 5);
+    assert.equal(out.ok, false);
+    assert.equal(out.warnings.length, 1);
+    assert.match(out.warnings[0], /price impact/i);
+    assert.match(out.warnings[0], /5%/);
   });
 
   test("get_stake_action_preview defaults direction to stake when omitted", async () => {
@@ -8781,6 +8805,8 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.price_impact_pct, 0);
     assert.match(out.summary, /root/);
     assert.match(out.summary, /no price impact/);
+    assert.deepEqual(out.warnings, []);
+    assert.equal(out.ok, true);
   });
 
   test("get_stake_action_preview output carries NO signable/extrinsic payload — only the human-readable summary", async () => {


### PR DESCRIPTION
Closes #6894

`get_stake_action_preview` already computed everything the `plan` shape from Bittensor's agent docs wants (fee-equivalent via `price_impact_pct`, effects via `estimated_out`/`effective_price_tao`), it just had no structured signal for "this preview is worth pausing on" — a huge-impact stake and a tiny one came back looking identical.

Added two fields to the tool's `outputSchema` and handler, nothing else changed:

- `warnings: string[]` — non-fatal cautions, empty array (never omitted/null) when none apply.
- `ok: boolean` — flips to `false` when a warning fires.

For the threshold I didn't want to invent a number out of thin air, so I went looking for precedent first. Turns out this repo already has one: ADR 0018 §3 documents a 5% default slippage tolerance for live staking transactions (`pre-sign-confirmation.tsx` protects real signed txs to that same band), and `subnets.$netuid.tsx`'s own slippage calculator already flags `price_impact_pct > 5` with a "down" tone in the UI. So `get_stake_action_preview` now uses that same 5% line: `price_impact_pct >= 5` pushes a warning string and sets `ok: false`. Kept the constant (`HIGH_PRICE_IMPACT_WARNING_PCT`) in `stake-quote.mjs` next to `MAX_INPUT_RESERVE_MULTIPLE` since that's where the other stake-quote-math constants already live.

Didn't touch `price_impact_pct` or rename anything — the issue was explicit about not forcing Bittensor's exact field names where this tool's own names are already clear, just adopting the warnings/ok shape.

Tested with two new cases in `tests/mcp-server.test.mjs`: a 15000 TAO stake against the SN64 fixture pool (~7.4% impact, over the threshold) asserts `ok: false` and a one-item `warnings` array mentioning the 5% line, and the existing low-impact (~0.5%) and root-subnet (0% impact) cases now also assert `warnings: []` / `ok: true` so the clean path stays pinned down. Ran the full local gate: `npm run test:ci` (9716 tests) + `npm run test:ci:artifacts`, `npm run lint`, `npm run format:check`, `npm run build` (no drift), `npm run validate`, `npm run validate:mcp` (196 tools, still green), `npm run validate:schemas`/`validate:api`/`validate:openapi`/`validate:types`, and the rest of the checks-job validators — all pass, working tree clean.

No `MCP_SERVER_VERSION` bump here per this repo's own convention (`sync-mcp-version` handles that post-merge), and no generated contract artifacts changed since MCP tool additions aren't part of the OpenAPI/contract build.