### PR TITLE
feat(ui): alternate bubble/radar view for the /subnets table

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/subnet-bubble-data.test.ts
+++ b/apps/ui/src/components/metagraphed/charts/subnet-bubble-data.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSubnetBubblePoints,
+  percentileRanks,
+  type SubnetBubbleSource,
+} from "./subnet-bubble-data";
+
+describe("percentileRanks", () => {
+  it("returns an empty array for no values", () => {
+    expect(percentileRanks([])).toEqual([]);
+  });
+
+  it("places a single value at the 50 midpoint", () => {
+    expect(percentileRanks([42])).toEqual([50]);
+  });
+
+  it("spreads distinct values evenly from 0 to 100, preserving input order", () => {
+    expect(percentileRanks([30, 10, 20])).toEqual([100, 0, 50]);
+  });
+
+  it("places a tied pair at the mean rank of the tied group", () => {
+    // sorted: 5(pos0), 5(pos1), 10(pos2) -> tie group avg position (0+1)/2=0.5
+    // -> pct = 0.5/2*100 = 25; the distinct 10 is at position 2 -> pct 100.
+    expect(percentileRanks([5, 5, 10])).toEqual([25, 25, 100]);
+  });
+
+  it("places every value at 50 when the whole set is tied", () => {
+    expect(percentileRanks([7, 7, 7, 7])).toEqual([50, 50, 50, 50]);
+  });
+
+  it("handles a tie group in the middle of the range", () => {
+    // sorted: 1(0), 5(1), 5(2), 5(3), 9(4) -> tie group avg position (1+3)/2=2
+    // -> pct = 2/4*100 = 50.
+    expect(percentileRanks([9, 1, 5, 5, 5])).toEqual([100, 0, 50, 50, 50]);
+  });
+});
+
+describe("buildSubnetBubblePoints", () => {
+  it("returns an empty array for no rows", () => {
+    expect(buildSubnetBubblePoints([])).toEqual([]);
+  });
+
+  it("excludes rows missing emission_share", () => {
+    const rows: SubnetBubbleSource[] = [
+      { netuid: 1, surfaces_count: 10 },
+      { netuid: 2, emission_share: 0.01, surfaces_count: 10 },
+    ];
+    const out = buildSubnetBubblePoints(rows);
+    expect(out.map((p) => p.netuid)).toEqual([2]);
+  });
+
+  it("excludes rows missing surfaces_count", () => {
+    const rows: SubnetBubbleSource[] = [
+      { netuid: 1, emission_share: 0.01 },
+      { netuid: 2, emission_share: 0.01, surfaces_count: 10 },
+    ];
+    const out = buildSubnetBubblePoints(rows);
+    expect(out.map((p) => p.netuid)).toEqual([2]);
+  });
+
+  it("returns an empty array when every row lacks a required axis metric", () => {
+    const rows: SubnetBubbleSource[] = [{ netuid: 1 }, { netuid: 2, emission_share: 0.01 }];
+    expect(buildSubnetBubblePoints(rows)).toEqual([]);
+  });
+
+  it("positions x by emission_share percentile rank and inverts y so more surfaces renders higher", () => {
+    const rows: SubnetBubbleSource[] = [
+      { netuid: 1, emission_share: 0.01, surfaces_count: 5 },
+      { netuid: 2, emission_share: 0.05, surfaces_count: 20 },
+    ];
+    const out = buildSubnetBubblePoints(rows);
+    const low = out.find((p) => p.netuid === 1)!;
+    const high = out.find((p) => p.netuid === 2)!;
+    expect(low.xPct).toBe(0);
+    expect(high.xPct).toBe(100);
+    // fewer surfaces -> lower rank -> inverted to a HIGHER yPct (nearer the bottom).
+    expect(low.yPct).toBe(100);
+    expect(high.yPct).toBe(0);
+  });
+
+  it("centers every row at 50/50 when every row shares the same emission_share and surfaces_count", () => {
+    const rows: SubnetBubbleSource[] = [
+      { netuid: 1, emission_share: 0.02, surfaces_count: 10 },
+      { netuid: 2, emission_share: 0.02, surfaces_count: 10 },
+    ];
+    const out = buildSubnetBubblePoints(rows);
+    expect(out.every((p) => p.xPct === 50 && p.yPct === 50)).toBe(true);
+  });
+
+  it("defaults a missing candidates_count to 0", () => {
+    const rows: SubnetBubbleSource[] = [{ netuid: 1, emission_share: 0.01, surfaces_count: 5 }];
+    const out = buildSubnetBubblePoints(rows);
+    expect(out[0].candidatesCount).toBe(0);
+  });
+
+  it("sizes bubbles by sqrt-scaled candidates_count so area (not radius) is proportional", () => {
+    const rows: SubnetBubbleSource[] = [
+      { netuid: 1, emission_share: 0.01, surfaces_count: 5, candidates_count: 1 },
+      { netuid: 2, emission_share: 0.02, surfaces_count: 6, candidates_count: 4 },
+    ];
+    const out = buildSubnetBubblePoints(rows);
+    const small = out.find((p) => p.netuid === 1)!;
+    const big = out.find((p) => p.netuid === 2)!;
+    // sqrt(1/4) * 100 = 50, sqrt(4/4) * 100 = 100
+    expect(small.sizePct).toBe(50);
+    expect(big.sizePct).toBe(100);
+  });
+
+  it("falls back to sizePct 0 when every row's candidates_count is 0 (zero max)", () => {
+    const rows: SubnetBubbleSource[] = [
+      { netuid: 1, emission_share: 0.01, surfaces_count: 5, candidates_count: 0 },
+      { netuid: 2, emission_share: 0.02, surfaces_count: 6 },
+    ];
+    const out = buildSubnetBubblePoints(rows);
+    expect(out.every((p) => p.sizePct === 0)).toBe(true);
+  });
+
+  it("defaults a missing health to unknown", () => {
+    const rows: SubnetBubbleSource[] = [{ netuid: 1, emission_share: 0.01, surfaces_count: 5 }];
+    const out = buildSubnetBubblePoints(rows);
+    expect(out[0].health).toBe("unknown");
+  });
+
+  it("passes through a provided health value", () => {
+    const rows: SubnetBubbleSource[] = [
+      { netuid: 1, emission_share: 0.01, surfaces_count: 5, health: "ok" },
+    ];
+    const out = buildSubnetBubblePoints(rows);
+    expect(out[0].health).toBe("ok");
+  });
+
+  it("interpolates diameterPx between the default min/max bounds by sizePct", () => {
+    const rows: SubnetBubbleSource[] = [
+      { netuid: 1, emission_share: 0.01, surfaces_count: 5, candidates_count: 0 },
+      { netuid: 2, emission_share: 0.02, surfaces_count: 6, candidates_count: 4 },
+    ];
+    const out = buildSubnetBubblePoints(rows);
+    expect(out.find((p) => p.netuid === 1)!.diameterPx).toBe(14);
+    expect(out.find((p) => p.netuid === 2)!.diameterPx).toBe(48);
+  });
+
+  it("honors custom min/max diameter bounds", () => {
+    const rows: SubnetBubbleSource[] = [
+      { netuid: 1, emission_share: 0.01, surfaces_count: 5, candidates_count: 0 },
+      { netuid: 2, emission_share: 0.02, surfaces_count: 6, candidates_count: 4 },
+    ];
+    const out = buildSubnetBubblePoints(rows, { minDiameterPx: 10, maxDiameterPx: 20 });
+    expect(out.find((p) => p.netuid === 1)!.diameterPx).toBe(10);
+    expect(out.find((p) => p.netuid === 2)!.diameterPx).toBe(20);
+  });
+
+  it("carries netuid/name/symbol through unchanged", () => {
+    const rows: SubnetBubbleSource[] = [
+      {
+        netuid: 7,
+        name: "Subnet Seven",
+        symbol: "SEV",
+        emission_share: 0.01,
+        surfaces_count: 5,
+      },
+    ];
+    const out = buildSubnetBubblePoints(rows);
+    expect(out[0]).toMatchObject({ netuid: 7, name: "Subnet Seven", symbol: "SEV" });
+  });
+});

