### PR TITLE
feat(api): add per-provider emission leaderboard at /api/v1/providers/emissions

### DIFF
--- a/src/provider-emissions.mjs
+++ b/src/provider-emissions.mjs
@@ -1,0 +1,97 @@
+// #6644: per-provider emission leaderboard — a cross-source rollup that sums,
+// for each provider, the current network-emission of every subnet it backs.
+//
+// Two already-existing artifacts are joined, no new ingestion (the issue's
+// explicit non-goal): the providers registry (`providers.json`, each provider
+// carrying the `netuids` it backs) and the economics snapshot (`economics.json`,
+// each subnet carrying `emission_share` — its fraction 0..1 of total network
+// emission — and `emission_tao`, the absolute rate when present). "Owner" is not
+// separately modeled as a clean provider→subnet tie (subnet ownership is an
+// on-chain `owner_coldkey`, not a provider id), so this aggregates over the
+// registry's existing provider→subnets "backs" association, which is the clean
+// 1:many link that already exists.
+//
+// This is the CURRENT emission snapshot aggregated per provider, not a
+// cumulative-historical total — no per-subnet lifetime-emission series exists to
+// sum, and building one would be new ingestion (out of scope). Fields are named
+// for what they are (`emission_share` / `emission_tao`), not "lifetime".
+
+function toFiniteNumber(value) {
+  const n = typeof value === "string" ? Number(value) : value;
+  return typeof n === "number" && Number.isFinite(n) ? n : null;
+}
+
+// Emission fractions are small (sum of 0..1 shares); keep 9 decimals like the
+// other tao/share rollups (account-portfolio) so a provider's share doesn't lose
+// precision when many small subnet shares are summed.
+function round9(value) {
+  return Math.round(value * 1e9) / 1e9;
+}
+
+/**
+ * Build the ranked per-provider emission leaderboard from the providers and
+ * economics artifacts.
+ *
+ * @param providersArtifact `{ providers: [{ id, name, kind, authority, netuids }] }`
+ * @param economicsArtifact `{ subnets: [{ netuid, emission_share, emission_tao }] }`
+ * @returns rows sorted by aggregate `emission_share` descending, each stamped
+ *   with a 1-based `rank`. A provider whose backed subnets carry no emission data
+ *   sorts last with `emission_share: 0` (still listed — absence of emission is a
+ *   real, informative state, not a reason to drop the provider).
+ */
+export function buildProviderEmissionsLeaderboard(
+  providersArtifact,
+  economicsArtifact,
+) {
+  const emissionByNetuid = new Map();
+  for (const subnet of economicsArtifact?.subnets ?? []) {
+    const netuid = toFiniteNumber(subnet?.netuid);
+    if (netuid != null) emissionByNetuid.set(netuid, subnet);
+  }
+
+  const rows = (providersArtifact?.providers ?? []).map((provider) => {
+    const netuids = Array.isArray(provider?.netuids) ? provider.netuids : [];
+    let shareSum = 0;
+    let taoSum = 0;
+    let taoContributors = 0;
+    let matched = 0;
+    for (const raw of netuids) {
+      const netuid = toFiniteNumber(raw);
+      if (netuid == null) continue;
+      const subnet = emissionByNetuid.get(netuid);
+      if (!subnet) continue;
+      matched += 1;
+      const share = toFiniteNumber(subnet.emission_share);
+      if (share != null) shareSum += share;
+      const tao = toFiniteNumber(subnet.emission_tao);
+      if (tao != null) {
+        taoSum += tao;
+        taoContributors += 1;
+      }
+    }
+    return {
+      id: provider?.id ?? null,
+      name: provider?.name ?? null,
+      kind: provider?.kind ?? null,
+      authority: provider?.authority ?? null,
+      subnet_count: netuids.length,
+      // How many of the provider's subnets actually resolved to an economics
+      // row — lets a consumer tell "0 emission" from "no data for these subnets".
+      emission_subnet_count: matched,
+      emission_share: round9(shareSum),
+      // null (not 0) when none of the matched subnets reported an absolute rate,
+      // so a genuine 0 is distinguishable from "tao not published".
+      emission_tao: taoContributors > 0 ? round9(taoSum) : null,
+      netuids,
+    };
+  });
+
+  rows.sort(
+    (a, b) =>
+      b.emission_share - a.emission_share ||
+      (b.emission_tao ?? 0) - (a.emission_tao ?? 0) ||
+      String(a.name ?? a.id ?? "").localeCompare(String(b.name ?? b.id ?? "")),
+  );
+
+  return rows.map((row, index) => ({ rank: index + 1, ...row }));
+}

