### PR TITLE
fix(data-api): retry once on a Hyperdrive connection-closed error

### DIFF
--- a/tests/data-api.test.mjs
+++ b/tests/data-api.test.mjs
@@ -129,6 +129,16 @@ const neuronStakeByHotkeyQueryFailure = vi.hoisted(() => ({ error: null }));
 // catch (captureDataApiError(err, url.pathname)), unlike every other flag
 // above which targets a route with its own dedicated fallback.
 const accountHistoryQueryFailure = vi.hoisted(() => ({ error: null }));
+// State for the GET /api/v1/blocks/:ref retry test (METAGRAPHED-7) only. Unlike every failure
+// hook above (which rejects every matching call for the test's duration), remainingFailures
+// counts DOWN so a test can simulate "fails once, then the retry with a fresh client succeeds"
+// (remainingFailures: 1) vs. "fails on both the original attempt and the retry" (2+). `code`
+// controls whether the rejection looks like postgres.js's own retryable connection error
+// (RETRYABLE_CONNECTION_ERROR_CODES in workers/data-api.mjs) or an unrelated error.
+const blockDetailConnectionFailure = vi.hoisted(() => ({
+  remainingFailures: 0,
+  code: "CONNECTION_CLOSED",
+}));
 
 vi.mock("postgres", () => ({
   default: () => {
@@ -296,6 +306,20 @@ vi.mock("postgres", () => ({
       if (/SELECT DISTINCT ON \(account\)/.test(text)) {
         return Promise.resolve(accountIdentityLatestHashes.current);
       }
+      if (
+        blockDetailConnectionFailure.remainingFailures > 0 &&
+        /FROM blocks WHERE block_number = \?/.test(text)
+      ) {
+        blockDetailConnectionFailure.remainingFailures -= 1;
+        return Promise.reject(
+          Object.assign(
+            new Error(
+              `write ${blockDetailConnectionFailure.code} mock.hyperdrive.local:5432`,
+            ),
+            { code: blockDetailConnectionFailure.code },
+          ),
+        );
+      }
       if (mockQueue.current.length) {
         return Promise.resolve(mockQueue.current.shift());
       }
@@ -433,6 +457,8 @@ beforeEach(() => {
   featuredValidatorsQueryFailure.error = null;
   accountIdentityJoinRows.current = [];
   accountIdentityJoinQueryFailure.error = null;
+  blockDetailConnectionFailure.remainingFailures = 0;
+  blockDetailConnectionFailure.code = "CONNECTION_CLOSED";
   mockRows.current = [
     {
       block_number: "123",
@@ -899,6 +925,37 @@ test("GET /api/v1/blocks/:ref on an unknown block skips the neighbor query", asy
   expect(body.prev_block_number).toBeNull();
   expect(body.next_block_number).toBeNull();
   expect(sqlCalls.length).toBe(2); // SET + the main lookup, no neighbor query
+});
+
+test("GET /api/v1/blocks/:ref retries once with a fresh client after a Hyperdrive CONNECTION_CLOSED, then succeeds (METAGRAPHED-7)", async () => {
+  blockDetailConnectionFailure.remainingFailures = 1;
+  // 4 slots: SET (attempt 1, discarded before the connection error), SET (attempt 2), the
+  // block-lookup row (attempt 2, the one that failed on attempt 1), the neighbor lookup.
+  mockQueue.current = [[], [], [BLOCK_ROW], [{ prev: 8586299, next: 8586301 }]];
+  const res = await req("/api/v1/blocks/8586300");
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.block.block_number).toBe(8586300);
+  expect(body.prev_block_number).toBe(8586299);
+  expect(body.next_block_number).toBe(8586301);
+});
+
+test("GET /api/v1/blocks/:ref falls through to the generic 502 when the retry also hits a connection error (METAGRAPHED-7)", async () => {
+  blockDetailConnectionFailure.remainingFailures = 2; // fails the original attempt AND the retry
+  const res = await req("/api/v1/blocks/8586300");
+  expect(res.status).toBe(502);
+  const body = await res.json();
+  expect(body.error).toBe("data query failed");
+});
+
+test("GET /api/v1/blocks/:ref does not retry a non-connection error, even once (METAGRAPHED-7 scoping)", async () => {
+  // remainingFailures would allow a "successful" retry if the code retried blindly -- asserting
+  // 502 here proves the retry is scoped to RETRYABLE_CONNECTION_ERROR_CODES, not every error.
+  blockDetailConnectionFailure.remainingFailures = 1;
+  blockDetailConnectionFailure.code = "SOME_OTHER_ERROR";
+  mockQueue.current = [[], [], [BLOCK_ROW], [{ prev: 8586299, next: 8586301 }]];
+  const res = await req("/api/v1/blocks/8586300");
+  expect(res.status).toBe(502);
 });
 
 test("GET /api/v1/blocks/summary is matched before /blocks/:ref (never treats 'summary' as a ref)", async () => {

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -383,6 +383,21 @@ function captureDataApiError(err, route) {
 const DATA_API_READ_TRANSACTION = "isolation level repeatable read read only";
 const ANALYTICS_DAY_MS = 24 * 60 * 60 * 1000;
 
+// METAGRAPHED-7: Hyperdrive closes/recycles pooled connections out from under a live query
+// under load -- postgres.js's Cloudflare build (node_modules/postgres/cf/src/connection.js)
+// surfaces this as one of these three `error.code`s (Errors.connection in cf/src/errors.js),
+// all transport-layer, never a query-correctness problem: CONNECTION_CLOSED (socket closed
+// mid-query), CONNECTION_DESTROYED (pool tore the connection down), CONNECT_TIMEOUT (the
+// initial handshake itself timed out). Retried once below, only for the read-only route
+// dispatcher (already scoped to a single sql.begin() transaction, so nothing can have
+// partially committed) -- never for the write/sync routes, where blindly retrying a batch
+// that may have partially applied would risk double-writes.
+const RETRYABLE_CONNECTION_ERROR_CODES = new Set([
+  "CONNECTION_CLOSED",
+  "CONNECTION_DESTROYED",
+  "CONNECT_TIMEOUT",
+]);
+
 // Resolve a ?window= label to a cutoff epoch-ms, matching the D1 loaders'
 // `Date.now() - days*DAY_MS` exactly. An unrecognized label falls back to the
 // map's default rather than erroring -- entities.mjs's own validation already
@@ -4511,7 +4526,7 @@ export default {
     // own, separately-gated big-int handling in src/extrinsics.mjs runs
     // instead; after the cast the wire type is `text` (OID 25), which this
     // override never sees.
-    const sql = postgres(env.HYPERDRIVE.connectionString, {
+    const hyperdriveConnectionOptions = {
       max: 5,
       prepare: false,
       fetch_types: false,
@@ -4524,7 +4539,8 @@ export default {
           parse: parseJsonPreservingBigIntegers,
         },
       },
-    });
+    };
+    const sql = postgres(env.HYPERDRIVE.connectionString, hyperdriveConnectionOptions);
 
     try {
       // sql.begin() reserves ONE physical connection for every query below,
@@ -4537,7 +4553,7 @@ export default {
       // READ-ONLY invariant (top of file) at the database level too, and
       // repeatable read keeps multi-statement analytics responses on one
       // stable snapshot while preserving each route's bounded timeouts.
-      return await sql.begin(DATA_API_READ_TRANSACTION, async (sql) => {
+      const dispatchReadRoutes = async (sql) => {
         await sql`SET statement_timeout = '3000ms'`;
 
         // GET /api/v1/blocks (D1 serving-cutover, #4656 followup): the recent-block
@@ -8486,7 +8502,23 @@ export default {
         }
 
         return json({ error: "not found" }, 404);
-      });
+      };
+
+      // METAGRAPHED-7: retry once, with a freshly created client, when Hyperdrive closed or
+      // destroyed the pooled connection out from under this transaction (see
+      // RETRYABLE_CONNECTION_ERROR_CODES's own header for why this is safe here specifically
+      // -- read-only dispatcher, one sql.begin() transaction, nothing can have partially
+      // committed). Any other error (a real query/schema problem, an unrecoverable retry)
+      // falls through to the outer catch below unchanged.
+      let activeSql = sql;
+      for (let attempt = 0; ; attempt += 1) {
+        try {
+          return await activeSql.begin(DATA_API_READ_TRANSACTION, dispatchReadRoutes);
+        } catch (err) {
+          if (attempt > 0 || !RETRYABLE_CONNECTION_ERROR_CODES.has(err?.code)) throw err;
+          activeSql = postgres(env.HYPERDRIVE.connectionString, hyperdriveConnectionOptions);
+        }
+      }
     } catch (err) {
       // Log internally (Wrangler observability) but NEVER leak DB error details
       // (schema, table, or connection info) to API clients.

--- a/workers/data-api.mjs
+++ b/workers/data-api.mjs
@@ -4540,7 +4540,10 @@ export default {
         },
       },
     };
-    const sql = postgres(env.HYPERDRIVE.connectionString, hyperdriveConnectionOptions);
+    const sql = postgres(
+      env.HYPERDRIVE.connectionString,
+      hyperdriveConnectionOptions,
+    );
 
     try {
       // sql.begin() reserves ONE physical connection for every query below,
@@ -8513,10 +8516,17 @@ export default {
       let activeSql = sql;
       for (let attempt = 0; ; attempt += 1) {
         try {
-          return await activeSql.begin(DATA_API_READ_TRANSACTION, dispatchReadRoutes);
+          return await activeSql.begin(
+            DATA_API_READ_TRANSACTION,
+            dispatchReadRoutes,
+          );
         } catch (err) {
-          if (attempt > 0 || !RETRYABLE_CONNECTION_ERROR_CODES.has(err?.code)) throw err;
-          activeSql = postgres(env.HYPERDRIVE.connectionString, hyperdriveConnectionOptions);
+          if (attempt > 0 || !RETRYABLE_CONNECTION_ERROR_CODES.has(err?.code))
+            throw err;
+          activeSql = postgres(
+            env.HYPERDRIVE.connectionString,
+            hyperdriveConnectionOptions,
+          );
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- `METAGRAPHED-7` fired 366+ times over 15h in production: Hyperdrive closes/recycles a pooled connection mid-query under load, surfacing to API clients as a bare 502 with no retry.
- The GET-route dispatcher already runs the whole request inside one `sql.begin()` read-only transaction, so retrying the entire transaction once with a freshly created client is safe (nothing can have partially committed).
- Scoped to exactly the three transport-layer postgres.js error codes (`CONNECTION_CLOSED`, `CONNECTION_DESTROYED`, `CONNECT_TIMEOUT`); any other error still falls straight through to the existing 502 path unchanged. Write/sync routes are untouched.

## Validation
- `npx vitest run tests/data-api.test.mjs` — 515/515 passing (3 new tests: retry-then-succeed, retry-also-fails-falls-through-to-502, non-retryable-error-not-retried)
- `npx eslint workers/data-api.mjs tests/data-api.test.mjs` — clean
- `node --check workers/data-api.mjs` — syntax OK
- Verified via coverage report that every changed line is exercised by the new tests