### PR TITLE
fix(ui): collapse NetworkSwitcher to icon-only below md so the mobile header stops overflowing (#6902)

### DIFF
--- a/apps/ui/src/components/metagraphed/network-switcher.tsx
+++ b/apps/ui/src/components/metagraphed/network-switcher.tsx
@@ -77,7 +77,13 @@ export function NetworkSwitcher() {
           title={`Network: ${network.label} · ${base}`}
         >
           <Globe2 className="size-3 text-ink-muted" />
-          <span className="text-ink-strong">{network.label}</span>
+          {/* #6902: below md the label is dropped so the trigger collapses to
+              an icon-only pill. It renders unconditionally (unlike its sibling
+              header actions, which are `hidden md:inline-flex`), and at 375px the
+              full "Mainnet" label pushed the shared header 10px past the viewport
+              site-wide. The button stays a full tap target that opens the same
+              network popover, so it remains reachable on mobile. */}
+          <span className="hidden md:inline text-ink-strong">{network.label}</span>
           <span className={classNames("inline-block size-1.5 rounded-full", dotCls)} aria-hidden />
           <ChevronDown className="size-3 text-ink-muted" />
         </button>


### PR DESCRIPTION
## Summary

Fixes the site-wide mobile header overflow in #6902. At 375px the shared header overflowed the viewport by 10px on every page.

Closes #6902

## Root cause

`NetworkSwitcher` rendered its full "Mainnet" text pill unconditionally at every breakpoint, while its sibling header actions (`ApiDrawerTrigger`, the developer-settings link, `SettingsPopover`, `WalletConnectButton`) are all `hidden md:inline-flex`. The extra label made the header actions row wider than the viewport at mobile width — confirmed by `document.body.scrollWidth = 385` vs `window.innerWidth = 375`, with the overflowing element being exactly the NetworkSwitcher pill.

## Fix

One-line, lowest-risk of the two options the issue sanctions ("collapse to icon-only at mobile width"): hide only the text label below `md` (`hidden md:inline`). The trigger collapses to an icon-only pill (globe + status dot + chevron), stays a full 44px tap target, and opens the same network popover — so mainnet/testnet switching remains reachable on mobile, not silently removed. No change at `md` and up.

- `apps/ui/src/components/metagraphed/network-switcher.tsx` — wrap the label span in `hidden md:inline`.

## Verification

- `document.body.scrollWidth <= window.innerWidth` at 375px after the fix (see before/after mobile shots: the pill goes from full "MAINNET …" overflowing the edge to an icon-only pill within bounds; the clipped wordmark "etagraph" → "etagraphed" is the reclaimed 10px).
- Desktop/tablet unchanged (bug is mobile-only), as expected by the issue.
- `npm run lint` / `prettier --check` clean; `network-switcher` unit test passes; typecheck green.
- The responsive-overflow e2e check stays green — this only *shrinks* overflow (removes the baselined `DIV:flex items-center gap-1` at `@375`), and the spec fails only on *new* violations, so the existing baseline still passes. I left the baseline unregenerated deliberately: regenerating it here (no live API data locally) would risk dropping legitimate data-dependent entries.

## Screenshots

3 viewports × 2 themes × before/after (fixed viewports, forced theme via `mg-theme`, never full-page):

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-after-mobile-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-after-tablet-dark.png)<br><sub>after</sub> |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/RealDiligent/metagraphed/screenshots/6902-header-after-desktop-dark.png)<br><sub>after</sub> |

## Risk / tradeoffs

- Mobile loses the text label but keeps a clear, functional dropdown affordance (globe + chevron) that opens the full labeled network menu on tap. Desktop/tablet are visually unchanged.