### PR TITLE
feat(ui): add a bubble view to /subnets (age × surfaces scatter)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnets-bubble-view.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-bubble-view.tsx
@@ -2,100 +2,24 @@ import { useMemo } from "react";
 import { EmptyState } from "@/components/metagraphed/states";
 import { healthColorVar } from "@/lib/health-tokens";
 import { formatNumber } from "@/lib/metagraphed/format";
-import type { HealthState, Subnet } from "@/lib/metagraphed/types";
+import { BUBBLE_PAD, BUBBLE_VB, buildBubbleLayout } from "@/lib/metagraphed/subnets-bubble-layout";
+import type { Subnet } from "@/lib/metagraphed/types";
 
 // #6884: an alternate "bubble" scan of /subnets over the SAME filtered list the
 // table renders — position/size/colour encoding instead of sorted rows, to spot
-// outliers a table hides (e.g. a young subnet that already has many participants).
-//
-// Axis defaults, all from fields the subnet LIST already carries (the table shows
-// them too; the list has no stake/emission — those are detail-only):
+// outliers a table hides. Encoding (all from fields the list already carries; the
+// list has no stake/emission — those are detail-only):
 //   x = age in days (established-ness)   y = verified surfaces (integration depth)
-//   bubble size = participants (active UIDs)
-//   colour = health state (operational traffic-light)
+//   bubble size = participants (active UIDs)   colour = health state
 // age×surfaces spreads better than age×participants (most subnets max UIDs at 256,
