### PR TITLE
feat(ui): surface conviction takeover urgency on the subnet leaderboard (#6883)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
@@ -4,8 +4,29 @@ import { subnetConvictionQuery } from "@/lib/metagraphed/queries";
 import { CopyableCode } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import {
+  convictionContest,
+  type ConvictionContestStatus,
+} from "@/lib/metagraphed/conviction-contest";
 
 const UNITS_PER_WHOLE = 1_000_000_000;
+
+// How the contest gap reads at a glance (#6883). Down/warn/muted tones follow
+// the health palette used elsewhere so "takeover imminent" reads as the alarm.
+const CONTEST_STATUS_META: Record<ConvictionContestStatus, { label: string; className: string }> = {
+  "takeover-imminent": {
+    label: "Takeover imminent",
+    className: "border-health-down/40 bg-health-down/10 text-health-down",
+  },
+  contested: {
+    label: "Contested",
+    className: "border-health-warn/40 bg-health-warn/10 text-health-warn",
+  },
+  secure: {
+    label: "Secure",
+    className: "border-border bg-surface/40 text-ink-muted",
+  },
+};
 
 // locked_mass/conviction arrive as raw rao-scale integers (mirrors every
 // other on-chain alpha/TAO amount in this codebase) -- divide before display.
@@ -51,8 +72,26 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
     );
   }
 
