### PR TITLE
feat(graphql): add adapter(slug) Query field parity (#6984)

### DIFF
--- a/src/graphql.mjs
+++ b/src/graphql.mjs
@@ -15,6 +15,9 @@ import { tryPostgresTier } from "../workers/postgres-tier.mjs";
 import { loadEndpointPoolsList } from "./endpoint-pools-mcp.mjs";
 import { loadRpcPoolsList } from "./rpc-pools-mcp.mjs";
 import { loadEndpointIncidentsList } from "./endpoint-incidents-mcp.mjs";
+// #6984: GraphQL parity for GET /api/v1/adapters/{slug}, reusing loadAdapter that
+// MCP get_adapter already calls (#3255) -- not a reimplementation.
+import { loadAdapter } from "./adapters-mcp.mjs";
 import {
   buildChainAxonRemovals,
   CHAIN_AXON_REMOVALS_WINDOWS,
@@ -386,6 +389,8 @@ export const SDL = `
     providers(limit: Int, cursor: String): ProviderList!
     "One provider with its subnets."
     provider(id: String!): Provider
+    "One adapter-backed public metrics snapshot by slug (e.g. 'gittensor', 'allways', 'sn-64'): the captured adapter snapshot, extension metadata, and netuid linkage. An invalid slug is a BAD_USER_INPUT error; a missing slug resolves to null (schema-stable, never a GraphQL error). Mirrors GET /api/v1/adapters/{slug}."
+    adapter(slug: String!): Adapter
     "Paginated per-subnet economic + validator metrics."
     economics(limit: Int, cursor: String): EconomicsList!
     "Curated public interface surfaces, optionally scoped to one subnet."
@@ -593,6 +598,22 @@ export const SDL = `
     netuids: [Int]!
     "The subnets this provider operates surfaces on."
     subnets: [Subnet!]!
+  }
+
+  "One adapter-backed public metrics snapshot. snapshot and extensions are opaque JSON -- their shape is adapter-specific. Mirrors GET /api/v1/adapters/{slug}'s data envelope."
+  type Adapter {
+    schema_version: Int!
+    contract_version: String
+    generated_at: String
+    slug: String!
+    subnet: String
+    netuid: Int
+    "Public-safe notes; may be a string or a string list depending on the adapter."
+    notes: JSON
+    "Captured adapter metrics payload; shape is adapter-specific."
+    snapshot: JSON
+    "Per-adapter extension metadata keyed by provider id; each value's shape is adapter-specific."
+    extensions: JSON
   }
 
   type EconomicsList {
@@ -3072,6 +3093,7 @@ export const FIELD_COMPLEXITY = {
   subnet: RELATIONSHIP_FIELD_COMPLEXITY,
   providers: RELATIONSHIP_FIELD_COMPLEXITY,
   provider: RELATIONSHIP_FIELD_COMPLEXITY,
+  adapter: RELATIONSHIP_FIELD_COMPLEXITY,
   economics: RELATIONSHIP_FIELD_COMPLEXITY,
   surfaces: RELATIONSHIP_FIELD_COMPLEXITY,
   endpoints: RELATIONSHIP_FIELD_COMPLEXITY,
@@ -4509,6 +4531,26 @@ const rootValue = {
     const data = await loadArtifact(context, `/metagraph/providers/${id}.json`);
     if (!data) return null;
     return providerNode(data.provider ?? data);
+  },
+
+  // #6984: reuse loadAdapter (the same loader MCP get_adapter already calls)
+  // unchanged -- same slug validation and artifact path as REST
+  // /api/v1/adapters/{slug}. invalid_params becomes BAD_USER_INPUT; any other
+  // loader miss (not_found / cold R2 / unavailable) resolves to null
+  // (schema-stable), matching provider's cold/absent convention -- never a
+  // GraphQL error for an unregistered slug.
+  async adapter({ slug }, context) {
+    try {
+      return await loadAdapter(context, { slug }, { readArtifact });
+    } catch (err) {
+      if (err?.toolError && err.code === "invalid_params") {
+        throw new GraphQLError(err.message, {
+          extensions: { code: "BAD_USER_INPUT" },
+        });
+      }
+      if (err?.toolError) return null;
+      throw err;
+    }
   },
 
   async economics({ limit, cursor }, context) {

--- a/tests/graphql.test.mjs
+++ b/tests/graphql.test.mjs
@@ -14912,3 +14912,89 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
     );
   });
 });
