### PR TITLE
feat(api): GraphQL parity for profiles (#6992)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -11,6 +11,10 @@ import { readArtifact, readHealthKv } from "../workers/storage.mjs";
 // own loader unchanged (same artifact read, filter, sort, and page logic REST
 // and MCP already use) -- not a reimplementation.
 import { loadSourceSnapshotsList } from "./source-snapshots-mcp.mjs";
+// #6992: GraphQL parity for profiles, reusing list_profiles' own loader
+// unchanged (same artifact read, filter, sort, and page logic REST and MCP
+// already use) -- not a reimplementation.
+import { loadProfilesList } from "./profiles-mcp.mjs";
 import { contractVersion } from "../workers/responses.mjs";
 import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 // #6985: GraphQL parity for the endpoint-pools/rpc-pools/endpoint-incidents REST
@@ -459,6 +463,8 @@ export const SDL = `
     endpoint_incidents(netuid: Int, kind: String, provider: String, status: String, severity: String, state: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): IncidentList!
     "Per-source input-hash ledger -- each registry data source's captured input hash and record count at ingest time, for detecting hash drift or seeing per-source contribution volume. Filter with q (keyword search across id/kind/path), sort with sort/order, and page with limit (1-100)/cursor. An invalid sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/source-snapshots."
     source_snapshots(q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): SourceSnapshotList!
+    "Public-safe subnet profile index -- completeness scores, surface/interface counts, curation level, review state, and confidence for every registered subnet. Filter by netuid/subnet_type/curation_level/review_state/confidence/profile_level, search name/slug/project/team/categories with q, sort with sort/order, and page with limit (1-1000)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/profiles."
+    profiles(netuid: Int, subnet_type: String, curation_level: String, review_state: String, confidence: String, profile_level: String, q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ProfileList!
     "Global operational health rollup with per-subnet summaries."
     health: GlobalHealth
     "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
@@ -1692,6 +1698,18 @@ export const SDL = `
     schema_version: String
     summary: JSON
     sources: [JSON!]!
+    total: Int!
+    returned: Int!
+    limit: Int!
+    cursor: Int!
+    next_cursor: Int
+    sort: String
+    order: String
+  }
+
+  type ProfileList {
+    captured_at: String
+    profiles: [JSON!]!
     total: Int!
     returned: Int!
     limit: Int!
@@ -3435,6 +3453,7 @@ export const FIELD_COMPLEXITY = {
   rpc_pools: RELATIONSHIP_FIELD_COMPLEXITY,
   endpoint_incidents: RELATIONSHIP_FIELD_COMPLEXITY,
   source_snapshots: RELATIONSHIP_FIELD_COMPLEXITY,
+  profiles: RELATIONSHIP_FIELD_COMPLEXITY,
   health: RELATIONSHIP_FIELD_COMPLEXITY,
   opportunity_boards: RELATIONSHIP_FIELD_COMPLEXITY,
   compare: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4947,6 +4966,17 @@ const rootValue = {
   // convention.
   source_snapshots(args, context) {
     return loadSourceSnapshotsList(context, args, { readArtifact });
+  },
+
+  // #6992: reuse list_profiles' own loader unchanged. Its readOptionalArtifact
+  // dep is called as (ctx, path) and expects data-or-null on a cold artifact
+  // (not a throw) -- this file's own loadArtifact(context, path) already has
+  // exactly that shape (readArtifact(context.env, path), null if not ok), so
+  // it's reused directly rather than adding a redundant wrapper.
+  profiles(args, context) {
+    return loadProfilesList(context, args, {
+      readOptionalArtifact: loadArtifact,
+    });
   },
 
   async health(_args, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -1575,6 +1575,97 @@ describe("graphql — source_snapshots", () => {
   });
 });
 
+// #6992: GraphQL parity for profiles, reusing list_profiles' own loader
+// unchanged (same filter/sort/page + error behavior as REST and MCP) rather
+// than a GraphQL-only reimplementation.
+describe("graphql — profiles", () => {
+  const PROFILE_ROW = {
+    netuid: 7,
+    slug: "allways",
+    name: "Allways",
+    completeness_score: 82,
+    curation_level: "machine-verified",
+    review_state: "verified",
+    confidence: "high",
+    profile_level: "operational",
+    surface_count: 5,
+  };
+
+  const PROFILES_BLOB = {
+    captured_at: "2026-06-20T00:00:00Z",
+    profiles: [
+      PROFILE_ROW,
+      {
+        ...PROFILE_ROW,
+        netuid: 1,
+        slug: "alpha",
+        name: "Alpha",
+        completeness_score: 60,
+        confidence: "medium",
+      },
+    ],
+  };
+
+  test("filters by netuid and paginates", async () => {
+    const env = fixtureEnv({ "/metagraph/profiles.json": PROFILES_BLOB });
+    const filtered = await gql(
+      "{ profiles(netuid: 7) { profiles total captured_at } }",
+      env,
+    );
+    assert.equal(filtered.status, 200);
+    assert.equal(filtered.body.data.profiles.total, 1);
+    assert.equal(filtered.body.data.profiles.profiles[0].slug, "allways");
+    assert.equal(
+      filtered.body.data.profiles.captured_at,
+      "2026-06-20T00:00:00Z",
+    );
+
+    const paged = await gql(
+      "{ profiles(limit: 1) { profiles total returned next_cursor } }",
+      env,
+    );
+    assert.equal(paged.body.data.profiles.profiles.length, 1);
+    assert.equal(paged.body.data.profiles.total, 2);
+    assert.equal(paged.body.data.profiles.returned, 1);
+    assert.ok(paged.body.data.profiles.next_cursor != null);
+  });
+
+  test("searches by q and sorts by completeness_score", async () => {
+    const env = fixtureEnv({ "/metagraph/profiles.json": PROFILES_BLOB });
+    const searched = await gql(
+      '{ profiles(q: "alpha") { profiles total } }',
+      env,
+    );
+    assert.equal(searched.body.data.profiles.total, 1);
+    assert.equal(searched.body.data.profiles.profiles[0].slug, "alpha");
+
+    const sorted = await gql(
+      '{ profiles(sort: "completeness_score", order: "desc") { profiles } }',
+      env,
+    );
+    assert.equal(sorted.body.data.profiles.profiles[0].slug, "allways");
+  });
+
+  test("surfaces an invalid curation_level as a GraphQL error, not a silent default", async () => {
+    const env = fixtureEnv({ "/metagraph/profiles.json": PROFILES_BLOB });
+    const { body } = await gql(
+      '{ profiles(curation_level: "bogus") { total } }',
+      env,
+    );
+    assert.ok(body.errors?.length);
+  });
+
+  test("surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
+    const { body } = await gql("{ profiles { total } }", emptyEnv);
+    assert.ok(body.errors?.length);
+    assert.equal(body.data, null);
+  });
+
+  test("FIELD_COMPLEXITY weights it like its sibling relationship fields", () => {
+    assert.equal(FIELD_COMPLEXITY.profiles, 5);
+  });
+});
+
 describe("graphql — economics pagination", () => {
   const env = () =>
     fixtureEnv({


### PR DESCRIPTION
## Summary
- Adds GraphQL parity for `profiles`, mirroring `GET /api/v1/profiles`.
- The issue's MCP-tool claim ("no MCP tool with 'profile' in its name") is already false on `upstream/main` — `list_profiles` / `loadProfilesList` in `src/profiles-mcp.mjs` already implement this route for MCP. This PR is GraphQL-only: it reuses that existing, already-tested loader unchanged rather than reimplementing filter/sort/pagination logic in `graphql.mjs`.

```js
// #6992: reuse list_profiles' own loader unchanged. Its readOptionalArtifact
// dep is called as (ctx, path) and expects data-or-null on a cold artifact
// (not a throw) -- this file's own loadArtifact(context, path) already has
// exactly that shape (readArtifact(context.env, path), null if not ok), so
// it's reused directly rather than adding a redundant wrapper.
profiles(args, context) {
  return loadProfilesList(context, args, { readOptionalArtifact: loadArtifact });
},
```

New SDL:
```graphql
profiles(netuid: Int, subnet_type: String, curation_level: String, review_state: String, confidence: String, profile_level: String, q: String, sort: String, order: String, fields: String, limit: Int, cursor: Int): ProfileList!
```

## Test plan
- [x] `npx vitest run tests/graphql.test.mjs` — 704/704 passing (5 new tests: netuid filter+pagination, q search+sort, invalid curation_level error, cold-artifact error, FIELD_COMPLEXITY check)
- [x] `npm run build && npm run validate` — clean
- [x] `npm test` — full suite green
- [x] `npx prettier --write` / `npx eslint` — clean

Closes #6992
