### PR TITLE
fix(ci): add fork-safe PR preview deploy pipeline for apps/ui

### DIFF
--- a/.github/workflows/ui-preview-deploy.yml
+++ b/.github/workflows/ui-preview-deploy.yml
@@ -1,0 +1,302 @@
+name: UI Preview Deploy
+
+# Deploy half of the fork-safe per-PR preview pipeline (see "UI Preview Build"'s own header for the
+# full rationale — mirrors JSONbored/loopover's identical ui-preview-deploy.yml). Triggered when "UI
+# Preview Build" completes. Because it runs on `workflow_run`, GitHub always executes the workflow
+# definition from the DEFAULT BRANCH (never the fork's), so it is trusted and may use secrets. It
+# downloads the built artifact (it never checks out or runs PR/fork source — it only uploads the
+# already-built bundle), deploys a transient preview version, and records the GitHub Deployment +
+# status that loopover's review bot reads to render the "after" screenshot.
+#
+# Security boundary: the BUILD ran fork code with NO secrets; this DEPLOY has secrets but runs NO fork
+# code (wrangler only uploads the bundle — fork code executes solely inside the isolated workers.dev
+# preview when the URL is later visited). This is what makes fork-PR previews safe.
+#
+# Required repo secrets (already present — used by publish-cloudflare.yml / check-worker-deploy-drift.yml):
+#   CLOUDFLARE_API_TOKEN   — token with "Workers Scripts:Edit" on the account
+#   CLOUDFLARE_ACCOUNT_ID  — the Cloudflare account id that owns metagraphed-ui
+
+on:
+  workflow_run:
+    workflows: ["UI Preview Build"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read # download the build artifact from the triggering run
+  deployments: write # record the preview Deployment loopover's review bot reads
+  pull-requests: read # resolve the (often fork) PR for this build by matching head SHA
+
+concurrency:
+  group: ui-preview-deploy-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy UI preview version
+    # Bind the ONE job that holds Cloudflare credentials to a GitHub deployment environment, so the org
+    # can attach approval gating and/or environment-scoped secrets to it. Unprotected by default (so
+    # previews stay automatic); add required reviewers in Settings → Environments → preview to require a
+    # manual approval before any (fork) preview deploys.
+    environment:
+      name: preview
+      url: ${{ steps.upload.outputs.preview_url }}
+    # Only successful build runs that originated from a pull_request (incl forks). A path-skipped or
+    # failed build still fires workflow_run with a non-success conclusion — ignore those.
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check Cloudflare secrets
+        id: cfg
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID not set — skipping preview deploy (before-only screenshots)."
+          fi
+
+      - name: Setup Node
+        if: steps.cfg.outputs.ready == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.23.1
+
+      # Pinned to this repo's own root wrangler devDependency version, installed globally since this
+      # job never checks out the repo (only the artifact) so node_modules/wrangler isn't available.
+      - name: Install trusted Wrangler
+        if: steps.cfg.outputs.ready == 'true'
+        run: npm install --global wrangler@4.110.0
+
+      # Cross-run download: the artifact lives on the triggering build run, not this one.
+      - name: Download built UI artifact
+        if: steps.cfg.outputs.ready == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ui-preview-dist
+          path: preview-dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      # The artifact was produced by the UNTRUSTED build (fork code). Validate it before handing it to
+      # wrangler: reject symlinks (a path-traversal / exfil vector when the bundle is processed), require
+      # the expected SSR build structure, and allowlist file extensions so a malicious build can't smuggle
+      # scripts/binaries/unexpected paths into the deploy.
+      - name: Validate downloaded artifact
+        if: steps.cfg.outputs.ready == 'true'
+        run: |
+          set -euo pipefail
+          cd preview-dist
+          # 1) No symlinks anywhere in the bundle.
+          symlinks="$(find . -type l)"
+          if [ -n "$symlinks" ]; then
+            echo "::error::Artifact contains symlinks — refusing to deploy:"
+            printf '%s\n' "$symlinks"
+            exit 1
+          fi
+          # 2) Required SSR build structure (server worker entry + public assets dir — apps/ui's own
+          #    Nitro cloudflare-module output names it "public", not "client").
+          test -f server/index.mjs || { echo "::error::artifact missing server/index.mjs"; exit 1; }
+          test -d public || { echo "::error::artifact missing public/ assets dir"; exit 1; }
+          # 3) Allowlist file extensions — fail on anything that isn't a normal web/build output (blocks
+          #    smuggled scripts/binaries). A few extensionless CF asset files are explicitly permitted.
+          unexpected="$(find . -regextype posix-extended -type f \
+            -not -iregex '.*\.(mjs|js|cjs|map|json|css|html?|txt|svg|png|jpe?g|gif|webp|avif|ico|bmp|woff2?|ttf|otf|eot|wasm|xml|webmanifest|md|csv|zip|wgsl|glb|gltf)$' \
+            -not -name '_headers' -not -name '_redirects' -not -name '_routes.json' -not -name '.assetsignore')"
+          if [ -n "$unexpected" ]; then
+            echo "::error::Artifact contains unexpected file types — refusing to deploy:"
+            printf '%s\n' "$unexpected"
+            exit 1
+          fi
+          echo "Artifact validated: no symlinks, expected SSR structure, allowlisted file types only."
+
+      # The Wrangler config is written HERE (trusted) — never taken from the PR — so a fork cannot
+      # control bindings, routes, or vars. It points at the downloaded built bundle. It deliberately
+      # OMITS the production custom-domain route (metagraph.sh): `wrangler versions upload` creates a
+      # 0%-traffic preview version (a workers.dev URL) and applies no routes, so the route is unused
+      # here — and omitting it guarantees that even a future switch to `wrangler deploy` could never
+      # point fork-built code at the production domain. Do not add a `routes` block to this preview
+      # config. Deliberately NOT the wrangler.json the untrusted build step generated (excluded from
+      # the uploaded artifact) — a malicious PR could otherwise smuggle bindings/vars through
+      # apps/ui/wrangler.jsonc.
+      - name: Write trusted preview Wrangler config
+        if: steps.cfg.outputs.ready == 'true'
+        run: |
+          cat > preview-dist/server/wrangler.preview.json <<'JSON'
+          {
+            "compatibility_date": "2026-07-17",
+            "name": "metagraphed-ui",
+            "workers_dev": true,
+            "preview_urls": true,
+            "compatibility_flags": ["nodejs_compat"],
+            "placement": {
+              "mode": "smart"
+            },
+            "observability": {
+              "enabled": true,
+              "logs": {
+                "enabled": true,
+                "head_sampling_rate": 1
+              },
+              "traces": {
+                "enabled": true,
+                "head_sampling_rate": 1
+              }
+            },
+            "vars": {
+              "VITE_METAGRAPH_API_BASE": "https://api.metagraph.sh"
+            },
+            "main": "index.mjs",
+            "assets": {
+              "binding": "ASSETS",
+              "directory": "../public"
+            },
+            "no_bundle": true,
+            "rules": [
+              {
+                "type": "ESModule",
+                "globs": ["**/*.mjs", "**/*.js"]
+              }
+            ]
+          }
+          JSON
+
+      - name: Upload preview version
+        id: upload
+        if: steps.cfg.outputs.ready == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -o pipefail
+          out=$(wrangler versions upload --config preview-dist/server/wrangler.preview.json 2>&1 | tee /dev/stderr)
+          # Take a workers.dev URL that belongs to the metagraphed-ui worker, so any other URL in the
+          # logs (or a changed output format) can't be recorded as the preview by mistake. Tolerant of
+          # the version-alias prefix (`<alias>-metagraphed-ui.<sub>.workers.dev`).
+          url=$(printf '%s\n' "$out" | grep -oiE 'https://[a-z0-9.-]+\.workers\.dev' | grep -i 'metagraphed-ui' | head -n1)
+          if [ -z "$url" ]; then
+            echo "::error::Could not parse an expected metagraphed-ui preview URL from wrangler output"
+            exit 1
+          fi
+          echo "preview_url=$url" >> "$GITHUB_OUTPUT"
+          echo "Preview: $url"
+
+      - name: Record deployment for loopover
+        if: steps.cfg.outputs.ready == 'true' && steps.upload.outputs.preview_url != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const url = ${{ toJSON(steps.upload.outputs.preview_url) }};
+            // Trust only the GitHub-set head_sha — never fork-supplied data.
+            const sha = context.payload.workflow_run.head_sha;
+            const slug = `${context.repo.owner}/${context.repo.repo}`;
+            // Resolve the PR for this build. Both signals below are EMPTY for fork PRs (the common case
+            // here): workflow_run.pull_requests is empty for cross-repo runs, and the commit→PR
+            // association API doesn't index a fork-head commit from the base repo. So we ALSO match the
+            // open PR whose head points at this exact build SHA — head.sha is GitHub-set (the base repo
+            // tracks the fork head as refs/pull/N/head), so it's safe to trust even for forks.
+            let prNumber = context.payload.workflow_run.pull_requests?.[0]?.number;
+            if (!prNumber) {
+              const assoc = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+              });
+              prNumber = assoc.data.find((p) => p.state === "open" && p.base.repo.full_name === slug)?.number;
+            }
+            if (!prNumber) {
+              // Fork-safe fallback: scan open PRs for the one whose head is this build's commit.
+              const openPrs = await github.paginate(github.rest.pulls.list, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                per_page: 100,
+              });
+              prNumber = openPrs.find((p) => p.head.sha === sha)?.number;
+            }
+            if (!prNumber) {
+              core.setFailed(`Could not resolve an open PR for ${sha} — skipping deployment record.`);
+              return;
+            }
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+              environment: `preview/pr-${prNumber}`,
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              description: "metagraphed UI preview",
+              // loopover's review bot reads `pr` here to re-review this exact PR once the preview is live.
+              payload: JSON.stringify({ pr: prNumber, head_sha: sha }),
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: "success",
+              environment: `preview/pr-${prNumber}`,
+              environment_url: url,
+              description: "Preview ready",
+            });
+            core.notice(`Preview deployment recorded for PR #${prNumber}: ${url}`);
+
+      - name: Record FAILED deployment for loopover
+        # Runs when an earlier step in this job failed (artifact validation rejected the bundle, the
+        # wrangler upload errored, etc.) — i.e. a deploy was attempted but never produced a preview.
+        # Record a `failure` deployment_status so loopover's review bot flips the "after" cell from an
+        # eternal spinner to a terminal "preview deploy failed" card, instead of waiting forever for a
+        # success event that will never come. Gated on CF creds so a credential-less skip records nothing.
+        if: failure() && steps.cfg.outputs.ready == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const sha = context.payload.workflow_run.head_sha; // GitHub-set; never fork-supplied
+            const slug = `${context.repo.owner}/${context.repo.repo}`;
+            // Same fork-safe PR resolution as the success step above.
+            let prNumber = context.payload.workflow_run.pull_requests?.[0]?.number;
+            if (!prNumber) {
+              const assoc = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+              });
+              prNumber = assoc.data.find((p) => p.state === "open" && p.base.repo.full_name === slug)?.number;
+            }
+            if (!prNumber) {
+              const openPrs = await github.paginate(github.rest.pulls.list, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                per_page: 100,
+              });
+              prNumber = openPrs.find((p) => p.head.sha === sha)?.number;
+            }
+            if (!prNumber) {
+              core.warning(`Preview deploy failed but could not resolve a PR for ${sha} — no failure status recorded.`);
+              return;
+            }
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+              environment: `preview/pr-${prNumber}`,
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              description: "metagraphed UI preview (failed)",
+              payload: JSON.stringify({ pr: prNumber, head_sha: sha }),
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: "failure",
+              environment: `preview/pr-${prNumber}`,
+              description: "Preview deploy failed",
+            });
+            core.notice(`Recorded FAILED preview deployment for PR #${prNumber}.`);

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -1,0 +1,98 @@
+name: UI Preview Build
+
+# Build half of the fork-safe per-PR preview pipeline. Runs for EVERY PR — including forks — and
+# deliberately WITHOUT secrets (fork PRs get a read-only token): it only produces the built `.output`
+# artifact. The trusted `ui-preview-deploy.yml` (triggered on workflow_run) then deploys that artifact
+# WITH secrets and records the GitHub Deployment that loopover's review bot reads for the "after"
+# screenshot in a PR's visual-preview table.
+#
+# Why this exists: apps/ui deploys to production via Cloudflare Workers Builds (a dashboard-configured
+# git integration on push to main — see apps/ui/vite.config.ts's own header comment), which never
+# surfaces a GitHub-visible signal (no check-run, no deployment, no PR comment) for a branch/PR build,
+# even though it does build one. loopover's preview-discovery chain (Deployments API → commit-check
+# scan → bot PR-comment scan) has nothing to find there, so "after" screenshots never render. This
+# workflow pair mirrors JSONbored/loopover's own identical `ui-preview.yml` / `ui-preview-deploy.yml`
+# pattern (same author, same TanStack Start + Nitro cloudflare-module stack, same problem, already
+# proven in production) rather than depending on Cloudflare's own preview mechanism at all.
+#
+# Why split into two workflows: a preview requires building the PR's UI, and building runs the PR's
+# (possibly fork-authored) code. Doing that here with no secret access — and deploying the resulting
+# bundle in a separate trusted step that never executes fork code — is the standard way to give fork
+# PRs previews without exposing Cloudflare credentials to untrusted code.
+
+on:
+  pull_request:
+    # Explicit list because the default (opened/synchronize/reopened) omits ready_for_review — once the
+    # build job below skips draft PRs, marking a PR ready must itself trigger a real preview build, not
+    # wait for the next push. Mirrors validate.yml's own pull_request.types list.
+    types: [opened, synchronize, reopened, ready_for_review]
+    # Matches validate.yml's own `run_ui_validation` path filter reasoning: apps/ui consumes
+    # packages/client and packages/ui-kit as live workspace links, whose committed dist/ bundles are
+    # what actually ends up in the built output.
+    paths:
+      - "apps/ui/**"
+      - "packages/client/**"
+      - "packages/ui-kit/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ui-preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build UI preview artifact
+    # Skip draft PRs (anti-abuse): a full npm ci + UI build on every push to a PR nobody has marked
+    # ready for review yet. Mirrors validate.yml's own draft-skip convention for the `ui` job.
+    if: ${{ github.event.pull_request.draft != true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.23.1
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      # Installs the whole workspace tree from the one root lockfile — there is no way to `npm ci` a
+      # single workspace in isolation. packages/client/dist and packages/ui-kit/dist are COMMITTED
+      # runtime bundles (see their own .gitignore comments), so this never rebuilds either sibling
+      # package — identical to what Cloudflare Workers Builds' own production deploy does.
+      - name: Install
+        run: npm ci
+
+      # Builds apps/ui only. Nitro's cloudflare-module preset writes the SSR worker entry + static
+      # assets to apps/ui/.output/{server,public} (NOT dist/ — verified against a real local build,
+      # this repo's own build output directory differs from loopover-ui's). VITE_METAGRAPH_API_BASE is
+      # a public URL (apps/ui/.env.example's own documented default), not a secret — points the preview
+      # at the real production API, same as loopover's own preview build does for its own backend.
+      - name: Build UI
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
+          VITE_METAGRAPH_API_BASE: https://api.metagraph.sh
+        run: npm run build --workspace=apps/ui
+
+      # The trusted deploy workflow downloads this by name + run-id. It contains only the built bundle
+      # (server/ + public/) — no secrets, no source needed downstream. Deliberately does NOT upload
+      # apps/ui/.output/server/wrangler.json: that file is generated from the untrusted checkout (a
+      # malicious PR could edit apps/ui/wrangler.jsonc to smuggle bindings/vars/routes into it), so the
+      # trusted deploy step writes its own wrangler config from scratch instead of trusting this one.
+      - name: Upload built UI artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ui-preview-dist
+          path: |
+            apps/ui/.output/server
+            apps/ui/.output/public
+            !apps/ui/.output/server/wrangler.json
+          if-no-files-found: error
+          retention-days: 1

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -8,6 +8,17 @@ const workflows = (await fs.readdir(workflowRoot))
   .sort();
 const errors = [];
 
+// Deploy-only workflows that intentionally never check out repo content are exempt from the
+// "missing checkout action" rule below. ui-preview-deploy.yml (workflow_run-triggered, holds
+// CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID) downloads a PRE-BUILT artifact from the separate,
+// checkout-less "UI Preview Build" job and deploys it -- checking out ANY code, even the trusted
+// default branch, in a job that also holds Cloudflare secrets would be a step backward from the
+// "never combine repo content with secrets in the same job" split this pair of workflows exists to
+// enforce, not a step forward. A narrow, named exception here (not a heuristic that could silently
+// exempt a future workflow that SHOULD have a checkout) is the correct fix, not a decorative
+// checkout added purely to satisfy this check.
+const NO_CHECKOUT_BY_DESIGN = new Set(["ui-preview-deploy.yml"]);
+
 for (const workflow of workflows) {
   const content = await fs.readFile(path.join(workflowRoot, workflow), "utf8");
   check(
@@ -45,7 +56,8 @@ for (const workflow of workflows) {
     "Discord notifications must be sent by the private Cloudflare gate, not GitHub Actions",
   );
   check(
-    /uses:\s+actions\/checkout@/.test(content),
+    NO_CHECKOUT_BY_DESIGN.has(workflow) ||
+      /uses:\s+actions\/checkout@/.test(content),
     workflow,
     "missing checkout action",
   );


### PR DESCRIPTION
## Summary

- `apps/ui` deploys to production via Cloudflare Workers Builds (dashboard-configured git
  integration on push to main), which never surfaces a GitHub-visible signal for a branch/PR build
  (no check-run, deployment, or comment) — confirmed empty against the Deployments API, commit
  statuses, and check-runs on a real PR. loopover's preview-discovery chain has nothing to find, so
  the "after" screenshot in its visual-preview table never renders for any PR touching `apps/ui`.
- Adds JSONbored/loopover's own proven `ui-preview.yml` / `ui-preview-deploy.yml` fork-safe
  two-workflow pattern (same author, same TanStack Start + Nitro `cloudflare-module` stack, same
  problem, already working in production for `loopover-ui`) rather than depending on Cloudflare's
  own dashboard-only preview mechanism.
- Narrows `scripts/validate-workflows.mjs`'s blanket "every workflow needs a checkout action" rule
  with one named exception for the new deploy workflow, which deliberately never checks out any code
  by design (see its own header comment) — adding a decorative checkout just to satisfy the rule
  would have weakened, not strengthened, the "never combine repo content with Cloudflare secrets in
  the same job" split this pair of workflows exists to enforce.

## What Changed

- **New `.github/workflows/ui-preview.yml`** — untrusted build half. Triggers on `pull_request`
  (including forks), no secrets. Checks out the PR head, installs the workspace (`packages/client`
  and `packages/ui-kit`'s committed `dist/` bundles mean no sibling-package rebuild is needed, same
  as production), builds `apps/ui` (`.output/server` + `.output/public` — verified against a real
  local build; this repo's Nitro output directory differs from `loopover-ui`'s `dist/`), and uploads
  the bundle as an artifact. Deliberately excludes the untrusted build's own generated
  `.output/server/wrangler.json` from the artifact — a malicious PR could edit `apps/ui/wrangler.jsonc`
  to smuggle bindings/vars/routes into it.
- **New `.github/workflows/ui-preview-deploy.yml`** — trusted deploy half. Triggers on
  `workflow_run` (always runs the default-branch's own copy of this file, so a PR can never smuggle
  a modified deploy step through its own branch). Downloads the build artifact, validates it (no
  symlinks, required SSR structure, allowlisted file extensions), writes a maintainer-authored
  (never PR-derived) Wrangler preview config, and runs `wrangler versions upload` — a 0%-traffic
  preview version at a `workers.dev` URL, never touching the `metagraph.sh` production route/domain.
  Records a real GitHub Deployment + status on success, and a `failure` deployment status if any step
  fails, so loopover's own "after" cell reads a terminal state either way instead of spinning forever.
  Uses the `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets already present in this repo (used
  by `publish-cloudflare.yml` / `check-worker-deploy-drift.yml`) — no new secrets needed.
- **`scripts/validate-workflows.mjs`** — added `NO_CHECKOUT_BY_DESIGN` (a `Set` containing only
  `ui-preview-deploy.yml`) as a narrow, named exception to the existing "missing checkout action"
  check, with an inline comment explaining why. Every other existing check in the file is unchanged.

No `.loopover.yml` changes needed on the loopover side: this produces a real GitHub Deployment, which
loopover's very first (always-active, zero-config) discovery step already reads automatically.

Closes #6973

## Template Used

- Backend/code change

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6973`).
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state —
      the two new workflows reference `secrets.CLOUDFLARE_API_TOKEN` / `secrets.CLOUDFLARE_ACCOUNT_ID`
      by name only (already-present repo secrets), never a literal value.
- [ ] Generated artifacts were produced by repo scripts, not hand-edited. — N/A, no generated
      artifacts touched (workflow YAML + one validator script, both hand-authored).
- [ ] R2-only/high-churn detail artifacts are not committed. — N/A.
- [ ] Public API/OpenAPI/schema changes are intentional and documented. — N/A, no API/schema changed.

## Validation

- [x] `node scripts/validate-workflows.mjs` — passes (`Validated 22 workflow file(s).`), including
      both new files.
- [x] `github-actionlint .github/workflows/ui-preview.yml .github/workflows/ui-preview-deploy.yml` —
      clean, no findings.
- [x] `npx prettier --check` / `npx eslint` on `scripts/validate-workflows.mjs` and both new
      workflow files — clean.
- [x] Verified the actual build output shape against a real local build (`npm ci --ignore-scripts &&
      npm run build --workspace=apps/ui`, with `VITE_METAGRAPH_API_BASE` set): confirmed
      `apps/ui/.output/server/index.mjs` + `apps/ui/.output/public/**` (no symlinks, all file
      extensions covered by the deploy workflow's allowlist), which is what the artifact
      validate/upload steps in this PR assume.
- [ ] `npm run check` / `npm run validate` / `npm run validate:schemas` / `npm run validate:api` /
      `npm run validate:openapi` / `npm run validate:types` / `npm run validate:artifact-budgets` /
      `npm run validate:docs` / `npm run validate:intake` / `npm run worker:test` /
      `npm run test:coverage` / `npm run scan:public-safety` — not run: none apply to this change
      (no registry data, schema, contract, worker, or public-content edits — only two new
      `.github/workflows/**` files and a narrow addition to one existing workflow validator script).
- [x] `git diff --check` — clean.

## Notes

- This is a maintainer-authored infra PR (not a community data contribution), so it intentionally
  doesn't touch `registry/**`.
- Once merged, this repo's own `apps/ui`/`packages/client`/`packages/ui-kit` PRs will start getting a
  real, GitHub-discoverable preview deployment automatically — no follow-up config change needed on
  either side.
