### PR TITLE
fix(registry): wire SN105 Beam MCP execute probe config (#7116)

### DIFF
--- a/registry/subnets/beam.json
+++ b/registry/subnets/beam.json
@@ -34,7 +34,13 @@
       "id": "sn-105-beam-openapi",
       "kind": "openapi",
       "name": "BeamCore API OpenAPI schema",
-      "notes": "Machine-readable OpenAPI 3.0 schema for the BeamCore control-plane HTTP API (title: BeamCore API). Served publicly at beamcore.b1m.ai; documents orchestrator, worker, validator, and health routes for SN105 Beam.",
+      "notes": "Machine-readable OpenAPI 3.0 schema for the BeamCore control-plane HTTP API (title: BeamCore API). Served publicly at beamcore.b1m.ai; documents orchestrator, worker, validator, and health routes for SN105 Beam. Live-verified 2026-07-20: GET returns OpenAPI 3.0 JSON (~10 KB).",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "beam",
       "public_safe": true,
       "review": {
@@ -55,7 +61,13 @@
       "id": "sn-105-beam-health",
       "kind": "subnet-api",
       "name": "BeamCore API health",
-      "notes": "Public no-auth GET /health on beamcore.b1m.ai returning control-plane liveness JSON (ok, db, schema, metagraph sync). Documented in the subnet OpenAPI spec on the same host; beamcore.b1m.ai is the CORE_SERVER_URL configured in the official Beam README.",
+      "notes": "Public no-auth GET /health on beamcore.b1m.ai returning control-plane liveness JSON (ok, db, schema, metagraph sync). Documented in the subnet OpenAPI spec on the same host; beamcore.b1m.ai is the CORE_SERVER_URL configured in the official Beam README. Live-verified 2026-07-20: HTTP 200 JSON; note assignment_dispatch can be multi-MB so MCP execute callers may prefer the smaller routing/worker-capacity surfaces for smoke tests.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
       "provider": "beam",
       "public_safe": true,
       "review": {


### PR DESCRIPTION
﻿## Summary

Prepare SN105 (Beam) for MCP execute (call_subnet_surface, #7014) by adding missing probe config on the two surfaces that lacked it and live-verifying all five issue-scoped endpoints return real JSON.

Closes #7116 (preparatory wiring; full end-to-end call_subnet_surface verification awaits Phase 1 landing in #7014).

## Surfaces verified (live 2026-07-20)

| surface_id | status | response |
|---|---|---|
| sn-105-beam-openapi | 200 | OpenAPI 3.0 JSON (~10 KB) |
| sn-105-beam-health | 200 | JSON (~3 MB; ssignment_dispatch dominates payload) |
| sn-105-beam-routing-orchestrators | 200 | JSON array of orchestrators (~5 KB) |
| sn-105-beam-worker-capacity | 200 | JSON {total_workers, by_orchestrator} |
| sn-105-beam-validators-orchestrators | 200 | JSON orchestrator list (~41 KB) |

## Registry changes

- **sn-105-beam-openapi**: add probe (GET, expect: json) — was missing despite captured schema
- **sn-105-beam-health**: add probe (GET, expect: json) — enables operational monitoring + execute resolution; notes document the large response body quirk

The three routing/validator subnet-api surfaces already had correct probe config and required no edits.

## Checklist

- [x] Changes exactly one registry/subnets/beam.json file
- [x] pm run validate:surface -- registry/subnets/beam.json passed
- [x] All five issue-scoped surfaces live-probed for real JSON responses (not health-ping metadata only)

## Test plan

- [ ] Gittensory Gate + CI green
- [ ] After #7014 merges: re-run each surface through call_subnet_surface and confirm body is returned (prefer routing/worker-capacity over health for smoke tests due to ~3 MB payload)