--- a/apps/ui/src/components/metagraphed/charts/subnet-bubble-data.ts
+++ b/apps/ui/src/components/metagraphed/charts/subnet-bubble-data.ts
@@ -1,0 +1,150 @@
+/**
+ * Pure "shape the /subnets list into bubble/radar chart points" logic (#6884).
+ * Kept separate from the rendering component (subnet-bubble-view.tsx) so the
+ * axis-normalization and size-scaling math get direct unit coverage without a
+ * React render — mirrors validator-dominance-ranking.ts's split.
+ *
+ * Axis defaults, chosen from what's already sortable on the /subnets table
+ * today, what get_registry_leaderboards ranks by, AND verified against live
+ * /api/v1/subnets + /api/v1/economics data before picking (129 live subnets,
+ * 2026-07-19):
+ *   - X = emission_share: already the sortable "Emission" table column; the
+ *     direct client analogue of the "highest-emission" leaderboard board.
+ *     127/129 subnets have a distinct value live — the best-spread economic
+ *     metric already on the row (participants was rejected: 109/129 subnets
+ *     sit at the exact 256-slot cap, which would collapse most bubbles onto
+ *     one x position; integration_readiness was rejected for the same
+ *     reason — 90/129 cluster on just two tiers, 83 and 86).
+ *   - Y = surfaces_count: already the sortable "Surfaces" table column; the
+ *     closest client-visible analogue to the "most-complete" /
+ *     "most-enriched" boards (breadth of registered surfaces). 25 distinct
+ *     values live, no single value shared by more than ~20 rows.
+ *   - size = candidates_count: unreviewed candidate-surface backlog, already
+ *     on every row from the base /api/v1/subnets payload (`candidate_count`,
+ *     normalized by normalizeSubnet) — a third, independent dimension
+ *     (community-discovered activity) that doesn't collapse onto either
+ *     axis. 16 distinct values live, well spread.
+ *   - color = health: already a table column + filter; the direct client
+ *     analogue to the "healthiest" leaderboard board.
+ * All four are already fetched for the existing table (no new query).
+ *
+ * Position uses PERCENTILE RANK, not linear min-max scaling. emission_share
+ * and surfaces_count are both power-law distributed in the live registry
+ * (most subnets earn a small emission share and carry few surfaces, with a
+ * long tail of outliers) — a linear scale would crush the majority into one
+ * corner. Percentile rank spreads every row across the full axis by relative
+ * standing instead, which is what a "scan for outliers" view needs: the
+ * bubbles that matter are the ones far from their peers, not the ones with a
+ * large absolute number.
+ */
+
+/** Minimal shape this module needs from a joined /subnets row. */
+export interface SubnetBubbleSource {
+  netuid: number;
+  name?: string | null;
+  symbol?: string | null;
+  emission_share?: number;
+  surfaces_count?: number;
+  candidates_count?: number;
+  health?: string;
+}
+
+/** One chart-ready bubble, pre-positioned as percentages of the plot area. */
+export interface SubnetBubblePoint {
+  netuid: number;
+  name?: string | null;
+  symbol?: string | null;
+  health: string;
+  emissionShare: number;
+  surfacesCount: number;
+  candidatesCount: number;
+  /** 0-100 position along the x axis (emission_share percentile rank), left to right. */
+  xPct: number;
+  /** 0-100 position along the y axis (surfaces_count percentile rank); more surfaces renders nearer the top. */
+  yPct: number;
+  /** 0-100 relative size, sqrt-scaled so bubble AREA (not radius) is proportional to candidatesCount. */
+  sizePct: number;
+  /** Bubble diameter in px, linearly interpolated between the configured min/max bounds. */
+  diameterPx: number;
+}
+
+export interface SubnetBubbleLayoutOptions {
+  /** Bubble diameter in px for the smallest candidates_count in the set. */
+  minDiameterPx?: number;
+  /** Bubble diameter in px for the largest candidates_count in the set. */
+  maxDiameterPx?: number;
+}
+
+const DEFAULT_MIN_DIAMETER_PX = 14;
+const DEFAULT_MAX_DIAMETER_PX = 48;
+const DEFAULT_HEALTH = "unknown";
+
+/**
+ * Percentile rank (0-100) for each value in `values`, preserving input
+ * order. Uses fractional ("average") ranking for ties — values sharing an
+ * exact tie are placed at the mean rank position of the tied group, rather
+ * than stacked in input order or all pinned to the same edge. A single value
+ * (n === 1) has no meaningful spread, so it's placed at the midpoint (50).
+ */
+export function percentileRanks(values: readonly number[]): number[] {
+  const n = values.length;
+  if (n === 0) return [];
+  if (n === 1) return [50];
+
+  const order = values.map((_, i) => i).sort((a, b) => values[a] - values[b]);
+  const avgPositionByValue = new Map<number, number>();
+  let i = 0;
+  while (i < n) {
+    let j = i;
+    while (j + 1 < n && values[order[j + 1]] === values[order[i]]) j++;
+    avgPositionByValue.set(values[order[i]], (i + j) / 2);
+    i = j + 1;
+  }
+  return values.map((v) => (avgPositionByValue.get(v)! / (n - 1)) * 100);
+}
+
+/**
+ * Build normalized bubble points from joined /subnets rows. Rows missing
+ * either axis metric (emission_share or surfaces_count) are excluded —
+ * there's nothing meaningful to plot without both coordinates.
+ * `candidates_count` and `health` are treated as optional/defaultable since
+ * they only drive size and color, not position.
+ */
+export function buildSubnetBubblePoints(
+  rows: readonly SubnetBubbleSource[],
+  options: SubnetBubbleLayoutOptions = {},
+): SubnetBubblePoint[] {
+  const minDiameterPx = options.minDiameterPx ?? DEFAULT_MIN_DIAMETER_PX;
+  const maxDiameterPx = options.maxDiameterPx ?? DEFAULT_MAX_DIAMETER_PX;
+
+  const plottable = rows.filter(
+    (r): r is SubnetBubbleSource & { emission_share: number; surfaces_count: number } =>
+      typeof r.emission_share === "number" && typeof r.surfaces_count === "number",
+  );
+  if (plottable.length === 0) return [];
+
+  const xRanks = percentileRanks(plottable.map((r) => r.emission_share));
+  const yRanksRaw = percentileRanks(plottable.map((r) => r.surfaces_count));
+  const sizes = plottable.map((r) => r.candidates_count ?? 0);
+  const sizeMax = Math.max(...sizes);
+
+  return plottable.map((r, idx) => {
+    const size = r.candidates_count ?? 0;
+    const sizePct = sizeMax > 0 ? Math.sqrt(size / sizeMax) * 100 : 0;
+    const diameterPx = minDiameterPx + (sizePct / 100) * (maxDiameterPx - minDiameterPx);
+    return {
+      netuid: r.netuid,
+      name: r.name,
+      symbol: r.symbol,
+      health: r.health ?? DEFAULT_HEALTH,
+      emissionShare: r.emission_share,
+      surfacesCount: r.surfaces_count,
+      candidatesCount: size,
+      xPct: xRanks[idx],
+      // Invert so higher surfaces_count renders nearer the top of the plot area.
+      yPct: 100 - yRanksRaw[idx],
+      sizePct,
+      diameterPx,
+    };
+  });
+}

