### PR TITLE
feat(api): mirror subnet market data (volume/OHLC/stake-quote/validators) in GraphQL

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -160,9 +160,19 @@ import {
   GLOBAL_VALIDATOR_SORTS,
   buildGlobalValidators,
   buildNeuronDetail,
+  buildSubnetValidators,
   buildValidatorDetail,
   overlayFeaturedValidators,
 } from "./metagraph-neurons.mjs";
+import { buildAlphaVolume } from "./alpha-volume.mjs";
+import {
+  buildSubnetOhlc,
+  OHLC_INTERVALS,
+  OHLC_INTERVAL_DEFAULT,
+  DEFAULT_OHLC_WINDOW_DAYS,
+  MAX_OHLC_WINDOW_DAYS,
+} from "./subnet-ohlc.mjs";
+import { computeStakeQuote, STAKE_QUOTE_DIRECTIONS } from "./stake-quote.mjs";
 import {
   ACCOUNTS_LIST_LIMIT_DEFAULT,
   ACCOUNTS_LIST_LIMIT_MAX,
@@ -346,6 +356,14 @@ export const SDL = `
     subnet_health_incidents(netuid: Int!, window: String): SubnetHealthIncidents!
     "One subnet's per-surface latency percentiles (p50/p90/p95/p99) over a 7d/30d window (default 7d), computed live from the success-only health-probe history. The latency-distribution companion of subnet_health_incidents' availability view. A subnet with no probe history resolves to a schema-stable empty surfaces list, never null. Mirrors GET /api/v1/subnets/{netuid}/health/percentiles."
     subnet_health_percentiles(netuid: Int!, window: String): SubnetHealthPercentiles!
+    "One subnet's rolling 24h alpha trading volume from the StakeAdded/StakeRemoved trade stream: buy/sell volume in alpha and TAO, trade counts, net flow, a buy-vs-sell sentiment ratio, and volume-to-market-cap ratio. A subnet with no trades resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/volume."
+    subnet_volume(netuid: Int!): SubnetVolume!
+    "One subnet's alpha-price OHLC candles bucketed by interval (1h or 1d, default 1h) over the trailing days window (default 90, max 365), from the same executed-trade stream subnet_volume reads. A subnet with no trades resolves to a schema-stable empty candle list, never null. Mirrors GET /api/v1/subnets/{netuid}/ohlc."
+    subnet_ohlc(netuid: Int!, interval: String, days: Int): SubnetOhlc!
+    "A read-only quote for a hypothetical stake/unstake against one subnet's live AMM pool: expected amount out, spot vs effective price, and estimated price impact. Computes nothing on-chain and signs nothing. Mirrors GET /api/v1/subnets/{netuid}/stake-quote."
+    subnet_stake_quote(netuid: Int!, amount: Float!, direction: String): SubnetStakeQuote!
+    "One subnet's current validator set (permitted neurons) from the live metagraph snapshot, with each validator's full neuron record. A subnet with no snapshot resolves to a schema-stable empty list, never null. Mirrors GET /api/v1/subnets/{netuid}/validators."
+    subnet_validators(netuid: Int!): SubnetValidatorList!
     "One subnet's chain-event activity summary over a 7d/30d/90d window (default 30d): total events, the per-kind and per-category breakdowns with hotkey/coldkey participation and TAO/alpha amounts, and a bounded newest-first recent-event list (limit 1-50, default 10). A subnet with no events resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/event-summary."
     subnet_event_summary(netuid: Int!, window: String, limit: Int): SubnetEventSummary!
     "One subnet's registry gap report — the reviewer-facing list of missing/incomplete surface coverage backing its curation state. Null when no gap report has been baked for the netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet_gaps MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/gaps."
@@ -2050,6 +2068,82 @@ export const SDL = `
     surfaces: JSON!
   }
 
