### PR TITLE
feat(ui): add gap% and contest-status badge to conviction leaderboard

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.test.ts
+++ b/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeConvictionGap,
+  convictionUrgencyTone,
+  estimateBlocksToOvertake,
+  formatBlocksAsDuration,
+} from "./subnet-conviction-leaderboard";
+import type { SubnetConvictionEntry } from "@/lib/metagraphed/types";
+
+// #6883: gap% + status badge + rough overtake-time estimate on the conviction
+// leaderboard, so a subnet's ownership contest reads as "how urgent" not
+// just "who's ahead".
+
+const entry = (
+  hotkey: string,
+  conviction: number,
+  lockedMass = conviction,
+): SubnetConvictionEntry => ({
+  hotkey,
+  is_owner: false,
+  locked_mass: lockedMass,
+  conviction,
+});
+
+describe("computeConvictionGap", () => {
+  it("returns null for an empty leaderboard", () => {
+    expect(computeConvictionGap([], null)).toBeNull();
+  });
+
+  it("returns a null gap for a single-entry (uncontested) leaderboard", () => {
+    const king = entry("king", 1000);
+    const gap = computeConvictionGap([king], "king");
+    expect(gap?.kingEntry.hotkey).toBe("king");
+    expect(gap?.runnerUp).toBeNull();
+    expect(gap?.gapPct).toBeNull();
+  });
+
+  it("computes gap% as a fraction of the king's conviction, not the challenger's", () => {
+    const king = entry("king", 1000);
+    const challenger = entry("challenger", 900);
+    const gap = computeConvictionGap([king, challenger], "king");
+    expect(gap?.gapPct).toBeCloseTo(10, 5); // (1000-900)/1000 * 100
+  });
+
+  it("a close contest yields a small gap%", () => {
+    const king = entry("king", 1000);
+    const challenger = entry("challenger", 980);
+    const gap = computeConvictionGap([king, challenger], "king");
+    expect(gap?.gapPct).toBeCloseTo(2, 5);
+  });
+
+  it("a wide gap yields a large gap%", () => {
+    const king = entry("king", 1000);
+    const challenger = entry("challenger", 100);
+    const gap = computeConvictionGap([king, challenger], "king");
+    expect(gap?.gapPct).toBeCloseTo(90, 5);
+  });
+
+  it("falls back to the top-conviction row when `king` doesn't match any entry", () => {
+    const a = entry("a", 1000);
+    const b = entry("b", 500);
+    const gap = computeConvictionGap([b, a], "unknown-hotkey");
+    expect(gap?.kingEntry.hotkey).toBe("a");
+    expect(gap?.runnerUp?.hotkey).toBe("b");
+  });
+
+  it("clamps a negative gap (king disagreeing with the top row) to 0", () => {
+    const low = entry("low", 500);
+    const high = entry("high", 1000);
+    // `king` points at the LOWER-conviction entry -- a data anomaly.
+    const gap = computeConvictionGap([low, high], "low");
+    expect(gap?.kingEntry.hotkey).toBe("low");
+    expect(gap?.gapPct).toBe(0);
+  });
+});
+
+describe("convictionUrgencyTone", () => {
+  it("is Secure for a null gap (uncontested)", () => {
+    expect(convictionUrgencyTone(null).label).toBe("Secure");
+  });
+
+  it("is Secure for a wide gap", () => {
+    expect(convictionUrgencyTone(50).label).toBe("Secure");
+  });
+
+  it("is Contested for a moderate gap", () => {
+    expect(convictionUrgencyTone(10).label).toBe("Contested");
+  });
+
+  it("is Takeover imminent for a narrow gap", () => {
+    expect(convictionUrgencyTone(2).label).toBe("Takeover imminent");
+  });
+
+  it("is Takeover imminent for a zero gap", () => {
+    expect(convictionUrgencyTone(0).label).toBe("Takeover imminent");
+  });
+});
+
+describe("estimateBlocksToOvertake", () => {
+  it("returns null when maturity_rate is unavailable", () => {
+    const king = entry("king", 1000);
+    const challenger = entry("challenger", 500, 2000);
+    expect(estimateBlocksToOvertake(king, challenger, null)).toBeNull();
+  });
+
+  it("returns null when the challenger's own ceiling (locked_mass) can never exceed the king", () => {
+    const king = entry("king", 1000);
+    const challenger = entry("challenger", 500, 800); // ceiling 800 < king's 1000
+    expect(estimateBlocksToOvertake(king, challenger, 934_866)).toBeNull();
+  });
+
+  it("returns null when the challenger has already fully matured (no headroom left)", () => {
+    const king = entry("king", 1000);
+    const challenger = entry("challenger", 2000, 2000); // conviction == locked_mass
+    expect(estimateBlocksToOvertake(king, challenger, 934_866)).toBeNull();
+  });
+
+  it("returns a positive finite block count for a challenger with real headroom", () => {
+    const king = entry("king", 1000);
+    const challenger = entry("challenger", 500, 2000);
+    const blocks = estimateBlocksToOvertake(king, challenger, 934_866);
+    expect(blocks).not.toBeNull();
+    expect(blocks as number).toBeGreaterThan(0);
+    expect(Number.isFinite(blocks as number)).toBe(true);
+  });
+
+  it("a challenger closer to its own ceiling needs fewer blocks than one further away", () => {
+    const king = entry("king", 1000);
+    // Both start below the king; "close" has less remaining headroom to its
+    // own ceiling relative to the gap it must close, so it matures faster.
+    const closeChallenger = entry("close", 900, 2000);
+    const farChallenger = entry("far", 200, 2000);
+    const closeBlocks = estimateBlocksToOvertake(king, closeChallenger, 934_866) as number;
+    const farBlocks = estimateBlocksToOvertake(king, farChallenger, 934_866) as number;
+    expect(closeBlocks).toBeLessThan(farBlocks);
+  });
+});
+
+describe("formatBlocksAsDuration", () => {
+  it("passes through null", () => {
+    expect(formatBlocksAsDuration(null)).toBeNull();
+  });
+
+  it("formats sub-day durations as '<1 day'", () => {
+    expect(formatBlocksAsDuration(10)).toBe("<1 day");
+  });
+
+  it("formats single-digit day durations as '~N day(s)'", () => {
+    // 5 days * 86400s / 12s-per-block = 36000 blocks
+    expect(formatBlocksAsDuration(36_000)).toBe("~5 days");
+  });
+
+  it("singularizes '~1 day'", () => {
+    // 1 day * 86400 / 12 = 7200 blocks
+    expect(formatBlocksAsDuration(7_200)).toBe("~1 day");
+  });
+
+  it("formats month-scale durations as '~N months'", () => {
+    // 90 days * 86400 / 12 = 648000 blocks
+    expect(formatBlocksAsDuration(648_000)).toBe("~3 months");
+  });
+});

