### PR TITLE
fix(ui): force-narrow SearchInput's min-width override with Tailwind's important modifier

### DIFF
--- a/apps/ui/src/routes/blocks.index.tsx
+++ b/apps/ui/src/routes/blocks.index.tsx
@@ -289,35 +289,41 @@ function BlocksTable() {
           onChange={(v) => setSearch({ spec_version: v, offset: 0 })}
           placeholder="Spec version…"
           inputMode="numeric"
-          className="min-w-[120px] max-w-[140px] flex-none"
+          // SearchInput's own base hardcodes `min-w-[180px]` unconditionally, which
+          // wins the same-property (min-width) cascade over a plain `min-w-[120px]`
+          // override here regardless of prop order (classNames() is a plain
+          // string-join, not tailwind-merge-aware -- see #6904); the trailing `!`
+          // forces this narrower floor to actually apply so max-w-[140px] can take
+          // effect as intended for this compact numeric filter.
+          className="min-w-[120px]! max-w-[140px] flex-none"
         />
         <SearchInput
           value={search.block_start}
           onChange={(v) => setSearch({ block_start: v, offset: 0 })}
           placeholder="Block from…"
           inputMode="numeric"
-          className="min-w-[120px] max-w-[140px] flex-none"
+          className="min-w-[120px]! max-w-[140px] flex-none"
         />
         <SearchInput
           value={search.block_end}
           onChange={(v) => setSearch({ block_end: v, offset: 0 })}
           placeholder="Block to…"
           inputMode="numeric"
-          className="min-w-[120px] max-w-[140px] flex-none"
+          className="min-w-[120px]! max-w-[140px] flex-none"
         />
         <SearchInput
           value={search.min_extrinsics}
           onChange={(v) => setSearch({ min_extrinsics: v, offset: 0 })}
           placeholder="Min extrinsics…"
           inputMode="numeric"
-          className="min-w-[120px] max-w-[140px] flex-none"
+          className="min-w-[120px]! max-w-[140px] flex-none"
         />
         <SearchInput
           value={search.min_events}
           onChange={(v) => setSearch({ min_events: v, offset: 0 })}
           placeholder="Min events…"
           inputMode="numeric"
-          className="min-w-[120px] max-w-[140px] flex-none"
+          className="min-w-[120px]! max-w-[140px] flex-none"
         />
         <PageSizeSelect
           value={search.limit}

--- a/apps/ui/src/routes/explorer.tsx
+++ b/apps/ui/src/routes/explorer.tsx
@@ -1929,13 +1929,18 @@ function ChainEventsFeedSection() {
         value={search.pallet}
         onChange={(v) => setSearch({ pallet: v, method: v.trim() ? search.method : "" })}
         placeholder="Filter by pallet"
-        className="min-w-[140px] flex-none font-mono text-[11px]"
+        // SearchInput's own base hardcodes `min-w-[180px]` unconditionally, which
+        // wins the same-property (min-width) cascade over a plain `min-w-[140px]`
+        // override regardless of prop order (classNames() is a plain string-join,
+        // not tailwind-merge-aware -- see #6904); the trailing `!` forces this
+        // narrower floor to actually apply for these compact pallet/method filters.
+        className="min-w-[140px]! flex-none font-mono text-[11px]"
       />
       <SearchInput
         value={search.method}
         onChange={(v) => setSearch({ method: v })}
         placeholder={search.pallet.trim() ? "Filter by method" : "Method (requires pallet)"}
-        className="min-w-[140px] flex-none font-mono text-[11px]"
+        className="min-w-[140px]! flex-none font-mono text-[11px]"
       />
     </>
   );


### PR DESCRIPTION
Closes #6904.

## Audit

`classNames()` (`apps/ui/src/lib/metagraphed/format.ts:110` / `packages/ui-kit/src/lib/format.ts:6`) is a plain `parts.filter(Boolean).join(" ")` — it doesn't resolve same-property Tailwind conflicts the way `tailwind-merge`'s `twMerge` does. The sibling issue #6903 (already merged, PR #6937) fixed one confirmed instance: `ExternalLink` hardcoding `inline-flex` beating a caller's `flex` override.

Audited every `SearchInput`/`classNames()` call site under `apps/ui/src/components/metagraphed`, `apps/ui/src/routes`, and `packages/ui-kit/src/components/metagraphed` for a caller trying to override a hardcoded display/layout utility (`flex`/`inline-flex`, `block`/`inline-block`, `w-*`, `truncate`/`whitespace-*` — the highest-risk categories per the confirmed instance).

**Genuine conflicts found and fixed** (2, both the same root cause: `SearchInput` in `table-controls.tsx:82` hardcodes `min-w-[180px]` ahead of any caller override in the joined string):

| Site | Caller's override | Verified effect |
|---|---|---|
| `blocks.index.tsx` — 5 filter inputs (`min-w-[120px]`) | `min-w-[120px]` loses to the `min-w-[180px]` base | **Visible**: at desktop width, the wider-than-intended inputs pushed the page-size selector onto its own wrapped row instead of fitting the filter row like every other control. Confirmed via Playwright + before/after screenshots below. |
| `explorer.tsx` — 2 pallet/method filter inputs (`min-w-[140px]`) | `min-w-[140px]` loses to the `min-w-[180px]` base | Same underlying conflict, but produces **zero pixel difference today** at any tested viewport — the fields' content width already exceeds both the 140px and 180px floors, so the wrong class winning happens to be masked. Fixed anyway since the conflict is real and would surface the moment either field's content got shorter. |

No other call site in the audited scope hardcodes a display/layout utility that a caller also tries to override — these 2 (+ the already-merged `ExternalLink` case) are the only genuine instances found across the app.

## Decision: per-site fix, not a repo-wide `tailwind-merge` swap

Fixed both sites with Tailwind v4's trailing `!` important modifier (`min-w-[120px]!`) rather than switching `classNames()` itself to a `tailwind-merge`-aware implementation:

- The already-merged #6903 fix took the identical single-call-site approach rather than touching the shared helper — an existing precedent for how this maintainer wants this bug class handled.
- A repo-wide `twMerge(clsx(...))` swap is a materially bigger, more opinionated change: a new dependency, a real (if small) bundle-size cost, and a much wider review/regression surface, for a bug class that — after this audit — has only **3 total confirmed instances** in the entire app (1 already merged, 2 in this PR).
- If a future audit turns up meaningfully more instances, revisiting the repo-wide swap would make more sense; right now the fix-per-site approach is proportionate to the actual blast radius.

## Testing

No new logic was added — both changes are class-string edits with no new branching, so no new unit tests apply (`classNames()` itself is untouched). Verified via Playwright against a live dev server that the `blocks.index.tsx` fix actually narrows the rendered input (180px → 140px effective width) and that the filter row now fits on one line instead of wrapping.

## Screenshots

### `/blocks` — Before / After (filter row width fix)

| Viewport · Theme | Before | After |
| ---- | ---- | ---- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/tryeverything24/metagraphed/screenshots/6904-after-mobile-dark.png)<br><sub>after</sub> |

`explorer.tsx`'s fix is intentionally not screenshotted separately — as noted above, it produces zero pixel difference at any tested viewport today (the fix is for correctness/future-proofing, not a currently-visible bug).
