### PR TITLE
fix(ui): stop the header overflowing the mobile viewport (NetworkSwitcher responsive)

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -215,7 +215,17 @@ export function AppShell({
               <div className="flex items-center gap-1">
                 <ApiDrawerTrigger />
 
-                <NetworkSwitcher />
+                {/* #6902: NetworkSwitcher was the one header action still
+                    rendering at every breakpoint — its siblings below
+                    (developer settings, SettingsPopover, WalletConnectButton)
+                    are all already `hidden md:inline-flex`, and ApiDrawerTrigger
+                    hides below md too. Left unhidden it overflowed the 375px
+                    mobile viewport by 10px (the switcher pill sat at right:385).
+                    Give it the same below-md treatment; it's relocated into the
+                    mobile navigation sheet so it stays reachable on touch. */}
+                <div className="hidden md:inline-flex">
+                  <NetworkSwitcher />
+                </div>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Link
@@ -318,6 +328,10 @@ export function AppShell({
                 <Compass className="size-3" /> Unofficial registry
               </div>
               <MobileMegaMenu onNavigate={() => setMobileOpen(false)} />
+              {/* #6902: the header NetworkSwitcher is `hidden` below md (it
+                  overflowed the mobile viewport), so this is its mobile home —
+                  same rationale as the wallet-connect note below. */}
+              <NetworkSwitcher />
               <div className="flex items-center gap-2">
                 <Link
                   to="/settings"


### PR DESCRIPTION
## Problem

Confirmed at 375px on every page (it's the shared header): the header overflows the viewport by 10px — `document.body.scrollWidth` 385 vs `window.innerWidth` 375. The overflowing element is the `NetworkSwitcher` pill (globe + "Mainnet" + chevron), which sat past the right edge.

## Root cause

`NetworkSwitcher` was the one header action still rendering at **every** breakpoint. Its siblings are all already hidden below `md`:
- the developer-settings link, `SettingsPopover`, and `WalletConnectButton` are `hidden md:inline-flex`
- `ApiDrawerTrigger`'s own button is `hidden md:inline-flex` too

Only `NetworkSwitcher` never got the treatment, so on mobile it overhung the row. (The issue also listed `ApiDrawerTrigger`, but that one is already responsive — `NetworkSwitcher` is the actual culprit.)

## Fix

One file, `apps/ui/src/components/metagraphed/app-shell.tsx`:
- Wrap the header `NetworkSwitcher` in `hidden md:inline-flex`, matching its siblings — so it no longer renders below `md`.
- **Relocate it into the mobile navigation Sheet**, beside the developer-settings / wallet-connect actions that already live there, so it stays reachable on touch (not silently removed — per the deliverable). Did **not** just add `overflow-x: hidden`.

Pure visibility/relocation; the `md`+ layout is unchanged.

## Verification

Mobile "before" shows the `Mainnet` pill overhanging the right edge (the brand even clips to "Metagraph"); "after" shows it gone from the top bar — the full "Metagraphed" brand now fits and `scrollWidth <= innerWidth`. Desktop/tablet are unchanged (expected — mobile-only bug).

| Viewport · Theme | Before | After |
|---|---|---|
| Mobile · light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6902-header-before-mobile-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6902-header-after-mobile-light.png) |
| Mobile · dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6902-header-before-mobile-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6902-header-after-mobile-dark.png) |
| Tablet · light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6902-header-before-tablet-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6902-header-after-tablet-light.png) |
| Tablet · dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6902-header-before-tablet-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6902-header-after-tablet-dark.png) |
| Desktop · light | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6902-header-before-desktop-light.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6902-header-after-desktop-light.png) |
| Desktop · dark | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6902-header-before-desktop-dark.png) | ![](https://raw.githubusercontent.com/davion-knight/metagraphed/screenshots/6902-header-after-desktop-dark.png) |

Closes #6902