### PR TITLE
feat(indexer-rs): migrate account-balances + validator-nominators into the poller

### DIFF
--- a/apps/indexer-rs/Cargo.lock
+++ b/apps/indexer-rs/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "bytes",
  "futures",
  "hex",
+ "scale-decode",
  "scale-info",
  "scale-value",
  "serde_json",

--- a/apps/indexer-rs/Cargo.toml
+++ b/apps/indexer-rs/Cargo.toml
@@ -14,6 +14,13 @@ scale-value = "0.18"
 # Metadata::types()'s PortableRegistry and this crate's would be considered
 # distinct nominal types despite being structurally identical.
 scale-info = "2.11"
+# Pinned to the exact version subxt 0.50.1 already resolves transitively
+# (verified via Cargo.lock), same convention as scale-info above -- needed
+# directly for the #[derive(DecodeAsType)] the poller's jobs use to decode
+# storage values into small typed structs (e.g. System::Account's
+# AccountInfo) instead of the generic scale_value::Value tree main.rs's own
+# dynamic decode uses.
+scale-decode = { version = "0.16.2", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tokio-postgres = "0.7"
 futures = "0.3"
@@ -23,6 +30,12 @@ blake2 = "0.10.6"      # extrinsic_hash = blake2_256(extrinsic bytes)
 serde_json = "1"
 bytes = "1.12.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+# test-util (start_paused / manual clock advance for retry_transient's own
+# tests) is deliberately NOT in the [dependencies] "full" feature set above --
+# it's testing-only and shouldn't ship in the built binary.
+tokio = { version = "1", features = ["test-util"] }
 
 [profile.release]
 opt-level = 3

--- a/apps/indexer-rs/src/bin/poller/jobs.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs.rs
@@ -1,1 +1,3 @@
+pub mod account_balances;
 pub mod subnet_ownership;
+pub mod validator_nominators;

--- a/apps/indexer-rs/src/bin/poller/jobs/account_balances.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/account_balances.rs
@@ -1,0 +1,281 @@
+// account-balances (metagraphed-infra#139) -- the second job migrated into
+// the poller, replacing scripts/fetch-account-balances.py's systemd
+// timer + `POST /api/v1/internal/account-balances-sync` HTTP round-trip
+// (metagraphed#6742) with a direct chain-to-Postgres write. Reads
+// System::Account directly via a raw storage-map scan for the exact same
+// reason the Python script does (its own header comment, reproduced here):
+// a direct state read is ground-truth by construction (whatever the chain
+// has stored right now), whereas reconstructing free/reserved from
+// transfer/stake/fee event-replay requires catching every possible
+// mutation path with zero misses.
+//
+// Covers EVERY account that has ever held a balance on-chain -- System is
+// the ground truth for existence itself, not just registered neurons or
+// addresses already seen in account_events.
+//
+// SCALE (measured by the Python script this replaces, 2026-07-19, against
+// our own fullnode): 542,618 total System::Account entries. Unlike
+// subnet-ownership's ~129-row "gather everything in memory, then write
+// once" shape, that's too large to buffer wholesale and still call this a
+// periodic poll -- this job streams System::Account page by page and COPYs
+// each CHUNK to Postgres as its own transaction (same COPY-to-staging +
+// upsert shape as ../../main.rs's own `flush()`, at indexer scale) rather
+// than accumulating one giant Vec. The tradeoff: a systemic failure (e.g. a
+// metadata mismatch after a runtime upgrade) is caught by the same
+// MAX_ERROR_RATE circuit breaker as subnet-ownership and stops the scan
+// immediately, but chunks already committed before that point stay
+// committed -- there is no whole-scan atomicity the way a "buffer
+// everything, write once" design would give. In practice this bounds the
+// blast radius to at most one CHUNK_SIZE of rows: a genuine systemic
+// decode failure fails from the very first entries, not sporadically
+// partway through a 542k-row stream.
+//
+// No prune step, matching handleAccountBalancesSync's own upsert-only
+// semantics (workers/data-api.mjs) exactly: an account whose balance drops
+// to zero is skipped (not written), same as the Python script -- it goes
+// stale in the table rather than being deleted. This table has always been
+// "every account that has EVER held a balance," not "every account with a
+// balance right now."
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use backfill_rs::{now_ms, rao_to_tao_exact, ChainClient};
+use scale_decode::DecodeAsType;
+use subxt::dynamic;
+use subxt::utils::AccountId32;
+
+use crate::JobOutcome;
+
+// Mirrors scripts/fetch-account-balances.py's own MAX_ERROR_RATE exactly
+// (same constant, same reasoning): above this fraction of scanned entries
+// erroring out, treat the run as systemically broken rather than
+// continuing to publish an increasingly-unreliable partial scan.
+const MAX_ERROR_RATE: f64 = 0.5;
+
+// Rows buffered before each COPY-to-staging + upsert transaction. Chosen to
+// bound per-chunk memory (a BalanceRow is two short strings + an i64) while
+// keeping the number of round-trip transactions for a full ~540k-row scan
+// reasonable (~110 chunks at this size).
+const CHUNK_SIZE: usize = 5_000;
+
+/// AccountInfo.data's two balance fields -- the only ones this job needs.
+/// Mirrors the dynamic-decode pattern subxt's own docs use for exactly this
+/// storage item (`examples/dynamic.rs`'s System.Account section): ignoring
+/// every other AccountInfo field (nonce, consumers, frozen, flags) is fine,
+/// DecodeAsType only requires the fields you name.
+#[derive(DecodeAsType)]
+struct AccountInfo {
+    data: AccountInfoData,
+}
+
+#[derive(DecodeAsType)]
+struct AccountInfoData {
+    free: u128,
+    reserved: u128,
+}
+
+struct BalanceRow {
+    ss58: String,
+    free_tao: String,
+    reserved_tao: String,
+}
+
+/// Connects its own chain + Postgres client and ticks `run` on `interval`
+/// forever -- see subnet_ownership::run_loop's doc comment for why every
+/// job owns its connections rather than sharing one.
+pub async fn run_loop(rpc_url: String, db_url: String, interval: Duration) {
+    let chain = match ChainClient::connect(rpc_url).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("account-balances: chain connect failed, job will not run: {e:#}");
+            return;
+        }
+    };
+    let mut pg = match backfill_rs::connect_pg(&db_url).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("account-balances: postgres connect failed, job will not run: {e:#}");
+            return;
+        }
+    };
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        ticker.tick().await;
+        let t0 = std::time::Instant::now();
+        let result = run(&chain, &mut pg).await;
+        crate::log_job_outcome("account-balances", &result, t0.elapsed(), interval);
+    }
+}
+
+async fn run(chain: &ChainClient, pg: &mut tokio_postgres::Client) -> Result<JobOutcome> {
+    let at = chain
+        .call(|api| async move { Ok(api.at_current_block().await?) })
+        .await
+        .context("at_current_block")?;
+
+    let addr = dynamic::storage::<(AccountId32,), AccountInfo>("System", "Account");
+    let mut iter = at
+        .storage()
+        .iter(addr, ())
+        .await
+        .context("System::Account iter")?;
+
+    let captured_at = now_ms();
+    let mut chunk = Vec::with_capacity(CHUNK_SIZE);
+    let mut scanned = 0u64;
+    let mut written = 0u64;
+    let mut errors = 0u64;
+
+    loop {
+        let Some(entry) = iter.next().await else {
+            break;
+        };
+        scanned += 1;
+
+        let decoded = (|| -> Result<Option<BalanceRow>> {
+            let entry = entry?;
+            let (account,) = entry.key()?.decode()?;
+            let info: AccountInfo = entry.value().decode()?;
+            if info.data.free == 0 && info.data.reserved == 0 {
+                // Existential-deposit-only/reaped accounts carry a real
+                // System::Account entry with zero free and zero reserved --
+                // skip rather than write a meaningless all-zero row (matches
+                // fetch-account-balances.py exactly).
+                return Ok(None);
+            }
+            Ok(Some(BalanceRow {
+                ss58: account.to_string(),
+                free_tao: rao_to_tao_exact(info.data.free),
+                reserved_tao: rao_to_tao_exact(info.data.reserved),
+            }))
+        })();
+
+        match decoded {
+            Ok(None) => {}
+            Ok(Some(row)) => chunk.push(row),
+            Err(e) => {
+                errors += 1;
+                if scanned <= 20 || errors.is_multiple_of(1000) {
+                    eprintln!("account-balances: entry #{scanned} decode failed: {e:#}");
+                }
+            }
+        }
+
+        let error_rate = errors as f64 / scanned as f64;
+        if error_rate > MAX_ERROR_RATE {
+            anyhow::bail!(
+                "error rate {errors}/{scanned} ({:.0}%) exceeds {:.0}% -- aborting scan \
+                 ({written} row(s) already committed in earlier chunks stay committed)",
+                error_rate * 100.0,
+                MAX_ERROR_RATE * 100.0
+            );
+        }
+
+        if chunk.len() >= CHUNK_SIZE {
+            written += upsert_chunk(pg, &chunk, captured_at).await?;
+            eprintln!("account-balances: {scanned} scanned, {written} written so far");
+            chunk.clear();
+        }
+    }
+
+    if !chunk.is_empty() {
+        written += upsert_chunk(pg, &chunk, captured_at).await?;
+    }
+
+    Ok(JobOutcome {
+        scanned,
+        written,
+        errors,
+    })
+}
+
+/// COPY-to-staging + upsert, matching ../../main.rs's `flush()` shape at
+/// indexer scale: a plain `INSERT ... ON CONFLICT` per row would be far
+/// slower for chunk-sized batches than one COPY + one merge statement.
+/// `WHERE account_balances.captured_at <= EXCLUDED.captured_at` matches
+/// handleAccountBalancesSync's own guard (workers/data-api.mjs) -- a
+/// slower/retried tick can never overwrite a newer captured_at with a
+/// stale one.
+async fn upsert_chunk(
+    pg: &mut tokio_postgres::Client,
+    rows: &[BalanceRow],
+    captured_at: i64,
+) -> Result<u64> {
+    let tx = pg.transaction().await?;
+    tx.batch_execute(
+        "CREATE TEMP TABLE s_account_balances (LIKE account_balances) ON COMMIT DROP;",
+    )
+    .await?;
+
+    {
+        let sink = tx
+            .copy_in(
+                "COPY s_account_balances (ss58, free_tao, reserved_tao, captured_at) FROM STDIN",
+            )
+            .await?;
+        let mut buf = String::new();
+        for r in rows {
+            buf.push_str(&format!(
+                "{}\t{}\t{}\t{}\n",
+                copy_escape(&r.ss58),
+                r.free_tao,
+                r.reserved_tao,
+                captured_at
+            ));
+        }
+        copy_send(sink, buf).await?;
+    }
+
+    let written = tx
+        .execute(
+            "INSERT INTO account_balances (ss58, free_tao, reserved_tao, captured_at)
+             SELECT ss58, free_tao, reserved_tao, captured_at FROM s_account_balances
+             ON CONFLICT (ss58) DO UPDATE SET
+               free_tao = EXCLUDED.free_tao,
+               reserved_tao = EXCLUDED.reserved_tao,
+               captured_at = EXCLUDED.captured_at
+             WHERE account_balances.captured_at <= EXCLUDED.captured_at",
+            &[],
+        )
+        .await
+        .context("upsert account_balances chunk")?;
+
+    tx.commit().await?;
+    Ok(written as u64)
+}
+
+/// Tab/newline/backslash-escapes a value for Postgres COPY text format.
+/// ss58 addresses never legitimately contain these bytes, but escaping
+/// defensively costs nothing and matches ../../main.rs's own `copy_escape`.
+fn copy_escape(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('\t', "\\t")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
+async fn copy_send(sink: tokio_postgres::CopyInSink<bytes::Bytes>, buf: String) -> Result<()> {
+    use futures::SinkExt;
+    let mut sink = std::pin::pin!(sink);
+    sink.send(bytes::Bytes::from(buf)).await?;
+    sink.close().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn copy_escape_handles_tabs_and_newlines() {
+        assert_eq!(copy_escape("a\tb\nc"), "a\\tb\\nc");
+    }
+
+    #[test]
+    fn copy_escape_leaves_plain_ss58_untouched() {
+        let ss58 = "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM";
+        assert_eq!(copy_escape(ss58), ss58);
+    }
+}

--- a/apps/indexer-rs/src/bin/poller/jobs/subnet_ownership.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/subnet_ownership.rs
@@ -44,11 +44,10 @@
 // scheduled interval -- an acceptable cost for a periodic poller, unlike
 // main.rs's live-follow hot path this same reasoning would NOT apply to.
 
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
-use backfill_rs::{AtBlock, ChainClient};
+use backfill_rs::{now_ms, retry_transient, AtBlock, ChainClient};
 use subxt::dynamic;
 use subxt::utils::AccountId32;
 
@@ -60,6 +59,9 @@ use crate::JobOutcome;
 // upgrade) rather than upsert a mostly-empty snapshot over a good one.
 const MAX_ERROR_RATE: f64 = 0.5;
 
+// See resolve_ownership's own doc comment for why individual fetches retry.
+const RETRY_ATTEMPTS: u32 = 3;
+
 const ZERO_ACCOUNT: AccountId32 = AccountId32([0u8; 32]);
 
 struct OwnershipRow {
@@ -68,7 +70,36 @@ struct OwnershipRow {
     owner_coldkey: String,
 }
 
-pub async fn run(chain: Arc<ChainClient>, pg: Arc<tokio_postgres::Client>) -> Result<JobOutcome> {
+/// Connects its own chain + Postgres client (each kept alive for the loop's
+/// lifetime, separate from every other job's connections -- see main.rs's
+/// own doc comment for why) and ticks `run` on `interval` forever, reporting
+/// through the shared `crate::log_job_outcome`.
+pub async fn run_loop(rpc_url: String, db_url: String, interval: Duration) {
+    let chain = match ChainClient::connect(rpc_url).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("subnet-ownership: chain connect failed, job will not run: {e:#}");
+            return;
+        }
+    };
+    let mut pg = match backfill_rs::connect_pg(&db_url).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("subnet-ownership: postgres connect failed, job will not run: {e:#}");
+            return;
+        }
+    };
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        ticker.tick().await;
+        let t0 = std::time::Instant::now();
+        let result = run(&chain, &mut pg).await;
+        crate::log_job_outcome("subnet-ownership", &result, t0.elapsed(), interval);
+    }
+}
+
+async fn run(chain: &ChainClient, pg: &mut tokio_postgres::Client) -> Result<JobOutcome> {
     let at = chain
         .call(|api| async move { Ok(api.at_current_block().await?) })
         .await
@@ -110,7 +141,7 @@ pub async fn run(chain: Arc<ChainClient>, pg: Arc<tokio_postgres::Client>) -> Re
     }
 
     let captured_at = now_ms();
