### PR TITLE
fix(api): wire the missing account-balances-sync public proxy

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -2892,6 +2892,72 @@ describe("handleScheduled ACCOUNT_EVENTS_ROLLUP_CRON", () => {
   });
 });
 
+// --- Internal sync write-path HTTP dispatch -----------------------------------
+//
+// Regression coverage for a real gap found live (2026-07-19): data-api.mjs's
+// own handleAccountBalancesSync existed and was fully tested at that layer,
+// but nothing in this public-facing Worker's handleRequest ever forwarded
+// POST /api/v1/internal/account-balances-sync to it -- every real
+// data-refresh-cron run since #6742 shipped 405'd on this exact path, so
+// account_balances never received a row from any caller. Each of these
+// routes is a thin `if (url.pathname === "...") return handleXProxy(...)`
+// registration with no dedicated test of its own confirming handleRequest
+// actually reaches it -- asserting the dispatch (not just the downstream
+// handler) is what would have caught this.
+//
+// Scoped to ONLY the routes with a real EXTERNAL caller (a box-side
+// data-refresh-cron script hitting the public domain, since it has no
+// service-binding access) -- deliberately excludes the many other
+// /api/v1/internal/* routes in data-api.mjs (health-checks-sync,
+// subnet-identity-sync, subnet-snapshot-sync, rpc-usage-sync/-prune,
+// compare-health, health-status-live, latest-block-number, ...): those are
+// each documented at their own definition as "own hourly cron, direct
+// env.DATA_API.fetch() service-binding call... not an external GitHub
+// Actions workflow" -- correctly reached only via a direct service-binding
+// call from elsewhere in THIS SAME Worker's code (src/health-prober.mjs,
+// src/subnet-identity-history.mjs, etc.), never through this public HTTP
+// dispatcher. Adding a public proxy for those would be unnecessary surface,
+// not a fix -- verified live (2026-07-19) that none of them have any
+// caller, in this repo or metagraphed-infra, that hits the public domain.
+describe("internal sync routes reach DATA_API through handleRequest", () => {
+  const INTERNAL_SYNC_ROUTES = [
+    "/api/v1/internal/neurons-sync",
+    "/api/v1/internal/account-identity-sync",
+    "/api/v1/internal/subnet-hyperparams-sync",
+    "/api/v1/internal/validator-nominator-counts-sync",
+    "/api/v1/internal/nominator-positions-sync",
+    "/api/v1/internal/account-balances-sync",
+  ];
+
+  for (const path of INTERNAL_SYNC_ROUTES) {
+    test(`POST ${path} forwards to DATA_API (not a 405 fallthrough)`, async () => {
+      let received = false;
+      const env = {
+        ...createLocalArtifactEnv(),
+        DATA_API: {
+          fetch(request) {
+            received = true;
+            assert.equal(new URL(request.url).pathname, path);
+            assert.equal(request.method, "POST");
+            return Response.json({ ok: true });
+          },
+        },
+      };
+      const res = await handleRequest(
+        req(path, { method: "POST", headers: { "x-test-token": "x" } }),
+        env,
+        {},
+      );
+      assert.equal(received, true, `${path} never reached DATA_API`);
+      assert.notEqual(
+        res.status,
+        405,
+        `${path} fell through to the generic method-not-allowed handler`,
+      );
+    });
+  }
+});
+
 // --- logEvent disabled --------------------------------------------------------
 describe("logEvent", () => {
   test("R2 timeout with logs disabled still produces a 504 (no log spam)", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1340,6 +1340,23 @@ async function handleNominatorPositionsSyncProxy(request, env) {
   });
 }
 
+// Proxies POST /api/v1/internal/account-balances-sync -- the write path into
+// account_balances (#6742). Same DATA_API service binding as the other
+// internal sync routes above. This proxy was missing entirely (data-api.mjs's
+// own handleAccountBalancesSync existed, but nothing in this public-facing
+// Worker ever forwarded to it) -- confirmed live 2026-07-19: every real
+// data-refresh-cron run since #6742 shipped 405'd on this exact route,
+// meaning account_balances has never received a row from any caller.
+async function handleAccountBalancesSyncProxy(request, env) {
+  return proxyToDataApi(request, env, {
+    code: "account_balances_sync_unavailable",
+    notBoundMessage:
+      "The account-balances sync tier is not bound to this deployment.",
+    unreadableMessage:
+      "The account-balances sync tier returned an unreadable response.",
+  });
+}
+
 // GET /api/v1/chain/stream (#4982, ADR 0015) -- the public realtime firehose
 // transport. SSE by default; a WebSocket Upgrade header on this same path
 // gets the WS transport instead. No auth: this is the same public read-only
@@ -1625,6 +1642,11 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // service binding.
   if (url.pathname === "/api/v1/internal/nominator-positions-sync") {
     return handleNominatorPositionsSyncProxy(request, env);
+  }
+  // The write path into account_balances (#6742) -- data-refresh-cron's
+  // account-balances job POSTs here. Same DATA_API service binding.
+  if (url.pathname === "/api/v1/internal/account-balances-sync") {
+    return handleAccountBalancesSyncProxy(request, env);
   }
   // The write path the #4981 box-side relay POSTs #4980's NOTIFY payloads to
   // (#4982, ADR 0015) -- forwards into ChainFirehoseHub after its own


### PR DESCRIPTION
## Summary

`data-api.mjs`'s `handleAccountBalancesSync` (#6742) existed and was fully tested at that layer, but nothing in this public-facing Worker's `handleRequest` ever forwarded `POST /api/v1/internal/account-balances-sync` to it — the route fell through to the generic 405 fallback for every caller since #6742 shipped.

## How this was found

Working through the wallet-flow-leaderboard epic (#6951) surfaced that `account_balances` didn't exist in production at all (a separate, already-fixed schema-apply gap). After applying the schema and provisioning the box's missing `account_balances_sync_secret` vault entry, the data-refresh-cron job ran for real:

```
fetch-account-balances: wrote 357589 nonzero-balance row(s) from 542726 scanned account(s) (0 error(s)) in 213s -> /out/account-balances.json
account-balances: syncing account-balances.json to https://api.metagraph.sh/api/v1/internal/account-balances-sync
curl: (22) The requested URL returned error: 405
```

The fetch worked perfectly; the sync has 405'd on every single run since this feature shipped, so `account_balances` has never received a row from any caller in production.

## Fix

Adds the missing proxy, mirroring `handleNominatorPositionsSyncProxy`'s exact shape — a thin `proxyToDataApi()` wrapper plus a dispatch registration next to the other internal sync routes.

## Test coverage gap this exposed

There was no test asserting `handleRequest` actually *dispatches* to any of these internal sync proxies — every existing test exercises `data-api.mjs`'s handler directly, so a missing dispatch registration was invisible to the suite. Added a regression test asserting the dispatch itself for every route with a real external caller.

While auditing this, I checked all 22 `/api/v1/internal/*` routes in `data-api.mjs` against what's wired in `workers/api.mjs`. Only this one was a real gap — the other ~16 unwired paths are deliberately internal-only (each documented at its own definition as "own hourly cron, direct `env.DATA_API.fetch()` service-binding call... not an external GitHub Actions workflow", called from `src/health-prober.mjs`/`src/subnet-identity-history.mjs`/etc. within this same Worker). Verified none of those have any caller — in this repo or `metagraphed-infra` — that hits the public domain, so they correctly have no proxy.

## Test plan

- [x] Full suite: 9889 tests pass; changed lines in `workers/api.mjs` at 100% patch coverage
- [x] `npm run build` — clean, no contract drift (this route isn't part of the public OpenAPI surface)
- [x] `node scripts/scan-public-safety.mjs` — clean
- [x] New regression test (`api-coverage.test.mjs`) asserts `handleRequest` reaches `DATA_API` for every externally-callable internal sync route, not just `account-balances-sync`