### PR TITLE
feat(api): mirror subnet health-percentiles/gaps/evidence/event-summary in GraphQL

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -123,6 +123,7 @@ import { composeLeaderboardsData } from "../workers/request-handlers/analytics-r
 import {
   loadCompareSubnets,
   loadSubnetHealthTrends,
+  loadSubnetPercentiles,
   loadSubnetUptime,
   loadSubnetIncidents,
   parseCompareDimensionList,
@@ -166,7 +167,12 @@ import {
   buildAccountSubnets,
   buildAccountSummary,
   buildAccountTransfers,
+  buildSubnetEventSummary,
   loadAccountHistory,
+  DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW,
+  SUBNET_EVENT_SUMMARY_WINDOWS,
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
+  SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
 } from "./account-events.mjs";
 import {
   DEFAULT_PROMETHEUS_WINDOW,
@@ -330,6 +336,14 @@ export const SDL = `
     subnet_uptime(netuid: Int!, window: String, min_samples: Int): SubnetUptime!
     "One subnet's per-surface SLA (uptime ratio) and reconstructed downtime incidents over a 7d/30d window (default 7d), computed live from the health-probe history: each surface's sample count, uptime_ratio, incident_count, total downtime_ms, and the gap-island incident list. A subnet with no probe history resolves to a schema-stable empty surfaces list, never null. Mirrors GET /api/v1/subnets/{netuid}/health/incidents."
     subnet_health_incidents(netuid: Int!, window: String): SubnetHealthIncidents!
+    "One subnet's per-surface latency percentiles (p50/p90/p95/p99) over a 7d/30d window (default 7d), computed live from the success-only health-probe history. The latency-distribution companion of subnet_health_incidents' availability view. A subnet with no probe history resolves to a schema-stable empty surfaces list, never null. Mirrors GET /api/v1/subnets/{netuid}/health/percentiles."
+    subnet_health_percentiles(netuid: Int!, window: String): SubnetHealthPercentiles!
+    "One subnet's chain-event activity summary over a 7d/30d/90d window (default 30d): total events, the per-kind and per-category breakdowns with hotkey/coldkey participation and TAO/alpha amounts, and a bounded newest-first recent-event list (limit 1-50, default 10). A subnet with no events resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/event-summary."
+    subnet_event_summary(netuid: Int!, window: String, limit: Int): SubnetEventSummary!
+    "One subnet's registry gap report — the reviewer-facing list of missing/incomplete surface coverage backing its curation state. Null when no gap report has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_gaps MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/gaps."
+    subnet_gaps(netuid: Int!): JSON
+    "One subnet's curation evidence record — the provenance trail (source URLs, checks, reviewer notes) behind its registry entry. Null when no evidence record has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_evidence MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/evidence."
+    subnet_evidence(netuid: Int!): JSON
     "Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals."
     subnet_axon_removals(netuid: Int!, window: String): SubnetAxonRemovals!
     "Per-subnet validator weight-setting activity over a 7d/30d window (distinct weight-setters, WeightsSet count, and sets per setter); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/weights."
@@ -1988,6 +2002,38 @@ export const SDL = `
     surfaces: JSON!
   }
 
+  "One subnet's per-surface success-only latency percentiles (#6980). Mirrors GET /api/v1/subnets/{netuid}/health/percentiles' data envelope."
+  type SubnetHealthPercentiles {
+    schema_version: Int!
+    netuid: Int!
+    window: String
+    observed_at: String
+    source: String
+    "Per operational surface: its success-only latency sample count and p50/p90/p95/p99 latency percentiles in ms. Opaque JSON passed through verbatim, matching the get_subnet_health_percentiles MCP/REST shape (like SubnetHealthIncidents.surfaces)."
+    surfaces: JSON!
+  }
+
+  "One subnet's chain-event activity summary over a window (#6980). Mirrors GET /api/v1/subnets/{netuid}/event-summary' data envelope."
+  type SubnetEventSummary {
+    schema_version: Int!
+    netuid: Int!
+    "The resolved window label (7d/30d/90d)."
+    window: String
+    observed_at: String
+    total_events: Int!
+    kind_count: Int!
+    category_count: Int!
+    recent_event_count: Int!
+    "The resolved recent-event cap actually applied (1-50, default 10)."
+    limit: Int!
+    "Per event category: its kind list and rolled-up counts. Opaque JSON passed through verbatim, matching the get_subnet_event_summary MCP/REST shape."
+    categories: JSON!
+    "Per event kind: event_count, hotkey/coldkey participation counts, TAO/alpha amounts, and first/last block + observed_at. Opaque JSON passed through verbatim."
+    event_kinds: JSON!
+    "The bounded newest-first recent-event list. Opaque JSON passed through verbatim."
+    recent_events: JSON!
+  }
+
   type ExtrinsicList {
     items: [Extrinsic!]!
     "Page count -- this feed has no cheap grand total, matching REST's extrinsic_count."
@@ -3000,6 +3046,10 @@ export const FIELD_COMPLEXITY = {
   subnet_health_trends: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_uptime: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_health_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_health_percentiles: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_event_summary: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_gaps: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_evidence: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_axon_removals: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_weights: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_moves: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4531,6 +4581,134 @@ const rootValue = {
       summary: data.summary ?? null,
       surfaces: data.surfaces ?? [],
     };
+  },
+
+  async subnet_health_percentiles({ netuid, window }, context) {
+    // Reuse the exact analyticsWindow parse/validate REST's percentiles handler
+    // uses (7d/30d, default 7d) -- an unsupported window is a GraphQL
+    // BAD_USER_INPUT error, not a silent empty result, matching
+    // subnet_health_incidents.
+    const windowUrl = new URL(context.request.url);
+    windowUrl.search = "";
+    if (window != null) windowUrl.searchParams.set("window", window);
+    const { label, error } = analyticsWindow(windowUrl);
+    if (error) {
+      throw new GraphQLError(error.message, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same tryPostgresTier(METAGRAPH_HEALTH_SOURCE) -> loadSubnetPercentiles
+    // fallback the REST route and the get_subnet_health_percentiles MCP tool
+    // share -- the tier owns the percentile computation, so nothing is
+    // duplicated here, and a subnet with no probe history yields a
+    // schema-stable empty surfaces list, never a GraphQL error.
+    const params = new URLSearchParams();
+    params.set("window", label);
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/health/percentiles`,
+          params,
+        ),
+        "METAGRAPH_HEALTH_SOURCE",
+      )) ??
+      (await loadSubnetPercentiles(netuid, {
+        window: label,
+        observedAt: await loadObservedAt(context),
+      }));
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? label,
+      observed_at: data.observed_at ?? null,
+      source: data.source ?? null,
+      surfaces: data.surfaces ?? [],
+    };
+  },
+
+  async subnet_event_summary({ netuid, window, limit }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same 7d/30d/90d window set the REST route + get_subnet_event_summary MCP
+    // tool accept (default 30d) -- an unsupported window is a GraphQL
+    // BAD_USER_INPUT error, not a silent card.
+    const windowParam = window ?? DEFAULT_SUBNET_EVENT_SUMMARY_WINDOW;
+    if (!Object.hasOwn(SUBNET_EVENT_SUMMARY_WINDOWS, windowParam)) {
+      throw new GraphQLError(
+        unsupportedWindowMessage(windowParam, SUBNET_EVENT_SUMMARY_WINDOWS),
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same 1..50 clamp (default 10) the REST route + MCP tool apply to the
+    // recent-event list, so an out-of-range limit is bounded rather than
+    // rejected -- matching their contract exactly.
+    const limitParam =
+      limit == null
+        ? SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT
+        : Math.min(
+            Math.max(Math.trunc(limit), 1),
+            SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
+          );
+    const params = new URLSearchParams();
+    params.set("window", windowParam);
+    params.set("limit", String(limitParam));
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(
+          context,
+          `/api/v1/subnets/${netuid}/event-summary`,
+          params,
+        ),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      buildSubnetEventSummary([], [], netuid, {
+        window: windowParam,
+        limit: limitParam,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? windowParam,
+      observed_at: data.observed_at ?? null,
+      total_events: data.total_events ?? 0,
+      kind_count: data.kind_count ?? 0,
+      category_count: data.category_count ?? 0,
+      recent_event_count: data.recent_event_count ?? 0,
+      limit: data.limit ?? limitParam,
+      categories: data.categories ?? [],
+      event_kinds: data.event_kinds ?? [],
+      recent_events: data.recent_events ?? [],
+    };
+  },
+
+  async subnet_gaps({ netuid }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same baked review-gaps artifact the REST route + get_subnet_gaps MCP tool
+    // read. The MCP tool raises not_found for a netuid with no report; GraphQL
+    // degrades to null instead, matching how every other artifact-backed
+    // resolver here treats a cold/absent artifact.
+    return loadArtifact(context, `/metagraph/review/gaps/${netuid}.json`);
+  },
+
+  async subnet_evidence({ netuid }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same baked evidence artifact the REST route + get_subnet_evidence MCP
+    // tool read; null when no record has been baked for this netuid.
+    return loadArtifact(context, `/metagraph/evidence/${netuid}.json`);
   },
 
   async subnet_health_incidents({ netuid, window }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -5911,6 +5911,269 @@ describe("graphql — subnet_concentration_history (#5901, neuron_daily trend + 
   });
 });
 
+describe("graphql — subnet_health_percentiles (#6980, live latency percentiles)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable empty surfaces list, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_health_percentiles(netuid: 5) {
+          schema_version netuid window surfaces
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const p = body.data.subnet_health_percentiles;
+    assert.equal(p.schema_version, 1);
+    assert.equal(p.netuid, 5);
+    assert.equal(p.window, "7d");
+    assert.deepEqual(p.surfaces, []);
+  });
+
+  test("resolves the Postgres-tier per-surface percentiles", async () => {
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 7,
+          window: "30d",
+          observed_at: "2026-07-19T00:00:00.000Z",
+          source: "live-cron-prober",
+          surfaces: [
+            {
+              surface: "api",
+              latency_sample_count: 120,
+              p50_ms: 88,
+              p90_ms: 210,
+              p95_ms: 280,
+              p99_ms: 640,
+            },
+          ],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      '{ subnet_health_percentiles(netuid: 7, window: "30d") { netuid window observed_at source surfaces } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const p = body.data.subnet_health_percentiles;
+    assert.equal(p.netuid, 7);
+    assert.equal(p.window, "30d");
+    assert.equal(p.source, "live-cron-prober");
+    assert.equal(p.surfaces[0].p95_ms, 280);
+  });
+
+  test("forwards the window to the health/percentiles Postgres path", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_HEALTH_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(
+      '{ subnet_health_percentiles(netuid: 3, window: "30d") { netuid } }',
+      env,
+    );
+    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/health/percentiles"));
+    assert.equal(capturedUrl.searchParams.get("window"), "30d");
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ subnet_health_percentiles(netuid: 5, window: "5d") { netuid } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.equal(body.data?.subnet_health_percentiles ?? null, null);
+  });
+
+  test("subnet_health_percentiles is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_health_percentiles, 5);
+  });
+});
+
+describe("graphql — subnet_event_summary (#6980, chain-event activity summary)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+
+  test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
+    const { status, body } = await gql(
+      `{ subnet_event_summary(netuid: 5) {
+          schema_version netuid window total_events kind_count category_count
+          recent_event_count limit categories event_kinds recent_events
+        } }`,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_event_summary, {
+      schema_version: 1,
+      netuid: 5,
+      window: "30d",
+      total_events: 0,
+      kind_count: 0,
+      category_count: 0,
+      recent_event_count: 0,
+      limit: 10,
+      categories: [],
+      event_kinds: [],
+      recent_events: [],
+    });
+  });
+
+  test("resolves the Postgres-tier summary", async () => {
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 7,
+          window: "7d",
+          observed_at: "2026-07-19T00:00:00.000Z",
+          total_events: 42,
+          kind_count: 3,
+          category_count: 2,
+          recent_event_count: 2,
+          limit: 10,
+          categories: [{ category: "stake", event_count: 30 }],
+          event_kinds: [{ event_kind: "StakeAdded", event_count: 30 }],
+          recent_events: [{ event_kind: "StakeAdded", block_number: 91 }],
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      '{ subnet_event_summary(netuid: 7, window: "7d") { netuid window total_events kind_count categories event_kinds recent_events } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const s = body.data.subnet_event_summary;
+    assert.equal(s.total_events, 42);
+    assert.equal(s.kind_count, 3);
+    assert.equal(s.categories[0].category, "stake");
+    assert.equal(s.recent_events[0].block_number, 91);
+  });
+
+  test("clamps the recent-event limit into 1..50 and forwards it", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql(
+      '{ subnet_event_summary(netuid: 3, window: "90d", limit: 999) { netuid } }',
+      env,
+    );
+    assert.ok(capturedUrl.pathname.endsWith("/subnets/3/event-summary"));
+    assert.equal(capturedUrl.searchParams.get("window"), "90d");
+    assert.equal(capturedUrl.searchParams.get("limit"), "50");
+  });
+
+  test("clamps a below-range limit up to 1", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({});
+        },
+      },
+    };
+    await gql("{ subnet_event_summary(netuid: 3, limit: 0) { netuid } }", env);
+    assert.equal(capturedUrl.searchParams.get("limit"), "1");
+  });
+
+  test("an unsupported window is a GraphQL error, not a silent card", async () => {
+    const { body } = await gql(
+      '{ subnet_event_summary(netuid: 5, window: "5d") { netuid } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/window/i.test(body.errors[0].message));
+    assert.equal(body.data?.subnet_event_summary ?? null, null);
+  });
+
+  test("a negative netuid is a GraphQL error", async () => {
+    const { body } = await gql(
+      "{ subnet_event_summary(netuid: -1) { netuid } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/netuid/i.test(body.errors[0].message));
+  });
+
+  test("subnet_event_summary is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_event_summary, 5);
+  });
+});
+
+describe("graphql — subnet_gaps / subnet_evidence (#6980, baked review artifacts)", () => {
+  test("subnet_gaps resolves the baked gap report", async () => {
+    const env = fixtureEnv({
+      "/metagraph/review/gaps/5.json": {
+        netuid: 5,
+        gaps: [{ kind: "api", missing: true }],
+      },
+    });
+    const { status, body } = await gql("{ subnet_gaps(netuid: 5) }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_gaps.netuid, 5);
+    assert.equal(body.data.subnet_gaps.gaps[0].kind, "api");
+  });
+
+  test("subnet_gaps degrades to null when no report is baked, never an error", async () => {
+    const { status, body } = await gql("{ subnet_gaps(netuid: 999) }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_gaps, null);
+  });
+
+  test("subnet_evidence resolves the baked evidence record", async () => {
+    const env = fixtureEnv({
+      "/metagraph/evidence/5.json": {
+        netuid: 5,
+        sources: ["https://example.com"],
+      },
+    });
+    const { status, body } = await gql("{ subnet_evidence(netuid: 5) }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_evidence.netuid, 5);
+  });
+
+  test("subnet_evidence degrades to null when no record is baked", async () => {
+    const { status, body } = await gql("{ subnet_evidence(netuid: 999) }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_evidence, null);
+  });
+
+  test("a negative netuid is a GraphQL error on both artifact fields", async () => {
+    for (const field of ["subnet_gaps", "subnet_evidence"]) {
+      const { body } = await gql(`{ ${field}(netuid: -1) }`);
+      assert.ok(body.errors, `expected a GraphQL error for ${field}`);
+      assert.ok(/netuid/i.test(body.errors[0].message));
+    }
+  });
+
+  test("both artifact fields are weighted as fan-out fields", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_gaps, 5);
+    assert.equal(FIELD_COMPLEXITY.subnet_evidence, 5);
+  });
+});
+
 describe("graphql — subnet_performance_history (#6981, neuron_daily reward-distribution trend)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Context

Four subnet-level diagnostic/coverage routes had REST + MCP but no GraphQL mirror — even though sibling routes on the same resources (`subnet_health_trends`, `subnet_health_incidents`) already were mirrored.

## Change

Four new `type Query` fields in `src/graphql.mjs`, following the existing `subnet_health_trends`/`subnet_health_incidents` pattern (same doc-comment style, same schema-stable-empty convention):

| Field | Mirrors |
|---|---|
| `subnet_health_percentiles(netuid, window)` | `/health/percentiles` — per-surface success-only latency p50/p90/p95/p99 over 7d/30d (default 7d) |
| `subnet_event_summary(netuid, window, limit)` | `/event-summary` — chain-event totals, per-kind/per-category breakdowns, bounded recent-event list over 7d/30d/90d (default 30d) |
| `subnet_gaps(netuid)` | `/gaps` — the baked registry gap report |
| `subnet_evidence(netuid)` | `/evidence` — the baked curation evidence record |

All four **reuse the shaping/loading functions REST and MCP already call** (`loadSubnetPercentiles`, `buildSubnetEventSummary`, and the same baked artifacts) — no aggregation logic is duplicated.

**Contract fidelity:**
- The two tier-backed fields keep their REST/MCP window contracts — an unsupported window raises `BAD_USER_INPUT`, and `event_summary`'s `limit` is **clamped into 1..50** (matching REST/MCP) rather than rejected.
- The two artifact-backed fields **degrade to `null`** when nothing has been baked for the netuid, matching how every other artifact-backed resolver here treats a cold artifact (the MCP tool raises `not_found`; GraphQL's convention is to degrade).
- Artifact payloads pass through as the existing opaque `JSON` scalar — the same treatment `SubnetHealthIncidents.surfaces` and `SubnetHealthTrends.windows` already get, since these are baked review documents with no src-side shape.

## Deliverables

- [x] `subnet_health_percentiles`, `subnet_gaps`, `subnet_evidence`, `subnet_event_summary` added to `type Query`
- [x] New output types (`SubnetHealthPercentiles`, `SubnetEventSummary`)
- [x] Test coverage for each new resolver

## Tests

18 new resolver tests: cold-store shapes, Postgres-tier hits, window/limit forwarding to the correct REST paths, limit clamping at **both** bounds, unsupported-window and negative-netuid errors, artifact hit *and* absent paths, and fan-out complexity weighting. Full suite green (632), eslint + prettier clean, public-safety scan clean, and **zero uncovered statements or branches** across all four new resolvers.

Closes #6980