--- a/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
@@ -1,11 +1,122 @@
 import { useQuery } from "@tanstack/react-query";
 import { Crown } from "lucide-react";
 import { subnetConvictionQuery } from "@/lib/metagraphed/queries";
+import type { SubnetConvictionEntry } from "@/lib/metagraphed/types";
 import { CopyableCode } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 
 const UNITS_PER_WHOLE = 1_000_000_000;
+
+// Gap thresholds are % of the king's conviction (see computeConvictionGap).
+// Grounded in docs/conviction-lock-mechanism.md: conviction moves on a
+// governance-controlled decay half-life (UnlockRate/MaturityRate, ~934,866
+// blocks / ~130 days by default) -- a challenger closes roughly half of
+// *their own* remaining headroom every half-life, not the whole gap in one
+// step, so even a well-funded challenger needs several cycles to close a
+// wide gap. Picked to read as: "days" of urgency vs. "months" of safety.
+const SECURE_GAP_PCT = 20; // closing this needs multiple maturity half-lives (months) absent a large fresh lock
+const CONTESTED_GAP_PCT = 5; // a real, watchable race -- not secure, not on the verge of flipping either
+// gap < CONTESTED_GAP_PCT => "Takeover imminent": within reach of one sizeable top-up, or a bit of king-side decay
+
+// Bittensor's fixed block time -- matches the ~12s/block conversion
+// docs/conviction-lock-mechanism.md itself uses for UnlockRate/MaturityRate.
+// Not governance-adjustable (unlike unlock_rate/maturity_rate), safe to
+// hardcode for a display-only day conversion.
+const BLOCK_SECONDS = 12;
+
+export interface ConvictionGap {
+  kingEntry: SubnetConvictionEntry;
+  runnerUp: SubnetConvictionEntry | null;
+  /** % of the king's conviction the runner-up is behind by; null = uncontested (no runner-up). */
+  gapPct: number | null;
+}
+
+/**
+ * Identifies the king and top active challenger from the leaderboard and
+ * computes the gap between them, as a % of the king's conviction. Doesn't
+ * trust array order or that `king` necessarily matches the top-conviction
+ * row (both are true in practice, but this is presentation code -- sort
+ * defensively rather than assume). Returns null only for an empty leaderboard.
+ */
+export function computeConvictionGap(
+  leaderboard: SubnetConvictionEntry[],
+  king: string | null,
+): ConvictionGap | null {
+  if (leaderboard.length === 0) return null;
+  const sorted = [...leaderboard].sort((a, b) => b.conviction - a.conviction);
+  const kingEntry = (king != null ? sorted.find((e) => e.hotkey === king) : undefined) ?? sorted[0];
+  const runnerUp = sorted.find((e) => e.hotkey !== kingEntry.hotkey) ?? null;
+  const rawGapPct =
+    runnerUp != null && kingEntry.conviction > 0
+      ? ((kingEntry.conviction - runnerUp.conviction) / kingEntry.conviction) * 100
+      : null;
+  // Clamp negative gaps (a data anomaly -- `king` disagreeing with the
+  // actual top row) to 0 rather than surfacing a nonsensical negative %.
+  const gapPct = rawGapPct == null ? null : Math.max(0, rawGapPct);
+  return { kingEntry, runnerUp, gapPct };
+}
+
+/** Status-badge label + Tailwind classes for a gap%, mirroring the
+ * border/bg/text `health-*` tone convention used by schema-drift.tsx. */
+export function convictionUrgencyTone(gapPct: number | null): { label: string; cls: string } {
+  if (gapPct == null || gapPct >= SECURE_GAP_PCT) {
+    return {
+      label: "Secure",
+      cls: "border-health-ok/30 bg-health-ok/10 text-health-ok",
+    };
+  }
+  if (gapPct >= CONTESTED_GAP_PCT) {
+    return {
+      label: "Contested",
+      cls: "border-health-warn/40 bg-health-warn/10 text-health-warn",
+    };
+  }
+  return {
+    label: "Takeover imminent",
+    cls: "border-health-down/40 bg-health-down/10 text-health-down",
+  };
+}
+
+/**
+ * Rough, explicitly-labeled estimate of how many blocks the runner-up would
+ * need to close the gap purely via ordinary conviction maturation (conviction
+ * matures toward locked_mass on a MaturityRate half-life, per
+ * docs/conviction-lock-mechanism.md). Assumes the king's conviction holds
+ * perfectly steady and the runner-up makes no further lock changes -- a
+ * simplifying, worst-case-for-the-incumbent assumption, NOT a prediction of
+ * what will actually happen. Returns null when there's no headroom for the
+ * runner-up to ever clear the king this way (already at its own ceiling, or
+ * its ceiling doesn't exceed the king's current conviction), or when
+ * maturity_rate isn't available.
+ */
+export function estimateBlocksToOvertake(
+  kingEntry: SubnetConvictionEntry,
+  runnerUp: SubnetConvictionEntry,
+  maturityRate: number | null,
+): number | null {
+  if (maturityRate == null || maturityRate <= 0) return null;
+  const ceiling = runnerUp.locked_mass;
+  if (ceiling <= kingEntry.conviction) return null; // can never clear the king by maturing alone
+  if (runnerUp.conviction >= ceiling) return null; // no headroom left to mature
+  const ratio = (ceiling - kingEntry.conviction) / (ceiling - runnerUp.conviction);
+  if (!(ratio > 0) || !(ratio < 1)) return null;
+  const blocks = -maturityRate * Math.log2(ratio);
+  return Number.isFinite(blocks) && blocks > 0 ? Math.ceil(blocks) : null;
+}
+
+/** Formats a block count as a rough "~N days"/"~N months" string, or null input-through. */
+export function formatBlocksAsDuration(blocks: number | null): string | null {
+  if (blocks == null) return null;
+  const days = (blocks * BLOCK_SECONDS) / 86_400;
+  if (days < 1) return "<1 day";
+  if (days < 30) {
+    const n = Math.round(days);
+    return `~${n} day${n === 1 ? "" : "s"}`;
+  }
+  const months = Math.round(days / 30);
+  return `~${months} month${months === 1 ? "" : "s"}`;
+}
 
 // locked_mass/conviction arrive as raw rao-scale integers (mirrors every
 // other on-chain alpha/TAO amount in this codebase) -- divide before display.
