### PR TITLE
feat(graphql): add network_randomness + evm_address parity

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -134,6 +134,8 @@ import { loadSubnetBurn } from "./subnet-burn.mjs";
 import { loadAccountBalance, isFinneySs58Address } from "./account-balance.mjs";
 import { loadSudoKey } from "./sudo-key.mjs";
 import { loadNetworkParameters } from "./network-parameters.mjs";
+import { loadRandomnessStatus } from "./randomness.mjs";
+import { loadAddressMapping, H160_PATTERN } from "./address-mapping.mjs";
 import {
   DEFAULT_GLOBAL_VALIDATOR_SORT,
   GLOBAL_VALIDATOR_LIMIT_DEFAULT,
@@ -482,6 +484,10 @@ export const SDL = `
     sudo_key: SudoKey
     "Live global Subtensor protocol/governance parameters (TaoWeight, StakeThreshold, PendingChildKeyCooldown), read directly from chain via RPC (not the Postgres tier). Each field is independently null on its own RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/network/parameters."
     network_parameters: NetworkParameters
+    "Live drand randomness-beacon status read directly from chain via RPC (not the Postgres tier): the newest and oldest stored beacon rounds and the span between them. Each field is independently null on its own RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/network/randomness."
+    network_randomness: NetworkRandomness
+    "Live EVM (H160) -> Substrate (SS58) account-address mapping for a 20-byte 0x-prefixed hex address, resolved directly from chain via RPC (not the Postgres tier). ss58 is null when the address has no association or the RPC lookup fails, schema-stable, never a GraphQL error. Mirrors GET /api/v1/evm/address/{h160}."
+    evm_address(h160: String!): EvmAddressMapping
     "Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Mirrors GET /api/v1/sudo."
     sudo(limit: Int, offset: Int, cursor: String, block: Int, call_function: String, success: Boolean): ExtrinsicList!
   }
@@ -2056,6 +2062,23 @@ export const SDL = `
     queried_at: String!
   }
 
+  "Live drand randomness-beacon status read from chain via RPC. Each field is independently null on its own RPC failure (schema-stable). Mirrors GET /api/v1/network/randomness's data envelope."
+  type NetworkRandomness {
+    schema_version: Int!
+    last_stored_round: Int
+    oldest_stored_round: Int
+    stored_round_span: Int
+    queried_at: String!
+  }
+
+  "Live EVM (H160) -> Substrate (SS58) account-address mapping read from chain via RPC. ss58 is null when the mapping cannot be resolved (schema-stable, never a GraphQL error). Mirrors GET /api/v1/evm/address/{h160}."
+  type EvmAddressMapping {
+    schema_version: Int!
+    h160: String!
+    ss58: String
+    queried_at: String!
+  }
+
   "Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary."
   type BlocksSummary {
     schema_version: Int!
@@ -2988,6 +3011,8 @@ export const FIELD_COMPLEXITY = {
   account_balance: LIVE_RPC_FIELD_COMPLEXITY,
   sudo_key: LIVE_RPC_FIELD_COMPLEXITY,
   network_parameters: LIVE_RPC_FIELD_COMPLEXITY,
+  network_randomness: LIVE_RPC_FIELD_COMPLEXITY,
+  evm_address: LIVE_RPC_FIELD_COMPLEXITY,
 };
 
 function fieldComplexity(fieldName) {
@@ -6958,6 +6983,29 @@ const rootValue = {
     // sets schema_version/queried_at unconditionally, so no `??` fallback is
     // needed for those.
     return loadNetworkParameters(context.env);
+  },
+  async network_randomness(_args, context) {
+    // Live chain RPC, not the Postgres tier -- reuses loadRandomnessStatus'
+    // own KV cache/TTL, matching REST's /network/randomness handler exactly.
+    // Each round field stays independently null on RPC failure (schema-stable),
+    // never a GraphQL error; schema_version/queried_at are always set.
+    return loadRandomnessStatus(context.env);
+  },
+  async evm_address({ h160 }, context) {
+    // Same H160_PATTERN validation the REST route + MCP get_evm_address_mapping
+    // use -- a malformed address is a GraphQL BAD_USER_INPUT error, not a card.
+    if (typeof h160 !== "string" || !H160_PATTERN.test(h160)) {
+      throw new GraphQLError(
+        "h160 must be a 20-byte 0x-prefixed hex address.",
+        {
+          extensions: { code: "BAD_USER_INPUT" },
+        },
+      );
+    }
+    // Live chain RPC, not the Postgres tier -- reuses loadAddressMapping's own
+    // KV cache/TTL, matching REST's /evm/address/{h160} handler exactly. ss58 is
+    // null on an unresolved mapping (schema-stable), never a GraphQL error.
+    return loadAddressMapping(context.env, h160);
   },
 };
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -12275,6 +12275,120 @@ describe("graphql — network_parameters (#6343, live chain RPC via network-para
   });
 });
 
