### PR TITLE
fix(ui): stop /blocks summary stat-tile labels clipping on mobile

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -190,6 +190,10 @@ function BlockProductionHeader() {
         eyebrow="Inter-block time"
         value={blockTime ? humaniseSeconds(blockTime.mean_ms / 1000) : "—"}
         hint={blockTime ? `p90 ${humaniseSeconds(blockTime.p90_ms / 1000)}` : undefined}
+        // #6905: these labels/hints ("Inter-block time", "Author decentralization",
+        // "ext/block · N events/block") clip mid-word in the ~165px-wide tiles of
+        // the 2-col mobile grid; wrap instead of truncating so they stay legible.
+        truncate={false}
       />
       <StatTile
         icon={Activity}
@@ -201,6 +205,7 @@ function BlockProductionHeader() {
             ? `ext/block · ${formatNumber(throughput.mean_events_per_block)} events/block`
             : undefined
         }
+        truncate={false}
       />
       <StatTile
         icon={Users}
@@ -208,6 +213,7 @@ function BlockProductionHeader() {
         value={nakamoto != null ? formatNumber(nakamoto) : "—"}
         hint="Nakamoto coefficient"
         tone={nakamotoStatTone}
+        truncate={false}
       />
     </div>
   );


### PR DESCRIPTION
## What

On `/blocks` at mobile width, the three `BlockProductionHeader` summary tiles sit in a 2-column grid (`grid-cols-2`), making each tile only ~165px wide. `StatTile` defaults `truncate={true}`, so the long eyebrows and hints clip mid-word and read illegibly — "INTER-BLOCK …", "AUTHOR DECEN…", "ext/bloc…", "Nakamoto coe…". Closes #6905.

## Fix

The issue offers two options; I took the first — pass **`truncate={false}`** to the three `StatTile` calls. That flips `StatTile` to its documented wrap mode (`leading-tight` eyebrow + `flex-wrap` hint row), so the labels/hints wrap onto a second line and stay fully legible, using the component's existing escape hatch with **no layout restructure**.

I chose this over switching the grid to `grid-cols-1` because it keeps the compact 2-up mobile layout (matching the tile density elsewhere on the page) while still showing every label in full; `grid-cols-1` would have made the summary much taller for the same information. Desktop and tablet (where the wider `md:grid-cols-3` tiles already fit each label on one line) render identically before and after.

## Screenshots

`/blocks` summary tiles, 3 viewports × 2 themes. The change is mobile-only (the labels only overflow their width at `grid-cols-2`); tablet/desktop are unchanged, included for completeness.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Mobile · Light | ![before mobile light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-stat-tiles/before-mobile-light.png) | ![after mobile light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-stat-tiles/after-mobile-light.png) |
| Mobile · Dark | ![before mobile dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-stat-tiles/before-mobile-dark.png) | ![after mobile dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-stat-tiles/after-mobile-dark.png) |
| Tablet · Light | ![before tablet light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-stat-tiles/before-tablet-light.png) | ![after tablet light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-stat-tiles/after-tablet-light.png) |
| Tablet · Dark | ![before tablet dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-stat-tiles/before-tablet-dark.png) | ![after tablet dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-stat-tiles/after-tablet-dark.png) |
| Desktop · Light | ![before desktop light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-stat-tiles/before-desktop-light.png) | ![after desktop light](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-stat-tiles/after-desktop-light.png) |
| Desktop · Dark | ![before desktop dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-stat-tiles/before-desktop-dark.png) | ![after desktop dark](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-stat-tiles/after-desktop-dark.png) |

## Testing

- `eslint` + `prettier --check` on the changed file — clean
- One-file change (`apps/ui/src/routes/blocks.index.tsx`), no `packages/ui-kit` change and no dist rebuild — `truncate` is an existing `StatTile` prop.
