### PR TITLE
content(ui): update homepage hero copy to reflect the shipped block explorer

### DIFF
--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -57,11 +57,11 @@ import type { Subnet } from "@/lib/metagraphed/types";
 export const Route = createFileRoute("/")({
   head: () => ({
     meta: [
-      { title: "Metagraphed — Bittensor public-interface registry" },
+      { title: "Metagraphed — Bittensor registry and block explorer" },
       {
         name: "description",
         content:
-          "Unofficial registry and explorer for Bittensor subnet APIs, schemas, docs, endpoints, providers, and health.",
+          "Unofficial Bittensor registry and chain-direct block explorer: subnet APIs, schemas, docs, endpoints, providers, health, blocks, extrinsics, events, and stake.",
       },
     ],
   }),
@@ -365,8 +365,9 @@ function HomeHero() {
             The public-interface registry for <span className="text-accent">Bittensor</span>.
           </h1>
           <p className="mg-fade-in mg-fade-in-delay-2 mt-5 max-w-xl text-base text-ink-muted leading-relaxed">
-            A builder-facing index of subnet APIs, schemas, docs, endpoints, providers, freshness,
-            and registry gaps. Not a block explorer.
+            A builder-facing index of subnet APIs, schemas, docs, endpoints, providers, and
+            freshness — plus a chain-direct block explorer: browse blocks, extrinsics, and events,
+            track stake and conviction, straight off the archive node.
           </p>
           <div className="mg-fade-in mg-fade-in-delay-3 mt-7 flex flex-wrap items-center gap-3">
             <Link


### PR DESCRIPTION
Closes #6901

## What changed

The homepage hero (and `<title>`/meta description) said **"Not a block explorer"** — true when
that line was written, false since. The product has since shipped a chain-direct block explorer
on top of the registry:

- `apps/ui/src/routes/blocks.index.tsx`, `blocks.$ref.tsx`
- `apps/ui/src/routes/extrinsics.index.tsx`, `extrinsics.$hash.tsx`
- `apps/ui/src/routes/events.index.tsx`
- `apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx` (OHLC candlesticks)
- `apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx`,
  `subnet-ownership-history.tsx` (stake/conviction tracking)

per `docs/block-explorer-data-model.md` and the master tracker `#2589`'s own framing
("already a live developer block explorer (~80-85%)").

### Before

> A builder-facing index of subnet APIs, schemas, docs, endpoints, providers, freshness, and
> registry gaps. **Not a block explorer.**

### After

> A builder-facing index of subnet APIs, schemas, docs, endpoints, providers, and freshness —
> plus a chain-direct block explorer: browse blocks, extrinsics, and events, track stake and
> conviction, straight off the archive node.

Also updated the `<title>` and meta description (line ~60) which had the same
registry-only framing.

## Screenshots

| Viewport | Theme | Before | After |
|---|---|---|---|
| Mobile (375×812) | Light | ![before](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6901-hero-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6901-hero-after-mobile-light.png) |
| Mobile (375×812) | Dark | ![before](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6901-hero-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6901-hero-after-mobile-dark.png) |
| Tablet (768×1024) | Light | ![before](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6901-hero-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6901-hero-after-tablet-light.png) |
| Tablet (768×1024) | Dark | ![before](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6901-hero-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6901-hero-after-tablet-dark.png) |
| Desktop (1280×800) | Light | ![before](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6901-hero-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6901-hero-after-desktop-light.png) |
| Desktop (1280×800) | Dark | ![before](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6901-hero-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6901-hero-after-desktop-dark.png) |

## Verification

- `cd apps/ui && npx eslint src/routes/index.tsx` — clean.
- `node scripts/scan-public-safety.mjs` — passed.
- Scoped to `apps/ui/src/routes/index.tsx` only; no backend/`workers/**` changes.
