### PR TITLE
feat(ui): overlay multi-subnet history in the compare drawer

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -3,23 +3,27 @@ import { useQuery } from "@tanstack/react-query";
 import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
 import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
-import { healthColorVar } from "@/lib/health-tokens";
-import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import {
+  SUBNET_HISTORY_METRICS,
+  SUBNET_HISTORY_WINDOWS,
+  pickMetricValues,
+  type SubnetHistoryWindow,
+} from "@/lib/metagraphed/subnet-history-metrics";
 import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
-
-// Lowercase windows, mirroring the /history API + the inline toggle conventions
-// used by health-trends.tsx. "all" maps to the API's widest supported window.
-type Win = "7d" | "30d" | "90d" | "1y" | "all";
-const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
 
 /**
  * Per-subnet on-chain history (#1302). A window selector drives a daily snapshot
  * series; each metric renders as a labelled Sparkline row (mirrors
  * subnet-growth-card.tsx's GrowthRow). Optional detail — renders null when the
  * subnet has no history yet, so it never clutters a cold profile.
+ *
+ * The window + metric vocabulary lives in lib/metagraphed/subnet-history-metrics
+ * so the compare drawer's multi-subnet overlay (#6885) offers exactly the same
+ * set without either side drifting.
  */
 export function SubnetHistoryChart({ netuid }: { netuid: number }) {
-  const [win, setWin] = useState<Win>("90d");
+  const [win, setWin] = useState<SubnetHistoryWindow>("90d");
   const {
     data: res,
     isLoading,
@@ -29,25 +33,16 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
   } = useQuery(subnetHistoryQuery(netuid, win));
   const points = useMemo<SubnetHistoryPoint[]>(() => res?.data?.points ?? [], [res?.data?.points]);
 
-  const series = useMemo(() => {
-    const pick = (key: keyof SubnetHistoryPoint) =>
-      points
-        .map((p) => p[key])
-        .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
-    return {
-      neurons: pick("neuron_count"),
-      validators: pick("validator_count"),
-      stake: pick("total_stake_tao"),
-      emission: pick("total_emission_tao"),
-    };
-  }, [points]);
+  const series = useMemo(
+    () =>
+      SUBNET_HISTORY_METRICS.map((metric) => ({
+        metric,
+        values: pickMetricValues(points, metric.field),
+      })),
+    [points],
+  );
 
-  const hasData =
-    series.neurons.length +
-      series.validators.length +
-      series.stake.length +
-      series.emission.length >
-    0;
+  const hasData = series.some((s) => s.values.length > 0);
 
   const windowSelector = (
     <div
@@ -55,7 +50,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
       aria-label="History window"
       className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
     >
-      {WINDOWS.map((w) => (
+      {SUBNET_HISTORY_WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
@@ -87,32 +82,17 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
         />
       ) : (
         <div className="rounded-xl border border-border bg-card p-4 space-y-3">
-          {series.neurons.length > 0 ? (
-            <HistoryRow label="Neurons" series={series.neurons} color="var(--accent)" />
-          ) : null}
-          {series.validators.length > 0 ? (
-            <HistoryRow
-              label="Validators"
-              series={series.validators}
-              color={healthColorVar("ok")}
-            />
-          ) : null}
-          {series.stake.length > 0 ? (
-            <HistoryRow
-              label="Total stake"
-              series={series.stake}
-              color={healthColorVar("warn")}
-              format={formatTao}
-            />
-          ) : null}
-          {series.emission.length > 0 ? (
-            <HistoryRow
-              label="Total emission"
-              series={series.emission}
-              color="var(--accent)"
-              format={formatTao}
-            />
-          ) : null}
+          {series.map(({ metric, values }) =>
+            values.length > 0 ? (
+              <HistoryRow
+                key={metric.key}
+                label={metric.label}
+                series={values}
+                color={metric.color}
+                format={metric.format}
+              />
+            ) : null,
+          )}
         </div>
       )}
     </div>

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -7,15 +7,27 @@ import { compareQuery } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { CompareSubnet, HealthState } from "@/lib/metagraphed/types";
 import { HealthPill, CurationChip } from "@jsonbored/ui-kit";
+import { SubnetsCompareHistoryChart } from "@/components/metagraphed/subnets-compare-history-chart";
+
+/** The two views of the expanded drawer: instant metrics, or history over time. */
+type CompareView = "metrics" | "history";
+const COMPARE_VIEWS: Array<{ key: CompareView; label: string }> = [
+  { key: "metrics", label: "Metrics" },
+  { key: "history", label: "History" },
+];
 
 /**
  * Floating bottom dock + expandable side-by-side compare drawer for selected
  * subnets. Selection state lives in localStorage via useCompareSelection so
  * it survives navigation. Pure presentation — does not mutate URL.
+ *
+ * The expanded view tabs between CompareGrid (current instant metrics) and
+ * SubnetsCompareHistoryChart (the multi-subnet history overlay, #6885).
  */
 export function SubnetsCompareDrawer() {
   const { selected, max, remove, clear } = useCompareSelection();
   const [expanded, setExpanded] = useState(false);
+  const [view, setView] = useState<CompareView>("metrics");
 
   if (selected.length === 0) return null;
 
@@ -81,7 +93,38 @@ export function SubnetsCompareDrawer() {
           </div>
 
           {/* Expanded side-by-side */}
-          {expanded && selected.length >= 2 ? <CompareGrid netuids={selected} /> : null}
+          {expanded && selected.length >= 2 ? (
+            <>
+              <div
+                role="tablist"
+                aria-label="Compare view"
+                className="flex items-center gap-1 border-t border-border px-3 py-1.5"
+              >
+                {COMPARE_VIEWS.map((v) => (
+                  <button
+                    key={v.key}
+                    type="button"
+                    role="tab"
+                    aria-selected={v.key === view}
+                    onClick={() => setView(v.key)}
+                    className={classNames(
+                      "rounded-full px-3 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                      v.key === view
+                        ? "bg-ink-strong text-paper"
+                        : "text-ink-muted hover:text-ink-strong",
+                    )}
+                  >
+                    {v.label}
+                  </button>
+                ))}
+              </div>
+              {view === "metrics" ? (
+                <CompareGrid netuids={selected} />
+              ) : (
+                <SubnetsCompareHistoryChart netuids={selected} />
+              )}
+            </>
+          ) : null}
         </div>
       </div>
     </div>

--- a/apps/ui/src/components/metagraphed/subnets-compare-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-history-chart.tsx
@@ -1,0 +1,182 @@
+import { useState } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import {
+  SUBNET_HISTORY_METRICS,
+  SUBNET_HISTORY_WINDOWS,
+  buildOverlayGeometry,
+  type SubnetHistoryMetricKey,
+  type SubnetHistoryWindow,
+} from "@/lib/metagraphed/subnet-history-metrics";
+
+// viewBox units. The SVG scales to its container via preserveAspectRatio="none",
+// with non-scaling strokes so lines stay hairline-thin at any width.
+const VIEW_W = 600;
+const VIEW_H = 160;
+
+/**
+ * Multi-subnet history overlay for the compare drawer (#6885). Fetches
+ * /subnets/{netuid}/history once per selected subnet and draws them on ONE set
+ * of shared axes — the time-series counterpart to CompareGrid's instant-metrics
+ * table.
+ *
+ * The metric list and window list come from lib/metagraphed/subnet-history-metrics,
+ * the same source SubnetHistoryChart uses for a single subnet, so the picker
+ * offers exactly what the per-subnet chart already exposes. Selection (and its
+ * cap) stays owned by useCompareSelection — this component only reads the
+ * netuids it is handed.
+ */
+export function SubnetsCompareHistoryChart({ netuids }: { netuids: number[] }) {
+  const [win, setWin] = useState<SubnetHistoryWindow>("90d");
+  const [metricKey, setMetricKey] = useState<SubnetHistoryMetricKey>("stake");
+
+  const metric =
+    SUBNET_HISTORY_METRICS.find((m) => m.key === metricKey) ?? SUBNET_HISTORY_METRICS[0]!;
+
+  const results = useQueries({
+    queries: netuids.map((netuid) => ({ ...subnetHistoryQuery(netuid, win), retry: 0 })),
+  });
+
+  const isPending = results.some((r) => r.isPending);
+  const isError = results.some((r) => r.isError);
+
+  // Cheap enough to derive on every render (the API caps a window at a few
+  // hundred daily points, times at most useCompareSelection's 4 subnets), so
+  // this stays a plain derivation rather than a memo keyed on unstable arrays.
+  const geo = buildOverlayGeometry(
+    netuids.map((netuid, i) => ({ netuid, points: results[i]?.data?.data?.points ?? [] })),
+    metric.field,
+    VIEW_W,
+    VIEW_H,
+  );
+
+  const format = (v: number | null) =>
+    v == null ? "—" : metric.format ? metric.format(v) : formatNumber(v);
+
+  // Each group stays a single non-wrapping row and scrolls horizontally if it
+  // still cannot fit: a segmented control that wraps orphans its last option
+  // inside the shared border and reads as broken. The two groups stack at <sm
+  // (both are full-width rows) and sit on one line from sm up.
+  const groupClass =
+    "inline-flex max-w-full shrink-0 overflow-x-auto rounded-md border border-border bg-surface/40 p-0.5";
+  const buttonClass = (active: boolean) =>
+    classNames(
+      "shrink-0 whitespace-nowrap rounded px-2.5 py-1 font-mono text-[11px] uppercase tracking-wider transition-colors",
+      active ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+    );
+
+  const controls = (
+    <div className="flex flex-col gap-2 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+      <div role="tablist" aria-label="Overlay metric" className={groupClass}>
+        {SUBNET_HISTORY_METRICS.map((m) => (
+          <button
+            key={m.key}
+            type="button"
+            role="tab"
+            aria-selected={m.key === metric.key}
+            onClick={() => setMetricKey(m.key)}
+            className={buttonClass(m.key === metric.key)}
+          >
+            {m.shortLabel}
+          </button>
+        ))}
+      </div>
+      <div role="tablist" aria-label="History window" className={groupClass}>
+        {SUBNET_HISTORY_WINDOWS.map((w) => (
+          <button
+            key={w}
+            type="button"
+            role="tab"
+            aria-selected={w === win}
+            onClick={() => setWin(w)}
+            className={buttonClass(w === win)}
+          >
+            {w}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="border-t border-border max-h-[55vh] overflow-auto">
+      {controls}
+      <div className="px-3 pb-3">
+        {isPending ? (
+          <div className="h-28 w-full animate-pulse sm:h-40 rounded-lg bg-border/40" />
+        ) : isError ? (
+          <div className="py-6 text-center">
+            <p className="font-mono text-[11px] text-ink-muted">Could not load history.</p>
+            <button
+              type="button"
+              onClick={() => results.forEach((r) => void r.refetch())}
+              className="mt-2 inline-flex h-7 items-center rounded-full border border-border bg-paper px-3 font-mono text-[10px] uppercase tracking-widest text-ink-strong transition-colors hover:border-accent/60 hover:text-accent"
+            >
+              Retry
+            </button>
+          </div>
+        ) : !geo ? (
+          <p className="py-6 text-center font-mono text-[11px] text-ink-muted">
+            No on-chain history for the selected subnets in this window.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex items-stretch gap-2 rounded-lg border border-border bg-card p-3">
+              <svg
+                viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+                preserveAspectRatio="none"
+                className="h-28 w-full min-w-0 flex-1 sm:h-40"
+                role="img"
+                aria-label={`${metric.label} over ${win} for ${netuids
+                  .map((n) => `SN${n}`)
+                  .join(", ")}`}
+              >
+                {geo.series.map((s) =>
+                  s.path ? (
+                    <path
+                      key={s.netuid}
+                      d={s.path}
+                      fill="none"
+                      stroke={s.color}
+                      strokeWidth={1.5}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      vectorEffect="non-scaling-stroke"
+                    />
+                  ) : null,
+                )}
+              </svg>
+              {/* Shared y domain, so the series are directly comparable. Sits
+                  beside the plot rather than over it — overlaid, these labels
+                  collided with the lines they annotate. */}
+              <div className="flex shrink-0 flex-col justify-between text-right font-mono text-[10px] text-ink-muted">
+                <span>{format(geo.max)}</span>
+                <span>{format(geo.min)}</span>
+              </div>
+            </div>
+            <div className="flex items-center justify-between font-mono text-[10px] text-ink-muted">
+              <span>{geo.dates[0]}</span>
+              <span>{geo.dates[geo.dates.length - 1]}</span>
+            </div>
+            <ul className="flex flex-wrap gap-x-4 gap-y-1.5">
+              {geo.series.map((s) => (
+                <li key={s.netuid} className="inline-flex items-center gap-1.5">
+                  <span
+                    aria-hidden
+                    className="size-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: s.color }}
+                  />
+                  <span className="font-mono text-[11px] text-ink-strong">SN{s.netuid}</span>
+                  <span className="font-mono text-[11px] tabular-nums text-ink-muted">
+                    {format(s.last)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/subnet-history-metrics.test.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-history-metrics.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import {
+  SUBNET_HISTORY_METRICS,
+  SUBNET_HISTORY_WINDOWS,
+  SUBNET_SERIES_COLORS,
+  buildOverlayGeometry,
+  pickMetricValues,
+  subnetSeriesColor,
+} from "./subnet-history-metrics";
+import type { SubnetHistoryPoint } from "./types";
+
+const point = (date: string, extra: Partial<SubnetHistoryPoint> = {}): SubnetHistoryPoint => ({
+  snapshot_date: date,
+  ...extra,
+});
+
+describe("subnet history metric vocabulary (#6885)", () => {
+  it("exposes the same four metrics the single-subnet chart renders", () => {
+    expect(SUBNET_HISTORY_METRICS.map((m) => m.key)).toEqual([
+      "neurons",
+      "validators",
+      "stake",
+      "emission",
+    ]);
+  });
+
+  it("formats only the tao-denominated metrics, leaving counts on the default", () => {
+    const byKey = Object.fromEntries(SUBNET_HISTORY_METRICS.map((m) => [m.key, m]));
+    expect(byKey.neurons!.format).toBeUndefined();
+    expect(byKey.validators!.format).toBeUndefined();
+    expect(byKey.stake!.format?.(1500)).toBe("1.5k τ");
+    expect(byKey.emission!.format?.(1500)).toBe("1.5k τ");
+  });
+
+  it("gives every metric a compact picker label that fits a 375px control", () => {
+    // The overlay's segmented control wraps (orphaning its last option) once the
+    // combined labels exceed the drawer's width at 375px. Budget derived from
+    // the measured control: ~7px per uppercase mono char + 20px padding each.
+    const width = SUBNET_HISTORY_METRICS.reduce((sum, m) => sum + m.shortLabel.length * 7 + 20, 0);
+    expect(width).toBeLessThan(351);
+    for (const m of SUBNET_HISTORY_METRICS) {
+      expect(m.shortLabel.length).toBeLessThanOrEqual(m.label.length);
+      expect(m.shortLabel).not.toHaveLength(0);
+    }
+  });
+
+  it("keeps the full label for the single-subnet chart's wider rows", () => {
+    const byKey = Object.fromEntries(SUBNET_HISTORY_METRICS.map((m) => [m.key, m]));
+    expect(byKey.stake!.label).toBe("Total stake");
+    expect(byKey.stake!.shortLabel).toBe("Stake");
+    expect(byKey.emission!.label).toBe("Total emission");
+    expect(byKey.emission!.shortLabel).toBe("Emission");
+  });
+
+  it("offers the windows the /history API supports", () => {
+    expect(SUBNET_HISTORY_WINDOWS).toEqual(["7d", "30d", "90d", "1y", "all"]);
+  });
+
+  it("cycles series colours so a selection larger than the palette still resolves", () => {
+    expect(subnetSeriesColor(0)).toBe(SUBNET_SERIES_COLORS[0]);
+    expect(subnetSeriesColor(SUBNET_SERIES_COLORS.length)).toBe(SUBNET_SERIES_COLORS[0]);
+    expect(subnetSeriesColor(SUBNET_SERIES_COLORS.length + 2)).toBe(SUBNET_SERIES_COLORS[2]);
+  });
+});
+
+describe("pickMetricValues", () => {
+  it("keeps only finite numbers", () => {
+    const points = [
+      point("2026-01-01", { neuron_count: 10 }),
+      point("2026-01-02", { neuron_count: undefined }),
+      point("2026-01-03", { neuron_count: Number.NaN }),
+      point("2026-01-04", { neuron_count: 12 }),
+    ];
+    expect(pickMetricValues(points, "neuron_count")).toEqual([10, 12]);
+  });
+
+  it("returns an empty array when the metric is absent throughout", () => {
+    expect(pickMetricValues([point("2026-01-01")], "total_stake_tao")).toEqual([]);
+  });
+});
+
+describe("buildOverlayGeometry", () => {
+  it("returns null when no subnet has a finite value", () => {
+    expect(
+      buildOverlayGeometry([{ netuid: 1, points: [point("2026-01-01")] }], "neuron_count", 100, 50),
+    ).toBeNull();
+  });
+
+  it("aligns subnets on a shared date axis rather than their own indices", () => {
+    // SN2 starts a day later; its first point must land at x of 2026-01-02,
+    // not at x=0 where naive per-series indexing would put it.
+    const geo = buildOverlayGeometry(
+      [
+        {
+          netuid: 1,
+          points: [
+            point("2026-01-01", { neuron_count: 0 }),
+            point("2026-01-02", { neuron_count: 0 }),
+            point("2026-01-03", { neuron_count: 0 }),
+          ],
+        },
+        {
+          netuid: 2,
+          points: [
+            point("2026-01-02", { neuron_count: 10 }),
+            point("2026-01-03", { neuron_count: 10 }),
+          ],
+        },
+      ],
+      "neuron_count",
+      100,
+      50,
+    );
+
+    expect(geo).not.toBeNull();
+    expect(geo!.dates).toEqual(["2026-01-01", "2026-01-02", "2026-01-03"]);
+    expect(geo!.series[1]!.path.startsWith("M50 ")).toBe(true);
+  });
+
+  it("shares one y domain across every series", () => {
+    const geo = buildOverlayGeometry(
+      [
+        { netuid: 1, points: [point("2026-01-01", { total_stake_tao: 5 })] },
+        { netuid: 2, points: [point("2026-01-01", { total_stake_tao: 95 })] },
+      ],
+      "total_stake_tao",
+      100,
+      50,
+    );
+    expect(geo!.min).toBe(5);
+    expect(geo!.max).toBe(95);
+  });
+
+  it("breaks the path at a gap instead of interpolating across it", () => {
+    // The axis only carries dates some subnet reported, so a hole exists only
+    // relative to the union: SN2 supplies 01-02, which SN1 is missing.
+    const geo = buildOverlayGeometry(
+      [
+        {
+          netuid: 1,
+          points: [
+            point("2026-01-01", { neuron_count: 1 }),
+            point("2026-01-03", { neuron_count: 3 }),
+          ],
+        },
+        {
+          netuid: 2,
+          points: [
+            point("2026-01-01", { neuron_count: 1 }),
+            point("2026-01-02", { neuron_count: 2 }),
+            point("2026-01-03", { neuron_count: 3 }),
+          ],
+        },
+      ],
+      "neuron_count",
+      100,
+      50,
+    );
+    expect(geo!.dates).toEqual(["2026-01-01", "2026-01-02", "2026-01-03"]);
+    // Two subpaths => two movetos, so nothing is drawn through the missing day.
+    expect(geo!.series[0]!.path.match(/M/g)).toHaveLength(2);
+    // The subnet with full coverage stays a single unbroken subpath.
+    expect(geo!.series[1]!.path.match(/M/g)).toHaveLength(1);
+  });
+
+  it("renders an isolated point as a zero-length line so it shows as a dot", () => {
+    const geo = buildOverlayGeometry(
+      [{ netuid: 7, points: [point("2026-01-01", { neuron_count: 4 })] }],
+      "neuron_count",
+      100,
+      50,
+    );
+    expect(geo!.series[0]!.path).toBe("M50 25L50 25");
+  });
+
+  it("centres a flat series vertically instead of pinning it to an edge", () => {
+    const geo = buildOverlayGeometry(
+      [
+        {
+          netuid: 1,
+          points: [
+            point("2026-01-01", { neuron_count: 8 }),
+            point("2026-01-02", { neuron_count: 8 }),
+          ],
+        },
+      ],
+      "neuron_count",
+      100,
+      50,
+    );
+    expect(geo!.series[0]!.path).toBe("M0 25L100 25");
+  });
+
+  it("maps the domain extremes to the padded top and bottom", () => {
+    const geo = buildOverlayGeometry(
+      [
+        {
+          netuid: 1,
+          points: [
+            point("2026-01-01", { neuron_count: 0 }),
+            point("2026-01-02", { neuron_count: 100 }),
+          ],
+        },
+      ],
+      "neuron_count",
+      100,
+      50,
+    );
+    // height 50, pad 2 => min at y=48, max at y=2.
+    expect(geo!.series[0]!.path).toBe("M0 48L100 2");
+  });
+
+  it("reports the latest finite value per subnet and keeps empty subnets listed", () => {
+    const geo = buildOverlayGeometry(
+      [
+        {
+          netuid: 1,
+          points: [
+            point("2026-01-01", { neuron_count: 1 }),
+            point("2026-01-02", { neuron_count: 9 }),
+          ],
+        },
+        { netuid: 2, points: [point("2026-01-01")] },
+      ],
+      "neuron_count",
+      100,
+      50,
+    );
+    expect(geo!.series[0]!.last).toBe(9);
+    expect(geo!.series[1]!.last).toBeNull();
+    expect(geo!.series[1]!.path).toBe("");
+    expect(geo!.series.map((s) => s.netuid)).toEqual([1, 2]);
+  });
+
+  it("assigns each subnet a distinct series colour", () => {
+    const geo = buildOverlayGeometry(
+      [
+        { netuid: 1, points: [point("2026-01-01", { neuron_count: 1 })] },
+        { netuid: 2, points: [point("2026-01-01", { neuron_count: 2 })] },
+      ],
+      "neuron_count",
+      100,
+      50,
+    );
+    expect(geo!.series[0]!.color).toBe(SUBNET_SERIES_COLORS[0]);
+    expect(geo!.series[1]!.color).toBe(SUBNET_SERIES_COLORS[1]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/subnet-history-metrics.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-history-metrics.ts
@@ -1,0 +1,231 @@
+import { healthColorVar } from "@/lib/health-tokens";
+import { formatTao } from "@/lib/metagraphed/format";
+import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
+
+/**
+ * Shared vocabulary for the /subnets/{netuid}/history series (#1302), extracted
+ * from subnet-history-chart.tsx so the single-subnet chart and the compare
+ * drawer's multi-subnet overlay (#6885) can never disagree about which windows
+ * and metrics exist. The single-subnet chart colours each metric differently;
+ * the overlay colours each SUBNET differently (SUBNET_SERIES_COLORS below),
+ * since there the metric is fixed and the subnet is the varying dimension.
+ */
+
+// Lowercase windows, mirroring the /history API + the inline toggle conventions
+// used by health-trends.tsx. "all" maps to the API's widest supported window.
+export type SubnetHistoryWindow = "7d" | "30d" | "90d" | "1y" | "all";
+export const SUBNET_HISTORY_WINDOWS: readonly SubnetHistoryWindow[] = [
+  "7d",
+  "30d",
+  "90d",
+  "1y",
+  "all",
+];
+
+export type SubnetHistoryMetricKey = "neurons" | "validators" | "stake" | "emission";
+
+/** A numeric field of SubnetHistoryPoint the chart can plot. */
+type SubnetHistoryField =
+  "neuron_count" | "validator_count" | "total_stake_tao" | "total_emission_tao";
+
+export interface SubnetHistoryMetric {
+  key: SubnetHistoryMetricKey;
+  label: string;
+  /**
+   * Compact label for the overlay's segmented picker. Same metric, shorter
+   * string: at 375px the full labels overflow the control and wrap onto a
+   * second row, which orphans the last option inside its own border. The
+   * single-subnet chart keeps `label` for its wider row layout.
+   */
+  shortLabel: string;
+  field: SubnetHistoryField;
+  /** Per-metric colour, used by the single-subnet chart only. */
+  color: string;
+  /**
+   * Value formatter. Deliberately optional: the count metrics render through
+   * the Sparkline/legend default so their display is unchanged by this
+   * extraction — only the τ-denominated metrics override it.
+   */
+  format?: (v: number) => string;
+}
+
+export const SUBNET_HISTORY_METRICS: readonly SubnetHistoryMetric[] = [
+  {
+    key: "neurons",
+    label: "Neurons",
+    shortLabel: "Neurons",
+    field: "neuron_count",
+    color: "var(--accent)",
+  },
+  {
+    key: "validators",
+    label: "Validators",
+    shortLabel: "Validators",
+    field: "validator_count",
+    color: healthColorVar("ok"),
+  },
+  {
+    key: "stake",
+    label: "Total stake",
+    shortLabel: "Stake",
+    field: "total_stake_tao",
+    color: healthColorVar("warn"),
+    format: formatTao,
+  },
+  {
+    key: "emission",
+    label: "Total emission",
+    shortLabel: "Emission",
+    field: "total_emission_tao",
+    color: "var(--accent)",
+    format: formatTao,
+  },
+];
+
+/**
+ * Categorical series colours for the overlay, one per selected subnet. Follows
+ * the `--chart-N` token convention (styles.css) and the existing modulo idiom
+ * (explorer.tsx's CALL_MIX_PALETTE, providers.index.tsx's kindPalette). Four
+ * entries covers useCompareSelection's MAX of 4; the modulo keeps it correct if
+ * that cap ever rises.
+ */
+export const SUBNET_SERIES_COLORS: readonly string[] = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+];
+
+export function subnetSeriesColor(index: number): string {
+  return SUBNET_SERIES_COLORS[index % SUBNET_SERIES_COLORS.length]!;
+}
+
+/** Pull the finite values of one metric out of a subnet's history points. */
+export function pickMetricValues(
+  points: readonly SubnetHistoryPoint[],
+  field: SubnetHistoryField,
+): number[] {
+  return points
+    .map((p) => p[field])
+    .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+}
+
+export interface SubnetHistoryInput {
+  netuid: number;
+  points: readonly SubnetHistoryPoint[];
+}
+
+export interface OverlaySeries {
+  netuid: number;
+  color: string;
+  /**
+   * SVG path data in the requested viewBox. Empty string when this subnet has
+   * no finite value for the metric — the legend still lists it, so the user can
+   * see that the subnet was included but had nothing to plot.
+   */
+  path: string;
+  /** Most recent finite value, for the legend readout. */
+  last: number | null;
+}
+
+export interface OverlayGeometry {
+  /** Union of snapshot dates across all subnets, ascending — the shared x axis. */
+  dates: readonly string[];
+  series: readonly OverlaySeries[];
+  /** Shared y domain, so the series are directly comparable against each other. */
+  min: number;
+  max: number;
+}
+
+const PAD = 2;
+
+/**
+ * Project several subnets' history onto ONE set of shared axes.
+ *
+ * x is the union of snapshot dates (subnets registered at different times have
+ * different-length series, so indexing each series by its own position would
+ * silently misalign them in time). y is a single domain spanning every series,
+ * which is what makes the overlay a real comparison rather than four
+ * independently-normalised lines that imply a similarity that isn't there.
+ *
+ * A subnet missing a date the union has leaves a gap: the path starts a new
+ * subpath rather than interpolating across it, so absent data never renders as
+ * a straight line that looks like real measurement.
+ *
+ * Returns null when no subnet has a single finite value for the metric.
+ */
+export function buildOverlayGeometry(
+  inputs: readonly SubnetHistoryInput[],
+  field: SubnetHistoryField,
+  width: number,
+  height: number,
+): OverlayGeometry | null {
+  const valueByDate = inputs.map((input) => {
+    const map = new Map<string, number>();
+    for (const p of input.points) {
+      const v = p[field];
+      if (typeof p.snapshot_date === "string" && typeof v === "number" && Number.isFinite(v)) {
+        map.set(p.snapshot_date, v);
+      }
+    }
+    return map;
+  });
+
+  const dateSet = new Set<string>();
+  for (const map of valueByDate) for (const date of map.keys()) dateSet.add(date);
+  // ISO-8601 dates sort correctly as plain strings.
+  const dates = [...dateSet].sort();
+  if (dates.length === 0) return null;
+
+  let min = Infinity;
+  let max = -Infinity;
+  for (const map of valueByDate) {
+    for (const v of map.values()) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+
+  const span = max - min;
+  const innerHeight = height - PAD * 2;
+  const step = dates.length > 1 ? width / (dates.length - 1) : 0;
+  const round = (n: number) => Math.round(n * 100) / 100;
+
+  const series = inputs.map((input, i) => {
+    const map = valueByDate[i]!;
+    // Contiguous runs of present dates; a missing date closes the current run.
+    const runs: Array<Array<[number, number]>> = [];
+    let run: Array<[number, number]> = [];
+    let last: number | null = null;
+
+    for (let di = 0; di < dates.length; di += 1) {
+      const v = map.get(dates[di]!);
+      if (v === undefined) {
+        if (run.length > 0) runs.push(run);
+        run = [];
+        continue;
+      }
+      last = v;
+      // A flat series (span 0) sits on the vertical centre rather than pinned to
+      // an edge, matching how a single-value Sparkline reads.
+      const x = dates.length > 1 ? di * step : width / 2;
+      const y = span === 0 ? height / 2 : height - PAD - ((v - min) / span) * innerHeight;
+      run.push([round(x), round(y)]);
+    }
+    if (run.length > 0) runs.push(run);
+
+    // A lone point is emitted as a zero-length line so stroke-linecap="round"
+    // renders it as a dot — a bare moveto would draw nothing at all.
+    const path = runs
+      .map((r) =>
+        r.length === 1
+          ? `M${r[0]![0]} ${r[0]![1]}L${r[0]![0]} ${r[0]![1]}`
+          : r.map(([x, y], j) => `${j === 0 ? "M" : "L"}${x} ${y}`).join(""),
+      )
+      .join("");
+
+    return { netuid: input.netuid, color: subnetSeriesColor(i), path, last };
+  });
+
+  return { dates, series, min, max };
+}


### PR DESCRIPTION
## Summary

- Adds a **History** tab to the compare drawer's expanded view, alongside the existing `CompareGrid`, overlaying every selected subnet's `/subnets/{netuid}/history` series on **one** set of shared axes — the time-series counterpart to the grid's instant metrics.
- Extracts the window + metric vocabulary that `subnet-history-chart.tsx` already had inline into `lib/metagraphed/subnet-history-metrics.ts`, and rewires the single-subnet chart to consume it, so the overlay's picker offers exactly the four metrics the per-subnet chart exposes rather than a parallel copy that can drift.
- No new endpoint and no new charting stack: N calls to the already-shipped history endpoint via `useQueries` (the existing idiom in `validator-apy-panel.tsx` / `your-positions-panel.tsx`), drawn as hand-rolled SVG the same way every other chart here is. No dependency added.
- Selection and its cap stay owned by `useCompareSelection`; series colours use the existing `--chart-N` tokens and the established `PALETTE[i % PALETTE.length]` idiom (`explorer.tsx`, `providers.index.tsx`).

> This supersedes #6922, which was closed. That version had a real mobile defect: at 375px the metric picker's full labels overflowed the segmented control and **wrapped onto a second row**, orphaning "TOTAL EMISSION" inside the shared border. This PR fixes that and tightens the whole panel on mobile — see the measurements below.

### Mobile layout, measured

The expanded panel is now **shorter than the Metrics panel that ships today**, so it covers less of the page, not more. Measured on the real rendered page (drawer card `getBoundingClientRect` vs `innerHeight`):

| Viewport | Metrics tab (ships today) | History tab (this PR) |
| --- | --- | --- |
| Mobile 375×812 | 427px — 53% of viewport | **398px — 49%** |
| Tablet 768×1024 | 395px — 39% | **375px — 37%** |
| Desktop 1280×800 | 395px — 49% | **375px — 47%** |

How that was achieved, all mobile-only:

- **The segmented controls never wrap.** Each group is a single non-wrapping row that scrolls horizontally only if it still cannot fit; the two groups stack at `<sm` and share one line from `sm` up. A wrapping segmented control is what made the previous version read as broken.
- **A compact `shortLabel` for the picker** ("Stake" / "Emission" instead of "Total stake" / "Total emission"). Same four metrics; the single-subnet chart keeps the full `label` for its wider row layout. This is what lets the four options fit one row at 375px without scrolling.
- **`h-28` chart on mobile, `sm:h-40` from tablet up.** Three series stay legible at the shorter height.

### Two deliberate charting decisions, called out for review

- **One shared y domain across all series, in absolute units — not per-series normalisation.** Normalising each subnet to its own 0–100% would make unrelated curves look comparable when they aren't. The tradeoff is real: comparing subnets of very different magnitude compresses the smaller one toward the axis. Absolute is the honest default; an index-to-100 toggle would be a reasonable follow-up but is beyond this issue's scope, so I did not invent one.
- **Gaps break the line rather than interpolating.** The x axis is the *union* of snapshot dates across the selected subnets, since subnets registered at different times have different-length series and indexing each by its own position would silently misalign them in time. Where a subnet has no value for a date another subnet reported, the path starts a new subpath — absent data never renders as a straight segment that reads like real measurement.

## Files touched

- `apps/ui/src/lib/metagraphed/subnet-history-metrics.ts` (new) — shared window/metric vocabulary plus `buildOverlayGeometry`, the pure projection of N subnets onto shared axes. No React, so it is directly unit-testable.
- `apps/ui/src/lib/metagraphed/subnet-history-metrics.test.ts` (new) — 17 tests: shared-axis alignment, shared y domain, gap breaking, isolated-point and flat-series edge cases, domain-extreme mapping, colour cycling, metric/window parity with the single-subnet chart, and a width budget asserting the picker labels fit a 375px control (the regression that closed #6922).
- `apps/ui/src/components/metagraphed/subnets-compare-history-chart.tsx` (new) — the overlay: metric picker, window selector, legend with per-subnet latest value, loading/error/empty states.
- `apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx` — adds the Metrics/History tablist above the expanded content; `CompareGrid` itself is unchanged.
- `apps/ui/src/components/metagraphed/subnet-history-chart.tsx` — consumes the shared vocabulary. Rendering unchanged: metric order, colours, full labels, and the count metrics' default formatting are all preserved (`format` stays optional so the count rows keep the Sparkline default).

## Verification

- `npm run lint --workspace=apps/ui` — 0 errors (241 pre-existing `react-refresh` warnings elsewhere, untouched).
- `npm run format:check --workspace=apps/ui` — clean.
- `npm run typecheck --workspace=apps/ui` — clean.
- `npm test --workspace=apps/ui` — 168 files / 1290 tests passing, 17 of them in the new file.
- `npm run test:e2e --workspace=apps/ui` — 28/28 passing, including the responsive-overflow check.
- `npm run build --workspace=apps/ui` — succeeds.
- **Both axes asserted at every captured combination**, not just horizontal: `scrollWidth <= clientWidth`, the drawer card fully inside the viewport (`top >= 0 && bottom <= innerHeight`), and no `[role="tablist"]` taller than a single button row. All 12 shots report clean on all three. `/subnets` with an expanded drawer is not covered by the e2e overflow baseline, so this was checked explicitly during capture.
- Captured against the **live** production API (`api.metagraph.sh`) with real history for SN1 / SN8 / SN64 — the legend values in the shots (2.58M / 3.02M / 3.73M τ) match the endpoint's own last data point.

## Screenshot table

3 viewports × 2 themes × before/after, `/subnets` with SN1 / SN8 / SN64 selected and the drawer expanded. The drawer is `fixed bottom-0`, so it is in frame at any scroll position. **Before** is the expanded drawer as it ships today (the metrics grid); **after** is the same drawer on the new History tab.

| Viewport · Theme | Before | After |
| ---------------- | ------ | ----- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-mobile-dark.png)<br><sub>after</sub> |

On mobile, because the History panel is shorter than the grid, the page's own description line ("Every active Finney netuid — root and application — with curation level, surface count, health, and freshness.") is fully readable above the drawer, where the before state clips it mid-sentence.

### Existing Metrics view — no regression

The same *after* build sitting on the **Metrics** tab, against the identical before shots. The grid renders exactly as it does today; only the tablist above it is new.

| Viewport · Theme | Before | After (Metrics tab) |
| ---------------- | ------ | ------------------- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6885
