### PR TITLE
feat(ui): make the compare drawer a mobile sheet and overlay subnet history

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -3,23 +3,27 @@ import { useQuery } from "@tanstack/react-query";
 import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
 import { Sparkline } from "@jsonbored/ui-kit";
 import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
-import { healthColorVar } from "@/lib/health-tokens";
-import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import {
+  SUBNET_HISTORY_METRICS,
+  SUBNET_HISTORY_WINDOWS,
+  pickMetricValues,
+  type SubnetHistoryWindow,
+} from "@/lib/metagraphed/subnet-history-metrics";
 import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
-
-// Lowercase windows, mirroring the /history API + the inline toggle conventions
-// used by health-trends.tsx. "all" maps to the API's widest supported window.
-type Win = "7d" | "30d" | "90d" | "1y" | "all";
-const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
 
 /**
  * Per-subnet on-chain history (#1302). A window selector drives a daily snapshot
  * series; each metric renders as a labelled Sparkline row (mirrors
  * subnet-growth-card.tsx's GrowthRow). Optional detail — renders null when the
  * subnet has no history yet, so it never clutters a cold profile.
+ *
+ * The window + metric vocabulary lives in lib/metagraphed/subnet-history-metrics
+ * so the compare drawer's multi-subnet overlay (#6885) offers exactly the same
+ * set without either side drifting.
  */
 export function SubnetHistoryChart({ netuid }: { netuid: number }) {
-  const [win, setWin] = useState<Win>("90d");
+  const [win, setWin] = useState<SubnetHistoryWindow>("90d");
   const {
     data: res,
     isLoading,
@@ -29,25 +33,16 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
   } = useQuery(subnetHistoryQuery(netuid, win));
   const points = useMemo<SubnetHistoryPoint[]>(() => res?.data?.points ?? [], [res?.data?.points]);
 
-  const series = useMemo(() => {
-    const pick = (key: keyof SubnetHistoryPoint) =>
-      points
-        .map((p) => p[key])
-        .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
-    return {
-      neurons: pick("neuron_count"),
-      validators: pick("validator_count"),
-      stake: pick("total_stake_tao"),
-      emission: pick("total_emission_tao"),
-    };
-  }, [points]);
+  const series = useMemo(
+    () =>
+      SUBNET_HISTORY_METRICS.map((metric) => ({
+        metric,
+        values: pickMetricValues(points, metric.field),
+      })),
+    [points],
+  );
 
-  const hasData =
-    series.neurons.length +
-      series.validators.length +
-      series.stake.length +
-      series.emission.length >
-    0;
+  const hasData = series.some((s) => s.values.length > 0);
 
   const windowSelector = (
     <div
@@ -55,7 +50,7 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
       aria-label="History window"
       className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
     >
-      {WINDOWS.map((w) => (
+      {SUBNET_HISTORY_WINDOWS.map((w) => (
         <button
           key={w}
           type="button"
@@ -87,32 +82,17 @@ export function SubnetHistoryChart({ netuid }: { netuid: number }) {
         />
       ) : (
         <div className="rounded-xl border border-border bg-card p-4 space-y-3">
-          {series.neurons.length > 0 ? (
-            <HistoryRow label="Neurons" series={series.neurons} color="var(--accent)" />
-          ) : null}
-          {series.validators.length > 0 ? (
-            <HistoryRow
-              label="Validators"
-              series={series.validators}
-              color={healthColorVar("ok")}
-            />
-          ) : null}
-          {series.stake.length > 0 ? (
-            <HistoryRow
-              label="Total stake"
-              series={series.stake}
-              color={healthColorVar("warn")}
-              format={formatTao}
-            />
-          ) : null}
-          {series.emission.length > 0 ? (
-            <HistoryRow
-              label="Total emission"
-              series={series.emission}
-              color="var(--accent)"
-              format={formatTao}
-            />
-          ) : null}
+          {series.map(({ metric, values }) =>
+            values.length > 0 ? (
+              <HistoryRow
+                key={metric.key}
+                label={metric.label}
+                series={values}
+                color={metric.color}
+                format={metric.format}
+              />
+            ) : null,
+          )}
         </div>
       )}
     </div>

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -7,29 +7,70 @@ import { compareQuery } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { CompareSubnet, HealthState } from "@/lib/metagraphed/types";
 import { HealthPill, CurationChip } from "@jsonbored/ui-kit";
+import { SubnetsCompareHistoryChart } from "@/components/metagraphed/subnets-compare-history-chart";
+import {
+  COMPARE_BODY_CLASS,
+  COMPARE_SCRIM_CLASS,
+  COMPARE_SHEET_CARD_CLASS,
+  COMPARE_SHEET_ROOT_CLASS,
+  COMPARE_SHEET_WRAPPER_CLASS,
+} from "@/lib/metagraphed/compare-drawer-layout";
+
+/** The two views of the expanded drawer: instant metrics, or history over time. */
+type CompareView = "metrics" | "history";
+const COMPARE_VIEWS: Array<{ key: CompareView; label: string }> = [
+  { key: "metrics", label: "Metrics" },
+  { key: "history", label: "History" },
+];
 
 /**
  * Floating bottom dock + expandable side-by-side compare drawer for selected
  * subnets. Selection state lives in localStorage via useCompareSelection so
  * it survives navigation. Pure presentation — does not mutate URL.
+ *
+ * The expanded view tabs between CompareGrid (current instant metrics) and
+ * SubnetsCompareHistoryChart (the multi-subnet history overlay, #6885).
  */
 export function SubnetsCompareDrawer() {
   const { selected, max, remove, clear } = useCompareSelection();
   const [expanded, setExpanded] = useState(false);
+  const [view, setView] = useState<CompareView>("metrics");
 
   if (selected.length === 0) return null;
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-40 pointer-events-none">
-      <div className="max-w-shell-max mx-auto px-4 md:px-10 pb-3">
+    <div
+      className={classNames(
+        "fixed inset-x-0 bottom-0 z-40 pointer-events-none",
+        // Expanded, the drawer becomes a bottom sheet below md so the content
+        // gets real room instead of being squeezed into a floating card over
+        // the page. From md up it stays the inline dock it has always been.
+        expanded && COMPARE_SHEET_ROOT_CLASS,
+      )}
+    >
+      {expanded ? (
+        <button
+          type="button"
+          aria-label="Close compare"
+          onClick={() => setExpanded(false)}
+          className={COMPARE_SCRIM_CLASS}
+        />
+      ) : null}
+      <div
+        className={classNames(
+          "max-w-shell-max mx-auto px-4 md:px-10 pb-3",
+          expanded && COMPARE_SHEET_WRAPPER_CLASS,
+        )}
+      >
         <div
           className={classNames(
             "pointer-events-auto rounded-xl border border-border bg-card/95 backdrop-blur shadow-[0_-8px_32px_-12px_color-mix(in_oklab,var(--ink-strong)_35%,transparent)]",
             "mg-fade-in",
+            expanded && COMPARE_SHEET_CARD_CLASS,
           )}
         >
           {/* Dock */}
-          <div className="flex flex-wrap items-center gap-2 px-3 py-2">
+          <div className="flex shrink-0 flex-wrap items-center gap-2 px-3 py-2">
             <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
               <BarChart3 className="size-3 text-accent" />
               Compare
@@ -81,7 +122,38 @@ export function SubnetsCompareDrawer() {
           </div>
 
           {/* Expanded side-by-side */}
-          {expanded && selected.length >= 2 ? <CompareGrid netuids={selected} /> : null}
+          {expanded && selected.length >= 2 ? (
+            <>
+              <div
+                role="tablist"
+                aria-label="Compare view"
+                className="flex shrink-0 items-center gap-1 border-t border-border px-3 py-1.5"
+              >
+                {COMPARE_VIEWS.map((v) => (
+                  <button
+                    key={v.key}
+                    type="button"
+                    role="tab"
+                    aria-selected={v.key === view}
+                    onClick={() => setView(v.key)}
+                    className={classNames(
+                      "rounded-full px-3 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+                      v.key === view
+                        ? "bg-ink-strong text-paper"
+                        : "text-ink-muted hover:text-ink-strong",
+                    )}
+                  >
+                    {v.label}
+                  </button>
+                ))}
+              </div>
+              {view === "metrics" ? (
+                <CompareGrid netuids={selected} />
+              ) : (
+                <SubnetsCompareHistoryChart netuids={selected} />
+              )}
+            </>
+          ) : null}
         </div>
       </div>
     </div>
@@ -225,9 +297,39 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
     );
   }
 
+  const cell = (netuid: number, row: (typeof rows)[number]) =>
+    isPending ? (
+      <span className="inline-block h-3 w-12 animate-pulse rounded bg-border/60" />
+    ) : (
+      row.render(netuid)
+    );
+
   return (
-    <div className="border-t border-border max-h-[55vh] overflow-auto">
-      <table className="min-w-full text-[12px]">
+    <div className={COMPARE_BODY_CLASS}>
+      {/*
+        Below md the side-by-side table cannot fit: with the label column plus
+        one column per subnet it always clipped the right-most subnet. Render a
+        card per subnet instead (the house `md:hidden` / `hidden md:block` pair),
+        driven by the SAME rows[] the table uses so the two can't drift.
+      */}
+      <ul className="space-y-2 p-3 md:hidden">
+        {netuids.map((n) => (
+          <li key={n} className="min-w-0 space-y-2 rounded-lg border border-border bg-card p-3">
+            <div className="font-mono text-[10px] uppercase tracking-widest text-ink-strong">
+              SN{n}
+            </div>
+            <dl className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-[11px]">
+              {rows.map((row) => (
+                <div key={row.label} className="flex items-baseline justify-between gap-2">
+                  <dt className="shrink-0 text-ink-muted">{row.label}</dt>
+                  <dd className="min-w-0 truncate text-right">{cell(n, row)}</dd>
+                </div>
+              ))}
+            </dl>
+          </li>
+        ))}
+      </ul>
+      <table className="hidden min-w-full text-[12px] md:table">
         <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
           <tr>
             <th className="sticky left-0 z-[2] w-40 bg-card/95 px-3 py-2 text-left font-mono text-[10px] uppercase tracking-widest text-ink-muted backdrop-blur">
@@ -251,11 +353,7 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
               </td>
               {netuids.map((n) => (
                 <td key={n} className="px-3 py-2">
-                  {isPending ? (
-                    <span className="inline-block h-3 w-12 animate-pulse rounded bg-border/60" />
-                  ) : (
-                    row.render(n)
-                  )}
+                  {cell(n, row)}
                 </td>
               ))}
             </tr>

--- a/apps/ui/src/components/metagraphed/subnets-compare-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-history-chart.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
+import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import {
+  SUBNET_HISTORY_METRICS,
+  SUBNET_HISTORY_WINDOWS,
+  buildOverlayGeometry,
+  type SubnetHistoryMetricKey,
+  type SubnetHistoryWindow,
+} from "@/lib/metagraphed/subnet-history-metrics";
+import { COMPARE_BODY_CLASS } from "@/lib/metagraphed/compare-drawer-layout";
+
+// viewBox units. The SVG scales to its container via preserveAspectRatio="none",
+// with non-scaling strokes so lines stay hairline-thin at any width.
+const VIEW_W = 600;
+const VIEW_H = 160;
+
+/**
+ * Multi-subnet history overlay for the compare drawer (#6885). Fetches
+ * /subnets/{netuid}/history once per selected subnet and draws them on ONE set
+ * of shared axes — the time-series counterpart to CompareGrid's instant-metrics
+ * table.
+ *
+ * The metric list and window list come from lib/metagraphed/subnet-history-metrics,
+ * the same source SubnetHistoryChart uses for a single subnet, so the picker
+ * offers exactly what the per-subnet chart already exposes. Selection (and its
+ * cap) stays owned by useCompareSelection — this component only reads the
+ * netuids it is handed.
+ */
+export function SubnetsCompareHistoryChart({ netuids }: { netuids: number[] }) {
+  const [win, setWin] = useState<SubnetHistoryWindow>("90d");
+  const [metricKey, setMetricKey] = useState<SubnetHistoryMetricKey>("stake");
+
+  const metric =
+    SUBNET_HISTORY_METRICS.find((m) => m.key === metricKey) ?? SUBNET_HISTORY_METRICS[0]!;
+
+  const results = useQueries({
+    queries: netuids.map((netuid) => ({ ...subnetHistoryQuery(netuid, win), retry: 0 })),
+  });
+
+  const isPending = results.some((r) => r.isPending);
+  const isError = results.some((r) => r.isError);
+
+  // Cheap enough to derive on every render (the API caps a window at a few
+  // hundred daily points, times at most useCompareSelection's 4 subnets), so
+  // this stays a plain derivation rather than a memo keyed on unstable arrays.
+  const geo = buildOverlayGeometry(
+    netuids.map((netuid, i) => ({ netuid, points: results[i]?.data?.data?.points ?? [] })),
+    metric.field,
+    VIEW_W,
+    VIEW_H,
+  );
+
+  const format = (v: number | null) =>
+    v == null ? "—" : metric.format ? metric.format(v) : formatNumber(v);
+
+  // Each group stays a single non-wrapping row and scrolls horizontally if it
+  // still cannot fit: a segmented control that wraps orphans its last option
+  // inside the shared border and reads as broken. The two groups stack at <sm
+  // (both are full-width rows) and sit on one line from sm up.
+  const groupClass =
+    "inline-flex max-w-full shrink-0 overflow-x-auto rounded-md border border-border bg-surface/40 p-0.5";
+  const buttonClass = (active: boolean) =>
+    classNames(
+      "shrink-0 whitespace-nowrap rounded px-2.5 py-1 font-mono text-[11px] uppercase tracking-wider transition-colors",
+      active ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+    );
+
+  const controls = (
+    <div className="flex flex-col gap-2 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+      <div role="tablist" aria-label="Overlay metric" className={groupClass}>
+        {SUBNET_HISTORY_METRICS.map((m) => (
+          <button
+            key={m.key}
+            type="button"
+            role="tab"
+            aria-selected={m.key === metric.key}
+            onClick={() => setMetricKey(m.key)}
+            className={buttonClass(m.key === metric.key)}
+          >
+            {m.shortLabel}
+          </button>
+        ))}
+      </div>
+      <div role="tablist" aria-label="History window" className={groupClass}>
+        {SUBNET_HISTORY_WINDOWS.map((w) => (
+          <button
+            key={w}
+            type="button"
+            role="tab"
+            aria-selected={w === win}
+            onClick={() => setWin(w)}
+            className={buttonClass(w === win)}
+          >
+            {w}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className={COMPARE_BODY_CLASS}>
+      {controls}
+      <div className="px-3 pb-3">
+        {isPending ? (
+          <div className="h-28 w-full animate-pulse sm:h-40 rounded-lg bg-border/40" />
+        ) : isError ? (
+          <div className="py-6 text-center">
+            <p className="font-mono text-[11px] text-ink-muted">Could not load history.</p>
+            <button
+              type="button"
+              onClick={() => results.forEach((r) => void r.refetch())}
+              className="mt-2 inline-flex h-7 items-center rounded-full border border-border bg-paper px-3 font-mono text-[10px] uppercase tracking-widest text-ink-strong transition-colors hover:border-accent/60 hover:text-accent"
+            >
+              Retry
+            </button>
+          </div>
+        ) : !geo ? (
+          <p className="py-6 text-center font-mono text-[11px] text-ink-muted">
+            No on-chain history for the selected subnets in this window.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex items-stretch gap-2 rounded-lg border border-border bg-card p-3">
+              <svg
+                viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+                preserveAspectRatio="none"
+                className="h-28 w-full min-w-0 flex-1 sm:h-40"
+                role="img"
+                aria-label={`${metric.label} over ${win} for ${netuids
+                  .map((n) => `SN${n}`)
+                  .join(", ")}`}
+              >
+                {geo.series.map((s) =>
+                  s.path ? (
+                    <path
+                      key={s.netuid}
+                      d={s.path}
+                      fill="none"
+                      stroke={s.color}
+                      strokeWidth={1.5}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      vectorEffect="non-scaling-stroke"
+                    />
+                  ) : null,
+                )}
+              </svg>
+              {/* Shared y domain, so the series are directly comparable. Sits
+                  beside the plot rather than over it — overlaid, these labels
+                  collided with the lines they annotate. */}
+              <div className="flex shrink-0 flex-col justify-between text-right font-mono text-[10px] text-ink-muted">
+                <span>{format(geo.max)}</span>
+                <span>{format(geo.min)}</span>
+              </div>
+            </div>
+            <div className="flex items-center justify-between font-mono text-[10px] text-ink-muted">
+              <span>{geo.dates[0]}</span>
+              <span>{geo.dates[geo.dates.length - 1]}</span>
+            </div>
+            <ul className="flex flex-wrap gap-x-4 gap-y-1.5">
+              {geo.series.map((s) => (
+                <li key={s.netuid} className="inline-flex items-center gap-1.5">
+                  <span
+                    aria-hidden
+                    className="size-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: s.color }}
+                  />
+                  <span className="font-mono text-[11px] text-ink-strong">SN{s.netuid}</span>
+                  <span className="font-mono text-[11px] tabular-nums text-ink-muted">
+                    {format(s.last)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/compare-drawer-layout.test.ts
+++ b/apps/ui/src/lib/metagraphed/compare-drawer-layout.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMPARE_BODY_CLASS,
+  COMPARE_SCRIM_CLASS,
+  COMPARE_SHEET_CARD_CLASS,
+  COMPARE_SHEET_ROOT_CLASS,
+  COMPARE_SHEET_WRAPPER_CLASS,
+} from "./compare-drawer-layout";
+
+const ALL = [
+  COMPARE_BODY_CLASS,
+  COMPARE_SCRIM_CLASS,
+  COMPARE_SHEET_CARD_CLASS,
+  COMPARE_SHEET_ROOT_CLASS,
+  COMPARE_SHEET_WRAPPER_CLASS,
+];
+
+describe("compare drawer layout tokens (#6885)", () => {
+  it("stays mobile-first — no max-* variants, which this codebase never uses", () => {
+    for (const cls of ALL) expect(cls).not.toMatch(/\bmax-(sm|md|lg|xl):/);
+  });
+
+  it("lets the body take leftover sheet height on mobile and caps it from md up", () => {
+    // Without min-h-0 a flex child refuses to shrink below its content, which is
+    // what pushes a sheet's card past the viewport.
+    expect(COMPARE_BODY_CLASS).toContain("min-h-0");
+    expect(COMPARE_BODY_CLASS).toContain("flex-1");
+    expect(COMPARE_BODY_CLASS).toContain("overflow-auto");
+    // Desktop keeps exactly the behaviour it shipped with.
+    expect(COMPARE_BODY_CLASS).toContain("md:max-h-[55vh]");
+    expect(COMPARE_BODY_CLASS).toContain("md:flex-none");
+  });
+
+  it("makes the card a flex column on mobile and restores block flow from md up", () => {
+    expect(COMPARE_SHEET_CARD_CLASS).toContain("flex");
+    expect(COMPARE_SHEET_CARD_CLASS).toContain("min-h-0");
+    expect(COMPARE_SHEET_CARD_CLASS).toContain("md:block");
+    expect(COMPARE_SHEET_CARD_CLASS).toContain("md:max-h-none");
+  });
+
+  it("expands the root to full screen on mobile only", () => {
+    expect(COMPARE_SHEET_ROOT_CLASS).toContain("top-0");
+    expect(COMPARE_SHEET_ROOT_CLASS).toContain("md:top-auto");
+  });
+
+  it("anchors the sheet to the bottom without changing desktop flow", () => {
+    expect(COMPARE_SHEET_WRAPPER_CLASS).toContain("justify-end");
+    expect(COMPARE_SHEET_WRAPPER_CLASS).toContain("h-full");
+    expect(COMPARE_SHEET_WRAPPER_CLASS).toContain("md:h-auto");
+    expect(COMPARE_SHEET_WRAPPER_CLASS).toContain("md:block");
+  });
+
+  it("keeps the scrim mobile-only and clickable", () => {
+    expect(COMPARE_SCRIM_CLASS).toContain("md:hidden");
+    expect(COMPARE_SCRIM_CLASS).toContain("pointer-events-auto");
+    expect(COMPARE_SCRIM_CLASS).toContain("inset-0");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/compare-drawer-layout.ts
+++ b/apps/ui/src/lib/metagraphed/compare-drawer-layout.ts
@@ -1,0 +1,29 @@
+/**
+ * Layout tokens for the subnets compare drawer, kept out of the components so
+ * both expanded views share one definition and it can be asserted in tests —
+ * mirroring explorer-leaderboard-layout.ts.
+ *
+ * Below `md` the expanded drawer is a bottom sheet: the body takes the leftover
+ * height of a flex column (`min-h-0 flex-1`) so long content scrolls inside the
+ * sheet instead of pushing the card past the viewport. From `md` up it keeps the
+ * original fixed `55vh` cap and normal block flow, so desktop is unchanged.
+ *
+ * The codebase is mobile-first (no `max-*` variants anywhere), so the mobile
+ * sheet behaviour is the BASE and `md:` restores the original dock.
+ */
+export const COMPARE_BODY_CLASS =
+  "min-h-0 flex-1 overflow-auto border-t border-border md:max-h-[55vh] md:flex-none";
+
+/** Full-screen sheet on mobile when expanded; bottom-anchored dock from md up. */
+export const COMPARE_SHEET_ROOT_CLASS = "top-0 md:top-auto";
+
+/** Pins the sheet's card to the bottom and lets it grow to the available height. */
+export const COMPARE_SHEET_WRAPPER_CLASS =
+  "relative flex h-full flex-col justify-end pt-3 md:block md:h-auto md:pt-0";
+
+/** Makes the card a flex column so the body can size against it. */
+export const COMPARE_SHEET_CARD_CLASS = "flex max-h-full min-h-0 flex-col md:block md:max-h-none";
+
+/** Tap-outside-to-close scrim, mobile only. Matches the mg-mega-scrim look. */
+export const COMPARE_SCRIM_CLASS =
+  "pointer-events-auto absolute inset-0 bg-[color-mix(in_oklab,var(--paper)_78%,transparent)] backdrop-blur-[2px] md:hidden";

--- a/apps/ui/src/lib/metagraphed/subnet-history-metrics.test.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-history-metrics.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import {
+  SUBNET_HISTORY_METRICS,
+  SUBNET_HISTORY_WINDOWS,
+  SUBNET_SERIES_COLORS,
+  buildOverlayGeometry,
+  pickMetricValues,
+  subnetSeriesColor,
+} from "./subnet-history-metrics";
+import type { SubnetHistoryPoint } from "./types";
+
+const point = (date: string, extra: Partial<SubnetHistoryPoint> = {}): SubnetHistoryPoint => ({
+  snapshot_date: date,
+  ...extra,
+});
+
+describe("subnet history metric vocabulary (#6885)", () => {
+  it("exposes the same four metrics the single-subnet chart renders", () => {
+    expect(SUBNET_HISTORY_METRICS.map((m) => m.key)).toEqual([
+      "neurons",
+      "validators",
+      "stake",
+      "emission",
+    ]);
+  });
+
+  it("formats only the tao-denominated metrics, leaving counts on the default", () => {
+    const byKey = Object.fromEntries(SUBNET_HISTORY_METRICS.map((m) => [m.key, m]));
+    expect(byKey.neurons!.format).toBeUndefined();
+    expect(byKey.validators!.format).toBeUndefined();
+    expect(byKey.stake!.format?.(1500)).toBe("1.5k τ");
+    expect(byKey.emission!.format?.(1500)).toBe("1.5k τ");
+  });
+
+  it("gives every metric a compact picker label that fits a 375px control", () => {
+    // The overlay's segmented control wraps (orphaning its last option) once the
+    // combined labels exceed the drawer's width at 375px. Budget derived from
+    // the measured control: ~7px per uppercase mono char + 20px padding each.
+    const width = SUBNET_HISTORY_METRICS.reduce((sum, m) => sum + m.shortLabel.length * 7 + 20, 0);
+    expect(width).toBeLessThan(351);
+    for (const m of SUBNET_HISTORY_METRICS) {
+      expect(m.shortLabel.length).toBeLessThanOrEqual(m.label.length);
+      expect(m.shortLabel).not.toHaveLength(0);
+    }
+  });
+
+  it("keeps the full label for the single-subnet chart's wider rows", () => {
+    const byKey = Object.fromEntries(SUBNET_HISTORY_METRICS.map((m) => [m.key, m]));
+    expect(byKey.stake!.label).toBe("Total stake");
+    expect(byKey.stake!.shortLabel).toBe("Stake");
+    expect(byKey.emission!.label).toBe("Total emission");
+    expect(byKey.emission!.shortLabel).toBe("Emission");
+  });
+
+  it("offers the windows the /history API supports", () => {
+    expect(SUBNET_HISTORY_WINDOWS).toEqual(["7d", "30d", "90d", "1y", "all"]);
+  });
+
+  it("cycles series colours so a selection larger than the palette still resolves", () => {
+    expect(subnetSeriesColor(0)).toBe(SUBNET_SERIES_COLORS[0]);
+    expect(subnetSeriesColor(SUBNET_SERIES_COLORS.length)).toBe(SUBNET_SERIES_COLORS[0]);
+    expect(subnetSeriesColor(SUBNET_SERIES_COLORS.length + 2)).toBe(SUBNET_SERIES_COLORS[2]);
+  });
+});
+
+describe("pickMetricValues", () => {
+  it("keeps only finite numbers", () => {
+    const points = [
+      point("2026-01-01", { neuron_count: 10 }),
+      point("2026-01-02", { neuron_count: undefined }),
+      point("2026-01-03", { neuron_count: Number.NaN }),
+      point("2026-01-04", { neuron_count: 12 }),
+    ];
+    expect(pickMetricValues(points, "neuron_count")).toEqual([10, 12]);
+  });
+
+  it("returns an empty array when the metric is absent throughout", () => {
+    expect(pickMetricValues([point("2026-01-01")], "total_stake_tao")).toEqual([]);
+  });
+});
+
+describe("buildOverlayGeometry", () => {
+  it("returns null when no subnet has a finite value", () => {
+    expect(
+      buildOverlayGeometry([{ netuid: 1, points: [point("2026-01-01")] }], "neuron_count", 100, 50),
+    ).toBeNull();
+  });
+
+  it("aligns subnets on a shared date axis rather than their own indices", () => {
+    // SN2 starts a day later; its first point must land at x of 2026-01-02,
+    // not at x=0 where naive per-series indexing would put it.
+    const geo = buildOverlayGeometry(
+      [
+        {
+          netuid: 1,
+          points: [
+            point("2026-01-01", { neuron_count: 0 }),
+            point("2026-01-02", { neuron_count: 0 }),
+            point("2026-01-03", { neuron_count: 0 }),
+          ],
+        },
+        {
+          netuid: 2,
+          points: [
+            point("2026-01-02", { neuron_count: 10 }),
+            point("2026-01-03", { neuron_count: 10 }),
+          ],
+        },
+      ],
+      "neuron_count",
+      100,
+      50,
+    );
+
+    expect(geo).not.toBeNull();
+    expect(geo!.dates).toEqual(["2026-01-01", "2026-01-02", "2026-01-03"]);
+    expect(geo!.series[1]!.path.startsWith("M50 ")).toBe(true);
+  });
+
+  it("shares one y domain across every series", () => {
+    const geo = buildOverlayGeometry(
+      [
+        { netuid: 1, points: [point("2026-01-01", { total_stake_tao: 5 })] },
+        { netuid: 2, points: [point("2026-01-01", { total_stake_tao: 95 })] },
+      ],
+      "total_stake_tao",
+      100,
+      50,
+    );
+    expect(geo!.min).toBe(5);
+    expect(geo!.max).toBe(95);
+  });
+
+  it("breaks the path at a gap instead of interpolating across it", () => {
+    // The axis only carries dates some subnet reported, so a hole exists only
+    // relative to the union: SN2 supplies 01-02, which SN1 is missing.
+    const geo = buildOverlayGeometry(
+      [
+        {
+          netuid: 1,
+          points: [
+            point("2026-01-01", { neuron_count: 1 }),
+            point("2026-01-03", { neuron_count: 3 }),
+          ],
+        },
+        {
+          netuid: 2,
+          points: [
+            point("2026-01-01", { neuron_count: 1 }),
+            point("2026-01-02", { neuron_count: 2 }),
+            point("2026-01-03", { neuron_count: 3 }),
+          ],
+        },
+      ],
+      "neuron_count",
+      100,
+      50,
+    );
+    expect(geo!.dates).toEqual(["2026-01-01", "2026-01-02", "2026-01-03"]);
+    // Two subpaths => two movetos, so nothing is drawn through the missing day.
+    expect(geo!.series[0]!.path.match(/M/g)).toHaveLength(2);
+    // The subnet with full coverage stays a single unbroken subpath.
+    expect(geo!.series[1]!.path.match(/M/g)).toHaveLength(1);
+  });
+
+  it("renders an isolated point as a zero-length line so it shows as a dot", () => {
+    const geo = buildOverlayGeometry(
+      [{ netuid: 7, points: [point("2026-01-01", { neuron_count: 4 })] }],
+      "neuron_count",
+      100,
+      50,
+    );
+    expect(geo!.series[0]!.path).toBe("M50 25L50 25");
+  });
+
+  it("centres a flat series vertically instead of pinning it to an edge", () => {
+    const geo = buildOverlayGeometry(
+      [
+        {
+          netuid: 1,
+          points: [
+            point("2026-01-01", { neuron_count: 8 }),
+            point("2026-01-02", { neuron_count: 8 }),
+          ],
+        },
+      ],
+      "neuron_count",
+      100,
+      50,
+    );
+    expect(geo!.series[0]!.path).toBe("M0 25L100 25");
+  });
+
+  it("maps the domain extremes to the padded top and bottom", () => {
+    const geo = buildOverlayGeometry(
+      [
+        {
+          netuid: 1,
+          points: [
+            point("2026-01-01", { neuron_count: 0 }),
+            point("2026-01-02", { neuron_count: 100 }),
+          ],
+        },
+      ],
+      "neuron_count",
+      100,
+      50,
+    );
+    // height 50, pad 2 => min at y=48, max at y=2.
+    expect(geo!.series[0]!.path).toBe("M0 48L100 2");
+  });
+
+  it("reports the latest finite value per subnet and keeps empty subnets listed", () => {
+    const geo = buildOverlayGeometry(
+      [
+        {
+          netuid: 1,
+          points: [
+            point("2026-01-01", { neuron_count: 1 }),
+            point("2026-01-02", { neuron_count: 9 }),
+          ],
+        },
+        { netuid: 2, points: [point("2026-01-01")] },
+      ],
+      "neuron_count",
+      100,
+      50,
+    );
+    expect(geo!.series[0]!.last).toBe(9);
+    expect(geo!.series[1]!.last).toBeNull();
+    expect(geo!.series[1]!.path).toBe("");
+    expect(geo!.series.map((s) => s.netuid)).toEqual([1, 2]);
+  });
+
+  it("assigns each subnet a distinct series colour", () => {
+    const geo = buildOverlayGeometry(
+      [
+        { netuid: 1, points: [point("2026-01-01", { neuron_count: 1 })] },
+        { netuid: 2, points: [point("2026-01-01", { neuron_count: 2 })] },
+      ],
+      "neuron_count",
+      100,
+      50,
+    );
+    expect(geo!.series[0]!.color).toBe(SUBNET_SERIES_COLORS[0]);
+    expect(geo!.series[1]!.color).toBe(SUBNET_SERIES_COLORS[1]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/subnet-history-metrics.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-history-metrics.ts
@@ -1,0 +1,231 @@
+import { healthColorVar } from "@/lib/health-tokens";
+import { formatTao } from "@/lib/metagraphed/format";
+import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
+
+/**
+ * Shared vocabulary for the /subnets/{netuid}/history series (#1302), extracted
+ * from subnet-history-chart.tsx so the single-subnet chart and the compare
+ * drawer's multi-subnet overlay (#6885) can never disagree about which windows
+ * and metrics exist. The single-subnet chart colours each metric differently;
+ * the overlay colours each SUBNET differently (SUBNET_SERIES_COLORS below),
+ * since there the metric is fixed and the subnet is the varying dimension.
+ */
+
+// Lowercase windows, mirroring the /history API + the inline toggle conventions
+// used by health-trends.tsx. "all" maps to the API's widest supported window.
+export type SubnetHistoryWindow = "7d" | "30d" | "90d" | "1y" | "all";
+export const SUBNET_HISTORY_WINDOWS: readonly SubnetHistoryWindow[] = [
+  "7d",
+  "30d",
+  "90d",
+  "1y",
+  "all",
+];
+
+export type SubnetHistoryMetricKey = "neurons" | "validators" | "stake" | "emission";
+
+/** A numeric field of SubnetHistoryPoint the chart can plot. */
+type SubnetHistoryField =
+  "neuron_count" | "validator_count" | "total_stake_tao" | "total_emission_tao";
+
+export interface SubnetHistoryMetric {
+  key: SubnetHistoryMetricKey;
+  label: string;
+  /**
+   * Compact label for the overlay's segmented picker. Same metric, shorter
+   * string: at 375px the full labels overflow the control and wrap onto a
+   * second row, which orphans the last option inside its own border. The
+   * single-subnet chart keeps `label` for its wider row layout.
+   */
+  shortLabel: string;
+  field: SubnetHistoryField;
+  /** Per-metric colour, used by the single-subnet chart only. */
+  color: string;
+  /**
+   * Value formatter. Deliberately optional: the count metrics render through
+   * the Sparkline/legend default so their display is unchanged by this
+   * extraction — only the τ-denominated metrics override it.
+   */
+  format?: (v: number) => string;
+}
+
+export const SUBNET_HISTORY_METRICS: readonly SubnetHistoryMetric[] = [
+  {
+    key: "neurons",
+    label: "Neurons",
+    shortLabel: "Neurons",
+    field: "neuron_count",
+    color: "var(--accent)",
+  },
+  {
+    key: "validators",
+    label: "Validators",
+    shortLabel: "Validators",
+    field: "validator_count",
+    color: healthColorVar("ok"),
+  },
+  {
+    key: "stake",
+    label: "Total stake",
+    shortLabel: "Stake",
+    field: "total_stake_tao",
+    color: healthColorVar("warn"),
+    format: formatTao,
+  },
+  {
+    key: "emission",
+    label: "Total emission",
+    shortLabel: "Emission",
+    field: "total_emission_tao",
+    color: "var(--accent)",
+    format: formatTao,
+  },
+];
+
+/**
+ * Categorical series colours for the overlay, one per selected subnet. Follows
+ * the `--chart-N` token convention (styles.css) and the existing modulo idiom
+ * (explorer.tsx's CALL_MIX_PALETTE, providers.index.tsx's kindPalette). Four
+ * entries covers useCompareSelection's MAX of 4; the modulo keeps it correct if
+ * that cap ever rises.
+ */
+export const SUBNET_SERIES_COLORS: readonly string[] = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+];
+
+export function subnetSeriesColor(index: number): string {
+  return SUBNET_SERIES_COLORS[index % SUBNET_SERIES_COLORS.length]!;
+}
+
+/** Pull the finite values of one metric out of a subnet's history points. */
+export function pickMetricValues(
+  points: readonly SubnetHistoryPoint[],
+  field: SubnetHistoryField,
+): number[] {
+  return points
+    .map((p) => p[field])
+    .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+}
+
+export interface SubnetHistoryInput {
+  netuid: number;
+  points: readonly SubnetHistoryPoint[];
+}
+
+export interface OverlaySeries {
+  netuid: number;
+  color: string;
+  /**
+   * SVG path data in the requested viewBox. Empty string when this subnet has
+   * no finite value for the metric — the legend still lists it, so the user can
+   * see that the subnet was included but had nothing to plot.
+   */
+  path: string;
+  /** Most recent finite value, for the legend readout. */
+  last: number | null;
+}
+
+export interface OverlayGeometry {
+  /** Union of snapshot dates across all subnets, ascending — the shared x axis. */
+  dates: readonly string[];
+  series: readonly OverlaySeries[];
+  /** Shared y domain, so the series are directly comparable against each other. */
+  min: number;
+  max: number;
+}
+
+const PAD = 2;
+
+/**
+ * Project several subnets' history onto ONE set of shared axes.
+ *
+ * x is the union of snapshot dates (subnets registered at different times have
+ * different-length series, so indexing each series by its own position would
+ * silently misalign them in time). y is a single domain spanning every series,
+ * which is what makes the overlay a real comparison rather than four
+ * independently-normalised lines that imply a similarity that isn't there.
+ *
+ * A subnet missing a date the union has leaves a gap: the path starts a new
+ * subpath rather than interpolating across it, so absent data never renders as
+ * a straight line that looks like real measurement.
+ *
+ * Returns null when no subnet has a single finite value for the metric.
+ */
+export function buildOverlayGeometry(
+  inputs: readonly SubnetHistoryInput[],
+  field: SubnetHistoryField,
+  width: number,
+  height: number,
+): OverlayGeometry | null {
+  const valueByDate = inputs.map((input) => {
+    const map = new Map<string, number>();
+    for (const p of input.points) {
+      const v = p[field];
+      if (typeof p.snapshot_date === "string" && typeof v === "number" && Number.isFinite(v)) {
+        map.set(p.snapshot_date, v);
+      }
+    }
+    return map;
+  });
+
+  const dateSet = new Set<string>();
+  for (const map of valueByDate) for (const date of map.keys()) dateSet.add(date);
+  // ISO-8601 dates sort correctly as plain strings.
+  const dates = [...dateSet].sort();
+  if (dates.length === 0) return null;
+
+  let min = Infinity;
+  let max = -Infinity;
+  for (const map of valueByDate) {
+    for (const v of map.values()) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+
+  const span = max - min;
+  const innerHeight = height - PAD * 2;
+  const step = dates.length > 1 ? width / (dates.length - 1) : 0;
+  const round = (n: number) => Math.round(n * 100) / 100;
+
+  const series = inputs.map((input, i) => {
+    const map = valueByDate[i]!;
+    // Contiguous runs of present dates; a missing date closes the current run.
+    const runs: Array<Array<[number, number]>> = [];
+    let run: Array<[number, number]> = [];
+    let last: number | null = null;
+
+    for (let di = 0; di < dates.length; di += 1) {
+      const v = map.get(dates[di]!);
+      if (v === undefined) {
+        if (run.length > 0) runs.push(run);
+        run = [];
+        continue;
+      }
+      last = v;
+      // A flat series (span 0) sits on the vertical centre rather than pinned to
+      // an edge, matching how a single-value Sparkline reads.
+      const x = dates.length > 1 ? di * step : width / 2;
+      const y = span === 0 ? height / 2 : height - PAD - ((v - min) / span) * innerHeight;
+      run.push([round(x), round(y)]);
+    }
+    if (run.length > 0) runs.push(run);
+
+    // A lone point is emitted as a zero-length line so stroke-linecap="round"
+    // renders it as a dot — a bare moveto would draw nothing at all.
+    const path = runs
+      .map((r) =>
+        r.length === 1
+          ? `M${r[0]![0]} ${r[0]![1]}L${r[0]![0]} ${r[0]![1]}`
+          : r.map(([x, y], j) => `${j === 0 ? "M" : "L"}${x} ${y}`).join(""),
+      )
+      .join("");
+
+    return { netuid: input.netuid, color: subnetSeriesColor(i), path, last };
+  });
+
+  return { dates, series, min, max };
+}


### PR DESCRIPTION
## Summary

Adds the multi-subnet history overlay #6885 asks for, **and first makes the drawer a surface that can host it on mobile.**

- **New History tab** in the compare drawer's expanded view, alongside `CompareGrid`, overlaying each selected subnet's `/subnets/{netuid}/history` on one set of shared axes. No new endpoint, no charting library: N calls to the already-shipped endpoint via `useQueries` (the existing idiom in `validator-apy-panel.tsx` / `your-positions-panel.tsx`), drawn as hand-rolled SVG like every other chart here.
- **Below `md`, the expanded drawer is now a bottom sheet** — full height, tap-outside-to-close scrim — instead of a floating card squeezed over the page.
- **Below `md`, `CompareGrid` renders one card per subnet** instead of the side-by-side table, driven by the *same* `rows[]` the table uses so the two can't drift.
- The window/metric vocabulary moves out of `subnet-history-chart.tsx` into `lib/metagraphed/subnet-history-metrics.ts`, and the single-subnet chart consumes it, so the overlay's picker offers exactly the four metrics that chart already exposes.
- **Desktop and tablet are unchanged** — every mobile behaviour above is the base style with a `md:` override restoring the original dock, matching the codebase's strictly mobile-first convention (there are zero `max-*` variants anywhere in `apps/ui`).

### Why the drawer change is in scope

This is deliberately more than "add a chart tab", so I want to be explicit about it rather than have it read as scope creep.

The issue's Expected Outcome is *"a user comparing subnets can see their history overlaid on one chart."* On mobile that was not reachable in the drawer as it stood: at 375px the expanded panel is a floating card over the page, and its side-by-side table — a label column plus one column per subnet — **always clipped the right-most subnet**. A previous attempt at this issue (#6922, closed) added the chart into that surface unchanged and was rejected as looking broken, correctly. Adding another tab to a container that can't display its existing tab is not delivering the issue.

So this PR fixes the container first. `CompareGrid`'s desktop rendering is untouched; what changes is that it gains a mobile rendering it never had.

### Mobile, measured

Drawer card `getBoundingClientRect()` against `innerHeight`, on the real rendered page:

| View | Before | After |
| --- | --- | --- |
| Metrics @ 375×812 | 427px — right-most subnet **clipped** | 636px sheet — **all 3 subnets fully legible**, scrolls |
| History @ 375×812 | *(did not exist)* | 398px — 49% of viewport |
| Metrics @ 1280×800 | 395px | 431px (tab row only) |
| History @ 1280×800 | *(did not exist)* | 375px |

The mobile Metrics sheet is taller because stacked cards show *everything* rather than clipping it — that is the fix, not a regression. It sits behind a scrim, so it reads as an intentional sheet.

Supporting mobile-only tightening of the chart tab: each segmented control is a single non-wrapping row (a wrapping one orphaned its last option inside the shared border — the specific defect that sank #6922), a compact `shortLabel` for the picker, and a `h-28 sm:h-40` chart.

### Two deliberate charting decisions

- **One shared y domain in absolute units, not per-series normalisation.** Normalising each subnet to its own 0–100% would make unrelated curves look comparable when they aren't. The tradeoff is real: subnets of very different magnitude compress the smaller one toward the axis. Absolute is the honest default; an index-to-100 toggle is a reasonable follow-up but I did not invent one here.
- **Gaps break the line rather than interpolating.** The x axis is the *union* of snapshot dates, since subnets registered at different times have different-length series and indexing each by its own position would silently misalign them in time. Where a subnet has no value for a date another subnet reported, the path starts a new subpath — absent data never renders as a straight segment that looks like real measurement.

## Files touched

- `apps/ui/src/lib/metagraphed/compare-drawer-layout.ts` (new) + `.test.ts` — the sheet/body layout class tokens, kept out of the components so both expanded views share one definition and it is assertable. Mirrors the existing `explorer-leaderboard-layout.ts` precedent.
- `apps/ui/src/lib/metagraphed/subnet-history-metrics.ts` (new) + `.test.ts` — shared window/metric vocabulary plus `buildOverlayGeometry`, the pure projection of N subnets onto shared axes. No React, so it is directly unit-testable.
- `apps/ui/src/components/metagraphed/subnets-compare-history-chart.tsx` (new) — the overlay: metric picker, window selector, legend, loading/error/empty states.
- `apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx` — Metrics/History tablist; sheet layout below `md`; `CompareGrid` gains the mobile card rendering. Desktop table markup unchanged.
- `apps/ui/src/components/metagraphed/subnet-history-chart.tsx` — consumes the shared vocabulary. Rendering unchanged: metric order, colours, full labels and the count metrics' default formatting are all preserved.

## Verification

- `npm run lint --workspace=apps/ui` — 0 errors (241 pre-existing `react-refresh` warnings elsewhere, untouched).
- `npm run format:check --workspace=apps/ui` — clean.
- `npm run typecheck --workspace=apps/ui` — clean.
- `npm test --workspace=apps/ui` — 169 files / 1297 tests passing, 23 of them new.
- `npm run test:e2e --workspace=apps/ui` — 28/28, including the responsive-overflow check.
- `npm run build --workspace=apps/ui` — succeeds.
- **Every captured combination asserts three things, not just one:** `scrollWidth <= clientWidth`; the drawer card fully inside the viewport (`top >= 0 && bottom <= innerHeight`); and no `[role="tablist"]` taller than a single button row. All 18 report clean. `/subnets` with an expanded drawer is not covered by the e2e overflow baseline, so this was checked explicitly at capture time.
- Captured against the **live** production API (`api.metagraph.sh`) with real history for SN1 / SN8 / SN64 — the legend values (2.58M / 3.02M / 3.73M τ) match the endpoint's own last data point.

## Screenshot table

3 viewports × 2 themes × before/after, `/subnets` with SN1 / SN8 / SN64 selected and the drawer expanded. **Before** is the drawer as it ships today (metrics grid); **after** is the new History tab.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-after-mobile-dark.png)<br><sub>after</sub> |

### Metrics view — before vs after

The same *after* build on the **Metrics** tab. Desktop/tablet render exactly as today (only the tab row is new); mobile is where the change is — the before column clips the right-most subnet, the after column shows all three as cards.

| Viewport · Theme | Before | After (Metrics tab) |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-overlay-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/cleanjunc/metagraphed/screenshots/6885-compare-metrics-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6885
