### PR TITLE
feat(ui): multi-subnet history overlay in the compare drawer (#6885)

### DIFF
--- a/apps/ui/src/components/metagraphed/compare-overlay-chart.tsx
+++ b/apps/ui/src/components/metagraphed/compare-overlay-chart.tsx
@@ -1,0 +1,143 @@
+import { useMemo, useState } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { subnetHistoryQuery } from "@/lib/metagraphed/queries";
+import { EmptyState } from "@/components/metagraphed/states";
+import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
+import {
+  buildOverlaySeries,
+  overlayDomain,
+  OVERLAY_METRICS,
+  type OverlayMetric,
+  type SubnetHistory,
+} from "@/lib/metagraphed/compare-overlay";
+import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
+
+const VIEW_W = 640;
+const VIEW_H = 180;
+const PAD = 6;
+
+// #6885: overlay the /history series of several selected subnets on one chart,
+// reusing the same metric keys subnet-history-chart.tsx exposes per subnet. One
+// useQueries batch fans out the already-shipped per-subnet history endpoint; the
+// series math lives in the unit-tested compare-overlay model.
+export function CompareOverlayChart({ netuids }: { netuids: number[] }) {
+  const [metric, setMetric] = useState<OverlayMetric>("total_stake_tao");
+
+  const results = useQueries({
+    queries: netuids.map((netuid) => subnetHistoryQuery(netuid, "90d")),
+  });
+
+  const histories = useMemo<SubnetHistory[]>(
+    () =>
+      netuids.map((netuid, i) => ({
+        netuid,
+        points: (results[i]?.data?.data?.points ?? []) as SubnetHistoryPoint[],
+      })),
+    [netuids, results],
+  );
+
+  const metricDef = OVERLAY_METRICS.find((m) => m.key === metric)!;
+  const series = useMemo(() => buildOverlaySeries(histories, metric), [histories, metric]);
+  const domain = useMemo(() => overlayDomain(series), [series]);
+  const isLoading = results.some((r) => r.isLoading);
+  const fmt = (v: number) => (metricDef.isTao ? formatTao(v) : formatNumber(v));
+
+  const metricPicker = (
+    <div
+      role="tablist"
+      aria-label="Overlay metric"
+      className="inline-flex flex-wrap rounded-md border border-border bg-surface/40 p-0.5"
+    >
+      {OVERLAY_METRICS.map((m) => (
+        <button
+          key={m.key}
+          type="button"
+          role="tab"
+          aria-selected={m.key === metric}
+          onClick={() => setMetric(m.key)}
+          className={classNames(
+            "px-2.5 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+            m.key === metric ? "bg-ink-strong text-paper" : "text-ink-muted hover:text-ink-strong",
+          )}
+        >
+          {m.label}
+        </button>
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="space-y-3 border-t border-border pt-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+          History overlay
+        </span>
+        {metricPicker}
+      </div>
+
+      {isLoading ? (
+        <div className="h-44 w-full animate-pulse rounded-xl border border-border bg-card" />
+      ) : series.length === 0 || domain == null ? (
+        <EmptyState
+          title="No overlapping history"
+          description="None of the selected subnets has enough on-chain history for this metric yet. Try another metric or different subnets."
+        />
+      ) : (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          <svg
+            viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+            width="100%"
+            height={VIEW_H}
+            preserveAspectRatio="none"
+            role="img"
+            aria-label={`${metricDef.label} over time overlaid across ${series.length} subnet${series.length === 1 ? "" : "s"}`}
+          >
+            {series.map((s) => (
+              <polyline
+                key={s.netuid}
+                fill="none"
+                stroke={s.color}
+                strokeWidth={1.5}
+                strokeLinejoin="round"
+                strokeLinecap="round"
+                points={polylinePoints(s.values, domain)}
+                vectorEffect="non-scaling-stroke"
+              />
+            ))}
+          </svg>
+          {/* Legend: one swatch per subnet with its latest value. */}
+          <ul className="flex flex-wrap gap-x-4 gap-y-1.5">
+            {series.map((s) => (
+              <li key={s.netuid} className="inline-flex items-center gap-1.5 font-mono text-[11px]">
+                <span
+                  aria-hidden
+                  className="inline-block size-2.5 rounded-sm"
+                  style={{ backgroundColor: s.color }}
+                />
+                <span className="text-ink-strong">SN{s.netuid}</span>
+                {s.last != null ? <span className="text-ink-muted">{fmt(s.last)}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Map a value series onto the shared [min,max] domain across the fixed viewBox,
+// oldest→newest left→right. A flat domain (min===max) pins to the vertical middle.
+function polylinePoints(values: number[], domain: { min: number; max: number }): string {
+  const span = domain.max - domain.min;
+  const n = values.length;
+  const innerW = VIEW_W - PAD * 2;
+  const innerH = VIEW_H - PAD * 2;
+  return values
+    .map((v, i) => {
+      const x = PAD + (n <= 1 ? innerW / 2 : (i / (n - 1)) * innerW);
+      const t = span === 0 ? 0.5 : (v - domain.min) / span;
+      const y = PAD + (1 - t) * innerH; // invert: higher value → higher on screen
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}

--- a/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/subnets-compare-drawer.tsx
@@ -7,6 +7,7 @@ import { compareQuery } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { CompareSubnet, HealthState } from "@/lib/metagraphed/types";
 import { HealthPill, CurationChip } from "@jsonbored/ui-kit";
+import { CompareOverlayChart } from "@/components/metagraphed/compare-overlay-chart";
 
 /**
  * Floating bottom dock + expandable side-by-side compare drawer for selected
@@ -16,6 +17,9 @@ import { HealthPill, CurationChip } from "@jsonbored/ui-kit";
 export function SubnetsCompareDrawer() {
   const { selected, max, remove, clear } = useCompareSelection();
   const [expanded, setExpanded] = useState(false);
+  // #6885: the expanded view has two panes — the existing metrics grid and a new
+  // multi-subnet history overlay chart.
+  const [view, setView] = useState<"metrics" | "chart">("metrics");
 
   if (selected.length === 0) return null;
 
@@ -81,7 +85,38 @@ export function SubnetsCompareDrawer() {
           </div>
 
           {/* Expanded side-by-side */}
-          {expanded && selected.length >= 2 ? <CompareGrid netuids={selected} /> : null}
+          {expanded && selected.length >= 2 ? (
+            <div className="space-y-3">
+              <div
+                role="tablist"
+                aria-label="Compare view"
+                className="inline-flex rounded-md border border-border bg-surface/40 p-0.5"
+              >
+                {(["metrics", "chart"] as const).map((v) => (
+                  <button
+                    key={v}
+                    type="button"
+                    role="tab"
+                    aria-selected={view === v}
+                    onClick={() => setView(v)}
+                    className={classNames(
+                      "px-3 py-1 text-[11px] font-mono uppercase tracking-wider rounded transition-colors",
+                      view === v
+                        ? "bg-ink-strong text-paper"
+                        : "text-ink-muted hover:text-ink-strong",
+                    )}
+                  >
+                    {v === "metrics" ? "Metrics" : "Chart"}
+                  </button>
+                ))}
+              </div>
+              {view === "metrics" ? (
+                <CompareGrid netuids={selected} />
+              ) : (
+                <CompareOverlayChart netuids={selected} />
+              )}
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/apps/ui/src/lib/metagraphed/compare-overlay.test.ts
+++ b/apps/ui/src/lib/metagraphed/compare-overlay.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOverlaySeries,
+  overlayDomain,
+  overlaySeriesColor,
+  OVERLAY_SERIES_COLORS,
+  type SubnetHistory,
+} from "./compare-overlay";
+
+const hist = (netuid: number, ...stakes: (number | undefined)[]): SubnetHistory => ({
+  netuid,
+  points: stakes.map((v, i) => ({
+    snapshot_date: `2026-07-${String(i + 1).padStart(2, "0")}`,
+    total_stake_tao: v,
+  })),
+});
+
+describe("overlaySeriesColor", () => {
+  it("assigns distinct colors by index and cycles past the palette length", () => {
+    expect(overlaySeriesColor(0)).toBe(OVERLAY_SERIES_COLORS[0]);
+    expect(overlaySeriesColor(1)).toBe(OVERLAY_SERIES_COLORS[1]);
+    const n = OVERLAY_SERIES_COLORS.length;
+    expect(overlaySeriesColor(n)).toBe(OVERLAY_SERIES_COLORS[0]); // wraps
+    expect(overlaySeriesColor(n + 2)).toBe(OVERLAY_SERIES_COLORS[2]);
+  });
+});
+
+describe("buildOverlaySeries", () => {
+  it("builds one series per subnet with finite values, in input order", () => {
+    const series = buildOverlaySeries([hist(1, 10, 20, 30), hist(7, 5, 6)], "total_stake_tao");
+    expect(series.map((s) => s.netuid)).toEqual([1, 7]);
+    expect(series[0]!.values).toEqual([10, 20, 30]);
+    expect(series[0]!.last).toBe(30);
+    expect(series[1]!.last).toBe(6);
+    // stable colors by position
+    expect(series[0]!.color).toBe(OVERLAY_SERIES_COLORS[0]);
+    expect(series[1]!.color).toBe(OVERLAY_SERIES_COLORS[1]);
+  });
+
+  it("filters out non-finite values but keeps the finite ones", () => {
+    const series = buildOverlaySeries([hist(1, 10, undefined, 30)], "total_stake_tao");
+    expect(series[0]!.values).toEqual([10, 30]);
+    expect(series[0]!.last).toBe(30);
+  });
+
+  it("drops a subnet entirely when it has no finite values for the metric", () => {
+    const series = buildOverlaySeries(
+      [hist(1, 10, 20), hist(7, undefined, undefined)],
+      "total_stake_tao",
+    );
+    expect(series.map((s) => s.netuid)).toEqual([1]);
+  });
+
+  it("returns an empty array for no histories", () => {
+    expect(buildOverlaySeries([], "total_stake_tao")).toEqual([]);
+  });
+
+  it("reads the requested metric key, not a fixed one", () => {
+    const h: SubnetHistory = {
+      netuid: 1,
+      points: [
+        { snapshot_date: "2026-07-01", neuron_count: 100, total_stake_tao: 5 },
+        { snapshot_date: "2026-07-02", neuron_count: 110, total_stake_tao: 6 },
+      ],
+    };
+    expect(buildOverlaySeries([h], "neuron_count")[0]!.values).toEqual([100, 110]);
+    expect(buildOverlaySeries([h], "total_stake_tao")[0]!.values).toEqual([5, 6]);
+  });
+});
+
+describe("overlayDomain", () => {
+  it("spans the min and max across every series", () => {
+    const series = buildOverlaySeries([hist(1, 10, 40), hist(7, 5, 25)], "total_stake_tao");
+    expect(overlayDomain(series)).toEqual({ min: 5, max: 40 });
+  });
+
+  it("returns null when there is nothing to plot", () => {
+    expect(overlayDomain([])).toBeNull();
+    expect(overlayDomain(buildOverlaySeries([hist(1)], "total_stake_tao"))).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/compare-overlay.ts
+++ b/apps/ui/src/lib/metagraphed/compare-overlay.ts
@@ -1,0 +1,88 @@
+import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
+
+// #6885: overlay model for the compare drawer's multi-subnet history chart. Pure
+// so the metric-extraction / series-alignment logic is unit-tested independent of
+// the React chart. Reuses the same metric keys subnet-history-chart.tsx already
+// exposes per subnet — no new metric is invented.
+
+export type OverlayMetric =
+  "neuron_count" | "validator_count" | "total_stake_tao" | "total_emission_tao";
+
+export const OVERLAY_METRICS: { key: OverlayMetric; label: string; isTao: boolean }[] = [
+  { key: "total_stake_tao", label: "Total stake", isTao: true },
+  { key: "total_emission_tao", label: "Total emission", isTao: true },
+  { key: "neuron_count", label: "Neurons", isTao: false },
+  { key: "validator_count", label: "Validators", isTao: false },
+];
+
+// The app's dedicated 6-slot chart palette (--chart-1..6 in ui-kit's theme), so
+// each overlaid subnet series gets a distinct, theme-aware color. Cycles if there
+// are more subnets than colors (the compare cap keeps this small in practice).
+export const OVERLAY_SERIES_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+];
+
+export function overlaySeriesColor(index: number): string {
+  return OVERLAY_SERIES_COLORS[index % OVERLAY_SERIES_COLORS.length]!;
+}
+
+export interface SubnetHistory {
+  netuid: number;
+  points: SubnetHistoryPoint[];
+}
+
+export interface OverlaySeries {
+  netuid: number;
+  color: string;
+  /** Finite metric values in chronological order (oldest→newest), API order preserved. */
+  values: number[];
+  /** The most recent finite value, or null when the series is empty. */
+  last: number | null;
+}
+
+/**
+ * Build one overlay series per subnet for the chosen metric. Subnets with no
+ * finite values for that metric are dropped (so an empty subnet never renders a
+ * flat/blank line); the returned array preserves input order for stable colors.
+ */
+export function buildOverlaySeries(
+  histories: readonly SubnetHistory[],
+  metric: OverlayMetric,
+): OverlaySeries[] {
+  const out: OverlaySeries[] = [];
+  histories.forEach((h, i) => {
+    const values = (h.points ?? [])
+      .map((p) => p[metric])
+      .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+    if (values.length === 0) return;
+    out.push({
+      netuid: h.netuid,
+      color: overlaySeriesColor(i),
+      values,
+      last: values[values.length - 1] ?? null,
+    });
+  });
+  return out;
+}
+
+/** Shared [min,max] domain across every overlaid series, so they're comparable on
+ *  one axis. Returns null when there's nothing to plot. */
+export function overlayDomain(
+  series: readonly OverlaySeries[],
+): { min: number; max: number } | null {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const s of series) {
+    for (const v of s.values) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+  return { min, max };
+}


### PR DESCRIPTION
## Summary

The compare drawer (`SubnetsCompareDrawer`) already lets a user select multiple subnets and see them side by side in a metrics grid (`CompareGrid`), but there was no way to overlay their **history** on one chart. This adds a Metrics ⇄ Chart tab to the expanded drawer; the Chart pane overlays each selected subnet's time-series on a single axis.

Direct precedent: Tao Swap's "Multi-chart" tool, per the issue.

## What changed

- **New Chart pane** in the drawer's expanded view, alongside the existing `CompareGrid` (a `Metrics`/`Chart` tab toggle). `CompareOverlayChart` fans out the already-shipped `GET /subnets/{netuid}/history` endpoint with one `useQueries` batch over the **same `selected` netuids** `CompareGrid` receives — no new endpoint, no new selection state, the existing max-selection cap untouched.
- **Metric picker** over the exact keys `subnet-history-chart.tsx` already exposes per subnet — Total stake / Total emission / Neurons / Validators — no invented metric.
- **One series per subnet**, overlaid on a shared `[min,max]` domain so they're comparable, each in a distinct theme-aware color from the app's `--chart-1..6` palette, with a legend showing each subnet's latest value. The SVG carries an `aria-label` describing the overlay.
- The series/domain math is a **pure, unit-tested model** (`compare-overlay.ts`): finite-value extraction per metric, subnets with no data for the metric dropped, stable color-by-index, shared domain.

## Tests

`compare-overlay.test.ts` — 8 cases: color cycling, per-subnet series build, non-finite filtering, dropping empty subnets, metric-key selection, and shared-domain min/max (incl. the empty/null cases).

## Validation

- `npm test --workspace=apps/ui` → 1282 passed (8 new)
- `npm run typecheck` / `npm run lint` / `npx prettier --check` (`--workspace=apps/ui`) → clean
- `npm run build --workspace=apps/ui` → clean

## Screenshots — before = Metrics grid only · after = new Chart tab with the overlay

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-before-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-before-desktop-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-after-desktop-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-after-desktop-light.png)<br><sub>after</sub> |
| Desktop · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-before-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-before-desktop-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-after-desktop-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-after-desktop-dark.png)<br><sub>after</sub> |
| Tablet · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-before-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-before-tablet-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-after-tablet-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-after-tablet-light.png)<br><sub>after</sub> |
| Tablet · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-before-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-before-tablet-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-after-tablet-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-after-tablet-dark.png)<br><sub>after</sub> |
| Mobile · Light | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-before-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-before-mobile-light.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-after-mobile-light.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-after-mobile-light.png)<br><sub>after</sub> |
| Mobile · Dark | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-before-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-before-mobile-dark.png)<br><sub>before</sub> | [<img src="https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-after-mobile-dark.png" width="260">](https://raw.githubusercontent.com/shin-core/metagraphed/screenshots/6885/6885-overlay-after-mobile-dark.png)<br><sub>after</sub> |

Closes #6885
