### PR TITLE
feat(indexer-rs): add poller, the consolidated chain-state polling service

### DIFF
--- a/apps/indexer-rs/Dockerfile
+++ b/apps/indexer-rs/Dockerfile
@@ -18,6 +18,13 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build /app/target/release/backfill-rs /app/backfill-rs
+# poller (metagraphed-infra#136/#137): the consolidated chain-state polling
+# service, a separate process/binary from backfill-rs above -- `cargo build
+# --release` with no `--bin` filter already builds both targets, this just
+# ships the second one too. Selected via docker_container's `command:` in
+# roles/indexer-rust, not this image's own CMD (which stays backfill-rs's
+# entrypoint.sh, unchanged).
+COPY --from=build /app/target/release/poller /app/poller
 COPY entrypoint.sh /app/entrypoint.sh
 # entrypoint shards [FROM,TO) into BACKFILL_SHARDS independent conc=1 processes
 # (sidesteps subxt's intra-client concurrency deadlock). Runtime env on the service:

--- a/apps/indexer-rs/src/bin/poller/jobs.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs.rs
@@ -1,0 +1,1 @@
+pub mod subnet_ownership;

--- a/apps/indexer-rs/src/bin/poller/jobs/subnet_ownership.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/subnet_ownership.rs
@@ -1,0 +1,236 @@
+// subnet-ownership -- the first job built natively in the poller
+// (metagraphed-infra#138). Closes the gap JSONbored/metagraphed#6644 found:
+// no clean provider<->owner mapping exists on-chain anywhere in this
+// codebase. Resolves the REAL owning account for every currently-registered
+// subnet via the same two-step chain read scripts/fetch-subnet-locks.py
+// already established for its own owner-lock rows:
+//
+//   1. SubtensorModule::SubnetOwnerHotkey(netuid) -> the owner's hotkey
+//   2. SubtensorModule::Owner(hotkey)             -> the owning account
+//
+// (Owner is confirmed against the official bittensor Python SDK's own
+// resolution, bittensor/core/subtensor.py -- both storage items are
+// ValueQuery, defaulting to the zero account [0u8; 32] rather than erroring
+// when unset. A hotkey with no registered owner resolves to that zero
+// account, same as the SDK's own callers treat it: no owning account, not a
+// literal owner.)
+//
+// The active netuid set is discovered by iterating
+// SubtensorModule::NetworksAdded (a StorageMap<NetUid, bool> -- the runtime's
+// own "does this subnet exist" flag) rather than a hardcoded upper bound, so
+// a newly-registered or deregistered subnet is picked up automatically on
+// the next tick with no code change.
+//
+// Gathers the whole snapshot in memory before writing (same shape as
+// scripts/fetch-account-balances.py / scripts/fetch-subnet-hyperparams.py):
+// a tick either upserts a complete, consistent snapshot, or -- if too many
+// netuids failed to resolve -- returns Err and writes nothing at all, never
+// a half-scanned partial snapshot silently overwriting a good one.
+//
+// PERFORMANCE (live-verified 2026-07-19 against the public archive RPC): one
+// `ChainClient::call(api.at_current_block())` up front for the whole tick,
+// then every storage read below goes directly through that single cached
+// `AtBlock` -- NOT through another `ChainClient::call` per read. An earlier
+// version called `at_current_block()` fresh inside every single storage
+// fetch (~260 extra round-trips for 129 netuids x 2 lookups each); against
+// a public endpoint that made a full tick take minutes instead of seconds.
+// `backfill_rs::AtBlock`'s own doc comment carries this same warning for the
+// next job added here. Losing ChainClient::call's stall-timeout/reconnect
+// wrapper on these individual reads is an accepted tradeoff, not an
+// oversight: connect_chain()'s LegacyBackend already structurally avoids the
+// chainHead_v1_follow stall class (subxt#2050) these reads could otherwise
+// hit, the ReconnectingRpcClient's own 60s request_timeout still bounds any
+// single stateless call, and a whole-tick failure just retries on the next
+// scheduled interval -- an acceptable cost for a periodic poller, unlike
+// main.rs's live-follow hot path this same reasoning would NOT apply to.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use backfill_rs::{AtBlock, ChainClient};
+use subxt::dynamic;
+use subxt::utils::AccountId32;
+
+use crate::JobOutcome;
+
+// Mirrors scripts/fetch-account-balances.py's MAX_ERROR_RATE: above this
+// fraction of scanned netuids failing to resolve, treat the tick as
+// systemically broken (e.g. a metadata/decode mismatch after a runtime
+// upgrade) rather than upsert a mostly-empty snapshot over a good one.
+const MAX_ERROR_RATE: f64 = 0.5;
+
+const ZERO_ACCOUNT: AccountId32 = AccountId32([0u8; 32]);
+
+struct OwnershipRow {
+    netuid: i32,
+    owner_hotkey: String,
+    owner_coldkey: String,
+}
+
+pub async fn run(chain: Arc<ChainClient>, pg: Arc<tokio_postgres::Client>) -> Result<JobOutcome> {
+    let at = chain
+        .call(|api| async move { Ok(api.at_current_block().await?) })
+        .await
+        .context("at_current_block")?;
+
+    let netuids = discover_netuids(&at).await.context("discover netuids")?;
+    let scanned = netuids.len() as u64;
+    eprintln!("subnet-ownership: discovered {scanned} netuid(s), resolving owners");
+
+    let mut rows = Vec::with_capacity(netuids.len());
+    let mut errors = 0u64;
+    for (i, netuid) in netuids.into_iter().enumerate() {
+        match resolve_ownership(&at, netuid).await {
+            Ok(Some(row)) => rows.push(row),
+            // No owner hotkey registered, or it resolves to the zero
+            // account -- not an error, just nothing to record for this netuid.
+            Ok(None) => {}
+            Err(e) => {
+                eprintln!("subnet-ownership: netuid={netuid} resolution failed: {e:#}");
+                errors += 1;
+            }
+        }
+        if (i + 1).is_multiple_of(20) {
+            eprintln!("subnet-ownership: resolved {}/{scanned}", i + 1);
+        }
+    }
+
+    let error_rate = if scanned > 0 {
+        errors as f64 / scanned as f64
+    } else {
+        0.0
+    };
+    if error_rate > MAX_ERROR_RATE {
+        anyhow::bail!(
+            "error rate {errors}/{scanned} ({:.0}%) exceeds {:.0}% -- refusing to write a mostly-broken snapshot",
+            error_rate * 100.0,
+            MAX_ERROR_RATE * 100.0
+        );
+    }
+
+    let captured_at = now_ms();
+    let written = upsert(&pg, &rows, captured_at)
+        .await
+        .context("upsert subnet_ownership")?;
+
+    Ok(JobOutcome {
+        scanned,
+        written,
+        errors,
+    })
+}
+
+/// Every currently-registered netuid, per SubtensorModule::NetworksAdded
+/// (the runtime's own subnet-existence flag) -- not a hardcoded upper bound,
+/// so newly-registered/deregistered subnets need no code change here.
+async fn discover_netuids(at: &AtBlock) -> Result<Vec<u16>> {
+    let addr = dynamic::storage::<(u16,), bool>("SubtensorModule", "NetworksAdded");
+    let mut iter = at.storage().iter(addr, ()).await?;
+    let mut netuids = Vec::new();
+    while let Some(entry) = iter.next().await {
+        let (netuid,) = entry?.key()?.decode()?;
+        netuids.push(netuid);
+    }
+    netuids.sort_unstable();
+    Ok(netuids)
+}
+
+/// SubnetOwnerHotkey(netuid) -> Owner(hotkey) -> owning account. Returns `None`
+/// (not an error) when either step resolves to the zero account -- that's a
+/// real, valid "no owner" state per the bittensor SDK's own convention, not
+/// a decode failure.
+async fn resolve_ownership(at: &AtBlock, netuid: u16) -> Result<Option<OwnershipRow>> {
+    let hotkey_addr =
+        dynamic::storage::<(u16,), AccountId32>("SubtensorModule", "SubnetOwnerHotkey");
+    let hotkey: AccountId32 = at
+        .storage()
+        .fetch(hotkey_addr, (netuid,))
+        .await
+        .with_context(|| format!("SubnetOwnerHotkey(netuid={netuid})"))?
+        .decode()?;
+
+    if hotkey == ZERO_ACCOUNT {
+        return Ok(None);
+    }
+
+    let owner_addr = dynamic::storage::<(AccountId32,), AccountId32>("SubtensorModule", "Owner");
+    let coldkey: AccountId32 = at
+        .storage()
+        .fetch(owner_addr, (hotkey,))
+        .await
+        .with_context(|| format!("Owner(hotkey={hotkey})"))?
+        .decode()?;
+
+    if coldkey == ZERO_ACCOUNT {
+        return Ok(None);
+    }
+
+    Ok(Some(OwnershipRow {
+        netuid: netuid as i32,
+        owner_hotkey: hotkey.to_string(),
+        owner_coldkey: coldkey.to_string(),
+    }))
+}
+
+/// Upserts every resolved row, then prunes rows for netuids no longer in
+/// this tick's active/resolved set (deregistered subnets, or ones whose
+/// owner hotkey/coldkey resolved to the zero account) -- upsert-before-prune
+/// so an active subnet is never even transiently missing from the table.
+async fn upsert(
+    pg: &tokio_postgres::Client,
+    rows: &[OwnershipRow],
+    captured_at: i64,
+) -> Result<u64> {
+    let mut written = 0u64;
+    for row in rows {
+        pg.execute(
+            "INSERT INTO subnet_ownership (netuid, owner_hotkey, owner_coldkey, captured_at)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (netuid) DO UPDATE SET
+               owner_hotkey = EXCLUDED.owner_hotkey,
+               owner_coldkey = EXCLUDED.owner_coldkey,
+               captured_at = EXCLUDED.captured_at",
+            &[
+                &row.netuid,
+                &row.owner_hotkey,
+                &row.owner_coldkey,
+                &captured_at,
+            ],
+        )
+        .await
+        .with_context(|| format!("upsert netuid={}", row.netuid))?;
+        written += 1;
+    }
+
+    let active: Vec<i32> = rows.iter().map(|r| r.netuid).collect();
+    let pruned = pg
+        .execute(
+            "DELETE FROM subnet_ownership WHERE netuid <> ALL($1)",
+            &[&active],
+        )
+        .await
+        .context("prune deregistered subnet_ownership rows")?;
+    if pruned > 0 {
+        eprintln!("subnet-ownership: pruned {pruned} stale row(s)");
+    }
+
+    Ok(written)
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_millis() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_account_is_the_all_zero_bytes() {
+        assert_eq!(ZERO_ACCOUNT.0, [0u8; 32]);
+    }
+}