--- a/tests/analytics-edge-cache.test.mjs
+++ b/tests/analytics-edge-cache.test.mjs
@@ -201,6 +201,23 @@ afterEach(() => {
   globalThis.caches = originalCaches;
 });
 
+describe("provider emissions route (#6644)", () => {
+  test("routes /api/v1/providers/emissions through the worker to a 200 ranked payload", async () => {
+    originalCaches = globalThis.caches;
+    mockCaches().install();
+    const env = analyticsEnv([]);
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/providers/emissions"),
+      env,
+      ctx,
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.ok(Array.isArray(body.data));
+  });
+});
+
 describe("analytics edge cache", () => {
   test("INVARIANT: cache key includes contract_version + snapshot stamp + netuid + window", async () => {
     // D1 fully eliminated (2026-07-17): percentiles always marks a Postgres-tier

--- a/tests/provider-emissions.test.mjs
+++ b/tests/provider-emissions.test.mjs
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildProviderEmissionsLeaderboard } from "../src/provider-emissions.mjs";
+
+const economics = {
+  subnets: [
+    { netuid: 1, emission_share: 0.1, emission_tao: 10 },
+    { netuid: 2, emission_share: 0.25, emission_tao: 25 },
+    { netuid: 3, emission_share: 0.05, emission_tao: null },
+    { netuid: 4, emission_share: 0.4, emission_tao: 40 },
+  ],
+};
+
+describe("buildProviderEmissionsLeaderboard", () => {
+  test("sums each provider's backed-subnet emission and ranks descending", () => {
+    const providers = {
+      providers: [
+        {
+          id: "alpha",
+          name: "Alpha",
+          kind: "team",
+          authority: "official",
+          netuids: [1, 2],
+        },
+        {
+          id: "beta",
+          name: "Beta",
+          kind: "team",
+          authority: "community",
+          netuids: [4],
+        },
+        { id: "gamma", name: "Gamma", netuids: [3] },
+      ],
+    };
+    const rows = buildProviderEmissionsLeaderboard(providers, economics);
+    assert.deepEqual(
+      rows.map((r) => [r.rank, r.id, r.emission_share, r.emission_tao]),
+      [
+        [1, "beta", 0.4, 40], // 0.4
+        [2, "alpha", 0.35, 35], // 0.1 + 0.25
+        [3, "gamma", 0.05, null], // 0.05, no tao reported
+      ],
+    );
+  });
+
+  test("counts total vs emission-matched subnets separately", () => {
+    const providers = {
+      providers: [
+        { id: "p", name: "P", netuids: [1, 999, 2] }, // 999 has no economics row
+      ],
+    };
+    const [row] = buildProviderEmissionsLeaderboard(providers, economics);
+    assert.equal(row.subnet_count, 3);
+    assert.equal(row.emission_subnet_count, 2);
+    assert.equal(row.emission_share, 0.35);
+    assert.equal(row.emission_tao, 35);
+  });
+
+  test("a provider whose subnets carry no emission data sorts last with 0 share, still listed", () => {
+    const providers = {
+      providers: [
+        { id: "empty", name: "Empty", netuids: [999] },
+        { id: "real", name: "Real", netuids: [4] },
+      ],
+    };
+    const rows = buildProviderEmissionsLeaderboard(providers, economics);
+    assert.equal(rows[0].id, "real");
+    assert.equal(rows[1].id, "empty");
+    assert.equal(rows[1].emission_share, 0);
+    assert.equal(rows[1].emission_tao, null);
+    assert.equal(rows[1].emission_subnet_count, 0);
+  });
+
+  test("emission_tao stays null when no matched subnet reports a rate, even with share", () => {
+    const [row] = buildProviderEmissionsLeaderboard(
+      { providers: [{ id: "g", name: "G", netuids: [3] }] },
+      economics,
+    );
+    assert.equal(row.emission_share, 0.05);
+    assert.equal(row.emission_tao, null);
+  });
+
+  test("coerces numeric-string emission fields and ignores non-finite ones", () => {
+    const rows = buildProviderEmissionsLeaderboard(
+      { providers: [{ id: "p", name: "P", netuids: [10, 11, 12] }] },
+      {
+        subnets: [
+          { netuid: 10, emission_share: "0.2", emission_tao: "5" },
+          { netuid: 11, emission_share: "not-a-number", emission_tao: NaN },
+          { netuid: 12, emission_share: 0.3, emission_tao: Infinity },
+        ],
+      },
+    );
+    assert.equal(rows[0].emission_share, 0.5); // 0.2 + 0.3, the bad share skipped
+    assert.equal(rows[0].emission_tao, 5); // only the "5" contributes
+  });
+
+  test("tolerates non-array / non-finite netuids and missing fields", () => {
+    const rows = buildProviderEmissionsLeaderboard(
+      {
+        providers: [
+          { id: "a", netuids: null },
+          { id: "b", netuids: [1, "x", null, 2] },
+        ],
+      },
+      economics,
+    );
+    const b = rows.find((r) => r.id === "b");
+    const a = rows.find((r) => r.id === "a");
+    assert.equal(b.emission_share, 0.35); // 1 + 2, junk entries skipped
+    assert.equal(a.subnet_count, 0);
+    assert.equal(a.emission_share, 0);
+    assert.equal(a.name, null);
+  });
+
+  test("breaks emission ties by tao then name for a stable order", () => {
+    const rows = buildProviderEmissionsLeaderboard(
+      {
+        providers: [
+          { id: "z", name: "Zeta", netuids: [1] },
+          { id: "a", name: "Aria", netuids: [1] },
+        ],
+      },
+      economics,
+    );
+    // equal share (0.1) and equal tao (10) -> name ascending: Aria before Zeta
+    assert.deepEqual(
+      rows.map((r) => r.name),
+      ["Aria", "Zeta"],
+    );
+  });
+
+  test("skips economics rows with a missing / non-finite netuid", () => {
+    const rows = buildProviderEmissionsLeaderboard(
+      { providers: [{ id: "p", name: "P", netuids: [1] }] },
+      {
+        subnets: [
+          { netuid: null, emission_share: 0.9 }, // no netuid -> not indexed
+          { netuid: "nope", emission_share: 0.9 }, // non-finite -> not indexed
+          { netuid: 1, emission_share: 0.1, emission_tao: 10 },
+        ],
+      },
+    );
+    assert.equal(rows[0].emission_share, 0.1); // the un-keyed rows never match
+  });
+
+  test("tie-break falls through name -> id -> empty string without throwing", () => {
+    // equal share (0.1) + equal tao (10); neither has a name, one has no id
+    const rows = buildProviderEmissionsLeaderboard(
+      {
+        providers: [
+          { id: "b", netuids: [1] },
+          { netuids: [1] }, // no name, no id -> "" side of the fallback
+        ],
+      },
+      economics,
+    );
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].id, null); // "" < "b" -> the name/id-less row ranks first
+    assert.equal(rows[1].id, "b");
+  });
+
+  test("tie on share orders a tao-bearing provider ahead of a tao-null one", () => {
+    // netuid 3 has share 0.05 tao null; craft another subnet with the same share
+    // but a real tao so the tao tie-break (?? 0) is exercised on a real value.
+    const rows = buildProviderEmissionsLeaderboard(
+      {
+        providers: [
+          { id: "notao", name: "NoTao", netuids: [3] }, // 0.05, tao null
+          { id: "withtao", name: "WithTao", netuids: [30] }, // 0.05, tao 7
+        ],
+      },
+      {
+        subnets: [
+          { netuid: 3, emission_share: 0.05, emission_tao: null },
+          { netuid: 30, emission_share: 0.05, emission_tao: 7 },
+        ],
+      },
+    );
+    assert.deepEqual(
+      rows.map((r) => r.id),
+      ["withtao", "notao"],
+    );
+  });
+
+  test("empty / missing artifacts yield an empty leaderboard, not a throw", () => {
+    assert.deepEqual(buildProviderEmissionsLeaderboard(null, null), []);
+    assert.deepEqual(buildProviderEmissionsLeaderboard({}, {}), []);
+    assert.deepEqual(
+      buildProviderEmissionsLeaderboard({ providers: [] }, economics),
+      [],
+    );
+  });
+});

--- a/tests/provider-emissions.test.mjs
+++ b/tests/provider-emissions.test.mjs
@@ -183,6 +183,27 @@ describe("buildProviderEmissionsLeaderboard", () => {
     );
   });
 
