### PR TITLE
feat(api): add agent_resources GraphQL field

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -165,6 +165,7 @@ import {
   overlayFeaturedValidators,
 } from "./metagraph-neurons.mjs";
 import { buildAlphaVolume } from "./alpha-volume.mjs";
+import { AGENT_RESOURCES_ARTIFACT } from "./agent-resources-mcp.mjs";
 import {
   buildSubnetOhlc,
   OHLC_INTERVALS,
@@ -395,6 +396,8 @@ export const SDL = `
     subnet_health_percentiles(netuid: Int!, window: String): SubnetHealthPercentiles!
     "One subnet's rolling 24h alpha trading volume from the StakeAdded/StakeRemoved trade stream: buy/sell volume in alpha and TAO, trade counts, net flow, a buy-vs-sell sentiment ratio, and volume-to-market-cap ratio. A subnet with no trades resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/volume."
     subnet_volume(netuid: Int!): SubnetVolume!
+    "The machine-readable AI-resources index: the copyable agent prompt (/agent.md), MCP server install metadata and tool listing, the Bittensor skill, llms.txt, OpenAPI, and links to the agent-facing APIs. Use it to bootstrap an agent integration before calling the catalog/search fields. Null when the index has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_agent_resources MCP/REST shape. Mirrors GET /api/v1/agent-resources."
+    agent_resources: JSON
     "One subnet's alpha-price OHLC candles bucketed by interval (1h or 1d, default 1h) over the trailing days window (default 90, max 365), from the same executed-trade stream subnet_volume reads. A subnet with no trades resolves to a schema-stable empty candle list, never null. Mirrors GET /api/v1/subnets/{netuid}/ohlc."
     subnet_ohlc(netuid: Int!, interval: String, days: Int): SubnetOhlc!
     "A read-only quote for a hypothetical stake/unstake against one subnet's live AMM pool: expected amount out, spot vs effective price, and estimated price impact. Computes nothing on-chain and signs nothing. Mirrors GET /api/v1/subnets/{netuid}/stake-quote."
@@ -3451,6 +3454,7 @@ export const FIELD_COMPLEXITY = {
   subnet_uptime: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_health_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_health_percentiles: RELATIONSHIP_FIELD_COMPLEXITY,
+  agent_resources: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_volume: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_ohlc: RELATIONSHIP_FIELD_COMPLEXITY,
   subnet_stake_quote: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -5023,6 +5027,13 @@ const rootValue = {
       summary: data.summary ?? null,
       surfaces: data.surfaces ?? [],
     };
+  },
+
+  async agent_resources(_args, context) {
+    // Same baked artifact the REST route + get_agent_resources MCP tool read.
+    // The MCP tool raises not_found when it is absent; GraphQL degrades to
+    // null instead, matching every other artifact-backed resolver here.
+    return loadArtifact(context, AGENT_RESOURCES_ARTIFACT);
   },
 
   async subnet_volume({ netuid }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -6094,6 +6094,34 @@ describe("graphql — subnet_concentration_history (#5901, neuron_daily trend + 
   });
 });
 
+describe("graphql — agent_resources (#6987, baked AI-resources index)", () => {
+  test("resolves the baked AI-resources index", async () => {
+    const env = fixtureEnv({
+      "/metagraph/agent-resources.json": {
+        schema_version: 1,
+        agent: { url: "https://metagraph.sh/agent.md" },
+        mcp: { server: "https://api.metagraph.sh/mcp", tool_count: 197 },
+      },
+    });
+    const { status, body } = await gql("{ agent_resources }", env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.agent_resources.schema_version, 1);
+    assert.equal(body.data.agent_resources.mcp.tool_count, 197);
+  });
+
+  test("degrades to null when the index has not been baked, never an error", async () => {
+    const { status, body } = await gql("{ agent_resources }");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.agent_resources, null);
+  });
+
+  test("agent_resources is weighted as a fan-out field", () => {
+    assert.equal(FIELD_COMPLEXITY.agent_resources, 5);
+  });
+});
+
 describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validators)", () => {
   function dataApi(response) {
     return { fetch: async () => response };


### PR DESCRIPTION
## Context

`GET /api/v1/agent-resources` — the machine-readable AI-resources index (copyable agent prompt, MCP server install metadata and tool listing, the skill, llms.txt, OpenAPI, and links to the agent-facing APIs) — was REST-only with no GraphQL field.

## Change

Adds `agent_resources` to `type Query`, reading the same baked `/metagraph/agent-resources.json` artifact the REST route and the `get_agent_resources` MCP tool already read — no loading logic duplicated.

- **Degrades to `null`** when the index has not been baked in an environment, rather than erroring. (The MCP tool raises `not_found`; GraphQL's convention here is to degrade — matching every other artifact-backed resolver.)
- Passes the payload through as the existing opaque **`JSON` scalar**, the same treatment `subnet_gaps`/`subnet_evidence` and `SubnetHealthTrends.windows` already get, since this is a baked index with no src-side shape.

As the issue notes, this one is deliberately **GraphQL-only, not GraphQL + MCP** — an MCP client already discovers the server's own tools via `tools/list`, so a tool for "list AI resources including MCP tools" would be a confusing self-reference. REST + GraphQL parity is the real gap.

## Deliverables

- [x] `agent_resources` GraphQL Query field
- [x] Test coverage

## Tests

3 new tests: the baked-index hit, the absent-artifact degrade-to-null path, and fan-out complexity weighting. Full suite green (697), eslint + prettier clean, public-safety scan clean, **zero uncovered statements or branches** on the new resolver.

Closes #6987