### PR TITLE
feat(ui): add a bubble view to /subnets (age × surfaces scatter)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnets-bubble-view.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-bubble-view.tsx
@@ -1,0 +1,219 @@
+import { useMemo } from "react";
+import { EmptyState } from "@/components/metagraphed/states";
+import { healthColorVar } from "@/lib/health-tokens";
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { HealthState, Subnet } from "@/lib/metagraphed/types";
+
+// #6884: an alternate "bubble" scan of /subnets over the SAME filtered list the
+// table renders — position/size/colour encoding instead of sorted rows, to spot
+// outliers a table hides (e.g. a young subnet that already has many participants).
+//
+// Axis defaults, all from fields the subnet LIST already carries (the table shows
+// them too; the list has no stake/emission — those are detail-only):
+//   x = age in days (established-ness)   y = verified surfaces (integration depth)
+//   bubble size = participants (active UIDs)
+//   colour = health state (operational traffic-light)
+// age×surfaces spreads better than age×participants (most subnets max UIDs at 256,
+// which bunches a participants axis at the top); it also tells a sharper story —
+// an old subnet low on the surface axis is under-integrated relative to its age.
+// Rendered as a fixed-viewBox SVG (no client measurement) so it draws server-side
+// and is URL-addressable via ?view=bubble, like the table/grid/matrix views.
+
+const FINNEY_BLOCK_SECONDS = 12;
+const SECONDS_PER_DAY = 86_400;
+
+function ageDays(s: Subnet): number | null {
+  const reg = s.registered_at_block;
+  const now = s.block;
+  if (typeof reg !== "number" || typeof now !== "number") return null;
+  const elapsed = now - reg;
+  if (!Number.isFinite(elapsed) || elapsed < 0) return null;
+  return Math.floor((elapsed * FINNEY_BLOCK_SECONDS) / SECONDS_PER_DAY);
+}
+
+const VB = { w: 900, h: 460 };
+const PAD = { top: 20, right: 24, bottom: 44, left: 56 };
+const R_MIN = 4;
+const R_MAX = 15;
+
+type Point = {
+  netuid: number;
+  name: string;
+  x: number;
+  y: number;
+  r: number;
+  color: string;
+  age: number;
+  participants: number;
+  surfaces: number;
+  health: HealthState;
+};
+
+function niceMax(v: number): number {
+  if (v <= 0) return 1;
+  const mag = Math.pow(10, Math.floor(Math.log10(v)));
+  return Math.ceil(v / mag) * mag;
+}
+
+export function SubnetsBubbleView({ rows }: { rows: Subnet[] }) {
+  const { points, xMax, yMax } = useMemo(() => {
+    const raw = rows
+      .map((s) => {
+        const age = ageDays(s);
+        const participants = typeof s.participants === "number" ? s.participants : null;
+        if (age == null || participants == null) return null;
+        return {
+          netuid: s.netuid,
+          name: s.name ?? `Subnet ${s.netuid}`,
+          age,
+          participants,
+          surfaces: typeof s.surfaces_count === "number" ? s.surfaces_count : 0,
+          health: (s.health ?? "unknown") as HealthState,
+        };
+      })
+      .filter((p): p is NonNullable<typeof p> => p !== null);
+
+    const xMax = niceMax(Math.max(1, ...raw.map((p) => p.age)));
+    const yMax = niceMax(Math.max(1, ...raw.map((p) => p.surfaces)));
+    const pMax = Math.max(1, ...raw.map((p) => p.participants));
+    const innerW = VB.w - PAD.left - PAD.right;
+    const innerH = VB.h - PAD.top - PAD.bottom;
+
+    const points: Point[] = raw.map((p) => ({
+      ...p,
+      x: PAD.left + (p.age / xMax) * innerW,
+      y: PAD.top + (1 - p.surfaces / yMax) * innerH,
+      r: R_MIN + (p.participants / pMax) * (R_MAX - R_MIN),
+      color: healthColorVar(
+        p.health === "ok"
+          ? "ok"
+          : p.health === "warn"
+            ? "warn"
+            : p.health === "down"
+              ? "down"
+              : "unknown",
+      ),
+    }));
+    return { points, xMax, yMax };
+  }, [rows]);
+
+  if (points.length === 0) {
+    return (
+      <EmptyState
+        title="Nothing to plot"
+        description="No subnets in the current filter have both an age and a participant count yet. Adjust the filters or switch back to the table."
+      />
+    );
+  }
+
+  const axisY = VB.h - PAD.bottom;
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-xl border border-border bg-card p-3">
+        <svg
+          viewBox={`0 0 ${VB.w} ${VB.h}`}
+          className="block w-full aspect-[900/460]"
+          role="img"
+          aria-label="Subnets by age in days (x) and verified surface count (y); bubble size is participant count, colour is health state"
+        >
+          {/* axes */}
+          <line x1={PAD.left} y1={PAD.top} x2={PAD.left} y2={axisY} stroke="var(--border)" />
+          <line x1={PAD.left} y1={axisY} x2={VB.w - PAD.right} y2={axisY} stroke="var(--border)" />
+          {/* axis labels */}
+          <text
+            x={PAD.left}
+            y={axisY + 28}
+            fill="var(--ink-muted)"
+            fontSize="12"
+            fontFamily="monospace"
+          >
+            0
+          </text>
+          <text
+            x={VB.w - PAD.right}
+            y={axisY + 28}
+            fill="var(--ink-muted)"
+            fontSize="12"
+            fontFamily="monospace"
+            textAnchor="end"
+          >
+            {formatNumber(xMax)}d
+          </text>
+          <text
+            x={(PAD.left + VB.w - PAD.right) / 2}
+            y={VB.h - 6}
+            fill="var(--ink-muted)"
+            fontSize="12"
+            fontFamily="monospace"
+            textAnchor="middle"
+          >
+            Age (days) →
+          </text>
+          <text
+            x={PAD.left - 10}
+            y={PAD.top + 4}
+            fill="var(--ink-muted)"
+            fontSize="12"
+            fontFamily="monospace"
+            textAnchor="end"
+          >
+            {formatNumber(yMax)}
+          </text>
+          <text
+            x={16}
+            y={(PAD.top + axisY) / 2}
+            fill="var(--ink-muted)"
+            fontSize="12"
+            fontFamily="monospace"
+            textAnchor="middle"
+            transform={`rotate(-90 16 ${(PAD.top + axisY) / 2})`}
+          >
+            Verified surfaces ↑
+          </text>
+          {/* bubbles — each links to the subnet detail (mirrors table row-click) */}
+          {points.map((p) => (
+            <a
+              key={p.netuid}
+              href={`/subnets/${p.netuid}`}
+              aria-label={`${p.name}: ${p.participants} participants, ~${p.age}d old`}
+            >
+              <circle
+                cx={p.x}
+                cy={p.y}
+                r={p.r}
+                fill={p.color}
+                fillOpacity={0.55}
+                stroke={p.color}
+                strokeWidth={1}
+              >
+                <title>
+                  {p.name} (#{p.netuid}) — ~{formatNumber(p.age)}d old,{" "}
+                  {formatNumber(p.participants)} participants, {formatNumber(p.surfaces)} surfaces,{" "}
+                  {p.health}
+                </title>
+              </circle>
+            </a>
+          ))}
+        </svg>
+      </div>
+      {/* legend */}
+      <ul className="flex flex-wrap gap-x-4 gap-y-1.5 text-[11px] text-ink-muted">
+        {(["ok", "warn", "down", "unknown"] as const).map((h) => (
+          <li key={h} className="inline-flex items-center gap-1.5">
+            <span
+              aria-hidden
+              className="inline-block size-2.5 rounded-full"
+              style={{ background: healthColorVar(h) }}
+            />
+            <span className="uppercase tracking-wider">{h}</span>
+          </li>
+        ))}
+        <li className="inline-flex items-center gap-1.5">
+          <span aria-hidden className="inline-block size-3 rounded-full border border-ink-muted" />
+          <span>bubble size = participants</span>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -37,7 +37,7 @@ export const tableSearchSchema = z.object({
   includeRoot: fallback(z.boolean(), true).default(true),
   // Layout state for list routes that support multiple views + row density.
   // Additive + optional with safe fallbacks so the toggles persist in the URL.
-  view: fallback(z.enum(["table", "grid", "matrix"]), "table").default("table"),
+  view: fallback(z.enum(["table", "grid", "matrix", "bubble"]), "table").default("table"),
   density: fallback(z.enum(["comfortable", "compact"]), "comfortable").default("comfortable"),
 });
 

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { Network, Radio, Layers, Activity, Coins } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { SubnetsBubbleView } from "@/components/metagraphed/subnets-bubble-view";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import {
   BrandIcon,
@@ -184,7 +185,11 @@ function SubnetsPage() {
         description="Every active Finney netuid — root and application — with curation level, surface count, health, and freshness."
         actions={
           <>
-            <ViewModeToggle value={search.view} onChange={setView} />
+            <ViewModeToggle
+              value={search.view}
+              onChange={setView}
+              options={["table", "grid", "matrix", "bubble"]}
+            />
             {search.view === "table" ? (
               <DensityToggle value={effectiveDensity} onChange={setDensity} />
             ) : null}
@@ -641,6 +646,19 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
       cursorInvalid={cursorInvalid}
     />
   );
+
+  // #6884: bubble view — an alternate scatter over the same filtered rows.
+  if (view === "bubble") {
+    return (
+      <div>
+        <div className="sticky top-14 z-20 -mx-4 md:mx-0 mb-3 bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80 border-b border-border md:border md:rounded md:bg-card px-3 py-2 md:p-2.5">
+          <div className="flex flex-wrap items-center gap-2">{filters}</div>
+        </div>
+        {rows.length === 0 && !hasNextPage ? emptyNode : <SubnetsBubbleView rows={rows} />}
+        <div className="mt-3">{footerNode}</div>
+      </div>
+    );
+  }
 
   // Grid / matrix views skip ListShell so they're not boxed in a table card.
   if (view === "grid" || view === "matrix") {

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2631,6 +2631,12 @@ var OPTIONS = [
     label: "Matrix",
     Icon: lucideReact.Grid3x3,
     ariaLabel: "Switch to matrix view"
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: lucideReact.ScatterChart,
+    ariaLabel: "Switch to bubble view"
   }
 ];
 function ViewModeToggle({

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1,7 +1,7 @@
 import * as React3 from 'react';
 import { useState, useRef, useEffect, useMemo, useCallback, useId } from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
-import { ChevronDown, X, Search, ArrowUp, Check, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Lock, AlertTriangle } from 'lucide-react';
+import { ChevronDown, X, Search, ArrowUp, Check, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, ScatterChart, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Lock, AlertTriangle } from 'lucide-react';
 import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
@@ -2602,6 +2602,12 @@ var OPTIONS = [
     label: "Matrix",
     Icon: Grid3x3,
     ariaLabel: "Switch to matrix view"
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: ScatterChart,
+    ariaLabel: "Switch to bubble view"
   }
 ];
 function ViewModeToggle({

--- a/packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx
+++ b/packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx
@@ -1,10 +1,10 @@
-import { LayoutGrid, List, Grid3x3 } from "lucide-react";
+import { LayoutGrid, List, Grid3x3, ScatterChart } from "lucide-react";
 import {
   SegmentedToggle,
   type SegmentedToggleOption,
 } from "@/components/ui/segmented-toggle";
 
-export type ViewMode = "table" | "grid" | "matrix";
+export type ViewMode = "table" | "grid" | "matrix" | "bubble";
 
 const OPTIONS: Array<SegmentedToggleOption<ViewMode>> = [
   {
@@ -24,6 +24,12 @@ const OPTIONS: Array<SegmentedToggleOption<ViewMode>> = [
     label: "Matrix",
     Icon: Grid3x3,
     ariaLabel: "Switch to matrix view",
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: ScatterChart,
+    ariaLabel: "Switch to bubble view",
   },
 ];
 


### PR DESCRIPTION
## What

Adds a 4th `/subnets` view mode — **Bubble** — alongside table/grid/matrix: a scatter plot over the **same filtered list** the table already renders, for spotting outliers a sorted table hides. It's URL-driven (`?view=bubble`) like the other views, so it deep-links and renders server-side. Clicking a bubble opens the subnet detail (mirrors table row-click); the existing category/health/etc. filters are shared (same `rows`). Closes #6884.

## Encoding & why (the axis-choice reasoning the issue asks for)

All four channels use fields the subnet **list** already carries (the table shows them too — the list has no stake/emission, those are detail-only):

- **x = age in days** (established-ness; from `registered_at_block`/`block`)
- **y = verified surface count** (integration depth)
- **bubble size = participants** (active UIDs)
- **colour = health state** (operational traffic-light: ok/warn/down/unknown)

I chose **age × surfaces** over the issue's "age × participants" example on purpose: **most subnets max their UID count at 256**, so a participants axis bunches nearly every bubble in a flat band at the top (I built it that way first — it looked cramped and uninformative). Surfaces spread across the range and tell a sharper story — *an old subnet sitting low on the surface axis is under-integrated relative to its age*, which is exactly the kind of outlier the table's sort can't surface. Participants still earns a channel as bubble size.

No charting library is added (the app ships none): it's a fixed-`viewBox` SVG, drawn server-side, mirroring the coordinate approach of the existing `Sparkline` primitive.

## Screenshots

`/subnets` list area — **before** the existing table, **after** the new bubble view (same subnets, same filters).

| Viewport · Theme | Before (table) | After (bubble) |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-mobile-dark.png)<br><sub>after</sub> |

## Testing

- `tsc --noEmit` — clean; `eslint`, `prettier --check` — clean
- ui-kit `ViewMode`/`ViewModeToggle` extended + `dist` rebuilt and committed (index.js/cjs)
- New view verified rendering server-side at `/subnets?view=bubble` across all 3 viewports + both themes
