### PR TITLE
feat(ui): overlay history chart tab in compare drawer

### DIFF
--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -7,6 +7,9 @@ import { compareQuery } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { CompareSubnet, HealthState } from "@/lib/metagraphed/types";
 import { HealthPill, CurationChip } from "@jsonbored/ui-kit";
+import { SubnetsCompareHistoryChart } from "@/components/metagraphed/subnets-compare-history-chart";
+
+type CompareView = "grid" | "chart";
 
 /**
  * Floating bottom dock + expandable side-by-side compare drawer for selected
@@ -16,6 +19,7 @@ import { HealthPill, CurationChip } from "@jsonbored/ui-kit";
 export function SubnetsCompareDrawer() {
   const { selected, max, remove, clear } = useCompareSelection();
   const [expanded, setExpanded] = useState(false);
+  const [view, setView] = useState<CompareView>("grid");
 
   if (selected.length === 0) return null;
 
@@ -81,7 +85,16 @@ export function SubnetsCompareDrawer() {
           </div>
 
           {/* Expanded side-by-side */}
-          {expanded && selected.length >= 2 ? <CompareGrid netuids={selected} /> : null}
+          {expanded && selected.length >= 2 ? (
+            <div className="border-t border-border">
+              <CompareViewTabs value={view} onChange={setView} />
+              {view === "grid" ? (
+                <CompareGrid netuids={selected} />
+              ) : (
+                <SubnetsCompareHistoryChart netuids={selected} />
+              )}
+            </div>
+          ) : null}
         </div>
       </div>
     </div>
