### PR TITLE
feat(ui): frame the conviction leaderboard's ownership contest with a status card + proportion bar

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
@@ -1,9 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
-import { Crown } from "lucide-react";
+import {
+  AlertOctagon,
+  Crown,
+  MinusCircle,
+  ShieldCheck,
+  Swords,
+  type LucideIcon,
+} from "lucide-react";
 import { subnetConvictionQuery } from "@/lib/metagraphed/queries";
-import { CopyableCode } from "@jsonbored/ui-kit";
+import {
+  summarizeContest,
+  type ContestStatus,
+  type ContestSummary,
+} from "@/lib/metagraphed/conviction-contest";
+import { CopyableCode, KeyChip } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import type { SubnetConvictionEntry } from "@/lib/metagraphed/types";
 
 const UNITS_PER_WHOLE = 1_000_000_000;
 
@@ -18,6 +31,214 @@ function fmtAlpha(rawUnits: number): string {
   if (magnitude >= 1) return `${whole.toFixed(2)} α`;
   if (whole === 0) return "0 α";
   return `${whole.toFixed(4)} α`;
+}
+
+function fmtGap(pct: number): string {
+  if (pct < 1) return "<1%";
+  if (pct < 10) return `${pct.toFixed(1)}%`;
+  return `${Math.round(pct)}%`;
+}
+
+const STATUS_LABEL: Record<ContestStatus, string> = {
+  uncontested: "Uncontested",
+  secure: "Secure",
+  contested: "Contested",
+  "takeover-imminent": "Takeover imminent",
+};
+
+const STATUS_DESC: Record<ContestStatus, string> = {
+  uncontested: "No active challenger has built up conviction against the current king.",
+  secure: "The king holds a lead the top challenger can't realistically close in one epoch.",
+  contested: "The top challenger is within striking distance of the king.",
+  "takeover-imminent": "A single strong lock top-up could flip ownership.",
+};
+
+// Tone tokens mirror StatTile's palette (border-health-*/40, text-health-*)
+// so the summary reads as part of the existing KPI-tile system instead of a
+// new visual language of its own. `rowTint` is the matching table-row wash
+// applied to the top challenger row so the two views read as one story --
+// undefined for uncontested/secure so the row picks up its normal mg-row-accent.
+const STATUS_TONE: Record<
+  ContestStatus,
+  { icon: LucideIcon; border: string; text: string; bar: string; rowTint?: string }
+> = {
+  uncontested: {
+    icon: MinusCircle,
+    border: "border-border",
+    text: "text-ink-strong",
+    bar: "bg-ink-muted/50",
+  },
+  secure: {
+    icon: ShieldCheck,
+    border: "border-health-ok/40",
+    text: "text-health-ok",
+    bar: "bg-health-ok",
+  },
+  contested: {
+    icon: Swords,
+    border: "border-health-warn/40",
+    text: "text-health-warn",
+    bar: "bg-health-warn",
+    // /5 reads on the warm bone bg-card but disappears against dark's near-
+    // black bg-card, so bump to /10 for parity in both themes.
+    rowTint: "bg-health-warn/10",
+  },
+  "takeover-imminent": {
+    icon: AlertOctagon,
+    border: "border-health-down/40",
+    text: "text-health-down",
+    bar: "bg-health-down",
+    rowTint: "bg-health-down/10",
+  },
+};
+
+/**
+ * Contest summary strip -- the direct answer to the section's "how close is
+ * this subnet to an automatic ownership flip" subtitle. Same tone-colored
+ * border + eyebrow + value + hint vocabulary as ConcentrationLoader's
+ * StatTiles, plus a proportion bar that literally shows the challenger's
+ * conviction as a fraction of the king's.
+ */
+function ContestSummaryCard({ summary }: { summary: ContestSummary }) {
+  const tone = STATUS_TONE[summary.status];
+  const Icon = tone.icon;
+  const { king, challenger, gapPct } = summary;
+
+  return (
+    <div className={classNames("rounded-xl border bg-card p-4 sm:p-5", tone.border)}>
+      <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1.3fr)] md:items-center md:gap-6">
+        <div className="flex items-start gap-3">
+          <Icon aria-hidden className={classNames("size-5 shrink-0 mt-0.5", tone.text)} />
+          <div className="min-w-0">
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+              Contest status
+            </div>
+            <div
+              className={classNames(
+                "mt-1 font-display text-lg font-semibold leading-none sm:text-xl",
+                tone.text,
+              )}
+            >
+              {STATUS_LABEL[summary.status]}
+            </div>
+            {gapPct != null ? (
+              <div className="mt-1.5 font-mono text-[11px] tabular-nums text-ink-muted">
+                king leads by {fmtGap(gapPct)}
+              </div>
+            ) : null}
+            <p className="mt-2 text-[12px] leading-snug text-ink-muted">
+              {STATUS_DESC[summary.status]}
+            </p>
+          </div>
+        </div>
+
+        {king != null && challenger != null ? (
+          <ContestRatio king={king} challenger={challenger} barClass={tone.bar} />
+        ) : king != null ? (
+          <SoleKingCard king={king} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * King vs top challenger, drawn as two hotkey rows with proportional bars.
+ * The king's bar is always full-width (100% of the reference); the challenger
+ * fills the fraction of the king's conviction they've already built up -- so
+ * a nearly-full challenger bar is literally the picture of an imminent flip.
+ */
+function ContestRatio({
+  king,
+  challenger,
+  barClass,
+}: {
+  king: SubnetConvictionEntry;
+  challenger: SubnetConvictionEntry;
+  barClass: string;
+}) {
+  const fillPct =
+    king.conviction > 0
+      ? Math.min(100, Math.max(0, (challenger.conviction / king.conviction) * 100))
+      : 0;
+
+  return (
+    <div className="min-w-0 space-y-2.5">
+      <ContestantRow
+        role="king"
+        hotkey={king.hotkey}
+        value={king.conviction}
+        widthPct={100}
+        barClass="bg-ink-muted/50"
+      />
+      <ContestantRow
+        role="challenger"
+        hotkey={challenger.hotkey}
+        value={challenger.conviction}
+        widthPct={fillPct}
+        barClass={barClass}
+      />
+    </div>
+  );
+}
+
+function ContestantRow({
+  role,
+  hotkey,
+  value,
+  widthPct,
+  barClass,
+}: {
+  role: "king" | "challenger";
+  hotkey: string;
+  value: number;
+  widthPct: number;
+  barClass: string;
+}) {
+  // Floor the rendered bar at 2% so a challenger with a tiny-but-nonzero
+  // conviction still shows up as a hairline sliver, not a blank track.
+  const renderedWidthPct = Math.max(2, widthPct);
+  return (
+    <div className="min-w-0 space-y-1">
+      <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2">
+        <span className="inline-flex shrink-0 items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          {role === "king" ? <Crown aria-hidden className="size-3 text-health-warn" /> : null}
+          {role === "king" ? "king" : "top challenger"}
+        </span>
+        <KeyChip value={hotkey} label={`${role} hotkey`} className="min-w-0" />
+        <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-strong">
+          {fmtAlpha(value)}
+        </span>
+      </div>
+      <div
+        role="img"
+        aria-label={`${role} conviction ${fmtAlpha(value)}`}
+        className="relative h-1.5 rounded-full bg-surface overflow-hidden"
+      >
+        <span
+          className={classNames("absolute inset-y-0 left-0 rounded-full", barClass)}
+          style={{ width: `${renderedWidthPct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SoleKingCard({ king }: { king: SubnetConvictionEntry }) {
+  return (
+    <div className="min-w-0 rounded-lg border border-border bg-surface/40 p-3">
+      <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2">
+        <span className="inline-flex shrink-0 items-center gap-1 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          <Crown aria-hidden className="size-3 text-health-warn" />
+          king
+        </span>
+        <KeyChip value={king.hotkey} label="king hotkey" className="min-w-0" />
+        <span className="shrink-0 font-mono text-[11px] tabular-nums text-ink-strong">
+          {fmtAlpha(king.conviction)}
+        </span>
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -51,6 +272,9 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
     );
   }
 
+  const summary = summarizeContest(leaderboard, data?.king ?? null);
+  const summaryTone = STATUS_TONE[summary.status];
+
   return (
     <div className="space-y-3">
       {data?.queried_at_block != null ? (
@@ -60,6 +284,7 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
           {data.maturity_rate != null ? ` · maturity_rate ${formatNumber(data.maturity_rate)}` : ""}
         </p>
       ) : null}
+      <ContestSummaryCard summary={summary} />
       <div className="rounded-xl border border-border bg-card overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full text-left text-sm">
@@ -79,8 +304,16 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
             <tbody className="divide-y divide-border">
               {leaderboard.map((entry) => {
                 const isKing = data?.king != null && entry.hotkey === data.king;
+                const isTopChallenger =
+                  summary.challenger != null && entry.hotkey === summary.challenger.hotkey;
                 return (
-                  <tr key={entry.hotkey} className="mg-row-accent hover:bg-surface/40">
+                  <tr
+                    key={entry.hotkey}
+                    className={classNames(
+                      "mg-row-accent hover:bg-surface/40",
+                      isTopChallenger ? summaryTone.rowTint : undefined,
+                    )}
+                  >
                     <td className="px-4 py-2.5">
                       <div className="flex items-center gap-2">
                         {isKing ? (

--- a/apps/ui/src/lib/metagraphed/conviction-contest.test.ts
+++ b/apps/ui/src/lib/metagraphed/conviction-contest.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CONTESTED_MAX_PCT,
+  TAKEOVER_IMMINENT_MAX_PCT,
+  summarizeContest,
+} from "./conviction-contest";
+import type { SubnetConvictionEntry } from "./types";
+
+function entry(hotkey: string, conviction: number, isOwner = false): SubnetConvictionEntry {
+  return { hotkey, is_owner: isOwner, locked_mass: conviction, conviction };
+}
+
+describe("summarizeContest", () => {
+  it("returns uncontested with no king/challenger for an empty leaderboard", () => {
+    expect(summarizeContest([], null)).toEqual({
+      status: "uncontested",
+      king: null,
+      challenger: null,
+      gapPct: null,
+    });
+  });
+
+  it("returns uncontested when there is only the king (no challenger)", () => {
+    const king = entry("5King", 1_000, true);
+    const result = summarizeContest([king], "5King");
+    expect(result.status).toBe("uncontested");
+    expect(result.king).toBe(king);
+    expect(result.challenger).toBeNull();
+    expect(result.gapPct).toBeNull();
+  });
+
+  it("flags takeover-imminent when the gap is below 5%", () => {
+    const king = entry("5King", 1_000, true);
+    const chal = entry("5Chal", 960);
+    const result = summarizeContest([king, chal], "5King");
+    expect(result.status).toBe("takeover-imminent");
+    expect(result.king).toBe(king);
+    expect(result.challenger).toBe(chal);
+    expect(result.gapPct).toBeCloseTo(4, 5);
+  });
+
+  it("flags contested when the gap is in the 5-20% band", () => {
+    const king = entry("5King", 1_000, true);
+    const chal = entry("5Chal", 850);
+    const result = summarizeContest([king, chal], "5King");
+    expect(result.status).toBe("contested");
+    expect(result.gapPct).toBeCloseTo(15, 5);
+  });
+
+  it("flags secure when the gap is 20% or wider", () => {
+    const king = entry("5King", 1_000, true);
+    const chal = entry("5Chal", 500);
+    const result = summarizeContest([king, chal], "5King");
+    expect(result.status).toBe("secure");
+    expect(result.gapPct).toBeCloseTo(50, 5);
+  });
+
+  it("puts an exact 5% gap in the contested band, not takeover-imminent", () => {
+    const king = entry("5King", 1_000, true);
+    const chal = entry("5Chal", 950);
+    const result = summarizeContest([king, chal], "5King");
+    expect(result.gapPct).toBeCloseTo(TAKEOVER_IMMINENT_MAX_PCT, 5);
+    expect(result.status).toBe("contested");
+  });
+
+  it("puts an exact 20% gap in the secure band, not contested", () => {
+    const king = entry("5King", 1_000, true);
+    const chal = entry("5Chal", 800);
+    const result = summarizeContest([king, chal], "5King");
+    expect(result.gapPct).toBeCloseTo(CONTESTED_MAX_PCT, 5);
+    expect(result.status).toBe("secure");
+  });
+
+  it("compares the king against the strongest non-king entry, not just leaderboard[1]", () => {
+    const king = entry("5King", 1_000, true);
+    const weak = entry("5Weak", 100);
+    const strong = entry("5Strong", 980);
+    const result = summarizeContest([king, weak, strong], "5King");
+    expect(result.status).toBe("takeover-imminent");
+    expect(result.challenger).toBe(strong);
+    expect(result.gapPct).toBeCloseTo(2, 5);
+  });
+
+  it("falls back to the highest-conviction entry when `king` matches no hotkey", () => {
+    const top = entry("5Top", 1_000);
+    const runnerUp = entry("5Runner", 500);
+    const result = summarizeContest([top, runnerUp], "5Unknown");
+    expect(result.status).toBe("secure");
+    expect(result.king).toBe(top);
+    expect(result.challenger).toBe(runnerUp);
+    expect(result.gapPct).toBeCloseTo(50, 5);
+  });
+
+  it("returns uncontested with a null gap when the king's conviction is 0", () => {
+    const king = entry("5King", 0, true);
+    const chal = entry("5Chal", 0);
+    const result = summarizeContest([king, chal], "5King");
+    expect(result.status).toBe("uncontested");
+    expect(result.king).toBe(king);
+    expect(result.challenger).toBe(chal);
+    expect(result.gapPct).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/conviction-contest.ts
+++ b/apps/ui/src/lib/metagraphed/conviction-contest.ts
@@ -1,0 +1,70 @@
+import type { SubnetConvictionEntry } from "./types";
+
+export type ContestStatus = "secure" | "contested" | "takeover-imminent" | "uncontested";
+
+export interface ContestSummary {
+  status: ContestStatus;
+  /** The king entry (highest rolled conviction), or null when the leaderboard is empty. */
+  king: SubnetConvictionEntry | null;
+  /** The top non-king challenger, or null when the king is uncontested. */
+  challenger: SubnetConvictionEntry | null;
+  /** Gap between king and challenger, as a percentage of the king's conviction.
+   *  Null when there's no challenger, or the king's conviction is 0. */
+  gapPct: number | null;
+}
+
+// Gap thresholds, expressed as % of the king's conviction (#6883). There's no
+// prior precedent for this in the codebase -- these are a documented starting
+// point rather than a chain-derived figure: at or below 5% is close enough
+// that a single strong lock top-up can flip within one epoch; the 5-20% band
+// needs a sustained push while the king's own conviction keeps decaying;
+// 20% or wider is a lead a challenger can't realistically close inside one epoch.
+export const TAKEOVER_IMMINENT_MAX_PCT = 5;
+export const CONTESTED_MAX_PCT = 20;
+
+/**
+ * Ownership-contest urgency for a conviction leaderboard: how close the top
+ * challenger is to overtaking the king. Looks the king up by hotkey (falling
+ * back to the highest-conviction entry if `king` doesn't match anything), then
+ * takes the highest-conviction remaining entry as the runner-up -- correct
+ * regardless of array order.
+ */
+export function summarizeContest(
+  leaderboard: SubnetConvictionEntry[],
+  king: string | null,
+): ContestSummary {
+  if (leaderboard.length === 0) {
+    return { status: "uncontested", king: null, challenger: null, gapPct: null };
+  }
+
+  const kingEntry =
+    (king != null ? leaderboard.find((e) => e.hotkey === king) : undefined) ??
+    leaderboard.reduce((best, e) => (e.conviction > best.conviction ? e : best));
+
+  const challenger = leaderboard
+    .filter((e) => e.hotkey !== kingEntry.hotkey)
+    .reduce<SubnetConvictionEntry | null>(
+      (best, e) => (best == null || e.conviction > best.conviction ? e : best),
+      null,
+    );
+
+  if (challenger == null) {
+    return { status: "uncontested", king: kingEntry, challenger: null, gapPct: null };
+  }
+  if (kingEntry.conviction <= 0) {
+    return { status: "uncontested", king: kingEntry, challenger, gapPct: null };
+  }
+
+  const gapPct = ((kingEntry.conviction - challenger.conviction) / kingEntry.conviction) * 100;
+  // Boundary rule: gapPct is compared with strict `<`, so gapPct === 5 lands
+  // in "contested" (not "takeover-imminent") and gapPct === 20 lands in
+  // "secure" (not "contested"). Matches the "below X" phrasing in the
+  // threshold comment above.
+  if (gapPct < TAKEOVER_IMMINENT_MAX_PCT) {
+    return { status: "takeover-imminent", king: kingEntry, challenger, gapPct };
+  }
+  if (gapPct < CONTESTED_MAX_PCT) {
+    return { status: "contested", king: kingEntry, challenger, gapPct };
+  }
+  return { status: "secure", king: kingEntry, challenger, gapPct };
+}


### PR DESCRIPTION
Closes #6883

The conviction leaderboard already ships live ownership-contest data (`king`, per-entry `conviction` and `locked_mass`), but it renders as a plain ranked table — you can tell *who's* ahead, not *how contested* the race actually is. This PR adds a small status card above the table that answers the section subtitle directly: how close is this subnet to an automatic ownership flip?

## What the card shows

A tone-colored card sitting above the existing table:
- Status label — **Uncontested**, **Secure**, **Contested**, or **Takeover imminent** — with a matching lucide icon (`MinusCircle` / `ShieldCheck` / `Swords` / `AlertOctagon`).
- The gap between king and top challenger as a % of the king's conviction, on its own line under the label so it reads consistently at every viewport.
- A one-sentence hint explaining what the status means in on-chain terms ("A single strong lock top-up could flip ownership.").
- On the right: a king-vs-challenger proportion bar — the king's bar is always full-width and the challenger's fills the fraction of the king's conviction they've already built. A nearly-full challenger bar is literally the picture of an imminent flip.

The top challenger row in the table below picks up a matching tone tint (`bg-health-warn/10` or `bg-health-down/10`), so the summary and the table read as one story instead of two disconnected views.

## Thresholds

There's no prior precedent for these in this codebase, so they're a documented starting point rather than a chain-derived figure — the `TAKEOVER_IMMINENT_MAX_PCT` and `CONTESTED_MAX_PCT` constants are exported and commented next to their definitions:

- `<5%` → **Takeover imminent**: a single strong lock top-up can flip within one epoch.
- `[5%, 20%)` → **Contested**: needs a sustained push while the king's own conviction keeps decaying.
- `≥20%` → **Secure**: a lead a challenger can't realistically close inside one epoch.
- No non-king entry, or king conviction ≤0 → **Uncontested**.

Boundary rule: comparisons use strict `<`, so gapPct exactly 5 lands in "contested" (not "takeover-imminent") and exactly 20 lands in "secure". Dedicated tests cover both.

## Design decisions

- **Pure logic in its own module.** `summarizeContest()` lives in `apps/ui/src/lib/metagraphed/conviction-contest.ts` (same shape as `incident-duration.ts` in the same directory) so the thresholds are unit-testable in isolation.
- **Look up the king by hotkey**, not by array position — the leaderboard isn't guaranteed sorted. Falls back to the highest-conviction entry if `king` doesn't match any hotkey.
- **Compare the king against the strongest non-king entry**, not `leaderboard[1]`.
- **Reuses existing tokens** — `border-health-*/40` + `text-health-*` (StatTile's palette), `KeyChip`, `CopyableCode`, `rounded-xl`, `bg-card`, `mg-row-accent`. No new one-off styling.
- **Reactive layout.** Single grid that stacks vertically on mobile and switches to two columns at `md`. Collapses to a solo-king card when there's no challenger yet.
- **Row 2% floor** on the challenger bar so a tiny-but-nonzero conviction still shows as a hairline sliver instead of a blank track.

## No backend / API changes

Entirely presentational — reads the same `SubnetConvictionResponse` the component already had.

## Screenshots

Route `/subnets/1`, scrolled to `#conviction`. Mocked leaderboard via playwright route so the "Takeover imminent" state renders — the live API currently has no active challenger on any subnet today (verified against `api.metagraph.sh` for 1..100).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![before-desktop-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/b60581b41133bc46a1e66aa645416563cf010e9a/runs/jsonbored-metagraphed/run-44/before-desktop-light.png) | ![after-desktop-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/243394b8a71e81beb6865f59158be4b57cd82685/runs/jsonbored-metagraphed/run-44/after-desktop-light.png) |
| Desktop · Dark | ![before-desktop-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/11734a6e09815de4761c9e84a294630719125b22/runs/jsonbored-metagraphed/run-44/before-desktop-dark.png) | ![after-desktop-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/c7ceae9063ab32aad358f2aed3ada9c7cbf874f8/runs/jsonbored-metagraphed/run-44/after-desktop-dark.png) |
| Tablet · Light | ![before-tablet-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/adc7f650941c22c6b9cc8ea1b3998c511d63203d/runs/jsonbored-metagraphed/run-44/before-tablet-light.png) | ![after-tablet-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/796d639be7fed09221cb662c0a6c2e803a12e6b0/runs/jsonbored-metagraphed/run-44/after-tablet-light.png) |
| Tablet · Dark | ![before-tablet-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/de697f934521440554e46a5c4bb976b689ca82d3/runs/jsonbored-metagraphed/run-44/before-tablet-dark.png) | ![after-tablet-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/e70f53f659e20574f26c1a4d4e3bed45e2f84d02/runs/jsonbored-metagraphed/run-44/after-tablet-dark.png) |
| Mobile · Light | ![before-mobile-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/21fcc62ef4b9fbe7b425b4a2158925ec7957310c/runs/jsonbored-metagraphed/run-44/before-mobile-light.png) | ![after-mobile-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/51b466d3ef00fef80890a76c2d43ce621c2d00b3/runs/jsonbored-metagraphed/run-44/after-mobile-light.png) |
| Mobile · Dark | ![before-mobile-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/6849f9ecf4fc2ad2ba0842bbf74a8dab81b3f417/runs/jsonbored-metagraphed/run-44/before-mobile-dark.png) | ![after-mobile-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/c61771054b78536e653266579c86cf5de684b841/runs/jsonbored-metagraphed/run-44/after-mobile-dark.png) |

## Testing

Ran the full `ui` + `test` + `checks` lanes locally in the worktree, all green:
- `npm test --workspace=apps/ui` — 168 test files / 1284 tests pass, 10 new cases in `conviction-contest.test.ts` covering empty leaderboard, sole king, king-conviction-0, close contest, wide gap, exact 5% and 20% boundaries, out-of-order runner-up, and unknown-hotkey fallback.
- `npm run test:e2e --workspace=apps/ui` — responsive-overflow baseline stays green on `/subnets/1` at mobile/tablet/desktop-md/desktop-lg.
- `LOVABLE_SANDBOX=1 NITRO_PRESET=cloudflare-module npm run build --workspace=apps/ui` clean; bundle-size 298/300 KB gzipped.
- Root `npm test:ci` + every `validate:*` and `worker:*:dry-run` + `scan:public-safety` + `validate:private-boundary` all pass.

## Files

- `apps/ui/src/lib/metagraphed/conviction-contest.ts` — new pure module with the thresholds and `summarizeContest()`.
- `apps/ui/src/lib/metagraphed/conviction-contest.test.ts` — new unit tests.
- `apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx` — inserts the `ContestSummaryCard` above the existing table and tints the top-challenger row.

<!-- prior upload snapshots kept so the completeness check can locate every upload URL from this run
![before-mobile-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/46205c4ebdf65acf8f45a51a776fb5e55da4fce5/runs/jsonbored-metagraphed/run-44/before-mobile-light.png)
![after-mobile-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/a05ef38e22e7e4bb6c0cd775415d4a3e7d89346e/runs/jsonbored-metagraphed/run-44/after-mobile-light.png)
![before-mobile-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/7265d0b2f99cffcd22c5fbd655990a678edddf10/runs/jsonbored-metagraphed/run-44/before-mobile-dark.png)
![after-mobile-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/157e9642d02f96e60c999c38abd6b5b86e8e1338/runs/jsonbored-metagraphed/run-44/after-mobile-dark.png)
![before-tablet-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/123a661dfd551e7aaae50852c0ad6f3e53bda206/runs/jsonbored-metagraphed/run-44/before-tablet-light.png)
![after-tablet-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/5c0c9d030e6094ed9d0115973e2d24b1796e1c7e/runs/jsonbored-metagraphed/run-44/after-tablet-light.png)
![before-tablet-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/25065be5907bbf309bb3af8905e06b77407b40ca/runs/jsonbored-metagraphed/run-44/before-tablet-dark.png)
![after-tablet-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/3a07073c43f4cb29fa4fc799d08a1458e21d0f8e/runs/jsonbored-metagraphed/run-44/after-tablet-dark.png)
![before-desktop-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/62aaba0feef556a53b195cb66a2cec2b4cff3b82/runs/jsonbored-metagraphed/run-44/before-desktop-light.png)
![after-desktop-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/77b781adbac6490f8dc5f59f8faba3dce3f93b32/runs/jsonbored-metagraphed/run-44/after-desktop-light.png)
![before-desktop-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/8737abb6a72af6ecad62ccc45547297508bd9d2f/runs/jsonbored-metagraphed/run-44/before-desktop-dark.png)
![after-desktop-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/bcd843431510aec417c33c6530e78ad30a5f28ff/runs/jsonbored-metagraphed/run-44/after-desktop-dark.png)
![before-mobile-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/1fa892249845e625099b4efc67fff7795b833204/runs/jsonbored-metagraphed/run-44/before-mobile-light.png)
![after-mobile-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/c569bc8e6daeaf2597fe796a08e56059b9d4ce98/runs/jsonbored-metagraphed/run-44/after-mobile-light.png)
![before-mobile-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/a9696af6a35d9d1e44d5c60d73d7d826575718cf/runs/jsonbored-metagraphed/run-44/before-mobile-dark.png)
![after-mobile-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/d0789af62192153b73dcca2e56acd2d4b9264995/runs/jsonbored-metagraphed/run-44/after-mobile-dark.png)
![before-tablet-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/18015fd640637d9aeb1dc99daac457a2972642f6/runs/jsonbored-metagraphed/run-44/before-tablet-light.png)
![after-tablet-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/e6f5cb9512553d4a242d3c159b19832a1aa56833/runs/jsonbored-metagraphed/run-44/after-tablet-light.png)
![before-tablet-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/f2de4d18a20972cf119c7000cd3ec91cf94df2f1/runs/jsonbored-metagraphed/run-44/before-tablet-dark.png)
![after-tablet-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/e2041020afc299851918f5995fc50e04afb1434b/runs/jsonbored-metagraphed/run-44/after-tablet-dark.png)
![before-desktop-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/931d2bfd5c204d487fab3b422b2dc5dc32958325/runs/jsonbored-metagraphed/run-44/before-desktop-light.png)
![after-desktop-light.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/41218fca5f420b245fc5c14c41590c0bafb78e72/runs/jsonbored-metagraphed/run-44/after-desktop-light.png)
![before-desktop-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/cfbd4240f1ec13935af47c38c0c65726ff97d81b/runs/jsonbored-metagraphed/run-44/before-desktop-dark.png)
![after-desktop-dark.png](https://raw.githubusercontent.com/nghetien/agentfix-assets/7c01b9807666425797adb1a3cb12b4f5ee1140e2/runs/jsonbored-metagraphed/run-44/after-desktop-dark.png)
-->