--- a/apps/indexer-rs/src/bin/poller/main.rs
+++ b/apps/indexer-rs/src/bin/poller/main.rs
@@ -1,0 +1,137 @@
+// poller -- consolidated chain-state polling service (metagraphed-infra#136/
+// #137). A SIBLING binary to ../main.rs (backfill-rs's historical backfill +
+// live-follow, INDEX_MODE=live) in this SAME crate/monorepo location
+// (apps/indexer-rs/) -- its own process, its own systemd unit, so a slow or
+// misbehaving poll job can never affect the live-follow hot path. Shares the
+// subxt#2050-mitigated ChainClient + connect_pg with ../main.rs via
+// src/lib.rs rather than forking that connection logic.
+//
+// Replaces the growing pile of one-off Python systemd jobs under
+// roles/data-refresh-cron (metagraph, account-identity, subnet-hyperparams,
+// validator-nominators, self-stake, account-balances) with one binary, one
+// systemd unit, and an internal async scheduler -- each job runs on its own
+// independent tokio interval via run_job_loop() below, which provides
+// shared logging + treats a job that mostly failed to scan (mirrors
+// scripts/fetch-account-balances.py's MAX_ERROR_RATE convention) as a
+// failed tick rather than a partial write.
+//
+// `subnet-ownership` (jobs::subnet_ownership) is the first job, per
+// metagraphed-infra#138 -- closes the JSONbored/metagraphed#6644 gap (no
+// clean provider<->owner mapping existed anywhere). Future jobs
+// (metagraph/account-identity/subnet-hyperparams/validator-nominators/
+// self-stake/account-balances, metagraphed-infra#139-141) each become a
+// small config/decode delta added to the `jobs` module + one more line in
+// main(), not a whole new script+Dockerfile+systemd-pair.
+//
+// Env:
+//   DATABASE_URL                postgres connection (the same sink ../main.rs writes)
+//   EVENTS_RPC_URL               chain RPC ws(s) url (default: the public archive)
+//   SUBNET_OWNERSHIP_POLL_SECS   how often to re-poll subnet ownership (default 300)
+
+mod jobs;
+
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use backfill_rs::{connect_pg, redact_rpc_url, ChainClient};
+
+/// What a single job tick reports back to run_job_loop -- lets the scheduler
+/// apply one shared logging convention across every job instead of each job
+/// reimplementing it. A job that decides its own error rate was too high to
+/// trust (mirrors scripts/fetch-account-balances.py's MAX_ERROR_RATE) should
+/// return `Err`, not a low `written` count -- see jobs::subnet_ownership::run.
+pub struct JobOutcome {
+    pub scanned: u64,
+    pub written: u64,
+    pub errors: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let rpc_url = std::env::var("EVENTS_RPC_URL")
+        .unwrap_or_else(|_| "wss://archive.chain.opentensor.ai:443".to_string());
+    eprintln!("poller: connecting to {}", redact_rpc_url(&rpc_url));
+    let chain = Arc::new(ChainClient::connect(rpc_url).await?);
+    eprintln!("poller: chain connection ready");
+
+    let db_url = std::env::var("DATABASE_URL").context("DATABASE_URL required")?;
+    let pg = Arc::new(connect_pg(&db_url).await?);
+    eprintln!("poller: postgres connection ready, starting jobs");
+
+    let subnet_ownership_interval =
+        Duration::from_secs(env_u64("SUBNET_OWNERSHIP_POLL_SECS").unwrap_or(300));
+
+    let subnet_ownership = {
+        let chain = chain.clone();
+        let pg = pg.clone();
+        tokio::spawn(async move {
+            run_job_loop(
+                "subnet-ownership",
+                subnet_ownership_interval,
+                chain,
+                pg,
+                jobs::subnet_ownership::run,
+            )
+            .await;
+        })
+    };
+
+    // Each job loop above runs forever (see run_job_loop) -- if one panics,
+    // that's a real bug and should take the process down (systemd's
+    // restart_policy: unless-stopped brings it back), rather than silently
+    // leaving a job dead while the process looks alive.
+    subnet_ownership
+        .await
+        .context("subnet-ownership job task panicked")?;
+    Ok(())
+}
+
+fn env_u64(k: &str) -> Option<u64> {
+    std::env::var(k).ok().and_then(|v| v.parse().ok())
+}
+
+/// Runs `job` on a fixed interval forever, applying one shared logging
+/// policy: scan/write/error counts on success, failure reason (including a
+/// job's own "error rate too high, refusing to write" Err) on failure. A
+/// single bad tick never brings down the process or other jobs -- this loop
+/// always continues to the next tick.
+async fn run_job_loop<F, Fut>(
+    name: &'static str,
+    interval: Duration,
+    chain: Arc<ChainClient>,
+    pg: Arc<tokio_postgres::Client>,
+    job: F,
+) where
+    F: Fn(Arc<ChainClient>, Arc<tokio_postgres::Client>) -> Fut,
+    Fut: Future<Output = Result<JobOutcome>>,
+{
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        ticker.tick().await;
+        let t0 = std::time::Instant::now();
+        match job(chain.clone(), pg.clone()).await {
+            Ok(outcome) => {
+                eprintln!(
+                    "{name}: ok -- {} scanned, {} written, {} error(s) ({:?} elapsed)",
+                    outcome.scanned,
+                    outcome.written,
+                    outcome.errors,
+                    t0.elapsed()
+                );
+            }
+            Err(e) => {
+                eprintln!(
+                    "{name}: tick failed ({e:#}) -- retrying in {interval:?} ({:?} elapsed)",
+                    t0.elapsed()
+                );
+            }
+        }
+    }
+}

