### PR TITLE
perf(api): split account summary event scan into two per-column seeks

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -1118,10 +1118,11 @@ test("GET /api/v1/extrinsics/:ref skips the embedded-events query on an unresolv
   expect(sqlCalls.length).toBe(2); // SET + the main lookup, no events query
 });
 
-test("GET /api/v1/accounts/:ss58 shapes the cross-subnet summary from one bounded event window", async () => {
+test("GET /api/v1/accounts/:ss58 shapes the cross-subnet summary from two merged, re-capped bounded scans", async () => {
   mockQueue.current = [
     [], // SET
-    [ACCOUNT_EVENT_ROW, { ...ACCOUNT_EVENT_ROW, netuid: 5 }], // scanRows
+    [ACCOUNT_EVENT_ROW], // hotkeyScanRows
+    [{ ...ACCOUNT_EVENT_ROW, netuid: 5 }], // coldkeyScanRows
     [{ netuid: 4, uid: 1, stake_tao: "10", validator_permit: 1, active: 1 }], // regRows
     [
       {
@@ -1144,14 +1145,18 @@ test("GET /api/v1/accounts/:ss58 shapes the cross-subnet summary from one bounde
   expect(body.recent_events.length).toBe(2);
   expect(body.activity.tx_count).toBe(3);
   expect(body.activity.modules_called[0].call_module).toBe("SubtensorModule");
-  expect(queryText()).toContain("WHERE (hotkey =");
-  expect(queryText()).toContain("OR coldkey =");
+  const text = queryText();
+  expect(text).toContain("FROM account_events WHERE hotkey =");
+  expect(text).toContain("FROM account_events WHERE coldkey =");
+  expect(text).toContain("hotkey IS NULL OR hotkey <>");
+  expect(text).not.toContain("WHERE (hotkey =");
 });
 
 test("GET /api/v1/accounts/:ss58 ignores null netuid events in subnet_count", async () => {
   mockQueue.current = [
     [], // SET
-    [ACCOUNT_EVENT_ROW, { ...ACCOUNT_EVENT_ROW, netuid: null }], // scanRows
+    [ACCOUNT_EVENT_ROW], // hotkeyScanRows
+    [{ ...ACCOUNT_EVENT_ROW, netuid: null }], // coldkeyScanRows
     [], // regRows
     [], // activityRows
     [], // moduleRows
@@ -1162,6 +1167,111 @@ test("GET /api/v1/accounts/:ss58 ignores null netuid events in subnet_count", as
   expect(body.event_count).toBe(2);
   expect(body.subnet_count).toBe(1);
   expect(body.recent_events.map((event) => event.netuid)).toEqual([4, null]);
+});
+
+test("GET /api/v1/accounts/:ss58 merges, re-sorts, and re-caps events from BOTH the hotkey and coldkey branches", async () => {
+  // An address with genuine activity under both hotkey and coldkey (e.g. a
+  // hotkey it owns, plus a separate account whose coldkey it is) must have
+  // both branches' rows merged into one newest-first, correctly-capped
+  // window -- not just whichever branch happened to be queried.
+  const hotkeyRow = {
+    ...ACCOUNT_EVENT_ROW,
+    block_number: "100",
+    event_index: 0,
+    event_kind: "StakeAdded",
+    hotkey: SS58,
+    coldkey: "5ColdOther",
+  };
+  const coldkeyRowNewer = {
+    ...ACCOUNT_EVENT_ROW,
+    block_number: "200",
+    event_index: 1,
+    event_kind: "StakeRemoved",
+    hotkey: "5HotOther",
+    coldkey: SS58,
+  };
+  const coldkeyRowOlder = {
+    ...ACCOUNT_EVENT_ROW,
+    block_number: "50",
+    event_index: 2,
+    event_kind: "WeightsSet",
+    hotkey: "5HotOther2",
+    coldkey: SS58,
+  };
+  mockQueue.current = [
+    [], // SET
+    [hotkeyRow], // hotkeyScanRows
+    [coldkeyRowNewer, coldkeyRowOlder], // coldkeyScanRows
+    [], // regRows
+    [], // activityRows
+    [], // moduleRows
+  ];
+  const res = await req(`/api/v1/accounts/${SS58}`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  // 3 distinct rows across both branches, correctly re-sorted newest-first
+  // by (block_number DESC, event_index DESC) regardless of which branch
+  // each row came from.
+  expect(body.event_count).toBe(3);
+  expect(body.recent_events.map((e) => e.block_number)).toEqual([200, 100, 50]);
+  expect(body.recent_events.map((e) => e.event_kind)).toEqual([
+    "StakeRemoved",
+    "StakeAdded",
+    "WeightsSet",
+  ]);
+});
+
+test("GET /api/v1/accounts/:ss58 breaks a same-block tie between branches by event_index DESC", async () => {
+  // Two rows sharing the SAME block_number (one from each branch) exercise the
+  // merge sort's tie-break path (blockDelta === 0), distinct from the
+  // block_number-DESC path the test above already covers.
+  const hotkeyRow = {
+    ...ACCOUNT_EVENT_ROW,
+    block_number: "500",
+    event_index: 1,
+    event_kind: "StakeAdded",
+    hotkey: SS58,
+    coldkey: "5ColdOther",
+  };
+  const coldkeyRow = {
+    ...ACCOUNT_EVENT_ROW,
+    block_number: "500",
+    event_index: 4,
+    event_kind: "StakeRemoved",
+    hotkey: "5HotOther",
+    coldkey: SS58,
+  };
+  mockQueue.current = [
+    [], // SET
+    [hotkeyRow], // hotkeyScanRows
+    [coldkeyRow], // coldkeyScanRows
+    [], // regRows
+    [], // activityRows
+    [], // moduleRows
+  ];
+  const res = await req(`/api/v1/accounts/${SS58}`);
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.recent_events.map((e) => e.event_index)).toEqual([4, 1]);
+  expect(body.recent_events.map((e) => e.event_kind)).toEqual([
+    "StakeRemoved",
+    "StakeAdded",
+  ]);
+});
+
+test("GET /api/v1/accounts/:ss58's coldkey scan excludes rows the hotkey scan already matched", async () => {
+  // A row where hotkey === coldkey === ss58 would match BOTH branches' raw
+  // WHERE predicates if the coldkey branch had no guard -- the query text
+  // must carry the `hotkey IS NULL OR hotkey <> $1` exclusion so Postgres
+  // itself never returns that row twice across the two result sets (the
+  // merge step has no separate app-level dedup; it trusts this SQL guard,
+  // mirroring the D1 predecessor's own coldkey-branch exclusion).
+  await req(`/api/v1/accounts/${SS58}`);
+  const coldkeyQuery = sqlCalls.find((call) =>
+    call.text.includes("FROM account_events WHERE coldkey ="),
+  );
+  expect(coldkeyQuery.text).toContain("(hotkey IS NULL OR hotkey <>");
+  expect(coldkeyQuery.values).toContain(SS58);
 });
 
 test("GET /api/v1/accounts/:ss58 with no matching rows returns a schema-stable empty summary", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -4625,22 +4625,49 @@ export default {
         // summary -- event aggregates, per-kind counts, 10 newest events,
         // current registrations, and bounded signing activity from the
         // extrinsics tier, mirroring the former src/account-events.mjs
-        // account-summary D1 loader (removed in #4772). Postgres has no INDEXED BY equivalent and
-        // evaluates (hotkey = $1 OR coldkey = $1) as one plan, so the D1
-        // path's two-branch UNION-of-seeks (each capped, then re-merged and
-        // re-capped) collapses to a single bounded ORDER BY/LIMIT scan here --
-        // the aggregate/kind/recent-events fields below all derive from that
-        // one CAP+1-row window, computed once client-side, rather than
+        // account-summary D1 loader (removed in #4772). Postgres has no
+        // INDEXED BY equivalent, and a single (hotkey = $1 OR coldkey = $1)
+        // WHERE forces one combined plan the planner can't always satisfy
+        // with an index-only scan for a sparse address -- risking a
+        // statement-timeout 500 under real load (Sentry METAGRAPHED-5,
+        // #6878). Restored the D1 predecessor's two-branch shape instead:
+        // one capped ORDER BY/LIMIT scan on hotkey = $1 (lets the planner use
+        // a plain index on hotkey/coldkey + (block_number, event_index)), a
+        // second on coldkey = $1 that excludes rows the hotkey branch already
+        // matched (so a self hotkey==coldkey account isn't double-counted),
+        // then merged + re-sorted + re-capped client-side to CAP+1 -- the
+        // aggregate/kind/recent-events fields below all derive from that
+        // merged CAP+1-row window, computed once client-side, rather than
         // separate SQL aggregates per field.
         const acctSummary = url.pathname.match(
           /^\/api\/v1\/accounts\/([^/]+)$/,
         );
         if (acctSummary) {
           const ss58 = decodeURIComponent(acctSummary[1]);
-          const scanRows = await sql`
+          const hotkeyScanRows = await sql`
           SELECT block_number, event_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at, extrinsic_index
-          FROM account_events WHERE (hotkey = ${ss58} OR coldkey = ${ss58})
+          FROM account_events WHERE hotkey = ${ss58}
           ORDER BY block_number DESC, event_index DESC LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1}`;
+          const coldkeyScanRows = await sql`
+          SELECT block_number, event_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at, extrinsic_index
+          FROM account_events WHERE coldkey = ${ss58} AND (hotkey IS NULL OR hotkey <> ${ss58})
+          ORDER BY block_number DESC, event_index DESC LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1}`;
+          // Each branch is already the account's own newest CAP+1 rows on its
+          // key, so the union's true newest CAP+1 rows are guaranteed to be
+          // present in this merged set -- re-sort by the same feed order and
+          // re-cap to CAP+1, matching what the single-scan query used to
+          // return in one step. block_number/event_index are NOT NULL columns
+          // (deploy/postgres/schema.sql), so a plain Number() coercion is
+          // enough here -- no null-fallback branch to keep covered.
+          const scanRows = hotkeyScanRows
+            .concat(coldkeyScanRows)
+            .sort((a, b) => {
+              const blockDelta =
+                Number(b.block_number) - Number(a.block_number);
+              if (blockDelta !== 0) return blockDelta;
+              return Number(b.event_index) - Number(a.event_index);
+            })
+            .slice(0, ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1);
           const regRows = await sql`
           SELECT netuid, uid, stake_tao, validator_permit, active FROM neurons
           WHERE hotkey = ${ss58} ORDER BY stake_tao DESC, netuid ASC`;


### PR DESCRIPTION
## What

`GET /api/v1/accounts/{ss58}` (the `#4832` Tier-1c cross-subnet account summary) built its event window from a single OR'd scan:

```sql
FROM account_events WHERE (hotkey = $1 OR coldkey = $1)
ORDER BY block_number DESC, event_index DESC LIMIT ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1
```

Postgres evaluates `(hotkey = $1 OR coldkey = $1)` as one combined plan that can't index-seek either column. For an address whose `account_events` rows are sparse relative to the table's `block_number DESC` order, the planner scans far more of the table than the `LIMIT` before it's confident it has the top-N — intermittently tripping the statement timeout in production (Sentry METAGRAPHED-5).

## Change

Restore the two-branch, per-column bounded scan the removed `src/account-events.mjs` D1 loader used (see #4772):

- Run two capped queries, each `ORDER BY block_number DESC, event_index DESC LIMIT CAP + 1`: one `WHERE hotkey = $1`, and one `WHERE coldkey = $1 AND (hotkey IS NULL OR hotkey <> $1)`. The `hotkey <>` guard on the coldkey branch excludes any row the hotkey branch already matched, so a self `hotkey == coldkey == ss58` account is never fetched twice — mirroring the D1 predecessor's own coldkey-branch exclusion, rather than adding a separate app-level dedup step.
- Merge the two result arrays and re-sort/re-cap client-side to `ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1` (`Number(b.block_number) - Number(a.block_number)`, tie-broken by `event_index`). `block_number`/`event_index` are `NOT NULL` columns (`deploy/postgres/schema.sql`), so the comparator is a plain numeric subtraction — no null-fallback branch to keep covered.

Correctness: each branch already returns the newest `CAP + 1` rows on its own column, so their union is guaranteed to contain the true global newest `CAP + 1`. Merging and re-capping reproduces the OR'd scan's result exactly, minus the timeout risk. Every downstream aggregate/kind/recent-events field derives from that same merged window unchanged — the response shape is identical.

## Index-scan rationale (Deliverable 2)

Spun up `deploy/docker-compose.yml`'s local Postgres/TimescaleDB service and confirmed the two indexes each branch relies on already exist in `deploy/postgres/schema.sql`:

```
"idx_ae_hotkey" btree (hotkey, block_number DESC)
"idx_ae_coldkey" btree (coldkey, block_number DESC)
```

A single-column equality predicate whose sort matches the index's second key (`block_number DESC`) lets each branch do a plain index range scan bounded by the `LIMIT`; the previous flat-OR predicate matched neither index cleanly. I wasn't able to get a representative-scale `EXPLAIN ANALYZE` run to completion in this environment in reasonable time (bulk-seeding `account_events` is slow through the table's `AFTER INSERT` firehose trigger), so I'm relying on the structural argument above plus the existing index definitions rather than a captured plan — happy to attach one if useful during review.

## Tests

- Existing `/api/v1/accounts/:ss58` summary tests (`tests/data-api.test.mjs`) updated to the two-query mock shape; assertions now check for the two separate `WHERE hotkey =` / `WHERE coldkey =` queries (and the `hotkey IS NULL OR hotkey <>` guard) instead of the old combined `WHERE (hotkey = ... OR coldkey = ...)`.
- New: an address with genuine activity under **both** `hotkey` and `coldkey` (two different rows, one from each branch) — confirms the merge produces a correctly-ordered, correctly-capped result.
- New: a same-`block_number` tie between the two branches — exercises the `event_index` tie-break path in the merge sort explicitly.
- New: asserts the coldkey branch's query text carries the `hotkey <>` exclusion guard, so Postgres itself (not app-level code) is what prevents double-counting a self `hotkey == coldkey` account's row.

`npx vitest run tests/data-api.test.mjs tests/account-events.test.mjs` — 556 passing, all changed lines covered (verified via `vitest run --coverage` scoped to these files: zero uncovered statements/branches in the diff range).

Closes #6878