--- a/apps/ui/src/components/metagraphed/charts/subnet-bubble-view.tsx
+++ b/apps/ui/src/components/metagraphed/charts/subnet-bubble-view.tsx
@@ -1,0 +1,113 @@
+import { Link } from "@tanstack/react-router";
+import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
+import { EmptyState } from "@/components/metagraphed/states";
+import { classNames } from "@/lib/metagraphed/format";
+import type { Subnet } from "@/lib/metagraphed/types";
+import { buildSubnetBubblePoints } from "./subnet-bubble-data";
+
+// #6884: bubble/radar alternate view for /subnets. Position encodes two axes,
+// bubble size a third metric, color a fourth — see subnet-bubble-data.ts for
+// why these four were picked (and why raw values are rank-normalized, not
+// linearly scaled). Takes the SAME already-filtered/sorted `rows`
+// SubnetGrid/SubnetMatrix render, so the table's category/health/etc. filters
+// carry over automatically; no separate filter surface.
+
+type SubnetBubbleRow = Subnet & {
+  health?: string;
+  emission_share?: number;
+  candidates_count?: number;
+};
+
+const HEALTH_DOT: Record<string, string> = {
+  ok: "bg-health-ok/80 hover:bg-health-ok",
+  warn: "bg-health-warn/75 hover:bg-health-warn",
+  down: "bg-health-down/80 hover:bg-health-down",
+  unknown: "bg-health-unknown/40 hover:bg-health-unknown/70",
+};
+
+function Legend({ colorClass, label }: { colorClass: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className={classNames("size-2 rounded-full", colorClass)} />
+      {label}
+    </span>
+  );
+}
+
+function formatEmission(share: number): string {
+  return `${(share * 100).toFixed(3)}%`;
+}
+
+export function SubnetBubbleView({ rows }: { rows: SubnetBubbleRow[] }) {
+  const points = buildSubnetBubblePoints(rows);
+
+  if (points.length === 0) {
+    return (
+      <EmptyState
+        title="Nothing to plot"
+        description="No subnets in the current filter have both an emission share and a surface count."
+      />
+    );
+  }
+
+  return (
+    <div className="rounded border border-border bg-card p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          Bubble view · {points.length} subnets
+        </div>
+        <div className="flex flex-wrap items-center gap-3 text-[10px] font-mono text-ink-muted">
+          <Legend colorClass="bg-health-ok" label="ok" />
+          <Legend colorClass="bg-health-warn" label="warn" />
+          <Legend colorClass="bg-health-down" label="down" />
+          <Legend colorClass="bg-health-unknown" label="unknown" />
+          <span className="text-ink-subtle">size = candidate surfaces</span>
+        </div>
+      </div>
+
+      <div className="flex items-stretch gap-2">
+        <div
+          className="flex w-4 shrink-0 flex-col items-center justify-between py-1 font-mono text-[9px] uppercase tracking-widest text-ink-subtle"
+          aria-hidden
+          style={{ writingMode: "vertical-rl" }}
+        >
+          <span>more surfaces</span>
+          <span>fewer surfaces</span>
+        </div>
+        <div className="min-w-0 flex-1">
+          <div
+            className="relative h-[360px] w-full overflow-visible rounded border border-border/70 bg-paper/40 sm:h-[440px] md:h-[520px]"
+            role="img"
+            aria-label={`Bubble chart of ${points.length} subnets: x axis emission share (percentile rank), y axis surface count (percentile rank), bubble size candidate-surface count, color health state`}
+          >
+            {points.map((p) => (
+              <EntityHoverCard key={p.netuid} kind="subnet" netuid={p.netuid}>
+                <Link
+                  to="/subnets/$netuid"
+                  params={{ netuid: p.netuid }}
+                  aria-label={`Subnet ${p.netuid}${p.name ? ` — ${p.name}` : ""} · emission ${formatEmission(p.emissionShare)} · ${p.surfacesCount} surfaces · ${p.candidatesCount} candidates · ${p.health}`}
+                  title={`#${p.netuid}${p.name ? ` · ${p.name}` : ""} · emission ${formatEmission(p.emissionShare)} · ${p.surfacesCount} surfaces · ${p.candidatesCount} candidates`}
+                  className={classNames(
+                    "mg-focus-ring absolute flex -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-border/60 font-mono text-[9px] font-medium text-white/95 transition-transform hover:z-10 hover:scale-110 focus-visible:z-10 focus-visible:scale-110",
+                    HEALTH_DOT[p.health] ?? HEALTH_DOT.unknown,
+                  )}
+                  style={{
+                    left: `${p.xPct}%`,
+                    top: `${p.yPct}%`,
+                    width: `${p.diameterPx}px`,
+                    height: `${p.diameterPx}px`,
+                  }}
+                >
+                  {p.diameterPx >= 24 ? p.netuid : null}
+                </Link>
+              </EntityHoverCard>
+            ))}
+          </div>
+          <div className="mt-1 text-right font-mono text-[9px] uppercase tracking-widest text-ink-subtle">
+            Emission share →
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -37,7 +37,7 @@ export const tableSearchSchema = z.object({
   includeRoot: fallback(z.boolean(), true).default(true),
   // Layout state for list routes that support multiple views + row density.
   // Additive + optional with safe fallbacks so the toggles persist in the URL.
-  view: fallback(z.enum(["table", "grid", "matrix"]), "table").default("table"),
+  view: fallback(z.enum(["table", "grid", "matrix", "bubble"]), "table").default("table"),
   density: fallback(z.enum(["comfortable", "compact"]), "comfortable").default("comfortable"),
 });
 

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -39,6 +39,7 @@ import {
   SortHeader,
 } from "@/components/metagraphed/table-controls";
 import { SubnetsSavedViews } from "@/components/metagraphed/subnets-saved-views";
+import { SubnetBubbleView } from "@/components/metagraphed/charts/subnet-bubble-view";
 import {
   SubnetsCompareDrawer,
   CompareToggle,
@@ -184,7 +185,11 @@ function SubnetsPage() {
         description="Every active Finney netuid — root and application — with curation level, surface count, health, and freshness."
         actions={
           <>
-            <ViewModeToggle value={search.view} onChange={setView} />
+            <ViewModeToggle
+              value={search.view}
+              options={["table", "grid", "matrix", "bubble"]}
+              onChange={setView}
+            />
             {search.view === "table" ? (
               <DensityToggle value={effectiveDensity} onChange={setDensity} />
             ) : null}
@@ -642,8 +647,8 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
     />
   );
 
-  // Grid / matrix views skip ListShell so they're not boxed in a table card.
-  if (view === "grid" || view === "matrix") {
+  // Grid / matrix / bubble views skip ListShell so they're not boxed in a table card.
+  if (view === "grid" || view === "matrix" || view === "bubble") {
     return (
       <div>
         <div className="sticky top-14 z-20 -mx-4 md:mx-0 mb-3 bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80 border-b border-border md:border md:rounded md:bg-card px-3 py-2 md:p-2.5">
@@ -653,8 +658,10 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
           emptyNode
         ) : view === "grid" ? (
           <SubnetGrid rows={rows} />
-        ) : (
+        ) : view === "matrix" ? (
           <SubnetMatrix rows={rows} />
+        ) : (
+          <SubnetBubbleView rows={rows} />
         )}
         <div className="mt-3">{footerNode}</div>
       </div>

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2631,6 +2631,12 @@ var OPTIONS = [
     label: "Matrix",
     Icon: lucideReact.Grid3x3,
     ariaLabel: "Switch to matrix view"
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: lucideReact.Radar,
+    ariaLabel: "Switch to bubble/radar view"
   }
 ];
 function ViewModeToggle({

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1,7 +1,7 @@
 import * as React3 from 'react';
 import { useState, useRef, useEffect, useMemo, useCallback, useId } from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
-import { ChevronDown, X, Search, ArrowUp, Check, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Lock, AlertTriangle } from 'lucide-react';
+import { ChevronDown, X, Search, ArrowUp, Check, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, Radar, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Lock, AlertTriangle } from 'lucide-react';
 import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
@@ -2602,6 +2602,12 @@ var OPTIONS = [
     label: "Matrix",
     Icon: Grid3x3,
     ariaLabel: "Switch to matrix view"
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: Radar,
+    ariaLabel: "Switch to bubble/radar view"
   }
 ];
 function ViewModeToggle({

--- a/packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx
+++ b/packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx
@@ -1,10 +1,10 @@
-import { LayoutGrid, List, Grid3x3 } from "lucide-react";
+import { LayoutGrid, List, Grid3x3, Radar } from "lucide-react";
 import {
   SegmentedToggle,
   type SegmentedToggleOption,
 } from "@/components/ui/segmented-toggle";
 
-export type ViewMode = "table" | "grid" | "matrix";
+export type ViewMode = "table" | "grid" | "matrix" | "bubble";
 
 const OPTIONS: Array<SegmentedToggleOption<ViewMode>> = [
   {
@@ -24,6 +24,12 @@ const OPTIONS: Array<SegmentedToggleOption<ViewMode>> = [
     label: "Matrix",
     Icon: Grid3x3,
     ariaLabel: "Switch to matrix view",
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: Radar,
+    ariaLabel: "Switch to bubble/radar view",
   },
 ];
 


### PR DESCRIPTION
Closes #6884

## Summary

Adds a table ⇄ bubble/radar view toggle to `/subnets`, over the exact same already-fetched
subnet list the table renders (`SubnetsTable`'s joined `rows` — no new query). Bubble
position encodes two axes, size a third metric, color a fourth:

- **X = emission share** (percentile rank) — already the sortable "Emission" table column;
  the direct client analogue of the `highest-emission` leaderboard board.
- **Y = surface count** (percentile rank, inverted so more surfaces renders higher) —
  already the sortable "Surfaces" table column; the closest client-visible analogue to the
  `most-complete` / `most-enriched` boards.
- **Size = candidate-surface count** (sqrt-scaled so bubble *area* is proportional) —
  already on every row from the base `/api/v1/subnets` payload (`candidate_count`), a third
  independent dimension (community-discovered activity) that doesn't collapse onto either
  axis.
- **Color = health state** — already a table column + filter; the direct analogue of the
  `healthiest` board.

Clicking a bubble navigates to `/subnets/{netuid}`, matching the table row's click
behavior. Existing category/health/root/status/service/readiness filters carry over
unchanged, since the bubble view is fed the same filtered+sorted `rows` `SubnetGrid` /
`SubnetMatrix` already render — no separate filter surface.

## Why these axes, not participants / integration_readiness

Both are already-sortable table columns and were the first candidates, but I checked their
actual spread against live `/api/v1/subnets` data (129 subnets, 2026-07-19) before committing
to them, and rejected both:

- `participants`: **109/129 subnets sit at the exact 256-slot registration cap.** A linear
  or even rank-based axis on this metric collapses 85% of all subnets onto (or right next
  to) the same x position — the chart would render as one dense clump plus a handful of
  outliers, defeating the "scan for outliers" purpose the issue describes.
- `integration_readiness`: **90/129 subnets sit on just two tiers (83 and 86).** Same
  collapse problem on the other axis.

`emission_share` (127/129 distinct values) and `surfaces_count` (25/129 distinct values, no
single value shared by more than ~20 rows) are both already-fetched, already-sortable, and
spread well enough to actually be useful as a 2D scan. I verified this against a real pull of
`/api/v1/subnets` + `/api/v1/economics` rather than assuming the schema implies a good
spread — screenshots below show the result (dots well distributed, not stacked in a corner).

Position also uses **percentile rank, not linear min-max scaling** (`percentileRanks` in
`subnet-bubble-data.ts`, with fractional/average-rank tie handling, fully unit tested).
`emission_share` and `surfaces_count` are both power-law distributed in the live registry —
a linear scale would still crush ~60-80% of subnets into one corner even without exact ties.
Percentile rank spreads every row by relative standing instead, which is what a scan-for-
outliers view needs: the bubbles that matter are the ones far from their peers, not the ones
with the largest absolute number.

## Files

- `apps/ui/src/components/metagraphed/charts/subnet-bubble-data.ts` — pure axis-normalization
  / percentile-rank / size-scaling logic, no React, mirrors the existing
  `validator-dominance-ranking.ts` split.
- `apps/ui/src/components/metagraphed/charts/subnet-bubble-data.test.ts` — 20 unit tests
  covering both `percentileRanks` (empty, single value, distinct values, tied groups at the
  edge and in the middle of the range, all-tied) and `buildSubnetBubblePoints` (missing-field
  exclusion, axis extremes, degenerate all-equal input, size defaulting/scaling, health
  defaulting, diameter interpolation with default and custom bounds).
- `apps/ui/src/components/metagraphed/charts/subnet-bubble-view.tsx` — the rendering
  component, reusing `EntityHoverCard` + `Link` the same way `SubnetMatrix` does.
- `apps/ui/src/routes/subnets.index.tsx` — wires the new view into the existing
  grid/matrix/bubble branch and the `ViewModeToggle` options.
- `apps/ui/src/lib/metagraphed/url-state.ts` — adds `"bubble"` to the shared `view` search
  param enum (also used by `/surfaces`, which already narrows any non-`"grid"` value to
  `"table"`, so this is a no-op there).
- `packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx` (+ rebuilt `dist/`) —
  adds a `"bubble"` option (Radar icon) to the shared segmented view toggle.

## Testing

```
cd apps/ui
npx eslint src/components/metagraphed/charts/subnet-bubble-data.ts \
  src/components/metagraphed/charts/subnet-bubble-data.test.ts \
  src/components/metagraphed/charts/subnet-bubble-view.tsx \
  src/routes/subnets.index.tsx src/lib/metagraphed/url-state.ts   # clean
npx prettier --check <same files>                                 # clean
npm run typecheck --workspace=apps/ui                              # clean
npm test --workspace=apps/ui                                       # 168 files / 1294 tests passing
cd .. && npm run typecheck --workspace=packages/ui-kit && npm test --workspace=packages/ui-kit  # clean, 75 tests passing
node scripts/scan-public-safety.mjs                                 # clean
LOVABLE_SANDBOX=1 NITRO_PRESET=cloudflare-module npm run build --workspace=apps/ui  # builds; initial client JS unaffected (298 KB / 300 KB budget, unchanged from main — /subnets is a lazy route chunk, excluded from the "/" cold-load measurement)
```

Manually verified with Playwright against a live dev server: toggle switches to the bubble
view and back, `?view=bubble&health=ok` narrows the plotted set the same way the table's
health filter does, and clicking a bubble navigates to `/subnets/{netuid}`.

## Screenshots

3 viewports × 2 themes × before/after on `/subnets` (default table view — the only visible
diff at rest is the new "Bubble" toggle option), plus a second table showing the new bubble
view itself.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-after-mobile-dark.png)<br><sub>after</sub> |

### New view itself (bubble/radar, toggled on)

| Viewport · Theme | Bubble view |
| --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-newview-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-newview-desktop-light.png)<br><sub>new view</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-newview-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-newview-desktop-dark.png)<br><sub>new view</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-newview-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-newview-tablet-light.png)<br><sub>new view</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-newview-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-newview-tablet-dark.png)<br><sub>new view</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-newview-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-newview-mobile-light.png)<br><sub>new view</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-newview-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6884-newview-mobile-dark.png)<br><sub>new view</sub> |
