### PR TITLE
feat(ui): account page child/parent delegation graph + entity labels

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.account-delegation.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-delegation.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountChildrenQuery, accountParentsQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const BOB = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+function resolveWith(path: string, data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: path,
+  });
+}
+
+async function runChildren(ss58: string) {
+  const opts = accountChildrenQuery(ss58);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+async function runParents(ss58: string) {
+  const opts = accountParentsQuery(ss58);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("accountChildrenQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits the children route and preserves a well-formed subnet row", async () => {
+    resolveWith(`/api/v1/accounts/${ALICE}/children`, {
+      schema_version: 1,
+      account: ALICE,
+      queried_at: "2026-07-20T00:00:00.000Z",
+      subnets: [
+        {
+          netuid: 1,
+          entries: [
+            {
+              child: BOB,
+              proportion: "9223372036854775807",
+              proportion_fraction: 0.5,
+            },
+          ],
+        },
+      ],
+    });
+    const res = await runChildren(ALICE);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${ALICE}/children`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(res.data).toMatchObject({
+      account: ALICE,
+      schema_version: 1,
+      queried_at: "2026-07-20T00:00:00.000Z",
+    });
+    expect(res.data.subnets).toEqual([
+      {
+        netuid: 1,
+        entries: [
+          {
+            child: BOB,
+            proportion: "9223372036854775807",
+            proportion_fraction: 0.5,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("preserves subnets: null as an RPC failure (distinct from empty)", async () => {
+    resolveWith(`/api/v1/accounts/${ALICE}/children`, {
+      account: ALICE,
+      subnets: null,
+    });
+    const res = await runChildren(ALICE);
+    expect(res.data.subnets).toBeNull();
+  });
+
+  it("drops incomplete entries and degrades junk payloads to an empty graph", async () => {
+    resolveWith(`/api/v1/accounts/${ALICE}/children`, {
+      account: ALICE,
+      subnets: [
+        { netuid: 1, entries: [{ child: BOB }] }, // missing proportion
+        { netuid: "x", entries: [] },
+        "not-a-subnet",
+      ],
+    });
+    const res = await runChildren(ALICE);
+    expect(res.data.subnets).toEqual([]);
+  });
+});
+
+describe("accountParentsQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits the parents route and preserves a well-formed subnet row", async () => {
+    resolveWith(`/api/v1/accounts/${ALICE}/parents`, {
+      schema_version: 1,
+      account: ALICE,
+      subnets: [
+        {
+          netuid: 18,
+          entries: [
+            {
+              parent: BOB,
+              proportion: "18446744073709551615",
+              proportion_fraction: 1,
+            },
+          ],
+        },
+      ],
+    });
+    const res = await runParents(ALICE);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${ALICE}/parents`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(res.data.subnets).toEqual([
+      {
+        netuid: 18,
+        entries: [
+          {
+            parent: BOB,
+            proportion: "18446744073709551615",
+            proportion_fraction: 1,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("preserves subnets: null as an RPC failure", async () => {
+    resolveWith(`/api/v1/accounts/${ALICE}/parents`, { account: ALICE, subnets: null });
+    const res = await runParents(ALICE);
+    expect(res.data.subnets).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.account-entities.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.account-entities.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiResult } from "./client";
+import { apiFetch } from "./client";
+import { accountEntitiesQuery } from "./queries";
+
+vi.mock("./client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client")>();
+  return { ...actual, apiFetch: vi.fn() };
+});
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+const ALICE = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+function resolveWith(data: unknown): void {
+  mockedApiFetch.mockResolvedValue({
+    data,
+    meta: {} as ApiResult<unknown>["meta"],
+    url: `/api/v1/accounts/${ALICE}/entities`,
+  });
+}
+
+async function runQuery(ss58: string) {
+  const opts = accountEntitiesQuery(ss58);
+  if (!opts.queryFn) throw new Error("expected a queryFn");
+  return opts.queryFn({
+    signal: new AbortController().signal,
+    queryKey: opts.queryKey,
+    meta: undefined,
+  } as unknown as Parameters<NonNullable<typeof opts.queryFn>>[0]);
+}
+
+describe("accountEntitiesQuery", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+  });
+
+  it("hits the entities route and passes through labels + ownership ties", async () => {
+    resolveWith({
+      schema_version: 1,
+      ss58: ALICE,
+      labels: [
+        {
+          name: "Binance Hot",
+          category: "exchange",
+          notes: "Exchange deposit coldkey",
+          source_urls: ["https://example.com/label"],
+        },
+      ],
+      ownership_tie_count: 1,
+      ownership_ties: [
+        {
+          netuid: 18,
+          role: "gained_ownership",
+          block_number: 5_000_000,
+          observed_at: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+    const res = await runQuery(ALICE);
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      `/api/v1/accounts/${ALICE}/entities`,
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+    expect(res.data).toMatchObject({
+      ss58: ALICE,
+      schema_version: 1,
+      ownership_tie_count: 1,
+    });
+    expect(res.data.labels).toEqual([
+      {
+        name: "Binance Hot",
+        category: "exchange",
+        notes: "Exchange deposit coldkey",
+        source_urls: ["https://example.com/label"],
+      },
+    ]);
+    expect(res.data.ownership_ties).toEqual([
+      {
+        netuid: 18,
+        role: "gained_ownership",
+        block_number: 5_000_000,
+        observed_at: "2026-07-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("drops invalid categories / roles and coerces junk cells", async () => {
+    resolveWith({
+      ss58: ALICE,
+      labels: [
+        { name: "Ops", category: "not-a-category", notes: null, source_urls: [123, "https://ok"] },
+        "not-a-label",
+      ],
+      ownership_ties: [
+        { netuid: 1, role: "gained_ownership", block_number: "x" },
+        { netuid: 2, role: "invented" },
+      ],
+    });
+    const res = await runQuery(ALICE);
+    expect(res.data.labels).toEqual([
+      {
+        name: "Ops",
+        category: null,
+        notes: null,
+        source_urls: ["https://ok"],
+      },
+    ]);
+    expect(res.data.ownership_ties).toEqual([
+      {
+        netuid: 1,
+        role: "gained_ownership",
+        block_number: null,
+        observed_at: null,
+      },
+    ]);
+    expect(res.data.ownership_tie_count).toBe(1);
+  });
+
+  it("degrades a cold / unlabeled account to empty arrays (never throws)", async () => {
+    for (const raw of [{}, null, { labels: "x", ownership_ties: "y" }]) {
+      resolveWith(raw);
+      const res = await runQuery(ALICE);
+      expect(res.data.ss58).toBe(ALICE);
+      expect(res.data.labels).toEqual([]);
+      expect(res.data.ownership_ties).toEqual([]);
+      expect(res.data.ownership_tie_count).toBe(0);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -46,8 +46,17 @@ import type {
   AccountDay,
   AccountEvent,
   AccountEventsPage,
+  AccountChildren,
   AccountCounterparties,
   AccountCounterparty,
+  AccountEntities,
+  AccountOwnershipTie,
+  AccountParents,
+  ChildDelegationEntry,
+  ChildDelegationSubnet,
+  EntityLabel,
+  ParentDelegationEntry,
+  ParentDelegationSubnet,
   AccountStakeFlow,
   AccountStakeFlowSubnet,
   AccountHistory,
@@ -2672,6 +2681,195 @@ export const accountCounterpartiesQuery = (ss58: string) =>
         meta: res.meta,
         url: res.url,
       } as ApiResult<AccountCounterparties>;
+    },
+    staleTime: STALE_MED,
+  });
+
+// #6999 / #6723: live child-hotkey delegation graph from ChildKeys storage.
+// `subnets: null` is an RPC failure (distinct from a confirmed empty `[]`).
+function normalizeChildDelegationEntry(raw: unknown): ChildDelegationEntry | null {
+  if (!isRecord(raw)) return null;
+  const proportion = firstString(raw.proportion);
+  const proportionFraction = firstFiniteNumber(raw.proportion_fraction);
+  if (proportion == null || proportionFraction == null) return null;
+  return {
+    child: firstString(raw.child) ?? null,
+    proportion,
+    proportion_fraction: proportionFraction,
+  };
+}
+
+function normalizeChildDelegationSubnet(raw: unknown): ChildDelegationSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  const entries = Array.isArray(raw.entries)
+    ? raw.entries.flatMap((row) => {
+        const entry = normalizeChildDelegationEntry(row);
+        return entry ? [entry] : [];
+      })
+    : [];
+  if (entries.length === 0) return null;
+  return { netuid, entries };
+}
+
+export const accountChildrenQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-children", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/children`, {
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      // Preserve explicit null (RPC failure) vs missing/junk → empty array.
+      const subnets =
+        d.subnets === null
+          ? null
+          : Array.isArray(d.subnets)
+            ? d.subnets.flatMap((row) => {
+                const subnet = normalizeChildDelegationSubnet(row);
+                return subnet ? [subnet] : [];
+              })
+            : [];
+      return {
+        data: {
+          account: firstString(d.account) ?? ss58,
+          schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+          subnets,
+          queried_at: firstString(d.queried_at) ?? null,
+        } as AccountChildren,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountChildren>;
+    },
+    staleTime: STALE_MED,
+  });
+
+// #6999 / #6723: live parent-hotkey delegation graph from ParentKeys storage.
+function normalizeParentDelegationEntry(raw: unknown): ParentDelegationEntry | null {
+  if (!isRecord(raw)) return null;
+  const proportion = firstString(raw.proportion);
+  const proportionFraction = firstFiniteNumber(raw.proportion_fraction);
+  if (proportion == null || proportionFraction == null) return null;
+  return {
+    parent: firstString(raw.parent) ?? null,
+    proportion,
+    proportion_fraction: proportionFraction,
+  };
+}
+
+function normalizeParentDelegationSubnet(raw: unknown): ParentDelegationSubnet | null {
+  if (!isRecord(raw)) return null;
+  const netuid = firstFiniteNumber(raw.netuid);
+  if (netuid == null) return null;
+  const entries = Array.isArray(raw.entries)
+    ? raw.entries.flatMap((row) => {
+        const entry = normalizeParentDelegationEntry(row);
+        return entry ? [entry] : [];
+      })
+    : [];
+  if (entries.length === 0) return null;
+  return { netuid, entries };
+}
+
+export const accountParentsQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-parents", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/parents`, {
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const subnets =
+        d.subnets === null
+          ? null
+          : Array.isArray(d.subnets)
+            ? d.subnets.flatMap((row) => {
+                const subnet = normalizeParentDelegationSubnet(row);
+                return subnet ? [subnet] : [];
+              })
+            : [];
+      return {
+        data: {
+          account: firstString(d.account) ?? ss58,
+          schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+          subnets,
+          queried_at: firstString(d.queried_at) ?? null,
+        } as AccountParents,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountParents>;
+    },
+    staleTime: STALE_MED,
+  });
+
+const ENTITY_LABEL_CATEGORIES = new Set(["exchange", "foundation", "operator", "other"]);
+
+function normalizeEntityLabel(raw: unknown): EntityLabel | null {
+  if (!isRecord(raw)) return null;
+  const categoryRaw = firstString(raw.category);
+  const category =
+    categoryRaw && ENTITY_LABEL_CATEGORIES.has(categoryRaw)
+      ? (categoryRaw as EntityLabel["category"])
+      : null;
+  const sourceUrls = Array.isArray(raw.source_urls)
+    ? raw.source_urls.flatMap((url) => {
+        const s = firstString(url);
+        return s ? [s] : [];
+      })
+    : [];
+  return {
+    name: firstString(raw.name) ?? null,
+    category,
+    notes: firstString(raw.notes) ?? null,
+    source_urls: sourceUrls,
+  };
+}
+
+function normalizeOwnershipTie(raw: unknown): AccountOwnershipTie | null {
+  if (!isRecord(raw)) return null;
+  const role = firstString(raw.role);
+  if (role !== "gained_ownership" && role !== "lost_ownership") return null;
+  return {
+    netuid: firstFiniteNumber(raw.netuid) ?? null,
+    role,
+    block_number: firstFiniteNumber(raw.block_number) ?? null,
+    observed_at: firstString(raw.observed_at) ?? null,
+  };
+}
+
+// #6999 / #6740: community entity labels + SubnetOwnerChanged ownership ties.
+export const accountEntitiesQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-entities", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<unknown>(`/api/v1/accounts/${ss58PathSegment(ss58)}/entities`, {
+        signal,
+      });
+      const d = isRecord(res.data) ? res.data : {};
+      const labels = Array.isArray(d.labels)
+        ? d.labels.flatMap((row) => {
+            const label = normalizeEntityLabel(row);
+            return label ? [label] : [];
+          })
+        : [];
+      const ownershipTies = Array.isArray(d.ownership_ties)
+        ? d.ownership_ties.flatMap((row) => {
+            const tie = normalizeOwnershipTie(row);
+            return tie ? [tie] : [];
+          })
+        : [];
+      return {
+        data: {
+          ss58: firstString(d.ss58) ?? ss58,
+          schema_version: firstFiniteNumber(d.schema_version) ?? 1,
+          labels,
+          ownership_tie_count: firstFiniteNumber(d.ownership_tie_count) ?? ownershipTies.length,
+          ownership_ties: ownershipTies,
+        } as AccountEntities,
+        meta: res.meta,
+        url: res.url,
+      } as ApiResult<AccountEntities>;
     },
     staleTime: STALE_MED,
   });

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1320,6 +1320,77 @@ export interface AccountCounterparties {
   counterparties: AccountCounterparty[];
   [key: string]: unknown;
 }
+/** One child-hotkey entry in /api/v1/accounts/{ss58}/children (#6723). */
+export interface ChildDelegationEntry {
+  child: string | null;
+  proportion: string;
+  proportion_fraction: number;
+}
+/** One subnet's children for an account (#6723). */
+export interface ChildDelegationSubnet {
+  netuid: number;
+  entries: ChildDelegationEntry[];
+}
+/**
+ * #6999 / #6723: live child-hotkey delegation graph from
+ * /api/v1/accounts/{ss58}/children. `subnets: null` means RPC failure;
+ * `subnets: []` is a confirmed empty graph.
+ */
+export interface AccountChildren {
+  account: string;
+  schema_version: number;
+  subnets: ChildDelegationSubnet[] | null;
+  queried_at: string | null;
+  [key: string]: unknown;
+}
+/** One parent-hotkey entry in /api/v1/accounts/{ss58}/parents (#6723). */
+export interface ParentDelegationEntry {
+  parent: string | null;
+  proportion: string;
+  proportion_fraction: number;
+}
+/** One subnet's parents for an account (#6723). */
+export interface ParentDelegationSubnet {
+  netuid: number;
+  entries: ParentDelegationEntry[];
+}
+/**
+ * #6999 / #6723: live parent-hotkey delegation graph from
+ * /api/v1/accounts/{ss58}/parents. Same null-vs-empty semantics as children.
+ */
+export interface AccountParents {
+  account: string;
+  schema_version: number;
+  subnets: ParentDelegationSubnet[] | null;
+  queried_at: string | null;
+  [key: string]: unknown;
+}
+/** One community-contributed entity label (#6737/#6738). */
+export interface EntityLabel {
+  name: string | null;
+  category: "exchange" | "foundation" | "operator" | "other" | null;
+  notes: string | null;
+  source_urls: string[];
+}
+/** One SubnetOwnerChanged ownership-transfer tie for an address (#6740). */
+export interface AccountOwnershipTie {
+  netuid: number | null;
+  role: "gained_ownership" | "lost_ownership";
+  block_number: number | null;
+  observed_at: string | null;
+}
+/**
+ * #6999 / #6740: entity labels + ownership ties from
+ * /api/v1/accounts/{ss58}/entities.
+ */
+export interface AccountEntities {
+  ss58: string;
+  schema_version: number;
+  labels: EntityLabel[];
+  ownership_tie_count: number;
+  ownership_ties: AccountOwnershipTie[];
+  [key: string]: unknown;
+}
 /** One per-subnet stake/unstake flow row in /accounts/{ss58}/stake-flow. */
 export interface AccountStakeFlowSubnet {
   netuid: number;

--- a/apps/ui/src/routes/accounts.$ss58.tsx
+++ b/apps/ui/src/routes/accounts.$ss58.tsx
@@ -15,12 +15,14 @@ import {
   Fingerprint,
   Gauge,
   Github,
+  GitBranch,
   Globe,
   MessageCircle,
   Radar,
   RefreshCw,
   Rows3,
   Scale,
+  Tags,
   Unplug,
   UserMinus,
   UserPlus,
@@ -49,7 +51,10 @@ import { AccountHistoryChart } from "@/components/metagraphed/account-history-ch
 import { AccountPositionHistoryChart } from "@/components/metagraphed/account-position-history-chart";
 import {
   accountAxonRemovalsQuery,
+  accountChildrenQuery,
   accountCounterpartiesQuery,
+  accountEntitiesQuery,
+  accountParentsQuery,
   accountStakeFlowQuery,
   accountPortfolioQuery,
   accountStakeMovesQuery,
@@ -77,6 +82,9 @@ import { subnetPositionSearch } from "@/lib/metagraphed/subnet-position-link";
 import { entityNotFoundMeta } from "@/lib/metagraphed/entity-not-found-meta";
 import type {
   AccountCounterparty,
+  ChildDelegationSubnet,
+  EntityLabel,
+  ParentDelegationSubnet,
   AccountStakeFlowSubnet,
   AccountRegistration,
   AccountSummary,
@@ -398,6 +406,10 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
       />
       {/* #3340: the aggregated fund-flow view over the same transfer data. */}
       <AccountCounterpartiesSection ss58={ss58} />
+      {/* #6999: live child/parent-hotkey delegation graph (#6723). */}
+      <AccountDelegationSection ss58={ss58} />
+      {/* #6999: community entity labels + SubnetOwnerChanged ownership ties (#6740). */}
+      <AccountEntitiesSection ss58={ss58} />
 
       {/* #6432: deliberately NOT "← All accounts" like the other detail pages'
           back-links. /accounts is a lookup form, not an index -- there is no
@@ -427,6 +439,9 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
             { label: "events", path: `/api/v1/accounts/${sourceRef}/events` },
             { label: "subnets", path: `/api/v1/accounts/${sourceRef}/subnets` },
             { label: "counterparties", path: `/api/v1/accounts/${sourceRef}/counterparties` },
+            { label: "children", path: `/api/v1/accounts/${sourceRef}/children` },
+            { label: "parents", path: `/api/v1/accounts/${sourceRef}/parents` },
+            { label: "entities", path: `/api/v1/accounts/${sourceRef}/entities` },
             { label: "stake-flow", path: `/api/v1/accounts/${sourceRef}/stake-flow` },
             { label: "serving", path: `/api/v1/accounts/${sourceRef}/serving` },
             { label: "prometheus", path: `/api/v1/accounts/${sourceRef}/prometheus` },
@@ -442,6 +457,9 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
           `/api/v1/accounts/${sourceRef}/events`,
           `/api/v1/accounts/${sourceRef}/subnets`,
           `/api/v1/accounts/${sourceRef}/counterparties`,
+          `/api/v1/accounts/${sourceRef}/children`,
+          `/api/v1/accounts/${sourceRef}/parents`,
+          `/api/v1/accounts/${sourceRef}/entities`,
           `/api/v1/accounts/${sourceRef}/stake-flow`,
           `/api/v1/accounts/${sourceRef}/serving`,
           `/api/v1/accounts/${sourceRef}/prometheus`,
@@ -1061,6 +1079,412 @@ function AccountCounterpartiesSection({ ss58 }: { ss58: string }) {
         <p className="mt-3 font-mono text-[10px] text-ink-muted">
           Showing the {rows.length} highest-volume of {formatNumber(parties.length)} counterparties.
         </p>
+      ) : null}
+    </SectionAnchor>
+  );
+}
+
+function fmtProportion(fraction: number): string {
+  return `${(fraction * 100).toFixed(2)}%`;
+}
+
+function flattenChildRows(subnets: ChildDelegationSubnet[]) {
+  return subnets.flatMap((subnet) =>
+    subnet.entries.map((entry, i) => ({
+      key: `${subnet.netuid}-${entry.child ?? "null"}-${i}`,
+      netuid: subnet.netuid,
+      hotkey: entry.child,
+      proportion: entry.proportion,
+      proportion_fraction: entry.proportion_fraction,
+    })),
+  );
+}
+
+function flattenParentRows(subnets: ParentDelegationSubnet[]) {
+  return subnets.flatMap((subnet) =>
+    subnet.entries.map((entry, i) => ({
+      key: `${subnet.netuid}-${entry.parent ?? "null"}-${i}`,
+      netuid: subnet.netuid,
+      hotkey: entry.parent,
+      proportion: entry.proportion,
+      proportion_fraction: entry.proportion_fraction,
+    })),
+  );
+}
+
+function DelegationEdgeTable({
+  rows,
+  hotkeyHeader,
+}: {
+  rows: Array<{
+    key: string;
+    netuid: number;
+    hotkey: string | null;
+    proportion: string;
+    proportion_fraction: number;
+  }>;
+  hotkeyHeader: string;
+}) {
+  if (rows.length === 0) {
+    return <p className="font-mono text-[11px] text-ink-muted">No entries on any subnet.</p>;
+  }
+  return (
+    <DataPanel>
+      <table className="w-full text-left text-sm">
+        <thead className="bg-surface/50">
+          <tr>
+            <th className={TH}>Subnet</th>
+            <th className={TH}>{hotkeyHeader}</th>
+            <th className={`${TH} text-right`}>Share</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {rows.map((row) => (
+            <tr key={row.key} className="hover:bg-surface/30">
+              <td className="px-5 py-4 font-mono text-[12px]">
+                <Link
+                  to="/subnets/$netuid"
+                  params={{ netuid: row.netuid }}
+                  className="text-ink-strong hover:text-accent hover:underline"
+                >
+                  SN{row.netuid}
+                </Link>
+              </td>
+              <td
+                className="px-5 py-4 font-mono text-[11px] text-ink-muted"
+                title={row.hotkey ?? undefined}
+              >
+                {row.hotkey ? (
+                  <Link
+                    to="/accounts/$ss58"
+                    params={{ ss58: row.hotkey }}
+                    className="hover:text-accent hover:underline"
+                  >
+                    {shortHash(row.hotkey)}
+                  </Link>
+                ) : (
+                  "—"
+                )}
+              </td>
+              <td
+                className="px-5 py-4 text-right font-mono text-[11px] tabular-nums text-ink"
+                title={row.proportion}
+              >
+                {fmtProportion(row.proportion_fraction)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </DataPanel>
+  );
+}
+
+// #6999: live child/parent-hotkey delegation graph from /children + /parents
+// (#6723). Self-contained + non-blocking like AccountCounterpartiesSection —
+// most accounts have an empty graph and render nothing; RPC failure
+// (`subnets: null`) is shown as a soft error for that half only.
+function AccountDelegationSection({ ss58 }: { ss58: string }) {
+  const childrenResult = useQuery(accountChildrenQuery(ss58));
+  const parentsResult = useQuery(accountParentsQuery(ss58));
+  const children = childrenResult.data?.data;
+  const parents = parentsResult.data?.data;
+  const SUBTITLE =
+    "Live child and parent hotkey relationships from on-chain ChildKeys / ParentKeys — who this account delegates stake-weight to, and who delegates to it, per subnet.";
+
+  const childrenPending = childrenResult.isPending && !children;
+  const parentsPending = parentsResult.isPending && !parents;
+  if (childrenPending && parentsPending) {
+    return (
+      <AccountFeedSectionSkeleton id="delegation" title="Delegation graph" subtitle={SUBTITLE} />
+    );
+  }
+
+  const childrenUnavailable = childrenResult.isError || children?.subnets === null;
+  const parentsUnavailable = parentsResult.isError || parents?.subnets === null;
+  const childRows = children?.subnets ? flattenChildRows(children.subnets) : [];
+  const parentRows = parents?.subnets ? flattenParentRows(parents.subnets) : [];
+  const childSubnetCount = children?.subnets?.length ?? 0;
+  const parentSubnetCount = parents?.subnets?.length ?? 0;
+  const hasAnyRows = childRows.length > 0 || parentRows.length > 0;
+  const bothConfirmedEmpty =
+    !childrenUnavailable &&
+    !parentsUnavailable &&
+    Array.isArray(children?.subnets) &&
+    Array.isArray(parents?.subnets) &&
+    !hasAnyRows;
+
+  if (bothConfirmedEmpty) return null;
+  if (
+    !hasAnyRows &&
+    !childrenUnavailable &&
+    !parentsUnavailable &&
+    (childrenPending || parentsPending)
+  ) {
+    return (
+      <AccountFeedSectionSkeleton id="delegation" title="Delegation graph" subtitle={SUBTITLE} />
+    );
+  }
+  if (!hasAnyRows && !childrenUnavailable && !parentsUnavailable) return null;
+
+  const badgeCount = childRows.length + parentRows.length;
+
+  return (
+    <SectionAnchor
+      id="delegation"
+      title="Delegation graph"
+      subtitle={SUBTITLE}
+      tone="accent"
+      info="Live ChildKeys / ParentKeys snapshot from /api/v1/accounts/{ss58}/children and /parents. Share is proportion_fraction (0..1 of u64::MAX). subnets: null means the RPC lookup failed for that side."
+      right={
+        badgeCount > 0 ? (
+          <SectionBadge tone="accent">{formatNumber(badgeCount)} edges</SectionBadge>
+        ) : undefined
+      }
+    >
+      <div className="mb-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatTile
+          icon={GitBranch}
+          eyebrow="Child edges"
+          tone="accent"
+          value={childrenUnavailable ? "—" : formatNumber(childRows.length)}
+          hint={childrenUnavailable ? "lookup unavailable" : "delegated to"}
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={GitBranch}
+          eyebrow="Child subnets"
+          value={childrenUnavailable ? "—" : formatNumber(childSubnetCount)}
+          hint="with ≥1 child"
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Users}
+          eyebrow="Parent edges"
+          value={parentsUnavailable ? "—" : formatNumber(parentRows.length)}
+          hint={parentsUnavailable ? "lookup unavailable" : "delegating in"}
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Users}
+          eyebrow="Parent subnets"
+          value={parentsUnavailable ? "—" : formatNumber(parentSubnetCount)}
+          hint="with ≥1 parent"
+          className={KPI_TILE}
+        />
+      </div>
+
+      <div className="space-y-8">
+        <div>
+          <h3 className="mb-3 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Children — stake-weight this account delegates out
+          </h3>
+          {childrenUnavailable ? (
+            <TableState
+              variant="error"
+              title="Couldn't load child hotkeys"
+              description="The children lookup is optional enrichment — parents (if any) still render below."
+              error={childrenResult.error}
+              onRetry={() => void childrenResult.refetch()}
+            />
+          ) : (
+            <DelegationEdgeTable rows={childRows} hotkeyHeader="Child hotkey" />
+          )}
+        </div>
+        <div>
+          <h3 className="mb-3 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Parents — hotkeys delegating stake-weight to this account
+          </h3>
+          {parentsUnavailable ? (
+            <TableState
+              variant="error"
+              title="Couldn't load parent hotkeys"
+              description="The parents lookup is optional enrichment — children (if any) still render above."
+              error={parentsResult.error}
+              onRetry={() => void parentsResult.refetch()}
+            />
+          ) : (
+            <DelegationEdgeTable rows={parentRows} hotkeyHeader="Parent hotkey" />
+          )}
+        </div>
+      </div>
+      {(children?.queried_at || parents?.queried_at) && (
+        <p className="mt-3 font-mono text-[10px] text-ink-muted">
+          Queried <TimeAgo at={children?.queried_at ?? parents?.queried_at ?? undefined} />
+        </p>
+      )}
+    </SectionAnchor>
+  );
+}
+
+function entityCategoryLabel(category: EntityLabel["category"]): string {
+  if (!category) return "unlabeled";
+  return category;
+}
+
+// #6999: community entity labels + SubnetOwnerChanged ownership ties from
+// /api/v1/accounts/{ss58}/entities (#6737/#6740). Same non-blocking pattern —
+// unlabeled addresses with no ownership-transfer history render nothing.
+function AccountEntitiesSection({ ss58 }: { ss58: string }) {
+  const result = useQuery(accountEntitiesQuery(ss58));
+  const data = result.data?.data;
+  const SUBTITLE =
+    "Community-contributed entity labels for this address, plus every SubnetOwnerChanged ownership-transfer tie it appears in.";
+
+  if (result.isPending && !data) {
+    return <AccountFeedSectionSkeleton id="entities" title="Entity labels" subtitle={SUBTITLE} />;
+  }
+  if (result.isError) {
+    return (
+      <SectionAnchor id="entities" title="Entity labels" subtitle={SUBTITLE} tone="accent">
+        <TableState
+          variant="error"
+          title="Couldn't load entity labels"
+          description="Entity labels are optional enrichment — the rest of the account page is unaffected."
+          error={result.error}
+          onRetry={() => void result.refetch()}
+        />
+      </SectionAnchor>
+    );
+  }
+
+  const labels = data?.labels ?? [];
+  const ties = data?.ownership_ties ?? [];
+  if (!data || (labels.length === 0 && ties.length === 0)) return null;
+
+  return (
+    <SectionAnchor
+      id="entities"
+      title="Entity labels"
+      subtitle={SUBTITLE}
+      tone="accent"
+      info="From /api/v1/accounts/{ss58}/entities — curated entity labels joined with SubnetOwnerChanged ownership-transfer ties. Genesis ownership with no transfer event does not appear here."
+      right={
+        <SectionBadge tone="accent">
+          {formatNumber(labels.length)} labels · {formatNumber(data.ownership_tie_count)} ties
+        </SectionBadge>
+      }
+    >
+      <div className="mb-4 grid gap-4 sm:grid-cols-2">
+        <StatTile
+          icon={Tags}
+          eyebrow="Labels"
+          tone="accent"
+          value={formatNumber(labels.length)}
+          hint="community-contributed"
+          className={KPI_TILE}
+        />
+        <StatTile
+          icon={Fingerprint}
+          eyebrow="Ownership ties"
+          value={formatNumber(data.ownership_tie_count)}
+          hint="SubnetOwnerChanged"
+          className={KPI_TILE}
+        />
+      </div>
+
+      {labels.length > 0 ? (
+        <div className="mb-6 space-y-3">
+          <h3 className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Labels
+          </h3>
+          <ul className="grid gap-3 sm:grid-cols-2">
+            {labels.map((label, i) => (
+              <li
+                key={`${label.name ?? "label"}-${i}`}
+                className="rounded-2xl border border-border/80 bg-card/95 p-4"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-medium text-ink-strong">
+                    {label.name ?? "Unnamed label"}
+                  </span>
+                  <span className="inline-flex items-center rounded-full border border-border bg-surface px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-ink-muted">
+                    {entityCategoryLabel(label.category)}
+                  </span>
+                </div>
+                {label.notes ? <p className="mt-2 text-sm text-ink-muted">{label.notes}</p> : null}
+                {label.source_urls.length > 0 ? (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {label.source_urls.map((url) => (
+                      <ExternalLink
+                        key={url}
+                        href={url}
+                        className="font-mono text-[11px] text-accent-text hover:underline"
+                      >
+                        source
+                      </ExternalLink>
+                    ))}
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {ties.length > 0 ? (
+        <div>
+          <h3 className="mb-3 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-muted">
+            Ownership ties
+          </h3>
+          <DataPanel>
+            <table className="w-full text-left text-sm">
+              <thead className="bg-surface/50">
+                <tr>
+                  <th className={TH}>Subnet</th>
+                  <th className={TH}>Role</th>
+                  <th className={`${TH} text-right`}>Block</th>
+                  <th className={`${TH} text-right`}>Observed</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {ties.map((tie, i) => (
+                  <tr
+                    key={`${tie.netuid ?? "x"}-${tie.role}-${tie.block_number ?? i}`}
+                    className="hover:bg-surface/30"
+                  >
+                    <td className="px-5 py-4 font-mono text-[12px]">
+                      {tie.netuid != null ? (
+                        <Link
+                          to="/subnets/$netuid"
+                          params={{ netuid: tie.netuid }}
+                          className="text-ink-strong hover:text-accent hover:underline"
+                        >
+                          SN{tie.netuid}
+                        </Link>
+                      ) : (
+                        <span className="text-ink-muted">—</span>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 font-mono text-[11px] text-ink">
+                      {tie.role === "gained_ownership" ? (
+                        <span className="text-health-ok">gained ownership</span>
+                      ) : (
+                        <span className="text-health-warn-text">lost ownership</span>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 text-right font-mono text-[12px]">
+                      {tie.block_number != null ? (
+                        <Link
+                          to="/blocks/$ref"
+                          params={{ ref: String(tie.block_number) }}
+                          className="text-ink hover:text-accent hover:underline"
+                        >
+                          #{formatNumber(tie.block_number)}
+                        </Link>
+                      ) : (
+                        <span className="text-ink-muted">—</span>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 text-right font-mono text-[11px] text-ink-muted">
+                      {tie.observed_at ? <TimeAgo at={tie.observed_at} /> : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </DataPanel>
+        </div>
       ) : null}
     </SectionAnchor>
   );


### PR DESCRIPTION
## Summary
- Adds an account-page **Delegation graph** section fed by `/api/v1/accounts/{ss58}/children` and `/parents` (live ChildKeys / ParentKeys edges), following the `AccountCounterpartiesSection` pattern.
- Adds an **Entity labels** section fed by `/api/v1/accounts/{ss58}/entities` (community labels + SubnetOwnerChanged ownership ties).
- Wires query normalizers + unit tests, and lists the three endpoints in the page's endpoint snippet + API source footer.

Closes #6999

## Screenshots

| | Before | After |
|---|---|---|
| Mobile light | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6999-before-mobile-light.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6999-after-mobile-light.png) |
| Mobile dark | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6999-before-mobile-dark.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6999-after-mobile-dark.png) |
| Tablet light | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6999-before-tablet-light.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6999-after-tablet-light.png) |
| Tablet dark | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6999-before-tablet-dark.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6999-after-tablet-dark.png) |
| Desktop light | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6999-before-desktop-light.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6999-after-desktop-light.png) |
| Desktop dark | ![before](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6999-before-desktop-dark.png) | ![after](https://raw.githubusercontent.com/jsdevninja/metagraphed/screenshots/6999-after-desktop-dark.png) |

## Test plan
- [x] `prettier --check` + `eslint` on touched files
- [x] `npm run typecheck --workspace=apps/ui`
- [x] `vitest` for `queries.account-delegation` + `queries.account-entities`
- [x] `vite build` (apps/ui)
- [ ] CI `ui` job (lint / typecheck / test / e2e overflow / build / bundle-budget)
- [ ] Manual: open an account with non-empty children/parents/entities and confirm sections render; empty accounts stay blank (same as counterparties)

Made with [Cursor](https://cursor.com)