+describe("graphql — network_randomness (#6990, live chain RPC via randomness.mjs)", () => {
+  function kvEnv(payload) {
+    return { METAGRAPH_CONTROL: { get: async () => payload } };
+  }
+
+  test("resolves the beacon-round status snapshot", async () => {
+    const env = kvEnv({
+      schema_version: 1,
+      last_stored_round: 1200,
+      oldest_stored_round: 900,
+      stored_round_span: 301,
+      queried_at: "2026-07-20T00:00:00.000Z",
+    });
+    const { status, body } = await gql(
+      "{ network_randomness { schema_version last_stored_round oldest_stored_round stored_round_span queried_at } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.network_randomness;
+    assert.equal(r.schema_version, 1);
+    assert.equal(r.last_stored_round, 1200);
+    assert.equal(r.oldest_stored_round, 900);
+    assert.equal(r.stored_round_span, 301);
+    assert.equal(r.queried_at, "2026-07-20T00:00:00.000Z");
+  });
+
+  test("null rounds resolve as a schema-stable card, never a GraphQL error", async () => {
+    const env = kvEnv({
+      schema_version: 1,
+      last_stored_round: null,
+      oldest_stored_round: null,
+      stored_round_span: null,
+      queried_at: "2026-07-20T00:00:00.000Z",
+    });
+    const { status, body } = await gql(
+      "{ network_randomness { last_stored_round stored_round_span queried_at } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.network_randomness;
+    assert.equal(r.last_stored_round, null);
+    assert.equal(r.stored_round_span, null);
+    assert.ok(r.queried_at);
+  });
+
+  test("network_randomness is weighted as a live-RPC field", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.network_randomness,
+      FIELD_COMPLEXITY.network_parameters,
+    );
+  });
+});
+
+describe("graphql — evm_address (#6990, live chain RPC via address-mapping.mjs)", () => {
+  function kvEnv(payload) {
+    return { METAGRAPH_CONTROL: { get: async () => payload } };
+  }
+  const H160 = "0x1234567890abcdef1234567890abcdef12345678";
+
+  test("resolves the h160 -> ss58 mapping", async () => {
+    const env = kvEnv({
+      schema_version: 1,
+      h160: H160,
+      ss58: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      queried_at: "2026-07-20T00:00:00.000Z",
+    });
+    const { status, body } = await gql(
+      `{ evm_address(h160: "${H160}") { schema_version h160 ss58 queried_at } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const r = body.data.evm_address;
+    assert.equal(r.schema_version, 1);
+    assert.equal(r.h160, H160);
+    assert.equal(r.ss58, "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+    assert.ok(r.queried_at);
+  });
+
+  test("an unresolved mapping resolves with null ss58, never a GraphQL error", async () => {
+    const env = kvEnv({
+      schema_version: 1,
+      h160: H160,
+      ss58: null,
+      queried_at: "2026-07-20T00:00:00.000Z",
+    });
+    const { status, body } = await gql(
+      `{ evm_address(h160: "${H160}") { h160 ss58 } }`,
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.evm_address.ss58, null);
+  });
+
+  test("a malformed h160 is a GraphQL BAD_USER_INPUT error, not a card", async () => {
+    const { body } = await gql(
+      '{ evm_address(h160: "not-an-address") { ss58 } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/h160/i.test(body.errors[0].message));
+    assert.equal(body.data?.evm_address ?? null, null);
+  });
+
+  test("evm_address is weighted as a live-RPC field", () => {
+    assert.equal(
+      FIELD_COMPLEXITY.evm_address,
+      FIELD_COMPLEXITY.network_parameters,
+    );
+  });
+});
+
 describe("graphql — subnet_recycled (#5691, live chain RPC via subnet-recycled.mjs)", () => {
   // Stub globalThis.fetch for one test, restore after — mirrors withFetchStub
   // in tests/subnet-recycled.test.mjs.


### PR DESCRIPTION
## Problem

Two chain-meta REST routes have MCP tools but no GraphQL field (verified against `origin/main`):
- `GET /api/v1/network/randomness` — MCP `get_randomness_status`
- `GET /api/v1/evm/address/{h160}` — MCP `get_evm_address_mapping`

## Fix

Add `network_randomness` and `evm_address(h160: String!)` Query fields, each **reusing the same live-RPC loader** (`loadRandomnessStatus` / `loadAddressMapping`) the REST route + MCP tool already call — live chain RPC with the loaders' own KV cache/TTL (not the Postgres tier), exactly mirroring the neighboring `network_parameters` field. Each field stays schema-stable and null on its own RPC failure, never a GraphQL error. `evm_address` validates `H160_PATTERN` (BAD_USER_INPUT on a malformed address, matching the MCP tool). Both registered as live-RPC fields in the complexity map. New output types `NetworkRandomness` and `EvmAddressMapping` mirror the loader shapes.

## Tests

KV-cached resolution + null passthrough for both fields, plus the malformed-h160 error path — all failing on the un-extended schema. Full `tests/graphql.test.mjs` (609) passes; `npm run validate`, prettier, eslint, worker:bundle:budget all pass; patch coverage clean; no artifact drift.

Closes #6990