### PR TITLE
fix(ui): header overflows viewport by 10px on mobile (NetworkSwitcher not responsive)

### DIFF
--- a/apps/ui/src/components/metagraphed/network-switcher.test.ts
+++ b/apps/ui/src/components/metagraphed/network-switcher.test.ts
@@ -28,3 +28,47 @@ describe("NetworkSwitcher custom API-origin input has an accessible name (#6422)
     expect(inputTag).toContain('aria-label="Custom API origin"');
   });
 });
+
+// #6902: the trigger button's label span + chevron rendered unconditionally,
+// pushing the shared header 10px past the viewport at 375px width (confirmed
+// via document.body.scrollWidth vs window.innerWidth on the live site). Fixed
+// by collapsing to icon+dot only below `sm`, so the network stays reachable
+// on mobile (tap still opens the same popover) instead of overflowing or
+// being silently removed.
+describe("NetworkSwitcher trigger collapses to icon-only on mobile (#6902)", () => {
+  const triggerButton = (() => {
+    const start = source.indexOf("<PopoverTrigger asChild>");
+    const open = source.indexOf("<button", start);
+    const close = source.indexOf("</button>", open) + "</button>".length;
+    return source.slice(open, close);
+  })();
+
+  it("still has an explicit accessible name once the label text is hidden", () => {
+    expect(triggerButton).toMatch(/aria-label=\{`Network: \$\{network\.label\}`\}/);
+  });
+
+  it("hides the network-label span below the sm breakpoint", () => {
+    // ">{network.label}<", not the bare expression -- that substring also
+    // occurs inside the aria-label/title template literals above.
+    const labelEnd = triggerButton.indexOf(">{network.label}<");
+    const spanOpen = triggerButton.lastIndexOf("<span", labelEnd);
+    const labelSpan = triggerButton.slice(spanOpen, labelEnd);
+    expect(labelSpan).toMatch(/className="[^"]*\bhidden\b[^"]*\bsm:inline\b[^"]*"/);
+  });
+
+  it("hides the chevron below the sm breakpoint", () => {
+    const chevron = triggerButton.slice(triggerButton.indexOf("<ChevronDown"));
+    expect(chevron).toMatch(/className="[^"]*\bhidden\b[^"]*\bsm:inline\b[^"]*"/);
+  });
+
+  it("never hides the globe icon or status dot, so the control stays visibly present at every width", () => {
+    const globe = triggerButton.slice(
+      triggerButton.indexOf("<Globe2"),
+      triggerButton.indexOf("<Globe2") + 60,
+    );
+    expect(globe).not.toMatch(/\bhidden\b/);
+    const dotSpanStart = triggerButton.indexOf('size-1.5 rounded-full", dotCls');
+    const dotSpan = triggerButton.slice(dotSpanStart - 60, dotSpanStart + 40);
+    expect(dotSpan).not.toMatch(/\bhidden\b/);
+  });
+});

--- a/apps/ui/src/components/metagraphed/network-switcher.tsx
+++ b/apps/ui/src/components/metagraphed/network-switcher.tsx
@@ -73,13 +73,17 @@ export function NetworkSwitcher() {
       <PopoverTrigger asChild>
         <button
           type="button"
+          aria-label={`Network: ${network.label}`}
           className="inline-flex items-center gap-1.5 rounded border border-border bg-card px-2 py-1 font-mono text-[10px] uppercase tracking-widest text-ink hover:border-ink/30 transition-colors min-h-11"
           title={`Network: ${network.label} · ${base}`}
         >
           <Globe2 className="size-3 text-ink-muted" />
-          <span className="text-ink-strong">{network.label}</span>
+          {/* #6902: below sm the label+chevron pushed the header 10px past the
+              viewport -- icon + status dot stay visible everywhere so the
+              network is still reachable/tappable on mobile, just collapsed. */}
+          <span className="hidden text-ink-strong sm:inline">{network.label}</span>
           <span className={classNames("inline-block size-1.5 rounded-full", dotCls)} aria-hidden />
-          <ChevronDown className="size-3 text-ink-muted" />
+          <ChevronDown className="hidden size-3 text-ink-muted sm:inline" aria-hidden />
         </button>
       </PopoverTrigger>
       <ClampedPopoverContent align="end" className="w-80 p-3 space-y-3">


### PR DESCRIPTION
## Summary

Root cause was narrower than the issue's initial diagnosis: `ApiDrawerTrigger`'s own trigger button already carries `hidden md:inline-flex lg:hidden xl:inline-flex` (`apps/ui/src/components/metagraphed/api-drawer.tsx:48`) — it was already correctly hidden below `md`. The actual, sole overflowing element is `NetworkSwitcher`'s trigger button (`apps/ui/src/components/metagraphed/network-switcher.tsx`), which had no responsive treatment at all.

Per the issue's own requirement, this collapses to icon-only rather than disappearing (`hidden md:inline-flex`, matching the dev-settings/wallet-connect pattern) — the network switcher is arguably more primary than those secondary actions, and there's no existing mobile-menu slot it could move into today (checked: `MobileMegaMenuBody` doesn't currently duplicate any of the secondary header actions for mobile). Below `sm` (640px) the label text and chevron hide; the globe icon + reachability-status dot stay visible and tappable at every width, opening the exact same popover.

### Verified directly, not just visually

```
document.body.scrollWidth vs window.innerWidth @ 375px, before → after:

/           385 vs 375 (overflow) → 375 vs 375 (OK)
/subnets    385 vs 375 (overflow) → 375 vs 375 (OK)
/validators 385 vs 375 (overflow) → 375 vs 375 (OK)
/blocks     385 vs 375 (overflow) → 375 vs 375 (OK)
/health     385 vs 375 (overflow) → 375 vs 375 (OK)
```

**One thing worth flagging:** `/subnets/1` also showed an overflow (490 vs 375) both before *and* after this fix — confirmed via `git stash` that it's identical with this change reverted, so it's unrelated to the header. Root-caused it while I was in there: an unwrapped `<a>` inside the "Integration Readiness" section (`apps/ui/src/components/metagraphed/readiness-scorecard.tsx:46`) doesn't truncate. That's already tracked separately as #6903 — not fixed here, left alone to keep this PR to the one component the issue actually names.

## Screenshots

3 viewports × 2 themes, header only. Mobile is the only one that changes — tablet/desktop before/after are intentionally identical, as the issue itself predicted.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-desktop-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-desktop-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-desktop-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-desktop-light-after.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-desktop-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-desktop-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-desktop-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-desktop-dark-after.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-tablet-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-tablet-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-tablet-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-tablet-light-after.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-tablet-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-tablet-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-tablet-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-tablet-dark-after.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-mobile-light-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-mobile-light-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-mobile-light-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-mobile-light-after.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-mobile-dark-before.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-mobile-dark-before.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-mobile-dark-after.png" width="260">](https://raw.githubusercontent.com/oktofeesh1/metagraphed/screenshots/6902-mobile-dark-after.png)<br><sub>after</sub> |

## Verification

- `npx prettier --check` / `npx eslint` on both changed files — clean.
- `npm run typecheck --workspace=apps/ui` — clean.
- `npm test --workspace=apps/ui` — 167 files / 1273 tests passing (4 new, covering the aria-label and the icon-only collapse on both the label span and the chevron).
- `document.body.scrollWidth <= window.innerWidth` at 375px verified directly (Playwright) on `/`, `/subnets`, `/validators`, `/blocks`, `/health` — all clean after the fix, all reproduced the reported overflow before it.
- Scoped to `network-switcher.tsx` + its test only.

Closes #6902