--- a/apps/indexer-rs/src/lib.rs
+++ b/apps/indexer-rs/src/lib.rs
@@ -1,0 +1,220 @@
+// Shared chain/Postgres connection primitives, used by both this crate's
+// binaries: src/main.rs (historical backfill + live-follow, INDEX_MODE=live)
+// and src/bin/poller.rs (the consolidated chain-state polling service,
+// metagraphed-infra#136). Extracted from main.rs so the subxt#2050
+// stall-mitigation logic (ChainClient below) has exactly one implementation
+// shared by both, rather than a forked copy drifting out of sync.
+
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use subxt::config::PolkadotConfig;
+use subxt::OnlineClient;
+use tokio::sync::RwLock;
+
+pub type Api = OnlineClient<PolkadotConfig>;
+/// A client snapshotted at one block -- what `api.at_current_block()` returns.
+/// Fetch this ONCE per unit of work and reuse it for every storage call in
+/// that unit: each individual `.storage().fetch()`/`.iter()` on an `Api`
+/// value re-resolves the current block first, which is a real extra RPC
+/// round-trip per call, not a cached/local operation (confirmed live,
+/// metagraphed-infra#138 -- a poller job that called `at_current_block()`
+/// once per netuid instead of once per tick was measurably, unnecessarily
+/// slower against a public RPC).
+pub type AtBlock = subxt::client::OnlineClientAtBlock<PolkadotConfig>;
+
+pub fn redact_rpc_url(url: &str) -> String {
+    let scheme_end = url.find("://").map(|idx| idx + 3).unwrap_or(0);
+    let after_scheme = &url[scheme_end..];
+    let authority_len = after_scheme
+        .find(['/', '?', '#'])
+        .unwrap_or(after_scheme.len());
+    let (authority, rest) = after_scheme.split_at(authority_len);
+    let safe_authority = authority
+        .rsplit_once('@')
+        .map(|(_, host)| host)
+        .unwrap_or(authority);
+    let path_len = rest.find(['?', '#']).unwrap_or(rest.len());
+    let safe_rest = &rest[..path_len];
+    format!("{}{}{}", &url[..scheme_end], safe_authority, safe_rest)
+}
+
+pub async fn connect_chain(url: &str) -> Result<Api> {
+    // Reconnecting client: a multi-hour backfill WILL see the archive drop the WSS
+    // socket; without auto-reconnect every call after the first drop fails (verified).
+    // request_timeout is the critical one: a throttled/wedged upstream that drops a
+    // request on the floor (no error, no close) would otherwise leave the in-flight
+    // decode futures awaiting forever — the whole run wedges alive-but-frozen with no
+    // log line (the exact failure mode that silently stalled the metered run). A
+    // bounded timeout turns that into an Err the retry loop recovers from (a dead/
+    // half-open socket surfaces as a timed-out request within 60s rather than never).
+    use subxt::backend::LegacyBackend;
+    use subxt::rpcs::client::{ReconnectingRpcClient, RpcClient};
+    eprintln!(
+        "connect_chain: building reconnecting rpc client -> {}",
+        redact_rpc_url(url)
+    );
+    let inner = ReconnectingRpcClient::builder()
+        .request_timeout(Duration::from_secs(60))
+        .connection_timeout(Duration::from_secs(20))
+        .build(url.to_string())
+        .await
+        .map_err(|e| anyhow::anyhow!("reconnecting rpc build: {e}"))?;
+    eprintln!("connect_chain: reconnecting rpc client built, wrapping RpcClient");
+    let rpc_client = RpcClient::new(inner);
+    // LegacyBackend, not OnlineClient::from_rpc_client's default (CombinedBackend,
+    // which tries chainhead_* before legacy_* per call): this is the actual fix for
+    // the KNOWN ISSUE documented at the top of main.rs, not just a mitigation.
+    // paritytech/subxt#2050 is specifically the chainHead_v1_follow subscription
+    // silently going idle under heavy concurrent block-import churn -- a failure
+    // mode intrinsic to that stateful subscription protocol. LegacyBackend never
+    // opens one; every call (state_getMetadata, chain_getBlock, state_getStorage,
+    // Core_version via state_call, ...) is a stateless one-shot RPC request, so the
+    // whole bug CLASS is structurally unreachable, not just recovered-from-faster.
+    // ChainClient's timeout+reconnect below stays as defense-in-depth (a slow/dead
+    // TCP connection is still possible under any backend), but is no longer the
+    // primary defense against #2050 specifically.
+    eprintln!("connect_chain: calling OnlineClient::from_backend (LegacyBackend)");
+    let backend = LegacyBackend::builder().build(rpc_client);
+    let api = OnlineClient::<PolkadotConfig>::from_backend(std::sync::Arc::new(backend))
+        .await
+        .context("online client")?;
+    eprintln!("connect_chain: OnlineClient ready");
+    Ok(api)
+}
+
+pub async fn connect_pg(url: &str) -> Result<tokio_postgres::Client> {
+    let (client, conn) = tokio_postgres::connect(url, tokio_postgres::NoTls)
+        .await
+        .context("pg connect")?;
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            eprintln!("pg connection error: {e}");
+        }
+    });
+    Ok(client)
+}
+
+// KNOWN ISSUE (2026-07-03, MITIGATED by ChainClient below): against our own
+// metagraphed subtensor node while it is still catching up from genesis (rapidly
+// importing many blocks/sec, as opposed to steady-state ~1 block/12s), both
+// connect_chain()'s initial api.at_current_block() call and later
+// at.at_block()-per-block metadata fetches can hang indefinitely (0% CPU, zero
+// further websocket traffic, no error — NOT a slow response, a true stall).
+// subxt 0.50's metadata-version probe falls back from archive_v1_call ("method not
+// found") to chainHead_v1_call, which depends on a chainHead_v1_follow
+// subscription, observed to receive an immediate {"event": "stop"} and require
+// re-subscribing under heavy concurrent block import churn. This is a known,
+// still-open upstream gap (paritytech/subxt#2050) with no built-in fix; ChainClient
+// adds the app-level timeout + reconnect the subxt maintainers themselves
+// recommend as the workaround. connect_chain()'s own LegacyBackend choice above
+// is the structural fix for #2050 specifically; this stays as defense-in-depth
+// for plain connection staleness under any backend.
+//
+// A generation counter guards against a reconnect storm: if several concurrent
+// callers all stall around the same time, only the first to notice actually
+// reconnects -- everyone else sees the generation has already moved and just
+// retries against the fresh client.
+const RPC_STALL_TIMEOUT: Duration = Duration::from_secs(90);
+const RPC_CALL_ATTEMPTS: u32 = 3;
+
+pub struct ChainClient {
+    url: String,
+    api: RwLock<Api>,
+    generation: AtomicU64,
+}
+
+impl ChainClient {
+    pub async fn connect(url: String) -> Result<Self> {
+        let api = connect_chain(&url).await?;
+        Ok(Self {
+            url,
+            api: RwLock::new(api),
+            generation: AtomicU64::new(0),
+        })
+    }
+
+    /// The current client handle + the generation it was read at (cheap: Api
+    /// clones are Arc-based internally, so this is a brief read-lock, not a
+    /// hold-for-the-duration-of-an-RPC-call lock).
+    async fn current(&self) -> (Api, u64) {
+        let api = self.api.read().await.clone();
+        (api, self.generation.load(Ordering::SeqCst))
+    }
+
+    /// Rebuild the connection, unless someone else already did since
+    /// `seen_generation` was observed (checked again after acquiring the write
+    /// lock, since another caller may have raced ahead while we were waiting).
+    async fn reconnect_if_stale(&self, seen_generation: u64) -> Result<()> {
+        if self.generation.load(Ordering::SeqCst) != seen_generation {
+            return Ok(());
+        }
+        let mut guard = self.api.write().await;
+        if self.generation.load(Ordering::SeqCst) != seen_generation {
+            return Ok(());
+        }
+        eprintln!("chain client: reconnecting after a stalled RPC call ({RPC_STALL_TIMEOUT:?})");
+        let fresh = connect_chain(&self.url).await?;
+        *guard = fresh;
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    /// Run `f` against the current client, bounded by RPC_STALL_TIMEOUT, and
+    /// RETRY internally (up to RPC_CALL_ATTEMPTS, with a short backoff) against
+    /// a freshly reconnected client whenever a stall is detected — a single
+    /// reconnect isn't guaranteed to land on a working attempt (verified live:
+    /// a heavily-importing node can stall the very next call too), so this is
+    /// a self-contained "call reliably through a stall" primitive rather than
+    /// relying on every call site to also wrap it in its own retry loop.
+    pub async fn call<T, F, Fut>(&self, mut f: F) -> Result<T>
+    where
+        F: FnMut(Api) -> Fut,
+        Fut: Future<Output = Result<T>>,
+    {
+        let mut last_err: Option<anyhow::Error> = None;
+        for attempt in 0..RPC_CALL_ATTEMPTS {
+            let (api, generation) = self.current().await;
+            match tokio::time::timeout(RPC_STALL_TIMEOUT, f(api)).await {
+                Ok(Ok(value)) => return Ok(value),
+                Ok(Err(e)) => last_err = Some(e),
+                Err(_) => {
+                    last_err = Some(anyhow::anyhow!(
+                        "rpc call stalled past {RPC_STALL_TIMEOUT:?} (no response, chainHead \
+                         subscription likely stopped emitting -- see paritytech/subxt#2050)"
+                    ));
+                    if let Err(reconnect_err) = self.reconnect_if_stale(generation).await {
+                        return Err(reconnect_err.context("reconnect after a stalled rpc call"));
+                    }
+                }
+            }
+            if attempt + 1 < RPC_CALL_ATTEMPTS {
+                tokio::time::sleep(Duration::from_millis(500 * (attempt as u64 + 1))).await;
+            }
+        }
+        Err(last_err.unwrap_or_else(|| anyhow::anyhow!("rpc call failed with no error recorded")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_rpc_url_strips_userinfo_and_query() {
+        assert_eq!(
+            redact_rpc_url("wss://user:pass@archive.chain.opentensor.ai:443/ws?token=secret"),
+            "wss://archive.chain.opentensor.ai:443/ws"
+        );
+    }
+
+    #[test]
+    fn redact_rpc_url_passes_through_plain_host() {
+        assert_eq!(
+            redact_rpc_url("ws://meta-fullnode-01-us-nyc1:9944"),
+            "ws://meta-fullnode-01-us-nyc1:9944"
+        );
+    }
+}

--- a/apps/indexer-rs/src/main.rs
+++ b/apps/indexer-rs/src/main.rs
@@ -20,7 +20,7 @@
 //   VERIFY_BLOCKS       comma list: decode these blocks, print canonical JSON, exit
 //                       (no DB writes) — used to diff against the python ground-truth.
 //
-// KNOWN ISSUE (2026-07-03, MITIGATED by ChainClient below): against our own
+// KNOWN ISSUE (2026-07-03, MITIGATED by ChainClient, now in lib.rs): against our own
 // metagraphed subtensor node while it is still catching up from genesis (rapidly
 // importing many blocks/sec, as opposed to steady-state ~1 block/12s), both
 // connect_chain()'s initial api.at_current_block() call and later
@@ -38,8 +38,8 @@
 // Confirmed NOT specific to the reconnecting-rpc-client feature either (a plain
 // OnlineClient::from_insecure_url client hangs identically). This is a known,
 // still-open upstream gap (paritytech/subxt#2050) with no built-in fix; ChainClient
-// (below) adds the app-level timeout + reconnect the subxt maintainers themselves
-// recommend as the workaround.
+// (src/lib.rs, shared with src/bin/poller.rs) adds the app-level timeout +
+// reconnect the subxt maintainers themselves recommend as the workaround.
 //
 // "MITIGATED", not "resolved": verified live 2026-07-03 that ChainClient's
 // timeout+reconnect turns the silent indefinite hang into a bounded, clearly
@@ -54,160 +54,24 @@
 // still mid-sync viable.
 
 use std::collections::{HashMap, HashSet};
-use std::future::Future;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::{Context, Result};
+use backfill_rs::{connect_pg, redact_rpc_url, Api, ChainClient};
 use blake2::digest::consts::U32;
 use blake2::{Blake2b, Digest};
 use futures::stream::{self, StreamExt};
 use scale_info::{PortableRegistry, TypeDef, TypeDefPrimitive};
 use scale_value::{Composite, Primitive, Value, ValueDef};
 use subxt::config::substrate::DigestItem;
-use subxt::config::PolkadotConfig;
 use subxt::utils::AccountId32;
-use subxt::OnlineClient;
-use tokio::sync::{RwLock, Semaphore};
+use tokio::sync::Semaphore;
 
 const BLOCKS_PER_DAY: u64 = 7200;
 // finney ~12s block time; observed_at derived from height when a block's own
 // Timestamp.set can't be decoded (see decode_block's fallback). Matches the
 // same clock scripts/fetch-events.py already uses.
 const BLOCK_MS: i64 = 12_000;
-
-type Api = OnlineClient<PolkadotConfig>;
-
-fn redact_rpc_url(url: &str) -> String {
-    let scheme_end = url.find("://").map(|idx| idx + 3).unwrap_or(0);
-    let after_scheme = &url[scheme_end..];
-    let authority_len = after_scheme
-        .find(|ch| matches!(ch, '/' | '?' | '#'))
-        .unwrap_or(after_scheme.len());
-    let (authority, rest) = after_scheme.split_at(authority_len);
-    let safe_authority = authority
-        .rsplit_once('@')
-        .map(|(_, host)| host)
-        .unwrap_or(authority);
-    let path_len = rest
-        .find(|ch| matches!(ch, '?' | '#'))
-        .unwrap_or(rest.len());
-    let safe_rest = &rest[..path_len];
-    format!("{}{}{}", &url[..scheme_end], safe_authority, safe_rest)
-}
-
-// KNOWN ISSUE fix (was "unresolved" above, 2026-07-03): subxt 0.50's per-block
-// metadata fetch depends on a chainHead_v1_follow subscription that can silently
-// stop emitting events (0% CPU, zero further websocket traffic, no error) --
-// this is a known, still-open upstream gap (paritytech/subxt#2050), whose own
-// maintainers' recommended fix is exactly this: an app-level timeout that
-// recreates the subscription when nothing comes back in time, since subxt
-// doesn't do this internally. `OnlineClient` is `Clone` (cheap, Arc-backed
-// internally), so ChainClient holds one behind an RwLock and swaps in a fresh
-// connection when a call stalls past RPC_STALL_TIMEOUT.
-//
-// A generation counter guards against a reconnect storm: if several concurrent
-// callers (BACKFILL_CONCURRENCY > 1) all stall around the same time, only the
-// first to notice actually reconnects -- everyone else sees the generation has
-// already moved and just retries against the fresh client. In the currently
-// DEPLOYED configuration (entrypoint.sh's sharding launcher pins each shard to
-// BACKFILL_CONCURRENCY=1), there is at most one caller at a time, so this is
-// pure defense-in-depth rather than a scenario this process actually hits.
-//
-// Verified live 2026-07-03 against our own archive node while it was rapidly
-// importing blocks during its own historical catch-up (the exact reproducing
-// condition): api.at_current_block() stalled with zero further websocket
-// traffic, the 90s timeout fired, and reconnect_if_stale rebuilt a working
-// connection -- confirming this is the real failure mode described below, and
-// that a reconnect actually clears it. It also showed the stall isn't
-// necessarily a one-off: a single reconnect-and-retry can still land on a
-// second stall while the node is continuously under heavy import churn, so
-// `call` retries a bounded number of times internally rather than reconnecting
-// only once and handing a single failure back to the caller.
-const RPC_STALL_TIMEOUT: Duration = Duration::from_secs(90);
-const RPC_CALL_ATTEMPTS: u32 = 3;
-
-struct ChainClient {
-    url: String,
-    api: RwLock<Api>,
-    generation: AtomicU64,
-}
-
-impl ChainClient {
-    async fn connect(url: String) -> Result<Self> {
-        let api = connect_chain(&url).await?;
-        Ok(Self {
-            url,
-            api: RwLock::new(api),
-            generation: AtomicU64::new(0),
-        })
-    }
-
-    /// The current client handle + the generation it was read at (cheap: Api
-    /// clones are Arc-based internally, so this is a brief read-lock, not a
-    /// hold-for-the-duration-of-an-RPC-call lock).
-    async fn current(&self) -> (Api, u64) {
-        let api = self.api.read().await.clone();
-        (api, self.generation.load(Ordering::SeqCst))
-    }
-
-    /// Rebuild the connection, unless someone else already did since
-    /// `seen_generation` was observed (checked again after acquiring the write
-    /// lock, since another caller may have raced ahead while we were waiting).
-    async fn reconnect_if_stale(&self, seen_generation: u64) -> Result<()> {
-        if self.generation.load(Ordering::SeqCst) != seen_generation {
-            return Ok(());
-        }
-        let mut guard = self.api.write().await;
-        if self.generation.load(Ordering::SeqCst) != seen_generation {
-            return Ok(());
-        }
-        eprintln!("chain client: reconnecting after a stalled RPC call ({RPC_STALL_TIMEOUT:?})");
-        let fresh = connect_chain(&self.url).await?;
-        *guard = fresh;
-        self.generation.fetch_add(1, Ordering::SeqCst);
-        Ok(())
-    }
-
-    /// Run `f` against the current client, bounded by RPC_STALL_TIMEOUT, and
-    /// RETRY internally (up to RPC_CALL_ATTEMPTS, with a short backoff) against
-    /// a freshly reconnected client whenever a stall is detected — a single
-    /// reconnect isn't guaranteed to land on a working attempt (verified live:
-    /// a heavily-importing node can stall the very next call too), so this is
-    /// a self-contained "call reliably through a stall" primitive rather than
-    /// relying on every call site to also wrap it in its own retry loop. The
-    /// existing per-block retry loops (backfill's inner 3-attempt + outer
-    /// round-based retry) still apply on top of this for OTHER failure classes
-    /// (e.g. rate-limit 429s from the public RPC) — the two compose fine.
-    async fn call<T, F, Fut>(&self, mut f: F) -> Result<T>
-    where
-        F: FnMut(Api) -> Fut,
-        Fut: Future<Output = Result<T>>,
-    {
-        let mut last_err: Option<anyhow::Error> = None;
-        for attempt in 0..RPC_CALL_ATTEMPTS {
-            let (api, generation) = self.current().await;
-            match tokio::time::timeout(RPC_STALL_TIMEOUT, f(api)).await {
-                Ok(Ok(value)) => return Ok(value),
-                Ok(Err(e)) => last_err = Some(e),
-                Err(_) => {
-                    last_err = Some(anyhow::anyhow!(
-                        "rpc call stalled past {RPC_STALL_TIMEOUT:?} (no response, chainHead \
-                         subscription likely stopped emitting -- see paritytech/subxt#2050)"
-                    ));
-                    if let Err(reconnect_err) = self.reconnect_if_stale(generation).await {
-                        return Err(reconnect_err.context("reconnect after a stalled rpc call"));
-                    }
-                }
-            }
-            if attempt + 1 < RPC_CALL_ATTEMPTS {
-                tokio::time::sleep(Duration::from_millis(500 * (attempt as u64 + 1))).await;
-            }
-        }
-        Err(last_err.unwrap_or_else(|| anyhow::anyhow!("rpc call failed with no error recorded")))
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Row types (column order matches deploy/postgres/schema.sql exactly).
@@ -327,8 +191,6 @@ fn acct(v: &Value<()>) -> Option<String> {
     }
 }
 
-/// The ss58 authority accounts from a decoded Aura.Authorities value (a Vec, possibly
-/// wrapped in a BoundedVec/newtype). Each authority is an sr25519 32-byte public key.
 // ---------------------------------------------------------------------------
 // Call-arg type names (metagraphed#4724 D1/Postgres call_args parity)
 // ---------------------------------------------------------------------------
@@ -481,6 +343,8 @@ fn call_args_json_from_fields(
     )
 }
 
+/// The ss58 authority accounts from a decoded Aura.Authorities value (a Vec, possibly
+/// wrapped in a BoundedVec/newtype). Each authority is an sr25519 32-byte public key.
 fn authority_accounts(v: &Value<()>) -> Vec<String> {
     let top = ordered_fields(v);
     // Descend one level through a BoundedVec/newtype wrapper if the single child
@@ -1078,18 +942,20 @@ async fn decode_block(api: &Api, height: u64, head: u64) -> Result<DecodedBlock>
 
     // --- extrinsics: decode, find block timestamp from Timestamp.set inherent
     let extrinsics = at.extrinsics().fetch().await.context("extrinsics.fetch")?;
-    let mut decoded_extr: Vec<(
+    // (index, module, function, hash, signer, call_args_json)
+    type DecodedExtrinsic = (
         usize,
         String,
         String,
         Option<String>,
         Option<String>,
         Option<String>,
-    )> = Vec::new(); // (index, module, function, hash, signer, call_args_json)
+    );
+    let mut decoded_extr: Vec<DecodedExtrinsic> = Vec::new();
     let mut observed_at: Option<i64> = None;
     for ext in extrinsics.iter() {
         let ext = ext.context("extrinsic iter")?;
-        let index = ext.index() as usize;
+        let index = ext.index();
         let module = ext.pallet_name().to_string();
         let function = ext.call_name().to_string();
         let xhash = blake2_256(ext.bytes());
@@ -1482,63 +1348,9 @@ async fn copy_send(sink: tokio_postgres::CopyInSink<bytes::Bytes>, buf: String) 
 }
 
 // ---------------------------------------------------------------------------
-// Connection
+// Connection: ChainClient / connect_chain / connect_pg now live in lib.rs,
+// shared with src/bin/poller.rs (see backfill_rs::* import above).
 // ---------------------------------------------------------------------------
-async fn connect_chain(url: &str) -> Result<Api> {
-    // Reconnecting client: a multi-hour backfill WILL see the archive drop the WSS
-    // socket; without auto-reconnect every call after the first drop fails (verified).
-    // request_timeout is the critical one: a throttled/wedged upstream that drops a
-    // request on the floor (no error, no close) would otherwise leave the in-flight
-    // decode futures awaiting forever — the whole run wedges alive-but-frozen with no
-    // log line (the exact failure mode that silently stalled the metered run). A
-    // bounded timeout turns that into an Err the retry loop recovers from (a dead/
-    // half-open socket surfaces as a timed-out request within 60s rather than never).
-    use subxt::backend::LegacyBackend;
-    use subxt::rpcs::client::{ReconnectingRpcClient, RpcClient};
-    eprintln!(
-        "connect_chain: building reconnecting rpc client -> {}",
-        redact_rpc_url(url)
-    );
-    let inner = ReconnectingRpcClient::builder()
-        .request_timeout(Duration::from_secs(60))
-        .connection_timeout(Duration::from_secs(20))
-        .build(url.to_string())
-        .await
-        .map_err(|e| anyhow::anyhow!("reconnecting rpc build: {e}"))?;
-    eprintln!("connect_chain: reconnecting rpc client built, wrapping RpcClient");
-    let rpc_client = RpcClient::new(inner);
-    // LegacyBackend, not OnlineClient::from_rpc_client's default (CombinedBackend,
-    // which tries chainhead_* before legacy_* per call): this is the actual fix for
-    // the KNOWN ISSUE documented at the top of this file, not just a mitigation.
-    // paritytech/subxt#2050 is specifically the chainHead_v1_follow subscription
-    // silently going idle under heavy concurrent block-import churn -- a failure
-    // mode intrinsic to that stateful subscription protocol. LegacyBackend never
-    // opens one; every call (state_getMetadata, chain_getBlock, state_getStorage,
-    // Core_version via state_call, ...) is a stateless one-shot RPC request, so the
-    // whole bug CLASS is structurally unreachable, not just recovered-from-faster.
-    // ChainClient's timeout+reconnect above stays as defense-in-depth (a slow/dead
-    // TCP connection is still possible under any backend), but is no longer the
-    // primary defense against #2050 specifically.
-    eprintln!("connect_chain: calling OnlineClient::from_backend (LegacyBackend)");
-    let backend = LegacyBackend::builder().build(rpc_client);
-    let api = OnlineClient::<PolkadotConfig>::from_backend(std::sync::Arc::new(backend))
-        .await
-        .context("online client")?;
-    eprintln!("connect_chain: OnlineClient ready");
-    Ok(api)
-}
-
-async fn connect_pg(url: &str) -> Result<tokio_postgres::Client> {
-    let (client, conn) = tokio_postgres::connect(url, tokio_postgres::NoTls)
-        .await
-        .context("pg connect")?;
-    tokio::spawn(async move {
-        if let Err(e) = conn.await {
-            eprintln!("pg connection error: {e}");
-        }
-    });
-    Ok(client)
-}
 
 // ---------------------------------------------------------------------------
 // Verify mode: decode blocks, print canonical JSON, no DB.
@@ -1821,7 +1633,7 @@ async fn run_live(client: &ChainClient, pg: &mut tokio_postgres::Client) -> Resu
                 .with_context(|| format!("live flush #{h}"))?;
             cursor = h;
             n += 1;
-            if n % 20 == 0 {
+            if n.is_multiple_of(20) {
                 eprintln!(
                     "live: #{h} · {} extr · {} ce",
                     d.extrinsics.len(),

--- a/deploy/postgres/schema.sql
+++ b/deploy/postgres/schema.sql
@@ -471,6 +471,26 @@ CREATE TABLE IF NOT EXISTS subnet_locks (
 );
 CREATE INDEX IF NOT EXISTS idx_subnet_locks_netuid ON subnet_locks (netuid);
 
+-- Real on-chain subnet ownership (metagraphed-infra#138; closes the gap
+-- JSONbored/metagraphed#6644 found -- no clean provider<->owner mapping
+-- existed anywhere). Latest-only snapshot, one row per currently-registered
+-- netuid, resolved via SubtensorModule::SubnetOwnerHotkey(netuid) ->
+-- SubtensorModule::Owner(hotkey) and written by apps/indexer-rs's poller
+-- binary (src/bin/poller.rs), NOT the JS Worker -- this is the first job in
+-- the consolidated chain-state polling service, not a data-refresh-cron/
+-- data-api.mjs sync route like every other table in this file. A netuid
+-- whose owner hotkey resolves to the zero account (unset/deregistered) is
+-- never written here, matching the bittensor SDK's own "no real owner"
+-- convention -- rows disappear (pruned) rather than being written as
+-- zero-account placeholders.
+CREATE TABLE IF NOT EXISTS subnet_ownership (
+  netuid        INTEGER NOT NULL,
+  owner_hotkey  TEXT NOT NULL,
+  owner_coldkey TEXT NOT NULL,
+  captured_at   BIGINT NOT NULL,
+  PRIMARY KEY (netuid)
+);
+
 -- Personal (coldkey) chain identity, latest-only (#4832 gap-closure Phase B;
 -- mirrors D1 migrations/0039_account_identity.sql). One row per account,
 -- upserted by the refresh-account-identity workflow's direct POST to


### PR DESCRIPTION
## Summary
- Adds `poller`, a new binary in `apps/indexer-rs` (sibling to `main.rs`'s backfill/live-follow, same crate/monorepo location -- not a new repo, not touching `main.rs`'s live-follow runtime behavior).
- Extracts `ChainClient`/`connect_chain`/`connect_pg`/`redact_rpc_url` into `src/lib.rs` so both binaries share one implementation of the subxt#2050 stall mitigation instead of a forked copy. Verified `main.rs`'s own 25 existing tests still pass unchanged.
- Implements `subnet-ownership` as the first native job: resolves `SubtensorModule::SubnetOwnerHotkey(netuid) -> SubtensorModule::Owner(hotkey)` for every currently-registered subnet (discovered via `SubtensorModule::NetworksAdded`, not a hardcoded bound) and upserts into a new `subnet_ownership` table. Closes the gap #6644 found -- no clean provider<->owner mapping existed anywhere in this codebase.
- Mirrors `scripts/fetch-account-balances.py`'s `MAX_ERROR_RATE` convention: a tick that fails to resolve more than half of what it scanned refuses to write, rather than upserting a mostly-broken snapshot.
- Replaces the growing pile of one-off Python systemd jobs under `roles/data-refresh-cron` with one binary + an internal per-job async scheduler -- future jobs become config/decode deltas in the same binary, not a new script+Dockerfile+systemd-pair each.
- Also fixed 4 pre-existing clippy warnings in `main.rs` encountered while extracting `lib.rs` (an orphaned doc comment, an unnecessary cast, a manual `%20==0`, an overly-complex tuple type) -- no behavior change, `cargo fmt`/`cargo test`/`cargo clippy` all clean.

## Test plan
- [x] `cargo build --release` / `cargo test --release` -- all 26 tests pass (25 pre-existing + 1 new)
- [x] `cargo fmt --check` / `cargo clippy --release --all-targets` -- clean
- [x] `node scripts/scan-public-safety.mjs` -- clean
- [x] Live-verified `subnet-ownership` end-to-end against the real public archive RPC + a scratch local Postgres: 129 netuids scanned, 128 written (root/netuid 0 has no owner, correctly excluded), 0 errors; spot-checked resolved owner rows look correct (real ss58 addresses, no zero-account leakage)
- [x] Companion metagraphed-infra PR adds the Ansible deployment task (gated off by default until the image is rebuilt with the new binary)