### PR TITLE
fix(ui): keep the mobile header within the viewport by relocating the network switcher (#6902)

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -215,7 +215,14 @@ export function AppShell({
               <div className="flex items-center gap-1">
                 <ApiDrawerTrigger />
 
-                <NetworkSwitcher />
+                {/* #6902: NetworkSwitcher was the one header action still rendering
+                    at every breakpoint (its siblings are all hidden below md),
+                    overflowing the mobile viewport by ~10px. Give it the same
+                    treatment and relocate it into the mobile nav sheet below so it
+                    stays reachable -- matching SettingsPopover/WalletConnectButton. */}
+                <div className="hidden md:inline-flex">
+                  <NetworkSwitcher />
+                </div>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Link
@@ -334,11 +341,23 @@ export function AppShell({
                     unreachable below `md` entirely. */}
                 <WalletConnectButton />
               </div>
-              <div className="mt-auto border-t border-border pt-3">
-                <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted mb-1.5">
-                  API base
+              <div className="mt-auto border-t border-border pt-3 space-y-3">
+                {/* #6902: mobile home for the NetworkSwitcher, which is `hidden`
+                    below md in the header row (same relocation as the settings/
+                    wallet actions above). Grouped with the API base as the
+                    environment controls. */}
+                <div>
+                  <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted mb-1.5">
+                    Network
+                  </div>
+                  <NetworkSwitcher />
                 </div>
-                <ApiBaseRow />
+                <div>
+                  <div className="font-mono text-[9px] uppercase tracking-widest text-ink-muted mb-1.5">
+                    API base
+                  </div>
+                  <ApiBaseRow />
+                </div>
               </div>
             </SheetContent>
           </Sheet>


### PR DESCRIPTION
## Summary

Fixes the site-wide mobile header overflow: at 375px the shared header overflowed the viewport by ~10px (`document.body.scrollWidth 385 > innerWidth 375`) on every page, because `NetworkSwitcher` was the one header action still rendering at every breakpoint while its siblings (developer-settings link, `SettingsPopover`, `WalletConnectButton`) are all `hidden` below `md`. `ApiDrawerTrigger` is already `hidden md:inline-flex`, so the overflowing element was exactly the `NetworkSwitcher` pill.

## Fix

Give `NetworkSwitcher` the same responsive treatment its siblings already have, and relocate it — not hide it — into the mobile navigation sheet, exactly as `SettingsPopover` and `WalletConnectButton` already do:

- **Header row:** wrap `NetworkSwitcher` in `hidden md:inline-flex` so it shows from `md` up (unchanged at `md`/`lg`/`xl`) and no longer renders on mobile. With it gone, the mobile header's action row has no visible children and the row fits.
- **Mobile sheet:** add `NetworkSwitcher` to the environment controls at the bottom of the hamburger menu, grouped under a "Network" label alongside the existing "API base" row — so it stays fully reachable on mobile.

This follows the issue's preferred approach (relocate to the mobile menu where the equivalent actions already live) rather than masking the symptom with `overflow-x: hidden`.

## Changed

- `apps/ui/src/components/metagraphed/app-shell.tsx` — header `NetworkSwitcher` wrapped in `hidden md:inline-flex`; a "Network" block added to the mobile nav sheet's environment section (1 file).

## Verification

- **Mobile (375px):** header no longer overflows — the network switcher moves out of the header row into the hamburger menu (see before/after below; the "before" shows the "Mainnet" pill clipped at the right edge).
- **Tablet (768px) / Desktop (1280px):** no visible change, as expected — `NetworkSwitcher` shows from `md` up exactly as before.
- `eslint` — clean; `tsc --noEmit` (apps/ui) — 0 errors; `prettier --check` — clean.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6902-header-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6902