+  test("a full tie among name/id-less providers still sorts (empty-string keys on both sides)", () => {
+    // Three providers all tied on share (0.1) and tao (10); two of them have
+    // neither name nor id, so both sides of the localeCompare fall all the way
+    // to "" during the pairwise comparisons.
+    const rows = buildProviderEmissionsLeaderboard(
+      {
+        providers: [
+          { netuids: [1] }, // no name, no id -> ""
+          { netuids: [1] }, // no name, no id -> ""
+          { id: "m", name: "M", netuids: [1] },
+        ],
+      },
+      economics,
+    );
+    assert.equal(rows.length, 3);
+    assert.deepEqual(
+      rows.map((r) => r.rank),
+      [1, 2, 3],
+    );
+  });
+
   test("empty / missing artifacts yield an empty leaderboard, not a throw", () => {
     assert.deepEqual(buildProviderEmissionsLeaderboard(null, null), []);
     assert.deepEqual(buildProviderEmissionsLeaderboard({}, {}), []);

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -700,6 +700,18 @@ describe("handleProviderEmissions", () => {
     );
     await errorJson(res);
   });
+
+  test("returns an empty leaderboard when the providers artifact is unavailable", async () => {
+    // ASSETS 404s -> readArtifact(providers.json) is not ok -> providers=null,
+    // and economics falls through to []; the route still 200s with data: [].
+    const env = {
+      ASSETS: { fetch: async () => new Response("not found", { status: 404 }) },
+    };
+    const body = await json(
+      await handleProviderEmissions(req(path), env, url(path)),
+    );
+    assert.deepEqual(body.data, []);
+  });
 });
 
 describe("handleLeaderboards", () => {

--- a/tests/request-handlers-analytics-routes.test.mjs
+++ b/tests/request-handlers-analytics-routes.test.mjs
@@ -17,6 +17,7 @@ import {
   handleCompareValidators,
   handleEconomicsTrends,
   handleLeaderboards,
+  handleProviderEmissions,
   handleTrajectory,
   handleUptime,
 } from "../workers/request-handlers/analytics-routes.mjs";
@@ -638,6 +639,66 @@ describe("handleUptime", () => {
     const body = await errorJson(res);
     assert.equal(res.status, 400);
     assert.equal(body.meta.parameter, "format");
+  });
+});
+
+describe("handleProviderEmissions", () => {
+  const path = "/api/v1/providers/emissions";
+
+  test("ranks providers by aggregate backed-subnet emission from the registry + a controlled economics snapshot", async () => {
+    // Control economics so the ranking is deterministic regardless of the
+    // committed economics artifact: give every netuid an emission_share equal
+    // to netuid/1000, so a provider's total scales with the netuids it backs.
+    configureAnalyticsRoutes({
+      readHealthMetaKv: async () => ({ last_run_at: OBSERVED_AT }),
+      readEconomicsCurrentKv: async () => ({
+        subnets: Array.from({ length: 400 }, (_, netuid) => ({
+          netuid,
+          emission_share: netuid / 1000,
+          emission_tao: netuid,
+        })),
+      }),
+    });
+    const env = createLocalArtifactEnv();
+    const body = await json(
+      await handleProviderEmissions(req(path), env, url(path)),
+    );
+    assert.ok(Array.isArray(body.data));
+    assert.ok(body.data.length > 0);
+    // ranks are sequential 1..N and emission_share is non-increasing
+    body.data.forEach((row, i) => assert.equal(row.rank, i + 1));
+    for (let i = 1; i < body.data.length; i++) {
+      assert.ok(
+        body.data[i - 1].emission_share >= body.data[i].emission_share,
+        "leaderboard is sorted by emission_share descending",
+      );
+    }
+    const top = body.data[0];
+    for (const key of [
+      "rank",
+      "id",
+      "name",
+      "subnet_count",
+      "emission_subnet_count",
+      "emission_share",
+      "emission_tao",
+      "netuids",
+    ]) {
+      assert.ok(key in top, `row is missing "${key}"`);
+    }
+    assert.ok(Array.isArray(top.netuids));
+    // with a full economics snapshot, the top provider actually summed to >0
+    assert.ok(top.emission_share > 0);
+  });
+
+  test("rejects unexpected query params", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleProviderEmissions(
+      req(path),
+      env,
+      url(`${path}?bogus=1`),
+    );
+    await errorJson(res);
   });
 });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -196,6 +196,7 @@ import {
   handleDomainSummary,
   handleEconomicsTrends,
   handleLeaderboards,
+  handleProviderEmissions,
   handleTrajectory,
   handleUptime,
 } from "./request-handlers/analytics-routes.mjs";
