### PR TITLE
feat(ui): add gap% and contest-status badge to conviction leaderboard

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
@@ -1,11 +1,40 @@
 import { useQuery } from "@tanstack/react-query";
 import { Crown } from "lucide-react";
 import { subnetConvictionQuery } from "@/lib/metagraphed/queries";
+import { contestGap, type ContestStatus } from "@/lib/metagraphed/conviction-contest";
 import { CopyableCode } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 
 const UNITS_PER_WHOLE = 1_000_000_000;
+
+const CONTEST_STATUS_LABEL: Record<ContestStatus, string> = {
+  secure: "Secure",
+  contested: "Contested",
+  "takeover-imminent": "Takeover imminent",
+};
+
+const CONTEST_STATUS_CLASS: Record<ContestStatus, string> = {
+  secure: "border-health-ok/40 bg-health-ok/10 text-health-ok",
+  contested: "border-health-warn/40 bg-health-warn/10 text-health-warn",
+  "takeover-imminent": "border-health-down/40 bg-health-down/10 text-health-down",
+};
+
+/** Gap%/status pill (#6883) -- see conviction-contest.ts for the threshold reasoning. */
+function ContestStatusBadge({ status, gapPct }: { status: ContestStatus; gapPct: number | null }) {
+  return (
+    <span
+      className={classNames(
+        "shrink-0 rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider",
+        CONTEST_STATUS_CLASS[status],
+      )}
+      title="Ownership-contest urgency: how close the top challenger's conviction is to the king's"
+    >
+      {CONTEST_STATUS_LABEL[status]}
+      {gapPct != null ? ` · ${gapPct < 1 ? "<1" : gapPct.toFixed(0)}% gap` : ""}
+    </span>
+  );
+}
 
 // locked_mass/conviction arrive as raw rao-scale integers (mirrors every
 // other on-chain alpha/TAO amount in this codebase) -- divide before display.
@@ -51,15 +80,22 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
     );
   }
 