+  "One subnet's rolling 24h alpha trading volume (#6979). Mirrors GET /api/v1/subnets/{netuid}/volume' data envelope."
+  type SubnetVolume {
+    schema_version: Int!
+    netuid: Int!
+    "The rolling window label this card covers (24h)."
+    window: String
+    buy_volume_alpha: Float!
+    sell_volume_alpha: Float!
+    total_volume_alpha: Float!
+    buy_volume_tao: Float!
+    sell_volume_tao: Float!
+    total_volume_tao: Float!
+    buy_count: Int!
+    sell_count: Int!
+    net_volume_alpha: Float!
+    "Buy share of total volume (0-1); null when there was no volume."
+    sentiment_ratio: Float
+    "Bucketed reading of sentiment_ratio (buying/selling/neutral)."
+    sentiment: String
+    "Total TAO volume over alpha market cap; null when market cap is unknown."
+    vol_mcap_ratio: Float
+  }
+
+  type SubnetOhlcCandle {
+    "Bucket start as epoch milliseconds -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int."
+    bucket_start: Float!
+    bucket_start_iso: String
+    open: Float
+    high: Float
+    low: Float
+    close: Float
+    volume_alpha: Float
+    volume_tao: Float
+    event_count: Int!
+  }
+
+  "One subnet's alpha-price OHLC candles (#6979). Mirrors GET /api/v1/subnets/{netuid}/ohlc' data envelope."
+  type SubnetOhlc {
+    schema_version: Int!
+    netuid: Int!
+    "The resolved bucket interval (1h/1d)."
+    interval: String
+    candles: [SubnetOhlcCandle!]!
+    "True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted."
+    root_excluded: Boolean!
+  }
+
+  "A read-only hypothetical stake/unstake quote against one subnet's live AMM pool (#6979). Mirrors GET /api/v1/subnets/{netuid}/stake-quote."
+  type SubnetStakeQuote {
+    schema_version: Int!
+    netuid: Int!
+    "stake (spends TAO for alpha) or unstake (spends alpha for TAO)."
+    direction: String
+    amount: Float
+    expected_out: Float
+    expected_out_unit: String
+    spot_price_tao: Float
+    effective_price_tao: Float
+    price_impact_pct: Float
+    tao_in_pool_tao: Float
+    alpha_in_pool: Float
+    "True for root (netuid 0), which quotes 1:1 with no price impact."
+    is_root: Boolean
+  }
+
+  "One subnet's current validator set (#6979). Mirrors GET /api/v1/subnets/{netuid}/validators' data envelope."
+  type SubnetValidatorList {
+    schema_version: Int!
+    netuid: Int!
+    validator_count: Int!
+    captured_at: String
+    block_number: Int
+    "Each permitted validator's live metagraph row -- the same NeuronState shape the neuron field returns."
+    validators: [NeuronState!]!
+  }
+
   "One subnet's per-surface success-only latency percentiles (#6980). Mirrors GET /api/v1/subnets/{netuid}/health/percentiles' data envelope."
   type SubnetHealthPercentiles {
     schema_version: Int!
@@ -3115,6 +3209,10 @@ export const FIELD_COMPLEXITY = {
   subnet_uptime: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_health_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_health_percentiles: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_volume: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_ohlc: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_stake_quote: RELATIONSHIP_FIELD_COMPLEXITY,
+  subnet_validators: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_event_summary: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_gaps: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_evidence: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4676,6 +4774,156 @@ const rootValue = {
       source: data.source ?? null,
       summary: data.summary ?? null,
       surfaces: data.surfaces ?? [],
+    };
+  },
+
+  async subnet_volume({ netuid }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // The vol/mcap ratio needs the subnet's alpha market cap, which lives in the
+    // economics artifact rather than the trade stream -- same two-source shape
+    // the REST route and get_subnet_volume MCP tool use.
+    const economics = await loadSubnetEconomics(context, netuid);
+    const marketCapTao =
+      typeof economics?.alpha_market_cap_tao === "number" &&
+      Number.isFinite(economics.alpha_market_cap_tao)
+        ? economics.alpha_market_cap_tao
+        : null;
+    // The tier serves this route inside a { data } envelope (unlike the flat
+    // cards), so unwrap it before falling back to the zeroed build.
+    const tier = await tryPostgresTier(
+      context.env,
+      postgresTierRequest(context, `/api/v1/subnets/${netuid}/volume`),
+      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+    );
+    const data = tier?.data ?? buildAlphaVolume([], netuid, { marketCapTao });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      window: data.window ?? null,
+      buy_volume_alpha: data.buy_volume_alpha ?? 0,
+      sell_volume_alpha: data.sell_volume_alpha ?? 0,
+      total_volume_alpha: data.total_volume_alpha ?? 0,
+      buy_volume_tao: data.buy_volume_tao ?? 0,
+      sell_volume_tao: data.sell_volume_tao ?? 0,
+      total_volume_tao: data.total_volume_tao ?? 0,
+      buy_count: data.buy_count ?? 0,
+      sell_count: data.sell_count ?? 0,
+      net_volume_alpha: data.net_volume_alpha ?? 0,
+      sentiment_ratio: data.sentiment_ratio ?? null,
+      sentiment: data.sentiment ?? null,
+      vol_mcap_ratio: data.vol_mcap_ratio ?? null,
+    };
+  },
+
+  async subnet_ohlc({ netuid, interval, days }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same interval/days validation the REST route + get_subnet_ohlc MCP tool
+    // apply -- out-of-contract input is a GraphQL BAD_USER_INPUT error rather
+    // than a silently-clamped card.
+    const intervalParam = interval ?? OHLC_INTERVAL_DEFAULT;
+    if (!Object.hasOwn(OHLC_INTERVALS, intervalParam)) {
+      throw new GraphQLError(
+        `interval must be one of: ${Object.keys(OHLC_INTERVALS).join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    const daysParam = days ?? DEFAULT_OHLC_WINDOW_DAYS;
+    if (!Number.isInteger(daysParam) || daysParam < 1) {
+      throw new GraphQLError("days must be a positive integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    if (daysParam > MAX_OHLC_WINDOW_DAYS) {
+      throw new GraphQLError(`days must be at most ${MAX_OHLC_WINDOW_DAYS}.`, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const params = new URLSearchParams();
+    params.set("interval", intervalParam);
+    params.set("days", String(daysParam));
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, `/api/v1/subnets/${netuid}/ohlc`, params),
+        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      )) ??
+      buildSubnetOhlc([], netuid, {
+        interval: intervalParam,
+        days: daysParam,
+      });
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      interval: data.interval ?? intervalParam,
+      candles: data.candles ?? [],
+      root_excluded: data.root_excluded ?? false,
+    };
+  },
+
+  async subnet_stake_quote({ netuid, amount, direction }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    const directionParam = direction ?? "stake";
+    if (!STAKE_QUOTE_DIRECTIONS.includes(directionParam)) {
+      throw new GraphQLError(
+        `direction must be one of: ${STAKE_QUOTE_DIRECTIONS.join(", ")}.`,
+        { extensions: { code: "BAD_USER_INPUT" } },
+      );
+    }
+    // Same pure computeStakeQuote over the live pool reserves the REST route +
+    // get_subnet_stake_quote MCP tool run -- no economics logic duplicated, and
+    // still strictly read-only (nothing is built, signed, or submitted).
+    const economics = await loadSubnetEconomics(context, netuid);
+    const result = computeStakeQuote({
+      netuid,
+      taoInPool: economics?.tao_in_pool_tao,
+      alphaInPool: economics?.alpha_in_pool,
+      amount,
+      direction: directionParam,
+    });
+    if (!result.ok) {
+      // The shared calculator's own contract errors (bad amount, dead pool)
+      // surface as BAD_USER_INPUT rather than a partially-filled card.
+      throw new GraphQLError(result.error, {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    return { schema_version: 1, ...result.quote };
+  },
+
+  async subnet_validators({ netuid }, context) {
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      throw new GraphQLError("netuid must be a non-negative integer.", {
+        extensions: { code: "BAD_USER_INPUT" },
+      });
+    }
+    // Same tryPostgresTier(METAGRAPH_NEURONS_SOURCE) -> buildSubnetValidators([])
+    // empty-snapshot fallback the REST route and list_subnet_validators share.
+    // REST takes no filter params here, so neither does this mirror.
+    const data =
+      (await tryPostgresTier(
+        context.env,
+        postgresTierRequest(context, `/api/v1/subnets/${netuid}/validators`),
+        "METAGRAPH_NEURONS_SOURCE",
+      )) ?? buildSubnetValidators([], netuid);
+    return {
+      schema_version: data.schema_version ?? 1,
+      netuid: data.netuid ?? netuid,
+      validator_count: data.validator_count ?? 0,
+      captured_at: data.captured_at ?? null,
+      block_number: data.block_number ?? null,
+      validators: data.validators ?? [],
     };
   },
 

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -6094,6 +6094,335 @@ describe("graphql — subnet_concentration_history (#5901, neuron_daily trend + 
   });
 });
 
+describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validators)", () => {
+  function dataApi(response) {
+    return { fetch: async () => response };
+  }
+  const POOL = {
+    "/metagraph/economics.json": {
+      subnets: [
+        {
+          netuid: 64,
+          tao_in_pool_tao: 201959.938748425,
+          alpha_in_pool: 2730860.150574127,
+          alpha_market_cap_tao: 5000,
+        },
+      ],
+    },
+  };
+
+  test("subnet_volume cold store returns a schema-stable zeroed card", async () => {
+    const { status, body } = await gql(
+      "{ subnet_volume(netuid: 5) { schema_version netuid total_volume_tao buy_count sentiment sentiment_ratio vol_mcap_ratio } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const v = body.data.subnet_volume;
+    assert.equal(v.schema_version, 1);
+    assert.equal(v.netuid, 5);
+    assert.equal(v.total_volume_tao, 0);
+    assert.equal(v.buy_count, 0);
+    assert.equal(v.sentiment, "neutral");
+    assert.equal(v.sentiment_ratio, null);
+    assert.equal(v.vol_mcap_ratio, null);
+  });
+
+  test("subnet_volume unwraps the tier's { data } envelope", async () => {
+    const env = {
+      ...fixtureEnv(POOL),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          data: {
+            schema_version: 1,
+            netuid: 64,
+            window: "24h",
+            buy_volume_tao: 12,
+            sell_volume_tao: 8,
+            total_volume_tao: 20,
+            buy_count: 3,
+            sell_count: 2,
+            sentiment: "buying",
+            sentiment_ratio: 0.6,
+          },
+        }),
+      ),
+    };
+    const { status, body } = await gql(
+      "{ subnet_volume(netuid: 64) { netuid window total_volume_tao buy_count sentiment sentiment_ratio } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const v = body.data.subnet_volume;
+    assert.equal(v.window, "24h");
+    assert.equal(v.total_volume_tao, 20);
+    assert.equal(v.sentiment, "buying");
+    assert.equal(v.sentiment_ratio, 0.6);
+  });
+
+  test("subnet_ohlc cold store returns an empty candle list", async () => {
+    const { status, body } = await gql(
+      "{ subnet_ohlc(netuid: 5) { schema_version netuid interval root_excluded candles { bucket_start open close } } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const o = body.data.subnet_ohlc;
+    assert.equal(o.interval, "1h");
+    assert.deepEqual(o.candles, []);
+    assert.equal(o.root_excluded, false);
+  });
+
+  test("subnet_ohlc forwards interval + days and returns tier candles", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            netuid: 7,
+            interval: "1d",
+            root_excluded: false,
+            candles: [
+              {
+                bucket_start: 1770000000000,
+                bucket_start_iso: "2026-02-02T00:00:00.000Z",
+                open: 0.1,
+                high: 0.2,
+                low: 0.09,
+                close: 0.15,
+                volume_alpha: 100,
+                volume_tao: 12,
+                event_count: 4,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      '{ subnet_ohlc(netuid: 7, interval: "1d", days: 30) { interval candles { bucket_start close event_count } } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.ok(capturedUrl.pathname.endsWith("/subnets/7/ohlc"));
+    assert.equal(capturedUrl.searchParams.get("interval"), "1d");
+    assert.equal(capturedUrl.searchParams.get("days"), "30");
+    const o = body.data.subnet_ohlc;
+    assert.equal(o.interval, "1d");
+    assert.equal(o.candles[0].bucket_start, 1770000000000);
+    assert.equal(o.candles[0].event_count, 4);
+  });
+
+  test("subnet_ohlc rejects an unsupported interval", async () => {
+    const { body } = await gql(
+      '{ subnet_ohlc(netuid: 5, interval: "5m") { interval } }',
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/interval/i.test(body.errors[0].message));
+  });
+
+  test("subnet_ohlc rejects days above the maximum window", async () => {
+    const { body } = await gql(
+      "{ subnet_ohlc(netuid: 5, days: 9999) { interval } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/days/i.test(body.errors[0].message));
+  });
+
+  test("subnet_ohlc rejects a non-positive days", async () => {
+    const { body } = await gql(
+      "{ subnet_ohlc(netuid: 5, days: 0) { interval } }",
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/days/i.test(body.errors[0].message));
+  });
+
+  test("subnet_stake_quote quotes against the live pool reserves", async () => {
+    const { status, body } = await gql(
+      "{ subnet_stake_quote(netuid: 64, amount: 1000) { schema_version netuid direction amount expected_out expected_out_unit spot_price_tao effective_price_tao price_impact_pct is_root } }",
+      fixtureEnv(POOL),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const q = body.data.subnet_stake_quote;
+    assert.equal(q.schema_version, 1);
+    assert.equal(q.netuid, 64);
+    assert.equal(q.direction, "stake");
+    assert.equal(q.expected_out_unit, "alpha");
+    assert.ok(q.expected_out > 0);
+    assert.ok(q.price_impact_pct > 0);
+    assert.equal(q.is_root, false);
+  });
+
+  test("subnet_stake_quote quotes an unstake (alpha in, TAO out)", async () => {
+    const { body } = await gql(
+      '{ subnet_stake_quote(netuid: 64, amount: 500, direction: "unstake") { direction expected_out_unit expected_out } }',
+      fixtureEnv(POOL),
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.subnet_stake_quote.direction, "unstake");
+    assert.equal(body.data.subnet_stake_quote.expected_out_unit, "tao");
+  });
+
+  test("subnet_stake_quote rejects an unsupported direction", async () => {
+    const { body } = await gql(
+      '{ subnet_stake_quote(netuid: 64, amount: 1, direction: "swap") { direction } }',
+      fixtureEnv(POOL),
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.ok(/direction/i.test(body.errors[0].message));
+  });
+
+  test("subnet_stake_quote surfaces the calculator's error for a subnet with no pool", async () => {
+    const { body } = await gql(
+      "{ subnet_stake_quote(netuid: 999, amount: 1) { expected_out } }",
+      fixtureEnv(POOL),
+    );
+    assert.ok(body.errors, "expected a GraphQL error");
+    assert.equal(body.data?.subnet_stake_quote ?? null, null);
+  });
+
+  test("subnet_validators cold store returns a schema-stable empty list", async () => {
+    const { status, body } = await gql(
+      "{ subnet_validators(netuid: 5) { schema_version netuid validator_count captured_at block_number validators { uid hotkey } } }",
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    const v = body.data.subnet_validators;
+    assert.equal(v.validator_count, 0);
+    assert.equal(v.captured_at, null);
+    assert.deepEqual(v.validators, []);
+  });
+
+  test("subnet_validators resolves the Postgres-tier validator set", async () => {
+    let capturedUrl;
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async (req) => {
+          capturedUrl = new URL(req.url);
+          return Response.json({
+            schema_version: 1,
+            netuid: 7,
+            validator_count: 1,
+            captured_at: "2026-07-19T00:00:00.000Z",
+            block_number: 91,
+            validators: [
+              {
+                uid: 3,
+                hotkey: "5Hotkey",
+                stake_tao: 1234.5,
+                validator_permit: true,
+              },
+            ],
+          });
+        },
+      },
+    };
+    const { status, body } = await gql(
+      "{ subnet_validators(netuid: 7) { netuid validator_count block_number validators { uid hotkey stake_tao validator_permit } } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.ok(capturedUrl.pathname.endsWith("/subnets/7/validators"));
+    const v = body.data.subnet_validators;
+    assert.equal(v.validator_count, 1);
+    assert.equal(v.block_number, 91);
+    assert.equal(v.validators[0].hotkey, "5Hotkey");
+    assert.equal(v.validators[0].stake_tao, 1234.5);
+  });
+
+  test("a negative netuid is a GraphQL error on every market-data field", async () => {
+    for (const q of [
+      "{ subnet_volume(netuid: -1) { netuid } }",
+      "{ subnet_ohlc(netuid: -1) { netuid } }",
+      "{ subnet_stake_quote(netuid: -1, amount: 1) { netuid } }",
+      "{ subnet_validators(netuid: -1) { netuid } }",
+    ]) {
+      const { body } = await gql(q);
+      assert.ok(body.errors, `expected a GraphQL error for ${q}`);
+      assert.ok(/netuid/i.test(body.errors[0].message));
+    }
+  });
+
+  test("a partial tier body falls back to defaults on every market-data field", async () => {
+    // Exercises the `?? default` branches: a tier that answers with an empty
+    // body must still yield the schema-stable card, never nulls or an error.
+    const volumeEnv = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: dataApi(Response.json({ data: {} })),
+    };
+    const vol = await gql(
+      "{ subnet_volume(netuid: 9) { schema_version netuid window total_volume_alpha total_volume_tao buy_volume_alpha sell_volume_alpha buy_volume_tao sell_volume_tao buy_count sell_count net_volume_alpha sentiment sentiment_ratio vol_mcap_ratio } }",
+      volumeEnv,
+    );
+    assert.equal(vol.body.errors, undefined);
+    assert.deepEqual(vol.body.data.subnet_volume, {
+      schema_version: 1,
+      netuid: 9,
+      window: null,
+      total_volume_alpha: 0,
+      total_volume_tao: 0,
+      buy_volume_alpha: 0,
+      sell_volume_alpha: 0,
+      buy_volume_tao: 0,
+      sell_volume_tao: 0,
+      buy_count: 0,
+      sell_count: 0,
+      net_volume_alpha: 0,
+      sentiment: null,
+      sentiment_ratio: null,
+      vol_mcap_ratio: null,
+    });
+
+    // A fresh Response per fetch -- a single Response body can only be consumed
+    // once, so reusing one would make the second query silently miss the tier.
+    const emptyTier = {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: { fetch: async () => Response.json({}) },
+    };
+    const ohlc = await gql(
+      "{ subnet_ohlc(netuid: 9) { schema_version netuid interval candles { open } root_excluded } }",
+      emptyTier,
+    );
+    assert.equal(ohlc.body.errors, undefined);
+    assert.deepEqual(ohlc.body.data.subnet_ohlc, {
+      schema_version: 1,
+      netuid: 9,
+      interval: "1h",
+      candles: [],
+      root_excluded: false,
+    });
+
+    const vals = await gql(
+      "{ subnet_validators(netuid: 9) { schema_version netuid validator_count captured_at block_number validators { uid } } }",
+      emptyTier,
+    );
+    assert.equal(vals.body.errors, undefined);
+    assert.deepEqual(vals.body.data.subnet_validators, {
+      schema_version: 1,
+      netuid: 9,
+      validator_count: 0,
+      captured_at: null,
+      block_number: null,
+      validators: [],
+    });
+  });
+
+  test("the market-data fields are weighted as fan-out fields", () => {
+    assert.equal(FIELD_COMPLEXITY.subnet_volume, 5);
+    assert.equal(FIELD_COMPLEXITY.subnet_ohlc, 5);
+    assert.equal(FIELD_COMPLEXITY.subnet_stake_quote, 5);
+    assert.equal(FIELD_COMPLEXITY.subnet_validators, 5);
+  });
+});
+
 describe("graphql — subnet_health_percentiles (#6980, live latency percentiles)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Context

Four subnet-level market/trading routes had REST + MCP but no GraphQL mirror, so a client building a subnet market-data view (price/volume chart, stake calculator, validator list) had to fall back to REST.

## Change

Four new `type Query` fields in `src/graphql.mjs`, each reusing the shaping function REST and MCP already call:

| Field | Mirrors |
|---|---|
| `subnet_volume(netuid)` | `/volume` — rolling 24h alpha volume, buy/sell split, sentiment ratio, vol/mcap ratio |
| `subnet_ohlc(netuid, interval, days)` | `/ohlc` — alpha-price candles, 1h/1d (default 1h), trailing days (default 90, max 365) |
| `subnet_stake_quote(netuid, amount, direction)` | `/stake-quote` — read-only AMM quote: expected out, spot vs effective price, price impact |
| `subnet_validators(netuid)` | `/validators` — the permitted validator set |

**Contract fidelity:**
- `interval`, `days`, and `direction` are validated exactly as the REST route and MCP tools validate them — out-of-contract input raises `BAD_USER_INPUT` rather than being silently clamped. The stake-quote calculator's own errors (bad amount, dead pool) surface the same way.
- `subnet_volume` **unwraps the tier's `{ data }` envelope** — this route uses one, unlike the flat cards.
- `subnet_validators` takes **no filter params**, matching REST (`limit` / `min_stake_tao` are MCP-only post-filters).
- Validators reuse the existing **`NeuronState`** type — the same record the `neuron` field already returns — rather than duplicating a neuron shape. (The existing top-level `validators` field is the cross-subnet leaderboard and does not cover this netuid-scoped list.)
- `SubnetOhlcCandle.bucket_start` is a `Float`, since epoch-ms exceeds GraphQL's 32-bit `Int`.

## Deliverables

- [x] `subnet_volume`, `subnet_ohlc`, `subnet_stake_quote`, `subnet_validators` reachable from GraphQL
- [x] New output types (`SubnetVolume`, `SubnetOhlc`/`SubnetOhlcCandle`, `SubnetStakeQuote`, `SubnetValidatorList`)
- [x] Test coverage for each new resolver

## Tests

16 new resolver tests: cold-store shapes, Postgres-tier hits, interval/days forwarding, invalid interval/days/direction and negative-netuid errors, the no-pool quote failure, and a **partial-tier-body case per tier-backed field** so every `?? default` branch is exercised. Full suite green (664), eslint + prettier clean, public-safety scan clean, and **zero uncovered statements or branches** across all four new resolvers.

Closes #6979