### PR TITLE
fix(ui): wrap /health status-filter chips so all are reachable on mobile (#6906)

### DIFF
--- a/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
+++ b/apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx
@@ -56,7 +56,7 @@ export function StatusMosaic({ className, limit = 240 }: { className?: string; l
             {rows.length} endpoint{rows.length === 1 ? "" : "s"}
           </h3>
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex flex-wrap items-center gap-1">
           {(["all", "ok", "warn", "down", "unknown"] as const).map((k) => {
             const active = filter === k;
             const n = k === "all" ? endpoints.length : (counts[k] ?? 0);


### PR DESCRIPTION
## Summary

The status-filter chip row in `/health`'s endpoint mosaic (`StatusMosaic`) rendered its five filter chips (`all` / `ok` / `warn` / `down` / `unknown`) plus the trailing info tooltip in a plain non-wrapping `flex items-center gap-1` row. At a 375px mobile viewport that row is ~418px wide, so it overflowed the card by ~43px — the last chip (`unknown`) and the info icon were cut off past the edge and unreachable without an unindicated horizontal scroll.

## Fix

Added `flex-wrap` to that one row so the chips wrap onto a second line when they can't fit, matching the wrapping filter-bar pattern already used elsewhere in the app (e.g. the "SAVED VIEWS" chip row in `subnets.index.tsx` and the filter bar at `subnets.index.tsx:650`, both `flex flex-wrap items-center gap-*`). No behavior, data, or markup change beyond the single class — the parent header is already `flex flex-wrap`, so the chip group now folds cleanly instead of clipping.

Result: all five status filters and the info icon are visible and tappable at 375px, with no horizontal overflow.

## Changed

- `apps/ui/src/components/metagraphed/analytics/status-mosaic.tsx` — `flex items-center gap-1` → `flex flex-wrap items-center gap-1` on the status-filter chip row (1 line).

## Validation

- `npx eslint` on the changed file — clean (0 errors)
- `npx tsc --noEmit` (apps/ui) — 0 errors
- `prettier --check` on the staged blob — clean
- Before/after screenshots captured with the repo's `npm run screenshots` tool (3 fixed viewports × 2 themes × before/after = 12 PNGs) — table below.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6906-health-chips-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6906
