### PR TITLE
feat(api): named invite-code cohorts + tier-aware fullnode rate limits

### DIFF
--- a/apps/ui/content/docs/rpc.mdx
+++ b/apps/ui/content/docs/rpc.mdx
@@ -64,6 +64,66 @@ Only safe read methods pass. Mutating and heavy prefixes are denied. State-query
 
 `author_`\* · `state_call`\* · `sudo_`\* · `payment_`\* · `contracts_`\*
 
+## Gated fullnode access
+
+An account-gated tier for real fullnode RPC access — not just the read-only proxy above. Requires a wallet-signed login and an invite code (private-launch only, not self-serve yet). Grants the same safe read methods as the public proxy, plus `author_submitExtrinsic` (real transaction broadcast), at a materially higher rate limit than the keyless tier.
+
+**1. Request a challenge**
+
+```bash tab="cURL"
+curl -s https://api.metagraph.sh/api/v1/auth/wallet/challenge \
+  -X POST -H 'content-type: application/json' \
+  -d '{"ss58":"YOUR_SS58_ADDRESS"}'
+```
+
+Returns a `message` to sign and how long it stays valid.
+
+**2. Sign the message with your wallet**
+
+Sign the returned `message` as raw bytes with your own wallet signer (e.g. `@polkadot/extension-dapp`'s `signRaw({ address, data: message, type: "bytes" })`). The signing key material never reaches this API — only the resulting signature does.
+
+**3. Verify and get a session**
+
+```bash tab="cURL"
+curl -s https://api.metagraph.sh/api/v1/auth/wallet/verify \
+  -X POST -H 'content-type: application/json' \
+  -d '{"ss58":"YOUR_SS58_ADDRESS","signature":"YOUR_HEX_SIGNATURE"}'
+```
+
+Returns a `session_token` — scoped only to key management (create/list/revoke your own keys), not itself the RPC credential.
+
+**4. Mint your key**
+
+```bash tab="cURL"
+curl -s https://api.metagraph.sh/api/v1/keys \
+  -X POST \
+  -H "authorization: Bearer YOUR_SESSION_TOKEN" \
+  -H "x-fullnode-invite-code: YOUR_INVITE_CODE"
+```
+
+Returns the full `mg_...` key exactly once — store it yourself; it's never shown again. Revoke anytime with `DELETE /api/v1/keys/{prefix}`, presenting the same session.
+
+**5. Call the gated proxy**
+
+```bash tab="cURL"
+curl -s 'https://api.metagraph.sh/rpc/v1/fullnode?authorization=YOUR_KEY' \
+  -X POST -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"chain_getHeader","params":[]}'
+```
+
+The key travels as an `?authorization=` query parameter, not a header — matching the convention several hosted-RPC providers already use, so existing WSS-shaped client code needs minimal changes to point here.
+
+<Callout title="Invite-only for now">
+  This tier isn't self-serve yet — invite codes are handed out directly, not published. If you were
+  given one, use it in step 4 above.
+</Callout>
+
+| What         | Value                                        | Notes                                                                              |
+| ------------ | -------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Endpoint     | `POST /rpc/v1/fullnode`                      | Isolated from the public `/rpc/v1/{network}` pool — no shared failover state.      |
+| Method scope | Safe read methods + `author_submitExtrinsic` | Every other `author_`/`sudo_`/`payment_`/`contracts_`/`state_call` call is denied. |
+| Key delivery | `?authorization=` query parameter            | Not an `Authorization` header.                                                     |
+
 ## Limits
 
 Hard caps on every proxied POST. Matching constants live in `workers/config.mjs` and `workers/request-handlers/rpc-proxy.mjs`.

--- a/docs/adr/0021-fullnode-rpc-cluster-access.md
+++ b/docs/adr/0021-fullnode-rpc-cluster-access.md
@@ -144,6 +144,23 @@ anti-abuse gate (contact + rate limit on an otherwise-open mint) — this one
 is binary access control, not abuse throttling, and applies in addition to
 wallet verification, not instead of it.
 
+### 4a. Evolution: named invite-code cohorts, not one shared secret (2026-07-19)
+
+The single shared invite code above generalized, in practice, to a short
+list of independently-provisioned codes (`workers/data-api.mjs`'s
+`FULLNODE_INVITE_CODE_TIERS`), each mapping to a distinct `tier` stamped on
+any key minted with it — e.g. a separate code for an owner-designated
+partner cohort onboarding its own users, distinct from the original
+private-team code. This preserves both properties section 4 required (a
+single rotation kills exactly one cohort's access, never the other's; each
+is still the "delete the check, keep everything else" relax-later
+mechanism) while adding per-cohort attribution and a per-cohort rate-limit
+policy (`workers/request-handlers/fullnode-rpc-proxy.mjs`'s
+`FULLNODE_RPC_TIER_RATE_LIMITS`) instead of one flat figure for every
+minted key. Deliberately a short, explicit list — not a general
+multi-tenant invite-code registry — until a third cohort actually
+materializes.
+
 ### 5. Tiering: one free tier at launch, matching taostats' own current reality
 
 Even taostats' own RBAC/billing is "coming soon" per their docs — there is no

--- a/tests/fullnode-rpc-proxy.test.mjs
+++ b/tests/fullnode-rpc-proxy.test.mjs
@@ -34,7 +34,7 @@ async function makeValidatedKeyEnv(overrides = {}) {
         new Response(
           JSON.stringify({
             secret_hash: secretHash,
-            tier: "free",
+            tier: overrides.tier ?? "free",
             revoked_at: overrides.revoked_at ?? null,
             account_id: 1,
           }),
@@ -151,6 +151,66 @@ test("429s when the per-key rate limiter denies", async () => {
     env,
   );
   assert.equal(res.status, 429);
+});
+
+test("gittensor-partner tier keys are rate-limited against the Gittensor binding, not the free one", async () => {
+  const { env, key } = await makeValidatedKeyEnv({
+    tier: "gittensor-partner",
+    FULLNODE_RPC_RATE_LIMITER: {
+      limit: async () => {
+        throw new Error(
+          "free-tier limiter must not be consulted for this tier",
+        );
+      },
+    },
+    FULLNODE_RPC_RATE_LIMITER_GITTENSOR: {
+      limit: async () => ({ success: false }),
+    },
+  });
+  const res = await call(
+    `/rpc/v1/fullnode?authorization=${key}`,
+    { body: { jsonrpc: "2.0", id: 1, method: "system_health" } },
+    env,
+  );
+  assert.equal(res.status, 429);
+  // The Gittensor tier's own, materially higher policy figure (6000/60s),
+  // not the free tier's (300/60s).
+  assert.equal(res.headers.get("x-ratelimit-limit"), "6000");
+});
+
+test("gittensor-partner tier keys succeed past a bound-and-allowing Gittensor limiter", async () => {
+  const { env, key } = await makeValidatedKeyEnv({
+    tier: "gittensor-partner",
+    FULLNODE_RPC_RATE_LIMITER_GITTENSOR: {
+      limit: async () => ({ success: true }),
+    },
+  });
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "ok" }), {
+      status: 200,
+    });
+  const res = await call(
+    `/rpc/v1/fullnode?authorization=${key}`,
+    { body: { jsonrpc: "2.0", id: 1, method: "system_health" } },
+    env,
+  );
+  assert.equal(res.status, 200);
+});
+
+test("an unrecognized tier falls back to the free-tier rate-limit policy", async () => {
+  const { env, key } = await makeValidatedKeyEnv({
+    tier: "some-future-tier",
+    FULLNODE_RPC_RATE_LIMITER: {
+      limit: async () => ({ success: false }),
+    },
+  });
+  const res = await call(
+    `/rpc/v1/fullnode?authorization=${key}`,
+    { body: { jsonrpc: "2.0", id: 1, method: "system_health" } },
+    env,
+  );
+  assert.equal(res.status, 429);
+  assert.equal(res.headers.get("x-ratelimit-limit"), "300");
 });
 
 test("400s on an unparsable/negative content-length header", async () => {

--- a/tests/wallet-auth-keys-route.test.mjs
+++ b/tests/wallet-auth-keys-route.test.mjs
@@ -552,6 +552,64 @@ test("keys create: 201 mints a key scoped to the session's account", async () =>
   assert.ok(insertCall.values.includes(11)); // account_id
 });
 
+test("keys create: mints a 'gittensor-partner'-tier key when the Gittensor invite code is presented", async () => {
+  const env = baseEnv({ FULLNODE_INVITE_CODE_GITTENSOR: "gittensor-code" });
+  const token = await sessionToken(12, "5GittensorUser");
+  mockQueue.current.push([{ id: 12 }]);
+  const res = await fetch(
+    req("/api/v1/keys", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "x-fullnode-invite-code": "gittensor-code",
+      },
+    }),
+    env,
+  );
+  assert.equal(res.status, 201);
+  const body = await res.json();
+  assert.equal(body.tier, "gittensor-partner");
+  const insertCall = sqlCalls.find((c) => /INSERT INTO api_keys/.test(c.text));
+  assert.ok(insertCall.values.includes("gittensor-partner"));
+});
+
+test("keys create: the private-team code and the Gittensor code are independent -- each still works when only one is configured", async () => {
+  const gittensorOnlyEnv = baseEnv({
+    FULLNODE_INVITE_CODE: undefined,
+    FULLNODE_INVITE_CODE_GITTENSOR: "gittensor-code",
+  });
+  const token = await sessionToken(13, "5Solo");
+  mockQueue.current.push([{ id: 13 }]);
+  const res = await fetch(
+    req("/api/v1/keys", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "x-fullnode-invite-code": "gittensor-code",
+      },
+    }),
+    gittensorOnlyEnv,
+  );
+  assert.equal(res.status, 201);
+  assert.equal((await res.json()).tier, "gittensor-partner");
+});
+
+test("keys create: 401 when the presented code matches neither configured cohort", async () => {
+  const env = baseEnv({ FULLNODE_INVITE_CODE_GITTENSOR: "gittensor-code" });
+  const token = await sessionToken();
+  const res = await fetch(
+    req("/api/v1/keys", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "x-fullnode-invite-code": "some-other-code",
+      },
+    }),
+    env,
+  );
+  assert.equal(res.status, 401);
+});
+
 test("keys revoke: 400 on a malformed prefix", async () => {
   const env = baseEnv();
   const token = await sessionToken();

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -3890,6 +3890,39 @@ async function requireAccountSession(request, env) {
   return { session };
 }
 
+// Named invite-code cohorts (evolved 2026-07-19 from ADR 0021 section 4's
+// single shared secret): each entry is its OWN independently rotatable/
+// revocable secret, mapped to the tier stamped on any key minted with it.
+// Onboarding a distinct partner cohort (their own users, self-serve via
+// their own code) never risks the original private-team code, and a
+// partner-cohort key stays permanently attributable -- exempt from
+// whatever the general 'free' tier's limits become later -- rather than
+// indistinguishable from it. Add an entry here (+ its own wrangler secret +
+// a matching FULLNODE_RPC_RATE_LIMITER_<NAME> binding, see
+// fullnode-rpc-proxy.mjs) for the next named cohort; this is deliberately a
+// short, explicit list, not a general multi-tenant invite-code registry --
+// two cohorts today (the private team, and an owner-designated partner
+// cohort, the Gittensor (SN74) team's own users).
+const FULLNODE_INVITE_CODE_TIERS = [
+  { envVar: "FULLNODE_INVITE_CODE", tier: "free" },
+  { envVar: "FULLNODE_INVITE_CODE_GITTENSOR", tier: "gittensor-partner" },
+];
+
+// Returns the tier for the first configured code the caller's header
+// matches (checking every configured entry, not short-circuiting on the
+// first configured-but-non-matching one), or null if none configured/
+// matched.
+function resolveInviteCodeTier(providedInvite, env) {
+  if (!providedInvite) return null;
+  for (const { envVar, tier } of FULLNODE_INVITE_CODE_TIERS) {
+    const configured = env[envVar];
+    if (configured && timingSafeEqual(providedInvite, configured)) {
+      return tier;
+    }
+  }
+  return null;
+}
+
 async function handleAccountKeyCreate(request, env) {
   const { session, error: sessionError } = await requireAccountSession(
     request,
@@ -3897,15 +3930,18 @@ async function handleAccountKeyCreate(request, env) {
   );
   if (sessionError) return sessionError;
 
-  const configuredInvite = env.FULLNODE_INVITE_CODE;
-  if (!configuredInvite) {
+  const anyConfigured = FULLNODE_INVITE_CODE_TIERS.some(
+    ({ envVar }) => env[envVar],
+  );
+  if (!anyConfigured) {
     return writeJson(
       { error: "fullnode key issuance is not provisioned on this deployment" },
       503,
     );
   }
   const providedInvite = request.headers.get(FULLNODE_INVITE_CODE_HEADER) || "";
-  if (!providedInvite || !timingSafeEqual(providedInvite, configuredInvite)) {
+  const tier = resolveInviteCodeTier(providedInvite, env);
+  if (!tier) {
     return writeJson(
       { error: `provide a valid ${FULLNODE_INVITE_CODE_HEADER} header` },
       401,
@@ -3931,11 +3967,13 @@ async function handleAccountKeyCreate(request, env) {
   }
 
   return withAccountsSql(env, async (sql) => {
+    // The session's signature already proved this account row exists at
+    // verify time; a missing row here means it was removed since -- decline
+    // rather than mint an orphaned key. Tier comes from the invite code
+    // presented above, NOT the account row -- the same wallet can mint keys
+    // under different cohorts if it legitimately holds more than one code.
     const [account] =
-      await sql`SELECT tier FROM rpc_accounts WHERE id = ${session.accountId}`;
-    // The session's signature already proved this row exists at verify time;
-    // a missing row here means the account was removed since -- decline
-    // rather than mint an orphaned key.
+      await sql`SELECT id FROM rpc_accounts WHERE id = ${session.accountId}`;
     if (!account) return writeJson({ error: "no such account" }, 404);
     const { prefix, secret, full } = generateApiKey();
     const secretHash = await hashApiKeySecret(secret);
@@ -3944,14 +3982,14 @@ async function handleAccountKeyCreate(request, env) {
       INSERT INTO api_keys
         (prefix, secret_hash, owner_contact, tier, account_id, created_at)
       VALUES (
-        ${prefix}, ${secretHash}, ${session.ss58}, ${account.tier},
+        ${prefix}, ${secretHash}, ${session.ss58}, ${tier},
         ${session.accountId}, ${now}
       )`;
     return writeJson(
       // Returned ONCE at creation, like ADR 0020's own mint route design and
       // chain_alert_triggers' owner_token -- never echoed back on any later
       // GET (handleAccountKeysList below selects prefix, never secret_hash).
-      { key: full, prefix, tier: account.tier, created_at: now },
+      { key: full, prefix, tier, created_at: now },
       201,
     );
   });

--- a/workers/request-handlers/fullnode-rpc-proxy.mjs
+++ b/workers/request-handlers/fullnode-rpc-proxy.mjs
@@ -66,12 +66,37 @@ const FULLNODE_RPC_HEALTH = new Map();
 // -- checked BEFORE key validation, by client IP, same posture and figure as
 // the public proxy's own RPC_RATE_LIMITER.
 export const FULLNODE_RPC_GUESS_RATE_LIMIT = { limit: 100, windowSeconds: 60 };
-// The actual per-key product limit (ADR 0021 section 5: "looser than the
-// existing anonymous pool's limits") -- checked AFTER a key validates,
-// keyed by prefix (public, non-secret, stable per key) rather than IP, so
-// legitimate traffic from many callers sharing one key isn't starved and one
-// key can't be inflated by rotating source IPs.
-export const FULLNODE_RPC_RATE_LIMIT = { limit: 300, windowSeconds: 60 };
+
+// Per-tier rate-limit policy, keyed by the SAME tier names
+// workers/data-api.mjs's FULLNODE_INVITE_CODE_TIERS stamps on a minted key
+// (ADR 0021 section 5: "looser than the existing anonymous pool's limits" --
+// now tier-differentiated rather than one flat figure, 2026-07-19).
+// 'gittensor-partner' is an owner-designated partner cohort with a
+// materially higher ceiling for real internal infra use, not casual dev
+// exploration; 'free' keeps the original figure. An unrecognized/future
+// tier falls back to 'free' rather than being unbounded. Each entry's own
+// Cloudflare Rate Limiting binding is checked AFTER a key validates, keyed
+// by prefix (public, non-secret, stable per key) rather than IP, so
+// legitimate traffic from many callers sharing one key isn't starved and
+// one key can't be inflated by rotating source IPs.
+export const FULLNODE_RPC_TIER_RATE_LIMITS = {
+  free: {
+    envVar: "FULLNODE_RPC_RATE_LIMITER",
+    limit: 300,
+    windowSeconds: 60,
+  },
+  "gittensor-partner": {
+    envVar: "FULLNODE_RPC_RATE_LIMITER_GITTENSOR",
+    limit: 6000,
+    windowSeconds: 60,
+  },
+};
+
+function rateLimitPolicyForTier(tier) {
+  return (
+    FULLNODE_RPC_TIER_RATE_LIMITS[tier] || FULLNODE_RPC_TIER_RATE_LIMITS.free
+  );
+}
 
 function parseFullnodeOrigins(env) {
   const raw = env?.FULLNODE_RPC_ORIGINS || "";
@@ -138,11 +163,13 @@ export async function handleFullnodeRpcProxyRequest(request, env, url) {
     );
   }
 
-  if (env.FULLNODE_RPC_RATE_LIMITER?.limit) {
+  const rateLimitPolicy = rateLimitPolicyForTier(auth.tier);
+  const rateLimiter = env[rateLimitPolicy.envVar];
+  if (rateLimiter?.limit) {
     // No fallback here: auth.ok already guarantees parseApiKey(rawKey)
     // parses (validateApiKey's own contract), so this can't be null.
     const { prefix: keyPrefix } = parseApiKey(rawKey);
-    const { success } = await env.FULLNODE_RPC_RATE_LIMITER.limit({
+    const { success } = await rateLimiter.limit({
       key: `fullnode-rpc:${keyPrefix}`,
     });
     if (!success) {
@@ -152,9 +179,9 @@ export async function handleFullnodeRpcProxyRequest(request, env, url) {
         429,
         {},
         {
-          "retry-after": String(FULLNODE_RPC_RATE_LIMIT.windowSeconds),
-          "x-ratelimit-limit": String(FULLNODE_RPC_RATE_LIMIT.limit),
-          "x-ratelimit-policy": `${FULLNODE_RPC_RATE_LIMIT.limit};w=${FULLNODE_RPC_RATE_LIMIT.windowSeconds}`,
+          "retry-after": String(rateLimitPolicy.windowSeconds),
+          "x-ratelimit-limit": String(rateLimitPolicy.limit),
+          "x-ratelimit-policy": `${rateLimitPolicy.limit};w=${rateLimitPolicy.windowSeconds}`,
         },
       );
     }

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -31,13 +31,22 @@
   //
   // Wallet-signature login + account-gated fullnode API keys (ADR 0021,
   // #6835, src/wallet-auth.mjs + workers/data-api.mjs's handleWallet*/
-  // handleAccountKeys* functions) need THREE more secrets:
+  // handleAccountKeys* functions) need secrets:
   //   wrangler secret put WALLET_SESSION_SECRET -c wrangler.data.jsonc
   //   wrangler secret put FULLNODE_INVITE_CODE -c wrangler.data.jsonc
+  //   wrangler secret put FULLNODE_INVITE_CODE_GITTENSOR -c wrangler.data.jsonc
   //   wrangler secret put API_KEY_LOOKUP_INTERNAL_TOKEN -c wrangler.data.jsonc
   // (WALLET_SESSION_SECRET signs the key-management session token;
   // FULLNODE_INVITE_CODE is the private-launch mint gate, a shared secret
   // handed to teammates out-of-band -- ADR 0021 section 4;
+  // FULLNODE_INVITE_CODE_GITTENSOR is a SEPARATE, independently rotatable
+  // code for the Gittensor (SN74) team's own users -- presenting it at mint
+  // time stamps 'gittensor-partner' tier instead of 'free' (see
+  // workers/data-api.mjs's FULLNODE_INVITE_CODE_TIERS and
+  // workers/request-handlers/fullnode-rpc-proxy.mjs's
+  // FULLNODE_RPC_TIER_RATE_LIMITS, wrangler.jsonc's own
+  // FULLNODE_RPC_RATE_LIMITER_GITTENSOR binding) -- neither code affects the
+  // other's holders if rotated/revoked;
   // API_KEY_LOOKUP_INTERNAL_TOKEN gates the internal key-prefix lookup route
   // the fullnode RPC gate's validator calls -- the SAME value must also be
   // set on the main Worker, wrangler.jsonc, see that file's own comment.)

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -653,5 +653,21 @@
         "period": 60,
       },
     },
+    // The 'gittensor-partner' tier's own, materially higher limit (20x the
+    // free tier) -- an owner-designated partner cohort (the Gittensor SN74
+    // team's own users) with real internal infra needs, not casual dev
+    // exploration. Keys get this tier by presenting
+    // FULLNODE_INVITE_CODE_GITTENSOR at mint time (see workers/data-api.mjs's
+    // FULLNODE_INVITE_CODE_TIERS). Skipped when the binding is absent (local
+    // dev/CI) -- falls back to the free-tier policy in that case, same as an
+    // unrecognized tier.
+    {
+      "name": "FULLNODE_RPC_RATE_LIMITER_GITTENSOR",
+      "namespace_id": "1011",
+      "simple": {
+        "limit": 6000,
+        "period": 60,
+      },
+    },
   ],
 }


### PR DESCRIPTION
## Summary

Evolves ADR 0021's single shared fullnode invite code (`#6880`) into a small named list, each mapped to a distinct `tier` stamped on any key minted with it (`workers/data-api.mjs`'s `FULLNODE_INVITE_CODE_TIERS`). An owner-designated partner cohort now gets its own independently rotatable/revocable invite code and a materially higher rate limit on the gated fullnode RPC route (`workers/request-handlers/fullnode-rpc-proxy.mjs`'s `FULLNODE_RPC_TIER_RATE_LIMITS`, new `FULLNODE_RPC_RATE_LIMITER_GITTENSOR` binding), without touching the original private-team code or its holders. Tier is resolved from the invite code presented at mint time, not inherited from the account row — the same wallet can hold keys under different cohorts if it legitimately has more than one code.

- `workers/data-api.mjs`: `FULLNODE_INVITE_CODE_TIERS` (named cohort list) + `resolveInviteCodeTier`, wired into `handleAccountKeyCreate`.
- `workers/request-handlers/fullnode-rpc-proxy.mjs`: `FULLNODE_RPC_TIER_RATE_LIMITS` (per-tier binding + policy lookup), replacing the single flat rate limit. Unrecognized/future tiers fall back to the `free` policy.
- `wrangler.jsonc` / `wrangler.data.jsonc`: new `FULLNODE_RPC_RATE_LIMITER_GITTENSOR` binding + `FULLNODE_INVITE_CODE_GITTENSOR` secret documentation.
- `docs/adr/0021-fullnode-rpc-cluster-access.md`: new subsection documenting this evolution.
- `apps/ui/content/docs/rpc.mdx`: self-serve documentation for the whole wallet-login → mint → gated-RPC flow (challenge/verify/mint/call, cURL walkthrough) — the mechanism itself is generic to any invite-code holder, not cohort-specific.

## Registry Safety

- [x] Links a tracked, currently-open issue (#6835 — this evolves the same ADR/epic #6880 shipped).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state (public-safety scanner passes clean).
- [x] No committed public API/OpenAPI/schema change — the affected routes were already `NON_CONTRACT_PATHS`-exempt.

## Validation

- [x] `npm run lint`
- [x] `npm run format:check` (targeted at changed files, both root and `apps/ui` prettier configs)
- [x] `npm run scan:public-safety`
- [x] Full suite: 9803/9803 passing
- [x] 100% statement/branch/function/line coverage on every changed section
- [x] `node scripts/worker-deploy-dry-run.mjs` passes; both `wrangler.jsonc` and `wrangler.data.jsonc` parse cleanly