@@ -3069,6 +3070,20 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         "economics-trends",
         () => handleEconomicsTrends(request, env, resolved.url),
         canonicalEconomicsTrendsCachePath(resolved.url, request),
+      );
+    }
+    // #6644: per-provider emission leaderboard — a derived rollup, matched
+    // before the artifact-alias provider routes so "emissions" is never read as
+    // a provider slug. Edge-cached like the sibling economics routes (no query
+    // params, so the pathname is the whole key).
+    if (resolved.url.pathname === "/api/v1/providers/emissions") {
+      return withEdgeCache(
+        request,
+        ctx,
+        env,
+        "provider-emissions",
+        () => handleProviderEmissions(request, env, resolved.url),
+        resolved.url.pathname,
       );
     }
     return handleApiRequest(request, env, resolved.url, DEFAULT_NETWORK, ctx);

--- a/workers/request-handlers/analytics-routes.mjs
+++ b/workers/request-handlers/analytics-routes.mjs
@@ -31,6 +31,7 @@ import {
   unsupportedWindowMessage,
 } from "../../src/neuron-history.mjs";
 import { loadEconomicsTrends } from "../../src/economics-trends.mjs";
+import { buildProviderEmissionsLeaderboard } from "../../src/provider-emissions.mjs";
 import {
   COMPARE_DIMENSIONS,
   COMPARE_VALIDATORS_MAX,
@@ -262,6 +263,31 @@ export async function handleEconomicsTrends(request, env, url) {
     "short",
   );
   return isFallback ? markD1FallbackResponse(response) : response;
+}
+
+// #6644: per-provider emission leaderboard. Joins the providers registry
+// (each provider's backed `netuids`) with the current economics snapshot
+// (per-subnet `emission_share`/`emission_tao`) and ranks providers by their
+// aggregate share — a cross-source rollup over two existing artifacts, no new
+// ingestion. Cached "short" like the sibling economics routes; the shaping is
+// unit-tested in src/provider-emissions.mjs.
+export async function handleProviderEmissions(request, env, url) {
+  const validationError = validateQueryParams(url, []);
+  if (validationError) return analyticsQueryError(validationError);
+  const [providersArtifact, subnets] = await Promise.all([
+    readArtifact(env, "/metagraph/providers.json"),
+    resolveEconomicsRows(env),
+  ]);
+  const providers = providersArtifact.ok ? providersArtifact.data : null;
+  const leaderboard = buildProviderEmissionsLeaderboard(providers, { subnets });
+  return envelopeResponse(
+    request,
+    {
+      data: leaderboard,
+      meta: await analyticsMeta(env, "/metagraph/providers.json", null),
+    },
+    "short",
+  );
 }
 
 // Long-term daily uptime history for one subnet's operational surfaces.


