### PR TITLE
fix(ui): stop /blocks summary stat-tile labels clipping on mobile

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -116,9 +116,9 @@ function BlocksPage() {
           fallback={
             // Shaped to BlockProductionHeader's own 3-tile grid (#6388), matching
             // subnets.index.tsx's tile-skeleton convention -- a single flat box
-            // here visibly jumps in height/columns once the real 2/3-col grid
+            // here visibly jumps in height/columns once the real 1/3-col grid
             // of StatTiles resolves.
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-8">
               <Skeleton className="h-20" />
               <Skeleton className="h-20" />
               <Skeleton className="h-20" />
@@ -184,7 +184,10 @@ function BlockProductionHeader() {
   const nakamoto = summary.author_concentration?.nakamoto_coefficient;
   const nakamotoStatTone = nakamotoTone(nakamoto);
   return (
-    <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-8">
+      {/* #6905: full-width tiles on mobile (grid-cols-1) so each label/hint fits
+          on one line instead of clipping mid-word in the old 2-col grid's cramped
+          ~165px cells; md+ keeps the 3-up row. */}
       <StatTile
         icon={Timer}
         eyebrow="Inter-block time"


### PR DESCRIPTION
## What

On `/blocks` at mobile width, the three `BlockProductionHeader` summary tiles sat in a 2-column grid (`grid-cols-2`), making each tile only ~165px wide. `StatTile`'s default truncation then clipped their long labels/hints mid-word — "INTER-BLOCK …", "AUTHOR DECEN…", "ext/bloc…", "Nakamoto coe…". Closes #6905.

## Fix

Switch the mobile grid to **`grid-cols-1`** so each tile spans the full width and shows its eyebrow and hint in full, on one line; `md:grid-cols-3` keeps the existing 3-up row on tablet/desktop. This is the issue's second suggested option — it reads much cleaner than wrapping the labels inside the cramped 2-col cells. The Suspense skeleton grid is updated to match (`grid-cols-1 md:grid-cols-3`) so the loading state doesn't shift columns when the real tiles resolve.

One-file change; no `packages/ui-kit` change.

## Screenshots

Full viewport at the required sizes (Mobile 375×812, Tablet 768×1024, Desktop 1280×800), each theme forced via `mg-theme`. The change is mobile-only; tablet/desktop are unchanged (already `md:grid-cols-3`), included for completeness.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6905-blocks-v2/after-mobile-dark.png)<br><sub>after</sub> |

## Note

Supersedes my earlier attempt (closed) that used `truncate={false}` to wrap the labels — this full-width approach reads cleaner, and the screenshots are re-captured at the required sizes.

## Testing

- `eslint` + `prettier --check` on the changed file — clean