+
+describe("graphql — adapter (#6984, reuses loadAdapter / MCP get_adapter)", () => {
+  const SAMPLE = {
+    schema_version: 1,
+    contract_version: "2026-07-01",
+    generated_at: "2026-07-01T00:00:00.000Z",
+    slug: "gittensor",
+    subnet: "Gittensor",
+    netuid: 74,
+    notes: ["public-safe only"],
+    snapshot: { status: "captured", adapter_kind: "gittensor" },
+    extensions: { gittensor: { kind: "gittensor" } },
+  };
+
+  const query = `{ adapter(slug: "gittensor") {
+    schema_version contract_version generated_at slug subnet netuid
+    notes snapshot extensions
+  } }`;
+
+  test("resolves a baked adapter artifact via loadAdapter", async () => {
+    const env = fixtureEnv({ "/metagraph/adapters/gittensor.json": SAMPLE });
+    const { status, body } = await gql(query, env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.adapter, SAMPLE);
+  });
+
+  test("a missing slug resolves to null (schema-stable), never a GraphQL error", async () => {
+    const env = fixtureEnv({
+      "/metagraph/adapters/gittensor.json": SAMPLE,
+    });
+    const { status, body } = await gql(
+      '{ adapter(slug: "missing") { slug } }',
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.adapter, null);
+  });
+
+  test("cold/absent store resolves to null", async () => {
+    const { status, body } = await gql(query);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(body.data.adapter, null);
+  });
+
+  test("an invalid slug is BAD_USER_INPUT, matching MCP get_adapter", async () => {
+    const { status, body } = await gql(
+      '{ adapter(slug: "Gittensor") { slug } }',
+    );
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data?.adapter ?? null, null);
+  });
+
+  test("an empty slug is BAD_USER_INPUT", async () => {
+    const { status, body } = await gql('{ adapter(slug: "  ") { slug } }');
+    assert.equal(status, 200);
+    assert.ok(body.errors.find((e) => e.extensions?.code === "BAD_USER_INPUT"));
+    assert.equal(body.data?.adapter ?? null, null);
+  });
+
+  test("a non-toolError from the artifact read is propagated", async () => {
+    const env = {
+      METAGRAPH_R2_LATEST_PREFIX: "latest/",
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return {
+            async json() {
+              throw new Error("corrupt adapter artifact");
+            },
+          };
+        },
+      },
+    };
+    const { status, body } = await gql(query, env);
+    assert.equal(status, 200);
+    assert.ok(body.errors?.length > 0);
+    assert.equal(body.data?.adapter ?? null, null);
+  });
+
+  test("is priced at the relationship-field complexity weight", () => {
+    assert.equal(FIELD_COMPLEXITY.adapter, FIELD_COMPLEXITY.provider);
+  });
+});


### PR DESCRIPTION
## Summary

- Add GraphQL `adapter(slug: String!)` so adapter-backed public metrics are reachable from all three surfaces (REST / GraphQL / MCP).
- Reuse `loadAdapter` from `src/adapters-mcp.mjs` — the same loader MCP `get_adapter` already calls (#3255) — rather than re-implementing slug validation or the artifact path.
- Invalid slug → `BAD_USER_INPUT`; missing/cold artifact → `null` (schema-stable), matching `provider`.

## What Changed

- `src/graphql.mjs`: `adapter(slug:)` Query field, `Adapter` output type, relationship field-complexity weight, resolver wrapping `loadAdapter`.
- `tests/graphql.test.mjs`: resolve / missing / cold / invalid-slug / non-toolError / complexity coverage.

## MCP note

MCP parity for this route already shipped as `get_adapter` in #3255 (`src/adapters-mcp.mjs` + `tests/adapters-mcp.test.mjs`). This PR completes the remaining GraphQL gap called out in #6984; no duplicate MCP tool was added.

Closes #6984

## Template Used

backend-code

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #6984`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. (GraphQL SDL only — no OpenAPI/schema JSON change.)

## Validation

- [x] `git diff --check`
- [x] prettier check on touched files
- [x] `npm test -- tests/graphql.test.mjs -t "adapter (#6984"` (7 passed)
- [x] `npm test -- tests/adapters-mcp.test.mjs` (16 passed — existing MCP coverage)
- [ ] `npm run check` (full pipeline needs `uv` for `sync:subnets:dry-run` in this environment)
- [ ] `npm run validate`
- [ ] `npm run test:coverage` (full suite — new resolver patch branches covered in focused run)


Made with [Cursor](https://cursor.com)