### PR DESCRIPTION
## What

Adds `GET /api/v1/providers/emissions` — a per-provider emission leaderboard that ranks each provider by the aggregate current network-emission of the subnets it backs. Closes #6644.

It's a cross-source rollup over two **existing** artifacts, no new ingestion (the issue's non-goal): the providers registry (each provider's backed `netuids`) joined with the economics snapshot (per-subnet `emission_share` — its 0..1 fraction of total network emission — and `emission_tao` where published).

## Ownership model (the issue's gating question)

The issue asks to confirm how "owner" is modeled before building. Subnet **ownership** is an on-chain `owner_coldkey` (an ss58 address, via the `SubnetOwnerChanged` conviction mechanism), which is **not** a clean provider→subnet tie — so per the non-goal I did **not** invent ownership-attribution logic. Instead this aggregates over the registry's existing provider→subnets **"backs"** association (`provider.netuids`), which is the clean 1:many link that already exists and is what the issue's Context points at ("the provider registry already associates each provider with its subnets").

Also honest about the metric: the only per-subnet emission data is the **current** economics snapshot, not a cumulative-historical series (none exists to sum, and building one would be new ingestion). So fields are named for exactly what they are (`emission_share` / `emission_tao`) rather than "lifetime".

## Changes

- **`src/provider-emissions.mjs`** — `buildProviderEmissionsLeaderboard(providers, economics)`: a pure shaping function. Sums each provider's backed-subnet emission, ranks by `emission_share` desc (tie-break: `emission_tao`, then name), and reports `emission_subnet_count` so a consumer can tell "0 emission" from "no economics data for these subnets". A provider whose subnets carry no data is still listed (last, `emission_share:0`).
- **`workers/request-handlers/analytics-routes.mjs`** — `handleProviderEmissions`, reading `providers.json` + the live economics rows (`resolveEconomicsRows`), enveloped and cached `short` like the sibling economics routes.
- **`workers/api.mjs`** — the route, matched *before* the artifact-alias provider routes so `emissions` is never parsed as a provider slug.

## Testing

- **`tests/provider-emissions.test.mjs`** (11 cases): ranking, tie-breaks, string/non-finite coercion, unmatched netuids, `emission_tao` null semantics, empty inputs. 100% line coverage of the shaping function.
- **`tests/request-handlers-analytics-routes.test.mjs`**: handler integration over a controlled economics snapshot — 200, sequential ranks, sorted descending, row shape; plus query-param rejection.
- **`tests/analytics-edge-cache.test.mjs`**: routes the path through the full worker (`handleRequest`) for dispatch coverage.
- Every added executable line across `src/` and `workers/` is covered (codecov patch verified locally). `eslint`, `prettier --check`, and `scan:public-safety` clean.

## Scope note

I kept this to the issue's two-item deliverable (pure shaping function + a live ranked route). I deliberately did **not** bundle the OpenAPI/contract-catalog registration in this PR: it regenerates several committed generated files (`openapi.json`, `types.d.ts`, `contract/index.d.ts`) whose diffs are easy to get subtly wrong. Happy to add that registration here in a follow-up commit if you'd prefer it in-PR — just say the word.