@@ -100,6 +113,47 @@ function compareHealthState(health: CompareSubnet["health"]): HealthState {
   if (ok >= total) return "ok";
   if (ok === 0) return "down";
   return "warn";
+}
+
+function CompareViewTabs({
+  value,
+  onChange,
+}: {
+  value: CompareView;
+  onChange: (v: CompareView) => void;
+}) {
+  const tabs: Array<{ id: CompareView; label: string }> = [
+    { id: "grid", label: "Metrics" },
+    { id: "chart", label: "Overlay chart" },
+  ];
+  return (
+    <div
+      role="tablist"
+      aria-label="Compare view"
+      className="flex items-center gap-1 border-b border-border px-3 py-2"
+    >
+      {tabs.map((t) => {
+        const active = value === t.id;
+        return (
+          <button
+            key={t.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(t.id)}
+            className={classNames(
+              "inline-flex items-center rounded-full border px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+              active
+                ? "border-accent/60 bg-accent/15 text-ink-strong"
+                : "border-border bg-paper text-ink-muted hover:text-ink-strong hover:border-ink/30",
+            )}
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </div>
+  );
 }
 
 function CompareGrid({ netuids }: { netuids: number[] }) {
@@ -212,7 +266,7 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
 
   if (isError) {
     return (
-      <div className="border-t border-border px-3 py-6 text-center">
+      <div className="px-3 py-6 text-center">
         <p className="font-mono text-[11px] text-ink-muted">Could not load comparison.</p>
         <button
           type="button"
@@ -226,7 +280,7 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
   }
 
   return (
-    <div className="border-t border-border max-h-[55vh] overflow-auto">
+    <div className="max-h-[55vh] overflow-auto">
       <table className="min-w-full text-[12px]">
         <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
           <tr>

--- a/apps/ui/src/components/metagraphed/subnets-compare-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-history-chart.tsx
@@ -1,0 +1,248 @@
+import { useState } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
+import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { classNames } from "@/lib/metagraphed/format";
+import {
+  OVERLAY_METRICS,
+  OVERLAY_METRIC_LABEL,
+  buildOverlayModel,
+  formatOverlayValue,
+  overlayColor,
+  overlayTotalPoints,
+  type OverlayMetric,
+  type OverlayModel,
+} from "@/lib/metagraphed/overlay-history";
+
+// Mirrors the window selector on SubnetHistoryChart / NeuronHistoryChart so
+// the picker feels the same in either place.
+type Win = "7d" | "30d" | "90d" | "1y" | "all";
+const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
+
+// Fixed SVG viewBox; `preserveAspectRatio="none"` lets the container width
+// drive the actual pixel size, matching how Sparkline scales.
+const CHART_W = 640;
+const CHART_H = 200;
+const PAD = 4;
+
+/**
+ * Multi-subnet overlay chart for the compare drawer (#6885). One `useQueries`
+ * call fans out to /subnets/{netuid}/history (the same endpoint SubnetHistoryChart
+ * already uses per-subnet) and renders one polyline per subnet on a shared axis.
+ * Chart primitives (colors, SVG path shape, aria wiring) mirror Sparkline so no
+ * new charting stack is introduced.
+ */
+export function SubnetsCompareHistoryChart({ netuids }: { netuids: number[] }) {
+  const [win, setWin] = useState<Win>("90d");
+  const [metric, setMetric] = useState<OverlayMetric>("stake");
+
+  const queries = useQueries({
+    queries: netuids.map((n) => ({ ...subnetHistoryQuery(n, win), retry: 0 })),
+  });
+
+  const isLoading = queries.some((q) => q.isLoading);
+  const allErrored = queries.length > 0 && queries.every((q) => q.isError);
+  const firstError = queries.find((q) => q.isError);
+
+  // buildOverlayModel is cheap and runs only on the drawer's expanded view;
+  // re-computing per render tracks queries + metric without a dynamic dep list.
+  const inputs = netuids.map((n, i) => ({
+    netuid: n,
+    points: queries[i]?.data?.data?.points ?? [],
+  }));
+  const model = buildOverlayModel(inputs, metric);
+  const hasData = overlayTotalPoints(model) > 0;
+
+  return (
+    <div className="space-y-3 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <MetricPicker value={metric} onChange={setMetric} />
+        <WindowPicker value={win} onChange={setWin} />
+      </div>
+
+      {isLoading ? (
+        <Skeleton className="h-48 w-full" />
+      ) : allErrored ? (
+        <ErrorState
+          error={firstError?.error}
+          onRetry={() => {
+            for (const q of queries) q.refetch();
+          }}
+          context="compare history"
+        />
+      ) : !hasData ? (
+        <EmptyState
+          title="No on-chain history"
+          description="Selected subnets have no daily snapshots for this metric and window yet."
+        />
+      ) : (
+        <>
+          <OverlayChart model={model} metric={metric} netuids={netuids} />
+          <OverlayLegend netuids={netuids} model={model} metric={metric} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function MetricPicker({
+  value,
+  onChange,
+}: {
+  value: OverlayMetric;
+  onChange: (m: OverlayMetric) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Overlay metric"
+      className="inline-flex flex-wrap rounded-md border border-border bg-surface/40 p-0.5"
+    >
+      {OVERLAY_METRICS.map((m) => (
+        <button
+          key={m}
+          type="button"
+          role="tab"
+          aria-selected={m === value}
+          onClick={() => onChange(m)}
+          className={classNames(
+            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            m === value ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {OVERLAY_METRIC_LABEL[m]}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function WindowPicker({ value, onChange }: { value: Win; onChange: (w: Win) => void }) {
+  return (
+    <div
+      role="tablist"
+      aria-label="History window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
+      {WINDOWS.map((w) => (
+        <button
+          key={w}
+          type="button"
+          role="tab"
+          aria-selected={w === value}
+          onClick={() => onChange(w)}
+          className={classNames(
+            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            w === value ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {w}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function OverlayChart({
+  model,
+  metric,
+  netuids,
+}: {
+  model: OverlayModel;
+  metric: OverlayMetric;
+  netuids: number[];
+}) {
+  const innerW = CHART_W - PAD * 2;
+  const innerH = CHART_H - PAD * 2;
+  const tSpan = model.tMax - model.tMin || 1;
+  const vSpan = model.vMax - model.vMin || 1;
+
+  const toX = (t: number) => PAD + ((t - model.tMin) / tSpan) * innerW;
+  const toY = (v: number) => PAD + innerH - ((v - model.vMin) / vSpan) * innerH;
+
+  const ariaLabel = `${OVERLAY_METRIC_LABEL[metric]} history overlay for subnets ${netuids.join(", ")}`;
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-3">
+      <svg
+        role="img"
+        aria-label={ariaLabel}
+        viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+        preserveAspectRatio="none"
+        className="block h-40 w-full sm:h-48"
+      >
+        <line
+          x1={PAD}
+          x2={CHART_W - PAD}
+          y1={PAD + innerH}
+          y2={PAD + innerH}
+          stroke="var(--border)"
+          strokeWidth={1}
+        />
+        {model.series.map((s, i) => {
+          if (s.points.length === 0) return null;
+          const color = overlayColor(i);
+          const d = s.points
+            .map((pt, j) => {
+              if (s.points.length === 1) {
+                const cx = PAD + innerW / 2;
+                const cy = toY(pt.v);
+                return `M${cx.toFixed(1)},${cy.toFixed(1)}`;
+              }
+              const x = toX(pt.t).toFixed(1);
+              const y = toY(pt.v).toFixed(1);
+              return `${j === 0 ? "M" : "L"}${x},${y}`;
+            })
+            .join(" ");
+          return (
+            <path
+              key={s.netuid}
+              d={d}
+              fill="none"
+              stroke={color}
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+function OverlayLegend({
+  netuids,
+  model,
+  metric,
+}: {
+  netuids: number[];
+  model: OverlayModel;
+  metric: OverlayMetric;
+}) {
+  return (
+    <ul className="flex flex-wrap items-center gap-x-4 gap-y-2">
+      {netuids.map((n, i) => {
+        const s = model.series[i];
+        const last = s?.points[s.points.length - 1];
+        const color = overlayColor(i);
+        return (
+          <li
+            key={n}
+            className="inline-flex items-baseline gap-1.5 font-mono text-[11px] text-ink-strong"
+          >
+            <span
+              aria-hidden
+              className="inline-block size-2 shrink-0 rounded-sm translate-y-[-1px]"
+              style={{ backgroundColor: color }}
+            />
+            <span>SN{n}</span>
+            <span className="text-ink-muted tabular-nums">
+              {last ? formatOverlayValue(metric, last.v) : "—"}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/overlay-history.test.ts
+++ b/apps/ui/src/lib/metagraphed/overlay-history.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import {
+  OVERLAY_COLORS,
+  OVERLAY_METRICS,
+  OVERLAY_METRIC_LABEL,
+  buildOverlayModel,
+  formatOverlayValue,
+  overlayColor,
+  overlayTotalPoints,
+  type OverlayInputSeries,
+} from "./overlay-history";
+import type { SubnetHistoryPoint } from "./types";
+
+const p = (date: string, extra: Partial<SubnetHistoryPoint> = {}): SubnetHistoryPoint => ({
+  snapshot_date: date,
+  ...extra,
+});
+
+describe("OVERLAY constants", () => {
+  it("exposes the four metrics with matching labels", () => {
+    expect(OVERLAY_METRICS).toEqual(["neurons", "validators", "stake", "emission"]);
+    for (const m of OVERLAY_METRICS) {
+      expect(typeof OVERLAY_METRIC_LABEL[m]).toBe("string");
+    }
+  });
+
+  it("provides six chart color tokens keyed to --chart-N", () => {
+    expect(OVERLAY_COLORS).toHaveLength(6);
+    OVERLAY_COLORS.forEach((c, i) => expect(c).toBe(`var(--chart-${i + 1})`));
+  });
+});
+
+describe("overlayColor", () => {
+  it("wraps by modulo for any positive index", () => {
+    expect(overlayColor(0)).toBe(OVERLAY_COLORS[0]);
+    expect(overlayColor(5)).toBe(OVERLAY_COLORS[5]);
+    expect(overlayColor(6)).toBe(OVERLAY_COLORS[0]);
+    expect(overlayColor(13)).toBe(OVERLAY_COLORS[1]);
+  });
+
+  it("normalises negative indices", () => {
+    expect(overlayColor(-1)).toBe(OVERLAY_COLORS[1]);
+    expect(overlayColor(-6)).toBe(OVERLAY_COLORS[0]);
+  });
+});
+
+describe("buildOverlayModel", () => {
+  it("returns empty ranges when no inputs are given", () => {
+    const model = buildOverlayModel([], "stake");
+    expect(model.series).toEqual([]);
+    expect(model.tMin).toBe(0);
+    expect(model.tMax).toBe(0);
+    expect(model.vMin).toBe(0);
+    expect(model.vMax).toBe(0);
+  });
+
+  it("returns empty ranges when inputs carry no finite values", () => {
+    const inputs: OverlayInputSeries[] = [
+      {
+        netuid: 1,
+        points: [p("2026-06-01"), p("2026-06-02", { total_stake_tao: Number.NaN })],
+      },
+    ];
+    const model = buildOverlayModel(inputs, "stake");
+    expect(model.series[0]!.points).toEqual([]);
+    expect(model.tMin).toBe(0);
+    expect(model.tMax).toBe(0);
+    expect(model.vMin).toBe(0);
+    expect(model.vMax).toBe(0);
+  });
+
+  it("picks the metric key, drops NaN / undefined, and sorts chronologically", () => {
+    const inputs: OverlayInputSeries[] = [
+      {
+        netuid: 7,
+        points: [
+          p("2026-06-03", { total_stake_tao: 30 }),
+          p("2026-06-01", { total_stake_tao: 10 }),
+          p("2026-06-02", { total_stake_tao: Number.NaN }),
+          p("2026-06-04", { total_stake_tao: 40 }),
+        ],
+      },
+    ];
+    const model = buildOverlayModel(inputs, "stake");
+    expect(model.series[0]!.netuid).toBe(7);
+    expect(model.series[0]!.points.map((q) => q.v)).toEqual([10, 30, 40]);
+    expect(model.vMin).toBe(10);
+    expect(model.vMax).toBe(40);
+    expect(model.tMin).toBe(Date.parse("2026-06-01"));
+    expect(model.tMax).toBe(Date.parse("2026-06-04"));
+  });
+
+  it("computes a shared range across multiple subnets", () => {
+    const inputs: OverlayInputSeries[] = [
+      {
+        netuid: 1,
+        points: [p("2026-06-01", { neuron_count: 5 }), p("2026-06-05", { neuron_count: 8 })],
+      },
+      {
+        netuid: 2,
+        points: [p("2026-06-02", { neuron_count: 2 }), p("2026-06-06", { neuron_count: 20 })],
+      },
+    ];
+    const model = buildOverlayModel(inputs, "neurons");
+    expect(model.tMin).toBe(Date.parse("2026-06-01"));
+    expect(model.tMax).toBe(Date.parse("2026-06-06"));
+    expect(model.vMin).toBe(2);
+    expect(model.vMax).toBe(20);
+    expect(model.series.map((s) => s.netuid)).toEqual([1, 2]);
+  });
+
+  it("skips points with malformed snapshot dates", () => {
+    const inputs: OverlayInputSeries[] = [
+      {
+        netuid: 1,
+        points: [p("not-a-date", { validator_count: 5 }), p("2026-06-02", { validator_count: 7 })],
+      },
+    ];
+    const model = buildOverlayModel(inputs, "validators");
+    expect(model.series[0]!.points).toEqual([{ t: Date.parse("2026-06-02"), v: 7 }]);
+  });
+
+  it("keeps subnets with no finite points but empty series", () => {
+    const inputs: OverlayInputSeries[] = [
+      { netuid: 1, points: [p("2026-06-01", { total_stake_tao: 10 })] },
+      { netuid: 2, points: [] },
+    ];
+    const model = buildOverlayModel(inputs, "stake");
+    expect(model.series).toHaveLength(2);
+    expect(model.series[1]!.points).toEqual([]);
+  });
+
+  it("picks emission when asked for it", () => {
+    const inputs: OverlayInputSeries[] = [
+      {
+        netuid: 1,
+        points: [
+          p("2026-06-01", { total_stake_tao: 999, total_emission_tao: 4 }),
+          p("2026-06-02", { total_emission_tao: 6 }),
+        ],
+      },
+    ];
+    const model = buildOverlayModel(inputs, "emission");
+    expect(model.series[0]!.points.map((q) => q.v)).toEqual([4, 6]);
+  });
+});
+
+describe("formatOverlayValue", () => {
+  it("uses formatTao for stake and emission", () => {
+    expect(formatOverlayValue("stake", 1234)).toMatch(/τ|TAO|1[,.]/);
+    expect(formatOverlayValue("emission", 0)).toMatch(/τ|TAO|0/);
+  });
+
+  it("uses formatNumber for counts", () => {
+    expect(formatOverlayValue("neurons", 1500)).toContain("1,500");
+    expect(formatOverlayValue("validators", 2)).toBe("2");
+  });
+});
+
+describe("overlayTotalPoints", () => {
+  it("sums points across every series", () => {
+    const model = buildOverlayModel(
+      [
+        { netuid: 1, points: [p("2026-06-01", { neuron_count: 1 })] },
+        {
+          netuid: 2,
+          points: [p("2026-06-01", { neuron_count: 2 }), p("2026-06-02", { neuron_count: 3 })],
+        },
+      ],
+      "neurons",
+    );
+    expect(overlayTotalPoints(model)).toBe(3);
+  });
+
+  it("returns 0 for an empty model", () => {
+    expect(overlayTotalPoints(buildOverlayModel([], "stake"))).toBe(0);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/overlay-history.ts
+++ b/apps/ui/src/lib/metagraphed/overlay-history.ts
@@ -1,0 +1,141 @@
+import { formatNumber, formatTao } from "./format";
+import type { SubnetHistoryPoint } from "./types";
+
+/**
+ * Metric picker + overlay-model helpers for the compare drawer's chart tab
+ * (#6885). Kept pure so tests can drive it without React or a QueryClient —
+ * the component only owns fetching and rendering.
+ */
+
+/** Metrics matching the per-subnet SubnetHistoryChart's rows. */
+export type OverlayMetric = "neurons" | "validators" | "stake" | "emission";
+
+export const OVERLAY_METRICS: readonly OverlayMetric[] = [
+  "neurons",
+  "validators",
+  "stake",
+  "emission",
+] as const;
+
+export const OVERLAY_METRIC_LABEL: Record<OverlayMetric, string> = {
+  neurons: "Neurons",
+  validators: "Validators",
+  stake: "Total stake",
+  emission: "Total emission",
+};
+
+const METRIC_KEY: Record<OverlayMetric, keyof SubnetHistoryPoint> = {
+  neurons: "neuron_count",
+  validators: "validator_count",
+  stake: "total_stake_tao",
+  emission: "total_emission_tao",
+};
+
+/** Chart color tokens, mirroring providers.index.tsx's palette usage. */
+export const OVERLAY_COLORS: readonly string[] = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+] as const;
+
+export function overlayColor(index: number): string {
+  return OVERLAY_COLORS[Math.abs(index) % OVERLAY_COLORS.length]!;
+}
+
+export interface OverlayInputSeries {
+  netuid: number;
+  points: SubnetHistoryPoint[];
+}
+
+export interface OverlaySeriesPoint {
+  t: number;
+  v: number;
+}
+
+export interface OverlaySeries {
+  netuid: number;
+  points: OverlaySeriesPoint[];
+}
+
+export interface OverlayModel {
+  series: OverlaySeries[];
+  tMin: number;
+  tMax: number;
+  vMin: number;
+  vMax: number;
+}
+
+function parseSnapshotDate(s: string | undefined): number | null {
+  if (!s) return null;
+  const t = Date.parse(s);
+  return Number.isFinite(t) ? t : null;
+}
+
+/**
+ * Build the overlay model from per-subnet history: pick the requested metric,
+ * coerce to finite numbers, sort each series by snapshot date, and compute a
+ * shared x/y range so every series scales to the same axes. Series with no
+ * finite points are still returned (empty points array) so the legend row
+ * stays lined up with the input order.
+ */
+export function buildOverlayModel(
+  inputs: readonly OverlayInputSeries[],
+  metric: OverlayMetric,
+): OverlayModel {
+  const key = METRIC_KEY[metric];
+  const series: OverlaySeries[] = inputs.map((input) => {
+    const pts: OverlaySeriesPoint[] = [];
+    for (const p of input.points) {
+      const t = parseSnapshotDate(p.snapshot_date);
+      const raw = p[key];
+      if (t == null) continue;
+      if (typeof raw !== "number" || !Number.isFinite(raw)) continue;
+      pts.push({ t, v: raw });
+    }
+    pts.sort((a, b) => a.t - b.t);
+    return { netuid: input.netuid, points: pts };
+  });
+
+  let tMin = Number.POSITIVE_INFINITY;
+  let tMax = Number.NEGATIVE_INFINITY;
+  let vMin = Number.POSITIVE_INFINITY;
+  let vMax = Number.NEGATIVE_INFINITY;
+  for (const s of series) {
+    for (const p of s.points) {
+      if (p.t < tMin) tMin = p.t;
+      if (p.t > tMax) tMax = p.t;
+      if (p.v < vMin) vMin = p.v;
+      if (p.v > vMax) vMax = p.v;
+    }
+  }
+
+  if (!Number.isFinite(tMin) || !Number.isFinite(tMax)) {
+    tMin = 0;
+    tMax = 0;
+  }
+  if (!Number.isFinite(vMin) || !Number.isFinite(vMax)) {
+    vMin = 0;
+    vMax = 0;
+  }
+
+  return { series, tMin, tMax, vMin, vMax };
+}
+
+/** Metric-aware value formatter for the legend and tooltips. */
+export function formatOverlayValue(metric: OverlayMetric, v: number): string {
+  if (metric === "stake" || metric === "emission") return formatTao(v);
+  return formatNumber(v);
+}
+
+/**
+ * Total point count across every series — a simple "has any data" signal the
+ * component uses to switch between the empty-state and the chart.
+ */
+export function overlayTotalPoints(model: OverlayModel): number {
+  let n = 0;
+  for (const s of model.series) n += s.points.length;
+  return n;
+}


### PR DESCRIPTION
Turns out the compare drawer already lets you pick up to four subnets and drop them side by side in `CompareGrid`, but there's no way to see how their on-chain history compares over time — you can only look at the current-instant metrics. Tao Swap's Multi-chart tool is the direct precedent for this among the 11 explorers surveyed. This adds an overlay chart tab to the existing drawer using the pieces already in the repo.

## What changed

The expanded drawer now has a tab bar with two views. **Metrics** keeps the existing `CompareGrid` unchanged. **Overlay chart** fans out `/api/v1/subnets/{netuid}/history` for every selected netuid via `useQueries` — the same endpoint `SubnetHistoryChart` already uses per-subnet, not a new one — and draws one polyline per subnet on a shared x/y axis, using the same SVG path shape as `Sparkline` so no new charting stack is introduced.

Above the chart sit two pickers:

- Metric: Neurons / Validators / Total stake / Total emission — exactly the four rows `subnet-history-chart.tsx` already renders per subnet.
- Window: 7d / 30d / 90d / 1y / all — same options every history chart in the repo has.

Series colors come from the `--chart-1..6` design tokens the palette already uses (see `providers.index.tsx`, `neuron-history-chart.tsx`), so it fits in both themes without any new color decisions. The legend under the chart shows `SN{n}` and the latest value, formatted with the same `formatTao` / `formatNumber` the per-subnet chart uses.

Model + range building is pulled out into `apps/ui/src/lib/metagraphed/overlay-history.ts` so it can be unit-tested without React. It skips points with malformed dates or non-finite metric values, sorts each series chronologically, and returns a shared min/max for both axes.

## Screenshots

| Viewport / Theme | Before (Metrics tab, current) | After — Metrics | After — Overlay chart |
| --- | --- | --- | --- |
| Desktop light | ![](https://raw.githubusercontent.com/nghetien/agentfix-assets/1b63d552d02d10f842184a5a34fe018d9a8be67f/runs/jsonbored-metagraphed/run-39/before-desktop-light-grid.png) | ![](https://raw.githubusercontent.com/nghetien/agentfix-assets/6185f7f963eaff5a26cb187db52011ef5ae44f41/runs/jsonbored-metagraphed/run-39/after-desktop-light-grid.png) | ![](https://raw.githubusercontent.com/nghetien/agentfix-assets/c3c8efbfb6a0c503476f20f359960345d52e4f00/runs/jsonbored-metagraphed/run-39/after-desktop-light-chart.png) |
| Desktop dark | ![](https://raw.githubusercontent.com/nghetien/agentfix-assets/444ba63414d1292544045cf99bcab46074ebff02/runs/jsonbored-metagraphed/run-39/before-desktop-dark-grid.png) | ![](https://raw.githubusercontent.com/nghetien/agentfix-assets/7244365109a5490ff56ee297088cc0ca4bc66648/runs/jsonbored-metagraphed/run-39/after-desktop-dark-grid.png) | ![](https://raw.githubusercontent.com/nghetien/agentfix-assets/d682ca7c00a7132bba7e9dc7931ebb77b0f51249/runs/jsonbored-metagraphed/run-39/after-desktop-dark-chart.png) |
| Mobile light | ![](https://raw.githubusercontent.com/nghetien/agentfix-assets/b2396ebba44bf03aa061675806cb24ef14fda115/runs/jsonbored-metagraphed/run-39/before-mobile-light-grid.png) | ![](https://raw.githubusercontent.com/nghetien/agentfix-assets/839cb4e122d09560c03397743c8cab43e982305d/runs/jsonbored-metagraphed/run-39/after-mobile-light-grid.png) | ![](https://raw.githubusercontent.com/nghetien/agentfix-assets/35c0ac076939a5862508d24f60e5bffc32b574ce/runs/jsonbored-metagraphed/run-39/after-mobile-light-chart.png) |
| Mobile dark | ![](https://raw.githubusercontent.com/nghetien/agentfix-assets/2eff8bbd2eaa2e2c5c86d5c3381ad3385c9cb6d2/runs/jsonbored-metagraphed/run-39/before-mobile-dark-grid.png) | ![](https://raw.githubusercontent.com/nghetien/agentfix-assets/38f760791dab4e7cd83a51a096d7bdbbddcf79e0/runs/jsonbored-metagraphed/run-39/after-mobile-dark-grid.png) | ![](https://raw.githubusercontent.com/nghetien/agentfix-assets/8aa02f9e862ddd9767f4a2872ef7f18ff22f3e45/runs/jsonbored-metagraphed/run-39/after-mobile-dark-chart.png) |

## Testing

Ran locally against the workflow: `npm run build`, root `test:ci`, `lint`, `format:check`, the full `validate` suite, `worker:bundle:budget`, `scan:public-safety`, `validate:private-boundary`, then `packages/ui-kit` build + typecheck + lint + test, then `apps/ui` lint + format:check + typecheck + test + build — all green. `overlay-history.test.ts` covers the range-building, metric selection, sort order, malformed-input handling, and empty-series edge cases (15 assertions). Also opened the drawer manually with 3 subnets selected, flipped every metric and every window, checked both themes at 1280×800 and 375×812; the chart re-scales on selection changes and the legend follows.

Closes #6885