-    let written = upsert(&pg, &rows, captured_at)
+    let written = upsert(pg, &rows, captured_at)
         .await
         .context("upsert subnet_ownership")?;
 
@@ -139,28 +170,32 @@ async fn discover_netuids(at: &AtBlock) -> Result<Vec<u16>> {
 /// SubnetOwnerHotkey(netuid) -> Owner(hotkey) -> owning account. Returns `None`
 /// (not an error) when either step resolves to the zero account -- that's a
 /// real, valid "no owner" state per the bittensor SDK's own convention, not
-/// a decode failure.
+/// a decode failure. Each fetch retries transient failures (RETRY_ATTEMPTS)
+/// -- live-verified 2026-07-19 that a single unretried fetch can hit the
+/// ReconnectingRpcClient's 60s request_timeout under concurrent multi-job
+/// load even though the same call reliably completes in under a second
+/// moments later (see `backfill_rs::retry_transient`'s own doc comment).
 async fn resolve_ownership(at: &AtBlock, netuid: u16) -> Result<Option<OwnershipRow>> {
     let hotkey_addr =
         dynamic::storage::<(u16,), AccountId32>("SubtensorModule", "SubnetOwnerHotkey");
-    let hotkey: AccountId32 = at
-        .storage()
-        .fetch(hotkey_addr, (netuid,))
-        .await
-        .with_context(|| format!("SubnetOwnerHotkey(netuid={netuid})"))?
-        .decode()?;
+    let hotkey: AccountId32 = retry_transient(RETRY_ATTEMPTS, || async {
+        Ok(at.storage().fetch(&hotkey_addr, (netuid,)).await?)
+    })
+    .await
+    .with_context(|| format!("SubnetOwnerHotkey(netuid={netuid})"))?
+    .decode()?;
 
     if hotkey == ZERO_ACCOUNT {
         return Ok(None);
     }
 
     let owner_addr = dynamic::storage::<(AccountId32,), AccountId32>("SubtensorModule", "Owner");
-    let coldkey: AccountId32 = at
-        .storage()
-        .fetch(owner_addr, (hotkey,))
-        .await
-        .with_context(|| format!("Owner(hotkey={hotkey})"))?
-        .decode()?;
+    let coldkey: AccountId32 = retry_transient(RETRY_ATTEMPTS, || async {
+        Ok(at.storage().fetch(&owner_addr, (hotkey,)).await?)
+    })
+    .await
+    .with_context(|| format!("Owner(hotkey={hotkey})"))?
+    .decode()?;
 
     if coldkey == ZERO_ACCOUNT {
         return Ok(None);
@@ -216,13 +251,6 @@ async fn upsert(
     }
 
     Ok(written)
-}
-
-fn now_ms() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system clock before unix epoch")
-        .as_millis() as i64
 }
 
 #[cfg(test)]

--- a/apps/indexer-rs/src/bin/poller/jobs/validator_nominators.rs
+++ b/apps/indexer-rs/src/bin/poller/jobs/validator_nominators.rs
@@ -1,0 +1,325 @@
+// validator-nominators (metagraphed-infra#139) -- migrates
+// scripts/fetch-validator-nominator-counts.py's Alpha full scan, replacing
+// its systemd timer + two HTTP sync routes
+// (POST /api/v1/internal/validator-nominator-counts-sync,
+// POST /api/v1/internal/nominator-positions-sync) with a direct
+// chain-to-Postgres write. One scan answers two questions (this script's
+// own doc comment, reproduced here): SubtensorModule::Alpha is a triple-key
+// (hotkey, coldkey, netuid) -> shares map with no cheaper way to query "just
+// this hotkey's nominators" or "just this account's positions" in bulk, and
+// no network-wide aggregate RPC exists for either -- a single full scan is
+// the only correct approach, so BOTH outputs are derived from that one pass
+// rather than scanning twice.
+//
+// SCALE (measured by the Python script this replaces, 2026-07-14, against
+// our own fullnode): 762,577 total Alpha rows, ~3,100 rows/sec sustained,
+// 112,552 distinct hotkeys, max single-hotkey nominator count 7,266.
+//
+// UNLIKE account_balances.rs's streaming-chunk design, this job buffers the
+// WHOLE scan in memory before writing anything: `share_fraction` (this
+// account's shares / ALL delegators' shares for that hotkey+netuid) can't be
+// computed for a row until every OTHER row sharing its (hotkey, netuid) has
+// also been seen, so there is no way to stream-commit a chunk independently
+// -- the group total is only known once the scan is complete. This mirrors
+// the Python script's own shape exactly (accumulate two in-memory maps,
+// derive both outputs, write once at the end).
+//
+// Units (#5233, carried over unchanged from the Python script this
+// replaces): Alpha's stored value is a fixed-point U64F64 SHARE count (a
+// `{bits: u64}` struct; true value is bits / 2**64), NOT a TAO/alpha
+// amount -- these are pool-internal accounting shares, normalized here into
+// a dimensionless share_fraction per (hotkey, coldkey, netuid) row. The
+// API-side join (src/account-nominator-positions.mjs) multiplies that
+// fraction by the already-ingested neurons.stake_tao at serve time.
+//
+// Root (netuid 0) is NOT covered: every Alpha entry at netuid 0 is always
+// bits=0 (root stake is TAO-denominated 1:1 with no alpha pool, #2550) --
+// skip rather than store a permanently-zero, useless ledger entry, same as
+// the Python script.
+//
+// No prune step for either output table, matching
+// handleValidatorNominatorCountsSync / handleNominatorPositionsSync's own
+// upsert-only semantics (workers/data-api.mjs) exactly.
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use backfill_rs::{now_ms, ChainClient};
+use scale_decode::DecodeAsType;
+use subxt::dynamic;
+use subxt::utils::AccountId32;
+
+use crate::JobOutcome;
+
+// Mirrors scripts/fetch-account-balances.py's MAX_ERROR_RATE convention
+// (same threshold, same reasoning), applied here to Alpha entries.
+const MAX_ERROR_RATE: f64 = 0.5;
+
+/// Alpha's stored value: a U64F64 fixed-point share count. "U64F64" is a
+/// 64-integer-bit + 64-fractional-bit format -- 128 bits total, so `bits`
+/// itself is a u128, NOT a u64 (live-verified 2026-07-19: decoding as u64
+/// failed outright with NumberOutOfRange on real values like
+/// 1844674407370955161600000000, which doesn't fit in 64 bits at all).
+/// True value is `bits as f64 / 2f64.powi(64)`, but this job only ever
+/// needs ratios of two `bits` values (share_fraction), so the raw integer
+/// is kept as-is and never converted to a float until the final division.
+#[derive(DecodeAsType)]
+struct Shares {
+    bits: u128,
+}
+
+struct NominatorPositionRow {
+    coldkey: String,
+    hotkey: String,
+    netuid: i32,
+    share_fraction: f32,
+}
+
+/// Connects its own chain + Postgres client and ticks `run` on `interval`
+/// forever -- see subnet_ownership::run_loop's doc comment for why every
+/// job owns its connections rather than sharing one.
+pub async fn run_loop(rpc_url: String, db_url: String, interval: Duration) {
+    let chain = match ChainClient::connect(rpc_url).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("validator-nominators: chain connect failed, job will not run: {e:#}");
+            return;
+        }
+    };
+    let mut pg = match backfill_rs::connect_pg(&db_url).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("validator-nominators: postgres connect failed, job will not run: {e:#}");
+            return;
+        }
+    };
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        ticker.tick().await;
+        let t0 = std::time::Instant::now();
+        let result = run(&chain, &mut pg).await;
+        crate::log_job_outcome("validator-nominators", &result, t0.elapsed(), interval);
+    }
+}
+
+async fn run(chain: &ChainClient, pg: &mut tokio_postgres::Client) -> Result<JobOutcome> {
+    let at = chain
+        .call(|api| async move { Ok(api.at_current_block().await?) })
+        .await
+        .context("at_current_block")?;
+
+    let addr =
+        dynamic::storage::<(AccountId32, AccountId32, u16), Shares>("SubtensorModule", "Alpha");
+    let mut iter = at
+        .storage()
+        .iter(addr, ())
+        .await
+        .context("SubtensorModule::Alpha iter")?;
+
+    // hotkey -> distinct coldkeys holding any stake on it (every Alpha
+    // entry counts, including netuid 0 and zero-share rows -- matches the
+    // Python script's own `nominators.setdefault(hotkey, set()).add(coldkey)`
+    // unconditional accumulation).
+    let mut nominators: HashMap<String, HashSet<String>> = HashMap::new();
+    // (hotkey, netuid) -> {coldkey: shares_bits} -- only netuid != 0 and
+    // shares > 0 (root is never share-tracked; a zero-share entry has
+    // nothing to normalize).
+    let mut shares_by_hotkey_netuid: HashMap<(String, i32), HashMap<String, u128>> = HashMap::new();
+
+    let mut scanned = 0u64;
+    let mut errors = 0u64;
+
+    loop {
+        let Some(entry) = iter.next().await else {
+            break;
+        };
+        scanned += 1;
+
+        let decoded = (|| -> Result<()> {
+            let entry = entry?;
+            let (hotkey, coldkey, netuid) = entry.key()?.decode()?;
+            let shares: Shares = entry.value().decode()?;
+
+            let hotkey: String = AccountId32::to_string(&hotkey);
+            let coldkey: String = AccountId32::to_string(&coldkey);
+
+            nominators
+                .entry(hotkey.clone())
+                .or_default()
+                .insert(coldkey.clone());
+
+            if netuid != 0 && shares.bits > 0 {
+                shares_by_hotkey_netuid
+                    .entry((hotkey, netuid as i32))
+                    .or_default()
+                    .insert(coldkey, shares.bits);
+            }
+            Ok(())
+        })();
+
+        if let Err(e) = decoded {
+            errors += 1;
+            if scanned <= 20 || errors.is_multiple_of(1000) {
+                eprintln!("validator-nominators: entry #{scanned} decode failed: {e:#}");
+            }
+        }
+
+        let error_rate = errors as f64 / scanned as f64;
+        if error_rate > MAX_ERROR_RATE {
+            anyhow::bail!(
+                "error rate {errors}/{scanned} ({:.0}%) exceeds {:.0}% -- aborting scan, nothing written",
+                error_rate * 100.0,
+                MAX_ERROR_RATE * 100.0
+            );
+        }
+
+        if scanned.is_multiple_of(100_000) {
+            eprintln!(
+                "validator-nominators: {scanned} Alpha rows scanned, {} distinct hotkeys so far",
+                nominators.len()
+            );
+        }
+    }
+
+    let captured_at = now_ms();
+
+    let count_rows: Vec<(String, i32)> = nominators
+        .iter()
+        .map(|(hotkey, coldkeys)| (hotkey.clone(), coldkeys.len() as i32))
+        .collect();
+
+    let position_rows: Vec<NominatorPositionRow> = shares_by_hotkey_netuid
+        .into_iter()
+        .flat_map(|((hotkey, netuid), coldkey_shares)| {
+            let total: u128 = coldkey_shares.values().sum();
+            coldkey_shares
+                .into_iter()
+                .map(move |(coldkey, bits)| NominatorPositionRow {
+                    coldkey,
+                    hotkey: hotkey.clone(),
+                    netuid,
+                    share_fraction: (bits as f64 / total as f64) as f32,
+                })
+        })
+        .collect();
+
+    let written = upsert(pg, &count_rows, &position_rows, captured_at)
+        .await
+        .context("upsert validator_nominator_counts + nominator_positions")?;
+
+    Ok(JobOutcome {
+        scanned,
+        written,
+        errors,
+    })
+}
+
+/// One transaction, two COPY-to-staging + upsert passes -- same shape as
+/// ../../main.rs's own `flush()` for multiple related tables in one
+/// atomic write.
+async fn upsert(
+    pg: &mut tokio_postgres::Client,
+    count_rows: &[(String, i32)],
+    position_rows: &[NominatorPositionRow],
+    captured_at: i64,
+) -> Result<u64> {
+    let tx = pg.transaction().await?;
+    tx.batch_execute(
+        "CREATE TEMP TABLE s_validator_nominator_counts (LIKE validator_nominator_counts) ON COMMIT DROP;
+         CREATE TEMP TABLE s_nominator_positions (LIKE nominator_positions) ON COMMIT DROP;",
+    )
+    .await?;
+
+    {
+        let sink = tx
+            .copy_in("COPY s_validator_nominator_counts (hotkey, nominator_count, captured_at) FROM STDIN")
+            .await?;
+        let mut buf = String::new();
+        for (hotkey, count) in count_rows {
+            buf.push_str(&format!(
+                "{}\t{count}\t{captured_at}\n",
+                copy_escape(hotkey)
+            ));
+        }
+        copy_send(sink, buf).await?;
+    }
+
+    {
+        let sink = tx
+            .copy_in("COPY s_nominator_positions (coldkey, hotkey, netuid, share_fraction, captured_at) FROM STDIN")
+            .await?;
+        let mut buf = String::new();
+        for r in position_rows {
+            buf.push_str(&format!(
+                "{}\t{}\t{}\t{}\t{captured_at}\n",
+                copy_escape(&r.coldkey),
+                copy_escape(&r.hotkey),
+                r.netuid,
+                r.share_fraction,
+            ));
+        }
+        copy_send(sink, buf).await?;
+    }
+
+    let counts_written = tx
+        .execute(
+            "INSERT INTO validator_nominator_counts (hotkey, nominator_count, captured_at)
+             SELECT hotkey, nominator_count, captured_at FROM s_validator_nominator_counts
+             ON CONFLICT (hotkey) DO UPDATE SET
+               nominator_count = EXCLUDED.nominator_count,
+               captured_at = EXCLUDED.captured_at",
+            &[],
+        )
+        .await
+        .context("upsert validator_nominator_counts")?;
+
+    tx.execute(
+        "INSERT INTO nominator_positions (coldkey, hotkey, netuid, share_fraction, captured_at)
+         SELECT coldkey, hotkey, netuid, share_fraction, captured_at FROM s_nominator_positions
+         ON CONFLICT (coldkey, hotkey, netuid) DO UPDATE SET
+           share_fraction = EXCLUDED.share_fraction,
+           captured_at = EXCLUDED.captured_at",
+        &[],
+    )
+    .await
+    .context("upsert nominator_positions")?;
+
+    tx.commit().await?;
+    Ok(counts_written as u64)
+}
+
+/// Tab/newline/backslash-escapes a value for Postgres COPY text format.
+fn copy_escape(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('\t', "\\t")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
+async fn copy_send(sink: tokio_postgres::CopyInSink<bytes::Bytes>, buf: String) -> Result<()> {
+    use futures::SinkExt;
+    let mut sink = std::pin::pin!(sink);
+    sink.send(bytes::Bytes::from(buf)).await?;
+    sink.close().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn share_fraction_normalizes_correctly_across_a_hotkey_netuid_group() {
+        let mut coldkey_shares = HashMap::new();
+        coldkey_shares.insert("alice".to_string(), 300u128);
+        coldkey_shares.insert("bob".to_string(), 700u128);
+        let total: u128 = coldkey_shares.values().sum();
+        let alice_fraction = coldkey_shares["alice"] as f64 / total as f64;
+        let bob_fraction = coldkey_shares["bob"] as f64 / total as f64;
+        assert!((alice_fraction - 0.3).abs() < 1e-9);
+        assert!((bob_fraction - 0.7).abs() < 1e-9);
+        assert!((alice_fraction + bob_fraction - 1.0).abs() < 1e-9);
+    }
+}

--- a/apps/indexer-rs/src/bin/poller/main.rs
+++ b/apps/indexer-rs/src/bin/poller/main.rs
@@ -10,18 +10,42 @@
 // roles/data-refresh-cron (metagraph, account-identity, subnet-hyperparams,
 // validator-nominators, self-stake, account-balances) with one binary, one
 // systemd unit, and an internal async scheduler -- each job runs on its own
-// independent tokio interval via run_job_loop() below, which provides
-// shared logging + treats a job that mostly failed to scan (mirrors
-// scripts/fetch-account-balances.py's MAX_ERROR_RATE convention) as a
-// failed tick rather than a partial write.
+// independent tokio interval, in its own `run_loop` (see jobs::subnet_ownership
+// for the pattern every job follows), reporting through the shared
+// `log_job_outcome` below so every job's ok/failed logging reads the same
+// way. A job that decided its own error rate was too high to trust (mirrors
+// scripts/fetch-account-balances.py's MAX_ERROR_RATE) should return `Err`
+// from its `run`, not a low `written` count.
 //
-// `subnet-ownership` (jobs::subnet_ownership) is the first job, per
-// metagraphed-infra#138 -- closes the JSONbored/metagraphed#6644 gap (no
-// clean provider<->owner mapping existed anywhere). Future jobs
-// (metagraph/account-identity/subnet-hyperparams/validator-nominators/
-// self-stake/account-balances, metagraphed-infra#139-141) each become a
-// small config/decode delta added to the `jobs` module + one more line in
-// main(), not a whole new script+Dockerfile+systemd-pair.
+// Each job owns its OWN Postgres connection AND its OWN chain (ChainClient)
+// connection -- connected once, kept for the life of the job's loop --
+// rather than sharing either across jobs.
+//
+// Postgres: some jobs (account-balances) need a real transaction
+// (`&mut Client`) for a COPY-to-staging + upsert bulk load, matching
+// ../main.rs's own `flush()` pattern at indexer scale -- a `&mut` borrow
+// can't be shared across concurrently-running job tasks.
+//
+// Chain: live-verified 2026-07-19 that sharing one ChainClient (one
+// underlying WebSocket) across two concurrently-running jobs is a real
+// problem, not just a theoretical one -- running subnet-ownership and
+// account-balances together, subnet-ownership's own simple single-key
+// SubnetOwnerHotkey fetches started hitting the ReconnectingRpcClient's 60s
+// request_timeout (each one individually took ~200ms-2.7s in isolation, see
+// subnet_ownership.rs's own PERFORMANCE note) -- account-balances' heavy
+// concurrent System::Account streaming was starving the shared connection.
+// A dedicated WebSocket per job (cheap: each job polls infrequently, these
+// are long-lived idle-most-of-the-time connections, not a connection-per-
+// request pattern) fully isolates one job's chain-RPC load from another's,
+// the same way the per-job Postgres connection isolates writes.
+//
+// There's deliberately no generic `run_job_loop<F>` scheduler taking an
+// arbitrary job closure: stable Rust can't cleanly express "an FnMut that
+// returns a future borrowing a per-job `&mut Postgres client`" without
+// boxing every future, so each job gets a small (~15-line) `run_loop`
+// instead. What's actually worth sharing -- the tick/log/never-crash-the-
+// process policy -- lives in `log_job_outcome` below, which every job's
+// `run_loop` calls after each tick.
 //
 // Env:
 //   DATABASE_URL                postgres connection (the same sink ../main.rs writes)
@@ -30,22 +54,43 @@
 
 mod jobs;
 
-use std::future::Future;
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use backfill_rs::{connect_pg, redact_rpc_url, ChainClient};
 
-/// What a single job tick reports back to run_job_loop -- lets the scheduler
-/// apply one shared logging convention across every job instead of each job
-/// reimplementing it. A job that decides its own error rate was too high to
-/// trust (mirrors scripts/fetch-account-balances.py's MAX_ERROR_RATE) should
-/// return `Err`, not a low `written` count -- see jobs::subnet_ownership::run.
+/// What a single job tick reports back to its own `run_loop` -- lets every
+/// job apply the same `log_job_outcome` logging convention instead of each
+/// one reimplementing it.
 pub struct JobOutcome {
     pub scanned: u64,
     pub written: u64,
     pub errors: u64,
+}
+
+/// Shared logging policy every job's own `run_loop` calls after each tick.
+pub fn log_job_outcome(
+    name: &str,
+    result: &Result<JobOutcome>,
+    elapsed: Duration,
+    interval: Duration,
+) {
+    match result {
+        Ok(outcome) => {
+            eprintln!(
+                "{name}: ok -- {} scanned, {} written, {} error(s) ({elapsed:?} elapsed)",
+                outcome.scanned, outcome.written, outcome.errors
+            );
+        }
+        Err(e) => {
+            eprintln!(
+                "{name}: tick failed ({e:#}) -- retrying in {interval:?} ({elapsed:?} elapsed)"
+            );
+        }
+    }
+}
+
+fn env_u64(k: &str) -> Option<u64> {
+    std::env::var(k).ok().and_then(|v| v.parse().ok())
 }
 
 #[tokio::main]
@@ -56,82 +101,54 @@ async fn main() -> Result<()> {
 
     let rpc_url = std::env::var("EVENTS_RPC_URL")
         .unwrap_or_else(|_| "wss://archive.chain.opentensor.ai:443".to_string());
-    eprintln!("poller: connecting to {}", redact_rpc_url(&rpc_url));
-    let chain = Arc::new(ChainClient::connect(rpc_url).await?);
-    eprintln!("poller: chain connection ready");
-
+    // Fail fast on a missing DATABASE_URL instead of each job independently
+    // discovering it's unset on its first tick.
     let db_url = std::env::var("DATABASE_URL").context("DATABASE_URL required")?;
-    let pg = Arc::new(connect_pg(&db_url).await?);
-    eprintln!("poller: postgres connection ready, starting jobs");
+    eprintln!("poller: starting jobs (each connects its own chain + postgres client)");
 
     let subnet_ownership_interval =
         Duration::from_secs(env_u64("SUBNET_OWNERSHIP_POLL_SECS").unwrap_or(300));
+    let account_balances_interval =
+        Duration::from_secs(env_u64("ACCOUNT_BALANCES_POLL_SECS").unwrap_or(6 * 3600));
+    let validator_nominators_interval =
+        Duration::from_secs(env_u64("VALIDATOR_NOMINATORS_POLL_SECS").unwrap_or(24 * 3600));
 
-    let subnet_ownership = {
-        let chain = chain.clone();
-        let pg = pg.clone();
-        tokio::spawn(async move {
-            run_job_loop(
-                "subnet-ownership",
-                subnet_ownership_interval,
-                chain,
-                pg,
-                jobs::subnet_ownership::run,
-            )
-            .await;
-        })
-    };
+    // One tokio task per job, each with its own name so a panic reports
+    // which job died rather than an anonymous "a job panicked". Add a new
+    // job here (spawn + push) as each one lands -- no other wiring needed,
+    // matching the "config/decode delta, not a new scheduler" goal from
+    // main.rs's own module doc comment above.
+    let names = [
+        "subnet-ownership",
+        "account-balances",
+        "validator-nominators",
+    ];
+    let handles = vec![
+        tokio::spawn(jobs::subnet_ownership::run_loop(
+            rpc_url.clone(),
+            db_url.clone(),
+            subnet_ownership_interval,
+        )),
+        tokio::spawn(jobs::account_balances::run_loop(
+            rpc_url.clone(),
+            db_url.clone(),
+            account_balances_interval,
+        )),
+        tokio::spawn(jobs::validator_nominators::run_loop(
+            rpc_url.clone(),
+            db_url.clone(),
+            validator_nominators_interval,
+        )),
+    ];
 
-    // Each job loop above runs forever (see run_job_loop) -- if one panics,
-    // that's a real bug and should take the process down (systemd's
-    // restart_policy: unless-stopped brings it back), rather than silently
-    // leaving a job dead while the process looks alive.
-    subnet_ownership
-        .await
-        .context("subnet-ownership job task panicked")?;
+    // Every job's `run_loop` runs forever -- select_all (NOT a sequential
+    // await, which would block on handles[0] forever and never notice a
+    // later job panicking) resolves as soon as ANY one of them returns,
+    // which only happens on a panic. That's a real bug and should take the
+    // process down (systemd's restart_policy: unless-stopped brings it
+    // back), rather than silently leaving a job dead while the process
+    // looks alive.
+    let (result, index, _remaining) = futures::future::select_all(handles).await;
+    result.with_context(|| format!("{} job task panicked", names[index]))?;
     Ok(())
-}
-
-fn env_u64(k: &str) -> Option<u64> {
-    std::env::var(k).ok().and_then(|v| v.parse().ok())
-}
-
-/// Runs `job` on a fixed interval forever, applying one shared logging
-/// policy: scan/write/error counts on success, failure reason (including a
-/// job's own "error rate too high, refusing to write" Err) on failure. A
-/// single bad tick never brings down the process or other jobs -- this loop
-/// always continues to the next tick.
-async fn run_job_loop<F, Fut>(
-    name: &'static str,
-    interval: Duration,
-    chain: Arc<ChainClient>,
-    pg: Arc<tokio_postgres::Client>,
-    job: F,
-) where
-    F: Fn(Arc<ChainClient>, Arc<tokio_postgres::Client>) -> Fut,
-    Fut: Future<Output = Result<JobOutcome>>,
-{
-    let mut ticker = tokio::time::interval(interval);
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-    loop {
-        ticker.tick().await;
-        let t0 = std::time::Instant::now();
-        match job(chain.clone(), pg.clone()).await {
-            Ok(outcome) => {
-                eprintln!(
-                    "{name}: ok -- {} scanned, {} written, {} error(s) ({:?} elapsed)",
-                    outcome.scanned,
-                    outcome.written,
-                    outcome.errors,
-                    t0.elapsed()
-                );
-            }
-            Err(e) => {
-                eprintln!(
-                    "{name}: tick failed ({e:#}) -- retrying in {interval:?} ({:?} elapsed)",
-                    t0.elapsed()
-                );
-            }
-        }
-    }
 }

--- a/apps/indexer-rs/src/lib.rs
+++ b/apps/indexer-rs/src/lib.rs
@@ -25,6 +25,67 @@ pub type Api = OnlineClient<PolkadotConfig>;
 /// slower against a public RPC).
 pub type AtBlock = subxt::client::OnlineClientAtBlock<PolkadotConfig>;
 
+/// Retries `f` up to `attempts` times with a short linear backoff -- for
+/// transient failures on a single stateless call against an already-
+/// resolved `AtBlock` snapshot. Lighter weight than `ChainClient::call`
+/// (no reconnect, no fresh `at_current_block()` -- see `AtBlock`'s own doc
+/// comment for why repeating that per call is a real cost to avoid), but
+/// still tolerant of the transient failures live-tested against the public
+/// archive RPC under concurrent multi-job load (metagraphed-infra#138): a
+/// bare, unretried storage fetch failed outright on the ReconnectingRpcClient's
+/// 60s request_timeout under contention, even though the SAME call reliably
+/// succeeded in under a second once that contention cleared moments later.
+pub async fn retry_transient<T, F, Fut>(attempts: u32, mut f: F) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    let mut last_err: Option<anyhow::Error> = None;
+    for attempt in 0..attempts.max(1) {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(e) => last_err = Some(e),
+        }
+        if attempt + 1 < attempts {
+            tokio::time::sleep(Duration::from_millis(300 * (attempt as u64 + 1))).await;
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("retry_transient: no attempts made")))
+}
+
+/// Now, as epoch milliseconds -- the `captured_at` clock every poller job
+/// uses for its snapshot rows (wall-clock, not chain-derived: unlike
+/// main.rs's block-anchored `observed_at`, these are polls, not events tied
+/// to a specific block). Matches the same `int(time.time() * 1000)`
+/// convention the Python fetch-*.py scripts these jobs replace already used.
+pub fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_millis() as i64
+}
+
+/// rao rendered as an EXACT TAO decimal string for Postgres NUMERIC. Never
+/// routes through f64 (the same precision-loss shape as metagraphed#2588's
+/// "Mechanism B" -- an exact rao integer discarded to a lossy double one
+/// line before rendering). Postgres NUMERIC is exact-precision, so an exact
+/// decimal string here is exact forever, with no ~9M-TAO ceiling at all.
+/// Shared by main.rs's `tao_str` (via a `Value<()>` wrapper) and the
+/// poller's jobs that decode a raw `u128` rao amount directly.
+pub fn rao_to_tao_exact(rao: u128) -> String {
+    let whole = rao / 1_000_000_000;
+    let frac = rao % 1_000_000_000;
+    if frac == 0 {
+        return whole.to_string();
+    }
+    let mut frac_str = format!("{frac:09}");
+    while frac_str.ends_with('0') {
+        frac_str.pop();
+    }
+    format!("{whole}.{frac_str}")
+}
+
 pub fn redact_rpc_url(url: &str) -> String {
     let scheme_end = url.find("://").map(|idx| idx + 3).unwrap_or(0);
     let after_scheme = &url[scheme_end..];
@@ -216,5 +277,67 @@ mod tests {
             redact_rpc_url("ws://meta-fullnode-01-us-nyc1:9944"),
             "ws://meta-fullnode-01-us-nyc1:9944"
         );
+    }
+
+    #[test]
+    fn rao_to_tao_exact_renders_whole_amounts_with_no_decimal_point() {
+        assert_eq!(rao_to_tao_exact(5_000_000_000), "5");
+    }
+
+    #[test]
+    fn rao_to_tao_exact_trims_trailing_zeros_in_the_fraction() {
+        assert_eq!(rao_to_tao_exact(1_500_000_000), "1.5");
+    }
+
+    #[test]
+    fn rao_to_tao_exact_is_exact_above_the_f64_double_rounding_threshold() {
+        // 2**53 rao (~9.007M TAO) is where `rao as f64 / 1e9` starts silently
+        // losing precision -- this must stay exact past that point.
+        assert_eq!(rao_to_tao_exact(9_007_199_254_740_993), "9007199.254740993");
+    }
+
+    #[test]
+    fn rao_to_tao_exact_zero_is_zero() {
+        assert_eq!(rao_to_tao_exact(0), "0");
+    }
+
+    #[tokio::test]
+    async fn retry_transient_returns_immediately_on_first_success() {
+        let mut calls = 0;
+        let result = retry_transient(3, || {
+            calls += 1;
+            async { Ok::<_, anyhow::Error>(42) }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(calls, 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_transient_succeeds_after_transient_failures() {
+        let attempt = std::cell::Cell::new(0);
+        let result = retry_transient(3, || {
+            attempt.set(attempt.get() + 1);
+            async {
+                if attempt.get() < 3 {
+                    anyhow::bail!("transient");
+                }
+                Ok(attempt.get())
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_transient_gives_up_after_exhausting_attempts() {
+        let attempt = std::cell::Cell::new(0);
+        let result: Result<()> = retry_transient(3, || {
+            attempt.set(attempt.get() + 1);
+            async { anyhow::bail!("always fails") }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(attempt.get(), 3);
     }
 }

--- a/apps/indexer-rs/src/main.rs
+++ b/apps/indexer-rs/src/main.rs
@@ -404,24 +404,11 @@ fn plausible_netuid(n: Option<i64>) -> Option<i64> {
 }
 
 /// py `_tao`: rao rendered as an EXACT TAO decimal string for Postgres NUMERIC.
-/// Never routes through f64 (the old `n as f64 / RAO` here was the same precision-
-/// loss shape as metagraphed#2588's "Mechanism B" -- an exact rao integer discarded
-/// to a lossy double one line before rendering -- just for this Rust indexer's
-/// Postgres sink, which #2588's D1/SQLite-REAL framing never covered). Postgres
-/// NUMERIC is exact-precision, so an exact decimal string here is exact forever,
-/// with no ~9M-TAO ceiling at all.
+/// The actual conversion (`rao_to_tao_exact`) lives in lib.rs, shared with the
+/// poller's jobs -- this just adapts it to the `Value<()>` this file decodes
+/// events/extrinsics into.
 fn tao_str(v: &Value<()>) -> Option<String> {
-    let rao = int_of(v)?;
-    let whole = rao / 1_000_000_000;
-    let frac = rao % 1_000_000_000;
-    if frac == 0 {
-        return Some(whole.to_string());
-    }
-    let mut frac_str = format!("{frac:09}");
-    while frac_str.ends_with('0') {
-        frac_str.pop();
-    }
-    Some(format!("{whole}.{frac_str}"))
+    Some(backfill_rs::rao_to_tao_exact(int_of(v)?))
 }
 
 fn nth<'a>(fields: &'a [&'a Value<()>], i: usize) -> Option<&'a Value<()>> {


### PR DESCRIPTION
## Summary
Continues #6960 -- two more `roles/data-refresh-cron` jobs consolidated into the poller (metagraphed-infra#139), each replacing a Python systemd timer + HTTP sync round-trip with a direct chain-to-Postgres write:

- **account-balances**: `System::Account` full scan (~540k rows). Streamed and COPY-committed in 5k-row chunks (not buffered wholesale) -- a systemic decode failure aborts the scan, but chunks already committed stay committed (documented tradeoff, see the file's own header comment).
- **validator-nominators**: `SubtensorModule::Alpha` full scan (~760k rows), the source for both `validator_nominator_counts` and `nominator_positions` in one pass (mirrors `scripts/fetch-validator-nominator-counts.py`'s own reasoning for why one scan answers both questions). Buffered in memory since `share_fraction` needs the full per-(hotkey,netuid) group before it can be computed -- can't stream-chunk this one.

Both mirror `scripts/fetch-account-balances.py`'s own `MAX_ERROR_RATE` circuit breaker and reuse the COPY-to-staging + upsert shape `main.rs`'s own `flush()` already established at indexer scale. Neither table gets a prune step, matching the existing `handleAccountBalancesSync` / `handleValidatorNominatorCountsSync` / `handleNominatorPositionsSync` upsert-only semantics exactly.

## Real bugs caught by live-testing, not just review
- **validator-nominators**: `Alpha`'s `bits` field is a **u128**, not u64 (U64F64 = 64 integer + 64 fractional bits = 128 total) -- decoding as u64 failed outright on real values like `1844674407370955161600000000`. Fixed and re-verified against 25 real `Alpha` entries with zero errors.
- **Cross-job connection contention**: running two jobs concurrently against one shared `ChainClient` starved each other's RPC calls under load -- subnet-ownership's simple single-key fetches started hitting the `ReconnectingRpcClient`'s 60s `request_timeout` while account-balances streamed heavily on the same WebSocket. Each job now connects its own dedicated chain client, matching the existing per-job Postgres-connection isolation.
- Even with isolated connections, a single unretried storage fetch could still hit a transient timeout under concurrent multi-job load (server-side contention on the public RPC, not the connection itself). Added `retry_transient` (`src/lib.rs`) for individual post-`at`-fetch reads, without reintroducing the per-call `at_current_block()` overhead that motivated caching `AtBlock` in the first place.
- `main.rs`'s scheduler grew from `tokio::join!` (two jobs) to `futures::select_all` over named handles -- the old sequential-await-in-a-loop shape would have silently never noticed a panic in any job after the first, since every job's `run_loop` runs forever.

## Test plan
- [x] `cargo build --release` / `cargo test --release` -- 38 tests pass (25 pre-existing + 13 new/updated)
- [x] `cargo fmt --check` / `cargo clippy --release --all-targets` -- clean
- [x] `node scripts/scan-public-safety.mjs` -- clean
- [x] Live-verified against the real public archive RPC + a scratch local Postgres:
  - account-balances: correct chunked writes, exact-precision `free_tao`/`reserved_tao` (spot-checked real ss58 rows)
  - validator-nominators: 25 real `Alpha` entries decoded with zero errors after the u128 fix; `share_fraction` normalization unit-tested
  - subnet-ownership + account-balances run concurrently end-to-end with zero resolution failures (down from 5 before the connection-isolation + retry fixes)