### PR TITLE
feat(ui): conviction leaderboard urgency framing embedded in the row

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-conviction-leaderboard.tsx
@@ -1,9 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
-import { Crown } from "lucide-react";
+import { AlertTriangle, Crown, Swords } from "lucide-react";
 import { subnetConvictionQuery } from "@/lib/metagraphed/queries";
 import { CopyableCode } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
+import {
+  rowGapPct,
+  summarizeContest,
+  type ContestStatus,
+} from "@/lib/metagraphed/conviction-contest";
 
 const UNITS_PER_WHOLE = 1_000_000_000;
 
@@ -20,6 +25,35 @@ function fmtAlpha(rawUnits: number): string {
   return `${whole.toFixed(4)} α`;
 }
 
+function fmtGapPct(pct: number): string {
+  if (pct >= 100) return "-100%";
+  if (pct >= 10) return `-${pct.toFixed(0)}%`;
+  if (pct >= 1) return `-${pct.toFixed(1)}%`;
+  return `-${pct.toFixed(2)}%`;
+}
+
+// Tone lookup for the top-challenger caption. `secure` gets a muted neutral
+// tone -- the gap number is still shown but not colored (nothing urgent to
+// signal); `uncontested` is unused here because a sole king has no
+// challenger row to caption.
+const CHALLENGER_TONE: Record<
+  ContestStatus,
+  { label: string | null; className: string; Icon: typeof AlertTriangle | null }
+> = {
+  "takeover-imminent": {
+    label: "Takeover imminent",
+    className: "text-health-down",
+    Icon: AlertTriangle,
+  },
+  contested: {
+    label: "Contested",
+    className: "text-health-warn",
+    Icon: Swords,
+  },
+  secure: { label: null, className: "text-ink-muted", Icon: null },
+  uncontested: { label: null, className: "text-ink-muted", Icon: null },
+};
+
 /**
  * Live per-subnet ownership-contest leaderboard (#6638, frontend companion
  * #6715): who currently holds the most rolled conviction on this subnet --
@@ -27,6 +61,16 @@ function fmtAlpha(rawUnits: number): string {
  * docs/conviction-lock-mechanism.md for the on-chain mechanism this rolls
  * forward from. Most subnets have no active challengers, so an empty
  * leaderboard is the common case, rendered as an EmptyState, not an error.
+ *
+ * Contest framing (#6883) is embedded IN the table itself: each non-king row
+ * shows a compact gap-behind-king caption stacked under the hotkey, and the
+ * top challenger's caption is tone-colored + labelled ("Takeover imminent" /
+ * "Contested") when the gap is actually urgent. There is deliberately no
+ * separate summary card above the table -- the section subtitle already asks
+ * the question, and the table itself answers it, on the actual entry. The
+ * caption lives INSIDE the hotkey cell rather than as a separate column so
+ * every viewport (mobile 375, tablet 768, desktop) renders the framing
+ * without horizontal scroll.
  */
 export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
   const { data: res, isLoading, isError, error, refetch } = useQuery(subnetConvictionQuery(netuid));
@@ -50,6 +94,15 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
       />
     );
   }
