### PR TITLE
feat(ui): overlay history chart tab in compare drawer

### DIFF
--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -7,15 +7,19 @@ import { compareQuery } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { CompareSubnet, HealthState } from "@/lib/metagraphed/types";
 import { HealthPill, CurationChip } from "@jsonbored/ui-kit";
+import { SubnetsCompareHistoryChart } from "@/components/metagraphed/subnets-compare-history-chart";
 
 /**
  * Floating bottom dock + expandable side-by-side compare drawer for selected
  * subnets. Selection state lives in localStorage via useCompareSelection so
  * it survives navigation. Pure presentation — does not mutate URL.
  */
+type ExpandedTab = "metrics" | "chart";
+
 export function SubnetsCompareDrawer() {
   const { selected, max, remove, clear } = useCompareSelection();
   const [expanded, setExpanded] = useState(false);
+  const [tab, setTab] = useState<ExpandedTab>("metrics");
 
   if (selected.length === 0) return null;
 
@@ -81,7 +85,18 @@ export function SubnetsCompareDrawer() {
           </div>
 
           {/* Expanded side-by-side */}
-          {expanded && selected.length >= 2 ? <CompareGrid netuids={selected} /> : null}
+          {expanded && selected.length >= 2 ? (
+            <div className="border-t border-border">
+              <ExpandedTabs value={tab} onChange={setTab} />
+              {tab === "metrics" ? (
+                <CompareGrid netuids={selected} />
+              ) : (
+                <div className="max-h-[55vh] overflow-auto">
+                  <SubnetsCompareHistoryChart netuids={selected} />
+                </div>
+              )}
+            </div>
+          ) : null}
         </div>
       </div>
     </div>
@@ -100,6 +115,42 @@ function compareHealthState(health: CompareSubnet["health"]): HealthState {
   if (ok >= total) return "ok";
   if (ok === 0) return "down";
   return "warn";
+}
+
+function ExpandedTabs({
+  value,
+  onChange,
+}: {
+  value: ExpandedTab;
+  onChange: (t: ExpandedTab) => void;
+}) {
+  const tabs: Array<{ id: ExpandedTab; label: string }> = [
+    { id: "metrics", label: "Metrics" },
+    { id: "chart", label: "Overlay chart" },
+  ];
+  return (
+    <div
+      role="tablist"
+      aria-label="Compare view"
+      className="flex items-center gap-1 border-b border-border bg-card/70 px-3 py-1.5"
+    >
+      {tabs.map((t) => (
+        <button
+          key={t.id}
+          type="button"
+          role="tab"
+          aria-selected={t.id === value}
+          onClick={() => onChange(t.id)}
+          className={classNames(
+            "rounded px-2.5 py-1 font-mono text-[10px] uppercase tracking-widest transition-colors",
+            t.id === value ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
 }
 
 function CompareGrid({ netuids }: { netuids: number[] }) {
@@ -212,7 +263,7 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
 
   if (isError) {
     return (
-      <div className="border-t border-border px-3 py-6 text-center">
+      <div className="px-3 py-6 text-center">
         <p className="font-mono text-[11px] text-ink-muted">Could not load comparison.</p>
         <button
           type="button"
@@ -226,7 +277,7 @@ function CompareGrid({ netuids }: { netuids: number[] }) {
   }
 
   return (
-    <div className="border-t border-border max-h-[55vh] overflow-auto">
+    <div className="max-h-[55vh] overflow-auto">
       <table className="min-w-full text-[12px]">
         <thead className="sticky top-0 bg-card/95 backdrop-blur z-[1]">
           <tr>

--- a/apps/ui/src/components/metagraphed/subnets-compare-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-history-chart.tsx
@@ -1,0 +1,268 @@
+import { useState } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
+import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
+import { classNames } from "@/lib/metagraphed/format";
+import {
+  OVERLAY_METRICS,
+  OVERLAY_METRIC_LABEL,
+  buildOverlayModel,
+  formatOverlayValue,
+  overlayColor,
+  overlayTotalPoints,
+  type OverlayMetric,
+  type OverlayModel,
+} from "@/lib/metagraphed/overlay-history";
+
+// Mirrors the window selector on SubnetHistoryChart / NeuronHistoryChart so
+// the picker feels the same in either place.
+type Win = "7d" | "30d" | "90d" | "1y" | "all";
+const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
+
+// Fixed SVG viewBox; `preserveAspectRatio="none"` lets the container width
+// drive the actual pixel size, matching how Sparkline scales.
+const CHART_W = 640;
+const CHART_H = 200;
+const PAD_X = 6;
+const PAD_Y = 6;
+
+/**
+ * Multi-subnet overlay chart for the compare drawer (#6885). One `useQueries`
+ * call fans out to /subnets/{netuid}/history (the same endpoint SubnetHistoryChart
+ * already uses per-subnet) and renders one polyline per subnet on a shared axis.
+ * Chart primitives (colors, SVG path shape, aria wiring) mirror Sparkline so no
+ * new charting stack is introduced.
+ */
+export function SubnetsCompareHistoryChart({ netuids }: { netuids: number[] }) {
+  const [win, setWin] = useState<Win>("90d");
+  const [metric, setMetric] = useState<OverlayMetric>("stake");
+
+  const queries = useQueries({
+    queries: netuids.map((n) => ({ ...subnetHistoryQuery(n, win), retry: 0 })),
+  });
+
+  const isLoading = queries.some((q) => q.isLoading);
+  const allErrored = queries.length > 0 && queries.every((q) => q.isError);
+  const firstError = queries.find((q) => q.isError);
+
+  const inputs = netuids.map((n, i) => ({
+    netuid: n,
+    points: queries[i]?.data?.data?.points ?? [],
+  }));
+  const model = buildOverlayModel(inputs, metric);
+  const hasData = overlayTotalPoints(model) > 0;
+
+  return (
+    <div className="space-y-3 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <MetricPicker value={metric} onChange={setMetric} />
+        <WindowPicker value={win} onChange={setWin} />
+      </div>
+
+      {isLoading ? (
+        <Skeleton className="h-48 w-full" />
+      ) : allErrored ? (
+        <ErrorState
+          error={firstError?.error}
+          onRetry={() => {
+            for (const q of queries) q.refetch();
+          }}
+          context="compare history"
+        />
+      ) : !hasData ? (
+        <EmptyState
+          title="No on-chain history"
+          description="Selected subnets have no daily snapshots for this metric and window yet."
+        />
+      ) : (
+        <>
+          <OverlayChart model={model} metric={metric} netuids={netuids} />
+          <OverlayLegend netuids={netuids} model={model} metric={metric} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function MetricPicker({
+  value,
+  onChange,
+}: {
+  value: OverlayMetric;
+  onChange: (m: OverlayMetric) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Overlay metric"
+      className="inline-flex flex-wrap rounded-md border border-border bg-surface/40 p-0.5"
+    >
+      {OVERLAY_METRICS.map((m) => (
+        <button
+          key={m}
+          type="button"
+          role="tab"
+          aria-selected={m === value}
+          onClick={() => onChange(m)}
+          className={classNames(
+            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            m === value ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {OVERLAY_METRIC_LABEL[m]}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function WindowPicker({ value, onChange }: { value: Win; onChange: (w: Win) => void }) {
+  return (
+    <div
+      role="tablist"
+      aria-label="History window"
+      className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+    >
+      {WINDOWS.map((w) => (
+        <button
+          key={w}
+          type="button"
+          role="tab"
+          aria-selected={w === value}
+          onClick={() => onChange(w)}
+          className={classNames(
+            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            w === value ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {w}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function OverlayChart({
+  model,
+  metric,
+  netuids,
+}: {
+  model: OverlayModel;
+  metric: OverlayMetric;
+  netuids: number[];
+}) {
+  const innerW = CHART_W - PAD_X * 2;
+  const innerH = CHART_H - PAD_Y * 2;
+  const tSpan = model.tMax - model.tMin || 1;
+  const vSpan = model.vMax - model.vMin || 1;
+
+  const toX = (t: number) => PAD_X + ((t - model.tMin) / tSpan) * innerW;
+  const toY = (v: number) => PAD_Y + innerH - ((v - model.vMin) / vSpan) * innerH;
+
+  const ariaLabel = `${OVERLAY_METRIC_LABEL[metric]} history overlay for subnets ${netuids.join(", ")}`;
+
+  const maxLabel = formatOverlayValue(metric, model.vMax);
+  const minLabel = formatOverlayValue(metric, model.vMin);
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-3">
+      <div className="flex items-stretch gap-2">
+        <div
+          aria-hidden
+          className="flex w-14 shrink-0 flex-col justify-between font-mono text-[10px] tabular-nums text-ink-muted"
+        >
+          <span className="text-right">{maxLabel}</span>
+          <span className="text-right">{minLabel}</span>
+        </div>
+        <svg
+          role="img"
+          aria-label={ariaLabel}
+          viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+          preserveAspectRatio="none"
+          className="block h-40 w-full sm:h-48"
+        >
+          <line
+            x1={PAD_X}
+            x2={CHART_W - PAD_X}
+            y1={PAD_Y + innerH}
+            y2={PAD_Y + innerH}
+            stroke="var(--border)"
+            strokeWidth={1}
+          />
+          <line
+            x1={PAD_X}
+            x2={CHART_W - PAD_X}
+            y1={PAD_Y}
+            y2={PAD_Y}
+            stroke="var(--border)"
+            strokeDasharray="2 3"
+            strokeWidth={1}
+          />
+          {model.series.map((s, i) => {
+            if (s.points.length === 0) return null;
+            const color = overlayColor(i);
+            const d = s.points
+              .map((pt, j) => {
+                if (s.points.length === 1) {
+                  const cx = PAD_X + innerW / 2;
+                  const cy = toY(pt.v);
+                  return `M${cx.toFixed(1)},${cy.toFixed(1)}`;
+                }
+                const x = toX(pt.t).toFixed(1);
+                const y = toY(pt.v).toFixed(1);
+                return `${j === 0 ? "M" : "L"}${x},${y}`;
+              })
+              .join(" ");
+            return (
+              <path
+                key={s.netuid}
+                d={d}
+                fill="none"
+                stroke={color}
+                strokeWidth={1.5}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            );
+          })}
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+function OverlayLegend({
+  netuids,
+  model,
+  metric,
+}: {
+  netuids: number[];
+  model: OverlayModel;
+  metric: OverlayMetric;
+}) {
+  return (
+    <ul className="flex flex-wrap items-center gap-x-4 gap-y-2">
+      {netuids.map((n, i) => {
+        const s = model.series[i];
+        const last = s?.points[s.points.length - 1];
+        const color = overlayColor(i);
+        return (
+          <li
+            key={n}
+            className="inline-flex items-baseline gap-1.5 font-mono text-[11px] text-ink-strong"
+          >
+            <span
+              aria-hidden
+              className="inline-block size-2 shrink-0 translate-y-[-1px] rounded-sm"
+              style={{ backgroundColor: color }}
+            />
+            <span>SN{n}</span>
+            <span className="tabular-nums text-ink-muted">
+              {last ? formatOverlayValue(metric, last.v) : "—"}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/overlay-history.test.ts
+++ b/apps/ui/src/lib/metagraphed/overlay-history.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import type { SubnetHistoryPoint } from "./types";
+import {
+  OVERLAY_COLORS,
+  OVERLAY_METRICS,
+  OVERLAY_METRIC_LABEL,
+  buildOverlayModel,
+  formatOverlayValue,
+  overlayColor,
+  overlayTotalPoints,
+} from "./overlay-history";
+
+// One helper that produces a point with just the fields we need — everything
+// else on SubnetHistoryPoint is optional so this stays valid.
+function point(date: string, fields: Partial<SubnetHistoryPoint> = {}): SubnetHistoryPoint {
+  return { snapshot_date: date, ...fields };
+}
+
+describe("OVERLAY_METRICS / labels", () => {
+  it("labels every declared metric", () => {
+    for (const m of OVERLAY_METRICS) {
+      expect(OVERLAY_METRIC_LABEL[m]).toBeTruthy();
+    }
+  });
+  it("exposes at least four distinct chart color tokens", () => {
+    expect(new Set(OVERLAY_COLORS).size).toBe(OVERLAY_COLORS.length);
+    expect(OVERLAY_COLORS.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe("overlayColor", () => {
+  it("cycles through the palette by index", () => {
+    for (let i = 0; i < OVERLAY_COLORS.length * 2 + 3; i++) {
+      expect(overlayColor(i)).toBe(OVERLAY_COLORS[i % OVERLAY_COLORS.length]);
+    }
+  });
+  it("handles negative indices without a runtime error", () => {
+    expect(overlayColor(-1)).toBe(OVERLAY_COLORS[1 % OVERLAY_COLORS.length]);
+  });
+});
+
+describe("buildOverlayModel", () => {
+  it("returns an empty-range zero model when there are no inputs", () => {
+    const m = buildOverlayModel([], "stake");
+    expect(m.series).toEqual([]);
+    expect(m.tMin).toBe(0);
+    expect(m.tMax).toBe(0);
+    expect(m.vMin).toBe(0);
+    expect(m.vMax).toBe(0);
+  });
+
+  it("returns an empty-range zero model when every input is empty", () => {
+    const m = buildOverlayModel([{ netuid: 1, points: [] }], "stake");
+    expect(m.series).toEqual([{ netuid: 1, points: [] }]);
+    expect(m.tMin).toBe(0);
+    expect(m.vMax).toBe(0);
+  });
+
+  it("keeps the caller's netuid order so the legend matches the input", () => {
+    const inputs = [
+      { netuid: 43, points: [] },
+      { netuid: 1, points: [] },
+      { netuid: 7, points: [] },
+    ];
+    const m = buildOverlayModel(inputs, "neurons");
+    expect(m.series.map((s) => s.netuid)).toEqual([43, 1, 7]);
+  });
+
+  it("picks the requested metric and coerces bad values away", () => {
+    const inputs = [
+      {
+        netuid: 1,
+        points: [
+          point("2026-01-01", { neuron_count: 10, total_stake_tao: 5 }),
+          point("2026-01-02", { neuron_count: 12 }),
+          point("2026-01-03", { neuron_count: Number.NaN }),
+          point("2026-01-04", { neuron_count: 14 }),
+        ],
+      },
+    ];
+    const m = buildOverlayModel(inputs, "neurons");
+    expect(m.series[0]!.points.map((p) => p.v)).toEqual([10, 12, 14]);
+  });
+
+  it("skips a point whose snapshot_date does not parse", () => {
+    const inputs = [
+      {
+        netuid: 1,
+        points: [
+          point("not-a-date", { total_stake_tao: 5 }),
+          point("2026-01-02", { total_stake_tao: 7 }),
+        ],
+      },
+    ];
+    const m = buildOverlayModel(inputs, "stake");
+    expect(m.series[0]!.points.map((p) => p.v)).toEqual([7]);
+  });
+
+  it("sorts each series ascending by timestamp", () => {
+    const inputs = [
+      {
+        netuid: 1,
+        points: [
+          point("2026-01-03", { total_emission_tao: 3 }),
+          point("2026-01-01", { total_emission_tao: 1 }),
+          point("2026-01-02", { total_emission_tao: 2 }),
+        ],
+      },
+    ];
+    const m = buildOverlayModel(inputs, "emission");
+    expect(m.series[0]!.points.map((p) => p.v)).toEqual([1, 2, 3]);
+  });
+
+  it("computes shared min/max across every series", () => {
+    const inputs = [
+      {
+        netuid: 1,
+        points: [
+          point("2026-01-01", { validator_count: 10 }),
+          point("2026-01-02", { validator_count: 20 }),
+        ],
+      },
+      {
+        netuid: 2,
+        points: [
+          point("2026-01-02", { validator_count: 5 }),
+          point("2026-01-04", { validator_count: 40 }),
+        ],
+      },
+    ];
+    const m = buildOverlayModel(inputs, "validators");
+    expect(m.vMin).toBe(5);
+    expect(m.vMax).toBe(40);
+    expect(m.tMin).toBe(Date.parse("2026-01-01"));
+    expect(m.tMax).toBe(Date.parse("2026-01-04"));
+  });
+
+  it("ignores non-numeric metric values (string, null, undefined)", () => {
+    const inputs = [
+      {
+        netuid: 1,
+        points: [
+          point("2026-01-01", { neuron_count: undefined }),
+          // exercise the "not a number" branch — untyped extra keys via `[key: string]: unknown`
+          { snapshot_date: "2026-01-02", neuron_count: "bad" } as unknown as SubnetHistoryPoint,
+          point("2026-01-03", { neuron_count: 5 }),
+        ],
+      },
+    ];
+    const m = buildOverlayModel(inputs, "neurons");
+    expect(m.series[0]!.points.map((p) => p.v)).toEqual([5]);
+  });
+});
+
+describe("formatOverlayValue", () => {
+  it("formats stake/emission through formatTao (τ suffix)", () => {
+    const s = formatOverlayValue("stake", 1000);
+    const e = formatOverlayValue("emission", 1000);
+    expect(s).toContain("τ");
+    expect(e).toContain("τ");
+  });
+  it("formats counts through formatNumber (no τ suffix)", () => {
+    const n = formatOverlayValue("neurons", 1234);
+    const v = formatOverlayValue("validators", 42);
+    expect(n).not.toContain("τ");
+    expect(v).not.toContain("τ");
+  });
+});
+
+describe("overlayTotalPoints", () => {
+  it("sums points across every series", () => {
+    const inputs = [
+      {
+        netuid: 1,
+        points: [
+          point("2026-01-01", { neuron_count: 1 }),
+          point("2026-01-02", { neuron_count: 2 }),
+        ],
+      },
+      {
+        netuid: 2,
+        points: [point("2026-01-01", { neuron_count: 3 })],
+      },
+    ];
+    const m = buildOverlayModel(inputs, "neurons");
+    expect(overlayTotalPoints(m)).toBe(3);
+  });
+  it("returns 0 on an empty model", () => {
+    expect(overlayTotalPoints(buildOverlayModel([], "stake"))).toBe(0);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/overlay-history.ts
+++ b/apps/ui/src/lib/metagraphed/overlay-history.ts
@@ -1,0 +1,141 @@
+import { formatNumber, formatTao } from "./format";
+import type { SubnetHistoryPoint } from "./types";
+
+/**
+ * Metric picker + overlay-model helpers for the compare drawer's chart tab
+ * (#6885). Kept pure so tests can drive it without React or a QueryClient —
+ * the component only owns fetching and rendering.
+ */
+
+/** Metrics matching the per-subnet SubnetHistoryChart's rows. */
+export type OverlayMetric = "neurons" | "validators" | "stake" | "emission";
+
+export const OVERLAY_METRICS: readonly OverlayMetric[] = [
+  "neurons",
+  "validators",
+  "stake",
+  "emission",
+] as const;
+
+export const OVERLAY_METRIC_LABEL: Record<OverlayMetric, string> = {
+  neurons: "Neurons",
+  validators: "Validators",
+  stake: "Total stake",
+  emission: "Total emission",
+};
+
+const METRIC_KEY: Record<OverlayMetric, keyof SubnetHistoryPoint> = {
+  neurons: "neuron_count",
+  validators: "validator_count",
+  stake: "total_stake_tao",
+  emission: "total_emission_tao",
+};
+
+/** Chart color tokens, mirroring providers.index.tsx's palette usage. */
+export const OVERLAY_COLORS: readonly string[] = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+] as const;
+
+export function overlayColor(index: number): string {
+  return OVERLAY_COLORS[Math.abs(index) % OVERLAY_COLORS.length]!;
+}
+
+export interface OverlayInputSeries {
+  netuid: number;
+  points: SubnetHistoryPoint[];
+}
+
+export interface OverlaySeriesPoint {
+  t: number;
+  v: number;
+}
+
+export interface OverlaySeries {
+  netuid: number;
+  points: OverlaySeriesPoint[];
+}
+
+export interface OverlayModel {
+  series: OverlaySeries[];
+  tMin: number;
+  tMax: number;
+  vMin: number;
+  vMax: number;
+}
+
+function parseSnapshotDate(s: string | undefined): number | null {
+  if (!s) return null;
+  const t = Date.parse(s);
+  return Number.isFinite(t) ? t : null;
+}
+
+/**
+ * Build the overlay model from per-subnet history: pick the requested metric,
+ * coerce to finite numbers, sort each series by snapshot date, and compute a
+ * shared x/y range so every series scales to the same axes. Series with no
+ * finite points are still returned (empty points array) so the legend row
+ * stays lined up with the input order.
+ */
+export function buildOverlayModel(
+  inputs: readonly OverlayInputSeries[],
+  metric: OverlayMetric,
+): OverlayModel {
+  const key = METRIC_KEY[metric];
+  const series: OverlaySeries[] = inputs.map((input) => {
+    const pts: OverlaySeriesPoint[] = [];
+    for (const p of input.points) {
+      const t = parseSnapshotDate(p.snapshot_date);
+      const raw = p[key];
+      if (t == null) continue;
+      if (typeof raw !== "number" || !Number.isFinite(raw)) continue;
+      pts.push({ t, v: raw });
+    }
+    pts.sort((a, b) => a.t - b.t);
+    return { netuid: input.netuid, points: pts };
+  });
+
+  let tMin = Number.POSITIVE_INFINITY;
+  let tMax = Number.NEGATIVE_INFINITY;
+  let vMin = Number.POSITIVE_INFINITY;
+  let vMax = Number.NEGATIVE_INFINITY;
+  for (const s of series) {
+    for (const p of s.points) {
+      if (p.t < tMin) tMin = p.t;
+      if (p.t > tMax) tMax = p.t;
+      if (p.v < vMin) vMin = p.v;
+      if (p.v > vMax) vMax = p.v;
+    }
+  }
+
+  if (!Number.isFinite(tMin) || !Number.isFinite(tMax)) {
+    tMin = 0;
+    tMax = 0;
+  }
+  if (!Number.isFinite(vMin) || !Number.isFinite(vMax)) {
+    vMin = 0;
+    vMax = 0;
+  }
+
+  return { series, tMin, tMax, vMin, vMax };
+}
+
+/** Metric-aware value formatter for the legend and tooltips. */
+export function formatOverlayValue(metric: OverlayMetric, v: number): string {
+  if (metric === "stake" || metric === "emission") return formatTao(v);
+  return formatNumber(v);
+}
+
+/**
+ * Total point count across every series — a simple "has any data" signal the
+ * component uses to switch between the empty-state and the chart.
+ */
+export function overlayTotalPoints(model: OverlayModel): number {
+  let n = 0;
+  for (const s of model.series) n += s.points.length;
+  return n;
+}


### PR DESCRIPTION
Compare drawer today shows a metrics grid side-by-side, but there's no way to see how the selected subnets have moved relative to each other over time. This adds a second tab to the drawer's expanded view — the existing metrics grid stays where it was, and the new **Overlay chart** tab fans out `/api/v1/subnets/{netuid}/history` for the current selection and draws one polyline per subnet on a shared axis, exactly the way Tao Swap's "Multi-chart" does it. Everything is wired through pieces the repo already ships (`subnetHistoryQuery`, the same window/metric enum as `subnet-history-chart.tsx`, `--chart-1..6` tokens, `Sparkline`'s SVG path shape) — no new charting stack, no new endpoint.

The pure data-shaping (metric pick + snapshot-date parse + shared range) lives in a small module (`apps/ui/src/lib/metagraphed/overlay-history.ts`) so the component only owns fetching + rendering; unit tests cover the empty/bad-input/ordering paths. Metric picker exposes the same four rows `SubnetHistoryChart` already renders (Neurons / Validators / Total stake / Total emission), window selector reuses the 7d/30d/90d/1y/all pattern, and the `max`-per-selection cap already enforced by `useCompareSelection` covers the fan-out naturally.

Closes #6885

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/0f51ee346dfe3ca537248f8491df9cf884bacfe6/runs/jsonbored-metagraphed/run-43/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/0f51ee346dfe3ca537248f8491df9cf884bacfe6/runs/jsonbored-metagraphed/run-43/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/94e25c749ed2e80d4c3ba59afc99522676c4c65c/runs/jsonbored-metagraphed/run-43/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/94e25c749ed2e80d4c3ba59afc99522676c4c65c/runs/jsonbored-metagraphed/run-43/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/e9dcffafb752a0cc8f64b8cfdf3637b31ac111e3/runs/jsonbored-metagraphed/run-43/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/e9dcffafb752a0cc8f64b8cfdf3637b31ac111e3/runs/jsonbored-metagraphed/run-43/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/58ad52d407c078c988982198025adddca9fec37b/runs/jsonbored-metagraphed/run-43/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/58ad52d407c078c988982198025adddca9fec37b/runs/jsonbored-metagraphed/run-43/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/2943493ad170c2fecdb9f5907812bb06b4070e62/runs/jsonbored-metagraphed/run-43/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/2943493ad170c2fecdb9f5907812bb06b4070e62/runs/jsonbored-metagraphed/run-43/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/86e779503408d315a661769446534a525ead8602/runs/jsonbored-metagraphed/run-43/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/86e779503408d315a661769446534a525ead8602/runs/jsonbored-metagraphed/run-43/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/7a8898c64c4bb441bc3091f640e7d1dd65789c68/runs/jsonbored-metagraphed/run-43/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/7a8898c64c4bb441bc3091f640e7d1dd65789c68/runs/jsonbored-metagraphed/run-43/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/b26b2095474d6ddcada2c7cb7eb367a21208bca6/runs/jsonbored-metagraphed/run-43/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/b26b2095474d6ddcada2c7cb7eb367a21208bca6/runs/jsonbored-metagraphed/run-43/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/ef81a6d9d7b2cf25119e03045388989ad8e5d04c/runs/jsonbored-metagraphed/run-43/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/ef81a6d9d7b2cf25119e03045388989ad8e5d04c/runs/jsonbored-metagraphed/run-43/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/0892fb7eb617679486c7616c90e109a6efbe8c12/runs/jsonbored-metagraphed/run-43/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/0892fb7eb617679486c7616c90e109a6efbe8c12/runs/jsonbored-metagraphed/run-43/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/7e35fe59028abbf113c023d6c05c4492e935866c/runs/jsonbored-metagraphed/run-43/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/7e35fe59028abbf113c023d6c05c4492e935866c/runs/jsonbored-metagraphed/run-43/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/0bd33173328ae9fb7222a4fe67605f7f7e4dc7bd/runs/jsonbored-metagraphed/run-43/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/0bd33173328ae9fb7222a4fe67605f7f7e4dc7bd/runs/jsonbored-metagraphed/run-43/after-mobile-dark.png)<br><sub>after</sub> |

Selected SN1/SN5/SN8 (any 2+-subnet selection triggers the drawer's expanded state) and clicked into the new Overlay chart tab on each capture; the metrics grid stays reachable on the Metrics tab.

## Testing

Locally green: `npm run lint --workspace=apps/ui`, `npm run format:check --workspace=apps/ui`, `npm run typecheck --workspace=apps/ui`, `npm test --workspace=apps/ui` (168 files / 1290 tests, incl. the new 16 in `overlay-history.test.ts`), `npm run test:e2e --workspace=apps/ui` (the responsive-overflow HAR replay), and `npm run build --workspace=apps/ui`. Also ran the full root gate: `npm run build`, `npm run test:ci`, `npm run test:ci:artifacts`, `npm run lint && npm run format:check`, `npm run validate`, and the `validate:*` set for schemas/api/mcp/ai/openapi/types/contract-drift/openapi-examples/generated-client/committed-seed/artifact-budgets/docs/intake/surface/adapters/private-boundary + `scan:public-safety` — all pass.