### PR TITLE
feat(ui): frame the conviction leaderboard's ownership contest with a status card + proportion bar

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
@@ -1,9 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
-import { Crown } from "lucide-react";
+import { AlertOctagon, Crown, MinusCircle, ShieldCheck, Swords } from "lucide-react";
 import { subnetConvictionQuery } from "@/lib/metagraphed/queries";
-import { CopyableCode } from "@jsonbored/ui-kit";
+import {
+  summarizeContest,
+  type ContestStatus,
+  type ContestSummary,
+} from "@/lib/metagraphed/conviction-contest";
+import { CopyableCode, KeyChip } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import type { SubnetConvictionEntry } from "@/lib/metagraphed/types";
 
 const UNITS_PER_WHOLE = 1_000_000_000;
 
@@ -18,6 +24,207 @@ function fmtAlpha(rawUnits: number): string {
   if (magnitude >= 1) return `${whole.toFixed(2)} α`;
   if (whole === 0) return "0 α";
   return `${whole.toFixed(4)} α`;
+}
+
+function fmtGap(pct: number): string {
+  if (pct < 1) return "<1%";
+  if (pct < 10) return `${pct.toFixed(1)}%`;
+  return `${Math.round(pct)}%`;
+}
+
+const STATUS_LABEL: Record<ContestStatus, string> = {
+  uncontested: "Uncontested",
+  secure: "Secure",
+  contested: "Contested",
+  "takeover-imminent": "Takeover imminent",
+};
+
+const STATUS_DESC: Record<ContestStatus, string> = {
+  uncontested: "No active challenger has built up conviction against the current king.",
+  secure: "The king holds a lead the top challenger can't realistically close in one epoch.",
+  contested: "The top challenger is within striking distance of the king.",
+  "takeover-imminent": "A single strong lock top-up could flip ownership.",
+};
+
+// Tone tokens mirror StatTile's palette (border-health-*/40, text-health-*)
+// so the summary reads as part of the existing KPI-tile system instead of a
+// new visual language of its own.
+const STATUS_TONE: Record<
+  ContestStatus,
+  { icon: typeof ShieldCheck; border: string; text: string; bar: string }
+> = {
+  uncontested: {
+    icon: MinusCircle,
+    border: "border-border",
+    text: "text-ink-strong",
+    bar: "bg-ink-muted/50",
+  },
+  secure: {
+    icon: ShieldCheck,
+    border: "border-health-ok/40",
+    text: "text-health-ok",
+    bar: "bg-health-ok",
+  },
+  contested: {
+    icon: Swords,
+    border: "border-health-warn/40",
+    text: "text-health-warn",
+    bar: "bg-health-warn",
+  },
+  "takeover-imminent": {
+    icon: AlertOctagon,
+    border: "border-health-down/40",
+    text: "text-health-down",
+    bar: "bg-health-down",
+  },
+};
+
+/**
+ * Contest summary strip -- the direct answer to the section's "how close is
+ * this subnet to an automatic ownership flip" subtitle. Same tone-colored
+ * border + eyebrow + value + hint vocabulary as ConcentrationLoader's
+ * StatTiles, plus a proportion bar that literally shows the challenger's
+ * conviction as a fraction of the king's.
+ */
+function ContestSummaryCard({ summary }: { summary: ContestSummary }) {
+  const tone = STATUS_TONE[summary.status];
+  const Icon = tone.icon;
+  const { king, challenger, gapPct } = summary;
+
+  return (
+    <div className={classNames("rounded-xl border bg-card p-4 sm:p-5", tone.border)}>
+      <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1.3fr)] md:items-center md:gap-6">
+        <div className="flex items-start gap-3">
+          <Icon aria-hidden className={classNames("size-5 shrink-0 mt-0.5", tone.text)} />
+          <div className="min-w-0">
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+              Contest status
+            </div>
+            <div className="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+              <span
+                className={classNames(
+                  "font-display text-lg font-semibold leading-none sm:text-xl",
+                  tone.text,
+                )}
+              >
+                {STATUS_LABEL[summary.status]}
+              </span>
+              {gapPct != null ? (
+                <span className="font-mono text-[11px] tabular-nums text-ink-muted">
+                  king leads by {fmtGap(gapPct)}
+                </span>
+              ) : null}
+            </div>
+            <p className="mt-2 text-[12px] leading-snug text-ink-muted">
+              {STATUS_DESC[summary.status]}
+            </p>
+          </div>
+        </div>
+
+        {king != null && challenger != null ? (
+          <ContestRatio king={king} challenger={challenger} barClass={tone.bar} />
+        ) : king != null ? (
+          <SoleKingCard king={king} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * King vs top challenger, drawn as two hotkey rows with proportional bars.
+ * The king's bar is always full-width (100% of the reference); the challenger
+ * fills the fraction of the king's conviction they've already built up -- so
+ * a nearly-full challenger bar is literally the picture of an imminent flip.
+ */
+function ContestRatio({
+  king,
+  challenger,
+  barClass,
+}: {
+  king: SubnetConvictionEntry;
+  challenger: SubnetConvictionEntry;
+  barClass: string;
+}) {
+  const fillPct =
+    king.conviction > 0
+      ? Math.min(100, Math.max(0, (challenger.conviction / king.conviction) * 100))
+      : 0;
+
+  return (
+    <div className="min-w-0 space-y-2.5">
+      <ContestantRow
+        role="king"
+        hotkey={king.hotkey}
+        value={king.conviction}
+        widthPct={100}
+        barClass="bg-ink-muted/50"
+      />
+      <ContestantRow
+        role="challenger"
+        hotkey={challenger.hotkey}
+        value={challenger.conviction}
+        widthPct={fillPct}
+        barClass={barClass}
+      />
+    </div>
+  );
+}
+
+function ContestantRow({
+  role,
+  hotkey,
+  value,
+  widthPct,
+  barClass,
+}: {
+  role: "king" | "challenger";
+  hotkey: string;
+  value: number;
+  widthPct: number;
+  barClass: string;
+}) {
+  return (
+    <div className="min-w-0 space-y-1">
+      <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2">
+        <span className="inline-flex shrink-0 items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          {role === "king" ? <Crown aria-hidden className="size-3 text-health-warn" /> : null}
+          {role === "king" ? "king" : "top challenger"}
+        </span>
+        <KeyChip value={hotkey} label={`${role} hotkey`} className="min-w-0" />
+        <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-strong">
+          {fmtAlpha(value)}
+        </span>
+      </div>
+      <div
+        role="img"
+        aria-label={`${role} conviction ${fmtAlpha(value)}`}
+        className="relative h-1.5 rounded-full bg-surface overflow-hidden"
+      >
+        <span
+          className={classNames("absolute inset-y-0 left-0 rounded-full", barClass)}
+          style={{ width: `${Math.max(2, widthPct)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SoleKingCard({ king }: { king: SubnetConvictionEntry }) {
+  return (
+    <div className="min-w-0 rounded-lg border border-border bg-surface/40 p-3">
+      <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2">
+        <span className="inline-flex shrink-0 items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          <Crown aria-hidden className="size-3 text-health-warn" />
+          king
+        </span>
+        <KeyChip value={king.hotkey} label="king hotkey" className="min-w-0" />
+        <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-strong">
+          {fmtAlpha(king.conviction)}
+        </span>
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -51,6 +258,8 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
     );
   }
 
+  const summary = summarizeContest(leaderboard, data?.king ?? null);
+
   return (
     <div className="space-y-3">
       {data?.queried_at_block != null ? (
@@ -60,6 +269,7 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
           {data.maturity_rate != null ? ` · maturity_rate ${formatNumber(data.maturity_rate)}` : ""}
         </p>
       ) : null}
+      <ContestSummaryCard summary={summary} />
       <div className="rounded-xl border border-border bg-card overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
@@ -79,8 +289,21 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
             <tbody className="divide-y divide-border">
               {leaderboard.map((entry) => {
                 const isKing = data?.king != null && entry.hotkey === data.king;
+                const isTopChallenger =
+                  summary.challenger != null && entry.hotkey === summary.challenger.hotkey;
                 return (
-                  <tr key={entry.hotkey} className="mg-row-accent hover:bg-surface/40">
+                  <tr
+                    key={entry.hotkey}
+                    className={classNames(
+                      "mg-row-accent hover:bg-surface/40",
+                      isTopChallenger &&
+                        (summary.status === "takeover-imminent"
+                          ? "bg-health-down/5"
+                          : summary.status === "contested"
+                            ? "bg-health-warn/5"
+                            : undefined),
+                    )}
+                  >
                     <td className="px-4 py-2.5">
                       <div className="flex items-center gap-2">
                         {isKing ? (

--- a/apps/ui/src/lib/metagraphed/conviction-contest.test.ts
+++ b/apps/ui/src/lib/metagraphed/conviction-contest.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { summarizeContest } from "./conviction-contest";
+import type { SubnetConvictionEntry } from "./types";
+
+function entry(hotkey: string, conviction: number, isOwner = false): SubnetConvictionEntry {
+  return { hotkey, is_owner: isOwner, locked_mass: conviction, conviction };
+}
+
+describe("summarizeContest", () => {
+  it("returns uncontested with no king/challenger for an empty leaderboard", () => {
+    expect(summarizeContest([], null)).toEqual({
+      status: "uncontested",
+      king: null,
+      challenger: null,
+      gapPct: null,
+    });
+  });
+
+  it("returns uncontested when there is only the king (no challenger)", () => {
+    const king = entry("5King", 1_000, true);
+    const result = summarizeContest([king], "5King");
+    expect(result.status).toBe("uncontested");
+    expect(result.king).toBe(king);
+    expect(result.challenger).toBeNull();
+    expect(result.gapPct).toBeNull();
+  });
+
+  it("flags takeover-imminent when the gap is below 5%", () => {
+    const king = entry("5King", 1_000, true);
+    const chal = entry("5Chal", 960);
+    const result = summarizeContest([king, chal], "5King");
+    expect(result.status).toBe("takeover-imminent");
+    expect(result.king).toBe(king);
+    expect(result.challenger).toBe(chal);
+    expect(result.gapPct).toBeCloseTo(4, 5);
+  });
+
+  it("flags contested when the gap is in the 5-20% band", () => {
+    const king = entry("5King", 1_000, true);
+    const chal = entry("5Chal", 850);
+    const result = summarizeContest([king, chal], "5King");
+    expect(result.status).toBe("contested");
+    expect(result.gapPct).toBeCloseTo(15, 5);
+  });
+
+  it("flags secure when the gap is 20% or wider", () => {
+    const king = entry("5King", 1_000, true);
+    const chal = entry("5Chal", 500);
+    const result = summarizeContest([king, chal], "5King");
+    expect(result.status).toBe("secure");
+    expect(result.gapPct).toBeCloseTo(50, 5);
+  });
+
+  it("compares the king against the strongest non-king entry, not just leaderboard[1]", () => {
+    const king = entry("5King", 1_000, true);
+    const weak = entry("5Weak", 100);
+    const strong = entry("5Strong", 980);
+    const result = summarizeContest([king, weak, strong], "5King");
+    expect(result.status).toBe("takeover-imminent");
+    expect(result.challenger).toBe(strong);
+    expect(result.gapPct).toBeCloseTo(2, 5);
+  });
+
+  it("falls back to the highest-conviction entry when `king` matches no hotkey", () => {
+    const top = entry("5Top", 1_000);
+    const runnerUp = entry("5Runner", 500);
+    const result = summarizeContest([top, runnerUp], "5Unknown");
+    expect(result.status).toBe("secure");
+    expect(result.king).toBe(top);
+    expect(result.challenger).toBe(runnerUp);
+    expect(result.gapPct).toBeCloseTo(50, 5);
+  });
+
+  it("returns uncontested with a null gap when the king's conviction is 0", () => {
+    const king = entry("5King", 0, true);
+    const chal = entry("5Chal", 0);
+    const result = summarizeContest([king, chal], "5King");
+    expect(result.status).toBe("uncontested");
+    expect(result.king).toBe(king);
+    expect(result.challenger).toBe(chal);
+    expect(result.gapPct).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/conviction-contest.ts
+++ b/apps/ui/src/lib/metagraphed/conviction-contest.ts
@@ -1,0 +1,66 @@
+import type { SubnetConvictionEntry } from "./types";
+
+export type ContestStatus = "secure" | "contested" | "takeover-imminent" | "uncontested";
+
+export interface ContestSummary {
+  status: ContestStatus;
+  /** The king entry (highest rolled conviction), or null when the leaderboard is empty. */
+  king: SubnetConvictionEntry | null;
+  /** The top non-king challenger, or null when the king is uncontested. */
+  challenger: SubnetConvictionEntry | null;
+  /** Gap between king and challenger, as a percentage of the king's conviction.
+   *  Null when there's no challenger, or the king's conviction is 0. */
+  gapPct: number | null;
+}
+
+// Gap thresholds, expressed as % of the king's conviction (#6883). There's no
+// prior precedent for this in the codebase -- these are a documented starting
+// point rather than a chain-derived figure: under 5% is close enough that a
+// single strong lock top-up can flip within one epoch; 5-20% needs a sustained
+// push while the king's own conviction keeps decaying; above 20% is a lead a
+// challenger can't realistically close inside one epoch.
+export const TAKEOVER_IMMINENT_MAX_PCT = 5;
+export const CONTESTED_MAX_PCT = 20;
+
+/**
+ * Ownership-contest urgency for a conviction leaderboard: how close the top
+ * challenger is to overtaking the king. Looks the king up by hotkey (falling
+ * back to the highest-conviction entry if `king` doesn't match anything), then
+ * takes the highest-conviction remaining entry as the runner-up -- correct
+ * regardless of array order.
+ */
+export function summarizeContest(
+  leaderboard: SubnetConvictionEntry[],
+  king: string | null,
+): ContestSummary {
+  if (leaderboard.length === 0) {
+    return { status: "uncontested", king: null, challenger: null, gapPct: null };
+  }
+
+  const kingEntry =
+    (king != null ? leaderboard.find((e) => e.hotkey === king) : undefined) ??
+    leaderboard.reduce((best, e) => (e.conviction > best.conviction ? e : best));
+
+  const challenger = leaderboard
+    .filter((e) => e.hotkey !== kingEntry.hotkey)
+    .reduce<SubnetConvictionEntry | null>(
+      (best, e) => (best == null || e.conviction > best.conviction ? e : best),
+      null,
+    );
+
+  if (challenger == null) {
+    return { status: "uncontested", king: kingEntry, challenger: null, gapPct: null };
+  }
+  if (kingEntry.conviction <= 0) {
+    return { status: "uncontested", king: kingEntry, challenger, gapPct: null };
+  }
+
+  const gapPct = ((kingEntry.conviction - challenger.conviction) / kingEntry.conviction) * 100;
+  if (gapPct < TAKEOVER_IMMINENT_MAX_PCT) {
+    return { status: "takeover-imminent", king: kingEntry, challenger, gapPct };
+  }
+  if (gapPct < CONTESTED_MAX_PCT) {
+    return { status: "contested", king: kingEntry, challenger, gapPct };
+  }
+  return { status: "secure", king: kingEntry, challenger, gapPct };
+}


### PR DESCRIPTION
The conviction leaderboard already had everything needed to answer the section's own "how close is this subnet to an automatic ownership flip" subtitle — it just rendered a plain ranked table and left the reader to work it out. #6883 asked for a gap%/status framing on top of that same data.

The last attempt at this (#6917) was closed as "badge feels lazily tossed in there without thought for UX/UI" — a small colored pill inline with the block-number caption, treating the section's headline info as a footnote. So this time it isn't a pill at all. It's a contest-summary card sitting where the answer belongs: right under the section subtitle, above the leaderboard, using the same tone-colored border + eyebrow + value + hint vocabulary as `ConcentrationLoader`'s `StatTile`s so it reads as part of the existing KPI-tile system, not a new visual language. Alongside the label, a two-row proportion bar — king full-width in muted, top challenger filling the fraction of the king's conviction they've already built up — so a near-full bar is literally the picture of an imminent flip. `KeyChip` for the hotkeys so mobile doesn't overflow, and the top-challenger row in the table gets a subtle tone-tinted background so the two views stay tied together.

Four states, four distinct icons + tones: Uncontested (`MinusCircle`, neutral — deliberately non-shield so it doesn't read the same as Secure), Secure (`ShieldCheck`, health-ok green), Contested (`Swords`, health-warn amber), Takeover imminent (`AlertOctagon`, health-down red). Thresholds are gap < 5% → takeover-imminent, 5–20% → contested, ≥ 20% → secure. No chain-derived precedent, so picked on the reasoning that under 5% is close enough for a single strong lock top-up to flip within one epoch, 5–20% needs a sustained push while the king's own conviction keeps decaying, and above 20% is a lead the challenger can't realistically close in one epoch — documented inline. Skipped the "time to overtake" stretch same as the last attempt: `docs/conviction-lock-mechanism.md` warns `UnlockRate`/`MaturityRate` are governance-adjustable and the roll-forward math isn't a presentation-only concern.

Pure gap/summary logic in `apps/ui/src/lib/metagraphed/conviction-contest.ts` (`summarizeContest`) — same shape as `incident-duration.ts` next door, tested on its own. Looks up king by hotkey, falls back to highest-conviction entry if `king` doesn't match (defensive), compares against highest-conviction non-king entry — correct regardless of array order. `conviction-contest.test.ts` covers empty, single-entry (`uncontested`), close contest below 5% (`takeover-imminent`), mid-range 15% (`contested`), wide 50% (`secure`), non-adjacent runner-up, unknown-king fallback, zero-conviction king. Local gate before pushing: `npm run build`, `test:ci`, `test:ci:artifacts`, `validate` + every `validate:*`, `scan:public-safety`, `validate:private-boundary`, `worker:bundle:budget`, and for `apps/ui`/`packages/ui-kit`: `build`, `typecheck`, `lint`, `format:check`, `test`, `test:e2e` — all green.

Screenshots use a local proxy that swaps only `/api/v1/subnets/{netuid}/conviction`, so before/after use the same page data everywhere else — the only diff is the summary card. No real subnet currently has an active conviction contest to shoot against. Four hand-picked netuids drive the four states: 1 = Secure (40% gap), 2 = Contested (12% gap), 3 = Takeover imminent (2.5% gap), 4 = Uncontested (king alone). Mobile HOTKEY table overflow visible in the shots is pre-existing `CopyableCode` behaviour and out of scope; the new summary card uses `KeyChip` and does not add to it.

**Secure — before/after, desktop & mobile, light & dark**

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/556841e40fa69387231e0d08bd34163fbc781da7/runs/jsonbored-metagraphed/run-38/before-secure-desktop-light.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/556841e40fa69387231e0d08bd34163fbc781da7/runs/jsonbored-metagraphed/run-38/before-secure-desktop-light.png" width="320"></a> | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/fd84d768313f1b0605243983e4d90aec0bf09728/runs/jsonbored-metagraphed/run-38/after-secure-desktop-light.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/fd84d768313f1b0605243983e4d90aec0bf09728/runs/jsonbored-metagraphed/run-38/after-secure-desktop-light.png" width="320"></a> |
| Desktop · Dark | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/7aef9dc37cf68d5b4af8c8d6f910c99d3f544222/runs/jsonbored-metagraphed/run-38/before-secure-desktop-dark.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/7aef9dc37cf68d5b4af8c8d6f910c99d3f544222/runs/jsonbored-metagraphed/run-38/before-secure-desktop-dark.png" width="320"></a> | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/e2408dbd9b71e39072774a1a89be9340ed2adc5f/runs/jsonbored-metagraphed/run-38/after-secure-desktop-dark.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/e2408dbd9b71e39072774a1a89be9340ed2adc5f/runs/jsonbored-metagraphed/run-38/after-secure-desktop-dark.png" width="320"></a> |
| Mobile · Light | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/f3c6d950262418fc9588e8b84c62d5c136a17872/runs/jsonbored-metagraphed/run-38/before-secure-mobile-light.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/f3c6d950262418fc9588e8b84c62d5c136a17872/runs/jsonbored-metagraphed/run-38/before-secure-mobile-light.png" width="180"></a> | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/2503f365e1bd4fffb6d73ce48abe1581c29ffc9b/runs/jsonbored-metagraphed/run-38/after-secure-mobile-light.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/2503f365e1bd4fffb6d73ce48abe1581c29ffc9b/runs/jsonbored-metagraphed/run-38/after-secure-mobile-light.png" width="180"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/4ee3c58d146eaf08203951322f39e57fde25d621/runs/jsonbored-metagraphed/run-38/before-secure-mobile-dark.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/4ee3c58d146eaf08203951322f39e57fde25d621/runs/jsonbored-metagraphed/run-38/before-secure-mobile-dark.png" width="180"></a> | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/3cb5c3853525bb507183bdef4afbe9c85ff0db7e/runs/jsonbored-metagraphed/run-38/after-secure-mobile-dark.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/3cb5c3853525bb507183bdef4afbe9c85ff0db7e/runs/jsonbored-metagraphed/run-38/after-secure-mobile-dark.png" width="180"></a> |

**Takeover imminent — red border + near-full challenger bar**

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Dark | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/92e024c0ad943cd5a5822c3b85ed5682ab583f9b/runs/jsonbored-metagraphed/run-38/before-takeover-desktop-dark.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/92e024c0ad943cd5a5822c3b85ed5682ab583f9b/runs/jsonbored-metagraphed/run-38/before-takeover-desktop-dark.png" width="320"></a> | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/6a031eec677ccd3b0102827dbf43c5a94b908ddc/runs/jsonbored-metagraphed/run-38/after-takeover-desktop-dark.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/6a031eec677ccd3b0102827dbf43c5a94b908ddc/runs/jsonbored-metagraphed/run-38/after-takeover-desktop-dark.png" width="320"></a> |
| Mobile · Light | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/406c7a50f685f3ebe8df614e1de81d9bfdb00228/runs/jsonbored-metagraphed/run-38/before-takeover-mobile-light.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/406c7a50f685f3ebe8df614e1de81d9bfdb00228/runs/jsonbored-metagraphed/run-38/before-takeover-mobile-light.png" width="180"></a> | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/c3bc88cd478ca5f432d9e0533f0f7db1e7a20ab6/runs/jsonbored-metagraphed/run-38/after-takeover-mobile-light.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/c3bc88cd478ca5f432d9e0533f0f7db1e7a20ab6/runs/jsonbored-metagraphed/run-38/after-takeover-mobile-light.png" width="180"></a> |

**Full state coverage — remaining state × viewport × theme (after only)**

| State | Desktop · Light | Desktop · Dark | Mobile · Light | Mobile · Dark |
| --- | --- | --- | --- | --- |
| Takeover imminent | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/77a736a16cf816a3d4d80531877a74a9c3a37472/runs/jsonbored-metagraphed/run-38/after-takeover-desktop-light.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/77a736a16cf816a3d4d80531877a74a9c3a37472/runs/jsonbored-metagraphed/run-38/after-takeover-desktop-light.png" width="200"></a> | (see main table above) | (see main table above) | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/df180cea6cdf5c10ff06d0723595adede242b78c/runs/jsonbored-metagraphed/run-38/after-takeover-mobile-dark.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/df180cea6cdf5c10ff06d0723595adede242b78c/runs/jsonbored-metagraphed/run-38/after-takeover-mobile-dark.png" width="120"></a> |
| Contested | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/d7cca35259930d83f89bd9dfe033a8516e44e530/runs/jsonbored-metagraphed/run-38/after-contested-desktop-light.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/d7cca35259930d83f89bd9dfe033a8516e44e530/runs/jsonbored-metagraphed/run-38/after-contested-desktop-light.png" width="200"></a> | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/f39ac2380daf2a0a99f0f89ca6f2ea0a59b7e9e3/runs/jsonbored-metagraphed/run-38/after-contested-desktop-dark.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/f39ac2380daf2a0a99f0f89ca6f2ea0a59b7e9e3/runs/jsonbored-metagraphed/run-38/after-contested-desktop-dark.png" width="200"></a> | — | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/485b38bca2c651b8ce9f970753b5a89eacd4d61c/runs/jsonbored-metagraphed/run-38/after-contested-mobile-dark.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/485b38bca2c651b8ce9f970753b5a89eacd4d61c/runs/jsonbored-metagraphed/run-38/after-contested-mobile-dark.png" width="120"></a> |
| Uncontested | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/84442b7c7c9e93f240b920aeb07bb5010c1068c2/runs/jsonbored-metagraphed/run-38/after-uncontested-desktop-light.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/84442b7c7c9e93f240b920aeb07bb5010c1068c2/runs/jsonbored-metagraphed/run-38/after-uncontested-desktop-light.png" width="200"></a> | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/77774b399b0f255e422adb6ac6d8c3161493bd0d/runs/jsonbored-metagraphed/run-38/after-uncontested-desktop-dark.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/77774b399b0f255e422adb6ac6d8c3161493bd0d/runs/jsonbored-metagraphed/run-38/after-uncontested-desktop-dark.png" width="200"></a> | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/0997b41b3f2a1fba903eeeea67aa216aed54cbc5/runs/jsonbored-metagraphed/run-38/after-uncontested-mobile-light.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/0997b41b3f2a1fba903eeeea67aa216aed54cbc5/runs/jsonbored-metagraphed/run-38/after-uncontested-mobile-light.png" width="120"></a> | <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/300ad772d8a9c720db408bb287139b7732266d18/runs/jsonbored-metagraphed/run-38/after-uncontested-mobile-dark.png"><img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/300ad772d8a9c720db408bb287139b7732266d18/runs/jsonbored-metagraphed/run-38/after-uncontested-mobile-dark.png" width="120"></a> |

<sub>Uncontested was captured twice: first with a `ShieldCheck` icon shared with Secure (<a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/602df3ebdf4c2789b0890fa2f74abd9c8e0b3855/runs/jsonbored-metagraphed/run-38/after-uncontested-desktop-light.png">desktop-light</a>, <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/e723368deffc050fc1c2ea07d77cd1a7aea13102/runs/jsonbored-metagraphed/run-38/after-uncontested-desktop-dark.png">desktop-dark</a>, <a href="https://raw.githubusercontent.com/nghetien/agentfix-assets/1858102ec269a9c37a015ee038b76b8acd8d9203/runs/jsonbored-metagraphed/run-38/after-uncontested-mobile-dark.png">mobile-dark</a>), then re-captured with `MinusCircle` after a self-review to keep the four states visually orthogonal — the shots in the coverage table above are the final version.</sub>

Closes #6883