### PR TITLE
fix(ui): constrain the readiness CTA width so its label truncates instead of overflowing (#6903)

### DIFF
--- a/apps/ui/src/components/metagraphed/readiness-scorecard.tsx
+++ b/apps/ui/src/components/metagraphed/readiness-scorecard.tsx
@@ -70,7 +70,13 @@ export function ReadinessScorecard({ profile }: { profile?: SubnetProfile }) {
       {cta?.url ? (
         <ExternalLink
           href={cta.url}
-          className="mt-3 flex items-center gap-2 rounded-lg border border-accent/30 bg-accent-surface px-3 py-2 text-sm"
+          // ExternalLink already provides the flex context via its base
+          // `inline-flex`; a `flex` override here loses the cascade to it and is
+          // a no-op. The missing piece was a width bound -- an unconstrained
+          // (shrink-to-fit) anchor never triggers the inner `truncate`, so the
+          // CTA overflowed the card (#6903). `w-full` constrains it to the card
+          // width, engaging the existing truncate chain.
+          className="mt-3 w-full items-center gap-2 rounded-lg border border-accent/30 bg-accent-surface px-3 py-2 text-sm"
         >
           <ArrowRight className="size-4 shrink-0 text-accent" />
           <span className="min-w-0 flex-1 truncate">

--- a/apps/ui/tests/e2e/overflow-baseline.json
+++ b/apps/ui/tests/e2e/overflow-baseline.json
@@ -10,7 +10,7 @@
   "/@1024": ["DIV:flex items-center gap-1", "DIV:flex-1 flex justify-end"],
   "/@1280": ["DIV:flex items-center gap-1"],
   "/subnets/1@375": [
-    "A:inline-flex items-center gap-1 underline decoration-ink/30 underline-offset-2 text-ink-strong hover:decoration-ink mt-3 flex items-center gap-2 rounded-lg border border-accent/30 bg-accent-surface px-3 py-2 text-sm",
+    "SPAN:min-w-0 flex-1 truncate",
     "DIV:flex items-center gap-1",
     "DIV:flex-1 flex justify-end"
   ],


### PR DESCRIPTION
## Summary

Fixes the Integration Readiness CTA overflowing its card on mobile. On `/subnets/1` (Apex) at 375px, the "Start here: {api} · {provider}" link extended ~120px past the card and viewport instead of truncating (measured: anchor right edge `479px` vs card right `359px`).

## Root cause

`ExternalLink` sets `inline-flex` as its base class; the caller passed `flex` as a className override. `classNames()` is a plain join (no `tailwind-merge`), so both land on the `<a>` and `inline-flex` wins the cascade. An `inline-flex` anchor is shrink-to-fit — it has **no width bound**, so it grows to its content. Without a width constraint, the inner `truncate` chain never has anything to shrink against, and the CTA runs off the edge. (The repo-wide `classNames`-vs-`twMerge` version is the sibling issue #6904; this fixes the specific instance.)

## Fix

One class change in the caller: the dead `flex` (a no-op — it loses the cascade to `ExternalLink`'s `inline-flex`) is replaced with `w-full`, constraining the anchor to the card width so the existing `truncate`/`min-w-0` chain engages and the label ellipsizes within the card. `ExternalLink` still provides the flex context; `items-center gap-2` still apply. No `!important`, no change to the shared `ExternalLink`.

## Overflow baseline

The `ui` job's responsive-overflow e2e detects elements whose layout box escapes the viewport. Once the CTA label truncates, its `min-w-0 flex-1 truncate` span is *visually* clipped (the ellipsis the user sees) but its layout box stays wide — the same intentional truncation artifact other truncating elements are already recorded for. So `overflow-baseline.json`'s `/subnets/1@375` entry swaps the old (now-contained) overflowing anchor for that span. With it, `npm run test:e2e --workspace=apps/ui` passes **28/28** locally.

## Verification (measured at 375px on `/subnets/1`, Apex)

| | anchor right | card right | overflow | label |
|---|---|---|---|---|
| Before | 479px | 359px | ~120px past card / off-viewport | not truncated |
| After | 342px | 359px | 0 (contained) | truncates with ellipsis |

- `npm run test:e2e --workspace=apps/ui` — 28/28 pass (was failing on `/subnets/1` mobile before the baseline update).
- `eslint` — clean; `tsc --noEmit` (apps/ui) — 0 errors; `prettier --check` — clean.
- Desktop/tablet unchanged (the CTA already fit at those widths).

## Changed

- `apps/ui/src/components/metagraphed/readiness-scorecard.tsx` — CTA `className`: `flex` → `w-full`.
- `apps/ui/tests/e2e/overflow-baseline.json` — `/subnets/1@375`: record the now-truncating CTA span, drop the now-contained anchor.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/real-venus/metagraphed/screenshots/6903-readiness-cta-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6903
