### PR TITLE
content(ui): fix homepage hero copy contradicting the shipped block explorer

### DIFF
--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -57,11 +57,11 @@ import type { Subnet } from "@/lib/metagraphed/types";
 export const Route = createFileRoute("/")({
   head: () => ({
     meta: [
-      { title: "Metagraphed — Bittensor public-interface registry" },
+      { title: "Metagraphed — Bittensor registry & block explorer" },
       {
         name: "description",
         content:
-          "Unofficial registry and explorer for Bittensor subnet APIs, schemas, docs, endpoints, providers, and health.",
+          "Unofficial registry and block explorer for Bittensor — subnet APIs, schemas, docs, endpoints, providers, health, plus live blocks, extrinsics, and events.",
       },
     ],
   }),
@@ -365,8 +365,8 @@ function HomeHero() {
             The public-interface registry for <span className="text-accent">Bittensor</span>.
           </h1>
           <p className="mg-fade-in mg-fade-in-delay-2 mt-5 max-w-xl text-base text-ink-muted leading-relaxed">
-            A builder-facing index of subnet APIs, schemas, docs, endpoints, providers, freshness,
-            and registry gaps. Not a block explorer.
+            A builder-facing index of subnet APIs, schemas, docs, endpoints, and providers — plus a
+            chain-direct block explorer for blocks, extrinsics, and events.
           </p>
           <div className="mg-fade-in mg-fade-in-delay-3 mt-7 flex flex-wrap items-center gap-3">
             <Link


### PR DESCRIPTION
## Summary

The homepage hero paragraph said **"Not a block explorer"** — true when that line was written, false since (`blocks`/`extrinsics`/`events` pages, chain-direct indexing, OHLC, conviction/ownership tracking, native staking). Rewrites it to positively state both halves of what the product is today, per `#2589`'s own framing ("already a live developer block explorer (~80-85%)").

### Before
> A builder-facing index of subnet APIs, schemas, docs, endpoints, providers, freshness, and registry gaps. **Not a block explorer.**

### After
> A builder-facing index of subnet APIs, schemas, docs, endpoints, and providers — plus a chain-direct block explorer for blocks, extrinsics, and events.

Also updated the `<title>`/meta description (line ~60), which had the same registry-only framing.

**Note on scope:** a prior PR for this issue (#6926) was closed by the maintainer for "way too much text on mobile" — its replacement copy ran to 225 characters. This rewrite is deliberately tighter (151 characters, vs. the original's 127) and renders at the **same 4-line wrap as the original** on a 375px viewport — verified directly (see screenshots below), not just estimated from character count. Trimmed "freshness, and registry gaps" from the registry-side list to make room for the block-explorer half without growing the visual footprint.

## Screenshots

3 viewports × 2 themes, hero section only, `/` with `mg-theme` forced per capture.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6901-mobile-dark-after.png)<br><sub>after</sub> |

## Verification

- `npx eslint apps/ui/src/routes/index.tsx` — clean (0 errors; 1 pre-existing, unrelated warning).
- `npx prettier --check apps/ui/src/routes/index.tsx` — clean.
- `npm run typecheck --workspace=apps/ui` — clean.
- `npm test --workspace=apps/ui` — 167 files / 1269 tests passing.
- Scoped to `apps/ui/src/routes/index.tsx` only.

Closes #6901
