### PR TITLE
feat(mcp): get_top_holders tool wrapping the balance leaderboard route

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -613,6 +613,13 @@ import {
   ACCOUNTS_LIST_LIMIT_DEFAULT,
   ACCOUNTS_LIST_LIMIT_MAX,
 } from "./accounts-list.mjs";
+import {
+  buildTopHoldersList,
+  TOP_HOLDERS_SORTS,
+  DEFAULT_TOP_HOLDERS_SORT,
+  TOP_HOLDERS_LIMIT_DEFAULT,
+  TOP_HOLDERS_LIMIT_MAX,
+} from "./top-holders.mjs";
 import { buildSubnetHyperparams } from "./subnet-hyperparams.mjs";
 import { buildSubnetHyperparamsHistory } from "./subnet-hyperparams-history.mjs";
 import { buildAlphaVolume } from "./alpha-volume.mjs";
@@ -8640,6 +8647,54 @@ export const MCP_TOOLS = [
     },
   },
   {
+    name: "get_top_holders",
+    title: "Get the balance-based top-holder leaderboard",
+    description:
+      "Fetch the balance-based top-holder leaderboard (#6741/#6743): every " +
+      "account (coldkey) with a nonzero free balance and/or delegated stake " +
+      "position, with free/delegated/total TAO columns list_accounts explicitly " +
+      "cannot derive. Sortable by total_tao (default), free_tao, or " +
+      "delegated_tao. The coldkey/balance-centric counterpart to list_accounts. " +
+      "Mirrors GET /api/v1/accounts/top-holders.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sort: {
+          type: "string",
+          enum: TOP_HOLDERS_SORTS,
+          description: "Ranking key (default total_tao).",
+        },
+        limit: {
+          type: "integer",
+          description: "Max accounts to return (1-100, default 20).",
+          minimum: 1,
+          maximum: TOP_HOLDERS_LIMIT_MAX,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const sort =
+        optionalEnum(args, "sort", TOP_HOLDERS_SORTS) ??
+        DEFAULT_TOP_HOLDERS_SORT;
+      const limit = clampLimit(
+        args?.limit,
+        TOP_HOLDERS_LIMIT_DEFAULT,
+        TOP_HOLDERS_LIMIT_MAX,
+      );
+      return (
+        (await tryPostgresTier(
+          ctx.env,
+          mcpNeuronsTierRequest("/api/v1/accounts/top-holders", {
+            sort,
+            limit,
+          }),
+          "METAGRAPH_TOP_HOLDERS_SOURCE",
+        )) ?? buildTopHoldersList([], { sort, limit })
+      );
+    },
+  },
+  {
     name: "get_block_chain_events",
     title: "Get every raw chain event in one block",
     description:
@@ -14366,6 +14421,25 @@ const TOOL_OUTPUT_SCHEMAS = {
         latest_captured_at: NULLABLE_STRING,
         latest_block_number: NULLABLE_INT,
         subnets: { type: "array", items: { type: "object" } },
+      }),
+    },
+  },
+  get_top_holders: {
+    type: "object",
+    additionalProperties: true,
+    required: ["sort", "limit", "account_count", "accounts"],
+    properties: {
+      schema_version: { type: "integer" },
+      sort: { type: "string", enum: TOP_HOLDERS_SORTS },
+      limit: { type: "integer" },
+      captured_at: NULLABLE_STRING,
+      account_count: { type: "integer" },
+      accounts: objectItems({
+        ss58: { type: "string" },
+        free_tao: ANY,
+        delegated_tao: ANY,
+        total_tao: ANY,
+        last_updated: NULLABLE_STRING,
       }),
     },
   },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -18080,7 +18080,10 @@ describe("MCP get_top_holders — Postgres tier wiring", () => {
     const res = await callTool("get_top_holders", {}, { env });
     assert.equal(res.body.result.isError, false);
     assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(captured, "/api/v1/accounts/top-holders?sort=total_tao&limit=20");
+    assert.equal(
+      captured,
+      "/api/v1/accounts/top-holders?sort=total_tao&limit=20",
+    );
   });
 
   test("flag=postgres falls back to the schema-stable empty shape on failure", async () => {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -18035,6 +18035,68 @@ describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () =>
     const res = await callTool("list_accounts", { sort: "bogus" });
     assert.equal(res.body.result.isError, true);
   });
