### PR TITLE
feat(api): add subnet_performance_history + subnet_yield_history GraphQL fields

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -79,8 +79,18 @@ import {
   SUBNET_WEIGHT_SETTERS_WINDOWS,
   DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
 } from "./subnet-weight-setters.mjs";
-import { buildSubnetYield } from "./subnet-yield.mjs";
-import { buildSubnetPerformance } from "./subnet-performance.mjs";
+import {
+  buildSubnetYield,
+  buildSubnetYieldHistory,
+  YIELD_HISTORY_WINDOWS,
+  DEFAULT_YIELD_HISTORY_WINDOW,
+} from "./subnet-yield.mjs";
+import {
+  buildSubnetPerformance,
+  buildSubnetPerformanceHistory,
+  PERFORMANCE_HISTORY_WINDOWS,
+  DEFAULT_PERFORMANCE_HISTORY_WINDOW,
+} from "./subnet-performance.mjs";
 import {
   buildConcentration,
   buildConcentrationHistory,
@@ -332,8 +342,12 @@ export const SDL = `
     subnet_weight_setters(netuid: Int!, window: String): SubnetWeightSetters!
     "Per-subnet emission-per-stake yield over the current metagraph snapshot: each UID's yield plus the subnet-wide aggregate and p25/median/p75/p90 distribution; a subnet with no neurons resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/yield."
     subnet_yield(netuid: Int!): SubnetYield!
+    "Per-subnet per-day emission-per-stake yield trend from the neuron_daily rollup over a 7d/30d/90d window (default 30d): each day's subnet-wide yield plus the mean/median/p25/p75/p90 distribution across UIDs, newest first; a subnet with no daily rollup resolves to a schema-stable empty series (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/yield/history."
+    subnet_yield_history(netuid: Int!, window: String): SubnetYieldHistory!
     "Per-subnet reward-distribution and score-spread card over the current neurons snapshot: incentive/dividends concentration plus p10–p90 trust/consensus/validator_trust; a subnet with no neurons resolves to a schema-stable zeroed card (metric blocks null), never null. Mirrors GET /api/v1/subnets/{netuid}/performance."
     subnet_performance(netuid: Int!): SubnetPerformance!
+    "Per-subnet per-day reward-distribution and score-spread trend from the neuron_daily rollup over a 7d/30d/90d window (default 30d): each day's incentive/dividends Gini, Nakamoto coefficient, and top-10% share plus mean/median trust, consensus, and validator_trust, newest first; a subnet with no daily rollup resolves to a schema-stable empty series (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/performance/history."
+    subnet_performance_history(netuid: Int!, window: String): SubnetPerformanceHistory!
     "Per-subnet stake and emission concentration over the current neurons snapshot: raw-UID and per-entity Gini/HHI/Nakamoto/top-K share for stake and emission, validator-only stake concentration, and a uids-per-entity Sybil signal; a subnet with no neurons resolves to a schema-stable zeroed card (metric blocks null), never null. Mirrors GET /api/v1/subnets/{netuid}/concentration."
     subnet_concentration(netuid: Int!): SubnetConcentration!
     "Per-subnet per-day stake and emission concentration trend from the neuron_daily rollup over a 7d/30d/90d window (default 30d): each day's stake/emission Gini, Nakamoto coefficient, and top-10% share, newest first; a subnet with no daily rollup resolves to a schema-stable empty series (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/concentration/history."
@@ -1851,6 +1865,58 @@ export const SDL = `
   }
 
   "One day's point in a subnet's concentration trend (#5901). Flattened (not nested) stake/emission metrics keep the series trivial to plot; each is null on a cold/empty day."