+
+  const summary = summarizeContest(leaderboard, data?.king ?? null);
+  const challengerHotkey = summary.challenger?.hotkey ?? null;
+  const rowTint =
+    summary.status === "takeover-imminent"
+      ? "bg-health-down/5"
+      : summary.status === "contested"
+        ? "bg-health-warn/5"
+        : null;
 
   return (
     <div className="space-y-3">
@@ -79,32 +132,60 @@ export function SubnetConvictionLeaderboard({ netuid }: { netuid: number }) {
             <tbody className="divide-y divide-border">
               {leaderboard.map((entry) => {
                 const isKing = data?.king != null && entry.hotkey === data.king;
+                const isChallenger = entry.hotkey === challengerHotkey;
+                const gap = rowGapPct(entry, summary.king);
+                const tone = isChallenger ? CHALLENGER_TONE[summary.status] : null;
+                const showLabel = isChallenger && tone?.label != null;
                 return (
-                  <tr key={entry.hotkey} className="mg-row-accent hover:bg-surface/40">
-                    <td className="px-4 py-2.5">
-                      <div className="flex items-center gap-2">
-                        {isKing ? (
-                          <Crown
-                            aria-label="Top-ranked (king)"
-                            className="size-3.5 shrink-0 text-health-warn"
-                          />
-                        ) : null}
-                        <CopyableCode value={entry.hotkey} className="max-w-full" />
-                        {entry.is_owner ? (
-                          <span
+                  <tr
+                    key={entry.hotkey}
+                    className={classNames(
+                      "mg-row-accent hover:bg-surface/40",
+                      isChallenger && rowTint ? rowTint : null,
+                    )}
+                  >
+                    <td className="px-4 py-2.5 align-top">
+                      <div className="flex flex-col gap-1">
+                        <div className="flex items-center gap-2">
+                          {isKing ? (
+                            <Crown
+                              aria-label="Top-ranked (king)"
+                              className="size-3.5 shrink-0 text-health-warn"
+                            />
+                          ) : null}
+                          <CopyableCode value={entry.hotkey} className="max-w-full" />
+                          {entry.is_owner ? (
+                            <span
+                              className={classNames(
+                                "shrink-0 rounded border border-border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted",
+                              )}
+                            >
+                              owner
+                            </span>
+                          ) : null}
+                        </div>
+                        {!isKing && gap != null ? (
+                          <div
                             className={classNames(
-                              "shrink-0 rounded border border-border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-muted",
+                              "flex items-center gap-1.5 font-mono text-[11px] tabular-nums",
+                              tone?.className ?? "text-ink-muted",
                             )}
                           >
-                            owner
-                          </span>
+                            {showLabel && tone?.Icon ? (
+                              <tone.Icon aria-hidden className="size-3 shrink-0" />
+                            ) : null}
+                            <span className={showLabel ? "font-medium" : undefined}>
+                              {fmtGapPct(gap)} behind
+                              {showLabel ? ` · ${tone.label}` : ""}
+                            </span>
+                          </div>
                         ) : null}
                       </div>
                     </td>
-                    <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink">
+                    <td className="px-4 py-2.5 align-top text-right font-mono text-[12px] tabular-nums text-ink">
                       {fmtAlpha(entry.locked_mass)}
                     </td>
-                    <td className="px-4 py-2.5 text-right font-mono text-[12px] tabular-nums text-ink-strong">
+                    <td className="px-4 py-2.5 align-top text-right font-mono text-[12px] tabular-nums text-ink-strong">
                       {fmtAlpha(entry.conviction)}
                     </td>
                   </tr>

--- a/apps/ui/src/lib/metagraphed/conviction-contest.test.ts
+++ b/apps/ui/src/lib/metagraphed/conviction-contest.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CONTESTED_MAX_PCT,
+  TAKEOVER_IMMINENT_MAX_PCT,
+  rowGapPct,
+  summarizeContest,
+} from "./conviction-contest";
+import type { SubnetConvictionEntry } from "./types";
+
+const entry = (
+  over: Partial<SubnetConvictionEntry> & { hotkey: string },
+): SubnetConvictionEntry => ({
+  is_owner: false,
+  locked_mass: 0,
+  conviction: 0,
+  ...over,
+});
+
+describe("summarizeContest", () => {
+  it("returns an uncontested summary for an empty leaderboard", () => {
+    expect(summarizeContest([], null)).toEqual({
+      status: "uncontested",
+      king: null,
+      challenger: null,
+      gapPct: null,
+    });
+  });
+
+  it("returns an uncontested summary when only the king is present", () => {
+    const king = entry({ hotkey: "5A", conviction: 1_000, is_owner: true });
+    expect(summarizeContest([king], "5A")).toEqual({
+      status: "uncontested",
+      king,
+      challenger: null,
+      gapPct: null,
+    });
+  });
+
+  it("falls back to the first leaderboard entry when king is not in the list", () => {
+    const first = entry({ hotkey: "5A", conviction: 900 });
+    const second = entry({ hotkey: "5B", conviction: 100 });
+    // king="5Z" absent -> first entry is treated as king; runner-up is second.
+    const summary = summarizeContest([first, second], "5Z");
+    expect(summary.king).toBe(first);
+    expect(summary.challenger).toBe(second);
+    expect(summary.status).toBe("secure"); // 89% gap
+  });
+
+  it("marks the contest as takeover-imminent when the gap is well within threshold", () => {
+    const king = entry({ hotkey: "5A", conviction: 1_000 });
+    const challenger = entry({ hotkey: "5B", conviction: 980 });
+    const summary = summarizeContest([king, challenger], "5A");
+    expect(summary.status).toBe("takeover-imminent");
+    expect(summary.gapPct).toBeCloseTo(2);
+  });
+
+  it("marks the contest as contested when the gap is between the two thresholds", () => {
+    const king = entry({ hotkey: "5A", conviction: 1_000 });
+    const challenger = entry({ hotkey: "5B", conviction: 850 });
+    const summary = summarizeContest([king, challenger], "5A");
+    expect(summary.status).toBe("contested");
+    expect(summary.gapPct).toBeCloseTo(15);
+  });
+
+  it("marks the contest as secure when the gap is comfortably beyond threshold", () => {
+    const king = entry({ hotkey: "5A", conviction: 1_000 });
+    const challenger = entry({ hotkey: "5B", conviction: 500 });
+    const summary = summarizeContest([king, challenger], "5A");
+    expect(summary.status).toBe("secure");
+    expect(summary.gapPct).toBeCloseTo(50);
+  });
+
+  it("treats an exact takeover threshold as takeover-imminent (inclusive lower band)", () => {
+    const king = entry({ hotkey: "5A", conviction: 100 });
+    const challenger = entry({ hotkey: "5B", conviction: 100 - TAKEOVER_IMMINENT_MAX_PCT });
+    expect(summarizeContest([king, challenger], "5A").status).toBe("takeover-imminent");
+  });
+
+  it("treats an exact contested threshold as contested (inclusive upper band)", () => {
+    const king = entry({ hotkey: "5A", conviction: 100 });
+    const challenger = entry({ hotkey: "5B", conviction: 100 - CONTESTED_MAX_PCT });
+    expect(summarizeContest([king, challenger], "5A").status).toBe("contested");
+  });
+
+  it("leaves gapPct null and marks contested when the king's conviction is zero", () => {
+    const king = entry({ hotkey: "5A", conviction: 0 });
+    const challenger = entry({ hotkey: "5B", conviction: 0 });
+    const summary = summarizeContest([king, challenger], "5A");
+    expect(summary.status).toBe("contested");
+    expect(summary.gapPct).toBeNull();
+  });
+
+  it("finds the challenger even when the leaderboard is not sorted", () => {
+    const challenger = entry({ hotkey: "5B", conviction: 300 });
+    const king = entry({ hotkey: "5A", conviction: 1_000 });
+    const summary = summarizeContest([challenger, king], "5A");
+    expect(summary.king).toBe(king);
+    expect(summary.challenger).toBe(challenger);
+    expect(summary.status).toBe("secure");
+  });
+});
+
+describe("rowGapPct", () => {
+  const king = entry({ hotkey: "5A", conviction: 1_000 });
+
+  it("returns null for the king row", () => {
+    expect(rowGapPct(king, king)).toBeNull();
+  });
+
+  it("returns null when there is no king", () => {
+    expect(rowGapPct(entry({ hotkey: "5B", conviction: 500 }), null)).toBeNull();
+  });
+
+  it("returns null when the king's conviction is zero", () => {
+    const zeroKing = entry({ hotkey: "5A", conviction: 0 });
+    expect(rowGapPct(entry({ hotkey: "5B", conviction: 0 }), zeroKing)).toBeNull();
+  });
+
+  it("returns the percent gap for a challenger below the king", () => {
+    expect(rowGapPct(entry({ hotkey: "5B", conviction: 900 }), king)).toBeCloseTo(10);
+    expect(rowGapPct(entry({ hotkey: "5C", conviction: 500 }), king)).toBeCloseTo(50);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/conviction-contest.ts
+++ b/apps/ui/src/lib/metagraphed/conviction-contest.ts
@@ -1,0 +1,82 @@
+import type { SubnetConvictionEntry } from "./types";
+
+// Contest-status thresholds -- how close is the ownership race?
+//
+// There's no existing precedent for these thresholds in the codebase, so
+// they're documented starting points:
+//   - "takeover-imminent" at <=5% because that's roughly the range a top
+//     challenger could close within one governance-parameter maturity window
+//     given typical UnlockRate/MaturityRate values (well inside a single
+//     day of active locking).
+//   - "contested" at <=20% because below a fifth-behind, a sustained
+//     challenge is meaningfully in reach; above that the king's lead is
+//     unlikely to flip without a large deliberate lock.
+// Both are exported so a follow-up can tune them without hunting through
+// component code.
+export const TAKEOVER_IMMINENT_MAX_PCT = 5;
+export const CONTESTED_MAX_PCT = 20;
+
+export type ContestStatus = "uncontested" | "secure" | "contested" | "takeover-imminent";
+
+export interface ContestSummary {
+  status: ContestStatus;
+  king: SubnetConvictionEntry | null;
+  challenger: SubnetConvictionEntry | null;
+  /**
+   * Gap between king and top challenger as a percent of the king's conviction
+   * (0-100). `null` when there is no challenger, or when the king's
+   * conviction is 0 (a well-formed empty-contest state that can't be
+   * expressed as a percentage).
+   */
+  gapPct: number | null;
+}
+
+/**
+ * Pure summary of the current ownership contest for a subnet: king, top
+ * challenger (if any), how far behind that challenger is, and a coarse
+ * status band. See TAKEOVER_IMMINENT_MAX_PCT / CONTESTED_MAX_PCT above for
+ * the thresholds. `king` is the `king` field from the API when present,
+ * otherwise the first leaderboard entry (mirrors what the table itself
+ * renders).
+ */
+export function summarizeContest(
+  leaderboard: readonly SubnetConvictionEntry[],
+  kingHotkey: string | null,
+): ContestSummary {
+  if (leaderboard.length === 0) {
+    return { status: "uncontested", king: null, challenger: null, gapPct: null };
+  }
+  const king =
+    (kingHotkey != null && leaderboard.find((e) => e.hotkey === kingHotkey)) || leaderboard[0];
+  const challenger = leaderboard.find((e) => e.hotkey !== king.hotkey) ?? null;
+  if (challenger == null) {
+    return { status: "uncontested", king, challenger: null, gapPct: null };
+  }
+  if (king.conviction <= 0) {
+    // A zero-conviction king with a challenger present is not a percent-
+    // expressible contest; treat as contested (there IS a rival) but leave
+    // gapPct null so the UI doesn't render "0%" or "NaN%".
+    return { status: "contested", king, challenger, gapPct: null };
+  }
+  const gapPct = ((king.conviction - challenger.conviction) / king.conviction) * 100;
+  let status: ContestStatus;
+  if (gapPct <= TAKEOVER_IMMINENT_MAX_PCT) status = "takeover-imminent";
+  else if (gapPct <= CONTESTED_MAX_PCT) status = "contested";
+  else status = "secure";
+  return { status, king, challenger, gapPct };
+}
+
+/**
+ * Gap between a non-king row and the king, as a percent of the king's
+ * conviction. Positive means "behind". `null` when the king's conviction
+ * is 0 (can't express) or when comparing the king to themselves.
+ */
+export function rowGapPct(
+  entry: SubnetConvictionEntry,
+  king: SubnetConvictionEntry | null,
+): number | null {
+  if (king == null) return null;
+  if (entry.hotkey === king.hotkey) return null;
+  if (king.conviction <= 0) return null;
+  return ((king.conviction - entry.conviction) / king.conviction) * 100;
+}


### PR DESCRIPTION
Follow-up to #6956, which was closed with a specific ask: `> It'd be nice to find a clean, organized way to consolidate the "Takeover" warning inside of the actual table, instead of needing to duplicate the entries and add an entirely new warning section for this single purpose.`

So this time the gap%-behind-king + status label live directly inside the leaderboard row itself — no separate summary card above the table, no duplicated king/challenger entries, no new "Contest status" section. Each non-king row shows a compact `-X% behind` caption stacked under the hotkey; the top challenger's caption is tone-colored and labelled when the gap is actually urgent (`⚠ Takeover imminent` red, `⚔ Contested` yellow), and the row gets a subtle `bg-health-{down,warn}/5` tint on that same challenger row. A comfortably-ahead king gets the plain `-X% behind` on other rows and no callout — the number alone tells that story, a colored label there would be noise.

I first tried this as a 4th "Gap to king" column but on 375px/768px the column and the whole `Takeover imminent` caption fell off the right edge of the table (the hotkey column is a 47-char SS58 address plus its copy button), so the whole point of the change disappeared on the two viewports the maintainer already flagged as the review bar for #4721/#4922 quality. Moving the caption into the hotkey cell instead — same table shape, no new column — renders identically at every viewport without horizontal scroll.

Thresholds are documented starting points at the top of `apps/ui/src/lib/metagraphed/conviction-contest.ts`:

- `TAKEOVER_IMMINENT_MAX_PCT = 5` — roughly a maturity window's closable gap at typical `UnlockRate`/`MaturityRate` values,
- `CONTESTED_MAX_PCT = 20` — a fifth-behind is a meaningful sustained challenge; above that the king's lead is unlikely to flip without a large deliberate lock.

Both are exported so a follow-up can tune them without touching the component.

Live API returns an empty leaderboard for most subnets, so the screenshots below use a playwright route stub for `/api/v1/subnets/1/conviction` so the takeover-imminent state is actually visible — the sole-king / empty-leaderboard paths still render exactly as they used to (Crown-only row / `EmptyState`), and the pure `summarizeContest`/`rowGapPct` helpers have unit-test coverage for both.

## Testing

Full local backend + `ui` CI lanes green: root `test:ci` + `test:ci:artifacts` + every `validate:*` including `contract-drift`/`schemas`/`api`/`mcp`/`ai`/`openapi`/`types`/`workflows`/`migrations`/`surface`/`docs`/`intake`/`artifact-budgets`/`client-sdk-sync`; `cloudflare:verify:dry-run` + r2/kv dry-runs + `worker:deploy:dry-run` + `worker:bundle:budget`; `scan:public-safety` + `validate:private-boundary`; the readme catalog stays fresh; python SDK unittest suite passes. On the `ui` job the `packages/client` + `packages/ui-kit` + api-reference-docs + catalog-docs drift checks all pass; `apps/ui` lint / typecheck / 1288 unit tests / e2e responsive-overflow / build (`LOVABLE_SANDBOX=1 NITRO_PRESET=cloudflare-module`) / 298 KB gzipped bundle-budget all green. `conviction-contest.test.ts` covers empty / sole-king / king-conviction-0 / exact-5% / exact-20% / unsorted-leaderboard / unknown-king-hotkey.

## Screenshots

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/e412446e8f6290c6dd9b8d7f6d07280f81d47d95/runs/jsonbored-metagraphed/run-51/before-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/e412446e8f6290c6dd9b8d7f6d07280f81d47d95/runs/jsonbored-metagraphed/run-51/before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/75e9e4732d4e96a31c5e3cec557265576f5b446c/runs/jsonbored-metagraphed/run-51/after-desktop-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/75e9e4732d4e96a31c5e3cec557265576f5b446c/runs/jsonbored-metagraphed/run-51/after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/b9f5f61976805fe80d145f62ee6c540c714dfb8a/runs/jsonbored-metagraphed/run-51/before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/b9f5f61976805fe80d145f62ee6c540c714dfb8a/runs/jsonbored-metagraphed/run-51/before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/0b2aeae25e062524843b92c3f32292b174c0ce1d/runs/jsonbored-metagraphed/run-51/after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/0b2aeae25e062524843b92c3f32292b174c0ce1d/runs/jsonbored-metagraphed/run-51/after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/7af2c7088b11bb617eba76e84fafeb070f33c381/runs/jsonbored-metagraphed/run-51/before-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/7af2c7088b11bb617eba76e84fafeb070f33c381/runs/jsonbored-metagraphed/run-51/before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/a07605a9facc57cc3f262d8afa6534b7750c3508/runs/jsonbored-metagraphed/run-51/after-tablet-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/a07605a9facc57cc3f262d8afa6534b7750c3508/runs/jsonbored-metagraphed/run-51/after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/457dc291237c02f43e25145d6b5742f880662a83/runs/jsonbored-metagraphed/run-51/before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/457dc291237c02f43e25145d6b5742f880662a83/runs/jsonbored-metagraphed/run-51/before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/17b7f397c68fec87c61eab3c25fbdd88cb3739f3/runs/jsonbored-metagraphed/run-51/after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/17b7f397c68fec87c61eab3c25fbdd88cb3739f3/runs/jsonbored-metagraphed/run-51/after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/b9bcf58543f1348ffd32cdc415bf7610fa9b591c/runs/jsonbored-metagraphed/run-51/before-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/b9bcf58543f1348ffd32cdc415bf7610fa9b591c/runs/jsonbored-metagraphed/run-51/before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/55131b4cbe551da5c559bf4bdecd9901b3fffc7d/runs/jsonbored-metagraphed/run-51/after-mobile-light.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/55131b4cbe551da5c559bf4bdecd9901b3fffc7d/runs/jsonbored-metagraphed/run-51/after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/6145a2530265806a314a4ebcbc0a26f1508ffdb2/runs/jsonbored-metagraphed/run-51/before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/6145a2530265806a314a4ebcbc0a26f1508ffdb2/runs/jsonbored-metagraphed/run-51/before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/nghetien/agentfix-assets/1644abf0716c36870fb65dcf3da7095cfe96c905/runs/jsonbored-metagraphed/run-51/after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/nghetien/agentfix-assets/1644abf0716c36870fb65dcf3da7095cfe96c905/runs/jsonbored-metagraphed/run-51/after-mobile-dark.png)<br><sub>after</sub> |

Closes #6883
