### PR TITLE
fix(ui): stop the /blocks summary stat tiles clipping labels on mobile (#6905)

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -187,12 +187,14 @@ function BlockProductionHeader() {
     <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
       <StatTile
         icon={Timer}
+        truncate={false}
         eyebrow="Inter-block time"
         value={blockTime ? humaniseSeconds(blockTime.mean_ms / 1000) : "—"}
         hint={blockTime ? `p90 ${humaniseSeconds(blockTime.p90_ms / 1000)}` : undefined}
       />
       <StatTile
         icon={Activity}
+        truncate={false}
         eyebrow="Throughput"
         // #3940: bare number like the sibling tiles -- unit + secondary metric live in the hint.
         value={throughput ? formatNumber(throughput.mean_extrinsics_per_block) : "—"}
@@ -204,6 +206,7 @@ function BlockProductionHeader() {
       />
       <StatTile
         icon={Users}
+        truncate={false}
         eyebrow="Author decentralization"
         value={nakamoto != null ? formatNumber(nakamoto) : "—"}
         hint="Nakamoto coefficient"


### PR DESCRIPTION
Closes #6905

## Summary

On `/blocks` at 375px, `BlockProductionHeader`'s three StatTiles sit in a 2-column grid (~165px each), and `StatTile` defaults `truncate` to `true` — so long eyebrows and hints clip illegibly mid-word: "INTER-BLOCK…", "AUTHOR DECE…", "ext/blo…", "Nakamoto co…".

## What Changed

- Pass `truncate={false}` to the three StatTiles — the component's own documented wrap mode ("the eyebrow/hint wrap instead of truncating"). It was simply never passed here.

The eyebrow and hint now wrap to a second line and read in full. `md+` is unaffected (the 3-column grid gives each tile ample width either way, so nothing wraps there).

## Screenshots — /blocks summary stat tiles

Before: labels clip mid-word. After: they wrap and are fully legible.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| **Mobile · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-after-mobile-light.png)<br><sub>after</sub> |
| **Mobile · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-after-mobile-dark.png)<br><sub>after</sub> |
| **Tablet · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-after-tablet-light.png)<br><sub>after</sub> |
| **Tablet · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-after-tablet-dark.png)<br><sub>after</sub> |
| **Desktop · Light** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-after-desktop-light.png)<br><sub>after</sub> |
| **Desktop · Dark** | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/luciferlive112116/metagraphed/screenshots/screenshots/6905/6905-stattile-after-desktop-dark.png)<br><sub>after</sub> |


## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6905`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none — UI-only)*

## Validation

- [x] `npx prettier --check` / `npx eslint` — clean (apps/ui config)
- [x] `npm run typecheck` — no new errors (`truncate` is a documented StatTile prop)
- [x] `git diff --check` clean
- [x] 12-image before/after matrix (3 viewports x 2 themes); eyebrow wrap-mode asserted per shot