-// which bunches a participants axis at the top); it also tells a sharper story —
-// an old subnet low on the surface axis is under-integrated relative to its age.
-// Rendered as a fixed-viewBox SVG (no client measurement) so it draws server-side
-// and is URL-addressable via ?view=bubble, like the table/grid/matrix views.
-
-const FINNEY_BLOCK_SECONDS = 12;
-const SECONDS_PER_DAY = 86_400;
-
-function ageDays(s: Subnet): number | null {
-  const reg = s.registered_at_block;
-  const now = s.block;
-  if (typeof reg !== "number" || typeof now !== "number") return null;
-  const elapsed = now - reg;
-  if (!Number.isFinite(elapsed) || elapsed < 0) return null;
-  return Math.floor((elapsed * FINNEY_BLOCK_SECONDS) / SECONDS_PER_DAY);
-}
-
-const VB = { w: 900, h: 460 };
-const PAD = { top: 20, right: 24, bottom: 44, left: 56 };
-const R_MIN = 4;
-const R_MAX = 15;
-
-type Point = {
-  netuid: number;
-  name: string;
-  x: number;
-  y: number;
-  r: number;
-  color: string;
-  age: number;
-  participants: number;
-  surfaces: number;
-  health: HealthState;
-};
-
-function niceMax(v: number): number {
-  if (v <= 0) return 1;
-  const mag = Math.pow(10, Math.floor(Math.log10(v)));
-  return Math.ceil(v / mag) * mag;
-}
+// bunching a participants axis at the top); it also tells a sharper story — an old
+// subnet low on the surface axis is under-integrated for its age. The coordinate/
+// scaling math lives in subnets-bubble-layout.ts (unit-tested). Rendered as a
+// fixed-viewBox SVG (no client measurement) so it draws server-side and is
+// URL-addressable via ?view=bubble, like the table/grid/matrix views.
 
 export function SubnetsBubbleView({ rows }: { rows: Subnet[] }) {
-  const { points, xMax, yMax } = useMemo(() => {
-    const raw = rows
-      .map((s) => {
-        const age = ageDays(s);
-        const participants = typeof s.participants === "number" ? s.participants : null;
-        if (age == null || participants == null) return null;
-        return {
-          netuid: s.netuid,
-          name: s.name ?? `Subnet ${s.netuid}`,
-          age,
-          participants,
-          surfaces: typeof s.surfaces_count === "number" ? s.surfaces_count : 0,
-          health: (s.health ?? "unknown") as HealthState,
-        };
-      })
-      .filter((p): p is NonNullable<typeof p> => p !== null);
-
-    const xMax = niceMax(Math.max(1, ...raw.map((p) => p.age)));
-    const yMax = niceMax(Math.max(1, ...raw.map((p) => p.surfaces)));
-    const pMax = Math.max(1, ...raw.map((p) => p.participants));
-    const innerW = VB.w - PAD.left - PAD.right;
-    const innerH = VB.h - PAD.top - PAD.bottom;
-
-    const points: Point[] = raw.map((p) => ({
-      ...p,
-      x: PAD.left + (p.age / xMax) * innerW,
-      y: PAD.top + (1 - p.surfaces / yMax) * innerH,
-      r: R_MIN + (p.participants / pMax) * (R_MAX - R_MIN),
-      color: healthColorVar(
-        p.health === "ok"
-          ? "ok"
-          : p.health === "warn"
-            ? "warn"
-            : p.health === "down"
-              ? "down"
-              : "unknown",
-      ),
-    }));
-    return { points, xMax, yMax };
-  }, [rows]);
+  const { points, xMax, yMax } = useMemo(() => buildBubbleLayout(rows), [rows]);
 
   if (points.length === 0) {
     return (
@@ -106,23 +30,35 @@ export function SubnetsBubbleView({ rows }: { rows: Subnet[] }) {
     );
   }
 
-  const axisY = VB.h - PAD.bottom;
+  const axisY = BUBBLE_VB.h - BUBBLE_PAD.bottom;
 
   return (
     <div className="space-y-3">
       <div className="rounded-xl border border-border bg-card p-3">
         <svg
-          viewBox={`0 0 ${VB.w} ${VB.h}`}
+          viewBox={`0 0 ${BUBBLE_VB.w} ${BUBBLE_VB.h}`}
           className="block w-full aspect-[900/460]"
           role="img"
           aria-label="Subnets by age in days (x) and verified surface count (y); bubble size is participant count, colour is health state"
         >
           {/* axes */}
-          <line x1={PAD.left} y1={PAD.top} x2={PAD.left} y2={axisY} stroke="var(--border)" />
-          <line x1={PAD.left} y1={axisY} x2={VB.w - PAD.right} y2={axisY} stroke="var(--border)" />
+          <line
+            x1={BUBBLE_PAD.left}
+            y1={BUBBLE_PAD.top}
+            x2={BUBBLE_PAD.left}
+            y2={axisY}
+            stroke="var(--border)"
+          />
+          <line
+            x1={BUBBLE_PAD.left}
+            y1={axisY}
+            x2={BUBBLE_VB.w - BUBBLE_PAD.right}
+            y2={axisY}
+            stroke="var(--border)"
+          />
           {/* axis labels */}
           <text
-            x={PAD.left}
+            x={BUBBLE_PAD.left}
             y={axisY + 28}
             fill="var(--ink-muted)"
             fontSize="12"
@@ -131,7 +67,7 @@ export function SubnetsBubbleView({ rows }: { rows: Subnet[] }) {
             0
           </text>
           <text
-            x={VB.w - PAD.right}
+            x={BUBBLE_VB.w - BUBBLE_PAD.right}
             y={axisY + 28}
             fill="var(--ink-muted)"
             fontSize="12"
@@ -141,8 +77,8 @@ export function SubnetsBubbleView({ rows }: { rows: Subnet[] }) {
             {formatNumber(xMax)}d
           </text>
           <text
-            x={(PAD.left + VB.w - PAD.right) / 2}
-            y={VB.h - 6}
+            x={(BUBBLE_PAD.left + BUBBLE_VB.w - BUBBLE_PAD.right) / 2}
+            y={BUBBLE_VB.h - 6}
             fill="var(--ink-muted)"
             fontSize="12"
             fontFamily="monospace"
@@ -151,8 +87,8 @@ export function SubnetsBubbleView({ rows }: { rows: Subnet[] }) {
             Age (days) →
           </text>
           <text
-            x={PAD.left - 10}
-            y={PAD.top + 4}
+            x={BUBBLE_PAD.left - 10}
+            y={BUBBLE_PAD.top + 4}
             fill="var(--ink-muted)"
             fontSize="12"
             fontFamily="monospace"
@@ -162,12 +98,12 @@ export function SubnetsBubbleView({ rows }: { rows: Subnet[] }) {
           </text>
           <text
             x={16}
-            y={(PAD.top + axisY) / 2}
+            y={(BUBBLE_PAD.top + axisY) / 2}
             fill="var(--ink-muted)"
             fontSize="12"
             fontFamily="monospace"
             textAnchor="middle"
-            transform={`rotate(-90 16 ${(PAD.top + axisY) / 2})`}
+            transform={`rotate(-90 16 ${(BUBBLE_PAD.top + axisY) / 2})`}
           >
             Verified surfaces ↑
           </text>

--- a/apps/ui/src/components/metagraphed/subnets-bubble-view.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-bubble-view.tsx
@@ -1,0 +1,219 @@
+import { useMemo } from "react";
+import { EmptyState } from "@/components/metagraphed/states";
+import { healthColorVar } from "@/lib/health-tokens";
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { HealthState, Subnet } from "@/lib/metagraphed/types";
+
+// #6884: an alternate "bubble" scan of /subnets over the SAME filtered list the
+// table renders — position/size/colour encoding instead of sorted rows, to spot
+// outliers a table hides (e.g. a young subnet that already has many participants).
+//
+// Axis defaults, all from fields the subnet LIST already carries (the table shows
+// them too; the list has no stake/emission — those are detail-only):
+//   x = age in days (established-ness)   y = verified surfaces (integration depth)
+//   bubble size = participants (active UIDs)
+//   colour = health state (operational traffic-light)
+// age×surfaces spreads better than age×participants (most subnets max UIDs at 256,
+// which bunches a participants axis at the top); it also tells a sharper story —
+// an old subnet low on the surface axis is under-integrated relative to its age.
+// Rendered as a fixed-viewBox SVG (no client measurement) so it draws server-side
+// and is URL-addressable via ?view=bubble, like the table/grid/matrix views.
+
+const FINNEY_BLOCK_SECONDS = 12;
+const SECONDS_PER_DAY = 86_400;
+
+function ageDays(s: Subnet): number | null {
+  const reg = s.registered_at_block;
+  const now = s.block;
+  if (typeof reg !== "number" || typeof now !== "number") return null;
+  const elapsed = now - reg;
+  if (!Number.isFinite(elapsed) || elapsed < 0) return null;
+  return Math.floor((elapsed * FINNEY_BLOCK_SECONDS) / SECONDS_PER_DAY);
+}
+
+const VB = { w: 900, h: 460 };
+const PAD = { top: 20, right: 24, bottom: 44, left: 56 };
+const R_MIN = 4;
+const R_MAX = 15;
+
+type Point = {
+  netuid: number;
+  name: string;
+  x: number;
+  y: number;
+  r: number;
+  color: string;
+  age: number;
+  participants: number;
+  surfaces: number;
+  health: HealthState;
+};
+
+function niceMax(v: number): number {
+  if (v <= 0) return 1;
+  const mag = Math.pow(10, Math.floor(Math.log10(v)));
+  return Math.ceil(v / mag) * mag;
+}
+
+export function SubnetsBubbleView({ rows }: { rows: Subnet[] }) {
+  const { points, xMax, yMax } = useMemo(() => {
+    const raw = rows
+      .map((s) => {
+        const age = ageDays(s);
+        const participants = typeof s.participants === "number" ? s.participants : null;
+        if (age == null || participants == null) return null;
+        return {
+          netuid: s.netuid,
+          name: s.name ?? `Subnet ${s.netuid}`,
+          age,
+          participants,
+          surfaces: typeof s.surfaces_count === "number" ? s.surfaces_count : 0,
+          health: (s.health ?? "unknown") as HealthState,
+        };
+      })
+      .filter((p): p is NonNullable<typeof p> => p !== null);
+
+    const xMax = niceMax(Math.max(1, ...raw.map((p) => p.age)));
+    const yMax = niceMax(Math.max(1, ...raw.map((p) => p.surfaces)));
+    const pMax = Math.max(1, ...raw.map((p) => p.participants));
+    const innerW = VB.w - PAD.left - PAD.right;
+    const innerH = VB.h - PAD.top - PAD.bottom;
+
+    const points: Point[] = raw.map((p) => ({
+      ...p,
+      x: PAD.left + (p.age / xMax) * innerW,
+      y: PAD.top + (1 - p.surfaces / yMax) * innerH,
+      r: R_MIN + (p.participants / pMax) * (R_MAX - R_MIN),
+      color: healthColorVar(
+        p.health === "ok"
+          ? "ok"
+          : p.health === "warn"
+            ? "warn"
+            : p.health === "down"
+              ? "down"
+              : "unknown",
+      ),
+    }));
+    return { points, xMax, yMax };
+  }, [rows]);
+
+  if (points.length === 0) {
+    return (
+      <EmptyState
+        title="Nothing to plot"
+        description="No subnets in the current filter have both an age and a participant count yet. Adjust the filters or switch back to the table."
+      />
+    );
+  }
+
+  const axisY = VB.h - PAD.bottom;
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-xl border border-border bg-card p-3">
+        <svg
+          viewBox={`0 0 ${VB.w} ${VB.h}`}
+          className="block w-full aspect-[900/460]"
+          role="img"
+          aria-label="Subnets by age in days (x) and verified surface count (y); bubble size is participant count, colour is health state"
+        >
+          {/* axes */}
+          <line x1={PAD.left} y1={PAD.top} x2={PAD.left} y2={axisY} stroke="var(--border)" />
+          <line x1={PAD.left} y1={axisY} x2={VB.w - PAD.right} y2={axisY} stroke="var(--border)" />
+          {/* axis labels */}
+          <text
+            x={PAD.left}
+            y={axisY + 28}
+            fill="var(--ink-muted)"
+            fontSize="12"
+            fontFamily="monospace"
+          >
+            0
+          </text>
+          <text
+            x={VB.w - PAD.right}
+            y={axisY + 28}
+            fill="var(--ink-muted)"
+            fontSize="12"
+            fontFamily="monospace"
+            textAnchor="end"
+          >
+            {formatNumber(xMax)}d
+          </text>
+          <text
+            x={(PAD.left + VB.w - PAD.right) / 2}
+            y={VB.h - 6}
+            fill="var(--ink-muted)"
+            fontSize="12"
+            fontFamily="monospace"
+            textAnchor="middle"
+          >
+            Age (days) →
+          </text>
+          <text
+            x={PAD.left - 10}
+            y={PAD.top + 4}
+            fill="var(--ink-muted)"
+            fontSize="12"
+            fontFamily="monospace"
+            textAnchor="end"
+          >
+            {formatNumber(yMax)}
+          </text>
+          <text
+            x={16}
+            y={(PAD.top + axisY) / 2}
+            fill="var(--ink-muted)"
+            fontSize="12"
+            fontFamily="monospace"
+            textAnchor="middle"
+            transform={`rotate(-90 16 ${(PAD.top + axisY) / 2})`}
+          >
+            Verified surfaces ↑
+          </text>
+          {/* bubbles — each links to the subnet detail (mirrors table row-click) */}
+          {points.map((p) => (
+            <a
+              key={p.netuid}
+              href={`/subnets/${p.netuid}`}
+              aria-label={`${p.name}: ${p.participants} participants, ~${p.age}d old`}
+            >
+              <circle
+                cx={p.x}
+                cy={p.y}
+                r={p.r}
+                fill={p.color}
+                fillOpacity={0.55}
+                stroke={p.color}
+                strokeWidth={1}
+              >
+                <title>
+                  {p.name} (#{p.netuid}) — ~{formatNumber(p.age)}d old,{" "}
+                  {formatNumber(p.participants)} participants, {formatNumber(p.surfaces)} surfaces,{" "}
+                  {p.health}
+                </title>
+              </circle>
+            </a>
+          ))}
+        </svg>
+      </div>
+      {/* legend */}
+      <ul className="flex flex-wrap gap-x-4 gap-y-1.5 text-[11px] text-ink-muted">
+        {(["ok", "warn", "down", "unknown"] as const).map((h) => (
+          <li key={h} className="inline-flex items-center gap-1.5">
+            <span
+              aria-hidden
+              className="inline-block size-2.5 rounded-full"
+              style={{ background: healthColorVar(h) }}
+            />
+            <span className="uppercase tracking-wider">{h}</span>
+          </li>
+        ))}
+        <li className="inline-flex items-center gap-1.5">
+          <span aria-hidden className="inline-block size-3 rounded-full border border-ink-muted" />
+          <span>bubble size = participants</span>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/subnets-bubble-layout.test.ts
+++ b/apps/ui/src/lib/metagraphed/subnets-bubble-layout.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUBBLE_PAD,
+  BUBBLE_VB,
+  buildBubbleLayout,
+  niceMax,
+  subnetAgeDays,
+} from "./subnets-bubble-layout";
+import type { Subnet } from "./types";
+
+// 7200 blocks/day at ~12s/block.
+const BLOCKS_PER_DAY = 7200;
+
+function subnet(over: Partial<Subnet>): Subnet {
+  return { netuid: 1, ...over };
+}
+
+describe("subnetAgeDays", () => {
+  it("converts a block delta to whole floored days", () => {
+    expect(subnetAgeDays(1000, 1000 + BLOCKS_PER_DAY * 42)).toBe(42);
+    expect(subnetAgeDays(0, BLOCKS_PER_DAY + BLOCKS_PER_DAY / 2)).toBe(1);
+    expect(subnetAgeDays(500, 500)).toBe(0);
+  });
+
+  it("returns null for reg-ahead-of-current / missing / non-finite blocks", () => {
+    expect(subnetAgeDays(2000, 1000)).toBeNull();
+    expect(subnetAgeDays(undefined, 1000)).toBeNull();
+    expect(subnetAgeDays(1000, null)).toBeNull();
+    expect(subnetAgeDays(NaN, 1000)).toBeNull();
+    expect(subnetAgeDays(1000, Infinity)).toBeNull();
+  });
+});
+
+describe("niceMax", () => {
+  it("rounds up to a nice axis maximum (a multiple of the value's magnitude)", () => {
+    expect(niceMax(5)).toBe(5); // magnitude 1 -> next integer
+    expect(niceMax(10)).toBe(10);
+    expect(niceMax(11)).toBe(20); // magnitude 10
+    expect(niceMax(42)).toBe(50);
+    expect(niceMax(250)).toBe(300); // magnitude 100
+    expect(niceMax(1)).toBe(1);
+  });
+
+  it("floors 0 / negative / non-finite to 1 (never divide by 0)", () => {
+    expect(niceMax(0)).toBe(1);
+    expect(niceMax(-5)).toBe(1);
+    expect(niceMax(NaN)).toBe(1);
+    expect(niceMax(Infinity)).toBe(1);
+  });
+});
+
+describe("buildBubbleLayout", () => {
+  const INNER_W = BUBBLE_VB.w - BUBBLE_PAD.left - BUBBLE_PAD.right;
+  const INNER_H = BUBBLE_VB.h - BUBBLE_PAD.top - BUBBLE_PAD.bottom;
+
+  it("drops rows without a computable age or participant count", () => {
+    const { points } = buildBubbleLayout([
+      subnet({ netuid: 1, registered_at_block: 0, block: BLOCKS_PER_DAY, participants: 10 }), // ok
+      subnet({ netuid: 2, participants: 10 }), // no blocks -> no age
+      subnet({ netuid: 3, registered_at_block: 0, block: BLOCKS_PER_DAY }), // no participants
+      subnet({ netuid: 4, registered_at_block: 5000, block: 1000, participants: 10 }), // reg ahead
+    ]);
+    expect(points.map((p) => p.netuid)).toEqual([1]);
+  });
+
+  it("returns an empty layout (no throw) for no plottable rows", () => {
+    expect(buildBubbleLayout([])).toEqual({ points: [], xMax: 1, yMax: 1 });
+    expect(buildBubbleLayout([subnet({ participants: 10 })]).points).toEqual([]);
+  });
+
+  it("places a single row without dividing by zero", () => {
+    const { points, xMax, yMax } = buildBubbleLayout([
+      subnet({
+        netuid: 7,
+        name: "Alpha",
+        registered_at_block: 0,
+        block: BLOCKS_PER_DAY * 5,
+        participants: 100,
+        surfaces_count: 3,
+        health: "ok",
+      }),
+    ]);
+    expect(points).toHaveLength(1);
+    const p = points[0]!;
+    expect(p.name).toBe("Alpha"); // uses the provided name (left of the ?? fallback)
+    expect(Number.isFinite(p.x)).toBe(true);
+    expect(Number.isFinite(p.y)).toBe(true);
+    expect(Number.isFinite(p.r)).toBe(true);
+    // age 5 with a single row -> xMax = niceMax(5) = 5 -> x at the right edge
+    expect(p.x).toBeCloseTo(BUBBLE_PAD.left + (5 / xMax) * INNER_W, 5);
+    // single row -> participants == pMax -> max radius
+    expect(p.r).toBe(15);
+    expect(yMax).toBeGreaterThanOrEqual(1);
+  });
+
+  it("handles all-zero ages and all-zero surfaces (both axes clamp to 1)", () => {
+    const rows = [1, 2, 3].map((n) =>
+      subnet({
+        netuid: n,
+        registered_at_block: 100,
+        block: 100,
+        participants: 5,
+        surfaces_count: 0,
+      }),
+    );
+    const { points, xMax, yMax } = buildBubbleLayout(rows);
+    expect(xMax).toBe(1);
+    expect(yMax).toBe(1);
+    // age 0 -> x at the left axis; surfaces 0 -> y at the bottom (1 - 0 = full innerH)
+    for (const p of points) {
+      expect(p.x).toBeCloseTo(BUBBLE_PAD.left, 5);
+      expect(p.y).toBeCloseTo(BUBBLE_PAD.top + INNER_H, 5);
+    }
+  });
+
+  it("maps health state to a colour var and defaults missing health to unknown", () => {
+    const { points } = buildBubbleLayout([
+      subnet({
+        netuid: 1,
+        registered_at_block: 0,
+        block: BLOCKS_PER_DAY,
+        participants: 5,
+        health: "warn",
+      }),
+      subnet({ netuid: 2, registered_at_block: 0, block: BLOCKS_PER_DAY, participants: 5 }), // no health
+    ]);
+    expect(points[0]!.color).toContain("--health-warn");
+    expect(points[1]!.health).toBe("unknown");
+    expect(points[1]!.color).toContain("--health-unknown");
+  });
+
+  it("scales radius between the min and max by participants", () => {
+    const { points } = buildBubbleLayout([
+      subnet({ netuid: 1, registered_at_block: 0, block: BLOCKS_PER_DAY, participants: 256 }),
+      subnet({ netuid: 2, registered_at_block: 0, block: BLOCKS_PER_DAY, participants: 0 }),
+    ]);
+    const big = points.find((p) => p.netuid === 1)!;
+    const small = points.find((p) => p.netuid === 2)!;
+    expect(big.r).toBe(15); // pMax
+    expect(small.r).toBe(4); // 0 participants -> R_MIN
+  });
+});

--- a/apps/ui/src/lib/metagraphed/subnets-bubble-layout.ts
+++ b/apps/ui/src/lib/metagraphed/subnets-bubble-layout.ts
@@ -1,0 +1,110 @@
+// #6884: pure coordinate/scaling math for the /subnets bubble view, extracted
+// from subnets-bubble-view.tsx so the division / clamping / date logic is
+// unit-testable in a node env without pulling in the React + SVG graph.
+import { healthColorVar } from "@/lib/health-tokens";
+import type { HealthState, Subnet } from "@/lib/metagraphed/types";
+
+export const FINNEY_BLOCK_SECONDS = 12;
+export const SECONDS_PER_DAY = 86_400;
+
+// SVG viewBox + inner padding + bubble radius range (shared with the component).
+export const BUBBLE_VB = { w: 900, h: 460 } as const;
+export const BUBBLE_PAD = { top: 20, right: 24, bottom: 44, left: 56 } as const;
+const R_MIN = 4;
+const R_MAX = 15;
+
+/**
+ * Whole days since a subnet registered, from its registration block and the
+ * snapshot's current block at ~12s/block. Returns null when either block is
+ * missing / non-finite or the registration block is ahead of the current one, so
+ * the caller can drop the point rather than plot a nonsensical negative age.
+ */
+export function subnetAgeDays(
+  registeredAtBlock: number | null | undefined,
+  currentBlock: number | null | undefined,
+): number | null {
+  if (
+    typeof registeredAtBlock !== "number" ||
+    typeof currentBlock !== "number" ||
+    !Number.isFinite(registeredAtBlock) ||
+    !Number.isFinite(currentBlock)
+  ) {
+    return null;
+  }
+  const elapsed = currentBlock - registeredAtBlock;
+  if (elapsed < 0) return null;
+  return Math.floor((elapsed * FINNEY_BLOCK_SECONDS) / SECONDS_PER_DAY);
+}
+
+/** Round a positive value up to a "nice" axis maximum (1, 2, … ×10^n). 0/neg → 1. */
+export function niceMax(v: number): number {
+  if (!Number.isFinite(v) || v <= 0) return 1;
+  const mag = Math.pow(10, Math.floor(Math.log10(v)));
+  return Math.ceil(v / mag) * mag;
+}
+
+function healthColor(health: HealthState): string {
+  return healthColorVar(
+    health === "ok" ? "ok" : health === "warn" ? "warn" : health === "down" ? "down" : "unknown",
+  );
+}
+
+export type BubblePoint = {
+  netuid: number;
+  name: string;
+  x: number;
+  y: number;
+  r: number;
+  color: string;
+  age: number;
+  participants: number;
+  surfaces: number;
+  health: HealthState;
+};
+
+/**
+ * Project the filtered subnet rows onto the bubble scatter: x = age, y = verified
+ * surfaces, radius = participants, colour = health — all on ONE shared domain so
+ * the bubbles are comparable. Rows without a computable age or participant count
+ * are dropped. Domains are clamped away from 0 (`Math.max(1, …)` / `|| 1`) so a
+ * single row, or all-equal values, never divides by zero.
+ */
+export function buildBubbleLayout(rows: Subnet[]): {
+  points: BubblePoint[];
+  xMax: number;
+  yMax: number;
+} {
+  const raw = rows
+    .map((s) => {
+      const age = subnetAgeDays(s.registered_at_block, s.block);
+      const participants = typeof s.participants === "number" ? s.participants : null;
+      if (age == null || participants == null) return null;
+      return {
+        netuid: s.netuid,
+        name: s.name ?? `Subnet ${s.netuid}`,
+        age,
+        participants,
+        surfaces: typeof s.surfaces_count === "number" ? s.surfaces_count : 0,
+        health: (s.health ?? "unknown") as HealthState,
+      };
+    })
+    .filter((p): p is NonNullable<typeof p> => p !== null);
+
+  if (raw.length === 0) return { points: [], xMax: 1, yMax: 1 };
+
+  const xMax = niceMax(Math.max(1, ...raw.map((p) => p.age)));
+  const yMax = niceMax(Math.max(1, ...raw.map((p) => p.surfaces)));
+  const pMax = Math.max(1, ...raw.map((p) => p.participants));
+  const innerW = BUBBLE_VB.w - BUBBLE_PAD.left - BUBBLE_PAD.right;
+  const innerH = BUBBLE_VB.h - BUBBLE_PAD.top - BUBBLE_PAD.bottom;
+
+  const points: BubblePoint[] = raw.map((p) => ({
+    ...p,
+    x: BUBBLE_PAD.left + (p.age / xMax) * innerW,
+    y: BUBBLE_PAD.top + (1 - p.surfaces / yMax) * innerH,
+    r: R_MIN + (p.participants / pMax) * (R_MAX - R_MIN),
+    color: healthColor(p.health),
+  }));
+
+  return { points, xMax, yMax };
+}

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -37,7 +37,7 @@ export const tableSearchSchema = z.object({
   includeRoot: fallback(z.boolean(), true).default(true),
   // Layout state for list routes that support multiple views + row density.
   // Additive + optional with safe fallbacks so the toggles persist in the URL.
-  view: fallback(z.enum(["table", "grid", "matrix"]), "table").default("table"),
+  view: fallback(z.enum(["table", "grid", "matrix", "bubble"]), "table").default("table"),
   density: fallback(z.enum(["comfortable", "compact"]), "comfortable").default("comfortable"),
 });
 

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { Network, Radio, Layers, Activity, Coins } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { SubnetsBubbleView } from "@/components/metagraphed/subnets-bubble-view";
 import { EmptyState, Skeleton } from "@/components/metagraphed/states";
 import {
   BrandIcon,
@@ -184,7 +185,11 @@ function SubnetsPage() {
         description="Every active Finney netuid — root and application — with curation level, surface count, health, and freshness."
         actions={
           <>
-            <ViewModeToggle value={search.view} onChange={setView} />
+            <ViewModeToggle
+              value={search.view}
+              onChange={setView}
+              options={["table", "grid", "matrix", "bubble"]}
+            />
             {search.view === "table" ? (
               <DensityToggle value={effectiveDensity} onChange={setDensity} />
             ) : null}
@@ -641,6 +646,19 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
       cursorInvalid={cursorInvalid}
     />
   );
+
+  // #6884: bubble view — an alternate scatter over the same filtered rows.
+  if (view === "bubble") {
+    return (
+      <div>
+        <div className="sticky top-14 z-20 -mx-4 md:mx-0 mb-3 bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80 border-b border-border md:border md:rounded md:bg-card px-3 py-2 md:p-2.5">
+          <div className="flex flex-wrap items-center gap-2">{filters}</div>
+        </div>
+        {rows.length === 0 && !hasNextPage ? emptyNode : <SubnetsBubbleView rows={rows} />}
+        <div className="mt-3">{footerNode}</div>
+      </div>
+    );
+  }
 
   // Grid / matrix views skip ListShell so they're not boxed in a table card.
   if (view === "grid" || view === "matrix") {

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2631,6 +2631,12 @@ var OPTIONS = [
     label: "Matrix",
     Icon: lucideReact.Grid3x3,
     ariaLabel: "Switch to matrix view"
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: lucideReact.ScatterChart,
+    ariaLabel: "Switch to bubble view"
   }
 ];
 function ViewModeToggle({

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1,7 +1,7 @@
 import * as React3 from 'react';
 import { useState, useRef, useEffect, useMemo, useCallback, useId } from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
-import { ChevronDown, X, Search, ArrowUp, Check, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Lock, AlertTriangle } from 'lucide-react';
+import { ChevronDown, X, Search, ArrowUp, Check, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, ScatterChart, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Lock, AlertTriangle } from 'lucide-react';
 import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
@@ -2602,6 +2602,12 @@ var OPTIONS = [
     label: "Matrix",
     Icon: Grid3x3,
     ariaLabel: "Switch to matrix view"
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: ScatterChart,
+    ariaLabel: "Switch to bubble view"
   }
 ];
 function ViewModeToggle({

--- a/packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx
+++ b/packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx
@@ -1,10 +1,10 @@
-import { LayoutGrid, List, Grid3x3 } from "lucide-react";
+import { LayoutGrid, List, Grid3x3, ScatterChart } from "lucide-react";
 import {
   SegmentedToggle,
   type SegmentedToggleOption,
 } from "@/components/ui/segmented-toggle";
 
-export type ViewMode = "table" | "grid" | "matrix";
+export type ViewMode = "table" | "grid" | "matrix" | "bubble";
 
 const OPTIONS: Array<SegmentedToggleOption<ViewMode>> = [
   {
@@ -24,6 +24,12 @@ const OPTIONS: Array<SegmentedToggleOption<ViewMode>> = [
     label: "Matrix",
     Icon: Grid3x3,
     ariaLabel: "Switch to matrix view",
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: ScatterChart,
+    ariaLabel: "Switch to bubble view",
   },
 ];
 


### PR DESCRIPTION
> Resubmit of a prior attempt that was auto-closed for one blocker: **no tests for the coordinate/scaling math**. This PR extracts that logic into a pure, node-tested `subnets-bubble-layout.ts` (10 tests: empty/single-row/all-zero/div-by-zero guards, date math, health mapping, radius scaling) with the component output unchanged. Everything else is as reviewed (CI was green, viz logic was praised).

## What

Adds a 4th `/subnets` view mode — **Bubble** — alongside table/grid/matrix: a scatter plot over the **same filtered list** the table already renders, for spotting outliers a sorted table hides. It's URL-driven (`?view=bubble`) like the other views, so it deep-links and renders server-side. Clicking a bubble opens the subnet detail (mirrors table row-click); the existing category/health/etc. filters are shared (same `rows`). Closes #6884.

## Encoding & why (the axis-choice reasoning the issue asks for)

All four channels use fields the subnet **list** already carries (the table shows them too — the list has no stake/emission, those are detail-only):

- **x = age in days** (established-ness; from `registered_at_block`/`block`)
- **y = verified surface count** (integration depth)
- **bubble size = participants** (active UIDs)
- **colour = health state** (operational traffic-light: ok/warn/down/unknown)

I chose **age × surfaces** over the issue's "age × participants" example on purpose: **most subnets max their UID count at 256**, so a participants axis bunches nearly every bubble in a flat band at the top (I built it that way first — it looked cramped and uninformative). Surfaces spread across the range and tell a sharper story — *an old subnet sitting low on the surface axis is under-integrated relative to its age*, which is exactly the kind of outlier the table's sort can't surface. Participants still earns a channel as bubble size.

No charting library is added (the app ships none): it's a fixed-`viewBox` SVG, drawn server-side, mirroring the coordinate approach of the existing `Sparkline` primitive.

## Screenshots

`/subnets` list area — **before** the existing table, **after** the new bubble view (same subnets, same filters).

| Viewport · Theme | Before (table) | After (bubble) |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/xfodev/metagraphed/screenshots/6884-subnets-bubble/after-mobile-dark.png)<br><sub>after</sub> |

## Testing

- `tsc --noEmit` — clean; `eslint`, `prettier --check` — clean
- ui-kit `ViewMode`/`ViewModeToggle` extended + `dist` rebuilt and committed (index.js/cjs)
- New view verified rendering server-side at `/subnets?view=bubble` across all 3 viewports + both themes