@@ -51,6 +162,14 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
     );
   }
 
+  const gap = computeConvictionGap(leaderboard, data?.king ?? null);
+  const tone = convictionUrgencyTone(gap?.gapPct ?? null);
+  const overtakeBlocks =
+    gap?.runnerUp != null
+      ? estimateBlocksToOvertake(gap.kingEntry, gap.runnerUp, data?.maturity_rate ?? null)
+      : null;
+  const overtakeDuration = formatBlocksAsDuration(overtakeBlocks);
+
   return (
     <div className="space-y-3">
       {data?.queried_at_block != null ? (
@@ -59,6 +178,31 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
           {data.unlock_rate != null ? ` · unlock_rate ${formatNumber(data.unlock_rate)}` : ""}
           {data.maturity_rate != null ? ` · maturity_rate ${formatNumber(data.maturity_rate)}` : ""}
         </p>
+      ) : null}
+      {gap != null ? (
+        <div className="flex flex-wrap items-center gap-2" aria-label="Ownership-contest urgency">
+          <span
+            className={classNames(
+              "rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest",
+              tone.cls,
+            )}
+          >
+            {tone.label}
+          </span>
+          {gap.gapPct != null ? (
+            <span className="font-mono text-[11px] text-ink-muted">
+              gap to king: {gap.gapPct.toFixed(1)}%
+            </span>
+          ) : (
+            <span className="font-mono text-[11px] text-ink-muted">no active challenger</span>
+          )}
+          {overtakeDuration != null ? (
+            <span className="font-mono text-[11px] text-ink-subtle-text">
+              · est. {overtakeDuration} to overtake at current rate (estimate, assumes the king
+              holds steady)
+            </span>
+          ) : null}
+        </div>
       ) : null}
       <div className="rounded-xl border border-border bg-card overflow-hidden">
         <div className="overflow-x-auto">

--- a/apps/ui/tests/e2e/capture-conviction-populated-screenshot.mjs
+++ b/apps/ui/tests/e2e/capture-conviction-populated-screenshot.mjs
@@ -1,0 +1,128 @@
+/**
+ * Supplementary screenshot capture for #6883 (conviction leaderboard urgency
+ * framing). As of writing, a live sweep of all 128 registered subnets found
+ * ZERO with an active conviction contest (every leaderboard is genuinely
+ * empty right now) -- so a real before/after pair against production data
+ * is honestly byte-identical and does not demonstrate the new gap%/badge
+ * UI at all. This script follows the same `page.route()` fixture-
+ * interception pattern already established in
+ * capture-validator-delegate-screenshots.mjs / capture-yield-percentile-
+ * screenshots.mjs to render the new UI against a realistic, schema-accurate
+ * mocked API response instead.
+ *
+ * Usage (with the "after" dev server already running):
+ *   UI_BASE_URL=http://localhost:8080 node tests/e2e/capture-conviction-populated-screenshot.mjs
+ *
+ * Writes 6 PNGs (3 viewports x 2 themes) to tmp/pr-screenshots/
+ * 6883-conviction-populated-<viewport>-<theme>.png.
+ */
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "../../../../tmp/pr-screenshots");
+const BASE_URL = process.env.UI_BASE_URL ?? "http://localhost:8080";
+const VIEWPORTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+const THEMES = ["light", "dark"];
+
+// Real API envelope shape (verified live against api.metagraph.sh), with a
+// synthetic 3-entry leaderboard: a king, a close challenger (~3% gap, so the
+// badge reads "Takeover imminent"), and a distant third entry.
+const CONVICTION_FIXTURE = {
+  ok: true,
+  schema_version: 1,
+  data: {
+    schema_version: 1,
+    netuid: 1,
+    queried_at_block: 8_656_366,
+    unlock_rate: 934_866,
+    maturity_rate: 311_622,
+    king: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    count: 3,
+    leaderboard: [
+      {
+        hotkey: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+        is_owner: true,
+        locked_mass: 1_000_000_000_000,
+        conviction: 980_000_000_000,
+      },
+      {
+        hotkey: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+        is_owner: false,
+        locked_mass: 1_100_000_000_000,
+        conviction: 950_000_000_000,
+      },
+      {
+        hotkey: "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
+        is_owner: false,
+        locked_mass: 900_000_000_000,
+        conviction: 400_000_000_000,
+      },
+    ],
+  },
+  meta: { artifact_path: "/api/v1/subnets/1/conviction", cache: "short", source: "fixture" },
+};
+
+async function setTheme(page, theme) {
+  await page.goto(`${BASE_URL}/`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((t) => {
+    localStorage.setItem("mg-theme", t);
+  }, theme);
+}
+
+async function installFixture(page) {
+  await page.route("**/api/v1/subnets/*/conviction**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(CONVICTION_FIXTURE),
+    });
+  });
+}
+
+async function openConvictionSection(page) {
+  await page.goto(`${BASE_URL}/subnets/1`, { waitUntil: "networkidle", timeout: 90_000 });
+  await page.getByText("Takeover imminent").waitFor({ state: "visible", timeout: 30_000 });
+  await page.evaluate(() => {
+    const el = document.getElementById("conviction");
+    if (!el) return;
+    const top = el.getBoundingClientRect().top + window.scrollY - 72;
+    window.scrollTo({ top: Math.max(0, top), behavior: "instant" });
+  });
+  await page.waitForTimeout(300);
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+
+  for (const viewport of VIEWPORTS) {
+    const context = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+    });
+    const page = await context.newPage();
+    await installFixture(page);
+
+    for (const theme of THEMES) {
+      await setTheme(page, theme);
+      await openConvictionSection(page);
+      const file = path.join(OUT_DIR, `6883-conviction-populated-${viewport.name}-${theme}.png`);
+      await page.screenshot({ path: file });
+      console.log(`wrote ${file}`);
+    }
+    await context.close();
+  }
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #6883.