+  type SubnetPerformanceHistoryPoint {
+    snapshot_date: String!
+    neuron_count: Int!
+    validator_count: Int!
+    active_count: Int!
+    incentive_gini: Float
+    incentive_nakamoto_coefficient: Int
+    incentive_top_10pct_share: Float
+    dividends_gini: Float
+    dividends_nakamoto_coefficient: Int
+    dividends_top_10pct_share: Float
+    trust_mean: Float
+    trust_median: Float
+    consensus_mean: Float
+    consensus_median: Float
+    validator_trust_mean: Float
+    validator_trust_median: Float
+  }
+
+  "Per-subnet per-day reward-distribution trend (#6981) from the neuron_daily rollup, newest first. An empty series (point_count 0) on a cold store, never a GraphQL error. The history twin of subnet_performance, mirroring GET /api/v1/subnets/{netuid}/performance/history."
+  type SubnetPerformanceHistory {
+    schema_version: Int!
+    netuid: Int!
+    "The resolved window label (7d/30d/90d)."
+    window: String
+    point_count: Int!
+    points: [SubnetPerformanceHistoryPoint!]!
+  }
+
+  type SubnetYieldHistoryPoint {
+    snapshot_date: String!
+    neuron_count: Int!
+    validator_count: Int!
+    yield_count: Int!
+    subnet_yield: Float
+    mean_yield: Float
+    median_yield: Float
+    p25_yield: Float
+    p75_yield: Float
+    p90_yield: Float
+  }
+
+  "Per-subnet per-day emission-per-stake yield trend (#6981) from the neuron_daily rollup, newest first. An empty series (point_count 0) on a cold store, never a GraphQL error. The history twin of subnet_yield, mirroring GET /api/v1/subnets/{netuid}/yield/history."
+  type SubnetYieldHistory {
+    schema_version: Int!
+    netuid: Int!
+    "The resolved window label (7d/30d/90d)."
+    window: String
+    point_count: Int!
+    points: [SubnetYieldHistoryPoint!]!
+  }
+
   type SubnetConcentrationHistoryPoint {
     snapshot_date: String!
     neuron_count: Int!
@@ -2940,7 +3006,9 @@ export const FIELD_COMPLEXITY = {
   subnet_stake_transfers: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weight_setters: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_yield: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_yield_history: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_performance: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_performance_history: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_concentration: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_concentration_history: RELATIONSHIP_FIELD_COMPLEXITY,
   neuron: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -3908,6 +3976,92 @@ const rootValue = {
       entity_stake: data.entity_stake ?? null,
       entity_emission: data.entity_emission ?? null,
       validator_stake: data.validator_stake ?? null,
+    };
+  },
+
+  async subnet_performance_history({ netuid, window }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same 7d/30d/90d window validation the REST route + MCP
+    // get_subnet_performance_history use -- an unsupported window is a GraphQL
+    // BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_PERFORMANCE_HISTORY_WINDOW;
+    if (!Object.hasOwn(PERFORMANCE_HISTORY_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, PERFORMANCE_HISTORY_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetPerformanceHistory([])
+    // empty-series fallback the neuron_daily-derived REST route + MCP tool use.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/performance/history`,
+          params,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ??
+      buildSubnetPerformanceHistory([], netuid, {
+        window: windowParam,
+        capped: false,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      point_count: data.point_count ?? 0,
+      points: data.points ?? [],
+    };
+  },
+
+  async subnet_yield_history({ netuid, window }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same 7d/30d/90d window validation the REST route + MCP
+    // get_subnet_yield_history use -- an unsupported window is a GraphQL
+    // BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_YIELD_HISTORY_WINDOW;
+    if (!Object.hasOwn(YIELD_HISTORY_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, YIELD_HISTORY_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetYieldHistory([])
+    // empty-series fallback the neuron_daily-derived REST route + MCP tool use.
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/yield/history`,
+          params,
+        ),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ??
+      buildSubnetYieldHistory([], netuid, {
+        window: windowParam,
+        capped: false,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      point_count: data.point_count ?? 0,
+      points: data.points ?? [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -5911,6 +5911,264 @@ describe("graphql — subnet_concentration_history (#5901, neuron_daily trend + 
   });
 });
 
+describe("graphql — subnet_performance_history (#6981, neuron_daily reward-distribution trend)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty series, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_performance_history(netuid: 5) {
+          schema_version netuid window point_count points { snapshot_date incentive_gini }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_performance_history, {
+      schema_version: 1,
+      netuid: 5,
+      window: "30d",
+      point_count: 0,
+      points: [],
+    });
+  });
+
+  test("resolves the Postgres-tier per-day trend points", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 7,
+          window: "7d",
+          point_count: 2,
+          points: [
+            {
+              snapshot_date: "2026-07-02",
+              neuron_count: 4,
+              validator_count: 2,
+              active_count: 3,
+              incentive_gini: 0.42,
+              incentive_nakamoto_coefficient: 2,
+              incentive_top_10pct_share: 0.55,
+              dividends_gini: 0.3,
+              dividends_nakamoto_coefficient: 1,
+              dividends_top_10pct_share: 0.7,
+              trust_mean: 0.61,
+              trust_median: 0.6,
+              consensus_mean: 0.5,
+              consensus_median: 0.49,
+              validator_trust_mean: 0.8,
+              validator_trust_median: 0.79,
+            },
+            {
+              snapshot_date: "2026-07-01",
+              neuron_count: 3,
+              validator_count: 1,
+              active_count: 2,
+              incentive_gini: 0.4,
+              incentive_nakamoto_coefficient: 2,
+              incentive_top_10pct_share: 0.5,
+              dividends_gini: 0.28,
+              dividends_nakamoto_coefficient: 1,
+              dividends_top_10pct_share: 0.68,
+              trust_mean: 0.58,
+              trust_median: 0.57,
+              consensus_mean: 0.47,
+              consensus_median: 0.46,
+              validator_trust_mean: 0.77,
+              validator_trust_median: 0.76,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_performance_history(netuid: 7, window: "7d") {
+          netuid window point_count
+          points { snapshot_date neuron_count validator_count incentive_gini dividends_top_10pct_share trust_median validator_trust_mean }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const h = body.data.subnet_performance_history;
+    assert.equal(h.netuid, 7);
+    assert.equal(h.window, "7d");
+    assert.equal(h.point_count, 2);
+    assert.equal(h.points.length, 2);
+    assert.equal(h.points[0].snapshot_date, "2026-07-02");
+    assert.equal(h.points[0].incentive_gini, 0.42);
+    assert.equal(h.points[0].validator_count, 2);
+    assert.equal(h.points[1].dividends_top_10pct_share, 0.68);
+    assert.equal(h.points[1].trust_median, 0.57);
+  });
+
+  test("forwards the window to the performance/history Postgres path", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(
+      '{ subnet_performance_history(netuid: 3, window: "90d") { point_count } }',
+      env,
+    );
+    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/performance/history"));
+    assert.equal(capturedUrl.searchParams.get("window"), "90d");
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent series", async () => {
+    const { body } = await gql(
+      '{ subnet_performance_history(netuid: 5, window: "5d") { point_count } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_performance_history ?? null, null);
+  });
+
+  test("a negative netuid is a GraphQL error, not an empty series", async () => {
+    const { body } = await gql(
+      "{ subnet_performance_history(netuid: -1) { point_count } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/netuid/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_performance_history ?? null, null);
+  });
+
+  test("subnet_performance_history is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_performance_history, 5);
+  });
+});
+
+describe("graphql — subnet_yield_history (#6981, neuron_daily emission-per-stake trend)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty series, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_yield_history(netuid: 5) {
+          schema_version netuid window point_count points { snapshot_date subnet_yield }
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_yield_history, {
+      schema_version: 1,
+      netuid: 5,
+      window: "30d",
+      point_count: 0,
+      points: [],
+    });
+  });
+
+  test("resolves the Postgres-tier per-day trend points", async () => {
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 7,
+          window: "7d",
+          point_count: 2,
+          points: [
+            {
+              snapshot_date: "2026-07-02",
+              neuron_count: 4,
+              validator_count: 2,
+              yield_count: 4,
+              subnet_yield: 0.0123,
+              mean_yield: 0.0131,
+              median_yield: 0.0129,
+              p25_yield: 0.011,
+              p75_yield: 0.015,
+              p90_yield: 0.017,
+            },
+            {
+              snapshot_date: "2026-07-01",
+              neuron_count: 3,
+              validator_count: 1,
+              yield_count: 3,
+              subnet_yield: 0.0119,
+              mean_yield: 0.0125,
+              median_yield: 0.0124,
+              p25_yield: 0.0105,
+              p75_yield: 0.0145,
+              p90_yield: 0.0166,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      `{ subnet_yield_history(netuid: 7, window: "7d") {
+          netuid window point_count
+          points { snapshot_date neuron_count validator_count yield_count subnet_yield median_yield p90_yield }
+        } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const h = body.data.subnet_yield_history;
+    assert.equal(h.netuid, 7);
+    assert.equal(h.window, "7d");
+    assert.equal(h.point_count, 2);
+    assert.equal(h.points.length, 2);
+    assert.equal(h.points[0].snapshot_date, "2026-07-02");
+    assert.equal(h.points[0].subnet_yield, 0.0123);
+    assert.equal(h.points[0].yield_count, 4);
+    assert.equal(h.points[1].median_yield, 0.0124);
+    assert.equal(h.points[1].p90_yield, 0.0166);
+  });
+
+  test("forwards the window to the yield/history Postgres path", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(
+      '{ subnet_yield_history(netuid: 3, window: "90d") { point_count } }',
+      env,
+    );
+    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/yield/history"));
+    assert.equal(capturedUrl.searchParams.get("window"), "90d");
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent series", async () => {
+    const { body } = await gql(
+      '{ subnet_yield_history(netuid: 5, window: "5d") { point_count } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_yield_history ?? null, null);
+  });
+
+  test("a negative netuid is a GraphQL error, not an empty series", async () => {
+    const { body } = await gql(
+      "{ subnet_yield_history(netuid: -1) { point_count } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/netuid/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_yield_history ?? null, null);
+  });
+
+  test("subnet_yield_history is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_yield_history, 5);
+  });
+});
+
 describe("graphql — neuron (#5900, Postgres-tier + neuron:null fallback)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Context

`subnet_performance` and `subnet_yield` already exist as current-snapshot GraphQL fields, but their `/history` REST counterparts had no GraphQL mirror — even though REST and MCP both already serve them (`get_subnet_performance_history`, `get_subnet_yield_history`). This closes that gap, following the existing `subnet_concentration` / `subnet_concentration_history` pairing precedent named in the issue.

## Change

Two new `type Query` fields in `src/graphql.mjs`:

| Field | Per-day series |
|---|---|
| `subnet_performance_history(netuid: Int!, window: String)` | incentive/dividends Gini, Nakamoto coefficient, top-10% share + mean/median trust, consensus, validator_trust |
| `subnet_yield_history(netuid: Int!, window: String)` | subnet-wide yield + mean/median/p25/p75/p90 distribution |

Both:
- **Reuse the shaping functions REST + MCP already call** (`buildSubnetPerformanceHistory`, `buildSubnetYieldHistory`) — no duplicated aggregation logic.
- Share the same **7d/30d/90d** window set (default `30d`); an unsupported window raises `BAD_USER_INPUT` rather than silently returning a card, matching `subnet_concentration_history`.
- Fall back to a **schema-stable empty series** (`point_count: 0`) on a cold store, never a GraphQL error.
- Are weighted `RELATIONSHIP_FIELD_COMPLEXITY` like their sibling fan-out fields.

Plus the matching `SubnetPerformanceHistory(Point)` / `SubnetYieldHistory(Point)` output types.

## Deliverables

- [x] `subnet_performance_history`, `subnet_yield_history` added to `type Query`
- [x] New output types
- [x] Test coverage for each new resolver

## Tests

12 new resolver tests (6 each): cold-store empty series, Postgres-tier hit with real points, window forwarding to the correct REST path, unsupported-window error, negative-netuid error, and complexity weighting. Full `tests/graphql.test.mjs` suite green (614), eslint + prettier clean, public-safety scan clean, and **zero uncovered statements or branches** across both new resolvers.

Closes #6981