+  const gap = contestGap(leaderboard, data?.king ?? null);
+
   return (
     <div className="space-y-3">
-      {data?.queried_at_block != null ? (
-        <p className="font-mono text-[11px] text-ink-muted">
-          Rolled forward to block #{formatNumber(data.queried_at_block)}
-          {data.unlock_rate != null ? ` · unlock_rate ${formatNumber(data.unlock_rate)}` : ""}
-          {data.maturity_rate != null ? ` · maturity_rate ${formatNumber(data.maturity_rate)}` : ""}
-        </p>
-      ) : null}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+        {data?.queried_at_block != null ? (
+          <p className="font-mono text-[11px] text-ink-muted">
+            Rolled forward to block #{formatNumber(data.queried_at_block)}
+            {data.unlock_rate != null ? ` · unlock_rate ${formatNumber(data.unlock_rate)}` : ""}
+            {data.maturity_rate != null
+              ? ` · maturity_rate ${formatNumber(data.maturity_rate)}`
+              : ""}
+          </p>
+        ) : null}
+        <ContestStatusBadge status={gap.status} gapPct={gap.gapPct} />
+      </div>
       <div className="rounded-xl border border-border bg-card overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">

--- a/apps/ui/src/lib/metagraphed/conviction-contest.test.ts
+++ b/apps/ui/src/lib/metagraphed/conviction-contest.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { contestGap } from "./conviction-contest";
+import type { SubnetConvictionEntry } from "./types";
+
+function entry(hotkey: string, conviction: number, isOwner = false): SubnetConvictionEntry {
+  return { hotkey, is_owner: isOwner, locked_mass: conviction, conviction };
+}
+
+describe("contestGap", () => {
+  it("is secure with a null gap for an empty leaderboard", () => {
+    expect(contestGap([], null)).toEqual({ status: "secure", gapPct: null });
+  });
+
+  it("is secure with a null gap when there's no challenger (single entry)", () => {
+    const king = entry("5King", 1_000, true);
+    expect(contestGap([king], "5King")).toEqual({ status: "secure", gapPct: null });
+  });
+
+  it("is takeover-imminent for a close contest (gap below 5%)", () => {
+    const king = entry("5King", 1_000, true);
+    const challenger = entry("5Chal", 960);
+    const result = contestGap([king, challenger], "5King");
+    expect(result.status).toBe("takeover-imminent");
+    expect(result.gapPct).toBeCloseTo(4, 5);
+  });
+
+  it("is contested for a mid-range gap (5-20%)", () => {
+    const king = entry("5King", 1_000, true);
+    const challenger = entry("5Chal", 850);
+    const result = contestGap([king, challenger], "5King");
+    expect(result.status).toBe("contested");
+    expect(result.gapPct).toBeCloseTo(15, 5);
+  });
+
+  it("is secure for a wide gap (>= 20%)", () => {
+    const king = entry("5King", 1_000, true);
+    const challenger = entry("5Chal", 500);
+    const result = contestGap([king, challenger], "5King");
+    expect(result.status).toBe("secure");
+    expect(result.gapPct).toBeCloseTo(50, 5);
+  });
+
+  it("compares the king against the highest non-king entry, not just leaderboard[1]", () => {
+    const king = entry("5King", 1_000, true);
+    const weak = entry("5Weak", 100);
+    const strong = entry("5Strong", 980);
+    const result = contestGap([king, weak, strong], "5King");
+    expect(result.status).toBe("takeover-imminent");
+    expect(result.gapPct).toBeCloseTo(2, 5);
+  });
+
+  it("falls back to the highest-conviction entry when king doesn't match any hotkey", () => {
+    const top = entry("5Top", 1_000);
+    const runnerUp = entry("5Runner", 500);
+    const result = contestGap([top, runnerUp], "5Unknown");
+    expect(result.status).toBe("secure");
+    expect(result.gapPct).toBeCloseTo(50, 5);
+  });
+
+  it("is secure with a null gap when the king's conviction is 0", () => {
+    const king = entry("5King", 0, true);
+    const challenger = entry("5Chal", 0);
+    expect(contestGap([king, challenger], "5King")).toEqual({ status: "secure", gapPct: null });
+  });
+});

--- a/apps/ui/src/lib/metagraphed/conviction-contest.ts
+++ b/apps/ui/src/lib/metagraphed/conviction-contest.ts
@@ -1,0 +1,48 @@
+import type { SubnetConvictionEntry } from "./types";
+
+export type ContestStatus = "secure" | "contested" | "takeover-imminent";
+
+export interface ContestGap {
+  status: ContestStatus;
+  /** Gap between the king and the top challenger, as a percentage of the king's conviction.
+   * Null when there's no challenger to compare against, or the king's conviction is 0. */
+  gapPct: number | null;
+}
+
+// Gap thresholds, expressed as % of the king's conviction (#6883). There's no existing
+// precedent for this in the codebase -- these are a documented starting point, not derived
+// from chain data: under 5% is close enough that a single strong lock top-up can close it
+// within one epoch; 5-20% needs a sustained push while the king's own conviction keeps decaying
+// in the meantime; above 20% is a lead a challenger can't realistically close in one epoch.
+const TAKEOVER_IMMINENT_MAX_PCT = 5;
+const CONTESTED_MAX_PCT = 20;
+
+/**
+ * Ownership-contest urgency for a conviction leaderboard: how close the top challenger is to
+ * overtaking the king. Looks the king entry up by hotkey (falling back to the highest-conviction
+ * entry if `king` doesn't match anything in `leaderboard`) and takes the highest-conviction
+ * remaining entry as the runner-up -- correct regardless of the array's sort order.
+ */
+export function contestGap(leaderboard: SubnetConvictionEntry[], king: string | null): ContestGap {
+  if (leaderboard.length === 0) return { status: "secure", gapPct: null };
+
+  const kingEntry =
+    (king != null ? leaderboard.find((e) => e.hotkey === king) : undefined) ??
+    leaderboard.reduce((best, e) => (e.conviction > best.conviction ? e : best));
+
+  const runnerUp = leaderboard
+    .filter((e) => e.hotkey !== kingEntry.hotkey)
+    .reduce<SubnetConvictionEntry | null>(
+      (best, e) => (best == null || e.conviction > best.conviction ? e : best),
+      null,
+    );
+
+  if (runnerUp == null || kingEntry.conviction <= 0) {
+    return { status: "secure", gapPct: null };
+  }
+
+  const gapPct = ((kingEntry.conviction - runnerUp.conviction) / kingEntry.conviction) * 100;
+  if (gapPct < TAKEOVER_IMMINENT_MAX_PCT) return { status: "takeover-imminent", gapPct };
+  if (gapPct < CONTESTED_MAX_PCT) return { status: "contested", gapPct };
+  return { status: "secure", gapPct };
+}


### PR DESCRIPTION
The conviction leaderboard on a subnet's page (`SubnetConvictionLeaderboard`) already had all the data needed to tell how close an ownership contest is — it just rendered a plain ranked table with a crown on the king. #6883 asked for a gap% between the king and the top challenger plus a Secure/Contested/Takeover-imminent badge, matching what a few competitor explorers already do with this same mechanic.

The new logic lives in `apps/ui/src/lib/metagraphed/conviction-contest.ts` (`contestGap()`), following the same pattern as `incident-duration.ts` — a small pure function the component imports, tested on its own rather than through component rendering. It looks up the king by hotkey (falling back to the highest-conviction entry if `king` doesn't match anything, which shouldn't happen given the API always sorts by conviction descending, but costs nothing to guard) and compares it against the highest-conviction remaining entry.

Thresholds: gap < 5% is `takeover-imminent`, 5–20% is `contested`, ≥20% (or no challenger at all) is `secure`. There's no existing precedent for this in the codebase to mirror, so I picked these on the reasoning that under 5% is close enough for a single strong lock top-up to close within one epoch, and above 20% needs a sustained multi-epoch push while the king's own conviction keeps decaying in the meantime — documented inline next to the constants.

I skipped the optional "time to overtake" stretch goal from the issue. `docs/conviction-lock-mechanism.md` (the research spike behind this whole feature) is explicit that `UnlockRate`/`MaturityRate` are governance-adjustable and warns against displaying a "days remaining" figure without verifying the live value and getting the exponential roll-forward math right — that felt like its own piece of work rather than something to bolt onto a presentation-only PR, so I left it as a natural follow-up.

The badge sits next to the existing "Rolled forward to block #..." line, using the same pill style as the `owner` tag already in this table and the same `health-ok`/`health-warn`/`health-down` tokens the incident timeline uses elsewhere, so it reads as part of the existing system rather than a new one.

Testing: added `conviction-contest.test.ts` covering empty leaderboard, single entry (no challenger), a close contest, a mid-range gap, a wide gap, a non-adjacent runner-up (king vs. the *highest* non-king entry, not just index 1), an unknown `king` value falling back correctly, and a zero-conviction king. Ran the full local gate before pushing: `npm run lint`, `format:check`, `typecheck`, `test`, `test:e2e`, and `build` for `apps/ui`, plus the root `validate`/`test:ci` suite and the Python SDK suite, all green.

Since this changes rendered output, here's the before/after across viewports and themes. No real subnet currently has an active conviction contest to screenshot against (most subnets have zero challengers, as the component's own empty-state copy says), so these use mocked leaderboard data (a king + one challenger at a ~5% gap) fed through a local proxy in front of the real API — same data in both columns, so the badge is the only difference:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/3f2cb9011f1a26370b4272690cec1895e81e1131/runs/jsonbored-metagraphed/run-21/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/3f2cb9011f1a26370b4272690cec1895e81e1131/runs/jsonbored-metagraphed/run-21/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/81c46d82a0ab91a2c64b30e03b3ccb2d21451aea/runs/jsonbored-metagraphed/run-21/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/81c46d82a0ab91a2c64b30e03b3ccb2d21451aea/runs/jsonbored-metagraphed/run-21/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/5628c4e01b0a5d7318c45e8f5a16f0f62deb31c4/runs/jsonbored-metagraphed/run-21/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/5628c4e01b0a5d7318c45e8f5a16f0f62deb31c4/runs/jsonbored-metagraphed/run-21/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/0af424f5e0ad7c8f635c7fabc73ae635d188dc51/runs/jsonbored-metagraphed/run-21/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/0af424f5e0ad7c8f635c7fabc73ae635d188dc51/runs/jsonbored-metagraphed/run-21/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/c6399ea5c7bb7742abf056b0cb83deac6ace5544/runs/jsonbored-metagraphed/run-21/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/c6399ea5c7bb7742abf056b0cb83deac6ace5544/runs/jsonbored-metagraphed/run-21/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/221f45056ab625ee162b9676fe4fc07816f5b5b3/runs/jsonbored-metagraphed/run-21/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/221f45056ab625ee162b9676fe4fc07816f5b5b3/runs/jsonbored-metagraphed/run-21/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/649583ad52182ceb6e95a59125827589286c9207/runs/jsonbored-metagraphed/run-21/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/649583ad52182ceb6e95a59125827589286c9207/runs/jsonbored-metagraphed/run-21/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/d6e42eb8874a80a80fa7a48a23b73749832e70d0/runs/jsonbored-metagraphed/run-21/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/d6e42eb8874a80a80fa7a48a23b73749832e70d0/runs/jsonbored-metagraphed/run-21/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/006bb4a30ac372b81546b843aeb5570c59f2c38c/runs/jsonbored-metagraphed/run-21/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/006bb4a30ac372b81546b843aeb5570c59f2c38c/runs/jsonbored-metagraphed/run-21/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/d0c1089201afdb91818d7921535c0bb9642ebbbb/runs/jsonbored-metagraphed/run-21/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/d0c1089201afdb91818d7921535c0bb9642ebbbb/runs/jsonbored-metagraphed/run-21/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/f1ad8f434a32902790004241efd7d3f9d28834b4/runs/jsonbored-metagraphed/run-21/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/f1ad8f434a32902790004241efd7d3f9d28834b4/runs/jsonbored-metagraphed/run-21/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/7a281b4bff72a36f9b67c86f8ab855ec1f7636c8/runs/jsonbored-metagraphed/run-21/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/7a281b4bff72a36f9b67c86f8ab855ec1f7636c8/runs/jsonbored-metagraphed/run-21/after-mobile-dark.png)<br><sub>after</sub> |

The mobile hotkey column overflowing (cutting off LOCKED MASS/CONVICTION) is a pre-existing table layout issue visible in the before shots too, not something this PR introduces.

Closes #6883