### PR TITLE
feat(ui): add bubble/scatter outlier view to the /subnets table

### DIFF
--- a/apps/ui/src/components/metagraphed/charts/subnet-bubble-chart.tsx
+++ b/apps/ui/src/components/metagraphed/charts/subnet-bubble-chart.tsx
@@ -1,0 +1,156 @@
+import { Link } from "@tanstack/react-router";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@jsonbored/ui-kit";
+import { classNames, formatNumber, formatSubnetAge, subnetAgeDays } from "@/lib/metagraphed/format";
+import type { Subnet } from "@/lib/metagraphed/types";
+import { bubbleDomain, layoutBubbles, type BubbleInput } from "./subnet-bubble-layout";
+
+// Reuse the exact health tokens the rest of the app tints subnets by
+// (subnets.index.tsx's matrix, HealthPill, SubnetPulseGrid) so a bubble's color
+// means the same thing everywhere.
+const HEALTH_FILL: Record<string, string> = {
+  ok: "var(--health-ok)",
+  warn: "var(--health-warn)",
+  down: "var(--health-down)",
+  unknown: "var(--health-unknown)",
+};
+
+const HEALTH_ORDER = ["ok", "warn", "down", "unknown"] as const;
+
+const MIN_R = 6;
+const MAX_R = 20;
+
+type Row = Subnet & { health?: string };
+
+/**
+ * Alternate "outlier map" view for /subnets (#6884): the same filtered subnet
+ * rows as the table, encoded on four channels instead of sorted into rows —
+ * x = subnet age, y = manifested surfaces, bubble size = participant count,
+ * color = health. Age × surfaces is the pair that makes the registry's own
+ * "how complete is this subnet for how long it has existed" outliers pop
+ * (young-but-well-surfaced, or old-but-sparse) the way a single sort column
+ * can't — the same completeness/health dimensions get_registry_leaderboards
+ * ranks by. Clicking a bubble opens /subnets/{netuid}, mirroring a table row.
+ */
+export function SubnetBubbleChart({ rows }: { rows: Row[] }) {
+  const inputs: BubbleInput[] = rows.map((s) => ({
+    netuid: s.netuid,
+    name: s.name,
+    x: subnetAgeDays(s.registered_at_block, s.block) ?? 0,
+    y: s.surfaces_count ?? 0,
+    size: s.participants ?? 0,
+    health: s.health ?? "unknown",
+  }));
+  const xDomain = bubbleDomain(inputs.map((d) => d.x));
+  const yDomain = bubbleDomain(inputs.map((d) => d.y));
+  const nodes = layoutBubbles(inputs, { minR: MIN_R, maxR: MAX_R });
+
+  return (
+    <div className="rounded border border-border bg-card p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-ink-muted">
+          Outlier map · {rows.length} subnets
+        </span>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[10px] text-ink-muted">
+          <span className="inline-flex items-center gap-1.5">
+            <span className="text-ink-subtle-text">size</span>
+            <span className="inline-block size-1.5 rounded-full bg-ink-muted/50" />
+            <span className="inline-block size-3 rounded-full bg-ink-muted/50" />
+            <span>participants</span>
+          </span>
+          <span className="inline-flex items-center gap-2">
+            {HEALTH_ORDER.map((h) => (
+              <span key={h} className="inline-flex items-center gap-1">
+                <span
+                  className="inline-block size-2 rounded-full"
+                  style={{ backgroundColor: HEALTH_FILL[h] }}
+                />
+                {h}
+              </span>
+            ))}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <div className="flex shrink-0 items-center justify-center">
+          <span className="[writing-mode:vertical-rl] rotate-180 font-mono text-[9px] uppercase tracking-widest text-ink-muted whitespace-nowrap">
+            Surfaces · {formatNumber(yDomain.min)}–{formatNumber(yDomain.max)} ↑
+          </span>
+        </div>
+        <div className="min-w-0 flex-1">
+          <div
+            className="relative aspect-square w-full overflow-hidden rounded-sm border border-border/60 bg-surface/40 sm:aspect-[5/2]"
+            role="group"
+            aria-label={`Subnet outlier map: ${rows.length} subnets plotted by age, surfaces, participants, and health`}
+          >
+            {/* Quiet quartile gridlines so position is readable without a full axis. */}
+            {[25, 50, 75].map((p) => (
+              <span
+                key={`v${p}`}
+                className="absolute inset-y-0 w-px bg-border/40"
+                style={{ left: `${p}%` }}
+              />
+            ))}
+            {[25, 50, 75].map((p) => (
+              <span
+                key={`h${p}`}
+                className="absolute inset-x-0 h-px bg-border/40"
+                style={{ top: `${p}%` }}
+              />
+            ))}
+            {/* Inset the plotting band by the max radius (in px, so it holds at
+                every viewport) — a bubble at a domain extreme then just touches
+                the frame instead of being clipped by overflow-hidden. */}
+            <div className="absolute" style={{ inset: MAX_R }}>
+              {nodes.map((n) => (
+                <Tooltip key={n.netuid} delayDuration={120}>
+                  <TooltipTrigger asChild>
+                    <Link
+                      to="/subnets/$netuid"
+                      params={{ netuid: n.netuid }}
+                      aria-label={`Subnet ${n.netuid}${n.name ? ` — ${n.name}` : ""} · ${formatNumber(n.y)} surfaces · ${formatNumber(n.size)} participants · health ${n.health}`}
+                      className="absolute rounded-full opacity-80 outline-none transition-transform hover:z-10 hover:scale-110 focus-visible:z-10 focus-visible:scale-110 focus-visible:ring-2 focus-visible:ring-accent"
+                      style={{
+                        left: `${n.cx}%`,
+                        top: `${n.cy}%`,
+                        width: n.r * 2,
+                        height: n.r * 2,
+                        marginLeft: -n.r,
+                        marginTop: -n.r,
+                        backgroundColor: HEALTH_FILL[n.health] ?? HEALTH_FILL.unknown,
+                        // A ring in the surface color "cuts out" overlapping
+                        // bubbles so a dense cluster still reads as distinct marks.
+                        border: "1.5px solid var(--card)",
+                      }}
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="text-xs">
+                    <div className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                      netuid {n.netuid}
+                    </div>
+                    <div className="font-display text-sm font-semibold text-ink-strong">
+                      {n.name ?? `Subnet ${n.netuid}`}
+                    </div>
+                    <dl className="mt-1 grid grid-cols-[auto_auto] gap-x-3 gap-y-0.5 text-[11px] text-ink-muted">
+                      <dt>age</dt>
+                      <dd className="text-right font-mono text-ink">{formatSubnetAge(n.x)}</dd>
+                      <dt>surfaces</dt>
+                      <dd className="text-right font-mono text-ink">{formatNumber(n.y)}</dd>
+                      <dt>participants</dt>
+                      <dd className="text-right font-mono text-ink">{formatNumber(n.size)}</dd>
+                      <dt>health</dt>
+                      <dd className="text-right font-mono text-ink">{n.health}</dd>
+                    </dl>
+                  </TooltipContent>
+                </Tooltip>
+              ))}
+            </div>
+          </div>
+          <div className="mt-1 text-center font-mono text-[9px] uppercase tracking-widest text-ink-muted">
+            Subnet age · {formatNumber(xDomain.min)}–{formatNumber(xDomain.max)} days →
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/charts/subnet-bubble-layout.test.ts
+++ b/apps/ui/src/components/metagraphed/charts/subnet-bubble-layout.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  bubbleDomain,
+  bubbleRadius,
+  layoutBubbles,
+  scaleLinear,
+  type BubbleInput,
+} from "./subnet-bubble-layout";
+
+describe("bubbleDomain", () => {
+  it("returns min/max over finite values", () => {
+    expect(bubbleDomain([3, 1, 9, 4])).toEqual({ min: 1, max: 9 });
+  });
+
+  it("ignores NaN / Infinity and defaults empty input to {0,0}", () => {
+    expect(bubbleDomain([NaN, Infinity, 5, -Infinity])).toEqual({ min: 5, max: 5 });
+    expect(bubbleDomain([])).toEqual({ min: 0, max: 0 });
+  });
+});
+
+describe("scaleLinear", () => {
+  it("maps the endpoints and midpoint of a domain", () => {
+    const d = { min: 0, max: 10 };
+    expect(scaleLinear(0, d, 0, 100)).toBe(0);
+    expect(scaleLinear(10, d, 0, 100)).toBe(100);
+    expect(scaleLinear(5, d, 0, 100)).toBe(50);
+  });
+
+  it("clamps out-of-range values into the output band", () => {
+    const d = { min: 0, max: 10 };
+    expect(scaleLinear(-5, d, 0, 100)).toBe(0);
+    expect(scaleLinear(20, d, 0, 100)).toBe(100);
+  });
+
+  it("centers a zero-width domain instead of dividing by zero", () => {
+    expect(scaleLinear(7, { min: 7, max: 7 }, 0, 100)).toBe(50);
+  });
+});
+
+describe("bubbleRadius", () => {
+  it("uses an area (sqrt) scale between min and max radius", () => {
+    const d = { min: 0, max: 100 };
+    expect(bubbleRadius(0, d, 4, 20)).toBe(4);
+    expect(bubbleRadius(100, d, 4, 20)).toBe(20);
+    // 25% of the value is 50% of the radius span (sqrt(0.25) = 0.5).
+    expect(bubbleRadius(25, d, 4, 20)).toBe(12);
+  });
+
+  it("falls back to the min radius for a zero-width domain", () => {
+    expect(bubbleRadius(9, { min: 9, max: 9 }, 4, 20)).toBe(4);
+  });
+});
+
+describe("layoutBubbles", () => {
+  const data: BubbleInput[] = [
+    { netuid: 1, x: 0, y: 0, size: 0, health: "ok" },
+    { netuid: 2, x: 10, y: 10, size: 100, health: "down" },
+  ];
+
+  it("flips the y axis so a higher metric sits nearer the top", () => {
+    const nodes = layoutBubbles(data, { minR: 4, maxR: 20 });
+    const byUid = Object.fromEntries(nodes.map((n) => [n.netuid, n]));
+    expect(byUid[1]!.cy).toBe(100); // lowest surfaces -> bottom
+    expect(byUid[2]!.cy).toBe(0); // highest surfaces -> top
+    expect(byUid[1]!.cx).toBe(0);
+    expect(byUid[2]!.cx).toBe(100);
+  });
+
+  it("draws the largest bubble first so small outliers stay clickable on top", () => {
+    const nodes = layoutBubbles(data, { minR: 4, maxR: 20 });
+    expect(nodes[0]!.netuid).toBe(2); // biggest size -> first in paint order
+    expect(nodes[nodes.length - 1]!.netuid).toBe(1);
+  });
+});

--- a/apps/ui/src/components/metagraphed/charts/subnet-bubble-layout.ts
+++ b/apps/ui/src/components/metagraphed/charts/subnet-bubble-layout.ts
@@ -1,0 +1,96 @@
+// Pure layout math for the /subnets bubble view (#6884). Kept dependency-free
+// and separate from the React component so the scaling/positioning invariants
+// can be unit-tested directly (same split as validator-dominance-ranking.ts).
+
+export interface BubbleInput {
+  netuid: number;
+  name?: string;
+  /** Raw horizontal metric (subnet age, days). */
+  x: number;
+  /** Raw vertical metric (manifested surface count). */
+  y: number;
+  /** Raw size metric (participant count). */
+  size: number;
+  /** Health state key: ok | warn | down | unknown. */
+  health: string;
+}
+
+export interface BubbleNode extends BubbleInput {
+  /** Horizontal center, 0–100 as a percent of the plot box (left). */
+  cx: number;
+  /** Vertical center, 0–100 as a percent of the plot box (top). Already
+   *  flipped so a higher `y` sits nearer the top. */
+  cy: number;
+  /** Radius in px (area-proportional to `size`). */
+  r: number;
+}
+
+export interface Domain {
+  min: number;
+  max: number;
+}
+
+/** Min/max over the finite numbers in `values`, defaulting to {0,0} when empty. */
+export function bubbleDomain(values: number[]): Domain {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const v of values) {
+    if (typeof v !== "number" || !Number.isFinite(v)) continue;
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  if (min === Infinity) return { min: 0, max: 0 };
+  return { min, max };
+}
+
+/**
+ * Map `v` from `domain` onto [outMin, outMax]. A zero-width domain (every value
+ * equal, or a single point) maps to the midpoint so the bubble lands centered
+ * rather than pinned to an edge or dividing by zero.
+ */
+export function scaleLinear(v: number, domain: Domain, outMin: number, outMax: number): number {
+  const span = domain.max - domain.min;
+  if (span <= 0) return (outMin + outMax) / 2;
+  const t = (v - domain.min) / span;
+  const clamped = t < 0 ? 0 : t > 1 ? 1 : t;
+  return outMin + clamped * (outMax - outMin);
+}
+
+/**
+ * Radius in px for a size metric, scaled by AREA (sqrt of the value) so the
+ * visual weight of a bubble tracks the metric honestly — the standard bubble
+ * encoding. A zero-width size domain renders every bubble at the min radius.
+ */
+export function bubbleRadius(size: number, domain: Domain, minR: number, maxR: number): number {
+  const span = domain.max - domain.min;
+  const s = typeof size === "number" && Number.isFinite(size) ? size : domain.min;
+  if (span <= 0) return minR;
+  const t = (s - domain.min) / span;
+  const clamped = t < 0 ? 0 : t > 1 ? 1 : t;
+  return minR + Math.sqrt(clamped) * (maxR - minR);
+}
+
+export interface LayoutOptions {
+  minR: number;
+  maxR: number;
+}
+
+/**
+ * Lay out bubbles inside a 0–100 percentage box. Callers place the box with CSS
+ * (padding for axis labels), so the percentages are resolution-independent and
+ * never overflow horizontally. Larger, denser bubbles are drawn first so small
+ * outliers stay clickable on top — the whole point of the view.
+ */
+export function layoutBubbles(data: BubbleInput[], opts: LayoutOptions): BubbleNode[] {
+  const xDomain = bubbleDomain(data.map((d) => d.x));
+  const yDomain = bubbleDomain(data.map((d) => d.y));
+  const sizeDomain = bubbleDomain(data.map((d) => d.size));
+  return data
+    .map((d) => ({
+      ...d,
+      cx: scaleLinear(d.x, xDomain, 0, 100),
+      cy: 100 - scaleLinear(d.y, yDomain, 0, 100),
+      r: bubbleRadius(d.size, sizeDomain, opts.minR, opts.maxR),
+    }))
+    .sort((a, b) => b.r - a.r);
+}

--- a/apps/ui/src/lib/metagraphed/url-state.ts
+++ b/apps/ui/src/lib/metagraphed/url-state.ts
@@ -37,7 +37,7 @@ export const tableSearchSchema = z.object({
   includeRoot: fallback(z.boolean(), true).default(true),
   // Layout state for list routes that support multiple views + row density.
   // Additive + optional with safe fallbacks so the toggles persist in the URL.
-  view: fallback(z.enum(["table", "grid", "matrix"]), "table").default("table"),
+  view: fallback(z.enum(["table", "grid", "matrix", "bubble"]), "table").default("table"),
   density: fallback(z.enum(["comfortable", "compact"]), "comfortable").default("comfortable"),
 });
 

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -39,6 +39,7 @@ import {
   SortHeader,
 } from "@/components/metagraphed/table-controls";
 import { SubnetsSavedViews } from "@/components/metagraphed/subnets-saved-views";
+import { SubnetBubbleChart } from "@/components/metagraphed/charts/subnet-bubble-chart";
 import {
   SubnetsCompareDrawer,
   CompareToggle,
@@ -184,7 +185,11 @@ function SubnetsPage() {
         description="Every active Finney netuid — root and application — with curation level, surface count, health, and freshness."
         actions={
           <>
-            <ViewModeToggle value={search.view} onChange={setView} />
+            <ViewModeToggle
+              value={search.view}
+              onChange={setView}
+              options={["table", "grid", "matrix", "bubble"]}
+            />
             {search.view === "table" ? (
               <DensityToggle value={effectiveDensity} onChange={setDensity} />
             ) : null}
@@ -642,10 +647,11 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
     />
   );
 
-  // Grid / matrix views skip ListShell so they're not boxed in a table card.
-  if (view === "grid" || view === "matrix") {
+  // Grid / matrix / bubble views skip ListShell so they're not boxed in a
+  // table card — they share the same filtered `rows` and the sticky filter bar.
+  if (view === "grid" || view === "matrix" || view === "bubble") {
     return (
-      <div>
+      <div id="subnets-list" className="scroll-mt-32">
         <div className="sticky top-14 z-20 -mx-4 md:mx-0 mb-3 bg-paper/95 backdrop-blur supports-[backdrop-filter]:bg-paper/80 border-b border-border md:border md:rounded md:bg-card px-3 py-2 md:p-2.5">
           <div className="flex flex-wrap items-center gap-2">{filters}</div>
         </div>
@@ -653,8 +659,10 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
           emptyNode
         ) : view === "grid" ? (
           <SubnetGrid rows={rows} />
-        ) : (
+        ) : view === "matrix" ? (
           <SubnetMatrix rows={rows} />
+        ) : (
+          <SubnetBubbleChart rows={rows} />
         )}
         <div className="mt-3">{footerNode}</div>
       </div>

--- a/packages/ui-kit/dist/index.cjs
+++ b/packages/ui-kit/dist/index.cjs
@@ -2631,6 +2631,12 @@ var OPTIONS = [
     label: "Matrix",
     Icon: lucideReact.Grid3x3,
     ariaLabel: "Switch to matrix view"
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: lucideReact.ScatterChart,
+    ariaLabel: "Switch to bubble view"
   }
 ];
 function ViewModeToggle({

--- a/packages/ui-kit/dist/index.js
+++ b/packages/ui-kit/dist/index.js
@@ -1,7 +1,7 @@
 import * as React3 from 'react';
 import { useState, useRef, useEffect, useMemo, useCallback, useId } from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
-import { ChevronDown, X, Search, ArrowUp, Check, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Lock, AlertTriangle } from 'lucide-react';
+import { ChevronDown, X, Search, ArrowUp, Check, Copy, Rows3, Rows2, Download, Info, AlertCircle, RefreshCw, Link, Link2, Share2, ChevronLeft, ChevronRight, Clock, Inbox, ExternalLink as ExternalLink$1, List, LayoutGrid, Grid3x3, ScatterChart, ChevronUp, Globe, BookOpen, Github, LayoutDashboard, Lock, AlertTriangle } from 'lucide-react';
 import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
@@ -2602,6 +2602,12 @@ var OPTIONS = [
     label: "Matrix",
     Icon: Grid3x3,
     ariaLabel: "Switch to matrix view"
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: ScatterChart,
+    ariaLabel: "Switch to bubble view"
   }
 ];
 function ViewModeToggle({

--- a/packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx
+++ b/packages/ui-kit/src/components/metagraphed/view-mode-toggle.tsx
@@ -1,10 +1,10 @@
-import { LayoutGrid, List, Grid3x3 } from "lucide-react";
+import { LayoutGrid, List, Grid3x3, ScatterChart } from "lucide-react";
 import {
   SegmentedToggle,
   type SegmentedToggleOption,
 } from "@/components/ui/segmented-toggle";
 
-export type ViewMode = "table" | "grid" | "matrix";
+export type ViewMode = "table" | "grid" | "matrix" | "bubble";
 
 const OPTIONS: Array<SegmentedToggleOption<ViewMode>> = [
   {
@@ -24,6 +24,12 @@ const OPTIONS: Array<SegmentedToggleOption<ViewMode>> = [
     label: "Matrix",
     Icon: Grid3x3,
     ariaLabel: "Switch to matrix view",
+  },
+  {
+    value: "bubble",
+    label: "Bubble",
+    Icon: ScatterChart,
+    ariaLabel: "Switch to bubble view",
   },
 ];
 


### PR DESCRIPTION
The `/subnets` page has only ever been a sorted table, which is great for "who's #1 by X" but hides outliers — a young subnet that's already well-surfaced, or an old one that's gone sparse. Subnet Radar and Backprop both built position/size/color views over comparable data for exactly that scan pattern, and #6884 asks for the same here. This adds a fourth view mode, **Bubble**, next to Table/Grid/Matrix.

## Screenshots

Before is the existing sortable table; after is the new outlier map over the same rows.

| Viewport · Theme | Before (table) | After (bubble) |
| --- | --- | --- |
| Desktop · Light | <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/756f909a8aeaf7b26baa4497ea7f515d1dff82ef/runs/jsonbored-metagraphed/run-48/before-table-desktop-light.png" width="240"> | <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/645f090378a8e53f5cc6618c37ee7203588b67d6/runs/jsonbored-metagraphed/run-48/after-bubble-desktop-light.png" width="240"> |
| Desktop · Dark | <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/f812717ff111f767c300d030c383c76b27108fa1/runs/jsonbored-metagraphed/run-48/before-table-desktop-dark.png" width="240"> | <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/4a22d815734d0857aaebcd2c87ebd4b4a6a6b994/runs/jsonbored-metagraphed/run-48/after-bubble-desktop-dark.png" width="240"> |
| Tablet · Light | <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/ed2d0d4f42f5a5b06f0e304f30695eefae37eea5/runs/jsonbored-metagraphed/run-48/before-table-tablet-light.png" width="240"> | <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/61f60aed00ade7f0ab596e9dd858f4e3c015d990/runs/jsonbored-metagraphed/run-48/after-bubble-tablet-light.png" width="240"> |
| Tablet · Dark | <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/ce79ca4f7d3468d6d8ccd8c221bdd7b75e3c0026/runs/jsonbored-metagraphed/run-48/before-table-tablet-dark.png" width="240"> | <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/6b2ec1146a359c77acf2d49fa1f6df2e2e25b6d2/runs/jsonbored-metagraphed/run-48/after-bubble-tablet-dark.png" width="240"> |
| Mobile · Light | <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/191dfd0eeff9088f8d0dc24e15126b927e382276/runs/jsonbored-metagraphed/run-48/before-table-mobile-light.png" width="240"> | <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/6d5727f560e7727b59f99d89a0d4f59755be0f6a/runs/jsonbored-metagraphed/run-48/after-bubble-mobile-light.png" width="240"> |
| Mobile · Dark | <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/1c649a9ddbc85e33e3cc2e51232aaf073db2a005/runs/jsonbored-metagraphed/run-48/before-table-mobile-dark.png" width="240"> | <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/9a2796f73bd7b4b9cb229065a7eaa3c0fef66562/runs/jsonbored-metagraphed/run-48/after-bubble-mobile-dark.png" width="240"> |

The view-mode toggle with Bubble active (the entry point), desktop and mobile:

<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/516261a97be4819b82cc5953cf6c35351fc18165/runs/jsonbored-metagraphed/run-48/toggle-desktop-light.png" width="240"> <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/731dcbf4854a63910091738e820f7cbc2f256f55/runs/jsonbored-metagraphed/run-48/toggle-desktop-dark.png" width="240"> <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/917c5153797abe77f860642a61b87cabbf13337d/runs/jsonbored-metagraphed/run-48/toggle-mobile-light.png" width="120"> <img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/c20506a72edbf9502b666cbee0fb12cdea77152e/runs/jsonbored-metagraphed/run-48/toggle-mobile-dark.png" width="120">

<!-- Note: an earlier tablet-dark capture had a theme flash-of-light on the chart card; it was re-shot for parity. Superseded image, kept for provenance only: https://raw.githubusercontent.com/nghetien/agentfix-assets/1fa6082f6b21b7bb72b59787ad067a2a80ce1b57/runs/jsonbored-metagraphed/run-48/after-bubble-tablet-dark.png -->

## How it works

It reuses the subnet rows already fetched for the table (no new query, no backend change) and encodes them on four channels: x = subnet age in days, y = manifested surface count, bubble size = participant count, color = health state. I picked age × surfaces for the axes because that's the "how complete is this subnet for how long it's existed" question a single sort column can't answer — the same completeness/health dimensions `get_registry_leaderboards` already ranks by. Colors are the app's existing `--health-ok/warn/down/unknown` tokens, so a green bubble means the same thing it does in the Matrix view and the HealthPill; radius is area-proportional (sqrt) so a bubble's visual weight tracks participant count honestly.

The chart lives inside the same filter bar as the other layouts, so category/health/search/readiness/root filters all still apply — it's the same filtered `rows` the table renders, just drawn differently rather than a second disconnected filter surface. Clicking a bubble routes to `/subnets/{netuid}`, mirroring the table's row-click; each bubble is a focusable `<Link>` with an aria-label carrying its numbers, and the largest bubbles are painted first so small outliers stay clickable on top.

The layout math (domain scaling, area radius, y-flip, paint order) is a dependency-free `subnet-bubble-layout.ts` split out from the component so it's unit-testable directly — the same split `validator-dominance-ranking.ts` uses.

## Testing

Ran the full `ui` job locally: ui-kit + apps/ui lint/format/typecheck, both vitest suites, the responsive-overflow e2e pass, the production build, and the gzip bundle-budget check — 298 KB / 300 KB, unchanged from main since the new component is a lazy `/subnets` route chunk. Added `subnet-bubble-layout.test.ts` covering the scaling, radius, y-flip and paint-order invariants. Also ran the root build + `validate` + backend coverage suite to confirm the regenerated `packages/ui-kit/dist` and the widened `ViewMode` enum didn't ripple anywhere else.

Closes #6884