### PR TITLE
docs(skill): warn against locator-scoped screenshot captures in Phase C2

### DIFF
--- a/.claude/skills/metagraphed/SKILL.md
+++ b/.claude/skills/metagraphed/SKILL.md
@@ -385,6 +385,14 @@ in `apps/ui/src`):
 Capture exactly that viewport, nothing more. If the changed content is below the fold, scroll to it
 first — don't reach for a full-page capture to get there.
 
+**Also never `locator.screenshot()` / `elementHandle.screenshot()`** (e.g.
+`page.locator(".hero").screenshot(...)`) as a shortcut to "just the changed part" — confirmed on
+#6928/#6933, both shipped with a locator-scoped capture instead of the fixed viewport. It crops to
+that element's own rendered box, not the fixed viewport frame this contract requires, so a
+reviewer can't see the change in its real page context (surrounding layout, whether anything else
+shifted). The only call to make is `page.screenshot({ path })` — no `fullPage`, no locator, after
+resizing the viewport and scrolling to the changed content if needed.
+
 **3. Force each theme explicitly — never rely on system/`prefers-color-scheme`** (it varies by capture
 environment, so it isn't reproducible run to run). In the page, before capturing:
 


### PR DESCRIPTION
## What

Adds an explicit anti-pattern callout to the Phase C2 screenshot contract in `.claude/skills/metagraphed/SKILL.md`, warning against `locator.screenshot()` / `elementHandle.screenshot()` as a shortcut for "just capture the changed part."

## Why

The contract already has a strong, specific warning for the *opposite* failure (over-capturing): `fullPage: true`, cited to #3757's broken 115,000–142,000px-tall screenshots. There was no equivalent concrete warning for under-capturing (element/locator-scoped capture) — even though "capture exactly that viewport, nothing more" already implies it, that implication wasn't concrete enough to stop the mistake in practice.

Confirmed on two real PRs, both from the same contributor: #6928 and #6933 both shipped with a locator-scoped capture instead of a fixed-viewport `page.screenshot()`. Both had to be corrected after the fact (screenshots replaced in place, same filenames, on the `screenshots` branch, plus a PR comment flagging it). A locator/element screenshot crops to that element's own rendered bounding box, not the fixed viewport frame the contract requires — so a reviewer can't see the change in its real page context (surrounding layout, whether anything else shifted).

## Change

Mirrors the existing #3757 callout's structure and specificity: names the exact wrong API, the right one, why, and cites the real occurrence.

No linked issue — this is a maintainer-authored documentation fix, not a contributor PR.