`SubnetConvictionLeaderboard` already ships live ownership-contest data (`king`, per-entry `conviction`/`locked_mass`) but renders it as a plain ranked table with a crown icon — no framing of *how close* the contest is.

## What's added

- `computeConvictionGap`: identifies the king and top challenger from the leaderboard and computes the gap between them as a % of the king's conviction.
- `convictionUrgencyTone`: maps a gap% to a **Secure** / **Contested** / **Takeover imminent** badge, with concrete thresholds (`SECURE_GAP_PCT=20`, `CONTESTED_GAP_PCT=5`) grounded in `docs/conviction-lock-mechanism.md`'s maturity half-life mechanics — a challenger closes roughly half of its own remaining headroom every ~130-day half-life, so even a well-funded challenger needs multiple cycles to close a wide gap. Full reasoning in the code comments.
- `estimateBlocksToOvertake` / `formatBlocksAsDuration`: a rough, clearly-labeled "time to overtake at current rate" estimate using the already-returned `maturity_rate`, explicitly framed as an estimate (governance parameters, not a guaranteed trajectory), and not shown when there's no real headroom for the challenger to ever clear the king.

No backend/API changes — pure presentation layer over already-fetched data, as the issue specifies.

## Testing

22 new unit tests covering all four functions: empty leaderboard, single entry (uncontested), close/wide gap computation, king/top-row mismatch fallback and negative-gap clamping, all three badge tiers, overtake-estimate null cases (no `maturity_rate`, no headroom, already matured) and relative ordering, and duration formatting at day/month scale.