+  const contest = convictionContest(leaderboard);
+  const contestMeta = CONTEST_STATUS_META[contest.status];
+
   return (
     <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span
+          className={classNames(
+            "inline-flex items-center rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest",
+            contestMeta.className,
+          )}
+        >
+          {contestMeta.label}
+        </span>
+        <span className="font-mono text-[11px] text-ink-muted">
+          {contest.gapPct != null
+            ? `Leader is ${contest.gapPct.toFixed(1)}% ahead of the top challenger`
+            : "No active challenger"}
+        </span>
+      </div>
       {data?.queried_at_block != null ? (
         <p className="font-mono text-[11px] text-ink-muted">
           Rolled forward to block #{formatNumber(data.queried_at_block)}

--- a/apps/ui/src/lib/metagraphed/conviction-contest.test.ts
+++ b/apps/ui/src/lib/metagraphed/conviction-contest.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  convictionContest,
+  CONVICTION_CONTESTED_GAP_PCT,
+  CONVICTION_TAKEOVER_GAP_PCT,
+} from "./conviction-contest";
+
+describe("convictionContest", () => {
+  it("treats an empty leaderboard as uncontested (no gap)", () => {
+    expect(convictionContest([])).toEqual({ gapPct: null, status: "secure" });
+  });
+
+  it("treats a single entry (no challenger) as secure with no gap", () => {
+    expect(convictionContest([{ conviction: 1000 }])).toEqual({
+      gapPct: null,
+      status: "secure",
+    });
+  });
+
+  it("flags a close contest (<=5% gap) as takeover-imminent", () => {
+    // leader 1000, challenger 970 -> 3% gap
+    const c = convictionContest([{ conviction: 1000 }, { conviction: 970 }]);
+    expect(c.status).toBe("takeover-imminent");
+    expect(c.gapPct).toBeCloseTo(3);
+  });
+
+  it("flags a meaningful challenger (<=25% gap) as contested", () => {
+    // leader 1000, challenger 800 -> 20% gap
+    const c = convictionContest([{ conviction: 1000 }, { conviction: 800 }]);
+    expect(c.status).toBe("contested");
+    expect(c.gapPct).toBeCloseTo(20);
+  });
+
+  it("flags a wide lead (>25% gap) as secure", () => {
+    // leader 1000, challenger 400 -> 60% gap
+    const c = convictionContest([{ conviction: 1000 }, { conviction: 400 }]);
+    expect(c.status).toBe("secure");
+    expect(c.gapPct).toBeCloseTo(60);
+  });
+
+  it("is order-agnostic — ranks by conviction, not array position", () => {
+    const c = convictionContest([{ conviction: 400 }, { conviction: 1000 }, { conviction: 970 }]);
+    // leader 1000, top challenger 970 -> imminent, regardless of input order
+    expect(c.status).toBe("takeover-imminent");
+    expect(c.gapPct).toBeCloseTo(3);
+  });
+
+  it("treats a non-positive leader as uncontested", () => {
+    expect(convictionContest([{ conviction: 0 }, { conviction: 0 }])).toEqual({
+      gapPct: null,
+      status: "secure",
+    });
+  });
+
+  it("is NaN-safe (non-finite convictions count as 0)", () => {
+    const c = convictionContest([{ conviction: 1000 }, { conviction: NaN }]);
+    // challenger treated as 0 -> 100% gap -> secure
+    expect(c.status).toBe("secure");
+    expect(c.gapPct).toBeCloseTo(100);
+  });
+
+  it("exposes the documented thresholds", () => {
+    expect(CONVICTION_TAKEOVER_GAP_PCT).toBe(5);
+    expect(CONVICTION_CONTESTED_GAP_PCT).toBe(25);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/conviction-contest.ts
+++ b/apps/ui/src/lib/metagraphed/conviction-contest.ts
@@ -1,0 +1,57 @@
+/**
+ * Ownership-contest framing for a subnet's conviction leaderboard (#6883).
+ *
+ * `conviction` is the exponentially-smoothed integral of locked_mass that
+ * actually determines the on-chain ownership flip (see the SubnetConviction
+ * type + docs/conviction-lock-mechanism.md). The "how close is the contest"
+ * signal three surveyed explorers independently built is a single number: how
+ * far ahead the leader is vs the top challenger, as a share of the leader's own
+ * conviction. This is a pure presentation derivation over already-fetched data.
+ */
+export type ConvictionContestStatus = "secure" | "contested" | "takeover-imminent";
+
+export interface ConvictionContest {
+  /** Leader-vs-top-challenger gap as a % of the leader's conviction, or null
+   *  when there is no challenger (0 or 1 entries, or a non-positive leader). */
+  gapPct: number | null;
+  status: ConvictionContestStatus;
+}
+
+// Thresholds are a presentation choice (no on-chain precedent to mirror):
+//  - <= 5%: the challenger is within a small roll-forward of the leader, so a
+//    few blocks of the governance unlock/maturity rates could flip ownership —
+//    the case actually worth flagging as urgent.
+//  - <= 25%: the challenger holds > 3/4 of the leader's conviction — a genuine
+//    contest, but not imminent.
+//  - otherwise (or no challenger): a commanding lead — secure.
+export const CONVICTION_TAKEOVER_GAP_PCT = 5;
+export const CONVICTION_CONTESTED_GAP_PCT = 25;
+
+/**
+ * Derive the contest gap% + status from a conviction leaderboard. Order-agnostic
+ * (ranks by `conviction`, so it does not assume the array is pre-sorted), and
+ * NaN-safe (non-finite convictions are treated as 0).
+ */
+export function convictionContest(
+  leaderboard: readonly { conviction: number }[],
+): ConvictionContest {
+  const convictions = leaderboard
+    .map((e) => (Number.isFinite(e.conviction) ? e.conviction : 0))
+    .sort((a, b) => b - a);
+
+  const leader = convictions[0];
+  const challenger = convictions[1];
+  // No challenger (0/1 entry) or a non-positive leader -> uncontested.
+  if (convictions.length < 2 || !(leader > 0)) {
+    return { gapPct: null, status: "secure" };
+  }
+
+  const gapPct = ((leader - challenger) / leader) * 100;
+  const status: ConvictionContestStatus =
+    gapPct <= CONVICTION_TAKEOVER_GAP_PCT
+      ? "takeover-imminent"
+      : gapPct <= CONVICTION_CONTESTED_GAP_PCT
+        ? "contested"
+        : "secure";
+  return { gapPct, status };
+}


### PR DESCRIPTION
## Summary

Adds a takeover-urgency read to the subnet **Ownership contest** leaderboard (`SubnetConvictionLeaderboard`). Previously the panel listed conviction holders but gave no at-a-glance sense of *how close* the subnet is to an automatic ownership flip — you had to eyeball two raw alpha figures and do the math. This surfaces that as a status badge + the leader-vs-top-challenger gap.

## What it adds

- A pure, framework-free helper `convictionContest(leaderboard)` (`apps/ui/src/lib/metagraphed/conviction-contest.ts`) that derives, order-agnostically and NaN-safely, the leader-vs-top-challenger gap as a share of the leader's own conviction and maps it to a status:
  - **Takeover imminent** — gap ≤ 5% (challenger within a small roll-forward of the leader)
  - **Contested** — gap ≤ 25% (challenger holds > ¾ of the leader's conviction)
  - **Secure** — wider lead, or no challenger
- A badge + one-line gap readout at the top of the leaderboard, tinted with the existing health palette (`health-down` / `health-warn` / muted) so "takeover imminent" reads as the alarm state. No change to the table itself.

The thresholds are a presentation choice (there's no on-chain precedent to mirror); they're named constants, documented at the definition, and asserted in the tests so they're easy to tune.

## Why a pure function + unit tests

The gap/status math is the only real logic here, so it lives in its own module with 9 vitest cases (empty, single-entry, close/meaningful/wide gaps, order-agnostic ranking, non-positive leader, NaN-safety, exposed thresholds) rather than being buried in JSX. The component change is a thin render of its result.

## A note on the screenshots

In live data essentially every subnet has **zero** active conviction challengers, so the leaderboard normally renders its EmptyState and the badge (which only applies with ≥ 2 entries) isn't reachable against production data. To show the change honestly, the before/after below intercept **only** the `GET /api/v1/subnets/{netuid}/conviction` response with one fixed, representative two-entry contest (leader 1000α, top challenger 970α → a 3% gap → the "takeover imminent" state); every other request hits the real dev server. Both variants use the identical mock and were captured against the same server, so the pair differs by exactly this PR's code and nothing else. (The capture helper is a dev-only e2e script and is not part of this PR's diff.)

## Changed

- `apps/ui/src/lib/metagraphed/conviction-contest.ts` (new) — pure `convictionContest()` + documented thresholds
- `apps/ui/src/lib/metagraphed/conviction-contest.test.ts` (new) — 9 unit tests
- `apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx` — render the badge + gap readout

## Validation

- `vitest run conviction-contest.test.ts` — 9/9 pass
- `tsc --noEmit` (apps/ui) — 0 errors
- `eslint` on the changed files — clean
- `prettier --check` on the staged blobs — clean

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6883-conviction-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6883