+
+  test("get_top_holders returns a schema-stable empty leaderboard (cold/absent Postgres tier)", async () => {
+    const res = await callTool("get_top_holders", {});
+    const out = res.body.result.structuredContent;
+    assert.equal(out.sort, "total_tao");
+    assert.equal(out.limit, 20);
+    assert.equal(out.account_count, 0);
+    assert.deepEqual(out.accounts, []);
+  });
+
+  test("get_top_holders accepts each REST-supported sort key with an empty leaderboard", async () => {
+    for (const sort of ["total_tao", "free_tao", "delegated_tao"]) {
+      const res = await callTool("get_top_holders", { sort, limit: 1 });
+      const out = res.body.result.structuredContent;
+      assert.equal(out.sort, sort);
+      assert.equal(out.limit, 1);
+    }
+  });
+
+  test("get_top_holders rejects an invalid sort", async () => {
+    const res = await callTool("get_top_holders", { sort: "bogus" });
+    assert.equal(res.body.result.isError, true);
+  });
+});
+
+// get_top_holders uses its own METAGRAPH_TOP_HOLDERS_SOURCE flag (#6741/
+// #6743), distinct from the shared METAGRAPH_NEURONS_SOURCE flag the CASES
+// table below tests -- verified separately here rather than folded into
+// that table, same isolation rationale as every other flag-scoped block.
+describe("MCP get_top_holders — Postgres tier wiring", () => {
+  test("flag=postgres uses Postgres data at the REST-equivalent path", async () => {
+    let captured;
+    const env = {
+      METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          const reqUrl = new URL(req.url);
+          captured = reqUrl.pathname + reqUrl.search;
+          return Response.json({ schema_version: 1, marker: "from-postgres" });
+        },
+      },
+    };
+    const res = await callTool("get_top_holders", {}, { env });
+    assert.equal(res.body.result.isError, false);
+    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
+    assert.equal(captured, "/api/v1/accounts/top-holders?sort=total_tao&limit=20");
+  });
+
+  test("flag=postgres falls back to the schema-stable empty shape on failure", async () => {
+    const env = {
+      METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    const res = await callTool("get_top_holders", {}, { env });
+    assert.equal(res.body.result.isError, false);
+    assert.equal(res.body.result.structuredContent.marker, undefined);
+    assert.equal(res.body.result.structuredContent.account_count, 0);
+  });
 });
 
 describe("MCP endpoint tools — live overlay staleness fix (#5225)", () => {


### PR DESCRIPTION
## Summary

- Adds `get_top_holders`, mirroring `list_accounts`' exact structure: same `inputSchema` shape (`sort`/`limit`), same `tryPostgresTier` wiring under its own `METAGRAPH_TOP_HOLDERS_SOURCE` flag, same schema-stable empty-leaderboard fallback when the Postgres tier is cold or absent.
- Registers the tool's output schema in `TOOL_OUTPUT_SCHEMAS`.
- No server-card/`MCP_SERVER_VERSION`/`server.json` changes needed — those are worker-computed post-merge per the contributor skill.

Originally stacked on #6949, rebased cleanly onto `main` now that it's merged.

Closes #6744

## Test plan

- [x] Full `mcp-server.test.mjs` suite (1182 tests) passes against rebased `main`
- [x] `npm run build` — clean, zero diff beyond the two files touched (confirms no server-card/version regen needed)
- [x] All six `validate:*` gates + `node scripts/scan-public-safety.mjs` — clean
- [x] Confirmed the MCP dispatch mechanism (`TOOLS_BY_NAME.get(name)`, exact Map lookup) has no analog to the REST-route dispatch-order bug fixed in #6949 — named-tool lookup can't be shadowed the way a regex-ordered route can