## Screenshots

A live sweep of all 128 registered subnets (2026-07-19) found **zero** with an active conviction contest — every leaderboard is genuinely empty right now, so a real before/after pair against production data is honestly byte-identical and doesn't demonstrate the new UI. The before/after pair below reflects that reality (and confirms the empty-state path is unaffected). Six supplementary images render the new UI against a realistic, schema-accurate mocked API response instead, using this repo's own established `page.route()` fixture-interception pattern (already used in `capture-validator-delegate-screenshots.mjs` / `capture-yield-percentile-screenshots.mjs`) — new script at `tests/e2e/capture-conviction-populated-screenshot.mjs`.

### Before / After (live data — empty leaderboard, unchanged)

| Viewport | Theme | Before | After |
|---|---|---|---|
| Mobile | Light | ![before](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-after-mobile-light.png) |
| Mobile | Dark | ![before](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-after-mobile-dark.png) |
| Tablet | Light | ![before](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-after-tablet-light.png) |
| Tablet | Dark | ![before](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-after-tablet-dark.png) |
| Desktop | Light | ![before](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-after-desktop-light.png) |
| Desktop | Dark | ![before](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-after-desktop-dark.png) |

### Supplementary: new UI with a populated leaderboard (mocked data)

| Viewport | Light | Dark |
|---|---|---|
| Mobile | ![populated](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-populated-mobile-light.png) | ![populated](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-populated-mobile-dark.png) |
| Tablet | ![populated](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-populated-tablet-light.png) | ![populated](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-populated-tablet-dark.png) |
| Desktop | ![populated](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-populated-desktop-light.png) | ![populated](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6883-conviction-populated-desktop-dark.png) |
