### PR TITLE
feat(api): chain-wide account balance snapshot (#6742)

### DIFF
--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -222,6 +222,26 @@ CREATE TABLE IF NOT EXISTS nominator_positions (
   PRIMARY KEY (coldkey, hotkey, netuid)
 );
 
+-- ---------------------------------------------------------------------------
+-- Chain-wide account balance snapshot (#6741/#6742) -- the balance-based
+-- top-holder leaderboard epic's foundational data tier. One row per account
+-- with a nonzero free or reserved balance, from a direct System::Account
+-- storage-map scan (scripts/fetch-account-balances.py) -- NOT reconstructed
+-- from transfer/stake/fee events, which can silently drift if any mutation
+-- path is missed. Covers every account that has ever held a balance,
+-- registered neuron or not -- joined with `neurons`.stake_tao at the API
+-- layer for the "Delegated"/"Total" leaderboard columns, not duplicated
+-- here.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS account_balances (
+  ss58          TEXT NOT NULL,
+  free_tao      NUMERIC NOT NULL,
+  reserved_tao  NUMERIC NOT NULL,
+  captured_at   BIGINT NOT NULL,
+  PRIMARY KEY (ss58)
+);
+CREATE INDEX IF NOT EXISTS idx_account_balances_free_tao ON account_balances (free_tao DESC);
+
 -- Daily per-UID history (mirror of D1 `neuron_daily`, ~10.8M rows / 370d).
 CREATE TABLE IF NOT EXISTS neuron_daily (
   netuid           INTEGER NOT NULL,

--- a/scripts/fetch-account-balances.py
+++ b/scripts/fetch-account-balances.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Chain-wide account balance snapshot (#6742) -- the balance-based
+top-holder leaderboard epic's (#6741) foundational data tier.
+
+Reads System::Account directly via a raw storage-map scan
+(query_map("System", "Account")) rather than reconstructing free/reserved
+balance from transfer/stake/fee events: a direct state read is ground-truth
+by construction (whatever the chain has stored right now), whereas
+event-replay requires catching every possible mutation path (transaction
+fees, existential-deposit reaping, staking rewards, slashing) with zero
+misses -- one missed event type silently drifts the number. This codebase's
+own stated bar for this data ("a true hub of accuracy") is best served by
+the read that can't drift, not the reconstruction that could.
+
+Covers EVERY account that has ever held a balance on-chain, not just
+registered neurons or addresses already seen in account_events -- System is
+the ground truth for existence itself; deriving scope from our own
+already-indexed activity would silently miss any address that only ever
+received a balance and never did anything we happen to index.
+
+Scale (measured live against our own fullnode, 2026-07-19): 542,618 total
+System::Account entries, key enumeration alone in ~91s. Comparable in row
+count to fetch-validator-nominator-counts.py's own 762,577-row Alpha scan
+(249s at ~3,100 rows/sec) -- same query_map(page_size=...) mechanism, same
+cost tier, no per-row runtime-API call (unlike fetch-self-stake.py's
+much more expensive get_stake() path).
+
+AccountInfo's `data` field is `{ free, reserved, frozen, flags }` (u128 each,
+raw planck/rao units, NOT wrapped in a bittensor SDK Balance object the way
+stake amounts are -- System::Account is a plain frame-system type, not a
+bittensor-specific one). Converted via the same whole/remainder split
+to_tao_exact uses elsewhere in this codebase, to avoid the >2**53 rao
+double-rounding a naive float(rao)/1e9 would introduce for real whale
+balances.
+
+Run: uv run --with bittensor python scripts/fetch-account-balances.py
+"""
+import argparse
+import json
+import os
+import sys
+import time
+
+OUT = os.environ.get("ACCOUNT_BALANCES_JSON", "dist/account-balances.json")
+PROGRESS_INTERVAL_S = 30
+QUERY_MAP_PAGE_SIZE = 1000
+# Above this fraction of scanned entries erroring out (malformed AccountInfo,
+# a decode failure), treat the run as systemically broken rather than
+# publishing a mostly-empty snapshot as if it were complete.
+MAX_ERROR_RATE = 0.5
+
+
+def _unwrap(value):
+    return value.value if hasattr(value, "value") else value
+
+
+def rao_to_tao_exact(rao):
+    """Exact rao->TAO conversion for a plain int, without the double-
+    rounding a naive float(rao)/1e9 introduces above 2**53 rao (~9M TAO) --
+    same whole/remainder split fetch-metagraph-native.py's to_tao_exact uses
+    for Balance objects, applied directly to a raw int since System::Account
+    values are plain frame-system u128s, not bittensor Balance instances."""
+    if rao is None:
+        return None
+    try:
+        rao = int(rao)
+    except (TypeError, ValueError):
+        return None
+    whole = rao // 1_000_000_000
+    remainder = (rao % 1_000_000_000) / 1e9
+    return whole + remainder
+
+
+def main():
+    import bittensor as bt  # lazy: matches every other chain-direct fetch script
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--network", default=os.environ.get("SUBTENSOR_RPC_URL") or "finney"
+    )
+    args = parser.parse_args()
+
+    s = bt.SubtensorApi(network=args.network)
+
+    t0 = time.time()
+    last_report = t0
+    captured_at = int(time.time() * 1000)
+
+    rows = []
+    errors = []
+    scanned = 0
+    for key, value in s.substrate.query_map(
+        "System", "Account", page_size=QUERY_MAP_PAGE_SIZE
+    ):
+        scanned += 1
+        try:
+            ss58 = str(_unwrap(key))
+            info = _unwrap(value)
+            data = _unwrap(info["data"]) if isinstance(info, dict) else info.data
+            free_rao = int(_unwrap(data["free"] if isinstance(data, dict) else data.free))
+            reserved_rao = int(
+                _unwrap(data["reserved"] if isinstance(data, dict) else data.reserved)
+            )
+        except Exception as exc:  # noqa: BLE001 -- one bad row must not sink the run
+            errors.append(f"{exc}")
+            continue
+
+        # Existential-deposit-only/reaped accounts carry a real System::Account
+        # entry with zero free and zero reserved (e.g. a sufficients-only
+        # entry) -- skip rather than publish a meaningless all-zero row.
+        if free_rao == 0 and reserved_rao == 0:
+            continue
+
+        rows.append(
+            {
+                "ss58": ss58,
+                "free_tao": rao_to_tao_exact(free_rao),
+                "reserved_tao": rao_to_tao_exact(reserved_rao),
+                "captured_at": captured_at,
+            }
+        )
+
+        now = time.time()
+        if now - last_report >= PROGRESS_INTERVAL_S:
+            sys.stderr.write(
+                f"fetch-account-balances: {scanned} accounts scanned, "
+                f"{len(rows)} nonzero-balance row(s) so far, "
+                f"{now - t0:.0f}s elapsed\n"
+            )
+            last_report = now
+
+    os.makedirs(os.path.dirname(OUT) or ".", exist_ok=True)
+    with open(OUT, "w") as fh:
+        json.dump(rows, fh)
+    sys.stderr.write(
+        f"fetch-account-balances: wrote {len(rows)} nonzero-balance row(s) "
+        f"from {scanned} scanned account(s) ({len(errors)} error(s)) in "
+        f"{time.time() - t0:.0f}s -> {OUT}\n"
+    )
+    if errors:
+        sys.stderr.write(
+            "fetch-account-balances: sample errors: "
+            + "; ".join(errors[:5])
+            + "\n"
+        )
+    if scanned and len(errors) > scanned * MAX_ERROR_RATE:
+        sys.stderr.write(
+            f"fetch-account-balances: error rate {len(errors)}/{scanned} "
+            f"exceeds {MAX_ERROR_RATE:.0%} -- treating as a systemic "
+            "failure, not a partial snapshot\n"
+        )
+        sys.exit(1)
+    if not scanned:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_fetch_account_balances.py
+++ b/scripts/test_fetch_account_balances.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Unit tests for fetch-account-balances.py's pure rao->TAO conversion
+(#6742).
+
+Runnable both ways:
+
+    python3 scripts/test_fetch_account_balances.py
+    python3 -m pytest scripts/test_fetch_account_balances.py
+
+Loaded by path (hyphenated filename), same convention as
+test_fetch_self_stake.py. Does not import the real `bittensor` package --
+rao_to_tao_exact is pure arithmetic, no SDK objects involved.
+"""
+import importlib.util
+import os
+import unittest
+
+_FAB_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "fetch-account-balances.py"
+)
+_spec = importlib.util.spec_from_file_location("fetch_account_balances_under_test", _FAB_PATH)
+_fab = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_fab)
+
+rao_to_tao_exact = _fab.rao_to_tao_exact
+
+
+class RaoToTaoExactTest(unittest.TestCase):
+    def test_none_returns_none(self):
+        self.assertIsNone(rao_to_tao_exact(None))
+
+    def test_zero(self):
+        self.assertEqual(rao_to_tao_exact(0), 0)
+
+    def test_small_value_matches_plain_division(self):
+        self.assertEqual(rao_to_tao_exact(2_500_000_000), 2.5)
+
+    def test_non_numeric_returns_none(self):
+        self.assertIsNone(rao_to_tao_exact("not-a-number"))
+
+    def test_exact_above_2_53_rao_where_naive_float_division_loses_precision(self):
+        # 10,000,000 TAO in rao -- comfortably above 2**53 rao (~9M TAO),
+        # where a naive float(rao) / 1e9 starts losing low-order digits.
+        rao = 10_000_000_123_456_789
+        result = rao_to_tao_exact(rao)
+        naive = float(rao) / 1e9
+        self.assertNotEqual(result, naive)
+        self.assertAlmostEqual(result, 10_000_000.123456789, places=6)
+
+    def test_accepts_a_string_int_too(self):
+        # query_map's decoded values are sometimes stringified ints
+        # depending on the substrate-interface type registry's own
+        # representation -- confirm the int(rao) coercion handles that.
+        self.assertEqual(rao_to_tao_exact("2500000000"), 2.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -112,6 +112,8 @@ const validatorNominatorCountsQueryFailure = vi.hoisted(() => ({
 const subnetTemposQueryFailure = vi.hoisted(() => ({ error: null }));
 // State for the nominator-positions-sync WRITE (#5233) tests only.
 const nominatorPositionsSyncFailure = vi.hoisted(() => ({ error: null }));
+// State for the account-balances-sync WRITE (#6742) tests only.
+const accountBalancesSyncFailure = vi.hoisted(() => ({ error: null }));
 // State for the nominator_positions READ (#5233) tests only -- same
 // isolation purpose as subnetTemposQueryFailure above, but for
 // loadNominatorPositions' own SELECT.
@@ -212,6 +214,12 @@ vi.mock("postgres", () => ({
         /INSERT INTO nominator_positions\b/.test(text)
       ) {
         return Promise.reject(nominatorPositionsSyncFailure.error);
+      }
+      if (
+        accountBalancesSyncFailure.error &&
+        /INSERT INTO account_balances\b/.test(text)
+      ) {
+        return Promise.reject(accountBalancesSyncFailure.error);
       }
       if (
         nominatorPositionsQueryFailure.error &&
@@ -372,6 +380,7 @@ const HEALTH_CHECKS_SYNC_SECRET = "test-health-checks-sync-secret";
 const SUBNET_SNAPSHOT_SYNC_SECRET = "test-subnet-snapshot-sync-secret";
 const RPC_USAGE_SYNC_SECRET = "test-rpc-usage-sync-secret";
 const NOMINATOR_POSITIONS_SYNC_SECRET = "test-nominator-positions-sync-secret";
+const ACCOUNT_BALANCES_SYNC_SECRET = "test-account-balances-sync-secret";
 const env = {
   HYPERDRIVE: { connectionString: "postgres://mock" },
   NEURONS_SYNC_SECRET,
@@ -385,6 +394,7 @@ const env = {
   SUBNET_SNAPSHOT_SYNC_SECRET,
   RPC_USAGE_SYNC_SECRET,
   NOMINATOR_POSITIONS_SYNC_SECRET,
+  ACCOUNT_BALANCES_SYNC_SECRET,
 };
 const ctx = { waitUntil() {} };
 const req = (path, init) =>
@@ -409,6 +419,7 @@ beforeEach(() => {
   subnetTemposQueryFailure.error = null;
   nominatorPositionsSyncFailure.error = null;
   nominatorPositionsQueryFailure.error = null;
+  accountBalancesSyncFailure.error = null;
   neuronStakeByHotkeyQueryFailure.error = null;
   accountHistoryQueryFailure.error = null;
   subnetIdentitySyncFailure.error = null;
@@ -5329,6 +5340,210 @@ test("nominator-positions-sync issues a single INSERT for a payload at or under 
   expect(res.status).toBe(200);
   const insertCalls = sqlCalls.filter((call) =>
     call.text.includes("INSERT INTO nominator_positions"),
+  );
+  expect(insertCalls.length).toBe(1);
+});
+
+// #6742: POST /api/v1/internal/account-balances-sync -- the write path into
+// account_balances (see workers/data-api.mjs's handleAccountBalancesSync).
+// Same latest-only-upsert shape as nominator-positions-sync above, a
+// single-column key instead of a composite one.
+function accountBalanceRow(overrides = {}) {
+  return {
+    ss58: "5Whale1",
+    free_tao: 1000.5,
+    reserved_tao: 25.25,
+    captured_at: 1_780_000_000_000,
+    ...overrides,
+  };
+}
+
+function postAccountBalances(body, { secret, raw } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (secret !== undefined) headers["x-account-balances-sync-token"] = secret;
+  return req("/api/v1/internal/account-balances-sync", {
+    method: "POST",
+    headers,
+    body: raw !== undefined ? raw : JSON.stringify(body ?? []),
+  });
+}
+
+test("account-balances-sync rejects a missing or wrong token (401)", async () => {
+  const wrong = await postAccountBalances([accountBalanceRow()], {
+    secret: "nope",
+  });
+  expect(wrong.status).toBe(401);
+  const missing = await postAccountBalances([accountBalanceRow()]);
+  expect(missing.status).toBe(401);
+});
+
+test("account-balances-sync is disabled (503) when ACCOUNT_BALANCES_SYNC_SECRET is not configured", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/account-balances-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-account-balances-sync-token": ACCOUNT_BALANCES_SYNC_SECRET,
+      },
+      body: JSON.stringify([accountBalanceRow()]),
+    }),
+    { ...env, ACCOUNT_BALANCES_SYNC_SECRET: undefined },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("account-balances-sync returns 503 when the HYPERDRIVE binding is unavailable", async () => {
+  const res = await worker.fetch(
+    new Request("https://d/api/v1/internal/account-balances-sync", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-account-balances-sync-token": ACCOUNT_BALANCES_SYNC_SECRET,
+      },
+      body: JSON.stringify([accountBalanceRow()]),
+    }),
+    { ...env, HYPERDRIVE: undefined },
+    ctx,
+  );
+  expect(res.status).toBe(503);
+});
+
+test("account-balances-sync rejects malformed JSON (400)", async () => {
+  const res = await postAccountBalances(null, {
+    secret: ACCOUNT_BALANCES_SYNC_SECRET,
+    raw: "{not json",
+  });
+  expect(res.status).toBe(400);
+});
+
+test("account-balances-sync rejects a body that isn't an array (400)", async () => {
+  const res = await postAccountBalances(null, {
+    secret: ACCOUNT_BALANCES_SYNC_SECRET,
+    raw: JSON.stringify({ nope: true }),
+  });
+  expect(res.status).toBe(400);
+});
+
+test("account-balances-sync rejects an empty array (400)", async () => {
+  const res = await postAccountBalances([], {
+    secret: ACCOUNT_BALANCES_SYNC_SECRET,
+  });
+  expect(res.status).toBe(400);
+});
+
+test("account-balances-sync rejects a body over the byte cap (413)", async () => {
+  const res = await postAccountBalances(null, {
+    secret: ACCOUNT_BALANCES_SYNC_SECRET,
+    raw: "[" + "1".repeat(200_000_001) + "]",
+  });
+  expect(res.status).toBe(413);
+});
+
+test("account-balances-sync rejects more rows than the per-request cap (413)", async () => {
+  const rows = Array.from({ length: 1_000_001 }, (_, i) =>
+    accountBalanceRow({ ss58: `5Whale${i}` }),
+  );
+  const res = await postAccountBalances(rows, {
+    secret: ACCOUNT_BALANCES_SYNC_SECRET,
+  });
+  expect(res.status).toBe(413);
+});
+
+test("account-balances-sync rejects a non-object/array row (400)", async () => {
+  const nullRow = await postAccountBalances(null, {
+    secret: ACCOUNT_BALANCES_SYNC_SECRET,
+    raw: JSON.stringify([null]),
+  });
+  expect(nullRow.status).toBe(400);
+
+  const arrayRow = await postAccountBalances(null, {
+    secret: ACCOUNT_BALANCES_SYNC_SECRET,
+    raw: JSON.stringify([["not", "an", "object"]]),
+  });
+  expect(arrayRow.status).toBe(400);
+});
+
+test("account-balances-sync rejects a row missing a required field or carrying an unknown key (400)", async () => {
+  const missingSs58 = await postAccountBalances(
+    [accountBalanceRow({ ss58: "" })],
+    { secret: ACCOUNT_BALANCES_SYNC_SECRET },
+  );
+  expect(missingSs58.status).toBe(400);
+
+  const negativeFree = await postAccountBalances(
+    [accountBalanceRow({ free_tao: -1 })],
+    { secret: ACCOUNT_BALANCES_SYNC_SECRET },
+  );
+  expect(negativeFree.status).toBe(400);
+
+  const negativeReserved = await postAccountBalances(
+    [accountBalanceRow({ reserved_tao: -1 })],
+    { secret: ACCOUNT_BALANCES_SYNC_SECRET },
+  );
+  expect(negativeReserved.status).toBe(400);
+
+  const badCapturedAt = await postAccountBalances(
+    [accountBalanceRow({ captured_at: "not-a-number" })],
+    { secret: ACCOUNT_BALANCES_SYNC_SECRET },
+  );
+  expect(badCapturedAt.status).toBe(400);
+
+  const unknownKey = await postAccountBalances(
+    [{ ...accountBalanceRow(), extra: 1 }],
+    { secret: ACCOUNT_BALANCES_SYNC_SECRET },
+  );
+  expect(unknownKey.status).toBe(400);
+});
+
+test("account-balances-sync accepts the wrapped {rows:[...]} form and upserts on ss58", async () => {
+  const res = await postAccountBalances(
+    { rows: [accountBalanceRow()] },
+    { secret: ACCOUNT_BALANCES_SYNC_SECRET },
+  );
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({ ok: true, account_balances_written: 1 });
+  expect(queryText()).toMatch(/INSERT INTO account_balances/);
+  expect(queryText()).toMatch(/ON CONFLICT \(ss58\)/);
+});
+
+test("account-balances-sync maps a DB failure to a clean 502 instead of throwing", async () => {
+  accountBalancesSyncFailure.error = new Error("connection reset");
+  const res = await postAccountBalances([accountBalanceRow()], {
+    secret: ACCOUNT_BALANCES_SYNC_SECRET,
+  });
+  expect(res.status).toBe(502);
+  expect((await res.json()).error).toBe("write failed");
+});
+
+test("account-balances-sync splits a payload over the per-statement param cap into multiple INSERT statements", async () => {
+  const MAX_ROWS_PER_BATCH = 10_000; // must match workers/data-api.mjs's own constant
+  const rows = Array.from({ length: MAX_ROWS_PER_BATCH + 1 }, (_, i) =>
+    accountBalanceRow({ ss58: `5Whale${i}` }),
+  );
+  const res = await postAccountBalances(rows, {
+    secret: ACCOUNT_BALANCES_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  expect((await res.json()).account_balances_written).toBe(rows.length);
+  const insertCalls = sqlCalls.filter((call) =>
+    call.text.includes("INSERT INTO account_balances"),
+  );
+  expect(insertCalls.length).toBe(2);
+});
+
+test("account-balances-sync issues a single INSERT for a payload at or under the per-statement batch size", async () => {
+  const rows = [
+    accountBalanceRow({ ss58: "5Whale1" }),
+    accountBalanceRow({ ss58: "5Whale2" }),
+  ];
+  const res = await postAccountBalances(rows, {
+    secret: ACCOUNT_BALANCES_SYNC_SECRET,
+  });
+  expect(res.status).toBe(200);
+  const insertCalls = sqlCalls.filter((call) =>
+    call.text.includes("INSERT INTO account_balances"),
   );
   expect(insertCalls.length).toBe(1);
 });

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -2120,6 +2120,136 @@ async function handleNominatorPositionsSync(request, env) {
   }
 }
 
+// --- POST /api/v1/internal/account-balances-sync (#6742) -------------------
+//
+// Chain-wide free/reserved balance snapshot, one row per account with a
+// nonzero balance -- scripts/fetch-account-balances.py's own header comment
+// on why this reads System::Account directly rather than reconstructing
+// balance from transfer/fee/stake events (a direct state read can't drift;
+// event-replay can, one missed mutation path at a time). Same "latest-only,
+// captured_at freshness guard" upsert shape as nominator-positions-sync.
+const ACCOUNT_BALANCE_INSERT_COLUMNS = [
+  "ss58",
+  "free_tao",
+  "reserved_tao",
+  "captured_at",
+];
+const ACCOUNT_BALANCES_SYNC_TOKEN_HEADER = "x-account-balances-sync-token";
+// floor(65535 / 4 columns) = 16383 -- batchedUpsert's per-statement row cap,
+// rounded down for headroom, matching NOMINATOR_POSITIONS_MAX_ROWS_PER_BATCH's
+// own rounding for a different column count.
+const ACCOUNT_BALANCES_MAX_ROWS_PER_BATCH = 10_000;
+// Generous headroom over the ~543k total System::Account entries observed
+// in the live full-scan probe (2026-07-19, ~530k after filtering all-zero
+// accounts) -- same order of magnitude as nominator-positions-sync's own
+// ceiling, not a tight bound.
+const ACCOUNT_BALANCES_SYNC_MAX_BODY_BYTES = 200_000_000;
+const ACCOUNT_BALANCES_SYNC_MAX_ROWS = 1_000_000;
+
+function validAccountBalanceSyncRow(row) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return false;
+  if (typeof row.ss58 !== "string" || row.ss58.length === 0) return false;
+  if (!Number.isFinite(row.free_tao) || row.free_tao < 0) return false;
+  if (!Number.isFinite(row.reserved_tao) || row.reserved_tao < 0) return false;
+  if (!Number.isFinite(row.captured_at)) return false;
+  for (const key of Object.keys(row)) {
+    if (!ACCOUNT_BALANCE_INSERT_COLUMNS.includes(key)) return false;
+  }
+  return true;
+}
+
+async function handleAccountBalancesSync(request, env) {
+  if (!env.ACCOUNT_BALANCES_SYNC_SECRET) {
+    return writeJson(
+      { error: "account-balances sync is not provisioned on this deployment" },
+      503,
+    );
+  }
+  const provided =
+    request.headers.get(ACCOUNT_BALANCES_SYNC_TOKEN_HEADER) || "";
+  if (
+    !provided ||
+    !timingSafeEqual(provided, env.ACCOUNT_BALANCES_SYNC_SECRET)
+  ) {
+    return writeJson(
+      { error: `provide a valid ${ACCOUNT_BALANCES_SYNC_TOKEN_HEADER} header` },
+      401,
+    );
+  }
+  if (!env.HYPERDRIVE?.connectionString) {
+    return writeJson({ error: "hyperdrive binding unavailable" }, 503);
+  }
+
+  const raw = await request.text();
+  if (utf8Bytes(raw).length > ACCOUNT_BALANCES_SYNC_MAX_BODY_BYTES) {
+    return writeJson(
+      { error: `body exceeds ${ACCOUNT_BALANCES_SYNC_MAX_BODY_BYTES} bytes` },
+      413,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return writeJson({ error: "body must be JSON" }, 400);
+  }
+  const incoming = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.rows)
+      ? parsed.rows
+      : null;
+  if (!incoming) {
+    return writeJson(
+      {
+        error:
+          "body must be a JSON array of account-balance rows (or {rows:[...]})",
+      },
+      400,
+    );
+  }
+  if (incoming.length > ACCOUNT_BALANCES_SYNC_MAX_ROWS) {
+    return writeJson(
+      { error: `at most ${ACCOUNT_BALANCES_SYNC_MAX_ROWS} rows per request` },
+      413,
+    );
+  }
+  if (!incoming.length || !incoming.every(validAccountBalanceSyncRow)) {
+    return writeJson(
+      { error: "rows must match the account-balance row shape" },
+      400,
+    );
+  }
+
+  const sql = postgres(env.HYPERDRIVE.connectionString, {
+    max: 5,
+    prepare: false,
+    fetch_types: false,
+  });
+
+  try {
+    await sql.begin(async (sql) => {
+      await sql`SET statement_timeout = '20000ms'`;
+      await batchedUpsert(
+        sql,
+        incoming,
+        (sql, batch) => sql`
+          INSERT INTO account_balances ${sql(batch, ...ACCOUNT_BALANCE_INSERT_COLUMNS)}
+          ON CONFLICT (ss58) DO UPDATE SET
+            free_tao = EXCLUDED.free_tao,
+            reserved_tao = EXCLUDED.reserved_tao,
+            captured_at = EXCLUDED.captured_at
+          WHERE account_balances.captured_at <= EXCLUDED.captured_at`,
+        ACCOUNT_BALANCES_MAX_ROWS_PER_BATCH,
+      );
+    });
+    return writeJson({ ok: true, account_balances_written: incoming.length });
+  } catch (err) {
+    console.error("data-api account-balances-sync write failed:", err);
+    captureDataApiError(err, "account-balances-sync");
+    return writeJson({ error: "write failed" }, 502);
+  }
+}
+
 // --- POST /api/v1/internal/subnet-identity-sync (#4832 gap-closure) -------
 //
 // The write path into subnet_identity_history -- architecturally different
@@ -4214,6 +4344,12 @@ export default {
       url.pathname === "/api/v1/internal/nominator-positions-sync"
     ) {
       return handleNominatorPositionsSync(request, env);
+    }
+    if (
+      request.method === "POST" &&
+      url.pathname === "/api/v1/internal/account-balances-sync"
+    ) {
+      return handleAccountBalancesSync(request, env);
     }
     if (
       request.method === "POST" &&

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -54,6 +54,15 @@
   // Until WALLET_SESSION_SECRET is set, POST /api/v1/auth/wallet/verify and
   // every /api/v1/keys route 503; the rpc_accounts/api_keys.account_id
   // schema is otherwise live once this file's schema.sql is applied.
+  //
+  // Chain-wide account balance snapshot (#6741/#6742, the balance-based
+  // top-holder leaderboard epic's data tier) needs:
+  //   wrangler secret put ACCOUNT_BALANCES_SYNC_SECRET -c wrangler.data.jsonc
+  // Set on metagraphed-infra's account-balances data-refresh job too
+  // (roles/data-refresh-cron's vault, same secret_var convention every
+  // other sync job uses). Until set, POST /api/v1/internal/account-balances-sync
+  // 503s; the account_balances table is otherwise live once this file's
+  // schema.sql is applied.
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "metagraphed-data-api",
   // Sentry deploy-entry wrapper (metagraphed#6479/#6485), not the raw


### PR DESCRIPTION
## Summary

Foundational data tier for the balance-based top-holder leaderboard epic (#6741). Part of #6742 (that issue also asks for the periodic scheduling; this PR delivers the capture script + table + sync route -- the metagraphed-infra companion PR wires the actual scheduled job and closes #6742 once it's live). Reads `System::Account` directly via a storage-map scan rather than reconstructing free/reserved balance from transfer/stake/fee events -- a direct state read is ground-truth by construction, while event-replay can silently drift if any mutation path is missed. Covers every account that has ever held a balance, registered neuron or not.

Real numbers, not estimates: measured live against our own fullnode (2026-07-19), **542,618 total System::Account entries**, full key enumeration in ~91s, batch value reads (`state_queryStorageAt`, 1000/call) in ~4 more minutes -- comparable in scale to `fetch-validator-nominator-counts.py`'s own 762,577-row scan (that script's own docstring: "daily is comfortable" for this job class).

## Changes

- `scripts/fetch-account-balances.py` (+ `test_fetch_account_balances.py`): `query_map("System", "Account")`, matching `fetch-self-stake.py`'s established structure exactly -- lazy `bittensor` import, `MAX_ERROR_RATE` systemic-failure guard, progress logging every 30s. Correct rao->TAO conversion (whole/remainder split, avoids float precision loss above 2**53 rao for real whale balances).
- `deploy/postgres/schema.sql`: new `account_balances` table (`ss58` PK, `free_tao`, `reserved_tao`, `captured_at`), indexed on `free_tao DESC` for the leaderboard sort.
- `workers/data-api.mjs`: `handleAccountBalancesSync` (`POST /api/v1/internal/account-balances-sync`), same latest-only `batchedUpsert` shape as `nominator-positions-sync`.
- `wrangler.data.jsonc`: `ACCOUNT_BALANCES_SYNC_SECRET` provisioning documented.

## Follow-ups (separate PRs, per this repo's "one focused change per PR")

- metagraphed-infra: Ansible job definition (closes #6742) -- daily->hourly account-balances data-refresh job on the indexer box, hitting the fullnode over the internal tailnet, same as `fetch-self-stake.py`
- Top-holders leaderboard route (#6743)
- `get_top_holders` MCP tool (#6744)

## Validation

- Full suite: 333 files / 9832 tests passing
- `npm run lint`, `npm run scan:public-safety` clean
- `node scripts/worker-deploy-dry-run.mjs` passes
- `python3 scripts/test_fetch_account_balances.py` passes (6/6, local-only -- this repo's Python fetch-script tests aren't CI-gated, matching every sibling script's own convention)

Owner-authored PR (JSONbored) -- linked-issue/review-gate requirements don't apply.